### PR TITLE
Turn RankFeatureShardPhase into utility class

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1099,7 +1099,6 @@ class NodeConstruction {
             threadPool,
             scriptService,
             bigArrays,
-            searchModule.getRankFeatureShardPhase(),
             searchModule.getFetchPhase(),
             responseCollectorService,
             circuitBreakerService,

--- a/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
@@ -35,7 +35,6 @@ import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.fetch.FetchPhase;
-import org.elasticsearch.search.rank.feature.RankFeatureShardPhase;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -119,7 +118,6 @@ class NodeServiceProvider {
         ThreadPool threadPool,
         ScriptService scriptService,
         BigArrays bigArrays,
-        RankFeatureShardPhase rankFeatureShardPhase,
         FetchPhase fetchPhase,
         ResponseCollectorService responseCollectorService,
         CircuitBreakerService circuitBreakerService,
@@ -132,7 +130,6 @@ class NodeServiceProvider {
             threadPool,
             scriptService,
             bigArrays,
-            rankFeatureShardPhase,
             fetchPhase,
             responseCollectorService,
             circuitBreakerService,

--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -231,7 +231,6 @@ import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.rank.RankDoc;
 import org.elasticsearch.search.rank.RankShardResult;
 import org.elasticsearch.search.rank.feature.RankFeatureDoc;
-import org.elasticsearch.search.rank.feature.RankFeatureShardPhase;
 import org.elasticsearch.search.rank.feature.RankFeatureShardResult;
 import org.elasticsearch.search.rescore.QueryRescorerBuilder;
 import org.elasticsearch.search.rescore.RescorerBuilder;
@@ -1297,10 +1296,6 @@ public class SearchModule {
                 spec.getName().getForRestApiVersion()
             )
         );
-    }
-
-    public RankFeatureShardPhase getRankFeatureShardPhase() {
-        return new RankFeatureShardPhase();
     }
 
     public FetchPhase getFetchPhase() {

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -286,7 +286,6 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     private final BigArrays bigArrays;
 
     private final FetchPhase fetchPhase;
-    private final RankFeatureShardPhase rankFeatureShardPhase;
     private volatile Executor searchExecutor;
     private volatile boolean enableQueryPhaseParallelCollection;
 
@@ -325,7 +324,6 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         ThreadPool threadPool,
         ScriptService scriptService,
         BigArrays bigArrays,
-        RankFeatureShardPhase rankFeatureShardPhase,
         FetchPhase fetchPhase,
         ResponseCollectorService responseCollectorService,
         CircuitBreakerService circuitBreakerService,
@@ -339,7 +337,6 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         this.scriptService = scriptService;
         this.responseCollectorService = responseCollectorService;
         this.bigArrays = bigArrays;
-        this.rankFeatureShardPhase = rankFeatureShardPhase;
         this.fetchPhase = fetchPhase;
         this.multiBucketConsumerService = new MultiBucketConsumerService(
             clusterService,
@@ -751,9 +748,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     searchContext.rankFeatureResult().incRef();
                     return searchContext.rankFeatureResult();
                 }
-                rankFeatureShardPhase.prepareForFetch(searchContext, request);
+                RankFeatureShardPhase.prepareForFetch(searchContext, request);
                 fetchPhase.execute(searchContext, docIds, null);
-                rankFeatureShardPhase.processFetch(searchContext);
+                RankFeatureShardPhase.processFetch(searchContext);
                 var rankFeatureResult = searchContext.rankFeatureResult();
                 rankFeatureResult.incRef();
                 return rankFeatureResult;

--- a/server/src/main/java/org/elasticsearch/search/rank/feature/RankFeatureShardPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/feature/RankFeatureShardPhase.java
@@ -35,9 +35,9 @@ public final class RankFeatureShardPhase {
 
     public static final RankFeatureShardResult EMPTY_RESULT = new RankFeatureShardResult(new RankFeatureDoc[0]);
 
-    public RankFeatureShardPhase() {}
+    private RankFeatureShardPhase() {}
 
-    public void prepareForFetch(SearchContext searchContext, RankFeatureShardRequest request) {
+    public static void prepareForFetch(SearchContext searchContext, RankFeatureShardRequest request) {
         if (logger.isTraceEnabled()) {
             logger.trace("{}", new SearchContextSourcePrinter(searchContext));
         }
@@ -58,7 +58,7 @@ public final class RankFeatureShardPhase {
         }
     }
 
-    public void processFetch(SearchContext searchContext) {
+    public static void processFetch(SearchContext searchContext) {
         if (logger.isTraceEnabled()) {
             logger.trace("{}", new SearchContextSourcePrinter(searchContext));
         }
@@ -92,7 +92,7 @@ public final class RankFeatureShardPhase {
         }
     }
 
-    private RankFeaturePhaseRankShardContext shardContext(SearchContext searchContext) {
+    private static RankFeaturePhaseRankShardContext shardContext(SearchContext searchContext) {
         return searchContext.request().source() != null && searchContext.request().source().rankBuilder() != null
             ? searchContext.request().source().rankBuilder().buildRankFeaturePhaseShardContext()
             : null;

--- a/server/src/test/java/org/elasticsearch/search/rank/RankFeatureShardPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rank/RankFeatureShardPhaseTests.java
@@ -219,8 +219,7 @@ public class RankFeatureShardPhaseTests extends ESTestCase {
             RankFeatureShardRequest request = mock(RankFeatureShardRequest.class);
             when(request.getDocIds()).thenReturn(new int[] { 4, 9, numDocs - 1 });
 
-            RankFeatureShardPhase rankFeatureShardPhase = new RankFeatureShardPhase();
-            rankFeatureShardPhase.prepareForFetch(searchContext, request);
+            RankFeatureShardPhase.prepareForFetch(searchContext, request);
 
             assertNotNull(searchContext.fetchFieldsContext());
             assertEquals(searchContext.fetchFieldsContext().fields().size(), 1);
@@ -248,8 +247,7 @@ public class RankFeatureShardPhaseTests extends ESTestCase {
             RankFeatureShardRequest request = mock(RankFeatureShardRequest.class);
             when(request.getDocIds()).thenReturn(new int[] { 4, 9, numDocs - 1 });
 
-            RankFeatureShardPhase rankFeatureShardPhase = new RankFeatureShardPhase();
-            rankFeatureShardPhase.prepareForFetch(searchContext, request);
+            RankFeatureShardPhase.prepareForFetch(searchContext, request);
 
             assertNull(searchContext.fetchFieldsContext());
             assertNull(searchContext.fetchResult());
@@ -274,8 +272,7 @@ public class RankFeatureShardPhaseTests extends ESTestCase {
             RankFeatureShardRequest request = mock(RankFeatureShardRequest.class);
             when(request.getDocIds()).thenReturn(new int[] { 4, 9, numDocs - 1 });
 
-            RankFeatureShardPhase rankFeatureShardPhase = new RankFeatureShardPhase();
-            expectThrows(TaskCancelledException.class, () -> rankFeatureShardPhase.prepareForFetch(searchContext, request));
+            expectThrows(TaskCancelledException.class, () -> RankFeatureShardPhase.prepareForFetch(searchContext, request));
         }
     }
 
@@ -318,11 +315,10 @@ public class RankFeatureShardPhaseTests extends ESTestCase {
             RankFeatureShardRequest request = mock(RankFeatureShardRequest.class);
             when(request.getDocIds()).thenReturn(new int[] { 4, 9, numDocs - 1 });
 
-            RankFeatureShardPhase rankFeatureShardPhase = new RankFeatureShardPhase();
             // this is called as part of the search context initialization
             // with the ResultsType.RANK_FEATURE type
             searchContext.addRankFeatureResult();
-            rankFeatureShardPhase.processFetch(searchContext);
+            RankFeatureShardPhase.processFetch(searchContext);
 
             assertNotNull(searchContext.rankFeatureResult());
             assertNotNull(searchContext.rankFeatureResult().rankFeatureResult());
@@ -365,11 +361,10 @@ public class RankFeatureShardPhaseTests extends ESTestCase {
             RankFeatureShardRequest request = mock(RankFeatureShardRequest.class);
             when(request.getDocIds()).thenReturn(new int[] { 4, 9, numDocs - 1 });
 
-            RankFeatureShardPhase rankFeatureShardPhase = new RankFeatureShardPhase();
             // this is called as part of the search context initialization
             // with the ResultsType.RANK_FEATURE type
             searchContext.addRankFeatureResult();
-            rankFeatureShardPhase.processFetch(searchContext);
+            RankFeatureShardPhase.processFetch(searchContext);
 
             assertNotNull(searchContext.rankFeatureResult());
             assertNotNull(searchContext.rankFeatureResult().rankFeatureResult());
@@ -410,11 +405,10 @@ public class RankFeatureShardPhaseTests extends ESTestCase {
             RankFeatureShardRequest request = mock(RankFeatureShardRequest.class);
             when(request.getDocIds()).thenReturn(new int[] { 4, 9, numDocs - 1 });
 
-            RankFeatureShardPhase rankFeatureShardPhase = new RankFeatureShardPhase();
             // this is called as part of the search context initialization
             // with the ResultsType.RANK_FEATURE type
             searchContext.addRankFeatureResult();
-            expectThrows(TaskCancelledException.class, () -> rankFeatureShardPhase.processFetch(searchContext));
+            expectThrows(TaskCancelledException.class, () -> RankFeatureShardPhase.processFetch(searchContext));
         } finally {
             if (searchHits != null) {
                 searchHits.decRef();

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -180,7 +180,6 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.FetchPhase;
-import org.elasticsearch.search.rank.feature.RankFeatureShardPhase;
 import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -2314,7 +2313,6 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     threadPool,
                     scriptService,
                     bigArrays,
-                    new RankFeatureShardPhase(),
                     new FetchPhase(Collections.emptyList()),
                     responseCollectorService,
                     new NoneCircuitBreakerService(),

--- a/test/framework/src/main/java/org/elasticsearch/node/MockNode.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/MockNode.java
@@ -42,7 +42,6 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.MockSearchService;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.fetch.FetchPhase;
-import org.elasticsearch.search.rank.feature.RankFeatureShardPhase;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
@@ -100,7 +99,6 @@ public class MockNode extends Node {
             ThreadPool threadPool,
             ScriptService scriptService,
             BigArrays bigArrays,
-            RankFeatureShardPhase rankFeatureShardPhase,
             FetchPhase fetchPhase,
             ResponseCollectorService responseCollectorService,
             CircuitBreakerService circuitBreakerService,
@@ -115,7 +113,6 @@ public class MockNode extends Node {
                     threadPool,
                     scriptService,
                     bigArrays,
-                    rankFeatureShardPhase,
                     fetchPhase,
                     responseCollectorService,
                     circuitBreakerService,
@@ -129,7 +126,6 @@ public class MockNode extends Node {
                 threadPool,
                 scriptService,
                 bigArrays,
-                rankFeatureShardPhase,
                 fetchPhase,
                 responseCollectorService,
                 circuitBreakerService,

--- a/test/framework/src/main/java/org/elasticsearch/search/MockSearchService.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/MockSearchService.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.internal.ReaderContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchRequest;
-import org.elasticsearch.search.rank.feature.RankFeatureShardPhase;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -83,7 +82,6 @@ public class MockSearchService extends SearchService {
         ThreadPool threadPool,
         ScriptService scriptService,
         BigArrays bigArrays,
-        RankFeatureShardPhase rankFeatureShardPhase,
         FetchPhase fetchPhase,
         ResponseCollectorService responseCollectorService,
         CircuitBreakerService circuitBreakerService,
@@ -96,7 +94,6 @@ public class MockSearchService extends SearchService {
             threadPool,
             scriptService,
             bigArrays,
-            rankFeatureShardPhase,
             fetchPhase,
             responseCollectorService,
             circuitBreakerService,


### PR DESCRIPTION
This class has no state, no need to pass instances of it around all its members can be static to simplify node construction and the code overall.
