### PR TITLE
[DOCS] Updates h7 and h8 formatting

### DIFF
--- a/docs/reference/connector/docs/connectors-box.asciidoc
+++ b/docs/reference/connector/docs/connectors-box.asciidoc
@@ -54,7 +54,7 @@ For additional operations, see <<es-connectors-usage>>.
 ====== Box Free Account
 
 [discrete#es-connectors-box-create-oauth-custom-app]
-======= Create Box User Authentication (OAuth 2.0) Custom App
+*Create Box User Authentication (OAuth 2.0) Custom App*
 
 You'll need to create an OAuth app in the Box developer console by following these steps:
 
@@ -64,7 +64,7 @@ You'll need to create an OAuth app in the Box developer console by following the
 4. Once the app is created, *Client ID* and *Client secret* values are available in the configuration tab. Keep these handy.
 
 [discrete#es-connectors-box-connector-generate-a-refresh-token]
-======= Generate a refresh Token
+*Generate a refresh Token*
 
 To generate a refresh token, follow these steps:
 
@@ -97,7 +97,7 @@ Save the refresh token from the response. You'll need this for the connector con
 ====== Box Enterprise Account
 
 [discrete#es-connectors-box-connector-create-box-server-authentication-client-credentials-grant-custom-app]
-======= Create Box Server Authentication (Client Credentials Grant) Custom App
+*Create Box Server Authentication (Client Credentials Grant) Custom App*
 
 1. Register a new app in the https://app.box.com/developers/console[Box dev console] with custom App and select Server Authentication (Client Credentials Grant).
 2. Check following permissions:
@@ -224,7 +224,7 @@ For additional operations, see <<es-connectors-usage>>.
 ====== Box Free Account
 
 [discrete#es-connectors-box-client-create-oauth-custom-app]
-======= Create Box User Authentication (OAuth 2.0) Custom App
+*Create Box User Authentication (OAuth 2.0) Custom App*
 
 You'll need to create an OAuth app in the Box developer console by following these steps:
 
@@ -234,7 +234,7 @@ You'll need to create an OAuth app in the Box developer console by following the
 4. Once the app is created, *Client ID* and *Client secret* values are available in the configuration tab. Keep these handy.
 
 [discrete#es-connectors-box-client-connector-generate-a-refresh-token]
-======= Generate a refresh Token
+*Generate a refresh Token*
 
 To generate a refresh token, follow these steps:
 
@@ -267,7 +267,7 @@ Save the refresh token from the response. You'll need this for the connector con
 ====== Box Enterprise Account
 
 [discrete#es-connectors-box-client-connector-create-box-server-authentication-client-credentials-grant-custom-app]
-======= Create Box Server Authentication (Client Credentials Grant) Custom App
+*Create Box Server Authentication (Client Credentials Grant) Custom App*
 
 1. Register a new app in the https://app.box.com/developers/console[Box dev console] with custom App and select Server Authentication (Client Credentials Grant).
 2. Check following permissions:

--- a/docs/reference/connector/docs/connectors-content-extraction.asciidoc
+++ b/docs/reference/connector/docs/connectors-content-extraction.asciidoc
@@ -183,7 +183,7 @@ Be aware that the self-managed connector will download files with randomized fil
 For that reason, we recommend using a dedicated directory for self-hosted extraction.
 
 [discrete#es-connectors-content-extraction-data-extraction-service-file-pointers-configuration-example]
-======= Example
+*Example*
 
 1. For this example, we will be using `/app/files` as both our local directory and our container directory.
 When you run the extraction service docker container, you can mount the directory as a volume using the command-line option `-v /app/files:/app/files`.
@@ -228,7 +228,7 @@ When using self-hosted extraction from a dockerized self-managed connector, ther
 * The self-managed connector and the extraction service will also need to share a volume. You can decide what directory inside these docker containers the volume will be mounted onto, but the directory must be the same for both docker containers.
 
 [discrete#es-connectors-content-extraction-data-extraction-service-file-pointers-configuration-dockerized-example]
-======= Example
+*Example*
 
 1. First, set up a volume for the two docker containers to share.
 This will be where files are downloaded into and then extracted from.

--- a/docs/reference/connector/docs/connectors-dropbox.asciidoc
+++ b/docs/reference/connector/docs/connectors-dropbox.asciidoc
@@ -190,7 +190,7 @@ When both are provided, priority is given to `file_categories`.
 We have some examples below for illustration.
 
 [discrete#es-connectors-dropbox-sync-rules-advanced-example-1]
-======= Example: Query only
+*Example: Query only*
 
 [source,js]
 ----
@@ -206,7 +206,7 @@ We have some examples below for illustration.
 // NOTCONSOLE
 
 [discrete#es-connectors-dropbox-sync-rules-advanced-example-2]
-======= Example: Query with file extension filter
+*Example: Query with file extension filter*
 
 [source,js]
 ----
@@ -225,7 +225,7 @@ We have some examples below for illustration.
 // NOTCONSOLE
 
 [discrete#es-connectors-dropbox-sync-rules-advanced-example-3]
-======= Example: Query with file category filter
+*Example: Query with file category filter*
 
 [source,js]
 ----
@@ -248,7 +248,7 @@ We have some examples below for illustration.
 // NOTCONSOLE
 
 [discrete#es-connectors-dropbox-sync-rules-advanced-limitations]
-======= Limitations
+*Limitations*
 
 * Content extraction is not supported for Dropbox *Paper* files when advanced sync rules are enabled.
 
@@ -474,7 +474,7 @@ When both are provided, priority is given to `file_categories`.
 We have some examples below for illustration.
 
 [discrete#es-connectors-dropbox-client-sync-rules-advanced-example-1]
-======= Example: Query only
+*Example: Query only*
 
 [source,js]
 ----
@@ -490,7 +490,7 @@ We have some examples below for illustration.
 // NOTCONSOLE
 
 [discrete#es-connectors-dropbox-client-sync-rules-advanced-example-2]
-======= Example: Query with file extension filter
+*Example: Query with file extension filter*
 
 [source,js]
 ----
@@ -509,7 +509,7 @@ We have some examples below for illustration.
 // NOTCONSOLE
 
 [discrete#es-connectors-dropbox-client-sync-rules-advanced-example-3]
-======= Example: Query with file category filter
+*Example: Query with file category filter*
 
 [source,js]
 ----
@@ -532,7 +532,7 @@ We have some examples below for illustration.
 // NOTCONSOLE
 
 [discrete#es-connectors-dropbox-client-sync-rules-advanced-limitations]
-======= Limitations
+*Limitations*
 
 * Content extraction is not supported for Dropbox *Paper* files when advanced sync rules are enabled.
 

--- a/docs/reference/connector/docs/connectors-github.asciidoc
+++ b/docs/reference/connector/docs/connectors-github.asciidoc
@@ -210,7 +210,7 @@ Advanced sync rules are defined through a source-specific DSL JSON snippet.
 The following sections provide examples of advanced sync rules for this connector.
 
 [discrete#es-connectors-github-sync-rules-advanced-branch]
-======= Indexing document and files based on branch name configured via branch key
+*Indexing document and files based on branch name configured via branch key*
 
 [source,js]
 ----
@@ -226,7 +226,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-github-sync-rules-advanced-issue-key]
-======= Indexing document based on issue query related to bugs via issue key
+*Indexing document based on issue query related to bugs via issue key*
 
 [source,js]
 ----
@@ -242,7 +242,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-github-sync-rules-advanced-pr-key]
-======= Indexing document based on PR query related to open PR's via PR key
+*Indexing document based on PR query related to open PR's via PR key*
 
 [source,js]
 ----
@@ -258,7 +258,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-github-sync-rules-advanced-issue-query-branch-name]
-======= Indexing document and files based on queries and branch name
+*Indexing document and files based on queries and branch name*
 
 [source,js]
 ----
@@ -283,7 +283,7 @@ Check the Elasticsearch index for the actual document count.
 ====
 
 [discrete#es-connectors-github-sync-rules-advanced-overlapping]
-======= Advanced rules for overlapping
+*Advanced rules for overlapping*
 
 [source,js]
 ----
@@ -550,7 +550,7 @@ Advanced sync rules are defined through a source-specific DSL JSON snippet.
 The following sections provide examples of advanced sync rules for this connector.
 
 [discrete#es-connectors-github-client-sync-rules-advanced-branch]
-======= Indexing document and files based on branch name configured via branch key
+*Indexing document and files based on branch name configured via branch key*
 
 [source,js]
 ----
@@ -566,7 +566,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-github-client-sync-rules-advanced-issue-key]
-======= Indexing document based on issue query related to bugs via issue key
+*Indexing document based on issue query related to bugs via issue key*
 
 [source,js]
 ----
@@ -582,7 +582,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-github-client-sync-rules-advanced-pr-key]
-======= Indexing document based on PR query related to open PR's via PR key
+*Indexing document based on PR query related to open PR's via PR key*
 
 [source,js]
 ----
@@ -598,7 +598,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-github-client-sync-rules-advanced-issue-query-branch-name]
-======= Indexing document and files based on queries and branch name
+*Indexing document and files based on queries and branch name*
 
 [source,js]
 ----
@@ -623,7 +623,7 @@ Check the Elasticsearch index for the actual document count.
 ====
 
 [discrete#es-connectors-github-client-sync-rules-advanced-overlapping]
-======= Advanced rules for overlapping
+*Advanced rules for overlapping*
 
 [source,js]
 ----

--- a/docs/reference/connector/docs/connectors-ms-sql.asciidoc
+++ b/docs/reference/connector/docs/connectors-ms-sql.asciidoc
@@ -196,7 +196,7 @@ Here are a few examples of advanced sync rules for this connector.
 ====
 
 [discrete#es-connectors-ms-sql-sync-rules-advanced-queries]
-======= Example: Two queries
+*Example: Two queries*
 
 These rules fetch all records from both the `employee` and `customer` tables. The data from these tables will be synced separately to Elasticsearch.
 
@@ -220,7 +220,7 @@ These rules fetch all records from both the `employee` and `customer` tables. Th
 // NOTCONSOLE
 
 [discrete#es-connectors-ms-sql-sync-rules-example-one-where]
-======= Example: One WHERE query
+*Example: One WHERE query*
 
 This rule fetches only the records from the `employee` table where the `emp_id` is greater than 5. Only these filtered records will be synced to Elasticsearch.
 
@@ -236,7 +236,7 @@ This rule fetches only the records from the `employee` table where the `emp_id` 
 // NOTCONSOLE
 
 [discrete#es-connectors-ms-sql-sync-rules-example-one-join]
-======= Example: One JOIN query
+*Example: One JOIN query*
 
 This rule fetches records by performing an INNER JOIN between the `employee` and `customer` tables on the condition that the `emp_id` in `employee` matches the `c_id` in `customer`. The result of this combined data will be synced to Elasticsearch.
 
@@ -484,7 +484,7 @@ Here are a few examples of advanced sync rules for this connector.
 ====
 
 [discrete#es-connectors-ms-sql-client-sync-rules-advanced-queries]
-======= Example: Two queries
+*Example: Two queries*
 
 These rules fetch all records from both the `employee` and `customer` tables. The data from these tables will be synced separately to Elasticsearch.
 
@@ -508,7 +508,7 @@ These rules fetch all records from both the `employee` and `customer` tables. Th
 // NOTCONSOLE
 
 [discrete#es-connectors-ms-sql-client-sync-rules-example-one-where]
-======= Example: One WHERE query
+*Example: One WHERE query*
 
 This rule fetches only the records from the `employee` table where the `emp_id` is greater than 5. Only these filtered records will be synced to Elasticsearch.
 
@@ -524,7 +524,7 @@ This rule fetches only the records from the `employee` table where the `emp_id` 
 // NOTCONSOLE
 
 [discrete#es-connectors-ms-sql-client-sync-rules-example-one-join]
-======= Example: One JOIN query
+*Example: One JOIN query*
 
 This rule fetches records by performing an INNER JOIN between the `employee` and `customer` tables on the condition that the `emp_id` in `employee` matches the `c_id` in `customer`. The result of this combined data will be synced to Elasticsearch.
 

--- a/docs/reference/connector/docs/connectors-network-drive.asciidoc
+++ b/docs/reference/connector/docs/connectors-network-drive.asciidoc
@@ -174,7 +174,7 @@ Advanced sync rules for this connector use *glob patterns*.
 The following sections provide examples of advanced sync rules for this connector.
 
 [discrete#es-connectors-network-drive-indexing-files-and-folders-recursively-within-folders]
-======= Indexing files and folders recursively within folders
+*Indexing files and folders recursively within folders*
 
 [source,js]
 ----
@@ -190,7 +190,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-network-drive-indexing-files-and-folders-directly-inside-folder]
-======= Indexing files and folders directly inside folder
+*Indexing files and folders directly inside folder*
 
 [source,js]
 ----
@@ -203,7 +203,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-network-drive-indexing-files-and-folders-directly-inside-a-set-of-folders]
-======= Indexing files and folders directly inside a set of folders
+*Indexing files and folders directly inside a set of folders*
 
 [source,js]
 ----
@@ -216,7 +216,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-network-drive-excluding-files-and-folders-that-match-a-pattern]
-======= Excluding files and folders that match a pattern
+*Excluding files and folders that match a pattern*
 
 [source,js]
 ----
@@ -432,7 +432,7 @@ Advanced sync rules for this connector use *glob patterns*.
 The following sections provide examples of advanced sync rules for this connector.
 
 [discrete#es-connectors-network-drive-client-indexing-files-and-folders-recursively-within-folders]
-======= Indexing files and folders recursively within folders
+*Indexing files and folders recursively within folders*
 
 [source,js]
 ----
@@ -448,7 +448,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-network-drive-client-indexing-files-and-folders-directly-inside-folder]
-======= Indexing files and folders directly inside folder
+*Indexing files and folders directly inside folder*
 
 [source,js]
 ----
@@ -461,7 +461,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-network-drive-client-indexing-files-and-folders-directly-inside-a-set-of-folders]
-======= Indexing files and folders directly inside a set of folders
+*Indexing files and folders directly inside a set of folders*
 
 [source,js]
 ----
@@ -474,7 +474,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-network-drive-client-excluding-files-and-folders-that-match-a-pattern]
-======= Excluding files and folders that match a pattern
+*Excluding files and folders that match a pattern*
 
 [source,js]
 ----

--- a/docs/reference/connector/docs/connectors-notion.asciidoc
+++ b/docs/reference/connector/docs/connectors-notion.asciidoc
@@ -140,7 +140,7 @@ Advanced sync rules for Notion take the following parameters:
 ====== Examples
 
 [discrete]
-======= Example 1
+*Example 1*
 
 Indexing every page where the title contains `Demo Page`:
 
@@ -160,7 +160,7 @@ Indexing every page where the title contains `Demo Page`:
 // NOTCONSOLE
 
 [discrete]
-======= Example 2
+*Example 2*
 
 Indexing every database where the title contains `Demo Database`:
 
@@ -180,7 +180,7 @@ Indexing every database where the title contains `Demo Database`:
 // NOTCONSOLE
 
 [discrete]
-======= Example 3
+*Example 3*
 
 Indexing every database where the title contains `Demo Database` and every page where the title contains `Demo Page`:
 
@@ -206,7 +206,7 @@ Indexing every database where the title contains `Demo Database` and every page 
 // NOTCONSOLE
 
 [discrete]
-======= Example 4
+*Example 4*
 
 Indexing all pages in the workspace:
 
@@ -226,7 +226,7 @@ Indexing all pages in the workspace:
 // NOTCONSOLE
 
 [discrete]
-======= Example 5
+*Example 5*
 
 Indexing all the pages and databases connected to the workspace:
 
@@ -243,7 +243,7 @@ Indexing all the pages and databases connected to the workspace:
 // NOTCONSOLE
 
 [discrete]
-======= Example 6
+*Example 6*
 
 Indexing all the rows of a database where the record is `true` for the column `Task completed` and its property(datatype) is a checkbox:
 
@@ -266,7 +266,7 @@ Indexing all the rows of a database where the record is `true` for the column `T
 // NOTCONSOLE
 
 [discrete]
-======= Example 7
+*Example 7*
 
 Indexing all rows of a specific database:
 
@@ -283,7 +283,7 @@ Indexing all rows of a specific database:
 // NOTCONSOLE
 
 [discrete]
-======= Example 8
+*Example 8*
 
 Indexing all blocks defined in `searches` and `database_query_filters`:
 
@@ -498,7 +498,7 @@ Advanced sync rules for Notion take the following parameters:
 ====== Examples
 
 [discrete]
-======= Example 1
+*Example 1*
 
 Indexing every page where the title contains `Demo Page`:
 
@@ -518,7 +518,7 @@ Indexing every page where the title contains `Demo Page`:
 // NOTCONSOLE
 
 [discrete]
-======= Example 2
+*Example 2*
 
 Indexing every database where the title contains `Demo Database`:
 
@@ -538,7 +538,7 @@ Indexing every database where the title contains `Demo Database`:
 // NOTCONSOLE
 
 [discrete]
-======= Example 3
+*Example 3*
 
 Indexing every database where the title contains `Demo Database` and every page where the title contains `Demo Page`:
 
@@ -564,7 +564,7 @@ Indexing every database where the title contains `Demo Database` and every page 
 // NOTCONSOLE
 
 [discrete]
-======= Example 4
+*Example 4*
 
 Indexing all pages in the workspace:
 
@@ -584,7 +584,7 @@ Indexing all pages in the workspace:
 // NOTCONSOLE
 
 [discrete]
-======= Example 5
+*Example 5*
 
 Indexing all the pages and databases connected to the workspace:
 
@@ -601,7 +601,7 @@ Indexing all the pages and databases connected to the workspace:
 // NOTCONSOLE
 
 [discrete]
-======= Example 6
+*Example 6*
 
 Indexing all the rows of a database where the record is `true` for the column `Task completed` and its property(datatype) is a checkbox:
 
@@ -624,7 +624,7 @@ Indexing all the rows of a database where the record is `true` for the column `T
 // NOTCONSOLE
 
 [discrete]
-======= Example 7
+*Example 7*
 
 Indexing all rows of a specific database:
 
@@ -641,7 +641,7 @@ Indexing all rows of a specific database:
 // NOTCONSOLE
 
 [discrete]
-======= Example 8
+*Example 8*
 
 Indexing all blocks defined in `searches` and `database_query_filters`:
 

--- a/docs/reference/connector/docs/connectors-onedrive.asciidoc
+++ b/docs/reference/connector/docs/connectors-onedrive.asciidoc
@@ -160,7 +160,7 @@ A <<es-connectors-sync-types-full, full sync>> is required for advanced sync rul
 Here are a few examples of advanced sync rules for this connector.
 
 [discrete#es-connectors-onedrive-sync-rules-advanced-examples-1]
-======= Example 1
+*Example 1*
 
 This rule skips indexing for files with `.xlsx` and `.docx` extensions.
 All other files and folders will be indexed.
@@ -176,7 +176,7 @@ All other files and folders will be indexed.
 // NOTCONSOLE
 
 [discrete#es-connectors-onedrive-sync-rules-advanced-examples-2]
-======= Example 2
+*Example 2*
 
 This rule focuses on indexing files and folders owned by `user1-domain@onmicrosoft.com` and `user2-domain@onmicrosoft.com` but excludes files with `.py` extension.
 
@@ -192,7 +192,7 @@ This rule focuses on indexing files and folders owned by `user1-domain@onmicroso
 // NOTCONSOLE
 
 [discrete#es-connectors-onedrive-sync-rules-advanced-examples-3]
-======= Example 3
+*Example 3*
 
 This rule indexes only the files and folders directly inside the root folder, excluding any `.md` files.
 
@@ -208,7 +208,7 @@ This rule indexes only the files and folders directly inside the root folder, ex
 // NOTCONSOLE
 
 [discrete#es-connectors-onedrive-sync-rules-advanced-examples-4]
-======= Example 4
+*Example 4*
 
 This rule indexes files and folders owned by `user1-domain@onmicrosoft.com` and `user3-domain@onmicrosoft.com` that are directly inside the `abc` folder, which is a subfolder of any folder under the `hello` directory in the root. Files with extensions `.pdf` and `.py` are excluded.
 
@@ -225,7 +225,7 @@ This rule indexes files and folders owned by `user1-domain@onmicrosoft.com` and 
 // NOTCONSOLE
 
 [discrete#es-connectors-onedrive-sync-rules-advanced-examples-5]
-======= Example 5
+*Example 5*
 
 This example contains two rules.
 The first rule indexes all files and folders owned by `user1-domain@onmicrosoft.com` and `user2-domain@onmicrosoft.com`.
@@ -245,7 +245,7 @@ The second rule indexes files for all other users, but skips files with a `.py` 
 // NOTCONSOLE
 
 [discrete#es-connectors-onedrive-sync-rules-advanced-examples-6]
-======= Example 6
+*Example 6*
 
 This example contains two rules.
 The first rule indexes all files owned by `user1-domain@onmicrosoft.com` and `user2-domain@onmicrosoft.com`, excluding `.md` files.
@@ -449,7 +449,7 @@ A <<es-connectors-sync-types-full, full sync>> is required for advanced sync rul
 Here are a few examples of advanced sync rules for this connector.
 
 [discrete#es-connectors-onedrive-client-sync-rules-advanced-examples-1]
-======= Example 1
+*Example 1*
 
 This rule skips indexing for files with `.xlsx` and `.docx` extensions.
 All other files and folders will be indexed.
@@ -465,7 +465,7 @@ All other files and folders will be indexed.
 // NOTCONSOLE
 
 [discrete#es-connectors-onedrive-client-sync-rules-advanced-examples-2]
-======= Example 2
+*Example 2*
 
 This rule focuses on indexing files and folders owned by `user1-domain@onmicrosoft.com` and `user2-domain@onmicrosoft.com` but excludes files with `.py` extension.
 
@@ -481,7 +481,7 @@ This rule focuses on indexing files and folders owned by `user1-domain@onmicroso
 // NOTCONSOLE
 
 [discrete#es-connectors-onedrive-client-sync-rules-advanced-examples-3]
-======= Example 3
+*Example 3*
 
 This rule indexes only the files and folders directly inside the root folder, excluding any `.md` files.
 
@@ -497,7 +497,7 @@ This rule indexes only the files and folders directly inside the root folder, ex
 // NOTCONSOLE
 
 [discrete#es-connectors-onedrive-client-sync-rules-advanced-examples-4]
-======= Example 4
+*Example 4*
 
 This rule indexes files and folders owned by `user1-domain@onmicrosoft.com` and `user3-domain@onmicrosoft.com` that are directly inside the `abc` folder, which is a subfolder of any folder under the `hello` directory in the root. Files with extensions `.pdf` and `.py` are excluded.
 
@@ -514,7 +514,7 @@ This rule indexes files and folders owned by `user1-domain@onmicrosoft.com` and 
 // NOTCONSOLE
 
 [discrete#es-connectors-onedrive-client-sync-rules-advanced-examples-5]
-======= Example 5
+*Example 5*
 
 This example contains two rules.
 The first rule indexes all files and folders owned by `user1-domain@onmicrosoft.com` and `user2-domain@onmicrosoft.com`.
@@ -534,7 +534,7 @@ The second rule indexes files for all other users, but skips files with a `.py` 
 // NOTCONSOLE
 
 [discrete#es-connectors-onedrive-client-sync-rules-advanced-examples-6]
-======= Example 6
+*Example 6*
 
 This example contains two rules.
 The first rule indexes all files owned by `user1-domain@onmicrosoft.com` and `user2-domain@onmicrosoft.com`, excluding `.md` files.

--- a/docs/reference/connector/docs/connectors-postgresql.asciidoc
+++ b/docs/reference/connector/docs/connectors-postgresql.asciidoc
@@ -188,7 +188,7 @@ Advanced sync rules are defined through a source-specific DSL JSON snippet.
 Here is some example data that will be used in the following examples.
 
 [discrete#connectors-postgresql-sync-rules-advanced-example-data-1]
-======= `employee` table
+*`employee` table*
 
 [cols="3*", options="header"]
 |===
@@ -199,7 +199,7 @@ Here is some example data that will be used in the following examples.
 |===
 
 [discrete#connectors-postgresql-sync-rules-advanced-example-2]
-======= `customer` table
+*`customer` table*
 
 [cols="3*", options="header"]
 |===
@@ -213,7 +213,7 @@ Here is some example data that will be used in the following examples.
 ====== Advanced sync rules examples
 
 [discrete#connectors-postgresql-sync-rules-advanced-examples-1]
-======= Multiple table queries
+*Multiple table queries*
 
 [source,js]
 ----
@@ -235,7 +235,7 @@ Here is some example data that will be used in the following examples.
 // NOTCONSOLE
 
 [discrete#connectors-postgresql-sync-rules-advanced-examples-1-id-columns]
-======= Multiple table queries with `id_columns`
+*Multiple table queries with `id_columns`*
 
 In 8.15.0, we added a new optional `id_columns` field in our advanced sync rules for the PostgreSQL connector.
 Use the `id_columns` field to ingest tables which do not have a primary key. Include the names of unique fields so that the connector can use them to generate unique IDs for documents.
@@ -264,7 +264,7 @@ Use the `id_columns` field to ingest tables which do not have a primary key. Inc
 This example uses the `id_columns` field to specify the unique fields `emp_id` and `c_id` for the `employee` and `customer` tables, respectively.
 
 [discrete#connectors-postgresql-sync-rules-advanced-examples-2]
-======= Filtering data with `WHERE` clause
+*Filtering data with `WHERE` clause*
 
 [source,js]
 ----
@@ -278,7 +278,7 @@ This example uses the `id_columns` field to specify the unique fields `emp_id` a
 // NOTCONSOLE
 
 [discrete#connectors-postgresql-sync-rules-advanced-examples-3]
-======= `JOIN` operations
+*`JOIN` operations*
 
 [source,js]
 ----
@@ -494,7 +494,7 @@ Advanced sync rules are defined through a source-specific DSL JSON snippet.
 Here is some example data that will be used in the following examples.
 
 [discrete#es-connectors-postgresql-client-sync-rules-advanced-example-data-1]
-======= `employee` table
+*`employee` table*
 
 [cols="3*", options="header"]
 |===
@@ -505,7 +505,7 @@ Here is some example data that will be used in the following examples.
 |===
 
 [discrete#es-connectors-postgresql-client-sync-rules-advanced-example-2]
-======= `customer` table
+*`customer` table*
 
 [cols="3*", options="header"]
 |===
@@ -519,7 +519,7 @@ Here is some example data that will be used in the following examples.
 ====== Advanced sync rules examples
 
 [discrete#es-connectors-postgresql-client-sync-rules-advanced-examples-1]
-======== Multiple table queries
+*Multiple table queries*
 
 [source,js]
 ----
@@ -541,7 +541,7 @@ Here is some example data that will be used in the following examples.
 // NOTCONSOLE
 
 [discrete#es-connectors-postgresql-client-sync-rules-advanced-examples-1-id-columns]
-======== Multiple table queries with `id_columns`
+*Multiple table queries with `id_columns`*
 
 In 8.15.0, we added a new optional `id_columns` field in our advanced sync rules for the PostgreSQL connector.
 Use the `id_columns` field to ingest tables which do not have a primary key. Include the names of unique fields so that the connector can use them to generate unique IDs for documents.
@@ -570,7 +570,7 @@ Use the `id_columns` field to ingest tables which do not have a primary key. Inc
 This example uses the `id_columns` field to specify the unique fields `emp_id` and `c_id` for the `employee` and `customer` tables, respectively.
 
 [discrete#es-connectors-postgresql-client-sync-rules-advanced-examples-2]
-======== Filtering data with `WHERE` clause
+*Filtering data with `WHERE` clause*
 
 [source,js]
 ----
@@ -584,7 +584,7 @@ This example uses the `id_columns` field to specify the unique fields `emp_id` a
 // NOTCONSOLE
 
 [discrete#es-connectors-postgresql-client-sync-rules-advanced-examples-3]
-======== `JOIN` operations
+*`JOIN` operations*
 
 [source,js]
 ----

--- a/docs/reference/connector/docs/connectors-s3.asciidoc
+++ b/docs/reference/connector/docs/connectors-s3.asciidoc
@@ -118,7 +118,7 @@ The connector will fetch file and folder data that matches the string.
 Defaults to `""` (syncs all bucket objects).
 
 [discrete#es-connectors-s3-sync-rules-advanced-examples]
-======= Advanced sync rules examples
+*Advanced sync rules examples*
 
 *Fetching files and folders recursively by prefix*
 
@@ -336,7 +336,7 @@ The connector will fetch file and folder data that matches the string.
 Defaults to `""` (syncs all bucket objects).
 
 [discrete#es-connectors-s3-client-sync-rules-advanced-examples]
-======= Advanced sync rules examples
+*Advanced sync rules examples*
 
 *Fetching files and folders recursively by prefix*
 

--- a/docs/reference/connector/docs/connectors-salesforce.asciidoc
+++ b/docs/reference/connector/docs/connectors-salesforce.asciidoc
@@ -227,7 +227,7 @@ They take the following parameters:
 Allowed values are *SOQL* and *SOSL*.
 
 [discrete#es-connectors-salesforce-sync-rules-advanced-fetch-query-language]
-======= Fetch documents based on the query and language specified
+*Fetch documents based on the query and language specified*
 
 **Example**: Fetch documents using SOQL query
 
@@ -256,7 +256,7 @@ Allowed values are *SOQL* and *SOSL*.
 // NOTCONSOLE
 
 [discrete#es-connectors-salesforce-sync-rules-advanced-fetch-objects]
-======= Fetch standard and custom objects using SOQL and SOSL queries
+*Fetch standard and custom objects using SOQL and SOSL queries*
 
 **Example**: Fetch documents for standard objects via SOQL and SOSL query.
 
@@ -293,7 +293,7 @@ Allowed values are *SOQL* and *SOSL*.
 // NOTCONSOLE
 
 [discrete#es-connectors-salesforce-sync-rules-advanced-fetch-standard-custom-fields]
-======= Fetch documents with standard and custom fields
+*Fetch documents with standard and custom fields*
 
 **Example**: Fetch documents with all standard and custom fields for Account object.
 
@@ -626,7 +626,7 @@ They take the following parameters:
 Allowed values are *SOQL* and *SOSL*.
 
 [discrete#es-connectors-salesforce-client-sync-rules-advanced-fetch-query-language]
-======= Fetch documents based on the query and language specified
+*Fetch documents based on the query and language specified*
 
 **Example**: Fetch documents using SOQL query
 
@@ -655,7 +655,7 @@ Allowed values are *SOQL* and *SOSL*.
 // NOTCONSOLE
 
 [discrete#es-connectors-salesforce-client-sync-rules-advanced-fetch-objects]
-======= Fetch standard and custom objects using SOQL and SOSL queries
+*Fetch standard and custom objects using SOQL and SOSL queries*
 
 **Example**: Fetch documents for standard objects via SOQL and SOSL query.
 
@@ -692,7 +692,7 @@ Allowed values are *SOQL* and *SOSL*.
 // NOTCONSOLE
 
 [discrete#es-connectors-salesforce-client-sync-rules-advanced-fetch-standard-custom-fields]
-======= Fetch documents with standard and custom fields
+*Fetch documents with standard and custom fields*
 
 **Example**: Fetch documents with all standard and custom fields for Account object.
 

--- a/docs/reference/connector/docs/connectors-servicenow.asciidoc
+++ b/docs/reference/connector/docs/connectors-servicenow.asciidoc
@@ -167,7 +167,7 @@ Advanced sync rules are defined through a source-specific DSL JSON snippet.
 The following sections provide examples of advanced sync rules for this connector.
 
 [discrete#es-connectors-servicenow-sync-rules-number-incident-service]
-======= Indexing document based on incident number for Incident service
+*Indexing document based on incident number for Incident service*
 
 [source,js]
 ----
@@ -181,7 +181,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-servicenow-sync-rules-active-false-user-service]
-======= Indexing document based on user activity state for User service
+*Indexing document based on user activity state for User service*
 
 [source,js]
 ----
@@ -195,7 +195,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-servicenow-sync-rules-author-administrator-knowledge-service]
-======= Indexing document based on author name for Knowledge service
+*Indexing document based on author name for Knowledge service*
 
 [source,js]
 ----
@@ -407,7 +407,7 @@ Advanced sync rules are defined through a source-specific DSL JSON snippet.
 The following sections provide examples of advanced sync rules for this connector.
 
 [discrete#es-connectors-servicenow-client-sync-rules-number-incident-service]
-======= Indexing document based on incident number for Incident service
+*Indexing document based on incident number for Incident service*
 
 [source,js]
 ----
@@ -421,7 +421,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-servicenow-client-sync-rules-active-false-user-service]
-======= Indexing document based on user activity state for User service
+*Indexing document based on user activity state for User service*
 
 [source,js]
 ----
@@ -435,7 +435,7 @@ The following sections provide examples of advanced sync rules for this connecto
 // NOTCONSOLE
 
 [discrete#es-connectors-servicenow-client-sync-rules-author-administrator-knowledge-service]
-======= Indexing document based on author name for Knowledge service
+*Indexing document based on author name for Knowledge service*
 
 [source,js]
 ----

--- a/docs/reference/connector/docs/connectors-sharepoint-online.asciidoc
+++ b/docs/reference/connector/docs/connectors-sharepoint-online.asciidoc
@@ -277,7 +277,7 @@ Example:
 This rule will not extract content of any drive items (files in document libraries) that haven't been modified for 60 days or more.
 
 [discrete#es-connectors-sharepoint-online-sync-rules-limitations]
-======= Limitations of sync rules with incremental syncs
+*Limitations of sync rules with incremental syncs*
 
 Changing sync rules after Sharepoint Online content has already been indexed can bring unexpected results, when using <<es-connectors-sync-types-incremental,incremental syncs>>.
 
@@ -288,7 +288,7 @@ Incremental syncs ensure _updates_ from 3rd-party system, but do not modify exis
 Let's take a look at several examples where incremental syncs might lead to inconsistent data on your index.
 
 [discrete#es-connectors-sharepoint-online-sync-rules-limitations-restrictive-added]
-======== Example: Restrictive basic sync rule added after a full sync
+*Example: Restrictive basic sync rule added after a full sync*
 
 Imagine your Sharepoint Online drive contains the following drive items:
 
@@ -322,7 +322,7 @@ If no files were changed, incremental sync will not receive information about ch
 After a *full sync*, the index will be updated and files that are excluded by sync rules will be removed.
 
 [discrete#es-connectors-sharepoint-online-sync-rules-limitations-restrictive-removed]
-======== Example: Restrictive basic sync rules removed after a full sync
+*Example: Restrictive basic sync rules removed after a full sync*
 
 Imagine that Sharepoint Online drive has the following drive items:
 
@@ -354,7 +354,7 @@ Afterwards, we can remove the filtering rule and run an incremental sync. If no 
 Only a *full sync* will include the items previously ignored by the sync rule.
 
 [discrete#es-connectors-sharepoint-online-sync-rules-limitations-restrictive-changed]
-======== Example: Advanced sync rules edge case
+*Example: Advanced sync rules edge case*
 
 Advanced sync rules can be applied to limit which documents will have content extracted.
 For example, it's possible to set a rule so that documents older than 180 days won't have content extracted.
@@ -763,7 +763,7 @@ Example:
 This rule will not extract content of any drive items (files in document libraries) that haven't been modified for 60 days or more.
 
 [discrete#es-connectors-sharepoint-online-client-sync-rules-limitations]
-======= Limitations of sync rules with incremental syncs
+*Limitations of sync rules with incremental syncs*
 
 Changing sync rules after Sharepoint Online content has already been indexed can bring unexpected results, when using <<es-connectors-sync-types-incremental,incremental syncs>>.
 
@@ -774,7 +774,7 @@ Incremental syncs ensure _updates_ from 3rd-party system, but do not modify exis
 Let's take a look at several examples where incremental syncs might lead to inconsistent data on your index.
 
 [discrete#es-connectors-sharepoint-online-client-sync-rules-limitations-restrictive-added]
-======== Example: Restrictive basic sync rule added after a full sync
+*Example: Restrictive basic sync rule added after a full sync*
 
 Imagine your Sharepoint Online drive contains the following drive items:
 
@@ -808,7 +808,7 @@ If no files were changed, incremental sync will not receive information about ch
 After a *full sync*, the index will be updated and files that are excluded by sync rules will be removed.
 
 [discrete#es-connectors-sharepoint-online-client-sync-rules-limitations-restrictive-removed]
-======== Example: Restrictive basic sync rules removed after a full sync
+*Example: Restrictive basic sync rules removed after a full sync*
 
 Imagine that Sharepoint Online drive has the following drive items:
 
@@ -840,7 +840,7 @@ Afterwards, we can remove the filtering rule and run an incremental sync. If no 
 Only a *full sync* will include the items previously ignored by the sync rule.
 
 [discrete#es-connectors-sharepoint-online-client-sync-rules-limitations-restrictive-changed]
-======== Example: Advanced sync rules edge case
+*Example: Advanced sync rules edge case*
 
 Advanced sync rules can be applied to limit which documents will have content extracted.
 For example, it's possible to set a rule so that documents older than 180 days won't have content extracted.


### PR DESCRIPTION
### Overview

This PR updates the [Connectors references](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-connectors-refs.html) section by replacing improperly rendered headings with bold formatting.

### Related issue

https://github.com/elastic/search-docs-team/issues/227