### PR TITLE
[DOCS] Fixes typo on "Get trained models statistics API" page

### DIFF
--- a/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
@@ -235,7 +235,7 @@ The reason for the current state. Usually only populated when the `routing_state
 (string)
 The current routing state.
 --
-* `starting`: The model is attempting to allocate on this model, inference calls are not yet accepted.
+* `starting`: The model is attempting to allocate on this node, inference calls are not yet accepted.
 * `started`: The model is allocated and ready to accept inference requests.
 * `stopping`: The model is being deallocated from this node.
 * `stopped`: The model is fully deallocated from this node.


### PR DESCRIPTION
This PR fixes a typo on the [Get trained models statistics API](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html) page.
