### PR TITLE
[8.x] Fix reconstituting version string from components (#117213)

### DIFF
--- a/docs/changelog/117213.yaml
+++ b/docs/changelog/117213.yaml
@@ -1,0 +1,6 @@
+pr: 117213
+summary: Fix reconstituting version string from components
+area: Ingest Node
+type: bug
+issues:
+ - 116950

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.ingest.useragent;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.Maps;
@@ -98,19 +99,8 @@ public class UserAgentProcessor extends AbstractProcessor {
                     }
                     break;
                 case VERSION:
-                    StringBuilder version = new StringBuilder();
                     if (uaClient.userAgent() != null && uaClient.userAgent().major() != null) {
-                        version.append(uaClient.userAgent().major());
-                        if (uaClient.userAgent().minor() != null) {
-                            version.append(".").append(uaClient.userAgent().minor());
-                            if (uaClient.userAgent().patch() != null) {
-                                version.append(".").append(uaClient.userAgent().patch());
-                                if (uaClient.userAgent().build() != null) {
-                                    version.append(".").append(uaClient.userAgent().build());
-                                }
-                            }
-                        }
-                        uaDetails.put("version", version.toString());
+                        uaDetails.put("version", versionToString(uaClient.userAgent()));
                     }
                     break;
                 case OS:
@@ -118,20 +108,10 @@ public class UserAgentProcessor extends AbstractProcessor {
                         Map<String, String> osDetails = Maps.newMapWithExpectedSize(3);
                         if (uaClient.operatingSystem().name() != null) {
                             osDetails.put("name", uaClient.operatingSystem().name());
-                            StringBuilder sb = new StringBuilder();
                             if (uaClient.operatingSystem().major() != null) {
-                                sb.append(uaClient.operatingSystem().major());
-                                if (uaClient.operatingSystem().minor() != null) {
-                                    sb.append(".").append(uaClient.operatingSystem().minor());
-                                    if (uaClient.operatingSystem().patch() != null) {
-                                        sb.append(".").append(uaClient.operatingSystem().patch());
-                                        if (uaClient.operatingSystem().build() != null) {
-                                            sb.append(".").append(uaClient.operatingSystem().build());
-                                        }
-                                    }
-                                }
-                                osDetails.put("version", sb.toString());
-                                osDetails.put("full", uaClient.operatingSystem().name() + " " + sb.toString());
+                                String version = versionToString(uaClient.operatingSystem());
+                                osDetails.put("version", version);
+                                osDetails.put("full", uaClient.operatingSystem().name() + " " + version);
                             }
                             uaDetails.put("os", osDetails);
                         }
@@ -161,6 +141,23 @@ public class UserAgentProcessor extends AbstractProcessor {
 
         ingestDocument.setFieldValue(targetField, uaDetails);
         return ingestDocument;
+    }
+
+    private static String versionToString(final UserAgentParser.VersionedName version) {
+        final StringBuilder versionString = new StringBuilder();
+        if (Strings.hasLength(version.major())) {
+            versionString.append(version.major());
+            if (Strings.hasLength(version.minor())) {
+                versionString.append(".").append(version.minor());
+                if (Strings.hasLength(version.patch())) {
+                    versionString.append(".").append(version.patch());
+                    if (Strings.hasLength(version.build())) {
+                        versionString.append(".").append(version.build());
+                    }
+                }
+            }
+        }
+        return versionString.toString();
     }
 
     @Override

--- a/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
+++ b/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
@@ -331,4 +331,21 @@ public class UserAgentProcessorTests extends ESTestCase {
         device.put("name", "Other");
         assertThat(target.get("device"), is(device));
     }
+
+    // From https://github.com/elastic/elasticsearch/issues/116950
+    @SuppressWarnings("unchecked")
+    public void testFirefoxVersion() {
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0");
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        processor.execute(ingestDocument);
+        Map<String, Object> data = ingestDocument.getSourceAndMetadata();
+
+        assertThat(data, hasKey("target_field"));
+        Map<String, Object> target = (Map<String, Object>) data.get("target_field");
+
+        assertThat(target.get("name"), is("Firefox"));
+        assertThat(target.get("version"), is("128.0"));
+    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix reconstituting version string from components (#117213)](https://github.com/elastic/elasticsearch/pull/117213)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)