### PR TITLE
[8.x] Use feature flags in OperatorPrivilegesIT (#117491)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -353,9 +353,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
   issue: https://github.com/elastic/elasticsearch/issues/117349
-- class: org.elasticsearch.xpack.security.operator.OperatorPrivilegesIT
-  method: testEveryActionIsEitherOperatorOnlyOrNonOperator
-  issue: https://github.com/elastic/elasticsearch/issues/102992
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/116175

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.security.operator;
 
+import org.elasticsearch.cluster.metadata.DataStream;
+
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -508,9 +510,9 @@ public class Constants {
         "indices:admin/data_stream/lifecycle/get",
         "indices:admin/data_stream/lifecycle/put",
         "indices:admin/data_stream/lifecycle/explain",
-        "indices:admin/data_stream/options/delete",
-        "indices:admin/data_stream/options/get",
-        "indices:admin/data_stream/options/put",
+        DataStream.isFailureStoreFeatureFlagEnabled() ? "indices:admin/data_stream/options/delete" : null,
+        DataStream.isFailureStoreFeatureFlagEnabled() ? "indices:admin/data_stream/options/get" : null,
+        DataStream.isFailureStoreFeatureFlagEnabled() ? "indices:admin/data_stream/options/put" : null,
         "indices:admin/delete",
         "indices:admin/flush",
         "indices:admin/flush[s]",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Use feature flags in OperatorPrivilegesIT (#117491)](https://github.com/elastic/elasticsearch/pull/117491)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)