### PR TITLE
[7.17] [Build] Declare mirror for eclipse p2 repository (#117732)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -14,6 +14,8 @@ import com.diffplug.gradle.spotless.SpotlessPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
+import java.util.Map;
+
 /**
  * This plugin configures formatting for Java source using Spotless
  * for Gradle. Since the act of formatting existing source can interfere
@@ -66,7 +68,13 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
                 java.importOrderFile(project.getRootProject().file(importOrderPath));
 
                 // Most formatting is done through the Eclipse formatter
-                java.eclipse().configFile(project.getRootProject().file(formatterConfigPath));
+<<<<<<< HEAD
+                java.eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/"))
+                    .configFile(new File(elasticsearchWorkspace, formatterConfigPath)).configFile(project.getRootProject().file(formatterConfigPath));
+=======
+                java.eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/"))
+                    .configFile(new File(elasticsearchWorkspace, formatterConfigPath));
+>>>>>>> c35777a175f ([Build] Declare mirror for eclipse p2 repository (#117732))
 
                 // Ensure blank lines are actually empty. Since formatters are applied in
                 // order, apply this one last, otherwise non-empty blank lines can creep

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -68,13 +68,8 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
                 java.importOrderFile(project.getRootProject().file(importOrderPath));
 
                 // Most formatting is done through the Eclipse formatter
-<<<<<<< HEAD
                 java.eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/"))
-                    .configFile(new File(elasticsearchWorkspace, formatterConfigPath)).configFile(project.getRootProject().file(formatterConfigPath));
-=======
-                java.eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/"))
-                    .configFile(new File(elasticsearchWorkspace, formatterConfigPath));
->>>>>>> c35777a175f ([Build] Declare mirror for eclipse p2 repository (#117732))
+                    configFile(project.getRootProject().file(formatterConfigPath));
 
                 // Ensure blank lines are actually empty. Since formatters are applied in
                 // order, apply this one last, otherwise non-empty blank lines can creep


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Build] Declare mirror for eclipse p2 repository (#117732)](https://github.com/elastic/elasticsearch/pull/117732)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)