### PR TITLE
[8.17] Restore original "is within leaf" value in SparseVectorFieldMapper (#118380)

### DIFF
--- a/docs/changelog/118380.yaml
+++ b/docs/changelog/118380.yaml
@@ -1,0 +1,5 @@
+pr: 118380
+summary: Restore original "is within leaf" value in `SparseVectorFieldMapper`
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapper.java
@@ -171,6 +171,7 @@ public class SparseVectorFieldMapper extends FieldMapper {
             );
         }
 
+        final boolean isWithinLeaf = context.path().isWithinLeafObject();
         String feature = null;
         try {
             // make sure that we don't expand dots in field names while parsing
@@ -205,7 +206,7 @@ public class SparseVectorFieldMapper extends FieldMapper {
                 context.addToFieldNames(fieldType().name());
             }
         } finally {
-            context.path().setWithinLeafObject(false);
+            context.path().setWithinLeafObject(isWithinLeaf);
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Restore original "is within leaf" value in SparseVectorFieldMapper (#118380)