### PR TITLE
Parse `PutPipelineRequest#source` earlier

### DIFF
--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/PipelineConfigurationBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/PipelineConfigurationBridge.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.logstashbridge.ingest;
 
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.logstashbridge.StableBridgeAPI;
 import org.elasticsearch.xcontent.XContentType;
@@ -21,7 +22,12 @@ public class PipelineConfigurationBridge extends StableBridgeAPI.Proxy<PipelineC
     }
 
     public PipelineConfigurationBridge(final String pipelineId, final String jsonEncodedConfig) {
-        this(new PipelineConfiguration(pipelineId, new BytesArray(jsonEncodedConfig), XContentType.JSON));
+        this(
+            new PipelineConfiguration(
+                pipelineId,
+                XContentHelper.convertToMap(new BytesArray(jsonEncodedConfig), true, XContentType.JSON).v2()
+            )
+        );
     }
 
     public String getId() {

--- a/server/src/main/java/org/elasticsearch/action/ingest/ParsedPutPipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/ParsedPutPipelineRequest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.ingest;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
+
+import java.util.Map;
+import java.util.Objects;
+
+public record ParsedPutPipelineRequest(
+    TimeValue masterNodeTimeout,
+    String id,
+    @Nullable Integer version,
+    Map<String, Object> pipelineConfig
+) {
+
+    public ParsedPutPipelineRequest {
+        Objects.requireNonNull(masterNodeTimeout);
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(pipelineConfig);
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequest.java
@@ -15,14 +15,12 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.xcontent.ToXContentObject;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class PutPipelineRequest extends AcknowledgedRequest<PutPipelineRequest> implements ToXContentObject {
+public class PutPipelineRequest extends AcknowledgedRequest<PutPipelineRequest> {
 
     private final String id;
     private final BytesReference source;
@@ -90,13 +88,12 @@ public class PutPipelineRequest extends AcknowledgedRequest<PutPipelineRequest> 
         out.writeOptionalInt(version);
     }
 
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        if (source != null) {
-            builder.rawValue(source.streamInput(), xContentType);
-        } else {
-            builder.startObject().endObject();
-        }
-        return builder;
+    public ParsedPutPipelineRequest parse() {
+        return new ParsedPutPipelineRequest(
+            masterNodeTimeout(),
+            getId(),
+            getVersion(),
+            XContentHelper.convertToMap(getSource(), true, getXContentType()).v2()
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
@@ -67,7 +67,7 @@ public class PutPipelineTransportAction extends AcknowledgedTransportMasterNodeA
     @Override
     protected void masterOperation(Task task, PutPipelineRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
         throws Exception {
-        ingestService.putPipeline(request, listener, (nodeListener) -> {
+        ingestService.putPipeline(request.parse(), listener, nodeListener -> {
             NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
             nodesInfoRequest.clear();
             nodesInfoRequest.addMetric(NodesInfoMetrics.Metric.INGEST.metricName());

--- a/server/src/main/java/org/elasticsearch/action/ingest/ReservedPipelineAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/ReservedPipelineAction.java
@@ -84,7 +84,8 @@ public class ReservedPipelineAction implements ReservedClusterStateHandler<List<
 
         ClusterState state = prevState.state();
 
-        for (var request : requests) {
+        for (var rawRequest : requests) {
+            final var request = rawRequest.parse();
             var nopUpdate = IngestService.isNoOpPipelineUpdate(state, request);
 
             if (nopUpdate) {

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -82,18 +82,6 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
         this.config = deepCopy(config, true); // defensive deep copy
     }
 
-    /**
-     * A convenience constructor that parses some bytes as a map representing a pipeline's config and then delegates to the
-     * conventional {@link #PipelineConfiguration(String, Map)} constructor.
-     *
-     * @param id the id of the pipeline
-     * @param config a parse-able bytes reference that will return a pipeline configuration
-     * @param xContentType the content-type to use while parsing the pipeline configuration
-     */
-    public PipelineConfiguration(String id, BytesReference config, XContentType xContentType) {
-        this(id, XContentHelper.convertToMap(config, true, xContentType).v2());
-    }
-
     public String getId() {
         return id;
     }

--- a/server/src/test/java/org/elasticsearch/action/ingest/GetPipelineResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/GetPipelineResponseTests.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.xcontentPipelineConfiguration;
 
 public class GetPipelineResponseTests extends AbstractXContentSerializingTestCase<GetPipelineResponse> {
 
@@ -48,7 +49,7 @@ public class GetPipelineResponseTests extends AbstractXContentSerializingTestCas
         builder.field("value", value);
         builder.endObject();
         builder.endObject();
-        return new PipelineConfiguration(pipelineId, BytesReference.bytes(builder), builder.contentType());
+        return xcontentPipelineConfiguration(pipelineId, BytesReference.bytes(builder), builder.contentType());
     }
 
     private Map<String, PipelineConfiguration> createPipelineConfigMap() throws IOException {
@@ -92,7 +93,7 @@ public class GetPipelineResponseTests extends AbstractXContentSerializingTestCas
             parser.nextToken();
             try (XContentBuilder contentBuilder = XContentBuilder.builder(parser.contentType().xContent())) {
                 contentBuilder.generator().copyCurrentStructure(parser);
-                PipelineConfiguration pipeline = new PipelineConfiguration(
+                PipelineConfiguration pipeline = xcontentPipelineConfiguration(
                     pipelineId,
                     BytesReference.bytes(contentBuilder),
                     contentBuilder.contentType()

--- a/server/src/test/java/org/elasticsearch/action/ingest/PutPipelineRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/PutPipelineRequestTests.java
@@ -9,13 +9,9 @@
 
 package org.elasticsearch.action.ingest;
 
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
@@ -23,7 +19,6 @@ import java.io.IOException;
 import static org.elasticsearch.ingest.IngestPipelineTestUtils.putJsonPipelineRequest;
 
 public class PutPipelineRequestTests extends ESTestCase {
-
     public void testSerializationWithXContent() throws IOException {
         PutPipelineRequest request = putJsonPipelineRequest("1", "{}");
         assertEquals(XContentType.JSON, request.getXContentType());
@@ -35,32 +30,5 @@ public class PutPipelineRequestTests extends ESTestCase {
         PutPipelineRequest serialized = new PutPipelineRequest(in);
         assertEquals(XContentType.JSON, serialized.getXContentType());
         assertEquals("{}", serialized.getSource().utf8ToString());
-    }
-
-    public void testToXContent() throws IOException {
-        XContentType xContentType = randomFrom(XContentType.values());
-        XContentBuilder pipelineBuilder = XContentBuilder.builder(xContentType.xContent());
-        pipelineBuilder.startObject().field(Pipeline.DESCRIPTION_KEY, "some random set of processors");
-        pipelineBuilder.startArray(Pipeline.PROCESSORS_KEY);
-        // Start first processor
-        pipelineBuilder.startObject();
-        pipelineBuilder.startObject("set");
-        pipelineBuilder.field("field", "foo");
-        pipelineBuilder.field("value", "bar");
-        pipelineBuilder.endObject();
-        pipelineBuilder.endObject();
-        // End first processor
-        pipelineBuilder.endArray();
-        pipelineBuilder.endObject();
-        PutPipelineRequest request = new PutPipelineRequest(
-            TEST_REQUEST_TIMEOUT,
-            TEST_REQUEST_TIMEOUT,
-            "1",
-            BytesReference.bytes(pipelineBuilder),
-            xContentType
-        );
-        XContentBuilder requestBuilder = XContentBuilder.builder(xContentType.xContent());
-        BytesReference actualRequestBody = BytesReference.bytes(request.toXContent(requestBuilder, ToXContent.EMPTY_PARAMS));
-        assertEquals(BytesReference.bytes(pipelineBuilder), actualRequestBody);
     }
 }

--- a/server/src/test/java/org/elasticsearch/ingest/SimulateIngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/SimulateIngestServiceTests.java
@@ -13,18 +13,17 @@ import org.elasticsearch.action.bulk.FailureStoreMetrics;
 import org.elasticsearch.action.bulk.SimulateBulkRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonPipelineConfiguration;
 import static org.elasticsearch.test.LambdaMatchers.transformedMatch;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -41,8 +40,8 @@ public class SimulateIngestServiceTests extends ESTestCase {
     }
 
     public void testGetPipeline() {
-        PipelineConfiguration pipelineConfiguration = new PipelineConfiguration("pipeline1", new BytesArray("""
-            {"processors": [{"processor1" : {}}]}"""), XContentType.JSON);
+        PipelineConfiguration pipelineConfiguration = jsonPipelineConfiguration("pipeline1", """
+            {"processors": [{"processor1" : {}}]}""");
         IngestMetadata ingestMetadata = new IngestMetadata(Map.of("pipeline1", pipelineConfiguration));
         Map<String, Processor.Factory> processors = new HashMap<>();
         processors.put(

--- a/test/framework/src/main/java/org/elasticsearch/ingest/IngestPipelineTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/IngestPipelineTestUtils.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.ESTestCase;
@@ -139,5 +140,26 @@ public class IngestPipelineTestUtils {
      */
     public static SimulatePipelineRequest jsonSimulatePipelineRequest(BytesReference jsonBytes) {
         return new SimulatePipelineRequest(ReleasableBytesReference.wrap(jsonBytes), XContentType.JSON);
+    }
+
+    /**
+     * Construct a new {@link PipelineConfiguration} whose content is the given JSON document, represented as a {@link String}.
+     */
+    public static PipelineConfiguration jsonPipelineConfiguration(String id, String jsonString) {
+        return jsonPipelineConfiguration(id, new BytesArray(jsonString));
+    }
+
+    /**
+     * Construct a new {@link PipelineConfiguration} whose content is the given JSON document, represented as a {@link BytesReference}.
+     */
+    public static PipelineConfiguration jsonPipelineConfiguration(String id, BytesReference jsonBytes) {
+        return xcontentPipelineConfiguration(id, jsonBytes, XContentType.JSON);
+    }
+
+    /**
+     * Construct a new {@link PipelineConfiguration} whose content is the given XContent document, represented as a {@link BytesReference}.
+     */
+    public static PipelineConfiguration xcontentPipelineConfiguration(String id, BytesReference xcontentBytes, XContentType xContentType) {
+        return new PipelineConfiguration(id, XContentHelper.convertToMap(xcontentBytes, true, xContentType).v2());
     }
 }

--- a/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistryTests.java
@@ -60,6 +60,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.xcontentPipelineConfiguration;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -546,7 +547,7 @@ public class APMIndexTemplateRegistryTests extends ESTestCase {
                     // we cannot mock PipelineConfiguration as it is a final class
                     ingestPipelineConfigurations.put(
                         ingestPipelineConfig.getId(),
-                        new PipelineConfiguration(ingestPipelineConfig.getId(), ingestPipelineConfig.loadConfig(), XContentType.YAML)
+                        xcontentPipelineConfiguration(ingestPipelineConfig.getId(), ingestPipelineConfig.loadConfig(), XContentType.YAML)
                     );
                 }
             }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/InferenceProcessorInfoExtractorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/InferenceProcessorInfoExtractorTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 
 import java.io.IOException;
@@ -34,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonPipelineConfiguration;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 
@@ -120,7 +120,7 @@ public class InferenceProcessorInfoExtractorTests extends ESTestCase {
         ) {
             configurations.put(
                 "pipeline_with_model_nested",
-                new PipelineConfiguration("pipeline_with_model_nested", BytesReference.bytes(xContentBuilder), XContentType.JSON)
+                jsonPipelineConfiguration("pipeline_with_model_nested", BytesReference.bytes(xContentBuilder))
             );
         }
 
@@ -163,7 +163,7 @@ public class InferenceProcessorInfoExtractorTests extends ESTestCase {
                     )
                 )
         ) {
-            return new PipelineConfiguration("pipeline_without_model_" + i, BytesReference.bytes(xContentBuilder), XContentType.JSON);
+            return jsonPipelineConfiguration("pipeline_without_model_" + i, BytesReference.bytes(xContentBuilder));
         }
     }
 
@@ -212,7 +212,7 @@ public class InferenceProcessorInfoExtractorTests extends ESTestCase {
             XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
                 .map(Collections.singletonMap("processors", Collections.singletonList(inferenceProcessorForModel(modelId))))
         ) {
-            return new PipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder), XContentType.JSON);
+            return jsonPipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder));
         }
     }
 
@@ -221,7 +221,7 @@ public class InferenceProcessorInfoExtractorTests extends ESTestCase {
             XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
                 .map(Collections.singletonMap("processors", Collections.singletonList(forEachProcessorWithInference(modelId))))
         ) {
-            return new PipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder), XContentType.JSON);
+            return jsonPipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder));
         }
     }
 
@@ -235,11 +235,7 @@ public class InferenceProcessorInfoExtractorTests extends ESTestCase {
                     )
                 )
         ) {
-            return new PipelineConfiguration(
-                "pipeline_with_script_and_model_" + modelId,
-                BytesReference.bytes(xContentBuilder),
-                XContentType.JSON
-            );
+            return jsonPipelineConfiguration("pipeline_with_script_and_model_" + modelId, BytesReference.bytes(xContentBuilder));
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.Index;
@@ -70,6 +69,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonPipelineConfiguration;
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.xcontentPipelineConfiguration;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -721,7 +722,7 @@ public class IndexTemplateRegistryTests extends ESTestCase {
         assertThat(request, instanceOf(PutPipelineRequest.class));
         final PutPipelineRequest putRequest = (PutPipelineRequest) request;
         assertThat(putRequest.getId(), oneOf(pipelineIds));
-        PipelineConfiguration pipelineConfiguration = new PipelineConfiguration(
+        PipelineConfiguration pipelineConfiguration = xcontentPipelineConfiguration(
             putRequest.getId(),
             putRequest.getSource(),
             putRequest.getXContentType()
@@ -798,11 +799,7 @@ public class IndexTemplateRegistryTests extends ESTestCase {
             // we cannot mock PipelineConfiguration as it is a final class
             ingestPipelines.put(
                 pipelineEntry.getKey(),
-                new PipelineConfiguration(
-                    pipelineEntry.getKey(),
-                    new BytesArray(Strings.format("{\"version\": %d}", pipelineEntry.getValue())),
-                    XContentType.JSON
-                )
+                jsonPipelineConfiguration(pipelineEntry.getKey(), Strings.format("{\"version\": %d}", pipelineEntry.getValue()))
             );
         }
         IngestMetadata ingestMetadata = new IngestMetadata(ingestPipelines);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
@@ -27,9 +27,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.Strings;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -39,7 +37,6 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
@@ -55,6 +52,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonPipelineConfiguration;
 import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_INDEX_PATTERN;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -437,11 +436,7 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
             // we cannot mock PipelineConfiguration as it is a final class
             ingestPipelines.put(
                 pipelineEntry.getKey(),
-                new PipelineConfiguration(
-                    pipelineEntry.getKey(),
-                    new BytesArray(Strings.format("{\"version\": %d}", pipelineEntry.getValue())),
-                    XContentType.JSON
-                )
+                jsonPipelineConfiguration(pipelineEntry.getKey(), format("{\"version\": %d}", pipelineEntry.getValue()))
             );
         }
         IngestMetadata ingestMetadata = new IngestMetadata(ingestPipelines);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistryTests.java
@@ -27,9 +27,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.Strings;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -38,7 +36,6 @@ import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
@@ -54,6 +51,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonPipelineConfiguration;
 import static org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry.ACCESS_CONTROL_INDEX_NAME_PATTERN;
 import static org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry.CONNECTOR_INDEX_NAME_PATTERN;
 import static org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry.CONNECTOR_SYNC_JOBS_INDEX_NAME_PATTERN;
@@ -472,11 +471,7 @@ public class ConnectorTemplateRegistryTests extends ESTestCase {
             // we cannot mock PipelineConfiguration as it is a final class
             ingestPipelines.put(
                 pipelineEntry.getKey(),
-                new PipelineConfiguration(
-                    pipelineEntry.getKey(),
-                    new BytesArray(Strings.format("{\"version\": %d}", pipelineEntry.getValue())),
-                    XContentType.JSON
-                )
+                jsonPipelineConfiguration(pipelineEntry.getKey(), format("{\"version\": %d}", pipelineEntry.getValue()))
             );
         }
         IngestMetadata ingestMetadata = new IngestMetadata(ingestPipelines);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -34,7 +34,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.MlConfigVersion;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigUpdate;
@@ -72,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonPipelineConfiguration;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -921,7 +921,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
                 .map(Collections.singletonMap("processors", Collections.singletonList(inferenceProcessorForModel(modelId))))
         ) {
-            return new PipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder), XContentType.JSON);
+            return jsonPipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder));
         }
     }
 
@@ -930,7 +930,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
                 .map(Collections.singletonMap("processors", Collections.singletonList(forEachProcessorWithInference(modelId))))
         ) {
-            return new PipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder), XContentType.JSON);
+            return jsonPipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder));
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
 import org.elasticsearch.xpack.core.ml.inference.ModelAliasMetadata;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
