### PR TITLE
Adding block for max_page_search_size in PivotConfig of new transforms

### DIFF
--- a/docs/changelog/118607.yaml
+++ b/docs/changelog/118607.yaml
@@ -1,0 +1,5 @@
+pr: 118607
+summary: Adding block for `max_page_search_size` in `PivotConfig` of new transforms
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PutTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PutTransformAction.java
@@ -119,6 +119,13 @@ public class PutTransformAction extends ActionType<AcknowledgedResponse> {
                 }
             }
 
+            if (config.getPivotConfig().getMaxPageSearchSize() != null) {
+                validationException = addValidationError(
+                    "[max_page_search_size] can no longer be set in the [pivot]. Please move it under [settings] instead",
+                    validationException
+                );
+            }
+
             return validationException;
         }
 


### PR DESCRIPTION
Issue - https://github.com/elastic/ml-team/issues/1410

TODO: Is there a way to manually test the case where a transform with max_page_search_size in the pivot config from before this change still works?
TODO: Do we have any automated testing for this?
TODO: Is there any other usages of the action aside from creating a new transform?