### PR TITLE
Add _field_names disabling to archival index tests

### DIFF
--- a/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/OldMappingsIT.java
+++ b/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/OldMappingsIT.java
@@ -13,6 +13,7 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.WarningsHandler;
@@ -166,7 +167,10 @@ public class OldMappingsIT extends ESRestTestCase {
         createRestoreRequest.addParameter("wait_for_completion", "true");
         createRestoreRequest.setJsonEntity("{\"indices\":\"" + indices.stream().collect(Collectors.joining(",")) + "\"}");
         createRestoreRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
-        assertOK(client().performRequest(createRestoreRequest));
+        Response response = client().performRequest(createRestoreRequest);
+        // check deprecation warning for "_field_name" disabling
+        assertTrue(response.getWarnings().stream().filter(s -> s.contains("Disabling _field_names is not necessary")).count() > 0);
+        assertOK(response);
     }
 
     private Request createIndex(String indexName, String file) throws IOException {

--- a/x-pack/qa/repository-old-versions/src/test/resources/org/elasticsearch/oldrepos/custom.json
+++ b/x-pack/qa/repository-old-versions/src/test/resources/org/elasticsearch/oldrepos/custom.json
@@ -1,4 +1,7 @@
 "_default_": {
+  "_field_names": {
+    "enabled": false
+  },
   "properties": {
     "apache2": {
       "properties": {


### PR DESCRIPTION
Disabling the "_field_names" field in mappings was possible until 8.x and now issues a deprecation warning. We need to maintain the ability to read these mappings for archival indices so this change adds this case to one of the index mappings in tests and checks for the deprecation warning for it.
