### PR TITLE
Removing old deprecation checks for standard token filter

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/analysis/AnalysisModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/AnalysisModule.java
@@ -10,18 +10,13 @@
 package org.elasticsearch.indices.analysis;
 
 import org.apache.lucene.analysis.LowerCaseFilter;
-import org.apache.lucene.analysis.TokenStream;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.NamedRegistry;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.IndexVersions;
-import org.elasticsearch.index.analysis.AbstractTokenFilterFactory;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.analysis.AnalyzerProvider;
 import org.elasticsearch.index.analysis.CharFilterFactory;
@@ -64,7 +59,6 @@ public final class AnalysisModule {
     }
 
     private static final IndexSettings NA_INDEX_SETTINGS;
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(AnalysisModule.class);
 
     private final HunspellService hunspellService;
     private final AnalysisRegistry analysisRegistry;
@@ -134,28 +128,6 @@ public final class AnalysisModule {
     ) {
         NamedRegistry<AnalysisProvider<TokenFilterFactory>> tokenFilters = new NamedRegistry<>("token_filter");
         tokenFilters.register("stop", StopTokenFilterFactory::new);
-        // Add "standard" for old indices (bwc)
-        tokenFilters.register("standard", new AnalysisProvider<TokenFilterFactory>() {
-            @Override
-            public TokenFilterFactory get(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-                if (indexSettings.getIndexVersionCreated().before(IndexVersions.V_7_0_0)) {
-                    deprecationLogger.warn(
-                        DeprecationCategory.ANALYSIS,
-                        "standard_deprecation",
-                        "The [standard] token filter name is deprecated and will be removed in a future version."
-                    );
-                } else {
-                    throw new IllegalArgumentException("The [standard] token filter has been removed.");
-                }
-                return new AbstractTokenFilterFactory(name, settings) {
-                    @Override
-                    public TokenStream create(TokenStream tokenStream) {
-                        return tokenStream;
-                    }
-                };
-            }
-
-        });
         tokenFilters.register("shingle", ShingleTokenFilterFactory::new);
         tokenFilters.register(
             "hunspell",
@@ -198,22 +170,6 @@ public final class AnalysisModule {
 
         // Add filters available in lucene-core
         preConfiguredTokenFilters.register("lowercase", PreConfiguredTokenFilter.singleton("lowercase", true, LowerCaseFilter::new));
-        // Add "standard" for old indices (bwc)
-        preConfiguredTokenFilters.register("standard", PreConfiguredTokenFilter.indexVersion("standard", true, (reader, version) -> {
-            // This was originally removed in 7_0_0 but due to a cacheing bug it was still possible
-            // in certain circumstances to create a new index referencing the standard token filter
-            // until version 7_5_2
-            if (version.before(IndexVersions.V_7_6_0)) {
-                deprecationLogger.warn(
-                    DeprecationCategory.ANALYSIS,
-                    "standard_deprecation",
-                    "The [standard] token filter is deprecated and will be removed in a future version."
-                );
-            } else {
-                throw new IllegalArgumentException("The [standard] token filter has been removed.");
-            }
-            return reader;
-        }));
         /* Note that "stop" is available in lucene-core but it's pre-built
          * version uses a set of English stop words that are in
          * lucene-analyzers-common so "stop" is defined in the analysis-common


### PR DESCRIPTION
standard token filter has been removed and unusable for all of v8. Removing it and deprecation checks completely for v9