### PR TITLE
Fix ResolveRefs may not resolve a resolvable aggregation with grouping

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -1356,6 +1356,18 @@ t:date
 2023-10-23T13:55:00
 ;
 
+resolvableAggregationWithGrouping
+required_capability: implicit_casting_string_literal_to_temporal_amount
+
+FROM sample_data
+| EVAL date = "2024-01-01"::datetime
+| STATS max = MAX(@timestamp) BY c = (date == "2024-01-01");
+
+max:date                 | c:boolean
+2023-10-23T13:55:01.543Z | true
+;
+
+
 evalDateTruncDayInStringNull
 required_capability: implicit_casting_string_literal_to_temporal_amount
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -675,7 +675,8 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
         }
 
         private static Attribute maybeResolveAttribute(UnresolvedAttribute ua, List<Attribute> childrenOutput, Logger logger) {
-            if (ua.customMessage()) {
+            // We need add check childrenOutput here to judge if the attribute can be resolved or not.
+            if (ua.customMessage() && childrenOutput.stream().noneMatch(a -> a.name().equals(ua.name()))) {
                 return ua;
             }
             return resolveAttribute(ua, childrenOutput, logger);
@@ -959,7 +960,8 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
         Collection<Attribute> attrList,
         java.util.function.Function<List<String>, String> messageProducer
     ) {
-        if (ua.customMessage()) {
+        // If we found matches size is not empty, we should return the matches
+        if (ua.customMessage() && matches.isEmpty()) {
             return List.of();
         }
         // none found - add error message


### PR DESCRIPTION
Closes #116781
When the `plan` first enters the execution of `resolveAggregate` method, we can observe that `c` as an `UnresolvedAttribute` object has a value for the `unresolvedMsg` attribute which is not `null`. However, the `customMessage` attribute is `false`. But In the `potentialCandidatesIfNoMatchesFound` method, calling `withUnresolvedMessage` to regenerate the `UnresolvedAttribute` object sets the `customMessage` attribute just based on whether `unresolvedMessage != null`. This behavior may be a little confusion.

Thus, relying solely on the `customMessage` attribute of `UnresolvedAttribute` for some judgments is insufficient and may lead to errors. To address this, I have added additional checks to ensure that the `maybeResolveAttribute` method and `potentialCandidatesIfNoMatchesFound` behavior as we expected.