### PR TITLE
[8.17] Remove unsupported async_search parameters from rest-api-spec (#117626)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -43,11 +43,6 @@
         "description":"Control whether the response should be stored in the cluster if it completed within the provided [wait_for_completion] time (default: false)",
         "default":false
       },
-      "keep_alive": {
-        "type": "time",
-        "description": "Update the time interval in which the results (partial or final) for this search will be available",
-        "default": "5d"
-      },
       "batched_reduce_size":{
         "type":"number",
         "description":"The number of shard results that should be reduced at once on the coordinating node. This value should be used as the granularity at which progress results will be made available.",
@@ -130,11 +125,6 @@
       "preference":{
         "type":"string",
         "description":"Specify the node or shard the operation should be performed on (default: random)"
-      },
-      "pre_filter_shard_size":{
-         "type":"number",
-         "default": 1,
-         "description":"Cannot be changed: this is to enforce the execution of a pre-filter roundtrip to retrieve statistics from each shard so that the ones that surely don’t hold any document matching the query get skipped."
       },
       "rest_total_hits_as_int":{
         "type":"boolean",


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Remove unsupported async_search parameters from rest-api-spec (#117626)