### PR TITLE
Remove v7x checks for sparse vector mappings

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapperTests.java
@@ -297,15 +297,6 @@ public class SparseVectorFieldMapperTests extends MapperTestCase {
     }
 
     @Override
-    protected String[] getParseMinimalWarnings(IndexVersion indexVersion) {
-        String[] additionalWarnings = null;
-        if (indexVersion.before(PREVIOUS_SPARSE_VECTOR_INDEX_VERSION)) {
-            additionalWarnings = new String[] { SparseVectorFieldMapper.ERROR_MESSAGE_7X };
-        }
-        return Strings.concatStringArrays(super.getParseMinimalWarnings(indexVersion), additionalWarnings);
-    }
-
-    @Override
     protected IndexVersion boostNotAllowedIndexVersion() {
         return NEW_SPARSE_VECTOR_INDEX_VERSION;
     }


### PR DESCRIPTION
removing old 7x checks for v9 upgrade.