### PR TITLE
Remove client.type setting

### DIFF
--- a/docs/changelog/118192.yaml
+++ b/docs/changelog/118192.yaml
@@ -1,0 +1,12 @@
+pr: 118192
+summary: Remove `client.type` setting
+area: Infra/Core
+type: breaking
+issues: []
+breaking:
+  title: Remove `client.type` setting
+  area: Infra/Core
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users
+  notable: false

--- a/docs/changelog/118192.yaml
+++ b/docs/changelog/118192.yaml
@@ -2,11 +2,10 @@ pr: 118192
 summary: Remove `client.type` setting
 area: Infra/Core
 type: breaking
-issues: []
+issues: [104574]
 breaking:
   title: Remove `client.type` setting
   area: Infra/Core
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  details: The node setting `client.type` has been ignored since the node client was removed in 8.0. The setting is now removed.
+  impact: Remove the `client.type` setting from `elasticsearch.yml` 
   notable: false

--- a/docs/changelog/118192.yaml
+++ b/docs/changelog/118192.yaml
@@ -5,7 +5,7 @@ type: breaking
 issues: [104574]
 breaking:
   title: Remove `client.type` setting
-  area: Infra/Core
+  area: Cluster and node setting
   details: The node setting `client.type` has been ignored since the node client was removed in 8.0. The setting is now removed.
   impact: Remove the `client.type` setting from `elasticsearch.yml` 
   notable: false

--- a/server/src/main/java/org/elasticsearch/client/internal/Client.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/Client.java
@@ -73,15 +73,7 @@ import java.util.concurrent.Executor;
  * @see org.elasticsearch.node.Node#client()
  */
 public interface Client extends ElasticsearchClient {
-
-    // Note: This setting is registered only for bwc. The value is never read.
-    Setting<String> CLIENT_TYPE_SETTING_S = new Setting<>("client.type", "node", (s) -> {
-        return switch (s) {
-            case "node", "transport" -> s;
-            default -> throw new IllegalArgumentException("Can't parse [client.type] must be one of [node, transport]");
-        };
-    }, Property.NodeScope, Property.Deprecated);
-
+    
     /**
      * The admin client that can be used to perform administrative operations.
      */

--- a/server/src/main/java/org/elasticsearch/client/internal/Client.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/Client.java
@@ -52,8 +52,6 @@ import org.elasticsearch.action.termvectors.TermVectorsResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.transport.RemoteClusterService;
@@ -73,7 +71,7 @@ import java.util.concurrent.Executor;
  * @see org.elasticsearch.node.Node#client()
  */
 public interface Client extends ElasticsearchClient {
-    
+
     /**
      * The admin client that can be used to perform administrative operations.
      */

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -20,7 +20,6 @@ import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.bootstrap.BootstrapSettings;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.InternalClusterInfoService;

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -483,7 +483,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
         AutoCreateIndex.AUTO_CREATE_INDEX_SETTING,
         BaseRestHandler.MULTI_ALLOW_EXPLICIT_INDEX,
         ClusterName.CLUSTER_NAME_SETTING,
-        Client.CLIENT_TYPE_SETTING_S,
         ClusterModule.SHARDS_ALLOCATOR_TYPE_SETTING,
         EsExecutors.NODE_PROCESSORS_SETTING,
         ThreadContext.DEFAULT_HEADERS_SETTING,


### PR DESCRIPTION
The client.type setting is a holdover from the node client which was removed in 8.0. The setting has been a noop since 8.0. This commit removes the setting.

relates #104574