### PR TITLE
[8.16] Adds warning to Create inference API page (#118073)

### DIFF
--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -10,7 +10,6 @@ Creates an {infer} endpoint to perform an {infer} task.
 * For built-in models and models uploaded through Eland, the {infer} APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the {infer} APIs to use these models or if you want to use non-NLP models, use the <<ml-df-trained-models-apis>>.
 ====
 
-
 [discrete]
 [[put-inference-api-request]]
 ==== {api-request-title}
@@ -46,6 +45,14 @@ Refer to the service list in the <<put-inference-api-desc,API description sectio
 ==== {api-description-title}
 
 The create {infer} API enables you to create an {infer} endpoint and configure a {ml} model to perform a specific {infer} task.
+
+[IMPORTANT]
+====
+* When creating an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
+* After creating the endpoint, wait for the model deployment to complete before using it. You can verify the deployment status by using the <<get-trained-models-stats, Get trained model statistics>> API. In the response, look for `"state": "fully_allocated"` and ensure the `"allocation_count"` matches the `"target_allocation_count"`.
+* Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
+====
+
 
 The following services are available through the {infer} API.
 You can find the available task types next to the service name. 


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Adds warning to Create inference API page (#118073)