### PR TITLE
Add the `USE_SYNTHETIC_SOURCE_FOR_RECOVERY_BACKPORT` Index Version

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -688,7 +688,11 @@ public final class IndexSettings {
 
                 // Verify that all nodes can handle this setting
                 var version = (IndexVersion) settings.get(SETTING_INDEX_VERSION_CREATED);
-                if (version.before(IndexVersions.USE_SYNTHETIC_SOURCE_FOR_RECOVERY)) {
+                if (version.before(IndexVersions.USE_SYNTHETIC_SOURCE_FOR_RECOVERY)
+                    && version.between(
+                        IndexVersions.USE_SYNTHETIC_SOURCE_FOR_RECOVERY_BACKPORT,
+                        IndexVersions.UPGRADE_TO_LUCENE_10_0_0
+                    ) == false) {
                     throw new IllegalArgumentException(
                         String.format(
                             Locale.ROOT,

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -132,6 +132,7 @@ public class IndexVersions {
     public static final IndexVersion LOGSDB_DEFAULT_IGNORE_DYNAMIC_BEYOND_LIMIT_BACKPORT = def(8_519_00_0, Version.LUCENE_9_12_0);
     public static final IndexVersion TIME_BASED_K_ORDERED_DOC_ID_BACKPORT = def(8_520_00_0, Version.LUCENE_9_12_0);
     public static final IndexVersion V8_DEPRECATE_SOURCE_MODE_MAPPER = def(8_521_00_0, Version.LUCENE_9_12_0);
+    public static final IndexVersion USE_SYNTHETIC_SOURCE_FOR_RECOVERY_BACKPORT = def(8_522_00_0, Version.LUCENE_9_12_0);
     public static final IndexVersion UPGRADE_TO_LUCENE_10_0_0 = def(9_000_00_0, Version.LUCENE_10_0_0);
     public static final IndexVersion LOGSDB_DEFAULT_IGNORE_DYNAMIC_BEYOND_LIMIT = def(9_001_00_0, Version.LUCENE_10_0_0);
     public static final IndexVersion TIME_BASED_K_ORDERED_DOC_ID = def(9_002_00_0, Version.LUCENE_10_0_0);

--- a/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
@@ -473,7 +473,36 @@ public class SourceFieldMapperTests extends MetadataMapperTestCase {
             IllegalArgumentException exc = expectThrows(
                 IllegalArgumentException.class,
                 () -> createMapperService(
-                    IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersions.USE_SYNTHETIC_SOURCE_FOR_RECOVERY),
+                    IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersions.USE_SYNTHETIC_SOURCE_FOR_RECOVERY_BACKPORT),
+                    settings,
+                    () -> false,
+                    topMapping(b -> {})
+                )
+            );
+            assertThat(
+                exc.getMessage(),
+                containsString(
+                    String.format(
+                        Locale.ROOT,
+                        "The setting [%s] is unavailable on this cluster",
+                        IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE_SETTING.getKey()
+                    )
+                )
+            );
+        }
+        {
+            Settings settings = Settings.builder()
+                .put(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), SourceFieldMapper.Mode.SYNTHETIC.toString())
+                .put(IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE_SETTING.getKey(), true)
+                .build();
+            IllegalArgumentException exc = expectThrows(
+                IllegalArgumentException.class,
+                () -> createMapperService(
+                    IndexVersionUtils.randomVersionBetween(
+                        random(),
+                        IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
+                        IndexVersions.DEPRECATE_SOURCE_MODE_MAPPER
+                    ),
                     settings,
                     () -> false,
                     topMapping(b -> {})


### PR DESCRIPTION
This PR introduces the backported `USE_SYNTHETIC_SOURCE_FOR_RECOVERY_BACKPORT` index version and updates the index version check to accommodate this addition.

Relates #114618