### PR TITLE
Remove long deprecated special 'base' case for similarity service

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -20,8 +20,6 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.search.similarities.Similarity.SimScorer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.TriFunction;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
@@ -40,7 +38,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class SimilarityService {
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(SimilarityService.class);
     public static final String DEFAULT_SIMILARITY = "BM25";
     private static final Map<String, Function<IndexVersion, Supplier<Similarity>>> DEFAULTS;
     public static final Map<String, TriFunction<Settings, IndexVersion, ScriptService, Similarity>> BUILT_IN;
@@ -115,13 +112,6 @@ public final class SimilarityService {
         defaultSimilarity = (providers.get("default") != null)
             ? providers.get("default").get()
             : providers.get(SimilarityService.DEFAULT_SIMILARITY).get();
-        if (providers.get("base") != null) {
-            deprecationLogger.warn(
-                DeprecationCategory.QUERIES,
-                "base_similarity_ignored",
-                "The [base] similarity is ignored since query normalization and coords have been removed"
-            );
-        }
     }
 
     /**


### PR DESCRIPTION
Originally deprecated, and special handling removed back in v6.0.0: https://github.com/elastic/elasticsearch/pull/24089

The original purpose of this was so that users could specify a similarity with name `base` and that could then adjust global coords and norms settings. However, that capability has long been removed and using the name for that special action isn't possible.

This change removes the deprecation, allowing users to use the `base` name as just a regular custom similarity name.

