### PR TITLE
Mute CSV tests for scoring in ES|QL for mixed cluster

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -222,6 +222,9 @@ tests:
 - class: "org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT"
   method: "test {scoring.*}"
   issue: https://github.com/elastic/elasticsearch/issues/117641
+- class: "org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT"
+  method: "test {scoring.*}"
+  issue: https://github.com/elastic/elasticsearch/issues/117641
 - class: org.elasticsearch.xpack.inference.InferenceCrudIT
   method: testSupportedStream
   issue: https://github.com/elastic/elasticsearch/issues/117745


### PR DESCRIPTION
fixes #https://github.com/elastic/elasticsearch/issues/117751