### PR TITLE
Fix bug in InferenceUpgradeTestCase.getConfigsWithBreakingChangeHandling

### DIFF
--- a/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/InferenceUpgradeTestCase.java
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/InferenceUpgradeTestCase.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static org.elasticsearch.core.Strings.format;
 

--- a/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/InferenceUpgradeTestCase.java
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/InferenceUpgradeTestCase.java
@@ -112,13 +112,10 @@ public class InferenceUpgradeTestCase extends AbstractRollingUpgradeTestCase {
     @SuppressWarnings("unchecked")
     // in version 8.15, there was a breaking change where "models" was renamed to "endpoints"
     LinkedList<Map<String, Object>> getConfigsWithBreakingChangeHandling(TaskType testTaskType, String oldClusterId) throws IOException {
-
+        var response = get(testTaskType, oldClusterId);
         LinkedList<Map<String, Object>> configs;
-        configs = new LinkedList<>(
-            (List<Map<String, Object>>) Objects.requireNonNullElse((get(testTaskType, oldClusterId).get("endpoints")), List.of())
-        );
-        configs.addAll(Objects.requireNonNullElse((List<Map<String, Object>>) get(testTaskType, oldClusterId).get("models"), List.of()));
-
+        configs = new LinkedList<>((List<Map<String, Object>>) response.getOrDefault("endpoints", List.of()));
+        configs.addAll((List<Map<String, Object>>) response.getOrDefault("models", List.of()));
         return configs;
     }
 }


### PR DESCRIPTION
We need to load the two fields from the same response. Otherwise, we can have a sort of race where we load "endpoints" from pre-8.15 as empty and then load "models" from a post-8.15 node also empty, resulting in an empty list because we took the wrong info from either response.

closes #118163 

