### PR TITLE
Fix BwC  synonyms tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -162,9 +162,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/117473
 - class: org.elasticsearch.repositories.s3.RepositoryS3EcsClientYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/117525
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set}
-  issue: https://github.com/elastic/elasticsearch/issues/116777
 - class: "org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT"
   method: "test {scoring.*}"
   issue: https://github.com/elastic/elasticsearch/issues/117641

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -69,4 +69,5 @@ tasks.named("yamlRestCompatTestTransform").configure ({ task ->
   task.skipTest("search/520_fetch_fields/fetch _seq_no via fields", "error code is changed from 5xx to 400 in 9.0")
   task.skipTest("search.vectors/41_knn_search_bbq_hnsw/Test knn search", "Scoring has changed in latest versions")
   task.skipTest("search.vectors/42_knn_search_bbq_flat/Test knn search", "Scoring has changed in latest versions")
+  task.skipTest("synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set", "Can't work until auto-expand replicas is 0-1 for synonyms index")
 })

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -1,8 +1,8 @@
----
-"Reload analyzers for specific synonym set":
+setup:
   - requires:
       cluster_features: ["gte_v8.10.0"]
       reason: Reloading analyzers for specific synonym set is introduced in 8.10.0
+
   # Create synonyms_set1
   - do:
       synonyms.put_synonym:
@@ -100,7 +100,12 @@
           - '{"index": {"_index": "my_index2", "_id": "2"}}'
           - '{"my_field": "goodbye"}'
 
-  # An update of synonyms_set1 must trigger auto-reloading of analyzers only for synonyms_set1
+---
+"Reload analyzers for specific synonym set":
+# These specific tests can't succeed in BwC, as synonyms auto-expand replicas are 0-all. Replicas can't be associated to
+#  upgraded nodes, and thus we are not able to guarantee that the shards are not failed.
+# This test is skipped for BwC until synonyms index has auto-exapnd replicas set to 0-1.
+
   - do:
       synonyms.put_synonym:
         id: synonyms_set1
@@ -108,13 +113,12 @@
           synonyms_set:
             - synonyms: "hello, salute"
             - synonyms: "ciao => goodbye"
+
   - match: { result: "updated" }
   - gt: { reload_analyzers_details._shards.total: 0 }
   - gt: { reload_analyzers_details._shards.successful: 0 }
   - match: { reload_analyzers_details._shards.failed: 0 }
-  - length: { reload_analyzers_details.reload_details: 1 } # reload details contain only a single index
-  - match: { reload_analyzers_details.reload_details.0.index: "my_index1" }
-  - match: { reload_analyzers_details.reload_details.0.reloaded_analyzers.0: "my_analyzer1" }
+
 
   # Confirm that the index analyzers are reloaded for my_index1
   - do:
@@ -126,6 +130,23 @@
               my_field:
                 query: salute
   - match: { hits.total.value: 1 }
+
+---
+"Check analyzer reloaded and non failed shards for bwc tests":
+
+  - do:
+      synonyms.put_synonym:
+        id: synonyms_set1
+        body:
+          synonyms_set:
+            - synonyms: "hello, salute"
+            - synonyms: "ciao => goodbye"
+  - match: { result: "updated" }
+  - gt: { reload_analyzers_details._shards.total: 0 }
+  - gt: { reload_analyzers_details._shards.successful: 0 }
+  - length: { reload_analyzers_details.reload_details: 1 } # reload details contain only a single index
+  - match: { reload_analyzers_details.reload_details.0.index: "my_index1" }
+  - match: { reload_analyzers_details.reload_details.0.reloaded_analyzers.0: "my_analyzer1" }
 
   # Confirm that the index analyzers are still the same for my_index2
   - do:


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/116777

BwC tests can't work with synonyms correctly, as auto expand replicas 0-all in the synonyms system index means that not all replicas will be available for the synonyms index when upgrading nodes to create a mixed cluster.

This makes some shard update failure in the synonyms operations as there can be race conditions on the update operations for shards that are marked as relocating. I haven't found a way to consistently deal with this on BwC on reload operations.

This PR creates two different tests for reloading synonyms, in which different conditions are checked. The conditions that fail in BwC are added to a test that is skipped in BwC. This way we have some coverage for both BwC and non-BwC tests, and we check all conditions needed in non-BwC tests.

When we have auto-expand replicas set to 0-1 in synonyms system index, this can be reverted. That is tracked in https://github.com/elastic/elasticsearch/issues/115382