### PR TITLE
[7.17] [ci] Add Alma Linux 9 to matrix in packaging and platform jobs (#118331)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -23,6 +23,7 @@ steps:
               - rhel-8
               - rhel-9
               - almalinux-8
+              - almalinux-9
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -24,6 +24,7 @@ steps:
               - rhel-8
               - rhel-9
               - almalinux-8
+              - almalinux-9
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -23,6 +23,7 @@ steps:
               - rhel-8
               - rhel-9
               - almalinux-8
+              - almalinux-9
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -3,9 +3,9 @@ config:
 steps:
   - group: packaging-tests-unix
     steps:
-      - label: "{{matrix.image}} / docker / packaging-tests-unix"
-        key: "packaging-tests-unix-docker"
-        command: ./.ci/scripts/packaging-test.sh destructiveDistroTest.docker
+      - label: "{{matrix.image}} / {{matrix.PACKAGING_TASK}} / packaging-tests-unix"
+        key: "packaging-tests-unix"
+        command: ./.ci/scripts/packaging-test.sh destructiveDistroTest.{{matrix.PACKAGING_TASK}}
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -26,62 +26,11 @@ steps:
               - rhel-8
               - rhel-9
               - almalinux-8
-        agents:
-          provider: gcp
-          image: family/elasticsearch-{{matrix.image}}
-          diskSizeGb: 350
-          machineType: custom-16-32768
-      - label: "{{matrix.image}} / packages / packaging-tests-unix"
-        key: "packaging-tests-unix-packages"
-        command: ./.ci/scripts/packaging-test.sh destructiveDistroTest.packages
-        timeout_in_minutes: 300
-        matrix:
-          setup:
-            image:
-              - debian-11
-              - debian-12
-              - opensuse-leap-15
-              - oraclelinux-7
-              - oraclelinux-8
-              - sles-12
-              - sles-15
-              - ubuntu-1804
-              - ubuntu-2004
-              - ubuntu-2204
-              - rocky-8
-              - rocky-9
-              - rhel-7
-              - rhel-8
-              - rhel-9
-              - almalinux-8
-        agents:
-          provider: gcp
-          image: family/elasticsearch-{{matrix.image}}
-          diskSizeGb: 350
-          machineType: custom-16-32768
-      - label: "{{matrix.image}} / archives / packaging-tests-unix"
-        key: "packaging-tests-unix-archives"
-        command: ./.ci/scripts/packaging-test.sh destructiveDistroTest.archives
-        timeout_in_minutes: 300
-        matrix:
-          setup:
-            image:
-              - debian-11
-              - debian-12
-              - opensuse-leap-15
-              - oraclelinux-7
-              - oraclelinux-8
-              - sles-12
-              - sles-15
-              - ubuntu-1804
-              - ubuntu-2004
-              - ubuntu-2204
-              - rocky-8
-              - rocky-9
-              - rhel-7
-              - rhel-8
-              - rhel-9
-              - almalinux-8
+              - almalinux-9
+            PACKAGING_TASK:
+              - docker
+              - packages
+              - archives
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/x-pack/test/smb-fixture/src/main/resources/provision/installsmb.sh
+++ b/x-pack/test/smb-fixture/src/main/resources/provision/installsmb.sh
@@ -22,7 +22,7 @@ cat $SSL_DIR/ca.pem >> /etc/ssl/certs/ca-certificates.crt
 
 mv /etc/samba/smb.conf /etc/samba/smb.conf.orig
 
-samba-tool domain provision --server-role=dc --use-rfc2307 --dns-backend=SAMBA_INTERNAL --realm=AD.TEST.ELASTICSEARCH.COM --domain=ADES --adminpass=Passw0rd
+samba-tool domain provision --server-role=dc --use-rfc2307 --dns-backend=SAMBA_INTERNAL --realm=AD.TEST.ELASTICSEARCH.COM --domain=ADES --adminpass=Passw0rd --use-ntvfs
 
 cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
 

--- a/x-pack/test/smb-fixture/src/main/resources/provision/installsmb.sh
+++ b/x-pack/test/smb-fixture/src/main/resources/provision/installsmb.sh
@@ -22,7 +22,7 @@ cat $SSL_DIR/ca.pem >> /etc/ssl/certs/ca-certificates.crt
 
 mv /etc/samba/smb.conf /etc/samba/smb.conf.orig
 
-samba-tool domain provision --server-role=dc --use-rfc2307 --dns-backend=SAMBA_INTERNAL --realm=AD.TEST.ELASTICSEARCH.COM --domain=ADES --adminpass=Passw0rd --use-ntvfs
+samba-tool domain provision --server-role=dc --use-rfc2307 --dns-backend=SAMBA_INTERNAL --realm=AD.TEST.ELASTICSEARCH.COM --domain=ADES --adminpass=Passw0rd
 
 cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci] Add Alma Linux 9 to matrix in packaging and platform jobs (#118331)](https://github.com/elastic/elasticsearch/pull/118331)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)