### PR TITLE
[8.17] add documentation for kuromoji_completion (#117808)

### DIFF
--- a/docs/plugins/analysis-kuromoji.asciidoc
+++ b/docs/plugins/analysis-kuromoji.asciidoc
@@ -750,3 +750,39 @@ Which results in:
   ]
 }
 --------------------------------------------------
+
+[[analysis-kuromoji-completion]]
+==== `kuromoji_completion` token filter
+
+The `kuromoji_completion` token filter adds Japanese romanized tokens to the term attributes along with the original tokens (surface forms).
+
+[source,console]
+--------------------------------------------------
+GET _analyze
+{
+  "analyzer": "kuromoji_completion",
+  "text": "寿司" <1>
+}
+--------------------------------------------------
+
+<1> Returns `寿司`, `susi` (Kunrei-shiki) and `sushi` (Hepburn-shiki).
+
+The `kuromoji_completion` token filter accepts the following settings:
+
+`mode`::
++
+--
+
+The tokenization mode determines how the tokenizer handles compound and
+unknown words. It can be set to:
+
+`index`::
+
+    Simple romanization. Expected to be used when indexing.
+
+`query`::
+
+    Input Method aware romanization. Expected to be used when querying.
+
+Defaults to `index`.
+--


### PR DESCRIPTION
Backports the following commits to 8.17:
 - add documentation for kuromoji_completion (#117808)