### PR TITLE
Add replica handling to the ILM MountSnapshotStep

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncWaitStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncWaitStep.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -20,6 +21,7 @@ import org.elasticsearch.xcontent.ToXContentObject;
  */
 public abstract class AsyncWaitStep extends Step {
 
+    @Nullable
     private final Client client;
 
     public AsyncWaitStep(StepKey key, StepKey nextStepKey, Client client) {
@@ -27,6 +29,7 @@ public abstract class AsyncWaitStep extends Step {
         this.client = client;
     }
 
+    @Nullable
     protected Client getClient() {
         return client;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DeleteAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DeleteAction.java
@@ -93,8 +93,7 @@ public class DeleteAction implements LifecycleAction {
             WaitUntilTimeSeriesEndTimePassesStep waitUntilTimeSeriesEndTimeStep = new WaitUntilTimeSeriesEndTimePassesStep(
                 waitTimeSeriesEndTimePassesKey,
                 cleanSnapshotKey,
-                Instant::now,
-                client
+                Instant::now
             );
             CleanupSnapshotStep cleanupSnapshotStep = new CleanupSnapshotStep(cleanSnapshotKey, deleteStepKey, client);
             DeleteStep deleteStep = new DeleteStep(deleteStepKey, nextStepKey, client);
@@ -108,8 +107,7 @@ public class DeleteAction implements LifecycleAction {
             WaitUntilTimeSeriesEndTimePassesStep waitUntilTimeSeriesEndTimeStep = new WaitUntilTimeSeriesEndTimePassesStep(
                 waitTimeSeriesEndTimePassesKey,
                 deleteStepKey,
-                Instant::now,
-                client
+                Instant::now
             );
             DeleteStep deleteStep = new DeleteStep(deleteStepKey, nextStepKey, client);
             return List.of(waitForNoFollowersStep, waitUntilTimeSeriesEndTimeStep, deleteStep);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleAction.java
@@ -200,8 +200,7 @@ public class DownsampleAction implements LifecycleAction {
         WaitUntilTimeSeriesEndTimePassesStep waitUntilTimeSeriesEndTimeStep = new WaitUntilTimeSeriesEndTimePassesStep(
             waitTimeSeriesEndTimePassesKey,
             readOnlyKey,
-            Instant::now,
-            client
+            Instant::now
         );
         // Mark source index as read-only
         ReadOnlyStep readOnlyStep = new ReadOnlyStep(readOnlyKey, generateDownsampleIndexNameKey, client);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeAction.java
@@ -162,8 +162,7 @@ public class ForceMergeAction implements LifecycleAction {
         WaitUntilTimeSeriesEndTimePassesStep waitUntilTimeSeriesEndTimeStep = new WaitUntilTimeSeriesEndTimePassesStep(
             waitTimeSeriesEndTimePassesKey,
             codecChange ? closeKey : forceMergeKey,
-            Instant::now,
-            client
+            Instant::now
         );
 
         // Indices already in this step key when upgrading need to know how to move forward but stop making the index

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
@@ -59,16 +59,6 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
         this.totalShardsPerNode = totalShardsPerNode;
     }
 
-    public MountSnapshotStep(
-        StepKey key,
-        StepKey nextStepKey,
-        Client client,
-        String restoredIndexPrefix,
-        MountSearchableSnapshotRequest.Storage storageType
-    ) {
-        this(key, nextStepKey, client, restoredIndexPrefix, storageType, null);
-    }
-
     @Override
     public boolean isRetryable() {
         return true;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
@@ -41,6 +41,7 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
     private final MountSearchableSnapshotRequest.Storage storageType;
     @Nullable
     private final Integer totalShardsPerNode;
+    private final int replicas;
 
     public MountSnapshotStep(
         StepKey key,
@@ -48,7 +49,8 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
         Client client,
         String restoredIndexPrefix,
         MountSearchableSnapshotRequest.Storage storageType,
-        @Nullable Integer totalShardsPerNode
+        @Nullable Integer totalShardsPerNode,
+        int replicas
     ) {
         super(key, nextStepKey, client);
         this.restoredIndexPrefix = restoredIndexPrefix;
@@ -57,6 +59,10 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
             throw new IllegalArgumentException("[" + SearchableSnapshotAction.TOTAL_SHARDS_PER_NODE.getPreferredName() + "] must be >= 1");
         }
         this.totalShardsPerNode = totalShardsPerNode;
+
+        // this isn't directly settable by the user, so validation by assertion is sufficient
+        assert replicas >= 0 : "number of replicas must be gte zero, but was [" + replicas + "]";
+        this.replicas = replicas;
     }
 
     @Override
@@ -75,6 +81,10 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
     @Nullable
     public Integer getTotalShardsPerNode() {
         return totalShardsPerNode;
+    }
+
+    public int getReplicas() {
+        return replicas;
     }
 
     @Override
@@ -152,10 +162,12 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
         }
 
         final Settings.Builder settingsBuilder = Settings.builder();
-
         overrideTierPreference(this.getKey().phase()).ifPresent(override -> settingsBuilder.put(DataTier.TIER_PREFERENCE, override));
         if (totalShardsPerNode != null) {
             settingsBuilder.put(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey(), totalShardsPerNode);
+        }
+        if (replicas > 0) {
+            settingsBuilder.put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, replicas);
         }
 
         final MountSearchableSnapshotRequest mountSearchableSnapshotRequest = new MountSearchableSnapshotRequest(
@@ -235,7 +247,7 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), restoredIndexPrefix, storageType, totalShardsPerNode);
+        return Objects.hash(super.hashCode(), restoredIndexPrefix, storageType, totalShardsPerNode, replicas);
     }
 
     @Override
@@ -250,6 +262,7 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
         return super.equals(obj)
             && Objects.equals(restoredIndexPrefix, other.restoredIndexPrefix)
             && Objects.equals(storageType, other.storageType)
-            && Objects.equals(totalShardsPerNode, other.totalShardsPerNode);
+            && Objects.equals(totalShardsPerNode, other.totalShardsPerNode)
+            && Objects.equals(replicas, other.replicas);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ReadOnlyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ReadOnlyAction.java
@@ -67,8 +67,7 @@ public class ReadOnlyAction implements LifecycleAction {
         WaitUntilTimeSeriesEndTimePassesStep waitUntilTimeSeriesEndTimeStep = new WaitUntilTimeSeriesEndTimePassesStep(
             waitTimeSeriesEndTimePassesKey,
             readOnlyKey,
-            Instant::now,
-            client
+            Instant::now
         );
         ReadOnlyStep readOnlyStep = new ReadOnlyStep(readOnlyKey, nextStepKey, client);
         return List.of(checkNotWriteIndexStep, waitUntilTimeSeriesEndTimeStep, readOnlyStep);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -230,8 +230,7 @@ public class SearchableSnapshotAction implements LifecycleAction {
         WaitUntilTimeSeriesEndTimePassesStep waitUntilTimeSeriesEndTimeStep = new WaitUntilTimeSeriesEndTimePassesStep(
             waitTimeSeriesEndTimePassesKey,
             skipGeneratingSnapshotKey,
-            Instant::now,
-            client
+            Instant::now
         );
 
         // When generating a snapshot, we either jump to the force merge step, or we skip the

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -113,6 +113,7 @@ public class SearchableSnapshotAction implements LifecycleAction {
         return snapshotRepository;
     }
 
+    @Nullable
     public Integer getTotalShardsPerNode() {
         return totalShardsPerNode;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -318,7 +318,8 @@ public class SearchableSnapshotAction implements LifecycleAction {
             client,
             getRestoredIndexPrefix(mountSnapshotKey),
             storageType,
-            totalShardsPerNode
+            totalShardsPerNode,
+            0
         );
         WaitForIndexColorStep waitForGreenIndexHealthStep = new WaitForIndexColorStep(
             waitForGreenRestoredIndexKey,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkAction.java
@@ -231,8 +231,7 @@ public class ShrinkAction implements LifecycleAction {
         WaitUntilTimeSeriesEndTimePassesStep waitUntilTimeSeriesEndTimeStep = new WaitUntilTimeSeriesEndTimePassesStep(
             waitTimeSeriesEndTimePassesKey,
             readOnlyKey,
-            Instant::now,
-            client
+            Instant::now
         );
         ReadOnlyStep readOnlyStep = new ReadOnlyStep(readOnlyKey, checkTargetShardsCountKey, client);
         CheckTargetShardsCountStep checkTargetShardsCountStep = new CheckTargetShardsCountStep(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Represents the lifecycle of an index from creation to deletion. A
@@ -49,7 +48,7 @@ public class TimeseriesLifecycleType implements LifecycleType {
     static final String DELETE_PHASE = "delete";
     public static final List<String> ORDERED_VALID_PHASES = List.of(HOT_PHASE, WARM_PHASE, COLD_PHASE, FROZEN_PHASE, DELETE_PHASE);
 
-    public static final List<String> ORDERED_VALID_HOT_ACTIONS = Stream.of(
+    public static final List<String> ORDERED_VALID_HOT_ACTIONS = List.of(
         SetPriorityAction.NAME,
         UnfollowAction.NAME,
         RolloverAction.NAME,
@@ -58,8 +57,8 @@ public class TimeseriesLifecycleType implements LifecycleType {
         ShrinkAction.NAME,
         ForceMergeAction.NAME,
         SearchableSnapshotAction.NAME
-    ).filter(Objects::nonNull).toList();
-    public static final List<String> ORDERED_VALID_WARM_ACTIONS = Stream.of(
+    );
+    public static final List<String> ORDERED_VALID_WARM_ACTIONS = List.of(
         SetPriorityAction.NAME,
         UnfollowAction.NAME,
         ReadOnlyAction.NAME,
@@ -68,8 +67,8 @@ public class TimeseriesLifecycleType implements LifecycleType {
         MigrateAction.NAME,
         ShrinkAction.NAME,
         ForceMergeAction.NAME
-    ).filter(Objects::nonNull).toList();
-    public static final List<String> ORDERED_VALID_COLD_ACTIONS = Stream.of(
+    );
+    public static final List<String> ORDERED_VALID_COLD_ACTIONS = List.of(
         SetPriorityAction.NAME,
         UnfollowAction.NAME,
         ReadOnlyAction.NAME,
@@ -78,7 +77,7 @@ public class TimeseriesLifecycleType implements LifecycleType {
         AllocateAction.NAME,
         MigrateAction.NAME,
         FreezeAction.NAME
-    ).filter(Objects::nonNull).toList();
+    );
     public static final List<String> ORDERED_VALID_FROZEN_ACTIONS = List.of(UnfollowAction.NAME, SearchableSnapshotAction.NAME);
     public static final List<String> ORDERED_VALID_DELETE_ACTIONS = List.of(WaitForSnapshotAction.NAME, DeleteAction.NAME);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStep.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
@@ -33,8 +32,8 @@ public class WaitUntilTimeSeriesEndTimePassesStep extends AsyncWaitStep {
     public static final String NAME = "check-ts-end-time-passed";
     private final Supplier<Instant> nowSupplier;
 
-    public WaitUntilTimeSeriesEndTimePassesStep(StepKey key, StepKey nextStepKey, Supplier<Instant> nowSupplier, Client client) {
-        super(key, nextStepKey, client);
+    public WaitUntilTimeSeriesEndTimePassesStep(StepKey key, StepKey nextStepKey, Supplier<Instant> nowSupplier) {
+        super(key, nextStepKey, null);
         this.nowSupplier = nowSupplier;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
@@ -204,7 +204,8 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 randomStepKey(),
                 client,
                 RESTORED_INDEX_PREFIX,
-                randomStorageType()
+                randomStorageType(),
+                null
             );
             performActionAndWait(step, indexMetadata, clusterState, null);
         }
@@ -239,7 +240,8 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                     randomStepKey(),
                     clientPropagatingOKResponse,
                     RESTORED_INDEX_PREFIX,
-                    randomStorageType()
+                    randomStorageType(),
+                    null
                 );
                 performActionAndWait(step, indexMetadata, clusterState, null);
             }
@@ -254,7 +256,8 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                     randomStepKey(),
                     clientPropagatingACCEPTEDResponse,
                     RESTORED_INDEX_PREFIX,
-                    randomStorageType()
+                    randomStorageType(),
+                    null
                 );
                 performActionAndWait(step, indexMetadata, clusterState, null);
             }
@@ -328,7 +331,8 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 randomStepKey(),
                 client,
                 RESTORED_INDEX_PREFIX,
-                randomStorageType()
+                randomStorageType(),
+                null
             );
             performActionAndWait(step, indexMetadata, clusterState, null);
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
@@ -290,46 +290,44 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
     }
 
     private void doTestMountWithoutSnapshotIndexNameInState(String prefix) throws Exception {
-        {
-            String indexNameSnippet = randomAlphaOfLength(10);
-            String indexName = prefix + indexNameSnippet;
-            String policyName = "test-ilm-policy";
-            Map<String, String> ilmCustom = new HashMap<>();
-            String snapshotName = indexName + "-" + policyName;
-            ilmCustom.put("snapshot_name", snapshotName);
-            String repository = "repository";
-            ilmCustom.put("snapshot_repository", repository);
+        String indexNameSnippet = randomAlphaOfLength(10);
+        String indexName = prefix + indexNameSnippet;
+        String policyName = "test-ilm-policy";
+        Map<String, String> ilmCustom = new HashMap<>();
+        String snapshotName = indexName + "-" + policyName;
+        ilmCustom.put("snapshot_name", snapshotName);
+        String repository = "repository";
+        ilmCustom.put("snapshot_repository", repository);
 
-            IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexName)
-                .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
-                .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, ilmCustom)
-                .numberOfShards(randomIntBetween(1, 5))
-                .numberOfReplicas(randomIntBetween(0, 5));
-            IndexMetadata indexMetadata = indexMetadataBuilder.build();
+        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexName)
+            .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, ilmCustom)
+            .numberOfShards(randomIntBetween(1, 5))
+            .numberOfReplicas(randomIntBetween(0, 5));
+        IndexMetadata indexMetadata = indexMetadataBuilder.build();
 
-            ClusterState clusterState = ClusterState.builder(emptyClusterState())
-                .metadata(Metadata.builder().put(indexMetadata, true).build())
-                .build();
+        ClusterState clusterState = ClusterState.builder(emptyClusterState())
+            .metadata(Metadata.builder().put(indexMetadata, true).build())
+            .build();
 
-            try (var threadPool = createThreadPool()) {
-                final var client = getRestoreSnapshotRequestAssertingClient(
-                    threadPool,
-                    repository,
-                    snapshotName,
-                    indexName,
-                    RESTORED_INDEX_PREFIX,
-                    indexNameSnippet,
-                    new String[] { LifecycleSettings.LIFECYCLE_NAME }
-                );
-                MountSnapshotStep step = new MountSnapshotStep(
-                    randomStepKey(),
-                    randomStepKey(),
-                    client,
-                    RESTORED_INDEX_PREFIX,
-                    randomStorageType()
-                );
-                performActionAndWait(step, indexMetadata, clusterState, null);
-            }
+        try (var threadPool = createThreadPool()) {
+            final var client = getRestoreSnapshotRequestAssertingClient(
+                threadPool,
+                repository,
+                snapshotName,
+                indexName,
+                RESTORED_INDEX_PREFIX,
+                indexNameSnippet,
+                new String[] { LifecycleSettings.LIFECYCLE_NAME }
+            );
+            MountSnapshotStep step = new MountSnapshotStep(
+                randomStepKey(),
+                randomStepKey(),
+                client,
+                RESTORED_INDEX_PREFIX,
+                randomStorageType()
+            );
+            performActionAndWait(step, indexMetadata, clusterState, null);
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
@@ -289,7 +289,7 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
         );
     }
 
-    public void doTestMountWithoutSnapshotIndexNameInState(String prefix) throws Exception {
+    private void doTestMountWithoutSnapshotIndexNameInState(String prefix) throws Exception {
         {
             String indexNameSnippet = randomAlphaOfLength(10);
             String indexName = prefix + indexNameSnippet;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
@@ -172,8 +172,16 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
     @Override
     protected SearchableSnapshotAction mutateInstance(SearchableSnapshotAction instance) {
         return switch (randomIntBetween(0, 2)) {
-            case 0 -> new SearchableSnapshotAction(randomAlphaOfLengthBetween(5, 10), instance.isForceMergeIndex());
-            case 1 -> new SearchableSnapshotAction(instance.getSnapshotRepository(), instance.isForceMergeIndex() == false);
+            case 0 -> new SearchableSnapshotAction(
+                randomAlphaOfLengthBetween(5, 10),
+                instance.isForceMergeIndex(),
+                instance.getTotalShardsPerNode()
+            );
+            case 1 -> new SearchableSnapshotAction(
+                instance.getSnapshotRepository(),
+                instance.isForceMergeIndex() == false,
+                instance.getTotalShardsPerNode()
+            );
             case 2 -> new SearchableSnapshotAction(
                 instance.getSnapshotRepository(),
                 instance.isForceMergeIndex(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
@@ -14,6 +14,8 @@ import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotR
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction.NAME;
 import static org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction.TOTAL_SHARDS_PER_NODE;
@@ -29,40 +31,23 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
         StepKey nextStepKey = new StepKey(phase, randomAlphaOfLengthBetween(1, 5), randomAlphaOfLengthBetween(1, 5));
 
         List<Step> steps = action.toSteps(null, phase, nextStepKey, null);
-        assertThat(steps.size(), is(action.isForceMergeIndex() ? 19 : 17));
 
-        List<StepKey> expectedSteps = action.isForceMergeIndex()
-            ? expectedStepKeysWithForceMerge(phase)
-            : expectedStepKeysNoForceMerge(phase);
-
-        assertThat(steps.get(0).getKey(), is(expectedSteps.get(0)));
-        assertThat(steps.get(1).getKey(), is(expectedSteps.get(1)));
-        assertThat(steps.get(2).getKey(), is(expectedSteps.get(2)));
-        assertThat(steps.get(3).getKey(), is(expectedSteps.get(3)));
-        assertThat(steps.get(4).getKey(), is(expectedSteps.get(4)));
-        assertThat(steps.get(5).getKey(), is(expectedSteps.get(5)));
-        assertThat(steps.get(6).getKey(), is(expectedSteps.get(6)));
-        assertThat(steps.get(7).getKey(), is(expectedSteps.get(7)));
-        assertThat(steps.get(8).getKey(), is(expectedSteps.get(8)));
-        assertThat(steps.get(9).getKey(), is(expectedSteps.get(9)));
-        assertThat(steps.get(10).getKey(), is(expectedSteps.get(10)));
-        assertThat(steps.get(11).getKey(), is(expectedSteps.get(11)));
-        assertThat(steps.get(12).getKey(), is(expectedSteps.get(12)));
-        assertThat(steps.get(13).getKey(), is(expectedSteps.get(13)));
-        assertThat(steps.get(14).getKey(), is(expectedSteps.get(14)));
-        assertThat(steps.get(15).getKey(), is(expectedSteps.get(15)));
-
-        if (action.isForceMergeIndex()) {
-            assertThat(steps.get(16).getKey(), is(expectedSteps.get(16)));
-            assertThat(steps.get(17).getKey(), is(expectedSteps.get(17)));
-            CreateSnapshotStep createSnapshotStep = (CreateSnapshotStep) steps.get(9);
-            assertThat(createSnapshotStep.getNextKeyOnIncomplete(), is(expectedSteps.get(8)));
-            validateWaitForDataTierStep(phase, steps, 10, 11);
-        } else {
-            CreateSnapshotStep createSnapshotStep = (CreateSnapshotStep) steps.get(7);
-            assertThat(createSnapshotStep.getNextKeyOnIncomplete(), is(expectedSteps.get(6)));
-            validateWaitForDataTierStep(phase, steps, 8, 9);
+        List<StepKey> expectedSteps = expectedStepKeys(phase, action.isForceMergeIndex());
+        assertThat(steps.size(), is(expectedSteps.size()));
+        for (int i = 0; i < expectedSteps.size(); i++) {
+            assertThat("steps match expectation at index " + i, steps.get(i).getKey(), is(expectedSteps.get(i)));
         }
+
+        int index = -1;
+        for (int i = 0; i < expectedSteps.size(); i++) {
+            if (expectedSteps.get(i).name().equals(CreateSnapshotStep.NAME)) {
+                index = i;
+                break;
+            }
+        }
+        CreateSnapshotStep createSnapshotStep = (CreateSnapshotStep) steps.get(index);
+        assertThat(createSnapshotStep.getNextKeyOnIncomplete(), is(expectedSteps.get(index - 1)));
+        validateWaitForDataTierStep(phase, steps, index + 1, index + 2);
     }
 
     private void validateWaitForDataTierStep(String phase, List<Step> steps, int waitForDataTierStepIndex, int mountStepIndex) {
@@ -108,15 +93,15 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
         assertEquals("[" + TOTAL_SHARDS_PER_NODE.getPreferredName() + "] must be >= 1", exception.getMessage());
     }
 
-    private List<StepKey> expectedStepKeysWithForceMerge(String phase) {
-        return List.of(
+    private List<StepKey> expectedStepKeys(String phase, boolean forceMergeIndex) {
+        return Stream.of(
             new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_SKIP_ACTION_STEP),
             new StepKey(phase, NAME, CheckNotDataStreamWriteIndexStep.NAME),
             new StepKey(phase, NAME, WaitForNoFollowersStep.NAME),
             new StepKey(phase, NAME, WaitUntilTimeSeriesEndTimePassesStep.NAME),
             new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_SKIP_GENERATE_AND_CLEAN),
-            new StepKey(phase, NAME, ForceMergeStep.NAME),
-            new StepKey(phase, NAME, SegmentCountStep.NAME),
+            forceMergeIndex ? new StepKey(phase, NAME, ForceMergeStep.NAME) : null,
+            forceMergeIndex ? new StepKey(phase, NAME, SegmentCountStep.NAME) : null,
             new StepKey(phase, NAME, GenerateSnapshotNameStep.NAME),
             new StepKey(phase, NAME, CleanupSnapshotStep.NAME),
             new StepKey(phase, NAME, CreateSnapshotStep.NAME),
@@ -129,29 +114,7 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
             new StepKey(phase, NAME, ReplaceDataStreamBackingIndexStep.NAME),
             new StepKey(phase, NAME, DeleteStep.NAME),
             new StepKey(phase, NAME, SwapAliasesAndDeleteSourceIndexStep.NAME)
-        );
-    }
-
-    private List<StepKey> expectedStepKeysNoForceMerge(String phase) {
-        return List.of(
-            new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_SKIP_ACTION_STEP),
-            new StepKey(phase, NAME, CheckNotDataStreamWriteIndexStep.NAME),
-            new StepKey(phase, NAME, WaitForNoFollowersStep.NAME),
-            new StepKey(phase, NAME, WaitUntilTimeSeriesEndTimePassesStep.NAME),
-            new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_SKIP_GENERATE_AND_CLEAN),
-            new StepKey(phase, NAME, GenerateSnapshotNameStep.NAME),
-            new StepKey(phase, NAME, CleanupSnapshotStep.NAME),
-            new StepKey(phase, NAME, CreateSnapshotStep.NAME),
-            new StepKey(phase, NAME, WaitForDataTierStep.NAME),
-            new StepKey(phase, NAME, MountSnapshotStep.NAME),
-            new StepKey(phase, NAME, WaitForIndexColorStep.NAME),
-            new StepKey(phase, NAME, CopyExecutionStateStep.NAME),
-            new StepKey(phase, NAME, CopySettingsStep.NAME),
-            new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_DATASTREAM_CHECK_KEY),
-            new StepKey(phase, NAME, ReplaceDataStreamBackingIndexStep.NAME),
-            new StepKey(phase, NAME, DeleteStep.NAME),
-            new StepKey(phase, NAME, SwapAliasesAndDeleteSourceIndexStep.NAME)
-        );
+        ).filter(Objects::nonNull).toList();
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStepTests.java
@@ -30,7 +30,7 @@ public class WaitUntilTimeSeriesEndTimePassesStepTests extends AbstractStepTestC
     protected WaitUntilTimeSeriesEndTimePassesStep createRandomInstance() {
         Step.StepKey stepKey = randomStepKey();
         Step.StepKey nextStepKey = randomStepKey();
-        return new WaitUntilTimeSeriesEndTimePassesStep(stepKey, nextStepKey, Instant::now, client);
+        return new WaitUntilTimeSeriesEndTimePassesStep(stepKey, nextStepKey, Instant::now);
     }
 
     @Override
@@ -42,12 +42,12 @@ public class WaitUntilTimeSeriesEndTimePassesStepTests extends AbstractStepTestC
             case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
             case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
         }
-        return new WaitUntilTimeSeriesEndTimePassesStep(key, nextKey, Instant::now, client);
+        return new WaitUntilTimeSeriesEndTimePassesStep(key, nextKey, Instant::now);
     }
 
     @Override
     protected WaitUntilTimeSeriesEndTimePassesStep copyInstance(WaitUntilTimeSeriesEndTimePassesStep instance) {
-        return new WaitUntilTimeSeriesEndTimePassesStep(instance.getKey(), instance.getNextStepKey(), Instant::now, client);
+        return new WaitUntilTimeSeriesEndTimePassesStep(instance.getKey(), instance.getNextStepKey(), Instant::now);
     }
 
     public void testEvaluateCondition() {
@@ -68,8 +68,7 @@ public class WaitUntilTimeSeriesEndTimePassesStepTests extends AbstractStepTestC
         WaitUntilTimeSeriesEndTimePassesStep step = new WaitUntilTimeSeriesEndTimePassesStep(
             randomStepKey(),
             randomStepKey(),
-            () -> currentTime,
-            client
+            () -> currentTime
         );
         {
             // end_time has lapsed already so condition must be met


### PR DESCRIPTION
A handful of cleanups, and then some scaffolding code. This adds the ability to set a number of replicas on the `MountSnapshotStep` in ILM (which is used by the `SearchableSnapshotAction`). The tests cover the scenario of the number of replicas being >=0, but the code itself never does down that path -- at least as of this PR, the number of replicas is still always actually just set to 0.

This is a work-in-progress PR that's leading to a real `>enhancement` PR, but this isn't that, this is more in the realm of https://en.wikipedia.org/wiki/Falsework.