### PR TITLE
[Test] Increase test secret key length

### DIFF
--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
@@ -77,12 +77,11 @@ public class RepositoryS3RestReloadCredentialsIT extends ESRestTestCase {
         keystoreSettings.put("s3.client.default.access_key", accessKey1);
         keystoreSettings.put("s3.client.default.secret_key", randomSecretKey());
         cluster.updateStoredSecureSettings();
-        final Request reloadSecureSettingsRequest = new Request("POST", "/_nodes/reload_secure_settings");
-        reloadSecureSettingsRequest.setJsonEntity("""
-            {
-              "secure_settings_password": "keystore-password"
-            }
-            """);
+        final Request reloadSecureSettingsRequest = newXContentRequest(
+            HttpMethod.POST,
+            "/_nodes/reload_secure_settings",
+            (b, p) -> b.field("secure_settings_password", "keystore-password")
+        );
         assertOK(client().performRequest(reloadSecureSettingsRequest));
 
         // Check access using initial credentials

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.repositories.s3;
 
 import fixture.s3.S3HttpFixture;
+import io.netty.handler.codec.http.HttpMethod;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -222,8 +222,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testStopWorksInMiddleOfProcessing
   issue: https://github.com/elastic/elasticsearch/issues/117591
-- class: org.elasticsearch.repositories.s3.RepositoryS3ClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/117596
 
 # Examples:
 #

--- a/test/fixtures/aws-sts-fixture/src/main/java/fixture/aws/sts/AwsStsHttpHandler.java
+++ b/test/fixtures/aws-sts-fixture/src/main/java/fixture/aws/sts/AwsStsHttpHandler.java
@@ -27,8 +27,8 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
 import static org.elasticsearch.test.ESTestCase.randomIdentifier;
+import static org.elasticsearch.test.ESTestCase.randomSecretKey;
 
 /**
  * Minimal HTTP handler that emulates the AWS STS server
@@ -103,7 +103,7 @@ public class AwsStsHttpHandler implements HttpHandler {
                     ROLE_ARN,
                     ROLE_NAME,
                     sessionToken,
-                    randomAlphaOfLengthBetween(14, 20).toLowerCase(Locale.ROOT),
+                    randomSecretKey(),
                     ZonedDateTime.now().plusDays(1L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ")),
                     accessKey
                 ).getBytes(StandardCharsets.UTF_8);

--- a/test/fixtures/aws-sts-fixture/src/main/java/fixture/aws/sts/AwsStsHttpHandler.java
+++ b/test/fixtures/aws-sts-fixture/src/main/java/fixture/aws/sts/AwsStsHttpHandler.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
 import static org.elasticsearch.test.ESTestCase.randomIdentifier;
 
 /**
@@ -102,7 +103,7 @@ public class AwsStsHttpHandler implements HttpHandler {
                     ROLE_ARN,
                     ROLE_NAME,
                     sessionToken,
-                    randomIdentifier(),
+                    randomAlphaOfLengthBetween(14, 20).toLowerCase(Locale.ROOT),
                     ZonedDateTime.now().plusDays(1L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ")),
                     accessKey
                 ).getBytes(StandardCharsets.UTF_8);

--- a/test/fixtures/ec2-imds-fixture/src/main/java/fixture/aws/imds/Ec2ImdsHttpHandler.java
+++ b/test/fixtures/ec2-imds-fixture/src/main/java/fixture/aws/imds/Ec2ImdsHttpHandler.java
@@ -23,10 +23,12 @@ import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
 import static org.elasticsearch.test.ESTestCase.randomIdentifier;
 
 /**
@@ -84,7 +86,7 @@ public class Ec2ImdsHttpHandler implements HttpHandler {
                         accessKey,
                         ZonedDateTime.now(Clock.systemUTC()).plusDays(1L).format(DateTimeFormatter.ISO_DATE_TIME),
                         randomIdentifier(),
-                        randomIdentifier(),
+                        randomAlphaOfLengthBetween(14, 20).toLowerCase(Locale.ROOT),
                         sessionToken
                     ).getBytes(StandardCharsets.UTF_8);
                     exchange.getResponseHeaders().add("Content-Type", "application/json");

--- a/test/fixtures/ec2-imds-fixture/src/main/java/fixture/aws/imds/Ec2ImdsHttpHandler.java
+++ b/test/fixtures/ec2-imds-fixture/src/main/java/fixture/aws/imds/Ec2ImdsHttpHandler.java
@@ -23,13 +23,12 @@ import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
-import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
 import static org.elasticsearch.test.ESTestCase.randomIdentifier;
+import static org.elasticsearch.test.ESTestCase.randomSecretKey;
 
 /**
  * Minimal HTTP handler that emulates the EC2 IMDS server
@@ -86,7 +85,7 @@ public class Ec2ImdsHttpHandler implements HttpHandler {
                         accessKey,
                         ZonedDateTime.now(Clock.systemUTC()).plusDays(1L).format(DateTimeFormatter.ISO_DATE_TIME),
                         randomIdentifier(),
-                        randomAlphaOfLengthBetween(14, 20).toLowerCase(Locale.ROOT),
+                        randomSecretKey(),
                         sessionToken
                     ).getBytes(StandardCharsets.UTF_8);
                     exchange.getResponseHeaders().add("Content-Type", "application/json");

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1359,6 +1359,13 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
+     * Generate a random string of at least 112 bits to satisfy minimum entropy requirement when running in FIPS mode.
+     */
+    public static String randomSecretKey() {
+        return randomAlphaOfLengthBetween(14, 20);
+    }
+
+    /**
      * Randomly choose between {@link EsExecutors#DIRECT_EXECUTOR_SERVICE} (which does not fork), {@link ThreadPool#generic}, and one of the
      * other named threadpool executors.
      */


### PR DESCRIPTION
Running with FIPS approved mode requires secret keys to be at least 114 bits long.

Relates: #117324
Resolves: #117596
Resolves: #117709
Resolves: #117710
Resolves: #117711
Resolves: #117712