### PR TITLE
ESQL: Ignore order in LookupMessageFromIndexKeepReordered

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -245,12 +245,6 @@ tests:
 - class: org.elasticsearch.packaging.test.ArchiveTests
   method: test41AutoconfigurationNotTriggeredWhenNodeCannotContainData
   issue: https://github.com/elastic/elasticsearch/issues/118110
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {lookup-join.LookupMessageFromIndexKeepReordered SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/118150
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {lookup-join.LookupMessageFromIndexKeepReordered ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/118151
 - class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS2UnavailableRemotesIT
   method: testEsqlRcs2UnavailableRemoteScenarios
   issue: https://github.com/elastic/elasticsearch/issues/117419

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -283,6 +283,7 @@ FROM sample_data
 | LOOKUP JOIN message_types_lookup ON message
 | KEEP type, client_ip, event_duration, message
 ;
+ignoreOrder:true
 
 type:keyword | client_ip:ip | event_duration:long | message:keyword
 Success      | 172.21.3.15  | 1756467             | Connected to 10.1.0.1


### PR DESCRIPTION
Fix #118150
Fix #118151

We should also ignore the order for this test, as the output rows are not deterministic in all cases.