### PR TITLE
Add link to Tasks experimental issue

### DIFF
--- a/docs/internal/DistributedArchitectureGuide.md
+++ b/docs/internal/DistributedArchitectureGuide.md
@@ -384,7 +384,8 @@ There are several more Decider Services, implementing the `AutoscalingDeciderSer
 
 The tasks infrastructure is used to track currently executing operations in the Elasticsearch cluster. The [Task management API] provides an interface for querying, cancelling, and monitoring the status of tasks.
 
-[!NOTE] The Task management API is experimental/beta, it's status and outstanding issues can be tracked [here](https://github.com/elastic/elasticsearch/issues/51628).
+> [!NOTE]
+> The Task management API is experimental/beta, it's status and outstanding issues can be tracked [here](https://github.com/elastic/elasticsearch/issues/51628).
 
 Each individual task is local to a node, but can be related to other tasks, on the same node or other nodes, via a parent-child relationship.
 

--- a/docs/internal/DistributedArchitectureGuide.md
+++ b/docs/internal/DistributedArchitectureGuide.md
@@ -384,10 +384,10 @@ There are several more Decider Services, implementing the `AutoscalingDeciderSer
 
 The tasks infrastructure is used to track currently executing operations in the Elasticsearch cluster. The [Task management API] provides an interface for querying, cancelling, and monitoring the status of tasks.
 
+Each individual task is local to a node, but can be related to other tasks, on the same node or other nodes, via a parent-child relationship.
+
 > [!NOTE]
 > The Task management API is experimental/beta, it's status and outstanding issues can be tracked [here](https://github.com/elastic/elasticsearch/issues/51628).
-
-Each individual task is local to a node, but can be related to other tasks, on the same node or other nodes, via a parent-child relationship.
 
 ### Task tracking and registration
 

--- a/docs/internal/DistributedArchitectureGuide.md
+++ b/docs/internal/DistributedArchitectureGuide.md
@@ -384,6 +384,8 @@ There are several more Decider Services, implementing the `AutoscalingDeciderSer
 
 The tasks infrastructure is used to track currently executing operations in the Elasticsearch cluster. The [Task management API] provides an interface for querying, cancelling, and monitoring the status of tasks.
 
+[!NOTE] The Task management API is experimental/beta, it's status and outstanding issues can be tracked [here](https://github.com/elastic/elasticsearch/issues/51628).
+
 Each individual task is local to a node, but can be related to other tasks, on the same node or other nodes, via a parent-child relationship.
 
 ### Task tracking and registration

--- a/docs/internal/DistributedArchitectureGuide.md
+++ b/docs/internal/DistributedArchitectureGuide.md
@@ -387,7 +387,7 @@ The tasks infrastructure is used to track currently executing operations in the 
 Each individual task is local to a node, but can be related to other tasks, on the same node or other nodes, via a parent-child relationship.
 
 > [!NOTE]
-> The Task management API is experimental/beta, it's status and outstanding issues can be tracked [here](https://github.com/elastic/elasticsearch/issues/51628).
+> The Task management API is experimental/beta, its status and outstanding issues can be tracked [here](https://github.com/elastic/elasticsearch/issues/51628).
 
 ### Task tracking and registration
 


### PR DESCRIPTION
This just adds a link to the Tasks API experimental issue from the architecture guide.

I think it's useful to include because there are sections in the guide explicitly dedicated to things that we plan to change (e.g. the structure/opacity of the ID strings, ability to retrieve Task results). 

It's good for the reader to know, in the event that those changes are made.

It uses some special GitHub markdown for the node, it renders like:

<img width="1035" alt="Screenshot 2024-12-06 at 9 32 06 am" src="https://github.com/user-attachments/assets/75c57b53-fc84-4e46-8536-3258241b8268">