@@ -69,6 +68,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonPipelineConfiguration;
 import static org.elasticsearch.xpack.ml.MachineLearning.UTILITY_THREAD_POOL_NAME;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -835,7 +835,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
                     )
                 )
         ) {
-            return new PipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder), XContentType.JSON);
+            return jsonPipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder));
         }
     }
 

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistryTests.java
@@ -19,10 +19,11 @@ import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.junit.After;
 import org.junit.Before;
+
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonPipelineConfiguration;
 
 public class LegacyStackTemplateRegistryTests extends ESTestCase {
     private LegacyStackTemplateRegistry registry;
@@ -55,7 +56,7 @@ public class LegacyStackTemplateRegistryTests extends ESTestCase {
         }
         registry.getIngestPipelines()
             .stream()
-            .map(ipc -> new PipelineConfiguration(ipc.getId(), ipc.loadConfig(), XContentType.JSON))
+            .map(ipc -> jsonPipelineConfiguration(ipc.getId(), ipc.loadConfig()))
             .map(PipelineConfiguration::getConfig)
             .forEach(p -> assertTrue((Boolean) p.get("deprecated")));
     }

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
@@ -61,6 +61,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonPipelineConfiguration;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.empty;
@@ -515,7 +516,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
         }
         registry.getIngestPipelines()
             .stream()
-            .map(ipc -> new PipelineConfiguration(ipc.getId(), ipc.loadConfig(), XContentType.JSON))
+            .map(ipc -> jsonPipelineConfiguration(ipc.getId(), ipc.loadConfig()))
             .map(PipelineConfiguration::getConfig)
             .forEach(p -> assertFalse((Boolean) p.get("deprecated")));
     }
@@ -633,7 +634,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
                 // we cannot mock PipelineConfiguration as it is a final class
                 ingestPipelines.put(
                     ingestPipelineConfig.getId(),
-                    new PipelineConfiguration(ingestPipelineConfig.getId(), ingestPipelineConfig.loadConfig(), XContentType.JSON)
+                    jsonPipelineConfiguration(ingestPipelineConfig.getId(), ingestPipelineConfig.loadConfig())
                 );
             }
         }


### PR DESCRIPTION
We don't need to pass around the REST request body verbatim when
processing a put-pipeline request, parsing it repeatedly as it's needed.
Instead we can parse the body once when starting to process the request
on the master, and pass the parsed `Map` around instead.

Relates #117038