### PR TITLE
Assert for empty routing table when hiding state

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/ClusterStateUpdaters.java
+++ b/server/src/main/java/org/elasticsearch/gateway/ClusterStateUpdaters.java
@@ -143,6 +143,7 @@ public class ClusterStateUpdaters {
                 .coordinationMetadata(state.metadata().coordinationMetadata())
                 .build();
 
+            assert state.routingTable().indicesRouting().isEmpty() : "routing table is not empty: " + state.routingTable().indicesRouting();
             return ClusterState.builder(state).metadata(metadata).blocks(blocks.build()).build();
         }
         return state;


### PR DESCRIPTION
Routing table should always be empty when hiding cluster state for not-recovered block. This PR adds an explicit assertion for it.
