### PR TITLE
[8.x] Update fallback setting

### DIFF
--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseService.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseService.java
@@ -38,7 +38,7 @@ final class SyntheticSourceLicenseService {
         "xpack.mapping.synthetic_source_fallback_to_stored_source",
         false,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.OperatorDynamic
     );
 
     static final LicensedFeature.Momentary SYNTHETIC_SOURCE_FEATURE = LicensedFeature.momentary(


### PR DESCRIPTION
Backport #118237 to 8.x. branch.

Update synthetic_source_fallback_to_stored_source setting to be an operator only setting.