### PR TITLE
[8.x] Update numeral format from '조' to '일조' for clarity (#118232)

### DIFF
--- a/docs/plugins/analysis-nori.asciidoc
+++ b/docs/plugins/analysis-nori.asciidoc
@@ -475,7 +475,7 @@ The input is untokenized text and the result is the single term attribute emitte
 - 영영칠 -> 7
 - 일영영영 -> 1000
 - 삼천2백2십삼 -> 3223
-- 조육백만오천일 -> 1000006005001
+- 일조육백만오천일 -> 1000006005001
 - ３.２천 ->  3200
 - １.２만３４５.６７ -> 12345.67
 - 4,647.100 -> 4647.1


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Update numeral format from '조' to '일조' for clarity (#118232)