### PR TITLE
[8.x] Log message for doc parsing errors includes index name (#118347)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -30,6 +30,7 @@ public class DocumentMapper {
     private final MapperMetrics mapperMetrics;
     private final IndexVersion indexVersion;
     private final Logger logger;
+    private final String indexName;
 
     /**
      * Create a new {@link DocumentMapper} that holds empty mappings.
@@ -67,6 +68,7 @@ public class DocumentMapper {
         this.mapperMetrics = mapperMetrics;
         this.indexVersion = version;
         this.logger = Loggers.getLogger(getClass(), indexName);
+        this.indexName = indexName;
 
         assert mapping.toCompressedXContent().equals(source) || isSyntheticSourceMalformed(source, version)
             : "provided source [" + source + "] differs from mapping [" + mapping.toCompressedXContent() + "]";
@@ -74,9 +76,9 @@ public class DocumentMapper {
 
     private void maybeLog(Exception ex) {
         if (logger.isDebugEnabled()) {
-            logger.debug("Error while parsing document: " + ex.getMessage(), ex);
+            logger.debug("Error while parsing document for index [" + indexName + "]: " + ex.getMessage(), ex);
         } else if (IntervalThrottler.DOCUMENT_PARSING_FAILURE.accept()) {
-            logger.error("Error while parsing document: " + ex.getMessage(), ex);
+            logger.info("Error while parsing document for index [" + indexName + "]: " + ex.getMessage(), ex);
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Log message for doc parsing errors includes index name (#118347)](https://github.com/elastic/elasticsearch/pull/118347)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)