### PR TITLE
ESQL: Simplify CombineProjections

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
@@ -148,6 +148,7 @@ public final class CombineProjections extends OptimizerRules.OptimizerRule<Unary
         AttributeMap<Attribute> aliases = new AttributeMap<>();
         for (NamedExpression ne : lowerProjections) {
             // record the alias
+            // Projections are just aliases for attributes, so casting is safe.
             aliases.put(ne.toAttribute(), (Attribute) Alias.unwrap(ne));
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
@@ -145,6 +145,9 @@ public final class CombineProjections extends OptimizerRules.OptimizerRule<Unary
         List<? extends NamedExpression> upperGroupings,
         List<? extends NamedExpression> lowerProjections
     ) {
+        assert upperGroupings.size() <= 1
+            || upperGroupings.stream().anyMatch(group -> group.anyMatch(expr -> expr instanceof Categorize)) == false
+            : "CombineProjections only tested with a single CATEGORIZE with no additional groups";
         // Collect the alias map for resolving the source (f1 = 1, f2 = f1, etc..)
         AttributeMap<Attribute> aliases = new AttributeMap<>();
         for (NamedExpression ne : lowerProjections) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
@@ -153,7 +153,7 @@ public final class CombineProjections extends OptimizerRules.OptimizerRule<Unary
             aliases.put(ne.toAttribute(), (Attribute) Alias.unwrap(ne));
         }
 
-        // Propagate any renames from the lower projection in the upper groupings.
+        // Propagate any renames from the lower projection into the upper groupings.
         // This can lead to duplicates: e.g.
         // | EVAL x = y | STATS ... BY x, y
         // All substitutions happen before; groupings must be attributes at this point except for CATEGORIZE which will be an alias like

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -1217,7 +1217,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
         var plan = plan("""
             from test
             | eval k = first_name, k1 = k
-            | stats s = sum(salary) by cat = CATEGORIZE(k)
+            | stats s = sum(salary) by cat = CATEGORIZE(k1)
             | keep s, cat
             """);
 


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/114317 needed to amend the `CombineProjections` logical optimizer rule to account for the `CATEGORIZE` function.

I believe this can be a tiny bit simplified, more specifically the method combineUpperGroupingsAndLowerProjections - c.f. https://github.com/elastic/elasticsearch/pull/114317#discussion_r1856524724.