### PR TITLE
No-op reset in SlicedInputStream

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStream.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStream.java
@@ -171,6 +171,10 @@ public abstract class SlicedInputStream extends InputStream {
                 if (markedSlice < 0 || markedSliceOffset < 0) {
                     throw new IOException("Mark has not been set");
                 }
+                if (initialized && nextSlice == markedSlice + 1 && currentSliceOffset == markedSliceOffset) {
+                    // Reset at the marked offset should return immediately without re-opening the slice
+                    return;
+                }
 
                 nextSlice = markedSlice;
                 initialized = true;

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
@@ -155,9 +155,10 @@ public class SlicedInputStreamTests extends ESTestCase {
 
         // Mark
         input.mark(randomNonNegativeInt());
+        int slicesOpenedAtMark = streamsOpened.size();
 
         // Read or skip up to another random point
-        final int moreBytes = randomIntBetween(0, bytes.length - mark);
+        int moreBytes = randomIntBetween(0, bytes.length - mark);
         if (moreBytes > 0) {
             if (randomBoolean()) {
                 final var moreBytesRead = new byte[moreBytes];
@@ -171,11 +172,13 @@ public class SlicedInputStreamTests extends ESTestCase {
 
         // Randomly read to EOF
         if (randomBoolean()) {
-            input.readAllBytes();
+            moreBytes += input.readAllBytes().length;
         }
 
         // Reset
         input.reset();
+        int slicesOpenedAfterReset = streamsOpened.size();
+        assert moreBytes > 0 || mark == 0 || slicesOpenedAfterReset == slicesOpenedAtMark : "Reset at mark should not re-open slices";
 
         // Read all remaining bytes, which should be the bytes from mark up to the end
         final int remainingBytes = bytes.length - mark;


### PR DESCRIPTION
Previously if reset was called at the exact marked offset, it would unnecessarily re-open the current slice and skip bytes. We now detect this situation, and just do nothing in this case.

Closes ES-10235