### PR TITLE
Make InferModelAction API timeout consistent with 30s default

### DIFF
--- a/docs/changelog/118451.yaml
+++ b/docs/changelog/118451.yaml
@@ -1,0 +1,5 @@
+pr: 118451
+summary: Make `InferModelAction` API timeout consistent with 30s default
+area: Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -76,7 +76,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             return builder;
         }
 
-        public static final TimeValue DEFAULT_TIMEOUT_FOR_API = TimeValue.timeValueSeconds(10);
+        public static final TimeValue DEFAULT_TIMEOUT_FOR_API = TimeValue.timeValueSeconds(30);
         public static final TimeValue DEFAULT_TIMEOUT_FOR_INGEST = TimeValue.MAX_VALUE;
 
         private final String id;


### PR DESCRIPTION
This bumps the default for inference API calls to 30s, see #112828 .