### PR TITLE
[8.x] Disabling the migration reindex yaml rest tests unless feature is available (#118382)

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestMigrationReindexAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestMigrationReindexAction.java
@@ -20,11 +20,16 @@ import org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction;
 import org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.ReindexDataStreamResponse;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
 
 public class RestMigrationReindexAction extends BaseRestHandler {
+    public static final String MIGRATION_REINDEX_CAPABILITY = "migration_reindex";
 
     @Override
     public String getName() {
@@ -47,6 +52,15 @@ public class RestMigrationReindexAction extends BaseRestHandler {
             reindexRequest,
             new ReindexDataStreamRestToXContentListener(channel)
         );
+    }
+
+    @Override
+    public Set<String> supportedCapabilities() {
+        Set<String> capabilities = new HashSet<>();
+        if (REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled()) {
+            capabilities.add(MIGRATION_REINDEX_CAPABILITY);
+        }
+        return Collections.unmodifiableSet(capabilities);
     }
 
     static class ReindexDataStreamRestToXContentListener extends RestBuilderListener<ReindexDataStreamResponse> {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/10_reindex.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/10_reindex.yml
@@ -6,6 +6,13 @@ setup:
 
 ---
 "Test Reindex With Unsupported Mode":
+  - requires:
+      reason: "migration reindex is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_migration/reindex
+          capabilities: [migration_reindex]
   - do:
       catch: /illegal_argument_exception/
       migrate.reindex:
@@ -19,6 +26,13 @@ setup:
 
 ---
 "Test Reindex With Nonexistent Data Stream":
+  - requires:
+      reason: "migration reindex is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_migration/reindex
+          capabilities: [migration_reindex]
   - do:
       catch: /resource_not_found_exception/
       migrate.reindex:
@@ -44,6 +58,13 @@ setup:
 
 ---
 "Test Reindex With Bad Data Stream Name":
+  - requires:
+      reason: "migration reindex is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_migration/reindex
+          capabilities: [migration_reindex]
   - do:
       catch: /illegal_argument_exception/
       migrate.reindex:
@@ -57,6 +78,13 @@ setup:
 
 ---
 "Test Reindex With Existing Data Stream":
+  - requires:
+      reason: "migration reindex is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_migration/reindex
+          capabilities: [migration_reindex]
   - do:
       indices.put_index_template:
         name: my-template1

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/20_reindex_status.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/20_reindex_status.yml
@@ -6,6 +6,13 @@ setup:
 
 ---
 "Test get reindex status with nonexistent task id":
+  - requires:
+      reason: "migration reindex is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_migration/reindex
+          capabilities: [migration_reindex]
   - do:
       catch: /resource_not_found_exception/
       migrate.get_reindex_status:
@@ -13,6 +20,13 @@ setup:
 
 ---
 "Test Reindex With Existing Data Stream":
+  - requires:
+      reason: "migration reindex is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_migration/reindex
+          capabilities: [migration_reindex]
   - do:
       indices.put_index_template:
         name: my-template1


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Disabling the migration reindex yaml rest tests unless feature is available (#118382)