### PR TITLE
[8.16] Updates minimum_number_of_allocations description (#117746)

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -18,7 +18,8 @@ end::adaptive-allocation-max-number[]
 
 tag::adaptive-allocation-min-number[]
 Specifies the minimum number of allocations to scale to.
-If set, it must be greater than or equal to `1`.
+If set, it must be greater than or equal to `0`.
+If not defined, the deployment scales to `0`.
 end::adaptive-allocation-min-number[]
 
 tag::aggregations[]


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Updates minimum_number_of_allocations description (#117746)