### PR TITLE
[8.x] Remove supersetSize and subsetSize from InternalSignificantTerms.Bucket (#117574)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -495,7 +495,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 for (SignificantTerms.Bucket bucket : sigTerms.getBuckets()) {
                     assertThat(
                         bucket.getSignificanceScore(),
-                        is((double) bucket.getSubsetDf() + bucket.getSubsetSize() + bucket.getSupersetDf() + bucket.getSupersetSize())
+                        is((double) bucket.getSubsetDf() + sigTerms.getSubsetSize() + bucket.getSupersetDf() + sigTerms.getSupersetSize())
                     );
                 }
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
@@ -59,7 +59,7 @@ public abstract class InternalMappedSignificantTerms<
         subsetSize = in.readVLong();
         supersetSize = in.readVLong();
         significanceHeuristic = in.readNamedWriteable(SignificanceHeuristic.class);
-        buckets = in.readCollectionAsList(stream -> bucketReader.read(stream, subsetSize, supersetSize, format));
+        buckets = in.readCollectionAsList(stream -> bucketReader.read(stream, format));
     }
 
     @Override
@@ -91,12 +91,12 @@ public abstract class InternalMappedSignificantTerms<
     }
 
     @Override
-    protected long getSubsetSize() {
+    public long getSubsetSize() {
         return subsetSize;
     }
 
     @Override
-    protected long getSupersetSize() {
+    public long getSupersetSize() {
         return supersetSize;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
@@ -53,13 +53,11 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
          */
         @FunctionalInterface
         public interface Reader<B extends Bucket<B>> {
-            B read(StreamInput in, long subsetSize, long supersetSize, DocValueFormat format) throws IOException;
+            B read(StreamInput in, DocValueFormat format) throws IOException;
         }
 
         long subsetDf;
-        long subsetSize;
         long supersetDf;
-        long supersetSize;
         /**
          * Ordinal of the bucket while it is being built. Not used after it is
          * returned from {@link Aggregator#buildAggregations(org.elasticsearch.common.util.LongArray)} and not
@@ -70,16 +68,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
         protected InternalAggregations aggregations;
         final transient DocValueFormat format;
 
-        protected Bucket(
-            long subsetDf,
-            long subsetSize,
-            long supersetDf,
-            long supersetSize,
-            InternalAggregations aggregations,
-            DocValueFormat format
-        ) {
-            this.subsetSize = subsetSize;
-            this.supersetSize = supersetSize;
+        protected Bucket(long subsetDf, long supersetDf, InternalAggregations aggregations, DocValueFormat format) {
             this.subsetDf = subsetDf;
             this.supersetDf = supersetDf;
             this.aggregations = aggregations;
@@ -89,9 +78,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
         /**
          * Read from a stream.
          */
-        protected Bucket(StreamInput in, long subsetSize, long supersetSize, DocValueFormat format) {
-            this.subsetSize = subsetSize;
-            this.supersetSize = supersetSize;
+        protected Bucket(StreamInput in, DocValueFormat format) {
             this.format = format;
         }
 
@@ -105,20 +92,10 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
             return supersetDf;
         }
 
-        @Override
-        public long getSupersetSize() {
-            return supersetSize;
-        }
-
-        @Override
-        public long getSubsetSize() {
-            return subsetSize;
-        }
-
         // TODO we should refactor to remove this, since buckets should be immutable after they are generated.
         // This can lead to confusing bugs if the bucket is re-created (via createBucket() or similar) without
         // the score
-        void updateScore(SignificanceHeuristic significanceHeuristic) {
+        void updateScore(SignificanceHeuristic significanceHeuristic, long subsetSize, long supersetSize) {
             score = significanceHeuristic.getScore(subsetDf, subsetSize, supersetDf, supersetSize);
         }
 
@@ -262,13 +239,11 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
                     buckets.forEach(entry -> {
                         final B b = createBucket(
                             entry.value.subsetDf[0],
-                            globalSubsetSize,
                             entry.value.supersetDf[0],
-                            globalSupersetSize,
                             entry.value.reducer.getAggregations(),
                             entry.value.reducer.getProto()
                         );
-                        b.updateScore(heuristic);
+                        b.updateScore(heuristic, globalSubsetSize, globalSupersetSize);
                         if (((b.score > 0) && (b.subsetDf >= minDocCount)) || reduceContext.isFinalReduce() == false) {
                             final B removed = ordered.insertWithOverflow(b);
                             if (removed == null) {
@@ -317,9 +292,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
                 .map(
                     b -> createBucket(
                         samplingContext.scaleUp(b.subsetDf),
-                        subsetSize,
                         samplingContext.scaleUp(b.supersetDf),
-                        supersetSize,
                         InternalAggregations.finalizeSampling(b.aggregations, samplingContext),
                         b
                     )
@@ -328,14 +301,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
         );
     }
 
-    abstract B createBucket(
-        long subsetDf,
-        long subsetSize,
-        long supersetDf,
-        long supersetSize,
-        InternalAggregations aggregations,
-        B prototype
-    );
+    abstract B createBucket(long subsetDf, long supersetDf, InternalAggregations aggregations, B prototype);
 
     protected abstract A create(long subsetSize, long supersetSize, List<B> buckets);
 
@@ -343,10 +309,6 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
      * Create an array to hold some buckets. Used in collecting the results.
      */
     protected abstract B[] createBucketsArray(int size);
-
-    protected abstract long getSubsetSize();
-
-    protected abstract long getSupersetSize();
 
     protected abstract SignificanceHeuristic getSignificanceHeuristic();
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
@@ -47,7 +47,6 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
-import java.util.function.Supplier;
 
 import static org.elasticsearch.search.aggregations.InternalOrder.isKeyOrder;
 
@@ -296,7 +295,7 @@ public final class MapStringTermsAggregator extends AbstractStringTermsAggregato
                     try (ObjectArrayPriorityQueue<B> ordered = buildPriorityQueue(size)) {
                         B spare = null;
                         BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningOrd);
-                        Supplier<B> emptyBucketBuilder = emptyBucketBuilder(owningOrd);
+                        BucketUpdater<B> bucketUpdater = bucketUpdater(owningOrd);
                         while (ordsEnum.next()) {
                             long docCount = bucketDocCount(ordsEnum.ord());
                             otherDocCounts.increment(ordIdx, docCount);
@@ -305,9 +304,9 @@ public final class MapStringTermsAggregator extends AbstractStringTermsAggregato
                             }
                             if (spare == null) {
                                 checkRealMemoryCBForInternalBucket();
-                                spare = emptyBucketBuilder.get();
+                                spare = buildEmptyBucket();
                             }
-                            updateBucket(spare, ordsEnum, docCount);
+                            bucketUpdater.updateBucket(spare, ordsEnum, docCount);
                             spare = ordered.insertWithOverflow(spare);
                         }
 
@@ -348,9 +347,9 @@ public final class MapStringTermsAggregator extends AbstractStringTermsAggregato
         abstract void collectZeroDocEntriesIfNeeded(long owningBucketOrd, boolean excludeDeletedDocs) throws IOException;
 
         /**
-         * Build an empty temporary bucket.
+         * Build an empty bucket.
          */
-        abstract Supplier<B> emptyBucketBuilder(long owningBucketOrd);
+        abstract B buildEmptyBucket();
 
         /**
          * Build a {@link PriorityQueue} to sort the buckets. After we've
@@ -362,7 +361,7 @@ public final class MapStringTermsAggregator extends AbstractStringTermsAggregato
          * Update fields in {@code spare} to reflect information collected for
          * this bucket ordinal.
          */
-        abstract void updateBucket(B spare, BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum, long docCount) throws IOException;
+        abstract BucketUpdater<B> bucketUpdater(long owningBucketOrd);
 
         /**
          * Build an array to hold the "top" buckets for each ordinal.
@@ -397,6 +396,10 @@ public final class MapStringTermsAggregator extends AbstractStringTermsAggregato
          * shard.
          */
         abstract R buildEmptyResult();
+    }
+
+    interface BucketUpdater<B extends InternalMultiBucketAggregation.InternalBucket> {
+        void updateBucket(B spare, BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum, long docCount) throws IOException;
     }
 
     /**
@@ -490,8 +493,8 @@ public final class MapStringTermsAggregator extends AbstractStringTermsAggregato
         }
 
         @Override
-        Supplier<StringTerms.Bucket> emptyBucketBuilder(long owningBucketOrd) {
-            return () -> new StringTerms.Bucket(new BytesRef(), 0, null, showTermDocCountError, 0, format);
+        StringTerms.Bucket buildEmptyBucket() {
+            return new StringTerms.Bucket(new BytesRef(), 0, null, showTermDocCountError, 0, format);
         }
 
         @Override
@@ -500,10 +503,12 @@ public final class MapStringTermsAggregator extends AbstractStringTermsAggregato
         }
 
         @Override
-        void updateBucket(StringTerms.Bucket spare, BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum, long docCount) throws IOException {
-            ordsEnum.readValue(spare.termBytes);
-            spare.docCount = docCount;
-            spare.bucketOrd = ordsEnum.ord();
+        BucketUpdater<StringTerms.Bucket> bucketUpdater(long owningBucketOrd) {
+            return (spare, ordsEnum, docCount) -> {
+                ordsEnum.readValue(spare.termBytes);
+                spare.docCount = docCount;
+                spare.bucketOrd = ordsEnum.ord();
+            };
         }
 
         @Override
@@ -615,9 +620,8 @@ public final class MapStringTermsAggregator extends AbstractStringTermsAggregato
         void collectZeroDocEntriesIfNeeded(long owningBucketOrd, boolean excludeDeletedDocs) throws IOException {}
 
         @Override
-        Supplier<SignificantStringTerms.Bucket> emptyBucketBuilder(long owningBucketOrd) {
-            long subsetSize = subsetSizes.get(owningBucketOrd);
-            return () -> new SignificantStringTerms.Bucket(new BytesRef(), 0, subsetSize, 0, 0, null, format, 0);
+        SignificantStringTerms.Bucket buildEmptyBucket() {
+            return new SignificantStringTerms.Bucket(new BytesRef(), 0, 0, null, format, 0);
         }
 
         @Override
@@ -626,20 +630,20 @@ public final class MapStringTermsAggregator extends AbstractStringTermsAggregato
         }
 
         @Override
-        void updateBucket(SignificantStringTerms.Bucket spare, BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum, long docCount)
-            throws IOException {
-
-            ordsEnum.readValue(spare.termBytes);
-            spare.bucketOrd = ordsEnum.ord();
-            spare.subsetDf = docCount;
-            spare.supersetDf = backgroundFrequencies.freq(spare.termBytes);
-            spare.supersetSize = supersetSize;
-            /*
-             * During shard-local down-selection we use subset/superset stats
-             * that are for this shard only. Back at the central reducer these
-             * properties will be updated with global stats.
-             */
-            spare.updateScore(significanceHeuristic);
+        BucketUpdater<SignificantStringTerms.Bucket> bucketUpdater(long owningBucketOrd) {
+            long subsetSize = subsetSizes.get(owningBucketOrd);
+            return (spare, ordsEnum, docCount) -> {
+                ordsEnum.readValue(spare.termBytes);
+                spare.bucketOrd = ordsEnum.ord();
+                spare.subsetDf = docCount;
+                spare.supersetDf = backgroundFrequencies.freq(spare.termBytes);
+                /*
+                 * During shard-local down-selection we use subset/superset stats
+                 * that are for this shard only. Back at the central reducer these
+                 * properties will be updated with global stats.
+                 */
+                spare.updateScore(significanceHeuristic, subsetSize, supersetSize);
+            };
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
@@ -43,7 +43,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.search.aggregations.InternalOrder.isKeyOrder;
@@ -177,7 +176,7 @@ public final class NumericTermsAggregator extends TermsAggregator {
                     try (ObjectArrayPriorityQueue<B> ordered = buildPriorityQueue(size)) {
                         B spare = null;
                         BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningBucketOrd);
-                        Supplier<B> emptyBucketBuilder = emptyBucketBuilder(owningBucketOrd);
+                        BucketUpdater<B> bucketUpdater = bucketUpdater(owningBucketOrd);
                         while (ordsEnum.next()) {
                             long docCount = bucketDocCount(ordsEnum.ord());
                             otherDocCounts.increment(ordIdx, docCount);
@@ -186,9 +185,9 @@ public final class NumericTermsAggregator extends TermsAggregator {
                             }
                             if (spare == null) {
                                 checkRealMemoryCBForInternalBucket();
-                                spare = emptyBucketBuilder.get();
+                                spare = buildEmptyBucket();
                             }
-                            updateBucket(spare, ordsEnum, docCount);
+                            bucketUpdater.updateBucket(spare, ordsEnum, docCount);
                             spare = ordered.insertWithOverflow(spare);
                         }
 
@@ -240,17 +239,16 @@ public final class NumericTermsAggregator extends TermsAggregator {
         abstract B[] buildBuckets(int size);
 
         /**
-         * Build a {@linkplain Supplier} that can be used to build "empty"
-         * buckets. Those buckets will then be {@link #updateBucket updated}
+         * Build an empty bucket. Those buckets will then be {@link #bucketUpdater(long)}  updated}
          * for each collected bucket.
          */
-        abstract Supplier<B> emptyBucketBuilder(long owningBucketOrd);
+        abstract B buildEmptyBucket();
 
         /**
          * Update fields in {@code spare} to reflect information collected for
          * this bucket ordinal.
          */
-        abstract void updateBucket(B spare, BucketOrdsEnum ordsEnum, long docCount) throws IOException;
+        abstract BucketUpdater<B> bucketUpdater(long owningBucketOrd);
 
         /**
          * Build a {@link ObjectArrayPriorityQueue} to sort the buckets. After we've
@@ -282,6 +280,10 @@ public final class NumericTermsAggregator extends TermsAggregator {
         abstract R buildEmptyResult();
     }
 
+    interface BucketUpdater<B extends InternalMultiBucketAggregation.InternalBucket> {
+        void updateBucket(B spare, BucketOrdsEnum ordsEnum, long docCount) throws IOException;
+    }
+
     abstract class StandardTermsResultStrategy<R extends InternalMappedTerms<R, B>, B extends InternalTerms.Bucket<B>> extends
         ResultStrategy<R, B> {
         protected final boolean showTermDocCountError;
@@ -304,13 +306,6 @@ public final class NumericTermsAggregator extends TermsAggregator {
         final void buildSubAggs(ObjectArray<B[]> topBucketsPerOrd) throws IOException {
             buildSubAggsForAllBuckets(topBucketsPerOrd, b -> b.bucketOrd, (b, aggs) -> b.aggregations = aggs);
         }
-
-        @Override
-        Supplier<B> emptyBucketBuilder(long owningBucketOrd) {
-            return this::buildEmptyBucket;
-        }
-
-        abstract B buildEmptyBucket();
 
         @Override
         final void collectZeroDocEntriesIfNeeded(long owningBucketOrd, boolean excludeDeletedDocs) throws IOException {
@@ -375,10 +370,12 @@ public final class NumericTermsAggregator extends TermsAggregator {
         }
 
         @Override
-        void updateBucket(LongTerms.Bucket spare, BucketOrdsEnum ordsEnum, long docCount) {
-            spare.term = ordsEnum.value();
-            spare.docCount = docCount;
-            spare.bucketOrd = ordsEnum.ord();
+        BucketUpdater<LongTerms.Bucket> bucketUpdater(long owningBucketOrd) {
+            return (LongTerms.Bucket spare, BucketOrdsEnum ordsEnum, long docCount) -> {
+                spare.term = ordsEnum.value();
+                spare.docCount = docCount;
+                spare.bucketOrd = ordsEnum.ord();
+            };
         }
 
         @Override
@@ -457,10 +454,12 @@ public final class NumericTermsAggregator extends TermsAggregator {
         }
 
         @Override
-        void updateBucket(DoubleTerms.Bucket spare, BucketOrdsEnum ordsEnum, long docCount) {
-            spare.term = NumericUtils.sortableLongToDouble(ordsEnum.value());
-            spare.docCount = docCount;
-            spare.bucketOrd = ordsEnum.ord();
+        BucketUpdater<DoubleTerms.Bucket> bucketUpdater(long owningBucketOrd) {
+            return (DoubleTerms.Bucket spare, BucketOrdsEnum ordsEnum, long docCount) -> {
+                spare.term = NumericUtils.sortableLongToDouble(ordsEnum.value());
+                spare.docCount = docCount;
+                spare.bucketOrd = ordsEnum.ord();
+            };
         }
 
         @Override
@@ -565,20 +564,22 @@ public final class NumericTermsAggregator extends TermsAggregator {
         }
 
         @Override
-        Supplier<SignificantLongTerms.Bucket> emptyBucketBuilder(long owningBucketOrd) {
-            long subsetSize = subsetSizes.get(owningBucketOrd);
-            return () -> new SignificantLongTerms.Bucket(0, subsetSize, 0, supersetSize, 0, null, format, 0);
+        SignificantLongTerms.Bucket buildEmptyBucket() {
+            return new SignificantLongTerms.Bucket(0, 0, 0, null, format, 0);
         }
 
         @Override
-        void updateBucket(SignificantLongTerms.Bucket spare, BucketOrdsEnum ordsEnum, long docCount) throws IOException {
-            spare.term = ordsEnum.value();
-            spare.subsetDf = docCount;
-            spare.supersetDf = backgroundFrequencies.freq(spare.term);
-            spare.bucketOrd = ordsEnum.ord();
-            // During shard-local down-selection we use subset/superset stats that are for this shard only
-            // Back at the central reducer these properties will be updated with global stats
-            spare.updateScore(significanceHeuristic);
+        BucketUpdater<SignificantLongTerms.Bucket> bucketUpdater(long owningBucketOrd) {
+            long subsetSize = subsetSizes.get(owningBucketOrd);
+            return (spare, ordsEnum, docCount) -> {
+                spare.term = ordsEnum.value();
+                spare.subsetDf = docCount;
+                spare.supersetDf = backgroundFrequencies.freq(spare.term);
+                spare.bucketOrd = ordsEnum.ord();
+                // During shard-local down-selection we use subset/superset stats that are for this shard only
+                // Back at the central reducer these properties will be updated with global stats
+                spare.updateScore(significanceHeuristic, subsetSize, supersetSize);
+            };
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTerms.java
@@ -30,23 +30,14 @@ public class SignificantLongTerms extends InternalMappedSignificantTerms<Signifi
 
         long term;
 
-        public Bucket(
-            long subsetDf,
-            long subsetSize,
-            long supersetDf,
-            long supersetSize,
-            long term,
-            InternalAggregations aggregations,
-            DocValueFormat format,
-            double score
-        ) {
-            super(subsetDf, subsetSize, supersetDf, supersetSize, aggregations, format);
+        public Bucket(long subsetDf, long supersetDf, long term, InternalAggregations aggregations, DocValueFormat format, double score) {
+            super(subsetDf, supersetDf, aggregations, format);
             this.term = term;
             this.score = score;
         }
 
-        Bucket(StreamInput in, long subsetSize, long supersetSize, DocValueFormat format) throws IOException {
-            super(in, subsetSize, supersetSize, format);
+        Bucket(StreamInput in, DocValueFormat format) throws IOException {
+            super(in, format);
             subsetDf = in.readVLong();
             supersetDf = in.readVLong();
             term = in.readLong();
@@ -136,16 +127,7 @@ public class SignificantLongTerms extends InternalMappedSignificantTerms<Signifi
 
     @Override
     public Bucket createBucket(InternalAggregations aggregations, SignificantLongTerms.Bucket prototype) {
-        return new Bucket(
-            prototype.subsetDf,
-            prototype.subsetSize,
-            prototype.supersetDf,
-            prototype.supersetSize,
-            prototype.term,
-            aggregations,
-            prototype.format,
-            prototype.score
-        );
+        return new Bucket(prototype.subsetDf, prototype.supersetDf, prototype.term, aggregations, prototype.format, prototype.score);
     }
 
     @Override
@@ -169,14 +151,7 @@ public class SignificantLongTerms extends InternalMappedSignificantTerms<Signifi
     }
 
     @Override
-    Bucket createBucket(
-        long subsetDf,
-        long subsetSize,
-        long supersetDf,
-        long supersetSize,
-        InternalAggregations aggregations,
-        SignificantLongTerms.Bucket prototype
-    ) {
-        return new Bucket(subsetDf, subsetSize, supersetDf, supersetSize, prototype.term, aggregations, format, prototype.score);
+    Bucket createBucket(long subsetDf, long supersetDf, InternalAggregations aggregations, SignificantLongTerms.Bucket prototype) {
+        return new Bucket(subsetDf, supersetDf, prototype.term, aggregations, format, prototype.score);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTerms.java
@@ -34,14 +34,12 @@ public class SignificantStringTerms extends InternalMappedSignificantTerms<Signi
         public Bucket(
             BytesRef term,
             long subsetDf,
-            long subsetSize,
             long supersetDf,
-            long supersetSize,
             InternalAggregations aggregations,
             DocValueFormat format,
             double score
         ) {
-            super(subsetDf, subsetSize, supersetDf, supersetSize, aggregations, format);
+            super(subsetDf, supersetDf, aggregations, format);
             this.termBytes = term;
             this.score = score;
         }
@@ -49,8 +47,8 @@ public class SignificantStringTerms extends InternalMappedSignificantTerms<Signi
         /**
          * Read from a stream.
          */
-        public Bucket(StreamInput in, long subsetSize, long supersetSize, DocValueFormat format) throws IOException {
-            super(in, subsetSize, supersetSize, format);
+        public Bucket(StreamInput in, DocValueFormat format) throws IOException {
+            super(in, format);
             termBytes = in.readBytesRef();
             subsetDf = in.readVLong();
             supersetDf = in.readVLong();
@@ -140,16 +138,7 @@ public class SignificantStringTerms extends InternalMappedSignificantTerms<Signi
 
     @Override
     public Bucket createBucket(InternalAggregations aggregations, SignificantStringTerms.Bucket prototype) {
-        return new Bucket(
-            prototype.termBytes,
-            prototype.subsetDf,
-            prototype.subsetSize,
-            prototype.supersetDf,
-            prototype.supersetSize,
-            aggregations,
-            prototype.format,
-            prototype.score
-        );
+        return new Bucket(prototype.termBytes, prototype.subsetDf, prototype.supersetDf, aggregations, prototype.format, prototype.score);
     }
 
     @Override
@@ -173,14 +162,7 @@ public class SignificantStringTerms extends InternalMappedSignificantTerms<Signi
     }
 
     @Override
-    Bucket createBucket(
-        long subsetDf,
-        long subsetSize,
-        long supersetDf,
-        long supersetSize,
-        InternalAggregations aggregations,
-        SignificantStringTerms.Bucket prototype
-    ) {
-        return new Bucket(prototype.termBytes, subsetDf, subsetSize, supersetDf, supersetSize, aggregations, format, prototype.score);
+    Bucket createBucket(long subsetDf, long supersetDf, InternalAggregations aggregations, SignificantStringTerms.Bucket prototype) {
+        return new Bucket(prototype.termBytes, subsetDf, supersetDf, aggregations, format, prototype.score);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTerms.java
@@ -17,6 +17,18 @@ import java.util.List;
  */
 public interface SignificantTerms extends MultiBucketsAggregation, Iterable<SignificantTerms.Bucket> {
 
+    /**
+     * @return The numbers of docs in the subset (also known as "foreground set").
+     * This number is equal to the document count of the containing aggregation.
+     */
+    long getSubsetSize();
+
+    /**
+     * @return The numbers of docs in the superset (ordinarily the background count
+     * of the containing aggregation).
+     */
+    long getSupersetSize();
+
     interface Bucket extends MultiBucketsAggregation.Bucket {
 
         /**
@@ -31,22 +43,10 @@ public interface SignificantTerms extends MultiBucketsAggregation, Iterable<Sign
         long getSubsetDf();
 
         /**
-         * @return The numbers of docs in the subset (also known as "foreground set").
-         * This number is equal to the document count of the containing aggregation.
-         */
-        long getSubsetSize();
-
-        /**
          * @return The number of docs in the superset containing a particular term (also
          * known as the "background count" of the bucket)
          */
         long getSupersetDf();
-
-        /**
-         * @return The numbers of docs in the superset (ordinarily the background count
-         * of the containing aggregation).
-         */
-        long getSupersetSize();
 
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedSignificantTerms.java
@@ -40,16 +40,8 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms<UnmappedS
      * {@linkplain UnmappedTerms} doesn't ever need to build it because it never returns any buckets.
      */
     protected abstract static class Bucket extends InternalSignificantTerms.Bucket<Bucket> {
-        private Bucket(
-            BytesRef term,
-            long subsetDf,
-            long subsetSize,
-            long supersetDf,
-            long supersetSize,
-            InternalAggregations aggregations,
-            DocValueFormat format
-        ) {
-            super(subsetDf, subsetSize, supersetDf, supersetSize, aggregations, format);
+        private Bucket(BytesRef term, long subsetDf, long supersetDf, InternalAggregations aggregations, DocValueFormat format) {
+            super(subsetDf, supersetDf, aggregations, format);
         }
     }
 
@@ -95,14 +87,7 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms<UnmappedS
     }
 
     @Override
-    Bucket createBucket(
-        long subsetDf,
-        long subsetSize,
-        long supersetDf,
-        long supersetSize,
-        InternalAggregations aggregations,
-        Bucket prototype
-    ) {
+    Bucket createBucket(long subsetDf, long supersetDf, InternalAggregations aggregations, Bucket prototype) {
         throw new UnsupportedOperationException("not supported for UnmappedSignificantTerms");
     }
 
@@ -153,12 +138,12 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms<UnmappedS
     }
 
     @Override
-    protected long getSubsetSize() {
+    public long getSubsetSize() {
         return 0;
     }
 
     @Override
-    protected long getSupersetSize() {
+    public long getSupersetSize() {
         return 0;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTermsTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTermsTestCase.java
@@ -59,8 +59,6 @@ public abstract class InternalSignificantTermsTestCase extends InternalMultiBuck
             InternalSignificantTerms.Bucket<?> sampledBucket = sampledIt.next();
             assertEquals(sampledBucket.subsetDf, samplingContext.scaleUp(reducedBucket.subsetDf));
             assertEquals(sampledBucket.supersetDf, samplingContext.scaleUp(reducedBucket.supersetDf));
-            assertEquals(sampledBucket.subsetSize, samplingContext.scaleUp(reducedBucket.subsetSize));
-            assertEquals(sampledBucket.supersetSize, samplingContext.scaleUp(reducedBucket.supersetSize));
             assertThat(sampledBucket.score, closeTo(reducedBucket.score, 1e-14));
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
@@ -49,17 +49,8 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
         Set<Long> terms = new HashSet<>();
         for (int i = 0; i < numBuckets; ++i) {
             long term = randomValueOtherThanMany(l -> terms.add(l) == false, random()::nextLong);
-            SignificantLongTerms.Bucket bucket = new SignificantLongTerms.Bucket(
-                subsetDfs[i],
-                subsetSize,
-                supersetDfs[i],
-                supersetSize,
-                term,
-                aggs,
-                format,
-                0
-            );
-            bucket.updateScore(significanceHeuristic);
+            SignificantLongTerms.Bucket bucket = new SignificantLongTerms.Bucket(subsetDfs[i], supersetDfs[i], term, aggs, format, 0);
+            bucket.updateScore(significanceHeuristic, subsetSize, supersetSize);
             buckets.add(bucket);
         }
         return new SignificantLongTerms(name, requiredSize, 1L, metadata, format, subsetSize, supersetSize, significanceHeuristic, buckets);
@@ -88,8 +79,6 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
                     buckets.add(
                         new SignificantLongTerms.Bucket(
                             randomLong(),
-                            randomNonNegativeLong(),
-                            randomNonNegativeLong(),
                             randomNonNegativeLong(),
                             randomNonNegativeLong(),
                             InternalAggregations.EMPTY,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
@@ -42,17 +42,8 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
         Set<BytesRef> terms = new HashSet<>();
         for (int i = 0; i < numBuckets; ++i) {
             BytesRef term = randomValueOtherThanMany(b -> terms.add(b) == false, () -> new BytesRef(randomAlphaOfLength(10)));
-            SignificantStringTerms.Bucket bucket = new SignificantStringTerms.Bucket(
-                term,
-                subsetDfs[i],
-                subsetSize,
-                supersetDfs[i],
-                supersetSize,
-                aggs,
-                format,
-                0
-            );
-            bucket.updateScore(significanceHeuristic);
+            SignificantStringTerms.Bucket bucket = new SignificantStringTerms.Bucket(term, subsetDfs[i], supersetDfs[i], aggs, format, 0);
+            bucket.updateScore(significanceHeuristic, subsetSize, supersetSize);
             buckets.add(bucket);
         }
         return new SignificantStringTerms(
@@ -91,8 +82,6 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
                     buckets.add(
                         new SignificantStringTerms.Bucket(
                             new BytesRef(randomAlphaOfLengthBetween(1, 10)),
-                            randomNonNegativeLong(),
-                            randomNonNegativeLong(),
                             randomNonNegativeLong(),
                             randomNonNegativeLong(),
                             InternalAggregations.EMPTY,

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractSignificanceHeuristicTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractSignificanceHeuristicTestCase.java
@@ -95,22 +95,20 @@ public abstract class AbstractSignificanceHeuristicTestCase extends ESTestCase {
         InternalMappedSignificantTerms<?, ?> read = (InternalMappedSignificantTerms<?, ?>) in.readNamedWriteable(InternalAggregation.class);
 
         assertEquals(sigTerms.getSignificanceHeuristic(), read.getSignificanceHeuristic());
+        assertThat(read.getSubsetSize(), equalTo(10L));
+        assertThat(read.getSupersetSize(), equalTo(20L));
         SignificantTerms.Bucket originalBucket = sigTerms.getBuckets().get(0);
         SignificantTerms.Bucket streamedBucket = read.getBuckets().get(0);
         assertThat(originalBucket.getKeyAsString(), equalTo(streamedBucket.getKeyAsString()));
         assertThat(originalBucket.getSupersetDf(), equalTo(streamedBucket.getSupersetDf()));
         assertThat(originalBucket.getSubsetDf(), equalTo(streamedBucket.getSubsetDf()));
-        assertThat(streamedBucket.getSubsetSize(), equalTo(10L));
-        assertThat(streamedBucket.getSupersetSize(), equalTo(20L));
     }
 
     InternalMappedSignificantTerms<?, ?> getRandomSignificantTerms(SignificanceHeuristic heuristic) {
         if (randomBoolean()) {
             SignificantLongTerms.Bucket bucket = new SignificantLongTerms.Bucket(
                 1,
-                2,
                 3,
-                4,
                 123,
                 InternalAggregations.EMPTY,
                 DocValueFormat.RAW,
@@ -121,9 +119,7 @@ public abstract class AbstractSignificanceHeuristicTestCase extends ESTestCase {
             SignificantStringTerms.Bucket bucket = new SignificantStringTerms.Bucket(
                 new BytesRef("someterm"),
                 1,
-                2,
                 3,
-                4,
                 InternalAggregations.EMPTY,
                 DocValueFormat.RAW,
                 randomDoubleBetween(0, 100, true)
@@ -136,15 +132,13 @@ public abstract class AbstractSignificanceHeuristicTestCase extends ESTestCase {
         List<InternalAggregation> aggs = createInternalAggregations();
         AggregationReduceContext context = InternalAggregationTestCase.emptyReduceContextBuilder().forFinalReduction();
         SignificantTerms reducedAgg = (SignificantTerms) InternalAggregationTestCase.reduce(aggs, context);
+        assertThat(reducedAgg.getSubsetSize(), equalTo(16L));
+        assertThat(reducedAgg.getSupersetSize(), equalTo(30L));
         assertThat(reducedAgg.getBuckets().size(), equalTo(2));
         assertThat(reducedAgg.getBuckets().get(0).getSubsetDf(), equalTo(8L));
-        assertThat(reducedAgg.getBuckets().get(0).getSubsetSize(), equalTo(16L));
         assertThat(reducedAgg.getBuckets().get(0).getSupersetDf(), equalTo(10L));
-        assertThat(reducedAgg.getBuckets().get(0).getSupersetSize(), equalTo(30L));
         assertThat(reducedAgg.getBuckets().get(1).getSubsetDf(), equalTo(8L));
-        assertThat(reducedAgg.getBuckets().get(1).getSubsetSize(), equalTo(16L));
         assertThat(reducedAgg.getBuckets().get(1).getSupersetDf(), equalTo(10L));
-        assertThat(reducedAgg.getBuckets().get(1).getSupersetSize(), equalTo(30L));
     }
 
     public void testBasicScoreProperties() {
@@ -234,9 +228,9 @@ public abstract class AbstractSignificanceHeuristicTestCase extends ESTestCase {
             : new AbstractSignificanceHeuristicTestCase.LongTestAggFactory();
 
         List<InternalAggregation> aggs = new ArrayList<>();
-        aggs.add(factory.createAggregation(significanceHeuristic, 4, 10, 1, (f, i) -> f.createBucket(4, 4, 5, 10, 0)));
-        aggs.add(factory.createAggregation(significanceHeuristic, 4, 10, 1, (f, i) -> f.createBucket(4, 4, 5, 10, 1)));
-        aggs.add(factory.createAggregation(significanceHeuristic, 8, 10, 2, (f, i) -> f.createBucket(4, 4, 5, 10, i)));
+        aggs.add(factory.createAggregation(significanceHeuristic, 4, 10, 1, (f, i) -> f.createBucket(4, 5, 0)));
+        aggs.add(factory.createAggregation(significanceHeuristic, 4, 10, 1, (f, i) -> f.createBucket(4, 5, 1)));
+        aggs.add(factory.createAggregation(significanceHeuristic, 8, 10, 2, (f, i) -> f.createBucket(4, 5, i)));
         return aggs;
     }
 
@@ -254,7 +248,7 @@ public abstract class AbstractSignificanceHeuristicTestCase extends ESTestCase {
 
         abstract A createAggregation(SignificanceHeuristic significanceHeuristic, long subsetSize, long supersetSize, List<B> buckets);
 
-        abstract B createBucket(long subsetDF, long subsetSize, long supersetDF, long supersetSize, long label);
+        abstract B createBucket(long subsetDF, long supersetDF, long label);
     }
 
     private class StringTestAggFactory extends TestAggFactory<SignificantStringTerms, SignificantStringTerms.Bucket> {
@@ -279,13 +273,11 @@ public abstract class AbstractSignificanceHeuristicTestCase extends ESTestCase {
         }
 
         @Override
-        SignificantStringTerms.Bucket createBucket(long subsetDF, long subsetSize, long supersetDF, long supersetSize, long label) {
+        SignificantStringTerms.Bucket createBucket(long subsetDF, long supersetDF, long label) {
             return new SignificantStringTerms.Bucket(
                 new BytesRef(Long.toString(label).getBytes(StandardCharsets.UTF_8)),
                 subsetDF,
-                subsetSize,
                 supersetDF,
-                supersetSize,
                 InternalAggregations.EMPTY,
                 DocValueFormat.RAW,
                 0
@@ -315,17 +307,8 @@ public abstract class AbstractSignificanceHeuristicTestCase extends ESTestCase {
         }
 
         @Override
-        SignificantLongTerms.Bucket createBucket(long subsetDF, long subsetSize, long supersetDF, long supersetSize, long label) {
-            return new SignificantLongTerms.Bucket(
-                subsetDF,
-                subsetSize,
-                supersetDF,
-                supersetSize,
-                label,
-                InternalAggregations.EMPTY,
-                DocValueFormat.RAW,
-                0
-            );
+        SignificantLongTerms.Bucket createBucket(long subsetDF, long supersetDF, long label) {
+            return new SignificantLongTerms.Bucket(subsetDF, supersetDF, label, InternalAggregations.EMPTY, DocValueFormat.RAW, 0);
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Remove supersetSize and subsetSize from InternalSignificantTerms.Bucket (#117574)