### PR TITLE
[8.x] [Test] Increase test secret key length (#117675)

### DIFF
--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.repositories.s3;
 
 import fixture.s3.S3HttpFixture;
+import io.netty.handler.codec.http.HttpMethod;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
@@ -54,8 +55,6 @@ public class RepositoryS3RestReloadCredentialsIT extends ESRestTestCase {
     }
 
     public void testReloadCredentialsFromKeystore() throws IOException {
-        assumeFalse("doesn't work in a FIPS JVM, but that's ok", inFipsJvm());
-
         // Register repository (?verify=false because we don't have access to the blob store yet)
         final var repositoryName = randomIdentifier();
         registerRepository(
@@ -70,15 +69,16 @@ public class RepositoryS3RestReloadCredentialsIT extends ESRestTestCase {
         final var accessKey1 = randomIdentifier();
         s3Fixture.setAccessKey(accessKey1);
         keystoreSettings.put("s3.client.default.access_key", accessKey1);
-        keystoreSettings.put("s3.client.default.secret_key", randomIdentifier());
+        keystoreSettings.put("s3.client.default.secret_key", randomSecretKey());
         cluster.updateStoredSecureSettings();
-        assertOK(client().performRequest(new Request("POST", "/_nodes/reload_secure_settings")));
+
+        assertOK(client().performRequest(createReloadSecureSettingsRequest()));
 
         // Check access using initial credentials
         assertOK(client().performRequest(verifyRequest));
 
         // Rotate credentials in blob store
-        final var accessKey2 = randomValueOtherThan(accessKey1, ESTestCase::randomIdentifier);
+        final var accessKey2 = randomValueOtherThan(accessKey1, ESTestCase::randomSecretKey);
         s3Fixture.setAccessKey(accessKey2);
 
         // Ensure that initial credentials now invalid
@@ -92,10 +92,17 @@ public class RepositoryS3RestReloadCredentialsIT extends ESRestTestCase {
         // Set up refreshed credentials
         keystoreSettings.put("s3.client.default.access_key", accessKey2);
         cluster.updateStoredSecureSettings();
-        assertOK(client().performRequest(new Request("POST", "/_nodes/reload_secure_settings")));
+        assertOK(client().performRequest(createReloadSecureSettingsRequest()));
 
         // Check access using refreshed credentials
         assertOK(client().performRequest(verifyRequest));
     }
 
+    private Request createReloadSecureSettingsRequest() throws IOException {
+        return newXContentRequest(
+            HttpMethod.POST,
+            "/_nodes/reload_secure_settings",
+            (b, p) -> inFipsJvm() ? b.field("secure_settings_password", "keystore-password") : b
+        );
+    }
 }

--- a/test/fixtures/ec2-imds-fixture/src/main/java/fixture/aws/imds/Ec2ImdsHttpHandler.java
+++ b/test/fixtures/ec2-imds-fixture/src/main/java/fixture/aws/imds/Ec2ImdsHttpHandler.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.elasticsearch.test.ESTestCase.randomIdentifier;
+import static org.elasticsearch.test.ESTestCase.randomSecretKey;
 
 /**
  * Minimal HTTP handler that emulates the EC2 IMDS server
@@ -82,7 +83,7 @@ public class Ec2ImdsHttpHandler implements HttpHandler {
                         accessKey,
                         ZonedDateTime.now(Clock.systemUTC()).plusDays(1L).format(DateTimeFormatter.ISO_DATE_TIME),
                         randomIdentifier(),
-                        randomIdentifier(),
+                        randomSecretKey(),
                         sessionToken
                     ).getBytes(StandardCharsets.UTF_8);
                     exchange.getResponseHeaders().add("Content-Type", "application/json");

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1354,6 +1354,13 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
+     * Generate a random string of at least 112 bits to satisfy minimum entropy requirement when running in FIPS mode.
+     */
+    public static String randomSecretKey() {
+        return randomAlphaOfLengthBetween(14, 20);
+    }
+
+    /**
      * Randomly choose between {@link EsExecutors#DIRECT_EXECUTOR_SERVICE} (which does not fork), {@link ThreadPool#generic}, and one of the
      * other named threadpool executors.
      */


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Test] Increase test secret key length (#117675)](https://github.com/elastic/elasticsearch/pull/117675)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)