### PR TITLE
[test] Remove synchronization from InternalTestCluster#getInstance

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1649,7 +1649,7 @@ public final class InternalTestCluster extends TestCluster {
         return getInstance(clazz, MASTER_NODE_PREDICATE);
     }
 
-    private synchronized <T> T getInstance(Class<T> clazz, Predicate<NodeAndClient> predicate) {
+    private <T> T getInstance(Class<T> clazz, Predicate<NodeAndClient> predicate) {
         NodeAndClient randomNodeAndClient = getRandomNodeAndClient(predicate);
         if (randomNodeAndClient == null) {
             throw new AssertionError("no node matches [" + predicate + "]");


### PR DESCRIPTION
The map of nodes is volatile and immutable and can be read without synchronization. Getting a class's instance from the node's injector is also thread safe.

Doing so prevents deadlocks if we restart the node while holding the `InternalTestCluster` lock and have a disruption scheme that internally calls `getInstance` from another thread.

```
  2> "elasticsearch[StatelessClusterIntegrityStressIT][server][T#1]" ID=3490 BLOCKED on org.elasticsearch.test.InternalTestCluster@18a6d098 owned by "elasticsearch[StatelessClusterIntegrityStressIT][server][T#2]" ID=3492
  2> 	at app//org.elasticsearch.test.InternalTestCluster.getInstance(InternalTestCluster.java:1653)
  2> 	- blocked on org.elasticsearch.test.InternalTestCluster@18a6d098
  2> 	at app//org.elasticsearch.test.InternalTestCluster.getInstance(InternalTestCluster.java:1620)
  2> 	at app//org.elasticsearch.test.disruption.NetworkDisruption.transport(NetworkDisruption.java:172)
  2> 	at app//org.elasticsearch.test.disruption.NetworkDisruption.applyToNodes(NetworkDisruption.java:157)
  2> 	at app//org.elasticsearch.test.disruption.Net  2> workDisruption.startDisrupting(NetworkDisruption.java:133)

 2> "elasticsearch[StatelessClusterIntegrityStressIT][server][T#2]" ID=3492 BLOCKED on org.elasticsearch.test.disruption.NetworkDisruption@60fd3a1e owned by "elasticsearch[StatelessClusterIntegrityStressIT][server][T#1]" ID=3490
   2> 	at app//org.elasticsearch.test.disruption.NetworkDisruption.applyToNode(NetworkDisruption.java:116)
   2> 	- blocked on org.elasticsearch.test.disruption.NetworkDisruption@60fd3a1e
   2> 	at app//org.elasticsearch.test.InternalTestCluster.applyDisruptionSchemeToNode(InternalTestCluster.java:2307)
   2> 	at app//org.elasticsearch.test.InternalTestCluster.publishNode(InternalTestCluster.java:2258)
   2> 	- locked org.elasticsearch.test.InternalTestCluster@18a6d098
   2> 	at app//org.elasticsearch.test.InternalTestCluster.restartNode(InternalTestCluster.java:1901)
   2> 	at app//org.elasticsearch.test.InternalTestCluster.restartNode(InternalTestCluster.java:1863)
   2> 	- locked org.elasticsearch.test.InternalTestCluster@18a6d098
 ```