### PR TITLE
[8.x] Document ES|QL categorize limitations (#117892)

### DIFF
--- a/docs/reference/esql/functions/description/categorize.asciidoc
+++ b/docs/reference/esql/functions/description/categorize.asciidoc
@@ -3,3 +3,9 @@
 *Description*
 
 Groups text messages into categories of similarly formatted text values.
+
+`CATEGORIZE` has the following limitations:
+
+* can't be used within other expressions
+* can't be used with multiple groupings
+* can't be used or referenced within aggregations

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Categorize.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Categorize.java
@@ -48,6 +48,12 @@ public class Categorize extends GroupingFunction implements Validatable {
     @FunctionInfo(
         returnType = "keyword",
         description = "Groups text messages into categories of similarly formatted text values.",
+        detailedDescription = """
+            `CATEGORIZE` has the following limitations:
+
+            * can't be used within other expressions
+            * can't be used with multiple groupings
+            * can't be used or referenced within aggregate functions""",
         examples = {
             @Example(
                 file = "docs",


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Document ES|QL categorize limitations (#117892)