### PR TITLE
[8.x][TEST] Wait for no pending operations on the index shard (#118244)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -320,9 +320,6 @@ tests:
 - class: org.elasticsearch.xpack.application.CohereServiceUpgradeIT
   method: testCohereEmbeddings {upgradedNodes=2}
   issue: https://github.com/elastic/elasticsearch/issues/116975
-- class: org.elasticsearch.xpack.searchablesnapshots.RetrySearchIntegTests
-  method: testRetryPointInTime
-  issue: https://github.com/elastic/elasticsearch/issues/117116
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
   issue: https://github.com/elastic/elasticsearch/issues/117027

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -127,6 +127,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
 
     @After
     public void assertConsistentHistoryInLuceneIndex() throws Exception {
+        internalCluster().beforeIndexDeletion();
         internalCluster().assertConsistentHistoryBetweenTranslogAndLuceneIndex();
     }
 


### PR DESCRIPTION
This fixes testRetryPointInTime which on teardown is looking to assert that the operations in the translog and in the lucene index are the same.

Previously we didn't wait for the translog operations to be applied. This changes `assertConsistentHistoryInLuceneIndex` to wait for the pending operations in the translog to be applied.

Fixes #117116

(cherry picked from commit b4e852a54be436d8b8036da0a0ec4a472d44524a)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #118244