### PR TITLE
Prototype: Semantic search in ES|QL with query rewrite

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ResolvedIndices.java
+++ b/server/src/main/java/org/elasticsearch/action/ResolvedIndices.java
@@ -52,7 +52,7 @@ public class ResolvedIndices {
         this.searchContextId = searchContextId;
     }
 
-    ResolvedIndices(
+    public ResolvedIndices(
         Map<String, OriginalIndices> remoteClusterIndices,
         @Nullable OriginalIndices localIndices,
         Map<Index, IndexMetadata> localIndexMetadata

--- a/x-pack/plugin/esql-core/build.gradle
+++ b/x-pack/plugin/esql-core/build.gradle
@@ -6,7 +6,7 @@ esplugin {
   name 'x-pack-esql-core'
   description 'Elasticsearch infrastructure plugin for ESQL'
   classname 'org.elasticsearch.xpack.esql.core.plugin.EsqlCorePlugin'
-  extendedPlugins = ['x-pack-core']
+  extendedPlugins = ['x-pack-core', 'x-pack-ml']
 }
 
 base {
@@ -17,6 +17,7 @@ dependencies {
   api "org.antlr:antlr4-runtime:${versions.antlr4}"
   api project(path: xpackModule('mapper-version'))
   compileOnly project(path: xpackModule('core'))
+  compileOnly project(path: xpackModule('ml'))
   testApi(project(xpackModule('esql-core:test-fixtures'))) {
     exclude group: 'org.elasticsearch.plugin', module: 'esql-core'
   }

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/querydsl/query/ChickenQueryBuilder.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/querydsl/query/ChickenQueryBuilder.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.core.querydsl.query;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.join.ScoreMode;
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.action.ResolvedIndices;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.InferenceFieldMetadata;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.MatchNoneQueryBuilder;
+import org.elasticsearch.index.query.NestedQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.QueryRewriteContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.inference.InferenceResults;
+import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.inference.InputType;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.search.vectors.KnnVectorQueryBuilder;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.inference.action.InferenceAction;
+import org.elasticsearch.xpack.core.ml.action.InferModelAction;
+import org.elasticsearch.xpack.core.ml.inference.results.ErrorInferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.results.MlTextEmbeddingResults;
+import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResults;
+import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+/*
+ This is a blatant copy of SemanticQueryBuilder which we cannot use since it lives in the
+ inference plugin which we cannot extend since it creates all sorts of "fun" dependency problems.
+ We are adding this here just to show that querying semantic text fields should just work if
+ we allow for query rewrites on the coordinator.
+ This query builder won't be added in a final implementation.
+ Instead, we will continue to use MatchQueryBuilder which in the future will support semantic_text.
+ */
+
+public class ChickenQueryBuilder extends AbstractQueryBuilder<ChickenQueryBuilder> {
+    public static final String NAME = "chicken";
+    private final String fieldName;
+    private final String query;
+    private final InferenceResults inferenceResults;
+    private final boolean noInferenceResults;
+    private final SetOnce<InferenceServiceResults> inferenceResultsSupplier;
+
+    private static final ParseField FIELD_FIELD = new ParseField("field");
+    private static final ParseField QUERY_FIELD = new ParseField("query");
+
+    private static final ConstructingObjectParser<ChickenQueryBuilder, Void> PARSER = new ConstructingObjectParser<>(
+        NAME,
+        false,
+        args -> new ChickenQueryBuilder((String) args[0], (String) args[1])
+    );
+
+    static {
+        PARSER.declareString(constructorArg(), FIELD_FIELD);
+        PARSER.declareString(constructorArg(), QUERY_FIELD);
+        declareStandardFields(PARSER);
+    }
+
+    public ChickenQueryBuilder(String fieldName, String query) {
+        this.fieldName = fieldName;
+        this.query = query;
+        this.inferenceResults = null;
+        this.inferenceResultsSupplier = null;
+        this.noInferenceResults = false;
+    }
+
+    private ChickenQueryBuilder(
+        ChickenQueryBuilder other,
+        SetOnce<InferenceServiceResults> inferenceResultsSupplier,
+        InferenceResults inferenceResults,
+        boolean noInferenceResults
+    ) {
+        this.fieldName = other.fieldName;
+        this.query = other.query;
+        this.boost = other.boost;
+        this.queryName = other.queryName;
+        this.inferenceResultsSupplier = inferenceResultsSupplier;
+        this.inferenceResults = inferenceResults;
+        this.noInferenceResults = noInferenceResults;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return TransportVersions.V_8_15_0;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeString(query);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.field(FIELD_FIELD.getPreferredName(), fieldName);
+        builder.field(QUERY_FIELD.getPreferredName(), query);
+        builder.endObject();
+    }
+
+    @Override
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
+        return null;
+    }
+
+    @Override
+    protected boolean doEquals(ChickenQueryBuilder other) {
+        return Objects.equals(fieldName, other.fieldName)
+            && Objects.equals(query, other.query)
+            && Objects.equals(inferenceResults, other.inferenceResults);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(fieldName, query, inferenceResults);
+    }
+
+    @Override
+    protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        SearchExecutionContext searchExecutionContext = queryRewriteContext.convertToSearchExecutionContext();
+        if (searchExecutionContext != null) {
+            return doRewriteBuildChickenQuery(searchExecutionContext);
+        }
+
+        return doRewriteGetInferenceResults(queryRewriteContext);
+    }
+
+    private QueryBuilder doRewriteBuildChickenQuery(SearchExecutionContext searchExecutionContext) {
+        MappedFieldType fieldType = searchExecutionContext.getFieldType(fieldName);
+
+        if (fieldType == null) {
+            return new MatchNoneQueryBuilder();
+        }
+        if (fieldType.typeName().equals("semantic_text")) {
+
+            if (inferenceResults == null) {
+                // This should never happen, but throw on it in case it ever does
+                throw new IllegalStateException("No inference results set for [semantic_text] field [" + fieldName + "]");
+            }
+
+            return semanticQuery(inferenceResults, fieldName);
+
+        } else {
+            throw new IllegalArgumentException(
+                "Field [" + fieldName + "] of type [" + fieldType.typeName() + "] does not support " + NAME + " queries"
+            );
+        }
+    }
+
+    private QueryBuilder doRewriteGetInferenceResults(QueryRewriteContext queryRewriteContext) {
+        if (inferenceResults != null || noInferenceResults) {
+            return this;
+        }
+
+        if (inferenceResultsSupplier != null) {
+            InferenceResults inferenceResults = validateAndConvertInferenceResults(inferenceResultsSupplier, fieldName);
+            return inferenceResults != null ? new ChickenQueryBuilder(this, null, inferenceResults, noInferenceResults) : this;
+        }
+
+        ResolvedIndices resolvedIndices = queryRewriteContext.getResolvedIndices();
+        if (resolvedIndices == null) {
+            throw new IllegalStateException(
+                "Rewriting on the coordinator node requires a query rewrite context with non-null resolved indices"
+            );
+        } else if (resolvedIndices.getRemoteClusterIndices().isEmpty() == false) {
+            throw new IllegalArgumentException(NAME + " query does not support cross-cluster search");
+        }
+
+        String inferenceId = getInferenceIdForForField(resolvedIndices.getConcreteLocalIndicesMetadata().values(), fieldName);
+        SetOnce<InferenceServiceResults> inferenceResultsSupplier = new SetOnce<>();
+        boolean noInferenceResults = false;
+        if (inferenceId != null) {
+            InferenceAction.Request inferenceRequest = new InferenceAction.Request(
+                TaskType.ANY,
+                inferenceId,
+                null,
+                List.of(query),
+                Map.of(),
+                InputType.SEARCH,
+                InferModelAction.Request.DEFAULT_TIMEOUT_FOR_API,
+                false
+            );
+
+            queryRewriteContext.registerAsyncAction(
+                (client, listener) -> executeAsyncWithOrigin(
+                    client,
+                    ML_ORIGIN,
+                    InferenceAction.INSTANCE,
+                    inferenceRequest,
+                    listener.delegateFailureAndWrap((l, inferenceResponse) -> {
+                        inferenceResultsSupplier.set(inferenceResponse.getResults());
+                        l.onResponse(null);
+                    })
+                )
+            );
+        } else {
+            // The inference ID can be null if either the field name or index name(s) are invalid (or both).
+            // If this happens, we set the "no inference results" flag to true so the rewrite process can continue.
+            // Invalid index names will be handled in the transport layer, when the query is sent to the shard.
+            // Invalid field names will be handled when the query is re-written on the shard, where we have access to the index mappings.
+            noInferenceResults = true;
+        }
+
+        return new ChickenQueryBuilder(this, noInferenceResults ? null : inferenceResultsSupplier, null, noInferenceResults);
+    }
+
+    private static InferenceResults validateAndConvertInferenceResults(
+        SetOnce<InferenceServiceResults> inferenceResultsSupplier,
+        String fieldName
+    ) {
+        InferenceServiceResults inferenceServiceResults = inferenceResultsSupplier.get();
+        if (inferenceServiceResults == null) {
+            return null;
+        }
+
+        List<? extends InferenceResults> inferenceResultsList = inferenceServiceResults.transformToCoordinationFormat();
+        if (inferenceResultsList.isEmpty()) {
+            throw new IllegalArgumentException("No inference results retrieved for field [" + fieldName + "]");
+        } else if (inferenceResultsList.size() > 1) {
+            // The inference call should truncate if the query is too large.
+            // Thus, if we receive more than one inference result, it is a server-side error.
+            throw new IllegalStateException(inferenceResultsList.size() + " inference results retrieved for field [" + fieldName + "]");
+        }
+
+        InferenceResults inferenceResults = inferenceResultsList.get(0);
+        if (inferenceResults instanceof ErrorInferenceResults errorInferenceResults) {
+            throw new IllegalStateException(
+                "Field [" + fieldName + "] query inference error: " + errorInferenceResults.getException().getMessage(),
+                errorInferenceResults.getException()
+            );
+        } else if (inferenceResults instanceof WarningInferenceResults warningInferenceResults) {
+            throw new IllegalStateException("Field [" + fieldName + "] query inference warning: " + warningInferenceResults.getWarning());
+        } else if (inferenceResults instanceof TextExpansionResults == false
+            && inferenceResults instanceof MlTextEmbeddingResults == false) {
+                throw new IllegalArgumentException(
+                    "Field ["
+                        + fieldName
+                        + "] expected query inference results to be of type ["
+                        + TextExpansionResults.NAME
+                        + "] or ["
+                        + MlTextEmbeddingResults.NAME
+                        + "], got ["
+                        + inferenceResults.getWriteableName()
+                        + "]. Has the inference endpoint configuration changed?"
+                );
+            }
+
+        return inferenceResults;
+    }
+
+    private static String getInferenceIdForForField(Collection<IndexMetadata> indexMetadataCollection, String fieldName) {
+        String inferenceId = null;
+        for (IndexMetadata indexMetadata : indexMetadataCollection) {
+            InferenceFieldMetadata inferenceFieldMetadata = indexMetadata.getInferenceFields().get(fieldName);
+            String indexInferenceId = inferenceFieldMetadata != null ? inferenceFieldMetadata.getSearchInferenceId() : null;
+            if (indexInferenceId != null) {
+                if (inferenceId != null && inferenceId.equals(indexInferenceId) == false) {
+                    throw new IllegalArgumentException("Field [" + fieldName + "] has multiple inference IDs associated with it");
+                }
+
+                inferenceId = indexInferenceId;
+            }
+        }
+
+        return inferenceId;
+    }
+
+    private static QueryBuilder semanticQuery(InferenceResults inferenceResults, String name) {
+        QueryBuilder childQueryBuilder = null;
+
+        if (inferenceResults instanceof TextExpansionResults) {
+            childQueryBuilder = textExpansionQueryBuilder((TextExpansionResults) inferenceResults, name);
+        } else if (inferenceResults instanceof MlTextEmbeddingResults) {
+            childQueryBuilder = knnQueryBuilder((MlTextEmbeddingResults) inferenceResults, name);
+        } else {
+            // This should never happen, but we handle it here either way
+            return new MatchNoneQueryBuilder();
+        }
+
+        String nestedFieldPath = name.concat(".inference.chunks");
+        return new NestedQueryBuilder(nestedFieldPath, childQueryBuilder, ScoreMode.Max);
+    }
+
+    private static QueryBuilder textExpansionQueryBuilder(TextExpansionResults textExpansionResults, String name) {
+        BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
+        for (var weightedToken : textExpansionResults.getWeightedTokens()) {
+            boolQuery.should(QueryBuilders.termQuery(embeddingsFieldName(name), weightedToken.token()).boost(weightedToken.weight()));
+        }
+        boolQuery.minimumShouldMatch(1);
+        return boolQuery;
+    }
+
+    private static QueryBuilder knnQueryBuilder(MlTextEmbeddingResults textEmbeddingResults, String name) {
+        float[] inference = textEmbeddingResults.getInferenceAsFloat();
+        return new KnnVectorQueryBuilder(embeddingsFieldName(name), inference, null, null, null);
+    }
+
+    private static String embeddingsFieldName(String name) {
+        return name.concat(".inference.chunks.embeddings");
+    }
+}

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/querydsl/query/ResolvedQueryBuilder.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/querydsl/query/ResolvedQueryBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.core.querydsl.query;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class ResolvedQueryBuilder extends Query {
+
+    private final QueryBuilder queryBuilder;
+
+    public ResolvedQueryBuilder(Source source, QueryBuilder queryBuilder) {
+        super(source);
+        this.queryBuilder = queryBuilder;
+    }
+
+    @Override
+    public QueryBuilder asBuilder() {
+        return queryBuilder;
+    }
+
+    @Override
+    protected String innerToString() {
+        return queryBuilder.toString();
+    }
+}

--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -22,7 +22,7 @@ esplugin {
   name 'x-pack-esql'
   description 'The plugin that powers ESQL for Elasticsearch'
   classname 'org.elasticsearch.xpack.esql.plugin.EsqlPlugin'
-  extendedPlugins = ['x-pack-esql-core', 'lang-painless', 'x-pack-ml']
+  extendedPlugins = ['x-pack-esql-core', 'lang-painless']
 }
 
 base {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
@@ -197,3 +197,62 @@ emp_no:integer | first_name:keyword | last_name:keyword
 10041          | Uri                 | Lenart         
 10043          | Yishay              | Tzvieli        
 ;
+
+testMatchWithSemanticText
+required_capability: match_function
+required_capability: semantic_text_type
+
+from semantic_text
+| where match(semantic_text_field, "something")
+| keep semantic_text_field
+| sort semantic_text_field asc
+;
+
+semantic_text_field:semantic_text
+all we have to decide is what to do with the time that is given to us
+be excellent to each other
+live long and prosper
+;
+
+
+testMatchWithSemanticTextMultiValueField
+required_capability: match_function
+required_capability: semantic_text_type
+
+from semantic_text metadata _id
+| where match(st_multi_value, "something") AND match(host, "host1")
+| keep _id, st_multi_value
+;
+
+_id: keyword | st_multi_value:semantic_text
+1            | ["Hello there!", "This is a random value", "for testing purposes"]
+;
+
+testMatchWithSemanticTextWithEvalsAndOtherFunctionsAndStats
+required_capability: match_function
+required_capability: semantic_text_type
+
+from semantic_text
+| where qstr("description:some*")
+| eval size = mv_count(st_multi_value)
+| where match(semantic_text_field, "something") AND size > 1 AND match(host, "host1")
+| STATS result = count(*)
+;
+
+result:long
+1
+;
+
+testMatchWithSemanticTextAndKql
+required_capability: match_function
+required_capability: semantic_text_type
+required_capability: kql_function
+
+from semantic_text
+| where kql("host:host1") AND match(semantic_text_field, "something")
+| KEEP host, semantic_text_field
+;
+
+host:keyword | semantic_text_field:semantic_text
+"host1"      | live long and prosper
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
 import org.elasticsearch.xpack.esql.session.Configuration;
 import org.elasticsearch.xpack.esql.session.EsqlSession;
 import org.elasticsearch.xpack.esql.session.IndexResolver;
+import org.elasticsearch.xpack.esql.session.QueryBuilderRewriter;
 import org.elasticsearch.xpack.esql.session.Result;
 import org.elasticsearch.xpack.esql.stats.Metrics;
 import org.elasticsearch.xpack.esql.stats.PlanningMetrics;
@@ -59,6 +60,7 @@ public class PlanExecutor {
         EsqlExecutionInfo executionInfo,
         IndicesExpressionGrouper indicesExpressionGrouper,
         EsqlSession.PlanRunner planRunner,
+        QueryBuilderRewriter queryBuilderRewriter,
         ActionListener<Result> listener
     ) {
         final PlanningMetrics planningMetrics = new PlanningMetrics();
@@ -73,7 +75,8 @@ public class PlanExecutor {
             mapper,
             verifier,
             planningMetrics,
-            indicesExpressionGrouper
+            indicesExpressionGrouper,
+            queryBuilderRewriter
         );
         QueryMetric clientId = QueryMetric.fromString("rest");
         metrics.total(clientId);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlExpressionTranslators.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlExpressionTranslators.java
@@ -24,7 +24,6 @@ import org.elasticsearch.xpack.esql.core.planner.ExpressionTranslator;
 import org.elasticsearch.xpack.esql.core.planner.ExpressionTranslators;
 import org.elasticsearch.xpack.esql.core.planner.TranslatorHandler;
 import org.elasticsearch.xpack.esql.core.querydsl.query.MatchAll;
-import org.elasticsearch.xpack.esql.core.querydsl.query.MatchQuery;
 import org.elasticsearch.xpack.esql.core.querydsl.query.NotQuery;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
 import org.elasticsearch.xpack.esql.core.querydsl.query.QueryStringQuery;
@@ -531,7 +530,7 @@ public final class EsqlExpressionTranslators {
     public static class MatchFunctionTranslator extends ExpressionTranslator<Match> {
         @Override
         protected Query asQuery(Match match, TranslatorHandler handler) {
-            return new MatchQuery(match.source(), ((FieldAttribute) match.field()).name(), match.queryAsText());
+            return match.asQuery();
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.esql.enrich.LookupFromIndexService;
 import org.elasticsearch.xpack.esql.execution.PlanExecutor;
 import org.elasticsearch.xpack.esql.session.Configuration;
 import org.elasticsearch.xpack.esql.session.EsqlSession.PlanRunner;
+import org.elasticsearch.xpack.esql.session.QueryBuilderRewriter;
 import org.elasticsearch.xpack.esql.session.Result;
 
 import java.io.IOException;
@@ -68,6 +69,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
     private final LookupFromIndexService lookupFromIndexService;
     private final AsyncTaskManagementService<EsqlQueryRequest, EsqlQueryResponse, EsqlQueryTask> asyncTaskManagementService;
     private final RemoteClusterService remoteClusterService;
+    private final QueryBuilderRewriter queryBuilderRewriter;
 
     @Inject
     @SuppressWarnings("this-escape")
@@ -121,6 +123,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             bigArrays
         );
         this.remoteClusterService = transportService.getRemoteClusterService();
+        this.queryBuilderRewriter = new QueryBuilderRewriter(searchService, clusterService);
     }
 
     @Override
@@ -191,6 +194,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             executionInfo,
             remoteClusterService,
             planRunner,
+            queryBuilderRewriter,
             listener.map(result -> toResponse(task, request, configuration, result))
         );
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/QueryBuilderRewriter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/QueryBuilderRewriter.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.session;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.ResolvedIndices;
+import org.elasticsearch.action.support.GroupedActionListener;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryRewriteContext;
+import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.search.SearchService;
+import org.elasticsearch.xpack.esql.expression.function.fulltext.Match;
+import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+
+// TODO: needs a better name than QueryBuilderRewriter???
+public class QueryBuilderRewriter {
+    private final SearchService searchService;
+    private final ClusterService clusterService;
+
+    public QueryBuilderRewriter(SearchService searchService, ClusterService clusterService) {
+        this.searchService = searchService;
+        this.clusterService = clusterService;
+    }
+
+    public void rewriteQueryBuilders(
+        LogicalPlan plan,
+        ActionListener<Result> listener,
+        BiConsumer<LogicalPlan, ActionListener<Result>> callback
+    ) {
+        Map<Index, IndexMetadata> indexMetadata = new HashMap<>();
+        Set<Match> functions = fullTextFunctions(plan);
+
+        Set<String> indexNames = indexNames(plan);
+        if (indexNames == null || indexNames.size() == 0 || functions.size() == 0) {
+            callback.accept(plan, listener);
+            return;
+        }
+
+        for (String indexName : indexNames(plan)) {
+            Index index = new Index(indexName, clusterService.state().metadata().index(indexName).getIndexUUID());
+            indexMetadata.put(index, clusterService.state().metadata().index(indexName));
+        }
+
+        /*
+            We might need to refactor ResolvedIndices into a base class - and for the search DSL we can subclass it because
+            it does more than what `QueryRewriteContext` needs.
+            Here I am passing an empty map for the first argument and null for the second.
+            That's because I know QueryRewriteContext does not actually need them.
+         */
+        Map<String, OriginalIndices> originalIndicesMap = new HashMap<>();
+        ResolvedIndices resolvedIndices = new ResolvedIndices(originalIndicesMap, null, indexMetadata);
+
+        QueryRewriteContext ctx = searchService.getRewriteContext(() -> System.currentTimeMillis(), resolvedIndices, null);
+
+        // this should be for all FullTextFunctions - not just Match
+        ConcurrentMap<Match, QueryBuilder> results = new ConcurrentHashMap<>();
+
+        GroupedActionListener<QueryBuilder> actionListener = new GroupedActionListener<>(
+            functions.size(),
+            new ActionListener<Collection<QueryBuilder>>() {
+                @Override
+                public void onResponse(Collection<QueryBuilder> ignored) {
+                    try {
+                        LogicalPlan newPlan = updatedPlan(plan, results);
+                        callback.accept(newPlan, listener);
+                    } catch (Exception e) {
+                        onFailure(e);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            }
+        );
+
+        for (Match fullTextFunction : functions) {
+            QueryBuilder queryBuilder = fullTextFunction.asQuery().asBuilder();
+
+            // We might want to have special handling for onFailure because the error message we return back
+            // should also include for which function the failure happened.
+            Rewriteable.rewriteAndFetch(queryBuilder, ctx, actionListener.delegateFailureAndWrap((next, nextQueryBuilder) -> {
+                // store nextQueryBuilder
+                results.put(fullTextFunction, nextQueryBuilder);
+                next.onResponse(nextQueryBuilder);
+            }));
+        }
+
+    }
+
+    public LogicalPlan updatedPlan(LogicalPlan plan, ConcurrentMap<Match, QueryBuilder> newQueryBuilders) {
+        LogicalPlan newPlan = plan.transformExpressionsDown(Match.class, m -> {
+            if (newQueryBuilders.keySet().contains(m)) {
+                return m.newWithQueryBuilder(newQueryBuilders.get(m));
+            }
+            return m;
+        });
+        newPlan.setAnalyzed();
+        return newPlan;
+    }
+
+    public Set<Match> fullTextFunctions(LogicalPlan plan) {
+        Set<Match> functions = new HashSet<>();
+        plan.forEachExpressionDown(Match.class, match -> functions.add(match));
+        return functions;
+    }
+
+    public Set<String> indexNames(LogicalPlan analyzedPlan) {
+        AtomicReference<Set<String>> indexNames = new AtomicReference<>();
+        analyzedPlan.forEachDown(EsRelation.class, esRelation -> { indexNames.set(esRelation.index().concreteIndices()); });
+
+        return indexNames.get();
+    }
+}


### PR DESCRIPTION
A prototype for an alternative to #116253 

This allows using `match` on `semantic_text` fields, but without the need to reimplement the logic for getting the inference results in ES|QL.
This leverages the same model of query rewrite phase we already have in _search on the coordinator.

I added a `ChickenQueryBuilder` to show that semantic search actually works, but what we actually want is to continue to use `MatchQueryBuilder` when the `match` query starts supporting `semantic_text` (which is in progress).
It also shows the two types of query rewrites that happen under the hood for semantic text, but those would not be directly exposed in ES|QL.

The nice thing about this approach is that we can reuse it when we add a `knn` function and we want to do something similar to the `query_vector_builder`:
```
{
  "knn": {
    "field": "dense-vector-field",
    "k": 10,
    "num_candidates": 100,
    "query_vector_builder": {
      "text_embedding": { 
        "model_id": "my-text-embedding-model",
        "model_text": "The opposite of blue" 
      }
    }
  }
}
```
Here the argument of `knn` is not a vector, but a text query with a specified `model_id` to transform the query text into a vector. We could use the same approach of having a `QueryBuilder` that gets a rewrite phase on the coordinator to get the embeddings. Then at least for knn, we do not have a requirement to have the concept of async functions in ES|QL.

While this PR is cutting a lot of corners I want to get some high level feedback on a few questions:

- do we agree that having a query builder rewrite phase is a better approach than #116253?
- I have put the query rewrite phase after the plan is analyzed (and optimized) in `EsqlSession` - is the a better place for it?
- with this approach every `FullTextFunction` would store its own `QueryBuilder` that would get rewritten on the coordinator. I guess we want every `FullTextFunction` to control the function -> query builder translation, but storing the `QueryBuilder` in the `FullTextFunction` takes this idea a bit further than some might expect

If we agree with this high level approach, the plan would be to split this into multiple phases:

1. All `FullTextFunction` will own their translation to Lucene queries and `FullTextFunction` instances will store their query builder.
2. Introduce the query rewrite phase on the coordinator that would rewrite the initial `QueryBuilder`s for `FullTextFunction`s and rewrite the `FullTextFunction` nodes with rewritten `QueryBuilder`s.
3. Finally - when `MatchQueryBuilder` supports semantic text, enable the `match` function to receive `semantic_text` fields to perform semantic search.



