### PR TITLE
[ML] Remove deprecated name for Frequent Item Sets aggregation

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1780,7 +1780,7 @@ public class MachineLearning extends Plugin
             ).addResultReader(InternalCategorizationAggregation::new)
                 .setAggregatorRegistrar(s -> s.registerUsage(CategorizeTextAggregationBuilder.NAME)),
             new AggregationSpec(
-                new ParseField(FrequentItemSetsAggregationBuilder.NAME, FrequentItemSetsAggregationBuilder.DEPRECATED_NAME),
+                FrequentItemSetsAggregationBuilder.NAME,
                 FrequentItemSetsAggregationBuilder::new,
                 checkAggLicense(FrequentItemSetsAggregationBuilder.PARSER, FREQUENT_ITEM_SETS_AGG_FEATURE)
             ).addResultReader(FrequentItemSetsAggregatorFactory.getResultReader())

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.Processors;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.features.NodeFeature;
@@ -1779,8 +1780,10 @@ public class MachineLearning extends Plugin
                 checkAggLicense(CategorizeTextAggregationBuilder.PARSER, CATEGORIZE_TEXT_AGG_FEATURE)
             ).addResultReader(InternalCategorizationAggregation::new)
                 .setAggregatorRegistrar(s -> s.registerUsage(CategorizeTextAggregationBuilder.NAME)),
+            // Allow using `frequent_items` for rest compatibility with 8.x
             new AggregationSpec(
-                FrequentItemSetsAggregationBuilder.NAME,
+                new ParseField(FrequentItemSetsAggregationBuilder.NAME, FrequentItemSetsAggregationBuilder.DEPRECATED_NAME)
+                    .forRestApiVersion(RestApiVersion.equalTo(RestApiVersion.V_8)),
                 FrequentItemSetsAggregationBuilder::new,
                 checkAggLicense(FrequentItemSetsAggregationBuilder.PARSER, FREQUENT_ITEM_SETS_AGG_FEATURE)
             ).addResultReader(FrequentItemSetsAggregatorFactory.getResultReader())

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
@@ -41,6 +41,9 @@ public final class FrequentItemSetsAggregationBuilder extends AbstractAggregatio
 
     public static final String NAME = "frequent_item_sets";
 
+    // name used between 8.4 - 8.6, kept for backwards compatibility until 9.0
+    public static final String DEPRECATED_NAME = "frequent_items";
+
     public static final double DEFAULT_MINIMUM_SUPPORT = 0.01;
     public static final int DEFAULT_MINIMUM_SET_SIZE = 1;
     public static final int DEFAULT_SIZE = 10;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
@@ -41,9 +41,6 @@ public final class FrequentItemSetsAggregationBuilder extends AbstractAggregatio
 
     public static final String NAME = "frequent_item_sets";
 
-    // name used between 8.4 - 8.6, kept for backwards compatibility until 9.0
-    public static final String DEPRECATED_NAME = "frequent_items";
-
     public static final double DEFAULT_MINIMUM_SUPPORT = 0.01;
     public static final int DEFAULT_MINIMUM_SET_SIZE = 1;
     public static final int DEFAULT_SIZE = 10;

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/frequent_item_sets_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/frequent_item_sets_agg.yml
@@ -530,42 +530,6 @@ setup:
           }
 
 ---
-"Test deprecated frequent items":
-  - skip:
-      features:
-        - "allowed_warnings"
-
-  - do:
-      allowed_warnings:
-        - 'Deprecated field [frequent_items] used, expected [frequent_item_sets] instead'
-
-      search:
-        index: store
-        body: >
-          {
-            "size": 0,
-            "aggs": {
-              "fi": {
-                "frequent_items": {
-                  "minimum_set_size": 3,
-                  "minimum_support": 0.3,
-                  "fields": [
-                    {"field": "features"},
-                    {"field": "error_message"}
-                  ]
-                }
-              }
-            }
-          }
-  - length: { aggregations.fi.buckets: 4 }
-  - match: { aggregations.fi.buckets.0.doc_count: 5 }
-  - match: { aggregations.fi.buckets.0.support: 0.5 }
-  - match: { aggregations.fi.buckets.0.key.error_message: ["compressor low pressure"] }
-  - match: { aggregations.fi.buckets.1.doc_count: 4 }
-  - match: { aggregations.fi.buckets.1.support: 0.4 }
-  - match: { aggregations.fi.buckets.1.key.error_message: ["engine overheated"] }
-
----
 "Test frequent items on empty index":
   - do:
       search:


### PR DESCRIPTION
We kept the deprecated name `frequent_items` for backwards compatibility in `8.x`. In 9.0 it can be removed.