### PR TITLE
[8.x] Watcher history index has too many indexed fields - (#71479) (#117701)

### DIFF
--- a/docs/changelog/117701.yaml
+++ b/docs/changelog/117701.yaml
@@ -1,0 +1,6 @@
+pr: 117701
+summary: Watcher history index has too many indexed fields -
+area: Watcher
+type: bug
+issues:
+ - 71479

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherIndexTemplateRegistryField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherIndexTemplateRegistryField.java
@@ -22,8 +22,9 @@ public final class WatcherIndexTemplateRegistryField {
     // version 14: move watch history to data stream
     // version 15: remove watches and triggered watches, these are now system indices
     // version 16: change watch history ILM policy
+    // version 17: exclude input chain from indexing
     // Note: if you change this, also inform the kibana team around the watcher-ui
-    public static final int INDEX_TEMPLATE_VERSION = 16;
+    public static final int INDEX_TEMPLATE_VERSION = 17;
     public static final String HISTORY_TEMPLATE_NAME = ".watch-history-" + INDEX_TEMPLATE_VERSION;
     public static final String HISTORY_TEMPLATE_NAME_NO_ILM = ".watch-history-no-ilm-" + INDEX_TEMPLATE_VERSION;
     public static final String[] TEMPLATE_NAMES = new String[] { HISTORY_TEMPLATE_NAME };

--- a/x-pack/plugin/core/template-resources/src/main/resources/watch-history-no-ilm.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/watch-history-no-ilm.json
@@ -54,6 +54,15 @@
               "enabled": false
             }
           }
+        },
+        {
+          "disabled_result_input_chain_fields": {
+            "path_match": "result.input.chain",
+            "mapping": {
+              "type": "object",
+              "enabled": false
+            }
+          }
         }
       ],
       "dynamic": false,

--- a/x-pack/plugin/core/template-resources/src/main/resources/watch-history.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/watch-history.json
@@ -55,6 +55,15 @@
               "enabled": false
             }
           }
+        },
+        {
+          "disabled_result_input_chain_fields": {
+            "path_match": "result.input.chain",
+            "mapping": {
+              "type": "object",
+              "enabled": false
+            }
+          }
         }
       ],
       "dynamic": false,

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
@@ -130,7 +130,7 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
             String chainedPath = SINGLE_MAPPING_NAME
                 + ".properties.result.properties.input.properties.chain.properties.chained.properties.search"
                 + ".properties.request.properties.body.enabled";
-            assertThat(source.getValue(chainedPath), is(false));
+            assertThat(source.getValue(chainedPath), nullValue());
         } else {
             String path = SINGLE_MAPPING_NAME
                 + ".properties.result.properties.input.properties.search.properties.request.properties.body.enabled";
@@ -168,11 +168,11 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
             XContentType.JSON
         );
 
-        // lets make sure the body fields are disabled
+        // let's make sure the body fields are disabled or, in the case of chained, the whole object is not indexed
         if (useChained) {
             String path = SINGLE_MAPPING_NAME
                 + ".properties.result.properties.input.properties.chain.properties.chained.properties.payload.enabled";
-            assertThat(source.getValue(path), is(false));
+            assertThat(source.getValue(path), nullValue());
         } else {
             String path = SINGLE_MAPPING_NAME + ".properties.result.properties.input.properties.payload.enabled";
             assertThat(source.getValue(path), is(false));


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Watcher history index has too many indexed fields - (#71479) (#117701)