### PR TITLE
ESQL: Fix LogicalPlanOptimizerTests testPlanSanityCheckWithBinaryPlans

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -317,9 +317,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testInvalidJSON
   issue: https://github.com/elastic/elasticsearch/issues/116521
-- class: org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizerTests
-  method: testPlanSanityCheckWithBinaryPlans
-  issue: https://github.com/elastic/elasticsearch/issues/118656
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -4911,8 +4911,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
             """);
 
         var project = as(plan, Project.class);
-        var limit = as(project.child(), Limit.class);
-        var join = as(limit.child(), Join.class);
+        var join = as(project.child(), Join.class);
 
         var joinWithInvalidLeftPlan = join.replaceChildren(join.right(), join.right());
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> logicalOptimizer.optimize(joinWithInvalidLeftPlan));


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/118656

The test expectation needs to adjusted now that we [push down limits past JOINs](https://github.com/elastic/elasticsearch/pull/118495).