### PR TITLE
Remove released vs unreleased distinction from VersionUtils

### DIFF
--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -86,7 +86,6 @@ tasks.named("thirdPartyAudit").configure {
 tasks.named("test").configure {
   systemProperty 'tests.gradle_index_compat_versions', buildParams.bwcVersions.indexCompatible.join(',')
   systemProperty 'tests.gradle_wire_compat_versions', buildParams.bwcVersions.wireCompatible.join(',')
-  systemProperty 'tests.gradle_unreleased_versions', buildParams.bwcVersions.unreleased.join(',')
 }
 
 tasks.register("integTest", Test) {

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -12,132 +12,15 @@ package org.elasticsearch.test;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.Tuple;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /** Utilities for selecting versions in tests */
 public class VersionUtils {
 
-    /**
-     * Sort versions that have backwards compatibility guarantees from
-     * those that don't. Doesn't actually check whether or not the versions
-     * are released, instead it relies on gradle to have already checked
-     * this which it does in {@code :core:verifyVersions}. So long as the
-     * rules here match up with the rules in gradle then this should
-     * produce sensible results.
-     * @return a tuple containing versions with backwards compatibility
-     * guarantees in v1 and versions without the guranteees in v2
-     */
-    static Tuple<List<Version>, List<Version>> resolveReleasedVersions(Version current, Class<?> versionClass) {
-        // group versions into major version
-        Map<Integer, List<Version>> majorVersions = Version.getDeclaredVersions(versionClass)
-            .stream()
-            .collect(Collectors.groupingBy(v -> (int) v.major));
-        // this breaks b/c 5.x is still in version list but master doesn't care about it!
-        // assert majorVersions.size() == 2;
-        // TODO: remove oldVersions, we should only ever have 2 majors in Version
-        List<List<Version>> oldVersions = splitByMinor(majorVersions.getOrDefault((int) current.major - 2, Collections.emptyList()));
-        List<List<Version>> previousMajor = splitByMinor(majorVersions.get((int) current.major - 1));
-        List<List<Version>> currentMajor = splitByMinor(majorVersions.get((int) current.major));
-
-        List<Version> unreleasedVersions = new ArrayList<>();
-        final List<List<Version>> stableVersions;
-        if (currentMajor.size() == 1) {
-            // on master branch
-            stableVersions = previousMajor;
-            // remove current
-            moveLastToUnreleased(currentMajor, unreleasedVersions);
-        } else {
-            // on a stable or release branch, ie N.x
-            stableVersions = currentMajor;
-            // remove the next maintenance bugfix
-            moveLastToUnreleased(previousMajor, unreleasedVersions);
-        }
-
-        // remove next minor
-        Version lastMinor = moveLastToUnreleased(stableVersions, unreleasedVersions);
-        if (lastMinor.revision == 0) {
-            if (stableVersions.get(stableVersions.size() - 1).size() == 1) {
-                // a minor is being staged, which is also unreleased
-                moveLastToUnreleased(stableVersions, unreleasedVersions);
-            }
-            // remove the next bugfix
-            if (stableVersions.isEmpty() == false) {
-                moveLastToUnreleased(stableVersions, unreleasedVersions);
-            }
-        }
-
-        // If none of the previous major was released, then the last minor and bugfix of the old version was not released either.
-        if (previousMajor.isEmpty()) {
-            assert currentMajor.isEmpty() : currentMajor;
-            // minor of the old version is being staged
-            moveLastToUnreleased(oldVersions, unreleasedVersions);
-            // bugix of the old version is also being staged
-            moveLastToUnreleased(oldVersions, unreleasedVersions);
-        }
-        List<Version> releasedVersions = Stream.of(oldVersions, previousMajor, currentMajor)
-            .flatMap(List::stream)
-            .flatMap(List::stream)
-            .collect(Collectors.toList());
-        Collections.sort(unreleasedVersions); // we add unreleased out of order, so need to sort here
-        return new Tuple<>(Collections.unmodifiableList(releasedVersions), Collections.unmodifiableList(unreleasedVersions));
-    }
-
-    // split the given versions into sub lists grouped by minor version
-    private static List<List<Version>> splitByMinor(List<Version> versions) {
-        Map<Integer, List<Version>> byMinor = versions.stream().collect(Collectors.groupingBy(v -> (int) v.minor));
-        return byMinor.entrySet().stream().sorted(Map.Entry.comparingByKey()).map(Map.Entry::getValue).collect(Collectors.toList());
-    }
-
-    // move the last version of the last minor in versions to the unreleased versions
-    private static Version moveLastToUnreleased(List<List<Version>> versions, List<Version> unreleasedVersions) {
-        List<Version> lastMinor = new ArrayList<>(versions.get(versions.size() - 1));
-        Version lastVersion = lastMinor.remove(lastMinor.size() - 1);
-        if (lastMinor.isEmpty()) {
-            versions.remove(versions.size() - 1);
-        } else {
-            versions.set(versions.size() - 1, lastMinor);
-        }
-        unreleasedVersions.add(lastVersion);
-        return lastVersion;
-    }
-
-    private static final List<Version> RELEASED_VERSIONS;
-    private static final List<Version> UNRELEASED_VERSIONS;
-    private static final List<Version> ALL_VERSIONS;
-
-    static {
-        Tuple<List<Version>, List<Version>> versions = resolveReleasedVersions(Version.CURRENT, Version.class);
-        RELEASED_VERSIONS = versions.v1();
-        UNRELEASED_VERSIONS = versions.v2();
-        List<Version> allVersions = new ArrayList<>(RELEASED_VERSIONS.size() + UNRELEASED_VERSIONS.size());
-        allVersions.addAll(RELEASED_VERSIONS);
-        allVersions.addAll(UNRELEASED_VERSIONS);
-        Collections.sort(allVersions);
-        ALL_VERSIONS = Collections.unmodifiableList(allVersions);
-    }
-
-    /**
-     * Returns an immutable, sorted list containing all released versions.
-     */
-    public static List<Version> allReleasedVersions() {
-        return RELEASED_VERSIONS;
-    }
-
-    /**
-     * Returns an immutable, sorted list containing all unreleased versions.
-     */
-    public static List<Version> allUnreleasedVersions() {
-        return UNRELEASED_VERSIONS;
-    }
+    private static final List<Version> ALL_VERSIONS = Version.getDeclaredVersions(Version.class);
 
     /**
      * Returns an immutable, sorted list containing all versions, both released and unreleased.
@@ -147,16 +30,16 @@ public class VersionUtils {
     }
 
     /**
-     * Get the released version before {@code version}.
+     * Get the version before {@code version}.
      */
     public static Version getPreviousVersion(Version version) {
-        for (int i = RELEASED_VERSIONS.size() - 1; i >= 0; i--) {
-            Version v = RELEASED_VERSIONS.get(i);
+        for (int i = ALL_VERSIONS.size() - 1; i >= 0; i--) {
+            Version v = ALL_VERSIONS.get(i);
             if (v.before(version)) {
                 return v;
             }
         }
-        throw new IllegalArgumentException("couldn't find any released versions before [" + version + "]");
+        throw new IllegalArgumentException("couldn't find any versions before [" + version + "]");
     }
 
     /**
@@ -169,22 +52,22 @@ public class VersionUtils {
     }
 
     /**
-     * Returns the released {@link Version} before the {@link Version#CURRENT}
+     * Returns the {@link Version} before the {@link Version#CURRENT}
      * where the minor version is less than the currents minor version.
      */
     public static Version getPreviousMinorVersion() {
-        for (int i = RELEASED_VERSIONS.size() - 1; i >= 0; i--) {
-            Version v = RELEASED_VERSIONS.get(i);
+        for (int i = ALL_VERSIONS.size() - 1; i >= 0; i--) {
+            Version v = ALL_VERSIONS.get(i);
             if (v.minor < Version.CURRENT.minor || v.major < Version.CURRENT.major) {
                 return v;
             }
         }
-        throw new IllegalArgumentException("couldn't find any released versions of the minor before [" + Build.current().version() + "]");
+        throw new IllegalArgumentException("couldn't find any versions of the minor before [" + Build.current().version() + "]");
     }
 
-    /** Returns the oldest released {@link Version} */
+    /** Returns the oldest {@link Version} */
     public static Version getFirstVersion() {
-        return RELEASED_VERSIONS.get(0);
+        return ALL_VERSIONS.get(0);
     }
 
     /** Returns a random {@link Version} from all available versions. */

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -9,19 +9,11 @@
 package org.elasticsearch.test;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.core.Booleans;
-import org.elasticsearch.core.Tuple;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static org.elasticsearch.Version.fromId;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
  * Tests VersionUtils. Note: this test should remain unchanged across major versions
@@ -30,7 +22,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 public class VersionUtilsTests extends ESTestCase {
 
     public void testAllVersionsSorted() {
-        List<Version> allVersions = VersionUtils.allReleasedVersions();
+        List<Version> allVersions = VersionUtils.allVersions();
         for (int i = 0, j = 1; j < allVersions.size(); ++i, ++j) {
             assertTrue(allVersions.get(i).before(allVersions.get(j)));
         }
@@ -58,9 +50,9 @@ public class VersionUtilsTests extends ESTestCase {
         got = VersionUtils.randomVersionBetween(random(), null, fromId(7000099));
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
         assertTrue(got.onOrBefore(fromId(7000099)));
-        got = VersionUtils.randomVersionBetween(random(), null, VersionUtils.allReleasedVersions().get(0));
+        got = VersionUtils.randomVersionBetween(random(), null, VersionUtils.allVersions().get(0));
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
-        assertTrue(got.onOrBefore(VersionUtils.allReleasedVersions().get(0)));
+        assertTrue(got.onOrBefore(VersionUtils.allVersions().get(0)));
 
         // unbounded upper
         got = VersionUtils.randomVersionBetween(random(), VersionUtils.getFirstVersion(), null);
@@ -83,265 +75,34 @@ public class VersionUtilsTests extends ESTestCase {
         assertEquals(got, VersionUtils.getFirstVersion());
         got = VersionUtils.randomVersionBetween(random(), Version.CURRENT, null);
         assertEquals(got, Version.CURRENT);
-
-        if (Booleans.parseBoolean(System.getProperty("build.snapshot", "true"))) {
-            // max or min can be an unreleased version
-            final Version unreleased = randomFrom(VersionUtils.allUnreleasedVersions());
-            assertThat(VersionUtils.randomVersionBetween(random(), null, unreleased), lessThanOrEqualTo(unreleased));
-            assertThat(VersionUtils.randomVersionBetween(random(), unreleased, null), greaterThanOrEqualTo(unreleased));
-            assertEquals(unreleased, VersionUtils.randomVersionBetween(random(), unreleased, unreleased));
-        }
-    }
-
-    public static class TestReleaseBranch {
-        public static final Version V_4_0_0 = Version.fromString("4.0.0");
-        public static final Version V_4_0_1 = Version.fromString("4.0.1");
-        public static final Version V_5_3_0 = Version.fromString("5.3.0");
-        public static final Version V_5_3_1 = Version.fromString("5.3.1");
-        public static final Version V_5_3_2 = Version.fromString("5.3.2");
-        public static final Version V_5_4_0 = Version.fromString("5.4.0");
-        public static final Version V_5_4_1 = Version.fromString("5.4.1");
-        public static final Version CURRENT = V_5_4_1;
-    }
-
-    public void testResolveReleasedVersionsForReleaseBranch() {
-        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(TestReleaseBranch.CURRENT, TestReleaseBranch.class);
-        List<Version> released = t.v1();
-        List<Version> unreleased = t.v2();
-
-        assertThat(
-            released,
-            equalTo(
-                Arrays.asList(
-                    TestReleaseBranch.V_4_0_0,
-                    TestReleaseBranch.V_5_3_0,
-                    TestReleaseBranch.V_5_3_1,
-                    TestReleaseBranch.V_5_3_2,
-                    TestReleaseBranch.V_5_4_0
-                )
-            )
-        );
-        assertThat(unreleased, equalTo(Arrays.asList(TestReleaseBranch.V_4_0_1, TestReleaseBranch.V_5_4_1)));
-    }
-
-    public static class TestStableBranch {
-        public static final Version V_4_0_0 = Version.fromString("4.0.0");
-        public static final Version V_4_0_1 = Version.fromString("4.0.1");
-        public static final Version V_5_0_0 = Version.fromString("5.0.0");
-        public static final Version V_5_0_1 = Version.fromString("5.0.1");
-        public static final Version V_5_0_2 = Version.fromString("5.0.2");
-        public static final Version V_5_1_0 = Version.fromString("5.1.0");
-        public static final Version CURRENT = V_5_1_0;
-    }
-
-    public void testResolveReleasedVersionsForUnreleasedStableBranch() {
-        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(TestStableBranch.CURRENT, TestStableBranch.class);
-        List<Version> released = t.v1();
-        List<Version> unreleased = t.v2();
-
-        assertThat(released, equalTo(Arrays.asList(TestStableBranch.V_4_0_0, TestStableBranch.V_5_0_0, TestStableBranch.V_5_0_1)));
-        assertThat(unreleased, equalTo(Arrays.asList(TestStableBranch.V_4_0_1, TestStableBranch.V_5_0_2, TestStableBranch.V_5_1_0)));
-    }
-
-    public static class TestStableBranchBehindStableBranch {
-        public static final Version V_4_0_0 = Version.fromString("4.0.0");
-        public static final Version V_4_0_1 = Version.fromString("4.0.1");
-        public static final Version V_5_3_0 = Version.fromString("5.3.0");
-        public static final Version V_5_3_1 = Version.fromString("5.3.1");
-        public static final Version V_5_3_2 = Version.fromString("5.3.2");
-        public static final Version V_5_4_0 = Version.fromString("5.4.0");
-        public static final Version V_5_5_0 = Version.fromString("5.5.0");
-        public static final Version CURRENT = V_5_5_0;
-    }
-
-    public void testResolveReleasedVersionsForStableBranchBehindStableBranch() {
-        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(
-            TestStableBranchBehindStableBranch.CURRENT,
-            TestStableBranchBehindStableBranch.class
-        );
-        List<Version> released = t.v1();
-        List<Version> unreleased = t.v2();
-
-        assertThat(
-            released,
-            equalTo(
-                Arrays.asList(
-                    TestStableBranchBehindStableBranch.V_4_0_0,
-                    TestStableBranchBehindStableBranch.V_5_3_0,
-                    TestStableBranchBehindStableBranch.V_5_3_1
-                )
-            )
-        );
-        assertThat(
-            unreleased,
-            equalTo(
-                Arrays.asList(
-                    TestStableBranchBehindStableBranch.V_4_0_1,
-                    TestStableBranchBehindStableBranch.V_5_3_2,
-                    TestStableBranchBehindStableBranch.V_5_4_0,
-                    TestStableBranchBehindStableBranch.V_5_5_0
-                )
-            )
-        );
-    }
-
-    public static class TestUnstableBranch {
-        public static final Version V_5_3_0 = Version.fromString("5.3.0");
-        public static final Version V_5_3_1 = Version.fromString("5.3.1");
-        public static final Version V_5_3_2 = Version.fromString("5.3.2");
-        public static final Version V_5_4_0 = Version.fromString("5.4.0");
-        public static final Version V_6_0_0 = Version.fromString("6.0.0");
-        public static final Version CURRENT = V_6_0_0;
-    }
-
-    public void testResolveReleasedVersionsForUnstableBranch() {
-        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(TestUnstableBranch.CURRENT, TestUnstableBranch.class);
-        List<Version> released = t.v1();
-        List<Version> unreleased = t.v2();
-
-        assertThat(released, equalTo(Arrays.asList(TestUnstableBranch.V_5_3_0, TestUnstableBranch.V_5_3_1)));
-        assertThat(unreleased, equalTo(Arrays.asList(TestUnstableBranch.V_5_3_2, TestUnstableBranch.V_5_4_0, TestUnstableBranch.V_6_0_0)));
-    }
-
-    public static class TestNewMajorRelease {
-        public static final Version V_5_6_0 = Version.fromString("5.6.0");
-        public static final Version V_5_6_1 = Version.fromString("5.6.1");
-        public static final Version V_5_6_2 = Version.fromString("5.6.2");
-        public static final Version V_6_0_0 = Version.fromString("6.0.0");
-        public static final Version V_6_0_1 = Version.fromString("6.0.1");
-        public static final Version CURRENT = V_6_0_1;
-    }
-
-    public void testResolveReleasedVersionsAtNewMajorRelease() {
-        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(
-            TestNewMajorRelease.CURRENT,
-            TestNewMajorRelease.class
-        );
-        List<Version> released = t.v1();
-        List<Version> unreleased = t.v2();
-
-        assertThat(released, equalTo(Arrays.asList(TestNewMajorRelease.V_5_6_0, TestNewMajorRelease.V_5_6_1, TestNewMajorRelease.V_6_0_0)));
-        assertThat(unreleased, equalTo(Arrays.asList(TestNewMajorRelease.V_5_6_2, TestNewMajorRelease.V_6_0_1)));
-    }
-
-    public static class TestVersionBumpIn6x {
-        public static final Version V_5_6_0 = Version.fromString("5.6.0");
-        public static final Version V_5_6_1 = Version.fromString("5.6.1");
-        public static final Version V_5_6_2 = Version.fromString("5.6.2");
-        public static final Version V_6_0_0 = Version.fromString("6.0.0");
-        public static final Version V_6_0_1 = Version.fromString("6.0.1");
-        public static final Version V_6_1_0 = Version.fromString("6.1.0");
-        public static final Version CURRENT = V_6_1_0;
-    }
-
-    public void testResolveReleasedVersionsAtVersionBumpIn6x() {
-        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(
-            TestVersionBumpIn6x.CURRENT,
-            TestVersionBumpIn6x.class
-        );
-        List<Version> released = t.v1();
-        List<Version> unreleased = t.v2();
-
-        assertThat(released, equalTo(Arrays.asList(TestVersionBumpIn6x.V_5_6_0, TestVersionBumpIn6x.V_5_6_1, TestVersionBumpIn6x.V_6_0_0)));
-        assertThat(
-            unreleased,
-            equalTo(Arrays.asList(TestVersionBumpIn6x.V_5_6_2, TestVersionBumpIn6x.V_6_0_1, TestVersionBumpIn6x.V_6_1_0))
-        );
-    }
-
-    public static class TestNewMinorBranchIn6x {
-        public static final Version V_5_6_0 = Version.fromString("5.6.0");
-        public static final Version V_5_6_1 = Version.fromString("5.6.1");
-        public static final Version V_5_6_2 = Version.fromString("5.6.2");
-        public static final Version V_6_0_0 = Version.fromString("6.0.0");
-        public static final Version V_6_0_1 = Version.fromString("6.0.1");
-        public static final Version V_6_1_0 = Version.fromString("6.1.0");
-        public static final Version V_6_1_1 = Version.fromString("6.1.1");
-        public static final Version V_6_1_2 = Version.fromString("6.1.2");
-        public static final Version V_6_2_0 = Version.fromString("6.2.0");
-        public static final Version CURRENT = V_6_2_0;
-    }
-
-    public void testResolveReleasedVersionsAtNewMinorBranchIn6x() {
-        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(
-            TestNewMinorBranchIn6x.CURRENT,
-            TestNewMinorBranchIn6x.class
-        );
-        List<Version> released = t.v1();
-        List<Version> unreleased = t.v2();
-
-        assertThat(
-            released,
-            equalTo(
-                Arrays.asList(
-                    TestNewMinorBranchIn6x.V_5_6_0,
-                    TestNewMinorBranchIn6x.V_5_6_1,
-                    TestNewMinorBranchIn6x.V_6_0_0,
-                    TestNewMinorBranchIn6x.V_6_0_1,
-                    TestNewMinorBranchIn6x.V_6_1_0,
-                    TestNewMinorBranchIn6x.V_6_1_1
-                )
-            )
-        );
-        assertThat(
-            unreleased,
-            equalTo(Arrays.asList(TestNewMinorBranchIn6x.V_5_6_2, TestNewMinorBranchIn6x.V_6_1_2, TestNewMinorBranchIn6x.V_6_2_0))
-        );
     }
 
     /**
-     * Tests that {@link Version#minimumCompatibilityVersion()} and {@link VersionUtils#allReleasedVersions()}
+     * Tests that {@link Version#minimumCompatibilityVersion()} and {@link VersionUtils#allVersions()}
      * agree with the list of wire compatible versions we build in gradle.
      */
     public void testGradleVersionsMatchVersionUtils() {
         // First check the index compatible versions
-        List<Version> released = VersionUtils.allReleasedVersions()
+        List<String> versions = VersionUtils.allVersions()
             .stream()
             /* Java lists all versions from the 5.x series onwards, but we only want to consider
              * ones that we're supposed to be compatible with. */
             .filter(v -> v.onOrAfter(Version.CURRENT.minimumCompatibilityVersion()))
+            .map(Version::toString)
             .toList();
-        VersionsFromProperty wireCompatible = new VersionsFromProperty("tests.gradle_wire_compat_versions");
-
-        Version minimumCompatibleVersion = Version.CURRENT.minimumCompatibilityVersion();
-        List<String> releasedWireCompatible = released.stream()
-            .filter(v -> Version.CURRENT.equals(v) == false)
-            .filter(v -> v.onOrAfter(minimumCompatibleVersion))
-            .map(Object::toString)
-            .toList();
-        assertEquals(releasedWireCompatible, wireCompatible.released);
-
-        List<String> unreleasedWireCompatible = VersionUtils.allUnreleasedVersions()
-            .stream()
-            .filter(v -> v.onOrAfter(minimumCompatibleVersion))
-            .map(Object::toString)
-            .toList();
-        assertEquals(unreleasedWireCompatible, wireCompatible.unreleased);
+        List<String> gradleVersions = versionFromProperty("tests.gradle_wire_compat_versions");
+        assertEquals(versions, gradleVersions);
     }
 
-    /**
-     * Read a versions system property as set by gradle into a tuple of {@code (releasedVersion, unreleasedVersion)}.
-     */
-    private class VersionsFromProperty {
-        private final List<String> released = new ArrayList<>();
-        private final List<String> unreleased = new ArrayList<>();
-
-        private VersionsFromProperty(String property) {
-            Set<String> allUnreleased = new HashSet<>(Arrays.asList(System.getProperty("tests.gradle_unreleased_versions", "").split(",")));
-            if (allUnreleased.isEmpty()) {
-                fail("[tests.gradle_unreleased_versions] not set or empty. Gradle should set this before running.");
-            }
-            String versions = System.getProperty(property);
-            assertNotNull("Couldn't find [" + property + "]. Gradle should set this before running the tests.", versions);
-            logger.info("Looked up versions [{}={}]", property, versions);
-
-            for (String version : versions.split(",")) {
-                if (allUnreleased.contains(version)) {
-                    unreleased.add(version);
-                } else {
-                    released.add(version);
-                }
-            }
+    private List<String> versionFromProperty(String property) {
+        List<String> versions = new ArrayList<>();
+        String versionsString = System.getProperty(property);
+        assertNotNull("Couldn't find [" + property + "]. Gradle should set this before running the tests.", versionsString);
+        logger.info("Looked up versions [{}={}]", property, versionsString);
+        for (String version : versionsString.split(",")) {
+            versions.add(version);
         }
+
+        return versions;
     }
 }


### PR DESCRIPTION
The recent branch support changes introduced in 8.15 make it impossible to infer unreleased versions simply from the version constants in the `Version` class. We could reimplement this using another source of "released" like `TransportVersions.csv` but it turns out this is actually unnecessary. Our changes to remove our reliance on `Version` altogether make this distinction irrelevant, so let's just rip out all that complexity.