### PR TITLE
[POC] Route completion request per service always to same node in a cluster

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -60,6 +60,7 @@ import org.elasticsearch.xpack.inference.action.TransportInferenceUsageAction;
 import org.elasticsearch.xpack.inference.action.TransportPutInferenceModelAction;
 import org.elasticsearch.xpack.inference.action.TransportUpdateInferenceModelAction;
 import org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilter;
+import org.elasticsearch.xpack.inference.common.ServiceToNodeGroupingClusterStateListener;
 import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.external.amazonbedrock.AmazonBedrockRequestSender;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
@@ -148,6 +149,7 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
     private final SetOnce<ElasticInferenceServiceComponents> elasticInferenceServiceComponents = new SetOnce<>();
     private final SetOnce<InferenceServiceRegistry> inferenceServiceRegistry = new SetOnce<>();
     private final SetOnce<ShardBulkInferenceActionFilter> shardBulkInferenceActionFilter = new SetOnce<>();
+    private final SetOnce<ServiceToNodeGroupingClusterStateListener> serviceToNodeGroupingClusterStateListener = new SetOnce<>();
     private List<InferenceServiceExtension> inferenceServiceExtensions;
 
     public InferencePlugin(Settings settings) {
@@ -194,6 +196,7 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
 
     @Override
     public Collection<?> createComponents(PluginServices services) {
+        var clusterService = services.clusterService();
         var throttlerManager = new ThrottlerManager(settings, services.threadPool(), services.clusterService());
         var truncator = new Truncator(settings, services.clusterService());
         serviceComponents.set(new ServiceComponents(services.threadPool(), throttlerManager, settings, truncator));
@@ -248,7 +251,7 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
         var factoryContext = new InferenceServiceExtension.InferenceServiceFactoryContext(
             services.client(),
             services.threadPool(),
-            services.clusterService(),
+            clusterService,
             settings
         );
 
@@ -267,7 +270,11 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
         var meterRegistry = services.telemetryProvider().getMeterRegistry();
         var stats = new PluginComponentBinding<>(InferenceStats.class, InferenceStats.create(meterRegistry));
 
-        return List.of(modelRegistry, registry, httpClientManager, stats);
+        serviceToNodeGroupingClusterStateListener.set(
+            new ServiceToNodeGroupingClusterStateListener(clusterService, inferenceServiceRegistry.get())
+        );
+
+        return List.of(modelRegistry, registry, httpClientManager, stats, serviceToNodeGroupingClusterStateListener.get());
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportInferenceAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportInferenceAction.java
@@ -136,6 +136,7 @@ public class TransportInferenceAction extends HandledTransportAction<InferenceAc
 
                 if(currentNodeShouldHandleRequest){
                     // Inference on current node
+                    log.info("Inference on current node [{}] for service [{}]", nodeClient.getLocalNodeId(), serviceName);
                     inferOnServiceWithMetrics(model, request, service.get(), timer, listener);
                 } else {
                         // Reroute to node responsible for service type

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ServiceToNodeGroupingClusterStateListener.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ServiceToNodeGroupingClusterStateListener.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.inference.InferenceService;
+import org.elasticsearch.inference.InferenceServiceRegistry;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.injection.guice.Inject;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ServiceToNodeGroupingClusterStateListener implements ClusterStateListener {
+
+    private static final Logger logger = LogManager.getLogger(ServiceToNodeGroupingClusterStateListener.class);
+
+    private final InferenceServiceRegistry serviceRegistry;
+
+    private final AtomicReference<Map<String, DiscoveryNode>> serviceToNodeGrouping = new AtomicReference<>();
+
+    @Inject
+    public ServiceToNodeGroupingClusterStateListener(ClusterService clusterService, InferenceServiceRegistry serviceRegistry) {
+        clusterService.addListener(this);
+        logger.info("ServiceToNodeGroupingClusterStateListener registered");
+        this.serviceRegistry = serviceRegistry;
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        boolean clusterTopologyChange = event.nodesChanged();
+
+        // Every node should land on the same grouping by calculation, so no need to put anything into the cluster state
+        if (clusterTopologyChange) {
+            var newClusterState = event.state();
+            var nodes = newClusterState.nodes().getAllNodes();
+            var streamingCompletionServices = completionServices();
+
+            // Nodes sorted by name
+            var nodeList = new ArrayList<>(nodes);
+            nodeList.sort(Comparator.comparing(DiscoveryNode::getName));
+
+            // Services sorted by name
+            streamingCompletionServices.sort(Comparator.comparing(InferenceService::name));
+
+            var newServiceToNodeGrouping = calculateServiceToNodeMapping(nodeList, streamingCompletionServices);
+
+            serviceToNodeGrouping.set(newServiceToNodeGrouping);
+
+            logger.info("Services to node grouping: {}", serviceToNodeGrouping.get());
+        }
+    }
+
+    private Map<String, DiscoveryNode> calculateServiceToNodeMapping(
+        List<DiscoveryNode> sortedNodes,
+        List<InferenceService> sortedServices
+    ) {
+        Map<String, DiscoveryNode> mapping = new HashMap<>();
+        int numberOfNodes = sortedNodes.size();
+        int numberOfServices = sortedServices.size();
+
+        for (int i = 0; i < numberOfServices; i++) {
+            // Wrap around nodes if services > nodes
+            DiscoveryNode assignedNode = sortedNodes.get(i % numberOfNodes);
+            mapping.put(sortedServices.get(i).name(), assignedNode);
+        }
+
+        return mapping;
+    }
+
+    public Map<String, DiscoveryNode> serviceToNodeGrouping() {
+        return serviceToNodeGrouping.get();
+    }
+
+    public List<InferenceService> completionServices() {
+        var services = serviceRegistry.getServices();
+        List<InferenceService> streamingCompletionServices = new ArrayList<>();
+
+        for (InferenceService inferenceService : services.values()) {
+            // TODO: get only services with active endpoints?
+            // TODO: change to streaming after POC
+            if (inferenceService.supportedTaskTypes().contains(TaskType.COMPLETION)) {
+                streamingCompletionServices.add(inferenceService);
+            }
+        }
+
+        return streamingCompletionServices;
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ServiceToNodeGroupingClusterStateListener.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ServiceToNodeGroupingClusterStateListener.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.inference.InferenceService;
 import org.elasticsearch.inference.InferenceServiceRegistry;
 import org.elasticsearch.inference.TaskType;
-import org.elasticsearch.injection.guice.Inject;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -33,7 +32,6 @@ public class ServiceToNodeGroupingClusterStateListener implements ClusterStateLi
 
     private final AtomicReference<Map<String, DiscoveryNode>> serviceToNodeGrouping = new AtomicReference<>();
 
-    @Inject
     public ServiceToNodeGroupingClusterStateListener(ClusterService clusterService, InferenceServiceRegistry serviceRegistry) {
         clusterService.addListener(this);
         logger.info("ServiceToNodeGroupingClusterStateListener registered");

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportInferenceActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportInferenceActionTests.java
@@ -72,7 +72,10 @@ public class TransportInferenceActionTests extends ESTestCase {
             modelRegistry,
             serviceRegistry,
             inferenceStats,
-            streamingTaskManager
+            streamingTaskManager,
+            mock(),
+            mock(),
+            mock()
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/ServiceToNodeGroupingClusterStateListenerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/ServiceToNodeGroupingClusterStateListenerTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.inference.InferencePlugin;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 0)
+public class ServiceToNodeGroupingClusterStateListenerTests extends ESIntegTestCase {
+
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    public void testInitialClusterGroupingCorrect() {
+        // Start cluster with multiple nodes
+        var numNodes = randomIntBetween(2, 5);
+        var nodeNames = internalCluster().startNodes(numNodes);
+        ensureStableCluster(numNodes);
+        Map<String, DiscoveryNode> serviceToNodeGrouping = null;
+
+        for (String nodeName : nodeNames) {
+            var serviceToNodeGroupingClusterStateListener = internalCluster().getInstance(
+                ServiceToNodeGroupingClusterStateListener.class,
+                nodeName
+            );
+            var streamingCompletionServices = serviceToNodeGroupingClusterStateListener.completionServices();
+
+            // First service to node grouping
+            if (serviceToNodeGrouping == null) {
+                serviceToNodeGrouping = serviceToNodeGroupingClusterStateListener.serviceToNodeGrouping();
+
+                // Contains a service to node mapping for every streaming completion service
+                assertThat(streamingCompletionServices.size(), equalTo(serviceToNodeGrouping.size()));
+                for (var service : streamingCompletionServices) {
+                    assertThat(serviceToNodeGrouping.containsKey(service.name()), equalTo(true));
+                }
+            } else {
+                // Service to node grouping is the same across all nodes
+                assertThat(serviceToNodeGroupingClusterStateListener.serviceToNodeGrouping(), equalTo(serviceToNodeGrouping));
+            }
+        }
+
+        // Assure that the service to node grouping happened
+        assertThat(serviceToNodeGrouping, notNullValue());
+    }
+
+    public void testAllServicesMapToOneNodeAfterAllExceptOneLeft() throws IOException {
+        // Start cluster with multiple nodes
+        var numNodes = randomIntBetween(2, 5);
+        var nodeNames = internalCluster().startNodes(numNodes);
+        ensureStableCluster(numNodes);
+
+        var nodeLeftInCluster = nodeNames.getFirst();
+        var currentNumberOfNodes = numNodes;
+
+        // Stop all nodes except one
+        for (String nodeName : nodeNames) {
+            // One node should be left in cluster
+            if (nodeName.equals(nodeLeftInCluster)) {
+                continue;
+            }
+
+            internalCluster().stopNode(nodeName);
+            currentNumberOfNodes--;
+            ensureStableCluster(currentNumberOfNodes);
+        }
+
+        var serviceToNodeGroupingClusterStateListener = internalCluster().getInstance(
+            ServiceToNodeGroupingClusterStateListener.class,
+            nodeLeftInCluster
+        );
+        var streamingCompletionServices = serviceToNodeGroupingClusterStateListener.completionServices();
+        var serviceToNodeGrouping = serviceToNodeGroupingClusterStateListener.serviceToNodeGrouping();
+
+        // All services map to the same node
+        assertThat(streamingCompletionServices.size(), equalTo(serviceToNodeGrouping.size()));
+        for (var service : streamingCompletionServices) {
+            assertThat(serviceToNodeGrouping.get(service.name()).getName(), equalTo(nodeLeftInCluster));
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(InferencePlugin.class);
+    }
+}


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/117505.

This POC is another option on how to address the current limitations with rate limiting inside the inference API for completion requests.

![image](https://github.com/user-attachments/assets/de971f5f-7ac2-4e38-9a71-b9beb28ae246)


**Idea:**
- A cluster state listener listens on cluster topology changes (node joins/leaves the cluster)
- Topology change detected: every node maps each service type supporting the `completion` task type to exactly one node; all nodes will come to the same result, so there's no need to update the cluster state and share the grouping
- A completion request can land on any node -> node checks, whether the node itself is the node to handle requests for this service type:
  - Yes: handle request and perform inference
  - No: reroute request to the node responsible for  the service type
- You don't need to approximate a cluster-wide rate limit as only one node per cluster handles the inference request, therefore a node-local rate limit is enough and essentially acts as a cluster-wide rate limit for the specific service provider

**How to verify:**
- Service to node grouping logic: run `ServiceToNodeGroupingClusterStateListenerTests` using `./gradlew ":x-pack:plugin:inference:test" --tests "org.elasticsearch.xpack.inference.common.ServiceToNodeGroupingClusterStateListenerTests" `
- Inter-node rerouting: adjust `numberOfNodes` in `elasticsearch.run.gradle` to `3` for example and observe the logs, while performing completion requests for different service providers. You'll see log messages indicating, if the node, which got the request originally handles the inference or if it re-routes the request inside the cluster:
```
...
[2024-11-28T13:36:41,857][INFO ][o.e.x.i.a.TransportInferenceAction] [runTask-0] Rerouting request from node [b-yQ8c9cQx6nXfegdN4iHQ] to node [Un2UBCFITPOLGHzSD0uOOg] for service [openai]
...
[2024-11-28T13:36:41,857][INFO ][o.e.x.i.a.TransportInferenceAction] [runTask-0] Inference on current node [Un2UBCFITPOLGHzSD0uOOg] for service [openai]
...
```