### PR TITLE
[8.17] fixes and unmutes testSearchableSnapshotShardsAreSkipped... (#118133)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -293,9 +293,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/61_enrich_ip/IP strings}
   issue: https://github.com/elastic/elasticsearch/issues/116529
-- class: org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsCanMatchOnCoordinatorIntegTests
-  method: testSearchableSnapshotShardsAreSkippedBySearchRequestWithoutQueryingAnyNodeWhenTheyAreOutsideOfTheQueryRange
-  issue: https://github.com/elastic/elasticsearch/issues/116523
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
   method: testInferDeploysDefaultElser
   issue: https://github.com/elastic/elasticsearch/issues/114913

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -379,7 +379,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
                     }
                     if (searchShardsResponse != null) {
                         for (SearchShardsGroup group : searchShardsResponse.getGroups()) {
-                            assertFalse("no shard should be marked as skipped", group.skipped());
+                            assertTrue("the shard is skipped because index value is outside the query time range", group.skipped());
                         }
                     }
                 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [fixes and unmutes testSearchableSnapshotShardsAreSkipped... (#118133)](https://github.com/elastic/elasticsearch/pull/118133)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)