### PR TITLE
Suppress the for-loop warnings since it is a conscious performance choice.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -66,6 +66,7 @@ import java.util.function.Predicate;
  * Note: This class is performance sensitive, so we pay extra attention on the data structure usage and we avoid streams and iterators
  * when possible in favor of the classic for-i loops.
  */
+@SuppressWarnings("ForLoopReplaceableByForEach")
 public class IndexNameExpressionResolver {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(IndexNameExpressionResolver.class);
 


### PR DESCRIPTION
Considering that using `for-loops` when possible instead of `for-each` is a conscious choice in this class (micro benchmarks showed an small but non-negligible improvement), we choose to suppress this type of warnings.