### PR TITLE
[8.x] Include hidden indices in DeprecationInfoAction (#118035)

### DIFF
--- a/docs/changelog/118035.yaml
+++ b/docs/changelog/118035.yaml
@@ -1,0 +1,6 @@
+pr: 118035
+summary: Include hidden indices in `DeprecationInfoAction`
+area: Indices APIs
+type: bug
+issues:
+ - 118020

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -366,7 +366,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
 
     public static class Request extends MasterNodeReadRequest<Request> implements IndicesRequest.Replaceable {
 
-        private static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(false, true, true, true);
+        private static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(false, true, true, true, true);
         private String[] indices;
 
         public Request(TimeValue masterNodeTimeout, String... indices) {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Include hidden indices in DeprecationInfoAction (#118035)