### PR TITLE
Remove code to handle 6.8 transport handshakes and pre-7.6 TCP headers

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundMessage.java
@@ -42,26 +42,20 @@ abstract class OutboundMessage extends NetworkMessage {
 
     BytesReference serialize(RecyclerBytesStreamOutput bytesStream) throws IOException {
         bytesStream.setTransportVersion(version);
-        bytesStream.skip(TcpHeader.headerSize(version));
+        bytesStream.skip(TcpHeader.HEADER_SIZE);
 
         // The compressible bytes stream will not close the underlying bytes stream
         BytesReference reference;
-        int variableHeaderLength = -1;
         final long preHeaderPosition = bytesStream.position();
 
-        if (version.onOrAfter(TcpHeader.VERSION_WITH_HEADER_SIZE)) {
-            writeVariableHeader(bytesStream);
-            variableHeaderLength = Math.toIntExact(bytesStream.position() - preHeaderPosition);
-        }
+        writeVariableHeader(bytesStream);
+        int variableHeaderLength = Math.toIntExact(bytesStream.position() - preHeaderPosition);
 
         final boolean compress = TransportStatus.isCompress(status);
         final StreamOutput stream = compress ? wrapCompressed(bytesStream) : bytesStream;
         final BytesReference zeroCopyBuffer;
         try {
             stream.setTransportVersion(version);
-            if (variableHeaderLength == -1) {
-                writeVariableHeader(stream);
-            }
             if (message instanceof BytesTransportRequest bRequest) {
                 bRequest.writeThin(stream);
                 zeroCopyBuffer = bRequest.bytes;
@@ -87,7 +81,7 @@ abstract class OutboundMessage extends NetworkMessage {
         }
 
         bytesStream.seek(0);
-        final int contentSize = reference.length() - TcpHeader.headerSize(version);
+        final int contentSize = reference.length() - TcpHeader.HEADER_SIZE;
         TcpHeader.writeHeader(bytesStream, requestId, status, version, contentSize, variableHeaderLength);
         return reference;
     }

--- a/server/src/main/java/org/elasticsearch/transport/TcpHeader.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpHeader.java
@@ -10,14 +10,11 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
 public class TcpHeader {
-
-    public static final TransportVersion VERSION_WITH_HEADER_SIZE = TransportVersions.V_7_6_0;
 
     public static final int MARKER_BYTES_SIZE = 2;
 
@@ -37,19 +34,9 @@ public class TcpHeader {
 
     public static final int VARIABLE_HEADER_SIZE_POSITION = VERSION_POSITION + VERSION_ID_SIZE;
 
-    private static final int PRE_76_HEADER_SIZE = VERSION_POSITION + VERSION_ID_SIZE;
+    public static final int BYTES_REQUIRED_FOR_VERSION = VERSION_POSITION + VERSION_ID_SIZE;
 
-    public static final int BYTES_REQUIRED_FOR_VERSION = PRE_76_HEADER_SIZE;
-
-    private static final int HEADER_SIZE = PRE_76_HEADER_SIZE + VARIABLE_HEADER_SIZE;
-
-    public static int headerSize(TransportVersion version) {
-        if (version.onOrAfter(VERSION_WITH_HEADER_SIZE)) {
-            return HEADER_SIZE;
-        } else {
-            return PRE_76_HEADER_SIZE;
-        }
-    }
+    public static final int HEADER_SIZE = BYTES_REQUIRED_FOR_VERSION + VARIABLE_HEADER_SIZE;
 
     private static final byte[] PREFIX = { (byte) 'E', (byte) 'S' };
 
@@ -63,17 +50,10 @@ public class TcpHeader {
     ) throws IOException {
         output.writeBytes(PREFIX);
         // write the size, the size indicates the remaining message size, not including the size int
-        if (version.onOrAfter(VERSION_WITH_HEADER_SIZE)) {
-            output.writeInt(contentSize + REQUEST_ID_SIZE + STATUS_SIZE + VERSION_ID_SIZE + VARIABLE_HEADER_SIZE);
-        } else {
-            output.writeInt(contentSize + REQUEST_ID_SIZE + STATUS_SIZE + VERSION_ID_SIZE);
-        }
+        output.writeInt(contentSize + REQUEST_ID_SIZE + STATUS_SIZE + VERSION_ID_SIZE + VARIABLE_HEADER_SIZE);
         output.writeLong(requestId);
         output.writeByte(status);
         output.writeInt(version.id());
-        if (version.onOrAfter(VERSION_WITH_HEADER_SIZE)) {
-            assert variableHeaderSize != -1 : "Variable header size not set";
-            output.writeInt(variableHeaderSize);
-        }
+        output.writeInt(variableHeaderSize);
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -41,43 +41,10 @@ final class TransportHandshaker {
      * ignores the body of the request. After the handshake, the OutboundHandler uses the min(local,remote) protocol version for all later
      * messages.
      *
-     * This version supports two handshake protocols, v6080099 and v7170099, which respectively have the same message structure as the
-     * transport protocols of v6.8.0 and v7.17.0. This node only sends v7170099 requests, but it can send a valid response to any v6080099
-     * requests that it receives.
+     * This version supports one handshake protocol, v7170099, which has the same message structure as the
+     * transport protocol of v7.17.0. This node only sends v7170099 requests.
      *
      * Here are some example messages, broken down to show their structure:
-     *
-     * ## v6080099 Request:
-     *
-     * 45 53                            -- 'ES' marker
-     * 00 00 00 34                      -- total message length
-     *    00 00 00 00 00 00 00 01       -- request ID
-     *    08                            -- status flags (0b1000 == handshake request)
-     *    00 5c c6 63                   -- handshake protocol version (0x5cc663 == 6080099)
-     *    00                            -- no request headers [1]
-     *    00                            -- no response headers [1]
-     *    01                            -- one feature [2]
-     *       06                         -- feature name length
-     *          78 2d 70 61 63 6b       -- feature name 'x-pack'
-     *    16                            -- action string size
-     *       69 6e 74 65 72 6e 61 6c    }
-     *       3a 74 63 70 2f 68 61 6e    }- ASCII representation of HANDSHAKE_ACTION_NAME
-     *       64 73 68 61 6b 65          }
-     *    00                            -- no parent task ID [3]
-     *    04                            -- payload length
-     *       8b d5 b5 03                -- max acceptable protocol version (vInt: 00000011 10110101 11010101 10001011 == 7170699)
-     *
-     * ## v6080099 Response:
-     *
-     * 45 53                            -- 'ES' marker
-     * 00 00 00 13                      -- total message length
-     *    00 00 00 00 00 00 00 01       -- request ID (copied from request)
-     *    09                            -- status flags (0b1001 == handshake response)
-     *    00 5c c6 63                   -- handshake protocol version (0x5cc663 == 6080099, copied from request)
-     *    00                            -- no request headers [1]
-     *    00                            -- no response headers [1]
-     *    c3 f9 eb 03                   -- max acceptable protocol version (vInt: 00000011 11101011 11111001 11000011 == 8060099)
-     *
      *
      * ## v7170099 Request:
      *
@@ -116,9 +83,8 @@ final class TransportHandshaker {
      * [3] Parent task ID should be empty; see org.elasticsearch.tasks.TaskId.writeTo for its structure.
      */
 
-    static final TransportVersion EARLIEST_HANDSHAKE_VERSION = TransportVersion.fromId(6080099);
     static final TransportVersion REQUEST_HANDSHAKE_VERSION = TransportVersions.MINIMUM_COMPATIBLE;
-    static final Set<TransportVersion> ALLOWED_HANDSHAKE_VERSIONS = Set.of(EARLIEST_HANDSHAKE_VERSION, REQUEST_HANDSHAKE_VERSION);
+    static final Set<TransportVersion> ALLOWED_HANDSHAKE_VERSIONS = Set.of(REQUEST_HANDSHAKE_VERSION);
 
     static final String HANDSHAKE_ACTION_NAME = "internal:tcp/handshake";
     private final ConcurrentMap<Long, HandshakeResponseHandler> pendingHandshakes = new ConcurrentHashMap<>();

--- a/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
@@ -85,12 +85,7 @@ public final class TransportLogger {
                 sb.append(", type: ").append(type);
                 sb.append(", version: ").append(version);
 
-                if (version.onOrAfter(TcpHeader.VERSION_WITH_HEADER_SIZE)) {
-                    sb.append(", header size: ").append(streamInput.readInt()).append('B');
-                } else {
-                    streamInput = decompressingStream(status, streamInput);
-                    assert InboundHandler.assertRemoteVersion(streamInput, version);
-                }
+                sb.append(", header size: ").append(streamInput.readInt()).append('B');
 
                 // read and discard headers
                 ThreadContext.readHeadersFromStream(streamInput);

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -27,8 +27,11 @@ import java.util.ArrayList;
 
 import static org.elasticsearch.common.bytes.ReleasableBytesReferenceStreamInputTests.wrapAsReleasable;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 
 public class InboundDecoderTests extends ESTestCase {
 
@@ -77,30 +80,28 @@ public class InboundDecoderTests extends ESTestCase {
 
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference totalBytes = message.serialize(os);
-            int totalHeaderSize = TcpHeader.headerSize(TransportVersion.current()) + totalBytes.getInt(
-                TcpHeader.VARIABLE_HEADER_SIZE_POSITION
-            );
+            int totalHeaderSize = TcpHeader.HEADER_SIZE + totalBytes.getInt(TcpHeader.VARIABLE_HEADER_SIZE_POSITION);
             final BytesReference messageBytes = totalBytes.slice(totalHeaderSize, totalBytes.length() - totalHeaderSize);
 
             InboundDecoder decoder = new InboundDecoder(recycler);
             final ArrayList<Object> fragments = new ArrayList<>();
             final ReleasableBytesReference releasable1 = wrapAsReleasable(totalBytes);
             int bytesConsumed = decoder.decode(releasable1, fragments::add);
-            assertEquals(totalHeaderSize, bytesConsumed);
+            assertThat(bytesConsumed, is(totalHeaderSize));
             assertTrue(releasable1.hasReferences());
 
             final Header header = (Header) fragments.get(0);
-            assertEquals(requestId, header.getRequestId());
-            assertEquals(TransportVersion.current(), header.getVersion());
+            assertThat(header.getRequestId(), is(requestId));
+            assertThat(header.getVersion(), is(TransportVersion.current()));
             assertFalse(header.isCompressed());
             assertFalse(header.isHandshake());
             if (isRequest) {
-                assertEquals(action, header.getActionName());
+                assertThat(header.getActionName(), is(action));
                 assertTrue(header.isRequest());
-                assertEquals(header.getHeaders().v1().get(headerKey), headerValue);
+                assertThat(header.getHeaders().v1(), hasEntry(headerKey, headerValue));
             } else {
                 assertTrue(header.isResponse());
-                assertThat(header.getHeaders().v2().get(headerKey), hasItems(headerValue));
+                assertThat(header.getHeaders().v2(), hasEntry(equalTo(headerKey), hasItems(headerValue)));
             }
             assertFalse(header.needsToReadVariableHeader());
             fragments.clear();
@@ -108,119 +109,19 @@ public class InboundDecoderTests extends ESTestCase {
             final BytesReference bytes2 = totalBytes.slice(bytesConsumed, totalBytes.length() - bytesConsumed);
             final ReleasableBytesReference releasable2 = wrapAsReleasable(bytes2);
             int bytesConsumed2 = decoder.decode(releasable2, fragments::add);
-            assertEquals(totalBytes.length() - totalHeaderSize, bytesConsumed2);
+            assertThat(bytesConsumed2, is(totalBytes.length() - totalHeaderSize));
 
             final Object content = fragments.get(0);
             final Object endMarker = fragments.get(1);
 
-            assertEquals(messageBytes, content);
+            assertThat(content, is(messageBytes));
             // Ref count is incremented since the bytes are forwarded as a fragment
             assertTrue(releasable2.hasReferences());
             releasable2.decRef();
             assertTrue(releasable2.hasReferences());
             assertTrue(releasable2.decRef());
-            assertEquals(InboundDecoder.END_CONTENT, endMarker);
+            assertThat(endMarker, is(InboundDecoder.END_CONTENT));
         }
-
-    }
-
-    public void testDecodePreHeaderSizeVariableInt() throws IOException {
-        // TODO: Can delete test on 9.0
-        Compression.Scheme compressionScheme = randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.DEFLATE, null);
-        String action = "test-request";
-        long requestId = randomNonNegativeLong();
-        final TransportVersion preHeaderVariableInt = TransportHandshaker.EARLIEST_HANDSHAKE_VERSION;
-        final String contentValue = randomAlphaOfLength(100);
-        // 8.0 is only compatible with handshakes on a pre-variable int version
-        final OutboundMessage message = new OutboundMessage.Request(
-            threadContext,
-            new TestRequest(contentValue),
-            preHeaderVariableInt,
-            action,
-            requestId,
-            true,
-            compressionScheme
-        );
-
-        try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
-            final BytesReference totalBytes = message.serialize(os);
-            int partialHeaderSize = TcpHeader.headerSize(preHeaderVariableInt);
-
-            InboundDecoder decoder = new InboundDecoder(recycler);
-            final ArrayList<Object> fragments = new ArrayList<>();
-            final ReleasableBytesReference releasable1 = wrapAsReleasable(totalBytes);
-            int bytesConsumed = decoder.decode(releasable1, fragments::add);
-            assertEquals(partialHeaderSize, bytesConsumed);
-            assertTrue(releasable1.hasReferences());
-
-            final Header header = (Header) fragments.get(0);
-            assertEquals(requestId, header.getRequestId());
-            assertEquals(preHeaderVariableInt, header.getVersion());
-            if (compressionScheme == null) {
-                assertFalse(header.isCompressed());
-            } else {
-                assertTrue(header.isCompressed());
-            }
-            assertTrue(header.isHandshake());
-            assertTrue(header.isRequest());
-            assertTrue(header.needsToReadVariableHeader());
-            fragments.clear();
-
-            final BytesReference bytes2 = totalBytes.slice(bytesConsumed, totalBytes.length() - bytesConsumed);
-            final ReleasableBytesReference releasable2 = wrapAsReleasable(bytes2);
-            int bytesConsumed2 = decoder.decode(releasable2, fragments::add);
-            if (compressionScheme == null) {
-                assertEquals(2, fragments.size());
-            } else {
-                assertEquals(3, fragments.size());
-                final Object body = fragments.get(1);
-                assertThat(body, instanceOf(ReleasableBytesReference.class));
-                ((ReleasableBytesReference) body).close();
-            }
-            assertEquals(InboundDecoder.END_CONTENT, fragments.get(fragments.size() - 1));
-            assertEquals(totalBytes.length() - bytesConsumed, bytesConsumed2);
-        }
-    }
-
-    public void testDecodeHandshakeCompatibility() throws IOException {
-        String action = "test-request";
-        long requestId = randomNonNegativeLong();
-        final String headerKey = randomAlphaOfLength(10);
-        final String headerValue = randomAlphaOfLength(20);
-        threadContext.putHeader(headerKey, headerValue);
-        TransportVersion handshakeCompat = TransportHandshaker.EARLIEST_HANDSHAKE_VERSION;
-        OutboundMessage message = new OutboundMessage.Request(
-            threadContext,
-            new TestRequest(randomAlphaOfLength(100)),
-            handshakeCompat,
-            action,
-            requestId,
-            true,
-            null
-        );
-
-        try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
-            final BytesReference bytes = message.serialize(os);
-            int totalHeaderSize = TcpHeader.headerSize(handshakeCompat);
-
-            InboundDecoder decoder = new InboundDecoder(recycler);
-            final ArrayList<Object> fragments = new ArrayList<>();
-            final ReleasableBytesReference releasable1 = wrapAsReleasable(bytes);
-            int bytesConsumed = decoder.decode(releasable1, fragments::add);
-            assertEquals(totalHeaderSize, bytesConsumed);
-            assertTrue(releasable1.hasReferences());
-
-            final Header header = (Header) fragments.get(0);
-            assertEquals(requestId, header.getRequestId());
-            assertEquals(handshakeCompat, header.getVersion());
-            assertFalse(header.isCompressed());
-            assertTrue(header.isHandshake());
-            assertTrue(header.isRequest());
-            // TODO: On 9.0 this will be true because all compatible versions with contain the variable header int
-            assertTrue(header.needsToReadVariableHeader());
-            fragments.clear();
-        }
-
     }
 
     public void testClientChannelTypeFailsDecodingRequests() throws Exception {
@@ -259,12 +160,10 @@ public class InboundDecoderTests extends ESTestCase {
             try (InboundDecoder decoder = new InboundDecoder(recycler, randomFrom(ChannelType.SERVER, ChannelType.MIX))) {
                 final ArrayList<Object> fragments = new ArrayList<>();
                 int bytesConsumed = decoder.decode(wrapAsReleasable(bytes), fragments::add);
-                int totalHeaderSize = TcpHeader.headerSize(TransportVersion.current()) + bytes.getInt(
-                    TcpHeader.VARIABLE_HEADER_SIZE_POSITION
-                );
-                assertEquals(totalHeaderSize, bytesConsumed);
+                int totalHeaderSize = TcpHeader.HEADER_SIZE + bytes.getInt(TcpHeader.VARIABLE_HEADER_SIZE_POSITION);
+                assertThat(bytesConsumed, is(totalHeaderSize));
                 final Header header = (Header) fragments.get(0);
-                assertEquals(requestId, header.getRequestId());
+                assertThat(header.getRequestId(), is(requestId));
             }
         }
     }
@@ -301,12 +200,10 @@ public class InboundDecoderTests extends ESTestCase {
             try (InboundDecoder decoder = new InboundDecoder(recycler, randomFrom(ChannelType.CLIENT, ChannelType.MIX))) {
                 final ArrayList<Object> fragments = new ArrayList<>();
                 int bytesConsumed = decoder.decode(wrapAsReleasable(bytes), fragments::add);
-                int totalHeaderSize = TcpHeader.headerSize(TransportVersion.current()) + bytes.getInt(
-                    TcpHeader.VARIABLE_HEADER_SIZE_POSITION
-                );
-                assertEquals(totalHeaderSize, bytesConsumed);
+                int totalHeaderSize = TcpHeader.HEADER_SIZE + bytes.getInt(TcpHeader.VARIABLE_HEADER_SIZE_POSITION);
+                assertThat(bytesConsumed, is(totalHeaderSize));
                 final Header header = (Header) fragments.get(0);
-                assertEquals(requestId, header.getRequestId());
+                assertThat(header.getRequestId(), is(requestId));
             }
         }
     }
@@ -346,29 +243,27 @@ public class InboundDecoderTests extends ESTestCase {
             final BytesStreamOutput out = new BytesStreamOutput();
             transportMessage.writeTo(out);
             final BytesReference uncompressedBytes = out.bytes();
-            int totalHeaderSize = TcpHeader.headerSize(TransportVersion.current()) + totalBytes.getInt(
-                TcpHeader.VARIABLE_HEADER_SIZE_POSITION
-            );
+            int totalHeaderSize = TcpHeader.HEADER_SIZE + totalBytes.getInt(TcpHeader.VARIABLE_HEADER_SIZE_POSITION);
 
             InboundDecoder decoder = new InboundDecoder(recycler);
             final ArrayList<Object> fragments = new ArrayList<>();
             final ReleasableBytesReference releasable1 = wrapAsReleasable(totalBytes);
             int bytesConsumed = decoder.decode(releasable1, fragments::add);
-            assertEquals(totalHeaderSize, bytesConsumed);
+            assertThat(bytesConsumed, is(totalHeaderSize));
             assertTrue(releasable1.hasReferences());
 
             final Header header = (Header) fragments.get(0);
-            assertEquals(requestId, header.getRequestId());
-            assertEquals(TransportVersion.current(), header.getVersion());
+            assertThat(header.getRequestId(), is(requestId));
+            assertThat(header.getVersion(), is(TransportVersion.current()));
             assertTrue(header.isCompressed());
             assertFalse(header.isHandshake());
             if (isRequest) {
-                assertEquals(action, header.getActionName());
+                assertThat(header.getActionName(), is(action));
                 assertTrue(header.isRequest());
-                assertEquals(header.getHeaders().v1().get(headerKey), headerValue);
+                assertThat(header.getHeaders().v1(), hasEntry(headerKey, headerValue));
             } else {
                 assertTrue(header.isResponse());
-                assertThat(header.getHeaders().v2().get(headerKey), hasItems(headerValue));
+                assertThat(header.getHeaders().v2(), hasEntry(equalTo(headerKey), hasItems(headerValue)));
             }
             assertFalse(header.needsToReadVariableHeader());
             fragments.clear();
@@ -376,60 +271,19 @@ public class InboundDecoderTests extends ESTestCase {
             final BytesReference bytes2 = totalBytes.slice(bytesConsumed, totalBytes.length() - bytesConsumed);
             final ReleasableBytesReference releasable2 = wrapAsReleasable(bytes2);
             int bytesConsumed2 = decoder.decode(releasable2, fragments::add);
-            assertEquals(totalBytes.length() - totalHeaderSize, bytesConsumed2);
+            assertThat(bytesConsumed2, is(totalBytes.length() - totalHeaderSize));
 
             final Object compressionScheme = fragments.get(0);
             final Object content = fragments.get(1);
             final Object endMarker = fragments.get(2);
 
-            assertEquals(scheme, compressionScheme);
-            assertEquals(uncompressedBytes, content);
+            assertThat(compressionScheme, is(scheme));
+            assertThat(content, is(uncompressedBytes));
             assertThat(content, instanceOf(ReleasableBytesReference.class));
             ((ReleasableBytesReference) content).close();
             // Ref count is not incremented since the bytes are immediately consumed on decompression
             assertTrue(releasable2.hasReferences());
-            assertEquals(InboundDecoder.END_CONTENT, endMarker);
-        }
-
-    }
-
-    public void testCompressedDecodeHandshakeCompatibility() throws IOException {
-        String action = "test-request";
-        long requestId = randomNonNegativeLong();
-        final String headerKey = randomAlphaOfLength(10);
-        final String headerValue = randomAlphaOfLength(20);
-        threadContext.putHeader(headerKey, headerValue);
-        TransportVersion handshakeCompat = TransportHandshaker.EARLIEST_HANDSHAKE_VERSION;
-        OutboundMessage message = new OutboundMessage.Request(
-            threadContext,
-            new TestRequest(randomAlphaOfLength(100)),
-            handshakeCompat,
-            action,
-            requestId,
-            true,
-            Compression.Scheme.DEFLATE
-        );
-
-        try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
-            final BytesReference bytes = message.serialize(os);
-            int totalHeaderSize = TcpHeader.headerSize(handshakeCompat);
-
-            InboundDecoder decoder = new InboundDecoder(recycler);
-            final ArrayList<Object> fragments = new ArrayList<>();
-            final ReleasableBytesReference releasable1 = wrapAsReleasable(bytes);
-            int bytesConsumed = decoder.decode(releasable1, fragments::add);
-            assertEquals(totalHeaderSize, bytesConsumed);
-            assertTrue(releasable1.hasReferences());
-
-            final Header header = (Header) fragments.get(0);
-            assertEquals(requestId, header.getRequestId());
-            assertEquals(handshakeCompat, header.getVersion());
-            assertTrue(header.isCompressed());
-            assertTrue(header.isHandshake());
-            assertTrue(header.isRequest());
-            // TODO: On 9.0 this will be true because all compatible versions with contain the variable header int
-            assertTrue(header.needsToReadVariableHeader());
-            fragments.clear();
+            assertThat(endMarker, is(InboundDecoder.END_CONTENT));
         }
     }
 
@@ -494,18 +348,16 @@ public class InboundDecoderTests extends ESTestCase {
             throw new AssertionError(e);
         }
 
-        var invalid = TransportVersion.fromId(TransportHandshaker.EARLIEST_HANDSHAKE_VERSION.id() - 1);
-        try {
-            InboundDecoder.checkHandshakeVersionCompatibility(invalid);
-            fail();
-        } catch (IllegalStateException expected) {
-            assertEquals(
+        var invalid = TransportVersion.fromId(TransportHandshaker.REQUEST_HANDSHAKE_VERSION.id() - 1);
+        var ex = expectThrows(IllegalStateException.class, () -> InboundDecoder.checkHandshakeVersionCompatibility(invalid));
+        assertThat(
+            ex.getMessage(),
+            equalTo(
                 "Received message from unsupported version: ["
                     + invalid
                     + "] allowed versions are: "
-                    + TransportHandshaker.ALLOWED_HANDSHAKE_VERSIONS,
-                expected.getMessage()
-            );
-        }
+                    + TransportHandshaker.ALLOWED_HANDSHAKE_VERSIONS
+            )
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -128,7 +128,6 @@ public class InboundHandlerTests extends ESTestCase {
 
     public void testRequestAndResponse() throws Exception {
         String action = "test-request";
-        int headerSize = TcpHeader.headerSize(TransportVersion.current());
         boolean isError = randomBoolean();
         AtomicReference<TestRequest> requestCaptor = new AtomicReference<>();
         AtomicReference<TestResponse> responseCaptor = new AtomicReference<>();
@@ -183,7 +182,7 @@ public class InboundHandlerTests extends ESTestCase {
 
         BytesRefRecycler recycler = new BytesRefRecycler(PageCacheRecycler.NON_RECYCLING_INSTANCE);
         BytesReference fullRequestBytes = request.serialize(new RecyclerBytesStreamOutput(recycler));
-        BytesReference requestContent = fullRequestBytes.slice(headerSize, fullRequestBytes.length() - headerSize);
+        BytesReference requestContent = fullRequestBytes.slice(TcpHeader.HEADER_SIZE, fullRequestBytes.length() - TcpHeader.HEADER_SIZE);
         Header requestHeader = new Header(
             fullRequestBytes.length() - 6,
             requestId,
@@ -208,7 +207,7 @@ public class InboundHandlerTests extends ESTestCase {
         }
 
         BytesReference fullResponseBytes = channel.getMessageCaptor().get();
-        BytesReference responseContent = fullResponseBytes.slice(headerSize, fullResponseBytes.length() - headerSize);
+        BytesReference responseContent = fullResponseBytes.slice(TcpHeader.HEADER_SIZE, fullResponseBytes.length() - TcpHeader.HEADER_SIZE);
         Header responseHeader = new Header(fullRequestBytes.length() - 6, requestId, responseStatus, TransportVersion.current());
         InboundMessage responseMessage = new InboundMessage(responseHeader, ReleasableBytesReference.wrap(responseContent), () -> {});
         responseHeader.finishParsingHeader(responseMessage.openOrGetStreamInput());

--- a/server/src/test/java/org/elasticsearch/transport/InboundPipelineTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundPipelineTests.java
@@ -275,9 +275,8 @@ public class InboundPipelineTests extends ESTestCase {
             }
 
             final BytesReference reference = message.serialize(streamOutput);
-            final int fixedHeaderSize = TcpHeader.headerSize(TransportVersion.current());
-            final int variableHeaderSize = reference.getInt(fixedHeaderSize - 4);
-            final int totalHeaderSize = fixedHeaderSize + variableHeaderSize;
+            final int variableHeaderSize = reference.getInt(TcpHeader.HEADER_SIZE - 4);
+            final int totalHeaderSize = TcpHeader.HEADER_SIZE + variableHeaderSize;
             final AtomicBoolean bodyReleased = new AtomicBoolean(false);
             for (int i = 0; i < totalHeaderSize - 1; ++i) {
                 try (ReleasableBytesReference slice = ReleasableBytesReference.wrap(reference.slice(i, 1))) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HeaderSizeLimitTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HeaderSizeLimitTests.java
@@ -138,7 +138,7 @@ public final class SecurityNetty4HeaderSizeLimitTests extends ESTestCase {
     public void testThatAcceptableHeaderSizeGoesThroughTheRemoteClusterPort() throws Exception {
         int messageLength = randomIntBetween(128, 256);
         long requestId = randomLongBetween(1L, 1000L);
-        int acceptableHeaderSize = randomIntBetween(0, maxHeaderSize - TcpHeader.headerSize(TransportVersion.current()));
+        int acceptableHeaderSize = randomIntBetween(0, maxHeaderSize - TcpHeader.HEADER_SIZE);
         try (
             ReleasableBytesStreamOutput out = new ReleasableBytesStreamOutput(
                 messageLength + TcpHeader.BYTES_REQUIRED_FOR_MESSAGE_SIZE,
@@ -163,8 +163,8 @@ public final class SecurityNetty4HeaderSizeLimitTests extends ESTestCase {
         int messageLength = randomIntBetween(128, 256);
         long requestId = randomLongBetween(1L, 1000L);
         int largeHeaderSize = randomIntBetween(
-            maxHeaderSize - TcpHeader.headerSize(TransportVersion.current()) + 1,
-            messageLength + TcpHeader.BYTES_REQUIRED_FOR_MESSAGE_SIZE - TcpHeader.headerSize(TransportVersion.current())
+            maxHeaderSize - TcpHeader.HEADER_SIZE + 1,
+            messageLength + TcpHeader.BYTES_REQUIRED_FOR_MESSAGE_SIZE - TcpHeader.HEADER_SIZE
         );
         try (
             ReleasableBytesStreamOutput out = new ReleasableBytesStreamOutput(
@@ -190,8 +190,8 @@ public final class SecurityNetty4HeaderSizeLimitTests extends ESTestCase {
         int messageLength = randomIntBetween(128, 256);
         long requestId = randomLongBetween(1L, 1000L);
         int largeHeaderSize = randomIntBetween(
-            maxHeaderSize - TcpHeader.headerSize(TransportVersion.current()) + 1,
-            messageLength + TcpHeader.BYTES_REQUIRED_FOR_MESSAGE_SIZE - TcpHeader.headerSize(TransportVersion.current())
+            maxHeaderSize - TcpHeader.HEADER_SIZE + 1,
+            messageLength + TcpHeader.BYTES_REQUIRED_FOR_MESSAGE_SIZE - TcpHeader.HEADER_SIZE
         );
         try (
             ReleasableBytesStreamOutput out = new ReleasableBytesStreamOutput(


### PR DESCRIPTION
Remove handling of v6 handshakes, and pre-7.6 TCP headers - the earliest version v9 should possibly talk to is 7.17.

An outstanding question I've got - is the code to handle pre-7.6 headers still required to properly refuse connections from pre-7.6 nodes, or will all pre-7.17 nodes be rejected outright by the handshaker before it gets to that stage?