### PR TITLE
Improve performance of H3.h3ToGeoBoundary

### DIFF
--- a/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
@@ -174,11 +174,11 @@ public final class H3 {
      * Find the cell {@link CellBoundary} coordinates for the cell
      */
     public static CellBoundary h3ToGeoBoundary(long h3) {
-        FaceIJK fijk = H3Index.h3ToFaceIjk(h3);
+        final FaceIJK fijk = H3Index.h3ToFaceIjk(h3);
         if (H3Index.H3_is_pentagon(h3)) {
-            return fijk.faceIjkPentToCellBoundary(H3Index.H3_get_resolution(h3), 0, Constants.NUM_PENT_VERTS);
+            return fijk.faceIjkPentToCellBoundary(H3Index.H3_get_resolution(h3));
         } else {
-            return fijk.faceIjkToCellBoundary(H3Index.H3_get_resolution(h3), 0, Constants.NUM_HEX_VERTS);
+            return fijk.faceIjkToCellBoundary(H3Index.H3_get_resolution(h3));
         }
     }
 


### PR DESCRIPTION
There are two clear code paths depending if a h3 bin belongs to even resolutions (class II) or uneven resolutions (class III). especializing the code paths for each type leads to an improvement in performance. 

In addition the internal methods takes a start and length parameter which come the H3 port. In this library we always compute the whole boundary so lets remove those parameters which makes the code easier to read.


Microbenchmarks before the change:
```
Benchmark                Mode  Cnt     Score    Error  Units
H3Benchmark.h3Boundary  thrpt   25  1591.085 ± 33.579  ops/s
H3Benchmark.pointToH3   thrpt   25   217.202 ±  2.287  ops/s
```

Microbenchmarks after the change:
```
Benchmark                Mode  Cnt     Score    Error  Units
H3Benchmark.h3Boundary  thrpt   25  1760.223 ± 75.764  ops/s
H3Benchmark.pointToH3   thrpt   25   216.286 ±  4.758  ops/s
```