### PR TITLE
[8.x]  [Build] Cache spotless p2 dependencies when baking ci image (#118523)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -17,8 +17,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Map;
 
 /**
  * This plugin configures formatting for Java source using Spotless
@@ -66,8 +64,7 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
                 java.importOrderFile(new File(elasticsearchWorkspace, importOrderPath));
 
                 // Most formatting is done through the Eclipse formatter
-                java.eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/"))
-                    .configFile(new File(elasticsearchWorkspace, formatterConfigPath));
+                java.eclipse().configFile(new File(elasticsearchWorkspace, formatterConfigPath));
 
                 // Ensure blank lines are actually empty. Since formatters are applied in
                 // order, apply this one last, otherwise non-empty blank lines can creep

--- a/build.gradle
+++ b/build.gradle
@@ -290,7 +290,10 @@ allprojects {
     if (project.path.contains(":distribution:docker")) {
       enabled = false
     }
-
+    if (project.path.contains(":libs:cli")) {
+      // ensure we resolve p2 dependencies for the spotless eclipse formatter
+      dependsOn "spotlessJavaCheck"
+    }
   }
 
   plugins.withId('lifecycle-base') {


### PR DESCRIPTION
Backports the following commits to 8.x:
 -  [Build] Cache spotless p2 dependencies when baking ci image (#118523)