### PR TITLE
fixes and unmutes testSearchableSnapshotShardsAreSkipped...

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -132,9 +132,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testInvalidJSON
   issue: https://github.com/elastic/elasticsearch/issues/116521
-- class: org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsCanMatchOnCoordinatorIntegTests
-  method: testSearchableSnapshotShardsAreSkippedBySearchRequestWithoutQueryingAnyNodeWhenTheyAreOutsideOfTheQueryRange
-  issue: https://github.com/elastic/elasticsearch/issues/116523
 - class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
   method: testSettingsApplied
   issue: https://github.com/elastic/elasticsearch/issues/116694

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -379,7 +379,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
                     }
                     if (searchShardsResponse != null) {
                         for (SearchShardsGroup group : searchShardsResponse.getGroups()) {
-                            assertFalse("no shard should be marked as skipped", group.skipped());
+                            assertTrue("the shard is skipped because index value is outside the query time range", group.skipped());
                         }
                     }
                 }


### PR DESCRIPTION
Before #115314 we were always querying at least one shard even if the shard was skipped due to it being rewritten to match none in by the coordinator re-write phase, effectively un-skipping it.
In this test case we are querying only one shard that is coord rewritten to match none because the query range is outside the timestamp search range we provide. 
The correct behaviour after #115314 is for the shard to be skipped, therefore I updated the test to match current expectations.

Closes #116523 
