### PR TITLE
Fixed variable name in Zstd publish script

### DIFF
--- a/dev-tools/publish_zstd_binaries.sh
+++ b/dev-tools/publish_zstd_binaries.sh
@@ -79,8 +79,8 @@ build_linux_jar() {
 }
 
 echo 'Building Linux jars...'
-LINUX_ARM_JAR=$(build_linux_jar "linux/amd64" "x86-64")
-LINUX_X86_JAR=$(build_linux_jar "linux/arm64" "aarch64")
+LINUX_ARM_JAR=$(build_linux_jar "linux/arm64" "aarch64")
+LINUX_X86_JAR=$(build_linux_jar "linux/amd64" "x86-64")
 
 build_windows_jar() {
   ARTIFACT="$TEMP/zstd-$VERSION-windows-x86-64.jar"

--- a/docs/changelog/118207.yaml
+++ b/docs/changelog/118207.yaml
@@ -1,1 +1,1 @@
-Fixed variable name in Zstd publish script for linux platform
+ixed variable name in Zstd publish script for linux platform

--- a/docs/changelog/118207.yaml
+++ b/docs/changelog/118207.yaml
@@ -1,0 +1,1 @@
+Fixed variable name in Zstd publish script for linux platform


### PR DESCRIPTION
Need to fix a small naming mistake in the `dev-tools/publish_zstd_binaries.sh` script. Where the var names of ARM and X86 binaries were interchanged. Would not throw any error but might confuse new developers.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)? Yes
- If submitting code, have you built your formula locally prior to submission with `gradle check`? Yes
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. Yes
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? Yes
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that. Yes
