### PR TITLE
Restore original "is within leaf" value in SparseVectorFieldMapper

### DIFF
--- a/docs/changelog/118380.yaml
+++ b/docs/changelog/118380.yaml
@@ -1,0 +1,5 @@
+pr: 118380
+summary: Restore original "is within leaf" value in `SparseVectorFieldMapper`
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapper.java
@@ -200,6 +200,7 @@ public class SparseVectorFieldMapper extends FieldMapper {
             );
         }
 
+        final boolean isWithinLeaf = context.path().isWithinLeafObject();
         String feature = null;
         try {
             // make sure that we don't expand dots in field names while parsing
@@ -234,7 +235,7 @@ public class SparseVectorFieldMapper extends FieldMapper {
                 context.addToFieldNames(fieldType().name());
             }
         } finally {
-            context.path().setWithinLeafObject(false);
+            context.path().setWithinLeafObject(isWithinLeaf);
         }
     }
 


### PR DESCRIPTION
Restore the original "is within leaf" value in the document parsing context after sparse vector parsing is complete. Fixes a bug discovered in #118190, the fix gets its own PR because its a general bug.
