### PR TITLE
[8.x] Move common system properties for test clusters to default provider (#117928)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
@@ -214,7 +214,7 @@ public abstract class AbstractLocalSpecBuilder<T extends LocalSpecBuilder<?>> im
         return cast(this);
     }
 
-    public T systemProperty(SystemPropertyProvider systemPropertyProvider) {
+    public T systemProperties(SystemPropertyProvider systemPropertyProvider) {
         this.systemPropertyProviders.add(systemPropertyProvider);
         return cast(this);
     }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
@@ -19,10 +19,8 @@ public final class DefaultLocalClusterSpecBuilder extends AbstractLocalClusterSp
 
     public DefaultLocalClusterSpecBuilder() {
         super();
-        this.apply(
-            c -> c.systemProperty("ingest.geoip.downloader.enabled.default", "false").systemProperty("tests.testfeatures.enabled", "true")
-        );
         this.apply(new FipsEnabledClusterConfigProvider());
+        this.systemProperties(new DefaultSystemPropertyProvider());
         this.settings(new DefaultSettingsProvider());
         this.environment(new DefaultEnvironmentProvider());
         this.rolesFile(Resource.fromClasspath("default_test_roles.yml"));

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSystemPropertyProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSystemPropertyProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.cluster.local;
+
+import org.elasticsearch.test.cluster.SystemPropertyProvider;
+
+import java.util.Map;
+
+import static java.util.Map.entry;
+
+public class DefaultSystemPropertyProvider implements SystemPropertyProvider {
+    @Override
+    public Map<String, String> get(LocalClusterSpec.LocalNodeSpec nodeSpec) {
+        return Map.ofEntries(entry("ingest.geoip.downloader.enabled.default", "false"), entry("tests.testfeatures.enabled", "true"));
+    }
+}

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
@@ -137,7 +137,7 @@ interface LocalSpecBuilder<T extends LocalSpecBuilder<?>> {
     /**
      * Register a {@link SystemPropertyProvider}.
      */
-    T systemProperty(SystemPropertyProvider systemPropertyProvider);
+    T systemProperties(SystemPropertyProvider systemPropertyProvider);
 
     /**
      * Adds an additional command line argument to node JVM arguments.


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Move common system properties for test clusters to default provider (#117928)