### PR TITLE
Acquire stats searcher for data stream stats (#117953)

### DIFF
--- a/docs/changelog/117953.yaml
+++ b/docs/changelog/117953.yaml
@@ -1,0 +1,5 @@
+pr: 117953
+summary: Acquire stats searcher for data stream stats
+area: Data streams
+type: bug
+issues: []

--- a/docs/changelog/118012.yaml
+++ b/docs/changelog/118012.yaml
@@ -1,0 +1,5 @@
+pr: 118012
+summary: Acquire stats searcher for data stream stats
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DataStreamsStatsTransportAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DataStreamsStatsTransportAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.ReadOnlyEngine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.index.store.StoreStats;
@@ -151,7 +152,7 @@ public class DataStreamsStatsTransportAction extends TransportBroadcastByNodeAct
             IndexAbstraction.DataStream dataStream = indexAbstraction.getParentDataStream();
             assert dataStream != null;
             long maxTimestamp = 0L;
-            try (Engine.Searcher searcher = indexShard.acquireSearcher("data_stream_stats")) {
+            try (Engine.Searcher searcher = indexShard.acquireSearcher(ReadOnlyEngine.FIELD_RANGE_SEARCH_SOURCE)) {
                 IndexReader indexReader = searcher.getIndexReader();
                 String fieldName = dataStream.getDataStream().getTimeStampField().getName();
                 byte[] maxPackedValue = PointValues.getMaxPackedValue(indexReader, fieldName);


### PR DESCRIPTION
Backport of #117953 to 7.17

Here, we only need to extract the minimum and maximum values of the  timestamp field; therefore, using a stats searcher should suffice. This is important for frozen indices.
