### PR TITLE
Disable check_on_startup for KibanaUserRoleIntegTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -52,12 +52,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
   issue: https://github.com/elastic/elasticsearch/issues/113325
-- class: org.elasticsearch.integration.KibanaUserRoleIntegTests
-  method: testFieldMappings
-  issue: https://github.com/elastic/elasticsearch/issues/113592
-- class: org.elasticsearch.integration.KibanaUserRoleIntegTests
-  method: testSearchAndMSearch
-  issue: https://github.com/elastic/elasticsearch/issues/113593
 - class: org.elasticsearch.xpack.transform.integration.TransformIT
   method: testStopWaitForCheckpoint
   issue: https://github.com/elastic/elasticsearch/issues/106113

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaUserRoleIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaUserRoleIntegTests.java
@@ -14,13 +14,16 @@ import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRespon
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.NativeRealmIntegTestCase;
 import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 
 import java.util.Map;
+import java.util.Random;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
@@ -58,6 +61,14 @@ public class KibanaUserRoleIntegTests extends NativeRealmIntegTestCase {
     @Override
     public String configUsersRoles() {
         return super.configUsersRoles() + "my_kibana_user:kibana_user\n" + "kibana_user:kibana_user";
+    }
+
+    @Override
+    protected Settings.Builder setRandomIndexSettings(Random random, Settings.Builder builder) {
+        // Prevent INDEX_CHECK_ON_STARTUP as a random setting since it could result in indices being checked for corruption before opening.
+        // When corruption is detected, it will prevent the shard from being opened. This check is expensive in terms of CPU and memory
+        // usage and causes intermittent CI failures due to timeout.
+        return super.setRandomIndexSettings(random, builder).put(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey(), false);
     }
 
     public void testFieldMappings() throws Exception {


### PR DESCRIPTION
Resolves: https://github.com/elastic/elasticsearch/issues/113592, https://github.com/elastic/elasticsearch/issues/113593

The tests try to create an index (logstash-20-12-2015):
```
14:18:18: [2024-09-26T14:18:18,859][INFO ][o.e.i.KibanaUserRoleIntegTests] [testFieldMappings] Index [1] docs async: [true] bulk: [false]
```

Then seeing a bunch of: 
```
  1> [2024-09-26T14:18:25,581][WARN ][o.e.i.s.IndexShard       ] [node_s0] [logstash-20-12-2015][0] performing expensive diagnostic checks during shard startup [index.shard.check_on_startup=true]; these checks should only be enabled temporarily, you must remove this index setting as soon as possible
  1> [2024-09-26T14:18:26,029][WARN ][o.e.i.s.IndexShard       ] [node_s0] [logstash-20-12-2015][1] performing expensive diagnostic checks during shard startup [index.shard.check_on_startup=true]; these checks should only be enabled temporarily, you must remove this index setting as soon as possible
  1> [2024-09-26T14:18:26,631][WARN ][o.e.i.s.IndexShard       ] [node_s0] [logstash-20-12-2015][2] performing expensive diagnostic checks during shard startup [index.shard.check_on_startup=true]; these checks should only be enabled temporarily, you must remove this index setting as soon as possible
  1> [2024-09-26T14:18:27,422][WARN ][o.e.i.s.IndexShard       ] [node_s0] [logstash-20-12-2015][3] performing expensive diagnostic checks during shard startup [index.shard.check_on_startup=true]; these checks should only be enabled temporarily, you must remove this index setting as soon as possible
```

These warnings appear to be spread out over a pretty long period of time and is likely what causes the timeout. 

This PR disables the [INDEX_CHECK_ON_STARTUP](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#_static_index_settings) to make sure the tests do not time out. 




