### PR TITLE
[8.x] Wrap jackson exception on malformed json string (#114445)

### DIFF
--- a/docs/changelog/114445.yaml
+++ b/docs/changelog/114445.yaml
@@ -1,0 +1,6 @@
+pr: 114445
+summary: Wrap jackson exception on malformed json string
+area: Infra/Core
+type: bug
+issues:
+ - 114142

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
@@ -108,7 +108,11 @@ public class JsonXContentParser extends AbstractXContentParser {
         if (currentToken().isValue() == false) {
             throwOnNoText();
         }
-        return parser.getText();
+        try {
+            return parser.getText();
+        } catch (JsonParseException e) {
+            throw newXContentParseException(e);
+        }
     }
 
     private void throwOnNoText() {

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/BulkRestIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/BulkRestIT.java
@@ -74,8 +74,7 @@ public class BulkRestIT extends HttpSmokeTestCase {
 
         ResponseException responseException = expectThrows(ResponseException.class, () -> getRestClient().performRequest(request));
         assertThat(responseException.getResponse().getStatusLine().getStatusCode(), equalTo(BAD_REQUEST.getStatus()));
-        assertThat(responseException.getMessage(), containsString("could not parse bulk request body"));
-        assertThat(responseException.getMessage(), containsString("json_parse_exception"));
+        assertThat(responseException.getMessage(), containsString("x_content_parse_exception"));
         assertThat(responseException.getMessage(), containsString("Invalid UTF-8"));
     }
 

--- a/server/src/test/java/org/elasticsearch/common/xcontent/json/JsonXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/json/JsonXContentTests.java
@@ -11,6 +11,9 @@ package org.elasticsearch.common.xcontent.json;
 
 import org.elasticsearch.common.xcontent.BaseXContentTestCase;
 import org.elasticsearch.xcontent.XContentGenerator;
+import org.elasticsearch.xcontent.XContentParseException;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
@@ -27,5 +30,15 @@ public class JsonXContentTests extends BaseXContentTestCase {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         XContentGenerator generator = JsonXContent.jsonXContent.createGenerator(os);
         doTestBigInteger(generator, os);
+    }
+
+    public void testMalformedJsonFieldThrowsXContentException() throws Exception {
+        String json = "{\"test\":\"/*/}";
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, json)) {
+            parser.nextToken();
+            parser.nextToken();
+            parser.nextToken();
+            assertThrows(XContentParseException.class, () -> parser.text());
+        }
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Wrap jackson exception on malformed json string (#114445)