### PR TITLE
Lazy compute description in ReplicationRequest.createTask

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -210,7 +210,12 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
 
     @Override
     public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-        return new ReplicationTask(id, type, action, getDescription(), parentTaskId, headers);
+        return new ReplicationTask(id, type, action, "", parentTaskId, headers) {
+            @Override
+            public String getDescription() {
+                return ReplicationRequest.this.getDescription();
+            }
+        };
     }
 
     @Override


### PR DESCRIPTION
These can at times be quite long strings, no need to materialize unless requested. This is showing up as allocating needless heap of O(GB) in some benchmarks during indexing needlessly (from `GlobalCheckpointSyncAction` and `BulkShardRequest`, all smallish individually but it adds up).
