### PR TITLE
 [8.16] Indicate that rescore isn't allowed with retrievers, yet (#118019)

### DIFF
--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -534,11 +534,11 @@ clauses in a <<query-dsl-bool-query, boolean query>>.
 
 ==== Restrictions on search parameters when specifying a retriever
 
-When a retriever is specified as part of a search the following elements are not allowed
-at the top-level and instead are only allowed as elements of specific retrievers:
+When a retriever is specified as part of a search, the following elements are not allowed at the top-level:
 
 * <<request-body-search-query, `query`>>
 * <<search-api-knn, `knn`>>
 * <<search-after, `search_after`>>
 * <<request-body-search-terminate-after, `terminate_after`>>
 * <<search-sort-param, `sort`>>
+* <<rescore, `rescore`>>


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Indicate that rescore isn't allowed with retrievers, yet (#118019)