### PR TITLE
[8.x] ESQL: Enable CATEGORIZE tests on non-snapshot builds (#117881)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -396,7 +396,7 @@ public class EsqlCapabilities {
         /**
          * Supported the text categorization function "CATEGORIZE".
          */
-        CATEGORIZE_V4(Build.current().isSnapshot()),
+        CATEGORIZE_V4,
 
         /**
          * QSTR function


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Enable CATEGORIZE tests on non-snapshot builds (#117881)