### PR TITLE
[8.17] Update sparse text embeddings API route for Inference Service

### DIFF
--- a/docs/changelog/118368.yaml
+++ b/docs/changelog/118368.yaml
@@ -1,0 +1,5 @@
+pr: 118368
+summary: "[8.17] Update sparse text embeddings API route for Inference Service"
+area: Inference
+type: enhancement
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModel.java
@@ -108,6 +108,6 @@ public class ElasticInferenceServiceSparseEmbeddingsModel extends ElasticInferen
             default -> throw new IllegalArgumentException("Unsupported model for EIS [" + modelId + "]");
         }
 
-        return new URI(elasticInferenceServiceComponents().eisGatewayUrl() + "/api/v1/sparse-text-embedding/" + modelIdUriPath);
+        return new URI(elasticInferenceServiceComponents().eisGatewayUrl() + "/api/v1/sparse-text-embeddings/" + modelIdUriPath);
     }
 }


### PR DESCRIPTION
Manual backport of #118025 (auto backport failed).

Per discussion with the Search Inference team, we're modifying the API path of ELSER embeddings in Elastic Inference Service: `/api/v1/sparse-text-embedding/ELSERv2` -> `/api/v1/sparse-text-embedding*s*/ELSERv2`.