### PR TITLE
[8.x] Fix invalid index mode (#118579)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -113,7 +113,7 @@ Index mode supports the following values:
 
 `standard`::: Standard indexing with default settings.
 
-`tsds`::: _(data streams only)_ Index mode optimized for storage of metrics. For more information, see <<tsds-index-settings>>.
+`time_series`::: _(data streams only)_ Index mode optimized for storage of metrics. For more information, see <<tsds-index-settings>>.
 
 `logsdb`::: _(data streams only)_ Index mode optimized for <<logs-data-stream,logs>>.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix invalid index mode (#118579)](https://github.com/elastic/elasticsearch/pull/118579)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)