### PR TITLE
[8.x] mute csv test for scoring in esql for mixed cluster (#117767)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -400,3 +400,6 @@ tests:
   - class: "org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT"
     method: "test {scoring.*}"
     issue: https://github.com/elastic/elasticsearch/issues/117641
+  - class: "org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT"
+    method: "test {scoring.*}"
+    issue: https://github.com/elastic/elasticsearch/issues/117641


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [mute csv test for scoring in esql for mixed cluster (#117767)](https://github.com/elastic/elasticsearch/pull/117767)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)