### PR TITLE
ESQL: Disable tests planned incorrectly on pre-8.13 (failing BWC)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
@@ -223,7 +223,8 @@ null               | null      | null
 ;
 
 
-overwriteName
+// the query is incorrectly physically plan (fails the verification) in pre-8.13.0 versions
+overwriteName#[skip:-8.12.99]
 from employees | sort emp_no asc | eval full_name = concat(first_name, " ", last_name) | dissect full_name "%{emp_no} %{b}" | keep full_name, emp_no, b | limit 3;
 
 full_name:keyword | emp_no:keyword | b:keyword
@@ -244,7 +245,8 @@ emp_no:integer | first_name:keyword | rest:keyword
 ;
 
 
-overwriteNameWhere
+// the query is incorrectly physically plan (fails the verification) in pre-8.13.0 versions
+overwriteNameWhere#[skip:-8.12.99]
 from employees | sort emp_no asc | eval full_name = concat(first_name, " ", last_name) | dissect full_name "%{emp_no} %{b}" | where emp_no == "Bezalel" | keep full_name, emp_no, b | limit 3;
 
 full_name:keyword | emp_no:keyword | b:keyword

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
@@ -199,6 +199,7 @@ null               | null      | null
 ;
 
 
+// the query is incorrectly physically plan (fails the verification) in pre-8.13.0 versions
 overwriteName#[skip:-8.12.99]
 from employees | sort emp_no asc | eval full_name = concat(first_name, " ", last_name) | grok full_name "%{WORD:emp_no} %{WORD:b}" | keep full_name, emp_no, b | limit 3;
 
@@ -209,6 +210,7 @@ Parto Bamford     | Parto          | Bamford
 ;
 
 
+// the query is incorrectly physically plan (fails the verification) in pre-8.13.0 versions
 overwriteNameWhere#[skip:-8.12.99]
 from employees | sort emp_no asc | eval full_name = concat(first_name, " ", last_name) | grok full_name "%{WORD:emp_no} %{WORD:b}" | where emp_no == "Bezalel" | keep full_name, emp_no, b | limit 3;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
@@ -199,7 +199,7 @@ null               | null      | null
 ;
 
 
-overwriteName
+overwriteName#[skip:-8.12.99]
 from employees | sort emp_no asc | eval full_name = concat(first_name, " ", last_name) | grok full_name "%{WORD:emp_no} %{WORD:b}" | keep full_name, emp_no, b | limit 3;
 
 full_name:keyword | emp_no:keyword | b:keyword
@@ -209,7 +209,7 @@ Parto Bamford     | Parto          | Bamford
 ;
 
 
-overwriteNameWhere
+overwriteNameWhere#[skip:-8.12.99]
 from employees | sort emp_no asc | eval full_name = concat(first_name, " ", last_name) | grok full_name "%{WORD:emp_no} %{WORD:b}" | where emp_no == "Bezalel" | keep full_name, emp_no, b | limit 3;
 
 full_name:keyword | emp_no:keyword | b:keyword

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -564,7 +564,7 @@ c:long | gender:keyword | trunk_worked_seconds:long
  0     | null           | 200000000
 ;
 
-byStringAndLongWithAlias
+byStringAndLongWithAlias#[skip:-8.12.99]
 FROM employees
 | EVAL trunk_worked_seconds = avg_worked_seconds / 100000000 * 100000000
 | RENAME  gender as g, trunk_worked_seconds as tws

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -564,6 +564,7 @@ c:long | gender:keyword | trunk_worked_seconds:long
  0     | null           | 200000000
 ;
 
+// the query is incorrectly physically plan (fails the verification) in pre-8.13.0 versions
 byStringAndLongWithAlias#[skip:-8.12.99]
 FROM employees
 | EVAL trunk_worked_seconds = avg_worked_seconds / 100000000 * 100000000


### PR DESCRIPTION
This prevents two tests in `grok` and `dissect` suites - `overwriteName` and `overwriteNameWhere` and one in the `stats` suite - `byStringAndLongWithAlias` - to run against pre-8.13.0 versions. Reason being that coordinators prior to that version can generate invalid node plans, that'd fail (verification) on 8.18+ nodes.