### PR TITLE
Remove deprecated Engine#newChangesSnapshot

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -942,24 +942,10 @@ public abstract class Engine implements Closeable {
     public abstract int countChanges(String source, long fromSeqNo, long toSeqNo) throws IOException;
 
     /**
-     * @deprecated This method is deprecated will and be removed once #114618 is applied to the serverless repository.
-     * @see #newChangesSnapshot(String, long, long, boolean, boolean, boolean, long)
-     */
-    @Deprecated
-    public abstract Translog.Snapshot newChangesSnapshot(
-        String source,
-        long fromSeqNo,
-        long toSeqNo,
-        boolean requiredFullRange,
-        boolean singleConsumer,
-        boolean accessStats
-    ) throws IOException;
-
-    /**
      * Creates a new history snapshot from Lucene for reading operations whose seqno in the requesting seqno range (both inclusive).
      * This feature requires soft-deletes enabled. If soft-deletes are disabled, this method will throw an {@link IllegalStateException}.
      */
-    public Translog.Snapshot newChangesSnapshot(
+    public abstract Translog.Snapshot newChangesSnapshot(
         String source,
         long fromSeqNo,
         long toSeqNo,
@@ -967,10 +953,7 @@ public abstract class Engine implements Closeable {
         boolean singleConsumer,
         boolean accessStats,
         long maxChunkSize
-    ) throws IOException {
-        // TODO: Remove this default implementation once the deprecated newChangesSnapshot is removed
-        return newChangesSnapshot(source, fromSeqNo, toSeqNo, requiredFullRange, singleConsumer, accessStats);
-    }
+    ) throws IOException;
 
     /**
      * Checks if this engine has every operations since  {@code startingSeqNo}(inclusive) in its history (either Lucene or translog)

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -3143,18 +3143,6 @@ public class InternalEngine extends Engine {
         long toSeqNo,
         boolean requiredFullRange,
         boolean singleConsumer,
-        boolean accessStats
-    ) throws IOException {
-        return newChangesSnapshot(source, fromSeqNo, toSeqNo, requiredFullRange, singleConsumer, accessStats, -1);
-    }
-
-    @Override
-    public Translog.Snapshot newChangesSnapshot(
-        String source,
-        long fromSeqNo,
-        long toSeqNo,
-        boolean requiredFullRange,
-        boolean singleConsumer,
         boolean accessStats,
         long maxChunkSize
     ) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -368,18 +368,6 @@ public class ReadOnlyEngine extends Engine {
         long toSeqNo,
         boolean requiredFullRange,
         boolean singleConsumer,
-        boolean accessStats
-    ) throws IOException {
-        return Translog.Snapshot.EMPTY;
-    }
-
-    @Override
-    public Translog.Snapshot newChangesSnapshot(
-        String source,
-        long fromSeqNo,
-        long toSeqNo,
-        boolean requiredFullRange,
-        boolean singleConsumer,
         boolean accessStats,
         long maxChunkSize
     ) {


### PR DESCRIPTION
The new method with the overloaded chunk size should be used instead. 
Relates #114618