### PR TITLE
ES|QL fix telemetry tests after promoting CATEGORIZE (#117878)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -412,8 +412,5 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.RegressionIT
   method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
   issue: https://github.com/elastic/elasticsearch/issues/117805
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
-  issue: https://github.com/elastic/elasticsearch/issues/117862
 - class: org.elasticsearch.xpack.security.authc.ldap.UserAttributeGroupsResolverTests
   issue: https://github.com/elastic/elasticsearch/issues/116537

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -163,4 +163,4 @@ setup:
   - match: {esql.functions.cos: $functions_cos}
   - gt: {esql.functions.to_long: $functions_to_long}
   - match: {esql.functions.coalesce: $functions_coalesce}
-  - length: {esql.functions: 118} # check the "sister" test above for a likely update to the same esql.functions length check
+  - length: {esql.functions: 119} # check the "sister" test above for a likely update to the same esql.functions length check


### PR DESCRIPTION
Manual backport of #117878

Fixes: https://github.com/elastic/elasticsearch/issues/117862