### PR TITLE
ESQL: Enable CATEGORIZE tests on non-snapshot builds

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -407,7 +407,7 @@ public class EsqlCapabilities {
         /**
          * Supported the text categorization function "CATEGORIZE".
          */
-        CATEGORIZE_V4(Build.current().isSnapshot()),
+        CATEGORIZE_V4,
 
         /**
          * QSTR function


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/117827 enabled `CATEGORIZE` in non-snapshot builds. Let's remove the snapshot-only marker from the corresponding capability so tests with `CATEGORIZE` are also run in release builds.
