### PR TITLE
Save O(1s) of CPU time in FieldSortIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -202,7 +202,6 @@ public class FieldSortIT extends ESIntegTestCase {
                         response -> {
                             for (int j = 0; j < response.getHits().getHits().length; j++) {
                                 assertThat(
-                                    response.toString() + "\n vs. \n" + allDocsResponse.toString(),
                                     response.getHits().getHits()[j].getId(),
                                     equalTo(allDocsResponse.getHits().getHits()[j].getId())
                                 );


### PR DESCRIPTION
Bit of a weird one I noticed when testing batched execution in a hot loop and profiling ...

I see this `toString` take ~2s of hot CPU time in some test runs which isn't entirely surprising. Rather than optimize this in some form, just dropping the string here which aligns the thing with other tests anyway.
