### PR TITLE
Add a method to get the major version number from BuildVersion

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/BuildVersion.java
+++ b/server/src/main/java/org/elasticsearch/env/BuildVersion.java
@@ -18,6 +18,7 @@ import org.elasticsearch.plugins.ExtensionLoader;
 import org.elasticsearch.xcontent.ToXContentFragment;
 
 import java.io.IOException;
+import java.util.OptionalInt;
 import java.util.ServiceLoader;
 
 /**
@@ -36,6 +37,11 @@ import java.util.ServiceLoader;
  * schemes.</p>
  */
 public abstract class BuildVersion implements ToXContentFragment, Writeable {
+
+    /**
+     * Returns the major version of this build, or {@link OptionalInt#empty} if major versions are not applicable.
+     */
+    public abstract OptionalInt majorVersion();
 
     /**
      * Check whether this version is on or after a minimum threshold.

--- a/server/src/main/java/org/elasticsearch/env/DefaultBuildVersion.java
+++ b/server/src/main/java/org/elasticsearch/env/DefaultBuildVersion.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.OptionalInt;
 
 /**
  * A {@link BuildVersion} that uses the same identifiers and compatibility constraints
@@ -45,6 +46,11 @@ final class DefaultBuildVersion extends BuildVersion {
 
     DefaultBuildVersion(StreamInput in) throws IOException {
         this(in.readVInt());
+    }
+
+    @Override
+    public OptionalInt majorVersion() {
+        return OptionalInt.of(Version.CURRENT.major);
     }
 
     @Override


### PR DESCRIPTION
To aid #118143, add a method to get the major version. This could be a more specific method (similar to `isFutureVersion`), `isNextMajorVersion`, but 'major version' is a concept that we need to use in Elasticsearch for continuing compatibility, so getting the actual id is probably useful. Open for discussion though.