### PR TITLE
Remove unsupported async_search parameters from rest-api-spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -43,11 +43,6 @@
         "description":"Control whether the response should be stored in the cluster if it completed within the provided [wait_for_completion] time (default: false)",
         "default":false
       },
-      "keep_alive": {
-        "type": "time",
-        "description": "Update the time interval in which the results (partial or final) for this search will be available",
-        "default": "5d"
-      },
       "batched_reduce_size":{
         "type":"number",
         "description":"The number of shard results that should be reduced at once on the coordinating node. This value should be used as the granularity at which progress results will be made available.",
@@ -130,11 +125,6 @@
       "preference":{
         "type":"string",
         "description":"Specify the node or shard the operation should be performed on (default: random)"
-      },
-      "pre_filter_shard_size":{
-         "type":"number",
-         "default": 1,
-         "description":"Cannot be changed: this is to enforce the execution of a pre-filter roundtrip to retrieve statistics from each shard so that the ones that surely don’t hold any document matching the query get skipped."
       },
       "rest_total_hits_as_int":{
         "type":"boolean",


### PR DESCRIPTION
Partly reverts commit 2f8bb0b23ce6070335fb750d9e76265f558ea3a9 introduced in https://github.com/elastic/elasticsearch/pull/117312.

@javanna pointed me to this comment that I had read but failed to fully take into account:

https://github.com/elastic/elasticsearch/blob/2ed318f21fc015609fa9b09d94115e3465c17615/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchAction.java#L60-L63

And indeed three parameters raise an exception:

https://github.com/elastic/elasticsearch/blob/2ed318f21fc015609fa9b09d94115e3465c17615/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java#L102-L126

However, I kept `ccs_minimize_roundtrips` which is explicitly supported (as stated in the comment too):

https://github.com/elastic/elasticsearch/blob/2ed318f21fc015609fa9b09d94115e3465c17615/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java#L84-L89