### PR TITLE
Add optional pull request check for running with entitlements enabled

### DIFF
--- a/.buildkite/pipelines/pull-request/part-1-entitlements.yml
+++ b/.buildkite/pipelines/pull-request/part-1-entitlements.yml
@@ -1,0 +1,11 @@
+config:
+  allow-labels: "test-entitlements"
+steps:
+  - label: part-1-entitlements
+    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.jvm.argline="-Des.entitlements.enabled=true" checkPart1
+    timeout_in_minutes: 300
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2004
+      machineType: custom-32-98304
+      buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-2-entitlements.yml
+++ b/.buildkite/pipelines/pull-request/part-2-entitlements.yml
@@ -1,0 +1,11 @@
+config:
+  allow-labels: "test-entitlements"
+steps:
+  - label: part-2-entitlements
+    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.jvm.argline="-Des.entitlements.enabled=true" checkPart2
+    timeout_in_minutes: 300
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2004
+      machineType: custom-32-98304
+      buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-3-entitlements.yml
+++ b/.buildkite/pipelines/pull-request/part-3-entitlements.yml
@@ -1,0 +1,11 @@
+config:
+  allow-labels: "test-entitlements"
+steps:
+  - label: part-3-entitlements
+    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.jvm.argline="-Des.entitlements.enabled=true" checkPart3
+    timeout_in_minutes: 300
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2004
+      machineType: custom-32-98304
+      buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4-entitlements.yml
+++ b/.buildkite/pipelines/pull-request/part-4-entitlements.yml
@@ -1,0 +1,11 @@
+config:
+  allow-labels: "test-entitlements"
+steps:
+  - label: part-4-entitlements
+    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.jvm.argline="-Des.entitlements.enabled=true" checkPart4
+    timeout_in_minutes: 300
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2004
+      machineType: custom-32-98304
+      buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-5-entitlements.yml
+++ b/.buildkite/pipelines/pull-request/part-5-entitlements.yml
@@ -1,0 +1,11 @@
+config:
+  allow-labels: "test-entitlements"
+steps:
+  - label: part-5-entitlements
+    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.jvm.argline="-Des.entitlements.enabled=true" checkPart5
+    timeout_in_minutes: 300
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2004
+      machineType: custom-32-98304
+      buildDirectory: /dev/shm/bk

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -876,10 +876,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         // Don't inherit anything from the environment for as that would lack reproducibility
         environment.clear();
         environment.putAll(getESEnvironment());
-        if (cliJvmArgs.isEmpty() == false) {
-            String cliJvmArgsString = String.join(" ", cliJvmArgs);
-            environment.put("CLI_JAVA_OPTS", cliJvmArgsString);
-        }
+        String cliJvmArgsString = String.join(" ", cliJvmArgs);
+        environment.put("CLI_JAVA_OPTS", cliJvmArgsString + " " + System.getProperty("tests.jvm.argline", ""));
 
         // Direct the stderr to the ES log file. This should capture any jvm problems to start.
         // Stdout is discarded because ES duplicates the log file to stdout when run in the foreground.


### PR DESCRIPTION
Adds new pull request jobs that is run with the `test-entitlements` label is added to a pull request. These jobs run the normal functional test suite, but passing `-Des.entitlements.enabled=true` to the tests to enable the security manager replacement.