### PR TITLE
[8.x] Always write unicast hosts file in tests (#118121)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
@@ -176,8 +176,9 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
         return nodes.get(index).getPid();
     }
 
+    @Override
     public void stopNode(int index, boolean forcibly) {
-        nodes.get(index).stop(false);
+        nodes.get(index).stop(forcibly);
     }
 
     @Override
@@ -252,9 +253,8 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
         execute(() -> nodes.parallelStream().forEach(node -> {
             try {
                 Path hostsFile = node.getWorkingDir().resolve("config").resolve("unicast_hosts.txt");
-                if (Files.notExists(hostsFile)) {
-                    Files.writeString(hostsFile, transportUris);
-                }
+                LOGGER.info("Writing unicast hosts file {} for node {}", hostsFile, node.getName());
+                Files.writeString(hostsFile, transportUris);
             } catch (IOException e) {
                 throw new UncheckedIOException("Failed to write unicast_hosts for: " + node, e);
             }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Always write unicast hosts file in tests (#118121)