### PR TITLE
 Fix rest-api-spec and docs for bulk API

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -257,6 +257,10 @@ include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 (Optional, Boolean) If `true`, the request's actions must target an index alias.
 Defaults to `false`.
 
+`require_data_stream`::
+(Optional, Boolean) If `true`, the request's actions must target a data stream (existing or to-be-created).
+Defaults to `false`.
+
 include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
 include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=source]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
@@ -56,10 +56,6 @@
         "type":"time",
         "description":"Explicit operation timeout"
       },
-      "type":{
-        "type":"string",
-        "description":"Default document type for items which don't provide one"
-      },
       "_source":{
         "type":"list",
         "description":"True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request"
@@ -78,11 +74,11 @@
       },
       "require_alias": {
         "type": "boolean",
-        "description": "Sets require_alias for all incoming documents. Defaults to unset (false)"
+        "description": "If true, the request’s actions must target an index alias. Defaults to false."
       },
       "require_data_stream": {
         "type": "boolean",
-        "description": "When true, requires the destination to be a data stream (existing or to-be-created). Default is false"
+        "description": "If true, the request's actions must target a data stream (existing or to-be-created). Default to false"
       },
       "list_executed_pipelines": {
         "type": "boolean",


### PR DESCRIPTION
This aligns the docs with the specs and remove the `type` parameter that is no longer supported in 9.0 and was removed in https://github.com/elastic/elasticsearch/pull/114850.