### PR TITLE
Remove test mute for OldRepositoryAccessIT testOldRepoAccess

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -326,9 +326,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.RetrySearchIntegTests
   method: testRetryPointInTime
   issue: https://github.com/elastic/elasticsearch/issues/117116
-- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-  method: testOldRepoAccess
-  issue: https://github.com/elastic/elasticsearch/issues/115631
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
   issue: https://github.com/elastic/elasticsearch/issues/117027


### PR DESCRIPTION
This has been fixed with #117649 on "main" and the changes causing this haven't been backported to 8.x. The test was muted due to occasional timeouts that are unrelated that should have been fixed in the meantime.
