### PR TITLE
Relax assertion - remove unnecessary times(1)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -314,9 +314,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/118220
 - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
   issue: https://github.com/elastic/elasticsearch/issues/118238
-- class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
-  method: testInvalidJSON
-  issue: https://github.com/elastic/elasticsearch/issues/116521
 
 # Examples:
 #

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -315,7 +315,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         writeTestFile(fileSettingsService.watchedFile(), "test_invalid_JSON");
         awaitOrBust(fileChangeBarrier);
 
-        verify(fileSettingsService, times(1)).onProcessFileChangesException(
+        verify(fileSettingsService).onProcessFileChangesException(
             argThat(e -> unwrapException(e) instanceof XContentParseException)
         );
 

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
@@ -315,14 +316,22 @@ public class FileSettingsServiceTests extends ESTestCase {
         writeTestFile(fileSettingsService.watchedFile(), "test_invalid_JSON");
         awaitOrBust(fileChangeBarrier);
 
-        verify(fileSettingsService).onProcessFileChangesException(argThat(e -> unwrapException(e) instanceof XContentParseException));
+        // These checks use atLeast(1) because the initial JSON is also invalid,
+        // and so we sometimes get two calls to these error-reporting methods
+        // depending on timing. Rather than trace down the root cause and fix
+        // it, we tolerate this for now because, hey, invalid JSON is invalid JSON
+        // and this is still testing what we want to test.
+
+        verify(fileSettingsService, Mockito.atLeast(1)).onProcessFileChangesException(
+            argThat(e -> unwrapException(e) instanceof XContentParseException)
+        );
 
         // Note: the name "processFileOnServiceStart" is a bit misleading because it is not
         // referring to fileSettingsService.start(). Rather, it is referring to the initialization
         // of the watcher thread itself, which occurs asynchronously when clusterChanged is first called.
 
         assertEquals(YELLOW, healthIndicatorService.calculate(false, null).status());
-        verify(healthIndicatorService).failureOccurred(contains(XContentParseException.class.getName()));
+        verify(healthIndicatorService, Mockito.atLeast(1)).failureOccurred(contains(XContentParseException.class.getName()));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -315,9 +315,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         writeTestFile(fileSettingsService.watchedFile(), "test_invalid_JSON");
         awaitOrBust(fileChangeBarrier);
 
-        verify(fileSettingsService).onProcessFileChangesException(
-            argThat(e -> unwrapException(e) instanceof XContentParseException)
-        );
+        verify(fileSettingsService).onProcessFileChangesException(argThat(e -> unwrapException(e) instanceof XContentParseException));
 
         // Note: the name "processFileOnServiceStart" is a bit misleading because it is not
         // referring to fileSettingsService.start(). Rather, it is referring to the initialization


### PR DESCRIPTION
The test doesn't so much care how many times a parse error is reported. It's more that the error is definitely reported.

`FileSettingsService` is a bit notorious for race conditions. This change makes the test a little more tolerant without losing the key thing it's testing for.

Fixes #116521 again.