### PR TITLE
[8.x] Specialize skip for InputStreamIndexInput (#118436)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/store/InputStreamIndexInput.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/store/InputStreamIndexInput.java
@@ -88,4 +88,15 @@ public class InputStreamIndexInput extends InputStream {
         indexInput.seek(markPointer);
         counter = markCounter;
     }
+
+    @Override
+    public long skip(long n) throws IOException {
+        long skipBytes = Math.min(n, Math.min(indexInput.length() - indexInput.getFilePointer(), limit - counter));
+        if (skipBytes <= 0) {
+            return 0;
+        }
+        indexInput.skipBytes(skipBytes);
+        counter += skipBytes;
+        return skipBytes;
+    }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Specialize skip for InputStreamIndexInput (#118436)