### PR TITLE
Make NestedHelper a utility class

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -321,8 +321,7 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
 
         // ToParentBlockJoinQuery requires that the inner query only matches documents
         // in its child space
-        NestedHelper nestedHelper = new NestedHelper(context.nestedLookup(), context::isFieldMapped);
-        if (nestedHelper.mightMatchNonNestedDocs(innerQuery, path)) {
+        if (NestedHelper.mightMatchNonNestedDocs(innerQuery, path, context)) {
             innerQuery = Queries.filtered(innerQuery, mapper.nestedTypeFilter());
         }
 

--- a/server/src/main/java/org/elasticsearch/index/search/NestedHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/NestedHelper.java
@@ -21,29 +21,21 @@ import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
-import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.NestedObjectMapper;
-
-import java.util.function.Predicate;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 /** Utility class to filter parent and children clauses when building nested
  * queries. */
 public final class NestedHelper {
 
-    private final NestedLookup nestedLookup;
-    private final Predicate<String> isMappedFieldPredicate;
-
-    public NestedHelper(NestedLookup nestedLookup, Predicate<String> isMappedFieldPredicate) {
-        this.nestedLookup = nestedLookup;
-        this.isMappedFieldPredicate = isMappedFieldPredicate;
-    }
+    private NestedHelper() {}
 
     /** Returns true if the given query might match nested documents. */
-    public boolean mightMatchNestedDocs(Query query) {
+    public static boolean mightMatchNestedDocs(Query query, SearchExecutionContext searchExecutionContext) {
         if (query instanceof ConstantScoreQuery) {
-            return mightMatchNestedDocs(((ConstantScoreQuery) query).getQuery());
+            return mightMatchNestedDocs(((ConstantScoreQuery) query).getQuery(), searchExecutionContext);
         } else if (query instanceof BoostQuery) {
-            return mightMatchNestedDocs(((BoostQuery) query).getQuery());
+            return mightMatchNestedDocs(((BoostQuery) query).getQuery(), searchExecutionContext);
         } else if (query instanceof MatchAllDocsQuery) {
             return true;
         } else if (query instanceof MatchNoDocsQuery) {
@@ -51,17 +43,17 @@ public final class NestedHelper {
         } else if (query instanceof TermQuery) {
             // We only handle term(s) queries and range queries, which should already
             // cover a high majority of use-cases
-            return mightMatchNestedDocs(((TermQuery) query).getTerm().field());
+            return mightMatchNestedDocs(((TermQuery) query).getTerm().field(), searchExecutionContext);
         } else if (query instanceof TermInSetQuery tis) {
             if (tis.getTermsCount() > 0) {
-                return mightMatchNestedDocs(tis.getField());
+                return mightMatchNestedDocs(tis.getField(), searchExecutionContext);
             } else {
                 return false;
             }
         } else if (query instanceof PointRangeQuery) {
-            return mightMatchNestedDocs(((PointRangeQuery) query).getField());
+            return mightMatchNestedDocs(((PointRangeQuery) query).getField(), searchExecutionContext);
         } else if (query instanceof IndexOrDocValuesQuery) {
-            return mightMatchNestedDocs(((IndexOrDocValuesQuery) query).getIndexQuery());
+            return mightMatchNestedDocs(((IndexOrDocValuesQuery) query).getIndexQuery(), searchExecutionContext);
         } else if (query instanceof final BooleanQuery bq) {
             final boolean hasRequiredClauses = bq.clauses().stream().anyMatch(BooleanClause::isRequired);
             if (hasRequiredClauses) {
@@ -69,13 +61,13 @@ public final class NestedHelper {
                     .stream()
                     .filter(BooleanClause::isRequired)
                     .map(BooleanClause::query)
-                    .allMatch(this::mightMatchNestedDocs);
+                    .allMatch(f -> mightMatchNestedDocs(f, searchExecutionContext));
             } else {
                 return bq.clauses()
                     .stream()
                     .filter(c -> c.occur() == Occur.SHOULD)
                     .map(BooleanClause::query)
-                    .anyMatch(this::mightMatchNestedDocs);
+                    .anyMatch(f -> mightMatchNestedDocs(f, searchExecutionContext));
             }
         } else if (query instanceof ESToParentBlockJoinQuery) {
             return ((ESToParentBlockJoinQuery) query).getPath() != null;
@@ -85,7 +77,7 @@ public final class NestedHelper {
     }
 
     /** Returns true if a query on the given field might match nested documents. */
-    boolean mightMatchNestedDocs(String field) {
+    private static boolean mightMatchNestedDocs(String field, SearchExecutionContext searchExecutionContext) {
         if (field.startsWith("_")) {
             // meta field. Every meta field behaves differently, eg. nested
             // documents have the same _uid as their parent, put their path in
@@ -94,36 +86,36 @@ public final class NestedHelper {
             // we might add a nested filter when it is nor required.
             return true;
         }
-        if (isMappedFieldPredicate.test(field) == false) {
+        if (searchExecutionContext.isFieldMapped(field) == false) {
             // field does not exist
             return false;
         }
-        return nestedLookup.getNestedParent(field) != null;
+        return searchExecutionContext.nestedLookup().getNestedParent(field) != null;
     }
 
     /** Returns true if the given query might match parent documents or documents
      *  that are nested under a different path. */
-    public boolean mightMatchNonNestedDocs(Query query, String nestedPath) {
+    public static boolean mightMatchNonNestedDocs(Query query, String nestedPath, SearchExecutionContext searchExecutionContext) {
         if (query instanceof ConstantScoreQuery) {
-            return mightMatchNonNestedDocs(((ConstantScoreQuery) query).getQuery(), nestedPath);
+            return mightMatchNonNestedDocs(((ConstantScoreQuery) query).getQuery(), nestedPath, searchExecutionContext);
         } else if (query instanceof BoostQuery) {
-            return mightMatchNonNestedDocs(((BoostQuery) query).getQuery(), nestedPath);
+            return mightMatchNonNestedDocs(((BoostQuery) query).getQuery(), nestedPath, searchExecutionContext);
         } else if (query instanceof MatchAllDocsQuery) {
             return true;
         } else if (query instanceof MatchNoDocsQuery) {
             return false;
         } else if (query instanceof TermQuery) {
-            return mightMatchNonNestedDocs(((TermQuery) query).getTerm().field(), nestedPath);
+            return mightMatchNonNestedDocs(searchExecutionContext, ((TermQuery) query).getTerm().field(), nestedPath);
         } else if (query instanceof TermInSetQuery tis) {
             if (tis.getTermsCount() > 0) {
-                return mightMatchNonNestedDocs(tis.getField(), nestedPath);
+                return mightMatchNonNestedDocs(searchExecutionContext, tis.getField(), nestedPath);
             } else {
                 return false;
             }
         } else if (query instanceof PointRangeQuery) {
-            return mightMatchNonNestedDocs(((PointRangeQuery) query).getField(), nestedPath);
+            return mightMatchNonNestedDocs(searchExecutionContext, ((PointRangeQuery) query).getField(), nestedPath);
         } else if (query instanceof IndexOrDocValuesQuery) {
-            return mightMatchNonNestedDocs(((IndexOrDocValuesQuery) query).getIndexQuery(), nestedPath);
+            return mightMatchNonNestedDocs(((IndexOrDocValuesQuery) query).getIndexQuery(), nestedPath, searchExecutionContext);
         } else if (query instanceof final BooleanQuery bq) {
             final boolean hasRequiredClauses = bq.clauses().stream().anyMatch(BooleanClause::isRequired);
             if (hasRequiredClauses) {
@@ -131,13 +123,13 @@ public final class NestedHelper {
                     .stream()
                     .filter(BooleanClause::isRequired)
                     .map(BooleanClause::query)
-                    .allMatch(q -> mightMatchNonNestedDocs(q, nestedPath));
+                    .allMatch(q -> mightMatchNonNestedDocs(q, nestedPath, searchExecutionContext));
             } else {
                 return bq.clauses()
                     .stream()
                     .filter(c -> c.occur() == Occur.SHOULD)
                     .map(BooleanClause::query)
-                    .anyMatch(q -> mightMatchNonNestedDocs(q, nestedPath));
+                    .anyMatch(q -> mightMatchNonNestedDocs(q, nestedPath, searchExecutionContext));
             }
         } else {
             return true;
@@ -146,7 +138,7 @@ public final class NestedHelper {
 
     /** Returns true if a query on the given field might match parent documents
      *  or documents that are nested under a different path. */
-    boolean mightMatchNonNestedDocs(String field, String nestedPath) {
+    private static boolean mightMatchNonNestedDocs(SearchExecutionContext searchExecutionContext, String field, String nestedPath) {
         if (field.startsWith("_")) {
             // meta field. Every meta field behaves differently, eg. nested
             // documents have the same _uid as their parent, put their path in
@@ -155,9 +147,10 @@ public final class NestedHelper {
             // we might add a nested filter when it is nor required.
             return true;
         }
-        if (isMappedFieldPredicate.test(field) == false) {
+        if (searchExecutionContext.isFieldMapped(field) == false) {
             return false;
         }
+        var nestedLookup = searchExecutionContext.nestedLookup();
         String nestedParent = nestedLookup.getNestedParent(field);
         if (nestedParent == null || nestedParent.startsWith(nestedPath) == false) {
             // the field is not a sub field of the nested path

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -444,10 +444,9 @@ final class DefaultSearchContext extends SearchContext {
     public Query buildFilteredQuery(Query query) {
         List<Query> filters = new ArrayList<>();
         NestedLookup nestedLookup = searchExecutionContext.nestedLookup();
-        NestedHelper nestedHelper = new NestedHelper(nestedLookup, searchExecutionContext::isFieldMapped);
         if (nestedLookup != NestedLookup.EMPTY
-            && nestedHelper.mightMatchNestedDocs(query)
-            && (aliasFilter == null || nestedHelper.mightMatchNestedDocs(aliasFilter))) {
+            && NestedHelper.mightMatchNestedDocs(query, searchExecutionContext)
+            && (aliasFilter == null || NestedHelper.mightMatchNestedDocs(aliasFilter, searchExecutionContext))) {
             filters.add(Queries.newNonNestedFilter(searchExecutionContext.indexVersionCreated()));
         }
 

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -481,10 +481,9 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
             }
             parentBitSet = context.bitsetFilter(parentFilter);
             if (filterQuery != null) {
-                NestedHelper nestedHelper = new NestedHelper(context.nestedLookup(), context::isFieldMapped);
                 // We treat the provided filter as a filter over PARENT documents, so if it might match nested documents
                 // we need to adjust it.
-                if (nestedHelper.mightMatchNestedDocs(filterQuery)) {
+                if (NestedHelper.mightMatchNestedDocs(filterQuery, context)) {
                     // Ensure that the query only returns parent documents matching `filterQuery`
                     filterQuery = Queries.filtered(filterQuery, parentFilter);
                 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
@@ -160,10 +160,8 @@ public final class DocumentPermissions implements CacheKey {
                 failIfQueryUsesClient(queryBuilder, context);
                 Query roleQuery = context.toQuery(queryBuilder).query();
                 filter.add(roleQuery, SHOULD);
-                NestedLookup nestedLookup = context.nestedLookup();
-                if (nestedLookup != NestedLookup.EMPTY) {
-                    NestedHelper nestedHelper = new NestedHelper(nestedLookup, context::isFieldMapped);
-                    if (nestedHelper.mightMatchNestedDocs(roleQuery)) {
+                if (context.nestedLookup() != NestedLookup.EMPTY) {
+                    if (NestedHelper.mightMatchNestedDocs(roleQuery, context)) {
                         roleQuery = new BooleanQuery.Builder().add(roleQuery, FILTER)
                             .add(Queries.newNonNestedFilter(context.indexVersionCreated()), FILTER)
                             .build();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -298,15 +298,11 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
         @Override
         public Query toQuery(QueryBuilder queryBuilder) {
             Query query = ctx.toQuery(queryBuilder).query();
-            NestedLookup nestedLookup = ctx.nestedLookup();
-            if (nestedLookup != NestedLookup.EMPTY) {
-                NestedHelper nestedHelper = new NestedHelper(nestedLookup, ctx::isFieldMapped);
-                if (nestedHelper.mightMatchNestedDocs(query)) {
-                    // filter out nested documents
-                    query = new BooleanQuery.Builder().add(query, BooleanClause.Occur.MUST)
-                        .add(newNonNestedFilter(ctx.indexVersionCreated()), BooleanClause.Occur.FILTER)
-                        .build();
-                }
+            if (ctx.nestedLookup() != NestedLookup.EMPTY && NestedHelper.mightMatchNestedDocs(query, ctx)) {
+                // filter out nested documents
+                query = new BooleanQuery.Builder().add(query, BooleanClause.Occur.MUST)
+                    .add(newNonNestedFilter(ctx.indexVersionCreated()), BooleanClause.Occur.FILTER)
+                    .build();
             }
             if (aliasFilter != AliasFilter.EMPTY) {
                 Query filterQuery = ctx.toQuery(aliasFilter.getQueryBuilder()).query();


### PR DESCRIPTION
Noticed instantiating these instances taking a visible and unexpected amount of CPU in profiling when working on batched query execution (probably from bootstrapping the lambda/callsite for the predicate). This fixes the logic to effectively disappear from profiling and makes it easier to reason about as well by removing the indirect use of the search context and just explicitly passing it around. No need to instantiate instances of this thing either, escape analysis probably isn't able to remove it because of the recursive instance method calls.