### PR TITLE
Dynamic runtime fields experiment.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -57,6 +57,7 @@ class FieldCapabilitiesFetcher {
         CancellableTask task,
         ShardId shardId,
         Predicate<String> fieldNameFilter,
+        String[] fields,
         String[] filters,
         String[] fieldTypes,
         QueryBuilder indexFilter,
@@ -78,6 +79,7 @@ class FieldCapabilitiesFetcher {
                 task,
                 shardId,
                 fieldNameFilter,
+                fields,
                 filters,
                 fieldTypes,
                 indexFilter,
@@ -93,6 +95,7 @@ class FieldCapabilitiesFetcher {
         CancellableTask task,
         ShardId shardId,
         Predicate<String> fieldNameFilter,
+        String[] fields,
         String[] filters,
         String[] fieldTypes,
         QueryBuilder indexFilter,
@@ -143,6 +146,18 @@ class FieldCapabilitiesFetcher {
             indicesService.getShardOrNull(shardId),
             includeEmptyFields
         );
+
+        // lie about unmapped fields:
+        for (String field : fields) {
+            if (field.endsWith(".keyword")) {
+                responseMap.put(field, new IndexFieldCapabilities(field, "keyword", false, true, true, false, null, Map.of()));
+            } else if (field.endsWith(".long")) {
+                responseMap.put(field, new IndexFieldCapabilities(field, "long", false, true, true, false, null, Map.of()));
+            } else if (field.endsWith(".double")) {
+                responseMap.put(field, new IndexFieldCapabilities(field, "double", false, true, true, false, null, Map.of()));
+            }
+        }
+
         if (indexMappingHash != null) {
             indexMappingHashToResponses.put(indexMappingHash, responseMap);
         }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -606,6 +606,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                                 (CancellableTask) task,
                                 shardId,
                                 fieldNameFilter,
+                                request.fields(),
                                 request.filters(),
                                 request.allowedTypes(),
                                 request.indexFilter(),

--- a/server/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -172,7 +172,7 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
 
     @Override
     protected QueryBuilder doIndexMetadataRewrite(QueryRewriteContext context) {
-        MappedFieldType fieldType = context.getFieldType(this.fieldName);
+        MappedFieldType fieldType = context.getFieldType(this.fieldName, QueryRewriteContext.UnmappedType.KEYWORD);
         if (fieldType == null) {
             return new MatchNoneQueryBuilder("The \"" + getName() + "\" query is against a field that does not exist");
         }
@@ -212,7 +212,7 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
 
     @Override
     protected Query doToQuery(SearchExecutionContext context) throws IOException {
-        MappedFieldType mapper = context.getFieldType(this.fieldName);
+        MappedFieldType mapper = context.getFieldType(this.fieldName, QueryRewriteContext.UnmappedType.KEYWORD);
         if (mapper == null) {
             throw new IllegalStateException("Rewrite first");
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -972,6 +972,13 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 }
             }
             var name = ua.name();
+            if (name.endsWith(".keyword")) {
+                return List.of(new FieldAttribute(ua.source(), name, new EsField(name, KEYWORD, Map.of(), true)));
+            } else if (name.endsWith(".long")) {
+                return List.of(new FieldAttribute(ua.source(), name, new EsField(name, LONG, Map.of(), true)));
+            }else if (name.endsWith(".double")) {
+                return List.of(new FieldAttribute(ua.source(), name, new EsField(name, DOUBLE, Map.of(), true)));
+            }
             UnresolvedAttribute unresolved = ua.withUnresolvedMessage(messageProducer.apply(StringUtils.findSimilar(name, names)));
             matches = singletonList(unresolved);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.search.NestedHelper;
 import org.elasticsearch.search.fetch.StoredFieldsSpec;
@@ -322,7 +323,20 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             if (asUnsupportedSource) {
                 return BlockLoader.CONSTANT_NULLS;
             }
-            MappedFieldType fieldType = ctx.getFieldType(name);
+
+            QueryRewriteContext.UnmappedType unmappedType = null;
+            if (name.endsWith(".keyword")) {
+                name = name.replace(".keyword", "");
+                unmappedType = QueryRewriteContext.UnmappedType.KEYWORD;
+            } else if (name.endsWith(".long")) {
+                name = name.replace(".long", "");
+                unmappedType = QueryRewriteContext.UnmappedType.LONG;
+            } else if (name.endsWith(".double")) {
+                name = name.replace(".double", "");
+                unmappedType = QueryRewriteContext.UnmappedType.DOUBLE;
+            }
+
+            MappedFieldType fieldType = ctx.getFieldType(name, unmappedType);
             if (fieldType == null) {
                 // the field does not exist in this context
                 return BlockLoader.CONSTANT_NULLS;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
@@ -168,7 +168,7 @@ public class SingleValueQuery extends Query {
 
         @Override
         protected org.apache.lucene.search.Query doToQuery(SearchExecutionContext context) throws IOException {
-            MappedFieldType ft = context.getFieldType(field);
+            MappedFieldType ft = context.getFieldType(field, QueryRewriteContext.UnmappedType.KEYWORD);
             if (ft == null) {
                 return new MatchNoDocsQuery("missing field [" + field + "]");
             }


### PR DESCRIPTION
Adding .keyword / .long / .double to unmapped fields results in es|ql just using it as field as if it exists. Compute engine / QueryRewriteContext play along and use .keyword/.long/.double as a hint and define a runtime field on the fly.

_search just assumes keyword for now.

Example:

```

PUT _index_template/my-index-template
{
  "index_patterns": ["logs-myapp-*"],
  "data_stream": { },
  "template": {
     "settings": {
        "index.mode": "logsdb"
     },
     "mappings": {
        "dynamic": "false"
     }
  },
  "priority": 1000
}

POST /logs-myapp-2/_doc
{
    "@timestamp": "2000-01-01",
    "my_field": "abc",
    "my_field2": 4
}

GET /logs-myapp-2/_search
{
    "query": {
        "term": {
            "my_field": "abc"
        }
    }
}

POST /_query
{
    "query": "FROM logs-myapp-2 | STATS min(my_field2.long) BY my_field.keyword"
}

POST /_query
{
    "query": "FROM logs-myapp-2 | KEEP @timestamp, my_field.keyword"
}
```