### PR TITLE
[8.x] Make Murmur3Hasher#update public (#117961)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/hash/Murmur3Hasher.java
+++ b/server/src/main/java/org/elasticsearch/common/hash/Murmur3Hasher.java
@@ -40,7 +40,12 @@ public class Murmur3Hasher {
         update(inputBytes, 0, inputBytes.length);
     }
 
-    private void update(byte[] inputBytes, int offset, int length) {
+    /**
+     * Similar to {@link #update(byte[])}, but processes a specific portion of the input bytes
+     * starting from the given {@code offset} for the specified {@code length}.
+     * @see #update(byte[])
+     */
+    public void update(byte[] inputBytes, int offset, int length) {
         if (remainderLength + length >= remainder.length) {
             if (remainderLength > 0) {
                 // fill rest of remainder from inputBytes and hash remainder


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Make Murmur3Hasher#update public (#117961)