### PR TITLE
[Entitlements] Implementing the correct exit functions (Runtime)

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -13,7 +13,11 @@ import java.net.URL;
 import java.net.URLStreamHandlerFactory;
 
 public interface EntitlementChecker {
-    void check$java_lang_System$exit(Class<?> callerClass, int status);
+
+    // Exit the JVM process
+    void check$$exit(Class<?> callerClass, Runtime runtime, int status);
+
+    void check$$halt(Class<?> callerClass, Runtime runtime, int status);
 
     // URLClassLoader ctor
     void check$java_net_URLClassLoader$(Class<?> callerClass, URL[] urls);

--- a/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/RestEntitlementsCheckAction.java
@@ -47,14 +47,21 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
     }
 
     private static final Map<String, CheckAction> checkActions = Map.ofEntries(
-        entry("system_exit", CheckAction.serverOnly(RestEntitlementsCheckAction::systemExit)),
+        entry("runtime_exit", CheckAction.serverOnly(RestEntitlementsCheckAction::runtimeExit)),
+        entry("runtime_halt", CheckAction.serverOnly(RestEntitlementsCheckAction::runtimeHalt)),
         entry("create_classloader", CheckAction.serverAndPlugin(RestEntitlementsCheckAction::createClassLoader))
     );
 
-    @SuppressForbidden(reason = "Specifically testing System.exit")
-    private static void systemExit() {
-        logger.info("Calling System.exit(123);");
-        System.exit(123);
+    @SuppressForbidden(reason = "Specifically testing Runtime.exit")
+    private static void runtimeExit() {
+        logger.info("Calling Runtime.exit;");
+        Runtime.getRuntime().exit(123);
+    }
+
+    @SuppressForbidden(reason = "Specifically testing Runtime.halt")
+    private static void runtimeHalt() {
+        logger.info("Calling Runtime.halt;");
+        Runtime.getRuntime().halt(123);
     }
 
     private static void createClassLoader() {

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -28,7 +28,12 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     }
 
     @Override
-    public void check$java_lang_System$exit(Class<?> callerClass, int status) {
+    public void check$$exit(Class<?> callerClass, Runtime runtime, int status) {
+        policyManager.checkExitVM(callerClass);
+    }
+
+    @Override
+    public void check$$halt(Class<?> callerClass, Runtime runtime, int status) {
         policyManager.checkExitVM(callerClass);
     }
 

--- a/libs/entitlement/src/main23/java/org/elasticsearch/entitlement/runtime/api/Java23ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main23/java/org/elasticsearch/entitlement/runtime/api/Java23ElasticsearchEntitlementChecker.java
@@ -19,8 +19,8 @@ public class Java23ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
     }
 
     @Override
-    public void check$java_lang_System$exit(Class<?> callerClass, int status) {
+    public void check$$exit(Class<?> callerClass, Runtime runtime, int status) {
         // TODO: this is just an example, we shouldn't really override a method implemented in the superclass
-        super.check$java_lang_System$exit(callerClass, status);
+        super.check$$exit(callerClass, runtime, status);
     }
 }


### PR DESCRIPTION
We choose `System.exit` as the first use case for Entitlements; however, the correct functions to check for permission to exit the JVM process are `Runtime.exit` and `Runtime.halt`; these are the "lower" side of the public JVM interface (they are publicly exposed _and_ call into the JVM, while `System.exit` just defers to `Runtime.exit`).

This PR fixes that, implementing check functions for `Runtime.exit` and `Runtime.halt` to replace `System.exit`

Closes ES-10348