### PR TITLE
ES|QL: Fix ESQL usage output (telemetry) non-snapshot version test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -248,9 +248,6 @@ tests:
 - class: org.elasticsearch.index.reindex.ReindexNodeShutdownIT
   method: testReindexWithShutdown
   issue: https://github.com/elastic/elasticsearch/issues/118040
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
-  issue: https://github.com/elastic/elasticsearch/issues/117862
 
 # Examples:
 #

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -163,4 +163,4 @@ setup:
   - match: {esql.functions.cos: $functions_cos}
   - gt: {esql.functions.to_long: $functions_to_long}
   - match: {esql.functions.coalesce: $functions_coalesce}
-  - length: {esql.functions: 123} # check the "sister" test above for a likely update to the same esql.functions length check
+  - length: {esql.functions: 124} # check the "sister" test above for a likely update to the same esql.functions length check


### PR DESCRIPTION
Off by one, due to https://github.com/elastic/elasticsearch/pull/116964

@craigtaverner I think the PR was supposed to be backported (the label is there at least), but apparently the bot didn't do it.
In case, we should fix it in the `8.x` PR as well.

Fixes: https://github.com/elastic/elasticsearch/issues/117862
