### PR TITLE
[8.x] fix/SearchStatesIt_failures

### DIFF
--- a/docs/changelog/117729.yaml
+++ b/docs/changelog/117729.yaml
@@ -1,0 +1,5 @@
+pr: 117729
+summary: "[8.x] fix/SearchStatesIt_failures"
+area: Search
+type: bug
+issues: []

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,7 +1,4 @@
 tests:
-- class: "org.elasticsearch.upgrades.SearchStatesIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/108991"
-  method: "testCanMatch"
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/esql/esql-async-query-api/line_17}
   issue: https://github.com/elastic/elasticsearch/issues/109260


### PR DESCRIPTION
This will backport the following commits from main to 8.x:

 #117618 