### PR TITLE
[8.17] Changes elser service to elasticsearch service in the Semantic search with the inference API page (#118536)

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -45,7 +45,7 @@ include::{es-ref-dir}/tab-widgets/inference-api/infer-api-task-widget.asciidoc[]
 ==== Create the index mapping
 
 The mapping of the destination index - the index that contains the embeddings that the model will create based on your input text - must be created.
-The destination index must have a field with the <<dense-vector, `dense_vector`>> field type for most models and the <<sparse-vector, `sparse_vector`>> field type for the sparse vector models like in the case of the `elser` service to index the output of the used model.
+The destination index must have a field with the <<dense-vector, `dense_vector`>> field type for most models and the <<sparse-vector, `sparse_vector`>> field type for the sparse vector models like in the case of the `elasticsearch` service to index the output of the used model.
 
 include::{es-ref-dir}/tab-widgets/inference-api/infer-api-mapping-widget.asciidoc[]
 

--- a/docs/reference/tab-widgets/inference-api/infer-api-requirements.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-requirements.asciidoc
@@ -8,7 +8,7 @@ the Cohere service.
 // tag::elser[]
 
 ELSER is a model trained by Elastic. If you have an {es} deployment, there is no
-further requirement for using the {infer} API with the `elser` service.
+further requirement for using the {infer} API with the `elasticsearch` service.
 
 // end::elser[]
 


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Changes elser service to elasticsearch service in the Semantic search with the inference API page (#118536)