### PR TITLE
[Build] Declare mirror for eclipse p2 repository

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -17,6 +17,8 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Map;
 
 /**
  * This plugin configures formatting for Java source using Spotless
@@ -64,7 +66,8 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
                 java.importOrderFile(new File(elasticsearchWorkspace, importOrderPath));
 
                 // Most formatting is done through the Eclipse formatter
-                java.eclipse().configFile(new File(elasticsearchWorkspace, formatterConfigPath));
+                java.eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/"))
+                    .configFile(new File(elasticsearchWorkspace, formatterConfigPath));
 
                 // Ensure blank lines are actually empty. Since formatters are applied in
                 // order, apply this one last, otherwise non-empty blank lines can creep


### PR DESCRIPTION
The spotlight plugin directly resolves dependencies from p2 which causes

`java.io.IOException: Failed to load eclipse jdt formatter` issues if that repo is not accessible.

This is a workaround for the eclipse p2 default repository being down resulting in all our ci jobs to fail.

The artifacts in question we wanna cache live in `~/.m2/repository`.

This seems related to https://github.com/elastic/elasticsearch/issues/100753