### PR TITLE
[8.x] Backport ignoreOrder marks on LOOKUP JOIN tests (#118136)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -444,6 +444,3 @@ tests:
 - class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
   method: testSettingsApplied
   issue: https://github.com/elastic/elasticsearch/issues/116694
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {lookup-join.LookupMessageFromIndexKeep ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/118399

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -140,6 +140,7 @@ FROM sample_data
 | EVAL client_ip = client_ip::keyword
 | LOOKUP JOIN clientips_lookup ON client_ip
 ;
+ignoreOrder:true
 
 @timestamp:date          | event_duration:long | message:keyword       | client_ip:keyword | env:keyword
 2023-10-23T13:55:01.543Z | 1756467             | Connected to 10.1.0.1 | 172.21.3.15       | Production
@@ -159,6 +160,7 @@ FROM sample_data
 | LOOKUP JOIN clientips_lookup ON client_ip
 | KEEP @timestamp, client_ip, event_duration, message, env
 ;
+ignoreOrder:true
 
 @timestamp:date          | client_ip:keyword | event_duration:long | message:keyword       | env:keyword
 2023-10-23T13:55:01.543Z | 172.21.3.15       | 1756467             | Connected to 10.1.0.1 | Production
@@ -243,6 +245,7 @@ required_capability: join_lookup_v4
 FROM sample_data
 | LOOKUP JOIN message_types_lookup ON message
 ;
+ignoreOrder:true
 
 @timestamp:date          | client_ip:ip | event_duration:long | message:keyword       | type:keyword
 2023-10-23T13:55:01.543Z | 172.21.3.15  | 1756467             | Connected to 10.1.0.1 | Success
@@ -261,6 +264,7 @@ FROM sample_data
 | LOOKUP JOIN message_types_lookup ON message
 | KEEP @timestamp, client_ip, event_duration, message, type
 ;
+ignoreOrder:true
 
 @timestamp:date          | client_ip:ip | event_duration:long | message:keyword       | type:keyword
 2023-10-23T13:55:01.543Z | 172.21.3.15  | 1756467             | Connected to 10.1.0.1 | Success


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/118399

# Backport

This will backport the following commits from `main` to `8.x`:
 - [ES|QL: make ignoreOrder parsing more strict in CSV tests (#118136)](https://github.com/elastic/elasticsearch/pull/118136)

**To be precise**, the strict `ignoreOrder` parsing was already backported, but the lookup tests were missing the `ignoreOrder` marks that were fixed in the original pull request. This backports only those.