### PR TITLE
ESQL: Disable remote enrich verification

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -276,9 +276,6 @@ tests:
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
   method: testBottomFieldSort
   issue: https://github.com/elastic/elasticsearch/issues/118214
-- class: org.elasticsearch.xpack.esql.action.CrossClustersEnrichIT
-  method: testTopNThenEnrichRemote
-  issue: https://github.com/elastic/elasticsearch/issues/118307
 - class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS1UnavailableRemotesIT
   method: testEsqlRcs1UnavailableRemoteScenarios
   issue: https://github.com/elastic/elasticsearch/issues/118350


### PR DESCRIPTION
This disables verifying the plans generated for remote ENRICHing.
It also re-enables corresponding failing test.

Related: #118531
Fixes #118307.