### PR TITLE
Update update.asciidoc

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -71,7 +71,7 @@ include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
 `_source`::
-(Optional, list) Set to `false` to disable source retrieval (default: `true`).
+(Optional, list) Set to `false` to disable source retrieval (default: `false`).
 You can also specify a comma-separated list of the fields you want to retrieve.
 
 `_source_excludes`::


### PR DESCRIPTION
Update doc for _source default value



```
POST some_index/_update/doc
{
  "doc": {
    "last_name": "new_name"
  }
}
```
It does not return the document source, however  

```
POST some_index/_update/doc?_source=true
{
  "doc": {
    "last_name": "new_name"
  }
}
```
Does