### PR TITLE
[DOCS] Updates 'minimum_number_of_allocations' description

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -18,7 +18,8 @@ end::adaptive-allocation-max-number[]
 
 tag::adaptive-allocation-min-number[]
 Specifies the minimum number of allocations to scale to.
-If set, it must be greater than or equal to `1`.
+If set, it must be greater than or equal to `0`.
+If not defined, the deployment scales to `0`.
 end::adaptive-allocation-min-number[]
 
 tag::aggregations[]


### PR DESCRIPTION
### Overview

This PR updates the description of `minimum_number_of_allocations` on the [Elasticsearch inference service](https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-service-elasticsearch.html) page
 as per this [Slack thread](https://elastic.slack.com/archives/C2AJLJHMM/p1732800414972229).

### Preview

![Screenshot 2024-11-29 at 09 29 57](https://github.com/user-attachments/assets/3edf8d1d-ee5e-4005-b703-8c82c39db392)

