### PR TITLE
[8.x] Remove bucketOrd field from InternalTerms and friends (#118044)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/BucketOrder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/BucketOrder.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
+import org.elasticsearch.search.aggregations.bucket.terms.BucketAndOrd;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 import org.elasticsearch.xcontent.ToXContentObject;
 
@@ -20,13 +21,12 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.function.ToLongFunction;
 
 /**
  * {@link Bucket} ordering strategy. Buckets can be order either as
  * "complete" buckets using {@link #comparator()} or against a combination
  * of the buckets internals with its ordinal with
- * {@link #partiallyBuiltBucketComparator(ToLongFunction, Aggregator)}.
+ * {@link #partiallyBuiltBucketComparator(Aggregator)}.
  */
 public abstract class BucketOrder implements ToXContentObject, Writeable {
     /**
@@ -102,7 +102,7 @@ public abstract class BucketOrder implements ToXContentObject, Writeable {
          * to validate this order because doing so checks all of the appropriate
          * paths.
          */
-        partiallyBuiltBucketComparator(null, aggregator);
+        partiallyBuiltBucketComparator(aggregator);
     }
 
     /**
@@ -121,7 +121,7 @@ public abstract class BucketOrder implements ToXContentObject, Writeable {
      * with it all the time.
      * </p>
      */
-    public abstract <T extends Bucket> Comparator<T> partiallyBuiltBucketComparator(ToLongFunction<T> ordinalReader, Aggregator aggregator);
+    public abstract <T extends Bucket> Comparator<BucketAndOrd<T>> partiallyBuiltBucketComparator(Aggregator aggregator);
 
     /**
      * Build a comparator for fully built buckets.

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.search.aggregations.Aggregator.BucketComparator;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
+import org.elasticsearch.search.aggregations.bucket.terms.BucketAndOrd;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.search.sort.SortValue;
@@ -31,7 +32,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
-import java.util.function.ToLongFunction;
 
 /**
  * Implementations for {@link Bucket} ordering strategies.
@@ -64,10 +64,10 @@ public abstract class InternalOrder extends BucketOrder {
         }
 
         @Override
-        public <T extends Bucket> Comparator<T> partiallyBuiltBucketComparator(ToLongFunction<T> ordinalReader, Aggregator aggregator) {
+        public <T extends Bucket> Comparator<BucketAndOrd<T>> partiallyBuiltBucketComparator(Aggregator aggregator) {
             try {
                 BucketComparator bucketComparator = path.bucketComparator(aggregator, order);
-                return (lhs, rhs) -> bucketComparator.compare(ordinalReader.applyAsLong(lhs), ordinalReader.applyAsLong(rhs));
+                return (lhs, rhs) -> bucketComparator.compare(lhs.ord, rhs.ord);
             } catch (IllegalArgumentException e) {
                 throw new AggregationExecutionException.InvalidPath("Invalid aggregation order path [" + path + "]. " + e.getMessage(), e);
             }
@@ -189,12 +189,13 @@ public abstract class InternalOrder extends BucketOrder {
         }
 
         @Override
-        public <T extends Bucket> Comparator<T> partiallyBuiltBucketComparator(ToLongFunction<T> ordinalReader, Aggregator aggregator) {
-            List<Comparator<T>> comparators = orderElements.stream()
-                .map(oe -> oe.partiallyBuiltBucketComparator(ordinalReader, aggregator))
-                .toList();
+        public <T extends Bucket> Comparator<BucketAndOrd<T>> partiallyBuiltBucketComparator(Aggregator aggregator) {
+            List<Comparator<BucketAndOrd<T>>> comparators = new ArrayList<>(orderElements.size());
+            for (BucketOrder order : orderElements) {
+                comparators.add(order.partiallyBuiltBucketComparator(aggregator));
+            }
             return (lhs, rhs) -> {
-                for (Comparator<T> c : comparators) {
+                for (Comparator<BucketAndOrd<T>> c : comparators) {
                     int result = c.compare(lhs, rhs);
                     if (result != 0) {
                         return result;
@@ -300,9 +301,9 @@ public abstract class InternalOrder extends BucketOrder {
         }
 
         @Override
-        public <T extends Bucket> Comparator<T> partiallyBuiltBucketComparator(ToLongFunction<T> ordinalReader, Aggregator aggregator) {
+        public <T extends Bucket> Comparator<BucketAndOrd<T>> partiallyBuiltBucketComparator(Aggregator aggregator) {
             Comparator<Bucket> comparator = comparator();
-            return comparator::compare;
+            return (lhs, rhs) -> comparator.compare(lhs.bucket, rhs.bucket);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BucketPriorityQueue.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BucketPriorityQueue.java
@@ -13,17 +13,17 @@ import org.elasticsearch.common.util.ObjectArrayPriorityQueue;
 
 import java.util.Comparator;
 
-public class BucketPriorityQueue<B> extends ObjectArrayPriorityQueue<B> {
+public class BucketPriorityQueue<B> extends ObjectArrayPriorityQueue<BucketAndOrd<B>> {
 
-    private final Comparator<? super B> comparator;
+    private final Comparator<BucketAndOrd<B>> comparator;
 
-    public BucketPriorityQueue(int size, BigArrays bigArrays, Comparator<? super B> comparator) {
+    public BucketPriorityQueue(int size, BigArrays bigArrays, Comparator<BucketAndOrd<B>> comparator) {
         super(size, bigArrays);
         this.comparator = comparator;
     }
 
     @Override
-    protected boolean lessThan(B a, B b) {
+    protected boolean lessThan(BucketAndOrd<B> a, BucketAndOrd<B> b) {
         return comparator.compare(a, b) > 0; // reverse, since we reverse again when adding to a list
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BucketSignificancePriorityQueue.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BucketSignificancePriorityQueue.java
@@ -12,14 +12,14 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArrayPriorityQueue;
 
-public class BucketSignificancePriorityQueue<B extends SignificantTerms.Bucket> extends ObjectArrayPriorityQueue<B> {
+public class BucketSignificancePriorityQueue<B extends SignificantTerms.Bucket> extends ObjectArrayPriorityQueue<BucketAndOrd<B>> {
 
     public BucketSignificancePriorityQueue(int size, BigArrays bigArrays) {
         super(size, bigArrays);
     }
 
     @Override
-    protected boolean lessThan(SignificantTerms.Bucket o1, SignificantTerms.Bucket o2) {
-        return o1.getSignificanceScore() < o2.getSignificanceScore();
+    protected boolean lessThan(BucketAndOrd<B> o1, BucketAndOrd<B> o2) {
+        return o1.bucket.getSignificanceScore() < o2.bucket.getSignificanceScore();
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -38,8 +38,6 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
             B read(StreamInput in, DocValueFormat format, boolean showDocCountError) throws IOException;
         }
 
-        long bucketOrd;
-
         protected long docCount;
         private long docCountError;
         protected InternalAggregations aggregations;
@@ -86,14 +84,6 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
 
         public void setDocCount(long docCount) {
             this.docCount = docCount;
-        }
-
-        public long getBucketOrd() {
-            return bucketOrd;
-        }
-
-        public void setBucketOrd(long bucketOrd) {
-            this.bucketOrd = bucketOrd;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
@@ -27,7 +27,6 @@ import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -190,7 +189,6 @@ public abstract class TermsAggregator extends DeferableBucketAggregator {
     protected final DocValueFormat format;
     protected final BucketCountThresholds bucketCountThresholds;
     protected final BucketOrder order;
-    protected final Comparator<InternalTerms.Bucket<?>> partiallyBuiltBucketComparator;
     protected final Set<Aggregator> aggsUsedForSorting;
     protected final SubAggCollectionMode collectMode;
 
@@ -209,7 +207,9 @@ public abstract class TermsAggregator extends DeferableBucketAggregator {
         super(name, factories, context, parent, metadata);
         this.bucketCountThresholds = bucketCountThresholds;
         this.order = order;
-        partiallyBuiltBucketComparator = order == null ? null : order.partiallyBuiltBucketComparator(b -> b.bucketOrd, this);
+        if (order != null) {
+            order.validate(this);
+        }
         this.format = format;
         if ((subAggsNeedScore() && descendsFromNestedAggregator(parent)) || context.isInSortOrderExecutionRequired()) {
             /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -195,12 +195,12 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 if (includeExclude != null) {
                     longFilter = includeExclude.convertToDoubleFilter();
                 }
-                resultStrategy = agg -> agg.new DoubleTermsResults(showTermDocCountError);
+                resultStrategy = agg -> agg.new DoubleTermsResults(showTermDocCountError, agg);
             } else {
                 if (includeExclude != null) {
                     longFilter = includeExclude.convertToLongFilter(valuesSourceConfig.format());
                 }
-                resultStrategy = agg -> agg.new LongTermsResults(showTermDocCountError);
+                resultStrategy = agg -> agg.new LongTermsResults(showTermDocCountError, agg);
             }
             return new NumericTermsAggregator(
                 name,
@@ -403,7 +403,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                     name,
                     factories,
                     new MapStringTermsAggregator.ValuesSourceCollectorSource(valuesSourceConfig),
-                    a -> a.new StandardTermsResults(valuesSourceConfig.getValuesSource()),
+                    a -> a.new StandardTermsResults(valuesSourceConfig.getValuesSource(), a),
                     order,
                     valuesSourceConfig.format(),
                     bucketCountThresholds,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -37,9 +37,6 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
     public static final TermsComparator TERMS_COMPARATOR = new TermsComparator();
 
     public static class Bucket extends AbstractInternalTerms.AbstractTermsBucket<Bucket> {
-
-        long bucketOrd;
-
         protected long docCount;
         protected InternalAggregations aggregations;
         private long docCountError;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Remove bucketOrd field from InternalTerms and friends (#118044)