### PR TITLE
Remove duplicative banner

### DIFF
--- a/docs/reference/esql/esql-across-clusters.asciidoc
+++ b/docs/reference/esql/esql-across-clusters.asciidoc
@@ -8,11 +8,6 @@
 
 preview::["{ccs-cap} for {esql} is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 
-[NOTE]
-====
-For {ccs-cap} with {esql} on version 8.16 or later, remote clusters must also be on version 8.16 or later.
-====
-
 With {esql}, you can execute a single query across multiple clusters.
 
 [discrete]


### PR DESCRIPTION
Remove the cross-cluster search compatibility banner in "Using ES|QL across clusters" -- it duplicates information in the compatibility matrix linked from the prerequisites, and was also generally 8.16-specific.

**Preview:** [before](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-cross-clusters.html) | [after](https://elasticsearch_bk_117844.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/esql-cross-clusters.html)

From a slack convo with @fin-yeates-elastic 