### PR TITLE
[8.17] [DOCS] Adds examples to inference processor docs (#116018)

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -735,3 +735,70 @@ You can also specify the target field as follows:
 
 In this case, {feat-imp} is exposed in the
 `my_field.foo.feature_importance` field.
+
+
+[discrete]
+[[inference-processor-examples]]
+==== {infer-cap} processor examples
+
+The following example uses an <<inference-apis,{infer} endpoint>> in an {infer} processor named `query_helper_pipeline` to perform a chat completion task.
+The processor generates an {es} query from natural language input using a prompt designed for a completion task type.
+Refer to <<put-inference-api-desc,this list>> for the {infer} service you use and check the corresponding examples of setting up an endpoint with the chat completion task type.
+
+
+[source,console]
+--------------------------------------------------
+PUT _ingest/pipeline/query_helper_pipeline
+{
+  "processors": [
+    {
+      "script": {
+        "source": "ctx.prompt = 'Please generate an elasticsearch search query on index `articles_index` for the following natural language query. Dates are in the field `@timestamp`, document types are in the field `type` (options are `news`, `publication`), categories in the field `category` and can be multiple (options are `medicine`, `pharmaceuticals`, `technology`), and document names are in the field `title` which should use a fuzzy match. Ignore fields which cannot be determined from the natural language query context: ' + ctx.content" <1>
+      }
+    },
+    {
+      "inference": {
+        "model_id": "openai_chat_completions", <2>
+        "input_output": {
+          "input_field": "prompt",
+          "output_field": "query"
+        }
+      }
+    },
+    {
+      "remove": {
+        "field": "prompt"
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// TEST[skip: An inference endpoint is required.]
+<1> The `prompt` field contains the prompt used for the completion task, created with <<modules-scripting-painless,Painless>>.
+`+ ctx.content` appends the natural language input to the prompt.
+<2> The ID of the pre-configured {infer} endpoint, which utilizes the <<infer-service-openai,`openai` service>> with the `completion` task type.
+
+The following API request will simulate running a document through the ingest pipeline created previously:
+
+[source,console]
+--------------------------------------------------
+POST _ingest/pipeline/query_helper_pipeline/_simulate
+{
+  "docs": [
+    {
+      "_source": {
+        "content": "artificial intelligence in medicine articles published in the last 12 months" <1>
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// TEST[skip: An inference processor with an inference endpoint is required.]
+<1> The natural language query used to generate an {es} query within the prompt created by the {infer} processor.
+
+
+[discrete]
+[[infer-proc-readings]]
+==== Further readings
+
+* https://www.elastic.co/search-labs/blog/openwebcrawler-llms-semantic-text-resume-job-search[Which job is the best for you? Using LLMs and semantic_text to match resumes to jobs]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[DOCS] Adds examples to inference processor docs (#116018)](https://github.com/elastic/elasticsearch/pull/116018)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)