### PR TITLE
Pull AWS SDK versions to top level

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -17,6 +17,8 @@ jna               = 5.12.1
 netty             = 4.1.115.Final
 commons_lang3     = 3.9
 google_oauth_client = 1.34.1
+awsv1sdk            = 1.12.270
+awsv2sdk            = 2.28.13
 
 antlr4            = 4.13.1
 # bouncy castle version for non-fips. fips jars use a different version

--- a/modules/repository-s3/build.gradle
+++ b/modules/repository-s3/build.gradle
@@ -18,15 +18,11 @@ esplugin {
   classname 'org.elasticsearch.repositories.s3.S3RepositoryPlugin'
 }
 
-versions << [
-  'aws': '1.12.270'
-]
-
 dependencies {
-  api "com.amazonaws:aws-java-sdk-s3:${versions.aws}"
-  api "com.amazonaws:aws-java-sdk-core:${versions.aws}"
-  api "com.amazonaws:aws-java-sdk-sts:${versions.aws}"
-  api "com.amazonaws:jmespath-java:${versions.aws}"
+  api "com.amazonaws:aws-java-sdk-s3:${versions.awsv1sdk}"
+  api "com.amazonaws:aws-java-sdk-core:${versions.awsv1sdk}"
+  api "com.amazonaws:aws-java-sdk-sts:${versions.awsv1sdk}"
+  api "com.amazonaws:jmespath-java:${versions.awsv1sdk}"
   api "org.apache.httpcomponents:httpclient:${versions.httpclient}"
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   api "commons-logging:commons-logging:${versions.commonslogging}"

--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -14,13 +14,9 @@ esplugin {
   classname 'org.elasticsearch.discovery.ec2.Ec2DiscoveryPlugin'
 }
 
-versions << [
-  'aws': '1.12.270'
-]
-
 dependencies {
-  api "com.amazonaws:aws-java-sdk-ec2:${versions.aws}"
-  api "com.amazonaws:aws-java-sdk-core:${versions.aws}"
+  api "com.amazonaws:aws-java-sdk-ec2:${versions.awsv1sdk}"
+  api "com.amazonaws:aws-java-sdk-core:${versions.awsv1sdk}"
   api "org.apache.httpcomponents:httpclient:${versions.httpclient}"
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   api "commons-logging:commons-logging:${versions.commonslogging}"

--- a/x-pack/plugin/inference/build.gradle
+++ b/x-pack/plugin/inference/build.gradle
@@ -26,10 +26,6 @@ base {
   archivesName = 'x-pack-inference'
 }
 
-versions << [
-  'aws2': '2.28.13'
-]
-
 dependencies {
   implementation project(path: ':libs:logging')
   compileOnly project(":server")
@@ -62,36 +58,36 @@ dependencies {
   implementation 'io.opencensus:opencensus-contrib-http-util:0.31.1'
 
   /* AWS SDK v2 */
-  implementation ("software.amazon.awssdk:bedrockruntime:${versions.aws2}")
-  api "software.amazon.awssdk:protocol-core:${versions.aws2}"
-  api "software.amazon.awssdk:aws-json-protocol:${versions.aws2}"
-  api "software.amazon.awssdk:third-party-jackson-core:${versions.aws2}"
-  api "software.amazon.awssdk:http-auth-aws:${versions.aws2}"
-  api "software.amazon.awssdk:checksums-spi:${versions.aws2}"
-  api "software.amazon.awssdk:checksums:${versions.aws2}"
-  api "software.amazon.awssdk:sdk-core:${versions.aws2}"
+  implementation ("software.amazon.awssdk:bedrockruntime:${versions.awsv2sdk}")
+  api "software.amazon.awssdk:protocol-core:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:aws-json-protocol:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:third-party-jackson-core:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:http-auth-aws:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:checksums-spi:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:checksums:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:sdk-core:${versions.awsv2sdk}"
   api "org.reactivestreams:reactive-streams:1.0.4"
   api "org.reactivestreams:reactive-streams-tck:1.0.4"
-  api "software.amazon.awssdk:profiles:${versions.aws2}"
-  api "software.amazon.awssdk:retries:${versions.aws2}"
-  api "software.amazon.awssdk:auth:${versions.aws2}"
-  api "software.amazon.awssdk:http-auth-aws-eventstream:${versions.aws2}"
+  api "software.amazon.awssdk:profiles:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:retries:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:auth:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:http-auth-aws-eventstream:${versions.awsv2sdk}"
   api "software.amazon.eventstream:eventstream:1.0.1"
-  api "software.amazon.awssdk:http-auth-spi:${versions.aws2}"
-  api "software.amazon.awssdk:http-auth:${versions.aws2}"
-  api "software.amazon.awssdk:identity-spi:${versions.aws2}"
-  api "software.amazon.awssdk:http-client-spi:${versions.aws2}"
-  api "software.amazon.awssdk:regions:${versions.aws2}"
-  api "software.amazon.awssdk:annotations:${versions.aws2}"
-  api "software.amazon.awssdk:utils:${versions.aws2}"
-  api "software.amazon.awssdk:aws-core:${versions.aws2}"
-  api "software.amazon.awssdk:metrics-spi:${versions.aws2}"
-  api "software.amazon.awssdk:json-utils:${versions.aws2}"
-  api "software.amazon.awssdk:endpoints-spi:${versions.aws2}"
-  api "software.amazon.awssdk:retries-spi:${versions.aws2}"
+  api "software.amazon.awssdk:http-auth-spi:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:http-auth:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:identity-spi:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:http-client-spi:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:regions:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:annotations:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:utils:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:aws-core:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:metrics-spi:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:json-utils:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:endpoints-spi:${versions.awsv2sdk}"
+  api "software.amazon.awssdk:retries-spi:${versions.awsv2sdk}"
 
   /* Netty (via AWS SDKv2) */
-  implementation "software.amazon.awssdk:netty-nio-client:${versions.aws2}"
+  implementation "software.amazon.awssdk:netty-nio-client:${versions.awsv2sdk}"
   runtimeOnly "io.netty:netty-buffer:${versions.netty}"
   runtimeOnly "io.netty:netty-codec-dns:${versions.netty}"
   runtimeOnly "io.netty:netty-codec-http2:${versions.netty}"


### PR DESCRIPTION
Today each relevant module defines the version of the AWS SDK that it
uses, which means there's a risk that we use different versions in
different modules. This commit pulls the version declarations to the top
level to make sure we keep everything in sync.