### PR TITLE
ES|QL: make ignoreOrder parsing more strict in CSV tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -245,8 +245,6 @@ tests:
 - class: org.elasticsearch.packaging.test.ArchiveTests
   method: test40AutoconfigurationNotTriggeredWhenNodeIsMeantToJoinExistingCluster
   issue: https://github.com/elastic/elasticsearch/issues/118029
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/117981
 - class: org.elasticsearch.packaging.test.ConfigurationTests
   method: test30SymlinkedDataPath
   issue: https://github.com/elastic/elasticsearch/issues/118111

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvSpecReader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvSpecReader.java
@@ -80,7 +80,12 @@ public final class CsvSpecReader {
                     testCase.expectedWarningsRegexString.add(regex);
                     testCase.expectedWarningsRegex.add(warningRegexToPattern(regex));
                 } else if (lower.startsWith("ignoreorder:")) {
-                    testCase.ignoreOrder = Boolean.parseBoolean(line.substring("ignoreOrder:".length()).trim());
+                    String value = lower.substring("ignoreOrder:".length()).trim();
+                    if ("true".equals(value)) {
+                        testCase.ignoreOrder = true;
+                    } else if ("false".equals(value) == false) {
+                        throw new IllegalArgumentException("Invalid value for ignoreOrder: [" + value + "], it can only be true or false");
+                    }
                 } else if (line.startsWith(";")) {
                     testCase.expectedResults = data.toString();
                     // clean-up and emit

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -140,7 +140,7 @@ FROM sample_data
 | EVAL client_ip = client_ip::keyword
 | LOOKUP JOIN clientips_lookup ON client_ip
 ;
-ignoreOrder:true;
+ignoreOrder:true
 
 @timestamp:date          | event_duration:long | message:keyword       | client_ip:keyword | env:keyword
 2023-10-23T13:55:01.543Z | 1756467             | Connected to 10.1.0.1 | 172.21.3.15       | Production
@@ -160,7 +160,7 @@ FROM sample_data
 | LOOKUP JOIN clientips_lookup ON client_ip
 | KEEP @timestamp, client_ip, event_duration, message, env
 ;
-ignoreOrder:true;
+ignoreOrder:true
 
 @timestamp:date          | client_ip:keyword | event_duration:long | message:keyword       | env:keyword
 2023-10-23T13:55:01.543Z | 172.21.3.15       | 1756467             | Connected to 10.1.0.1 | Production
@@ -245,7 +245,7 @@ required_capability: join_lookup_v4
 FROM sample_data
 | LOOKUP JOIN message_types_lookup ON message
 ;
-ignoreOrder:true;
+ignoreOrder:true
 
 @timestamp:date          | client_ip:ip | event_duration:long | message:keyword       | type:keyword
 2023-10-23T13:55:01.543Z | 172.21.3.15  | 1756467             | Connected to 10.1.0.1 | Success
@@ -264,7 +264,7 @@ FROM sample_data
 | LOOKUP JOIN message_types_lookup ON message
 | KEEP @timestamp, client_ip, event_duration, message, type
 ;
-ignoreOrder:true;
+ignoreOrder:true
 
 @timestamp:date          | client_ip:ip | event_duration:long | message:keyword       | type:keyword
 2023-10-23T13:55:01.543Z | 172.21.3.15  | 1756467             | Connected to 10.1.0.1 | Success


### PR DESCRIPTION
The parsing of `ignoreOrder` in csv tests was too lenient, accepting anything different from `true` as a `false` (including `true;`, that was pretty misleading).

Now it throws an exception in case the value is not `true/false`.

Fixes: https://github.com/elastic/elasticsearch/issues/117981