### PR TITLE
ES|QL: reduce mute scope for Mixed Cluster tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -403,8 +403,6 @@ tests:
 - class: "org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT"
   method: "test {scoring.*}"
   issue: https://github.com/elastic/elasticsearch/issues/117641
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/117784
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {scoring.QstrWithFieldAndScoringSortedEval}
   issue: https://github.com/elastic/elasticsearch/issues/117751

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -522,7 +522,7 @@ h:d  | languages:i
 1.41 | null
 ;
 
-groupByAlias
+groupByAlias#[skip:-8.13.99,reason:muted, see https://github.com/elastic/elasticsearch/issues/117770]
 from employees | rename languages as l | keep l, height | stats m = min(height) by l | sort l;
 
 m:d  | l:i
@@ -982,7 +982,7 @@ c:l
 49  
 ;         
 
-countEvalExpWithGrouping
+countEvalExpWithGrouping#[skip:-8.13.99,reason:muted, see https://github.com/elastic/elasticsearch/issues/117784]
 from employees | rename languages as l | eval e = case(emp_no < 10050, emp_no, null) | stats c = count(e) by l | sort l;
 
 c:l | l:i 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -951,7 +951,7 @@ c:l
 49
 ;
 
-countFieldWithGrouping
+countFieldWithGrouping#[skip:-8.13.99,reason:muted, see https://github.com/elastic/elasticsearch/issues/117784]
 from employees | rename languages as l | where emp_no < 10050 | stats c = count(emp_no) by l | sort l;
 
 c:l | l:i 
@@ -963,7 +963,7 @@ c:l | l:i
 10 | null
 ;
 
-countFieldWithAliasWithGrouping
+countFieldWithAliasWithGrouping#[skip:-8.13.99,reason:muted, see https://github.com/elastic/elasticsearch/issues/117784]
 from employees | rename languages as l | eval e = emp_no | where emp_no < 10050 | stats c = count(e) by l | sort l;
 
 c:l | l:i 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/version.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/version.csv-spec
@@ -159,7 +159,7 @@ id:i           |name:s         |version:v      |o:v
 13             |lllll          |null           |null 
 ;
 
-countVersion
+countVersion#[skip:-8.13.99,reason:muted, see https://github.com/elastic/elasticsearch/issues/117784]
 FROM apps | RENAME name AS k | STATS v = COUNT(version) BY k | SORT k;
 
 v:l     | k:s


### PR DESCRIPTION
Some bwc test failures caused the complete mute of `MixedClusterEsqlSpecIT` test suite.

This PR reduces the scope of the mute a bit.

See https://github.com/elastic/elasticsearch/issues/117784 and https://github.com/elastic/elasticsearch/issues/117770