### PR TITLE
Create the mapping explicitly for RequestIndexFilteringTestCase

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -230,12 +230,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.plugin.ClusterRequestTests
   method: testFallbackIndicesOptions
   issue: https://github.com/elastic/elasticsearch/issues/117937
-- class: org.elasticsearch.xpack.esql.qa.single_node.RequestIndexFilteringIT
-  method: testFieldExistsFilter_KeepWildcard
-  issue: https://github.com/elastic/elasticsearch/issues/117935
-- class: org.elasticsearch.xpack.esql.qa.multi_node.RequestIndexFilteringIT
-  method: testFieldExistsFilter_KeepWildcard
-  issue: https://github.com/elastic/elasticsearch/issues/117935
 - class: org.elasticsearch.xpack.ml.integration.RegressionIT
   method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
   issue: https://github.com/elastic/elasticsearch/issues/117805

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RequestIndexFilteringTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RequestIndexFilteringTestCase.java
@@ -101,7 +101,7 @@ public abstract class RequestIndexFilteringTestCase extends ESRestTestCase {
         indexTimestampData(docsTest1, "test1", "2024-11-26", "id1");
         indexTimestampData(docsTest2, "test2", "2023-11-26", "id2");
 
-        // filter includes only test1. Columns are rows of test2 are filtered out
+        // filter includes only test1. Columns and rows of test2 are filtered out
         RestEsqlTestCase.RequestObjectBuilder builder = existsFilter("id1").query("FROM test*");
         Map<String, Object> result = runEsql(builder);
         assertMap(
@@ -252,6 +252,9 @@ public abstract class RequestIndexFilteringTestCase extends ESRestTestCase {
                 "properties": {
                   "@timestamp": {
                     "type": "date"
+                  },
+                  "value": {
+                    "type": "long"
                   },
                   "%differentiator_field_name%": {
                     "type": "integer"


### PR DESCRIPTION
Otherwise, the mapping will not contain the "value" field and 0 documents indices.

Fixes 
https://github.com/elastic/elasticsearch/issues/117934
https://github.com/elastic/elasticsearch/issues/117935
