### PR TITLE
[DOC] Small doc fix for updates related to _source defaults

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -71,7 +71,7 @@ include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
 `_source`::
-(Optional, list) Set to `false` to disable source retrieval (default: `true`).
+(Optional, list) Set to `true` to enable source retrieval (default: `false`).
 You can also specify a comma-separated list of the fields you want to retrieve.
 
 `_source_excludes`::


### PR DESCRIPTION
Community member found an error in the docs related to the update api and the default for `_source`: 
https://elasticstack.slack.com/archives/C018C7B9T5F/p1734000667617069

Quickly validated with this query: 
```
curl -XPOST --header 'Content-Type: application/json' "http://localhost:9200/test/_update/1?_source=true" -d '{
  "doc": {
    "text": "new_name3"
  },
  "doc_as_upsert": true
}'
```

with `_source=true` or `_source=text`  in the query params I get:

```
{
    "_index": "test",
    "_id": "1",
    "_version": 2,
    "result": "noop",
    "_shards": {
        "total": 0,
        "successful": 0,
        "failed": 0
    },
    "_seq_no": 1,
    "_primary_term": 1,
    "get": {
        "_seq_no": 1,
        "_primary_term": 1,
        "found": true,
        "_source": {
            "text": "new_name3"
        }
    }
}
```

without `_source` in the query params I get:

```
{
    "_index": "test",
    "_id": "1",
    "_version": 2,
    "result": "noop",
    "_shards": {
        "total": 0,
        "successful": 0,
        "failed": 0
    },
    "_seq_no": 1,
    "_primary_term": 1
}
```

This is the correct behavior we want.  So I just inverted the language in the docs.
