### PR TITLE
Remove lifecycle from CircuitBreakerService

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerService.java
@@ -58,7 +58,7 @@ public class PreallocatedCircuitBreakerService extends CircuitBreakerService imp
     }
 
     @Override
-    protected void doClose() {
+    public void close() {
         preallocated.close();
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerService.java
@@ -10,13 +10,12 @@
 package org.elasticsearch.indices.breaker;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.component.AbstractLifecycleComponent;
 
 /**
  * Interface for Circuit Breaker services, which provide breakers to classes
  * that load field data.
  */
-public abstract class CircuitBreakerService extends AbstractLifecycleComponent {
+public abstract class CircuitBreakerService {
 
     protected CircuitBreakerService() {}
 
@@ -34,14 +33,5 @@ public abstract class CircuitBreakerService extends AbstractLifecycleComponent {
      * @return stats about a specific breaker
      */
     public abstract CircuitBreakerStats stats(String name);
-
-    @Override
-    protected void doStart() {}
-
-    @Override
-    protected void doStop() {}
-
-    @Override
-    protected void doClose() {}
 
 }

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1459,7 +1459,6 @@ class NodeConstruction {
             case "none" -> new NoneCircuitBreakerService();
             default -> throw new IllegalArgumentException("Unknown circuit breaker type [" + type + "]");
         };
-        resourcesToClose.add(circuitBreakerService);
         modules.bindToInstance(CircuitBreakerService.class, circuitBreakerService);
 
         pluginBreakers.forEach(t -> {

--- a/server/src/test/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerServiceTests.java
@@ -25,100 +25,94 @@ import static org.hamcrest.Matchers.startsWith;
 
 public class PreallocatedCircuitBreakerServiceTests extends ESTestCase {
     public void testUseNotPreallocated() {
-        try (HierarchyCircuitBreakerService real = real()) {
-            try (PreallocatedCircuitBreakerService preallocated = preallocateRequest(real, 1024)) {
-                CircuitBreaker b = preallocated.getBreaker(CircuitBreaker.REQUEST);
-                b.addEstimateBytesAndMaybeBreak(100, "test");
-                b.addWithoutBreaking(-100);
-            }
-            assertThat(real.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
+        HierarchyCircuitBreakerService real = real();
+        try (PreallocatedCircuitBreakerService preallocated = preallocateRequest(real, 1024)) {
+            CircuitBreaker b = preallocated.getBreaker(CircuitBreaker.REQUEST);
+            b.addEstimateBytesAndMaybeBreak(100, "test");
+            b.addWithoutBreaking(-100);
         }
+        assertThat(real.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
     }
 
     public void testUseLessThanPreallocated() {
-        try (HierarchyCircuitBreakerService real = real()) {
-            try (PreallocatedCircuitBreakerService preallocated = preallocateRequest(real, 1024)) {
-                CircuitBreaker b = preallocated.getBreaker(CircuitBreaker.REQUEST);
-                b.addEstimateBytesAndMaybeBreak(100, "test");
-                b.addWithoutBreaking(-100);
-            }
-            assertThat(real.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
+        HierarchyCircuitBreakerService real = real();
+        try (PreallocatedCircuitBreakerService preallocated = preallocateRequest(real, 1024)) {
+            CircuitBreaker b = preallocated.getBreaker(CircuitBreaker.REQUEST);
+            b.addEstimateBytesAndMaybeBreak(100, "test");
+            b.addWithoutBreaking(-100);
         }
+        assertThat(real.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
     }
 
     public void testCloseIsIdempotent() {
-        try (HierarchyCircuitBreakerService real = real()) {
-            try (PreallocatedCircuitBreakerService preallocated = preallocateRequest(real, 1024)) {
-                CircuitBreaker b = preallocated.getBreaker(CircuitBreaker.REQUEST);
-                b.addEstimateBytesAndMaybeBreak(100, "test");
-                b.addWithoutBreaking(-100);
-                preallocated.close();
-                assertThat(real.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
-            } // Closes again which should do nothing
+        HierarchyCircuitBreakerService real = real();
+        try (PreallocatedCircuitBreakerService preallocated = preallocateRequest(real, 1024)) {
+            CircuitBreaker b = preallocated.getBreaker(CircuitBreaker.REQUEST);
+            b.addEstimateBytesAndMaybeBreak(100, "test");
+            b.addWithoutBreaking(-100);
+            preallocated.close();
             assertThat(real.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
-        }
+        } // Closes again which should do nothing
+        assertThat(real.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
     }
 
     public void testUseMoreThanPreallocated() {
-        try (HierarchyCircuitBreakerService real = real()) {
-            try (PreallocatedCircuitBreakerService preallocated = preallocateRequest(real, 1024)) {
-                CircuitBreaker b = preallocated.getBreaker(CircuitBreaker.REQUEST);
-                b.addEstimateBytesAndMaybeBreak(2048, "test");
-                b.addWithoutBreaking(-2048);
-            }
-            assertThat(real.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
+        HierarchyCircuitBreakerService real = real();
+        try (PreallocatedCircuitBreakerService preallocated = preallocateRequest(real, 1024)) {
+            CircuitBreaker b = preallocated.getBreaker(CircuitBreaker.REQUEST);
+            b.addEstimateBytesAndMaybeBreak(2048, "test");
+            b.addWithoutBreaking(-2048);
         }
+        assertThat(real.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
     }
 
     public void testPreallocateMoreThanRemains() {
-        try (HierarchyCircuitBreakerService real = real()) {
-            long limit = real.getBreaker(CircuitBreaker.REQUEST).getLimit();
-            Exception e = expectThrows(CircuitBreakingException.class, () -> preallocateRequest(real, limit + 1024));
-            assertThat(e.getMessage(), startsWith("[request] Data too large, data for [preallocate[test]] would be ["));
-        }
+        HierarchyCircuitBreakerService real = real();
+        long limit = real.getBreaker(CircuitBreaker.REQUEST).getLimit();
+        Exception e = expectThrows(CircuitBreakingException.class, () -> preallocateRequest(real, limit + 1024));
+        assertThat(e.getMessage(), startsWith("[request] Data too large, data for [preallocate[test]] would be ["));
     }
 
     public void testRandom() {
-        try (HierarchyCircuitBreakerService real = real()) {
-            CircuitBreaker realBreaker = real.getBreaker(CircuitBreaker.REQUEST);
-            long preallocatedBytes = randomLongBetween(1, (long) (realBreaker.getLimit() * .8));
-            try (PreallocatedCircuitBreakerService preallocated = preallocateRequest(real, preallocatedBytes)) {
-                CircuitBreaker b = preallocated.getBreaker(CircuitBreaker.REQUEST);
-                boolean usedPreallocated = false;
-                long current = 0;
-                for (int i = 0; i < 10000; i++) {
-                    if (current >= preallocatedBytes) {
-                        usedPreallocated = true;
-                    }
-                    if (usedPreallocated) {
-                        assertThat(realBreaker.getUsed(), equalTo(current));
-                    } else {
-                        assertThat(realBreaker.getUsed(), equalTo(preallocatedBytes));
-                    }
-                    if (current > 0 && randomBoolean()) {
-                        long delta = randomLongBetween(-Math.min(current, realBreaker.getLimit() / 100), 0);
-                        b.addWithoutBreaking(delta);
-                        current += delta;
-                        continue;
-                    }
-                    long delta = randomLongBetween(0, realBreaker.getLimit() / 100);
-                    if (randomBoolean()) {
-                        b.addWithoutBreaking(delta);
-                        current += delta;
-                        continue;
-                    }
-                    if (current + delta < realBreaker.getLimit()) {
-                        b.addEstimateBytesAndMaybeBreak(delta, "test");
-                        current += delta;
-                        continue;
-                    }
-                    Exception e = expectThrows(CircuitBreakingException.class, () -> b.addEstimateBytesAndMaybeBreak(delta, "test"));
-                    assertThat(e.getMessage(), startsWith("[request] Data too large, data for [test] would be ["));
+        HierarchyCircuitBreakerService real = real();
+        CircuitBreaker realBreaker = real.getBreaker(CircuitBreaker.REQUEST);
+        long preallocatedBytes = randomLongBetween(1, (long) (realBreaker.getLimit() * .8));
+        try (PreallocatedCircuitBreakerService preallocated = preallocateRequest(real, preallocatedBytes)) {
+            CircuitBreaker b = preallocated.getBreaker(CircuitBreaker.REQUEST);
+            boolean usedPreallocated = false;
+            long current = 0;
+            for (int i = 0; i < 10000; i++) {
+                if (current >= preallocatedBytes) {
+                    usedPreallocated = true;
                 }
-                b.addWithoutBreaking(-current);
+                if (usedPreallocated) {
+                    assertThat(realBreaker.getUsed(), equalTo(current));
+                } else {
+                    assertThat(realBreaker.getUsed(), equalTo(preallocatedBytes));
+                }
+                if (current > 0 && randomBoolean()) {
+                    long delta = randomLongBetween(-Math.min(current, realBreaker.getLimit() / 100), 0);
+                    b.addWithoutBreaking(delta);
+                    current += delta;
+                    continue;
+                }
+                long delta = randomLongBetween(0, realBreaker.getLimit() / 100);
+                if (randomBoolean()) {
+                    b.addWithoutBreaking(delta);
+                    current += delta;
+                    continue;
+                }
+                if (current + delta < realBreaker.getLimit()) {
+                    b.addEstimateBytesAndMaybeBreak(delta, "test");
+                    current += delta;
+                    continue;
+                }
+                Exception e = expectThrows(CircuitBreakingException.class, () -> b.addEstimateBytesAndMaybeBreak(delta, "test"));
+                assertThat(e.getMessage(), startsWith("[request] Data too large, data for [test] would be ["));
             }
-            assertThat(real.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
+            b.addWithoutBreaking(-current);
         }
+        assertThat(real.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
     }
 
     private HierarchyCircuitBreakerService real() {

--- a/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -527,49 +527,46 @@ public class BigArraysTests extends ESTestCase {
      */
     public void testPreallocate() {
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        HierarchyCircuitBreakerService realBreakers = new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            Settings.EMPTY,
+            List.of(),
+            clusterSettings
+        );
+        BigArrays unPreAllocated = new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), realBreakers);
+        long toPreallocate = randomLongBetween(4000, 10000);
+        CircuitBreaker realBreaker = realBreakers.getBreaker(CircuitBreaker.REQUEST);
+        assertThat(realBreaker.getUsed(), equalTo(0L));
         try (
-            HierarchyCircuitBreakerService realBreakers = new HierarchyCircuitBreakerService(
-                CircuitBreakerMetrics.NOOP,
-                Settings.EMPTY,
-                List.of(),
-                clusterSettings
+            PreallocatedCircuitBreakerService prealloctedBreakerService = new PreallocatedCircuitBreakerService(
+                realBreakers,
+                CircuitBreaker.REQUEST,
+                toPreallocate,
+                "test"
             )
         ) {
-            BigArrays unPreAllocated = new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), realBreakers);
-            long toPreallocate = randomLongBetween(4000, 10000);
-            CircuitBreaker realBreaker = realBreakers.getBreaker(CircuitBreaker.REQUEST);
-            assertThat(realBreaker.getUsed(), equalTo(0L));
-            try (
-                PreallocatedCircuitBreakerService prealloctedBreakerService = new PreallocatedCircuitBreakerService(
-                    realBreakers,
-                    CircuitBreaker.REQUEST,
-                    toPreallocate,
-                    "test"
-                )
-            ) {
+            assertThat(realBreaker.getUsed(), equalTo(toPreallocate));
+            BigArrays preallocated = unPreAllocated.withBreakerService(prealloctedBreakerService);
+
+            // We don't grab any bytes just making a new BigArrays
+            assertThat(realBreaker.getUsed(), equalTo(toPreallocate));
+
+            List<BigArray> arrays = new ArrayList<>();
+            for (int i = 0; i < 30; i++) {
+                // We're well under the preallocation so grabbing a little array doesn't allocate anything
+                arrays.add(preallocated.newLongArray(1));
                 assertThat(realBreaker.getUsed(), equalTo(toPreallocate));
-                BigArrays preallocated = unPreAllocated.withBreakerService(prealloctedBreakerService);
-
-                // We don't grab any bytes just making a new BigArrays
-                assertThat(realBreaker.getUsed(), equalTo(toPreallocate));
-
-                List<BigArray> arrays = new ArrayList<>();
-                for (int i = 0; i < 30; i++) {
-                    // We're well under the preallocation so grabbing a little array doesn't allocate anything
-                    arrays.add(preallocated.newLongArray(1));
-                    assertThat(realBreaker.getUsed(), equalTo(toPreallocate));
-                }
-
-                // Allocating a large array *does* allocate some bytes
-                arrays.add(preallocated.newLongArray(1024));
-                long expectedMin = (PageCacheRecycler.LONG_PAGE_SIZE + arrays.size()) * Long.BYTES;
-                assertThat(realBreaker.getUsed(), greaterThanOrEqualTo(expectedMin));
-                // 64 should be enough room for each BigArray object
-                assertThat(realBreaker.getUsed(), lessThanOrEqualTo(expectedMin + 64 * arrays.size()));
-                Releasables.close(arrays);
             }
-            assertThat(realBreaker.getUsed(), equalTo(0L));
+
+            // Allocating a large array *does* allocate some bytes
+            arrays.add(preallocated.newLongArray(1024));
+            long expectedMin = (PageCacheRecycler.LONG_PAGE_SIZE + arrays.size()) * Long.BYTES;
+            assertThat(realBreaker.getUsed(), greaterThanOrEqualTo(expectedMin));
+            // 64 should be enough room for each BigArray object
+            assertThat(realBreaker.getUsed(), lessThanOrEqualTo(expectedMin + 64 * arrays.size()));
+            Releasables.close(arrays);
         }
+        assertThat(realBreaker.getUsed(), equalTo(0L));
     }
 
     private List<BigArraysHelper> bigArrayCreators(final long maxSize, final boolean withBreaking) {

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -200,39 +200,38 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
             .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "150mb")
             .put(HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "150mb")
             .build();
-        try (
-            CircuitBreakerService service = new HierarchyCircuitBreakerService(
-                CircuitBreakerMetrics.NOOP,
-                clusterSettings,
-                Collections.emptyList(),
-                new ClusterSettings(clusterSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
-            )
-        ) {
-            CircuitBreaker requestCircuitBreaker = service.getBreaker(CircuitBreaker.REQUEST);
-            CircuitBreaker fieldDataCircuitBreaker = service.getBreaker(CircuitBreaker.FIELDDATA);
 
-            assertEquals(new ByteSizeValue(200, ByteSizeUnit.MB).getBytes(), service.stats().getStats(CircuitBreaker.PARENT).getLimit());
-            assertEquals(new ByteSizeValue(150, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getLimit());
-            assertEquals(new ByteSizeValue(150, ByteSizeUnit.MB).getBytes(), fieldDataCircuitBreaker.getLimit());
+        CircuitBreakerService service = new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            clusterSettings,
+            Collections.emptyList(),
+            new ClusterSettings(clusterSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
 
-            fieldDataCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should not break");
-            assertEquals(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), fieldDataCircuitBreaker.getUsed(), 0.0);
-            requestCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should not break");
-            assertEquals(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getUsed(), 0.0);
-            requestCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should not break");
-            assertEquals(new ByteSizeValue(100, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getUsed(), 0.0);
-            CircuitBreakingException exception = expectThrows(
-                CircuitBreakingException.class,
-                () -> requestCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should break")
-            );
-            assertThat(exception.getMessage(), containsString("[parent] Data too large, data for [should break] would be"));
-            assertThat(exception.getMessage(), containsString("which is larger than the limit of [209715200/200mb]"));
-            assertThat(exception.getMessage(), containsString("usages ["));
-            assertThat(exception.getMessage(), containsString("fielddata=54001664/51.5mb"));
-            assertThat(exception.getMessage(), containsString("inflight_requests=0/0b"));
-            assertThat(exception.getMessage(), containsString("request=157286400/150mb"));
-            assertThat(exception.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
-        }
+        CircuitBreaker requestCircuitBreaker = service.getBreaker(CircuitBreaker.REQUEST);
+        CircuitBreaker fieldDataCircuitBreaker = service.getBreaker(CircuitBreaker.FIELDDATA);
+
+        assertEquals(new ByteSizeValue(200, ByteSizeUnit.MB).getBytes(), service.stats().getStats(CircuitBreaker.PARENT).getLimit());
+        assertEquals(new ByteSizeValue(150, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getLimit());
+        assertEquals(new ByteSizeValue(150, ByteSizeUnit.MB).getBytes(), fieldDataCircuitBreaker.getLimit());
+
+        fieldDataCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should not break");
+        assertEquals(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), fieldDataCircuitBreaker.getUsed(), 0.0);
+        requestCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should not break");
+        assertEquals(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getUsed(), 0.0);
+        requestCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should not break");
+        assertEquals(new ByteSizeValue(100, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getUsed(), 0.0);
+        CircuitBreakingException exception = expectThrows(
+            CircuitBreakingException.class,
+            () -> requestCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should break")
+        );
+        assertThat(exception.getMessage(), containsString("[parent] Data too large, data for [should break] would be"));
+        assertThat(exception.getMessage(), containsString("which is larger than the limit of [209715200/200mb]"));
+        assertThat(exception.getMessage(), containsString("usages ["));
+        assertThat(exception.getMessage(), containsString("fielddata=54001664/51.5mb"));
+        assertThat(exception.getMessage(), containsString("inflight_requests=0/0b"));
+        assertThat(exception.getMessage(), containsString("request=157286400/150mb"));
+        assertThat(exception.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
 
         assertCircuitBreakerLimitWarning();
     }
@@ -683,42 +682,41 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
             .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "150mb")
             .put(HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "150mb")
             .build();
-        try (
-            CircuitBreakerService service = new HierarchyCircuitBreakerService(
-                CircuitBreakerMetrics.NOOP,
-                clusterSettings,
-                Collections.emptyList(),
-                new ClusterSettings(clusterSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
-            )
-        ) {
-            CircuitBreaker requestCircuitBreaker = service.getBreaker(CircuitBreaker.REQUEST);
-            CircuitBreaker fieldDataCircuitBreaker = service.getBreaker(CircuitBreaker.FIELDDATA);
+        CircuitBreakerService service = new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            clusterSettings,
+            Collections.emptyList(),
+            new ClusterSettings(clusterSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+        CircuitBreaker requestCircuitBreaker = service.getBreaker(CircuitBreaker.REQUEST);
+        CircuitBreaker fieldDataCircuitBreaker = service.getBreaker(CircuitBreaker.FIELDDATA);
 
-            CircuitBreaker.Durability expectedDurability;
-            if (randomBoolean()) {
-                fieldDataCircuitBreaker.addEstimateBytesAndMaybeBreak(mb(100), "should not break");
-                requestCircuitBreaker.addEstimateBytesAndMaybeBreak(mb(70), "should not break");
-                expectedDurability = CircuitBreaker.Durability.PERMANENT;
-            } else {
-                fieldDataCircuitBreaker.addEstimateBytesAndMaybeBreak(mb(70), "should not break");
-                requestCircuitBreaker.addEstimateBytesAndMaybeBreak(mb(120), "should not break");
-                expectedDurability = CircuitBreaker.Durability.TRANSIENT;
-            }
-
-            CircuitBreakingException exception = expectThrows(
-                CircuitBreakingException.class,
-                () -> fieldDataCircuitBreaker.addEstimateBytesAndMaybeBreak(mb(40), "should break")
-            );
-
-            assertThat(exception.getMessage(), containsString("[parent] Data too large, data for [should break] would be"));
-            assertThat(exception.getMessage(), containsString("which is larger than the limit of [209715200/200mb]"));
-            assertThat(
-                "Expected [" + expectedDurability + "] due to [" + exception.getMessage() + "]",
-                exception.getDurability(),
-                equalTo(expectedDurability)
-            );
+        CircuitBreaker.Durability expectedDurability;
+        if (randomBoolean()) {
+            fieldDataCircuitBreaker.addEstimateBytesAndMaybeBreak(mb(100), "should not break");
+            requestCircuitBreaker.addEstimateBytesAndMaybeBreak(mb(70), "should not break");
+            expectedDurability = CircuitBreaker.Durability.PERMANENT;
+        } else {
+            fieldDataCircuitBreaker.addEstimateBytesAndMaybeBreak(mb(70), "should not break");
+            requestCircuitBreaker.addEstimateBytesAndMaybeBreak(mb(120), "should not break");
+            expectedDurability = CircuitBreaker.Durability.TRANSIENT;
         }
+
+        CircuitBreakingException exception = expectThrows(
+            CircuitBreakingException.class,
+            () -> fieldDataCircuitBreaker.addEstimateBytesAndMaybeBreak(mb(40), "should break")
+        );
+
+        assertThat(exception.getMessage(), containsString("[parent] Data too large, data for [should break] would be"));
+        assertThat(exception.getMessage(), containsString("which is larger than the limit of [209715200/200mb]"));
+        assertThat(
+            "Expected [" + expectedDurability + "] due to [" + exception.getMessage() + "]",
+            exception.getDurability(),
+            equalTo(expectedDurability)
+        );
+
         assertCircuitBreakerLimitWarning();
+
     }
 
     public void testAllocationBucketsBreaker() {
@@ -727,34 +725,31 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
             .put(HierarchyCircuitBreakerService.USE_REAL_MEMORY_USAGE_SETTING.getKey(), "false")
             .build();
 
-        try (
-            HierarchyCircuitBreakerService service = new HierarchyCircuitBreakerService(
-                CircuitBreakerMetrics.NOOP,
-                clusterSettings,
-                Collections.emptyList(),
-                new ClusterSettings(clusterSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
-            )
-        ) {
+        HierarchyCircuitBreakerService service = new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            clusterSettings,
+            Collections.emptyList(),
+            new ClusterSettings(clusterSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
 
-            long parentLimitBytes = service.getParentLimit();
-            assertEquals(new ByteSizeValue(100, ByteSizeUnit.BYTES).getBytes(), parentLimitBytes);
+        long parentLimitBytes = service.getParentLimit();
+        assertEquals(new ByteSizeValue(100, ByteSizeUnit.BYTES).getBytes(), parentLimitBytes);
 
-            CircuitBreaker breaker = service.getBreaker(CircuitBreaker.REQUEST);
-            MultiBucketConsumerService.MultiBucketConsumer multiBucketConsumer = new MultiBucketConsumerService.MultiBucketConsumer(
-                10000,
-                breaker
-            );
+        CircuitBreaker breaker = service.getBreaker(CircuitBreaker.REQUEST);
+        MultiBucketConsumerService.MultiBucketConsumer multiBucketConsumer = new MultiBucketConsumerService.MultiBucketConsumer(
+            10000,
+            breaker
+        );
 
-            // make sure used bytes is greater than the total circuit breaker limit
-            breaker.addWithoutBreaking(200);
-            // make sure that we check on the following call
-            for (int i = 0; i < 1023; i++) {
-                multiBucketConsumer.accept(0);
-            }
-            CircuitBreakingException exception = expectThrows(CircuitBreakingException.class, () -> multiBucketConsumer.accept(1024));
-            assertThat(exception.getMessage(), containsString("[parent] Data too large, data for [allocated_buckets] would be"));
-            assertThat(exception.getMessage(), containsString("which is larger than the limit of [100/100b]"));
+        // make sure used bytes is greater than the total circuit breaker limit
+        breaker.addWithoutBreaking(200);
+        // make sure that we check on the following call
+        for (int i = 0; i < 1023; i++) {
+            multiBucketConsumer.accept(0);
         }
+        CircuitBreakingException exception = expectThrows(CircuitBreakingException.class, () -> multiBucketConsumer.accept(1024));
+        assertThat(exception.getMessage(), containsString("[parent] Data too large, data for [allocated_buckets] would be"));
+        assertThat(exception.getMessage(), containsString("which is larger than the limit of [100/100b]"));
 
         assertCircuitBreakerLimitWarning();
     }
@@ -790,21 +785,18 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
     }
 
     public void testCustomCircuitBreakers() {
-        try (
-            CircuitBreakerService service = new HierarchyCircuitBreakerService(
-                CircuitBreakerMetrics.NOOP,
-                Settings.EMPTY,
-                Arrays.asList(new BreakerSettings("foo", 100, 1.2), new BreakerSettings("bar", 200, 0.1)),
-                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
-            )
-        ) {
-            assertThat(service.getBreaker("foo"), is(not(nullValue())));
-            assertThat(service.getBreaker("foo").getOverhead(), equalTo(1.2));
-            assertThat(service.getBreaker("foo").getLimit(), equalTo(100L));
-            assertThat(service.getBreaker("bar"), is(not(nullValue())));
-            assertThat(service.getBreaker("bar").getOverhead(), equalTo(0.1));
-            assertThat(service.getBreaker("bar").getLimit(), equalTo(200L));
-        }
+        CircuitBreakerService service = new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            Settings.EMPTY,
+            Arrays.asList(new BreakerSettings("foo", 100, 1.2), new BreakerSettings("bar", 200, 0.1)),
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+        assertThat(service.getBreaker("foo"), is(not(nullValue())));
+        assertThat(service.getBreaker("foo").getOverhead(), equalTo(1.2));
+        assertThat(service.getBreaker("foo").getLimit(), equalTo(100L));
+        assertThat(service.getBreaker("bar"), is(not(nullValue())));
+        assertThat(service.getBreaker("bar").getOverhead(), equalTo(0.1));
+        assertThat(service.getBreaker("bar").getLimit(), equalTo(200L));
     }
 
     private static long mb(long size) {
@@ -812,28 +804,25 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
     }
 
     public void testUpdatingUseRealMemory() {
-        try (
-            HierarchyCircuitBreakerService service = new HierarchyCircuitBreakerService(
-                CircuitBreakerMetrics.NOOP,
-                Settings.EMPTY,
-                Collections.emptyList(),
-                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
-            )
-        ) {
-            // use real memory default true
-            assertTrue(service.isTrackRealMemoryUsage());
-            assertThat(service.getOverLimitStrategy(), instanceOf(HierarchyCircuitBreakerService.G1OverLimitStrategy.class));
+        HierarchyCircuitBreakerService service = new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            Settings.EMPTY,
+            Collections.emptyList(),
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+        // use real memory default true
+        assertTrue(service.isTrackRealMemoryUsage());
+        assertThat(service.getOverLimitStrategy(), instanceOf(HierarchyCircuitBreakerService.G1OverLimitStrategy.class));
 
-            // update use_real_memory to false
-            service.updateUseRealMemorySetting(false);
-            assertFalse(service.isTrackRealMemoryUsage());
-            assertThat(service.getOverLimitStrategy(), not(instanceOf(HierarchyCircuitBreakerService.G1OverLimitStrategy.class)));
+        // update use_real_memory to false
+        service.updateUseRealMemorySetting(false);
+        assertFalse(service.isTrackRealMemoryUsage());
+        assertThat(service.getOverLimitStrategy(), not(instanceOf(HierarchyCircuitBreakerService.G1OverLimitStrategy.class)));
 
-            // update use_real_memory to true
-            service.updateUseRealMemorySetting(true);
-            assertTrue(service.isTrackRealMemoryUsage());
-            assertThat(service.getOverLimitStrategy(), instanceOf(HierarchyCircuitBreakerService.G1OverLimitStrategy.class));
-        }
+        // update use_real_memory to true
+        service.updateUseRealMemorySetting(true);
+        assertTrue(service.isTrackRealMemoryUsage());
+        assertThat(service.getOverLimitStrategy(), instanceOf(HierarchyCircuitBreakerService.G1OverLimitStrategy.class));
     }
 
     public void testApplySettingForUpdatingUseRealMemory() {
@@ -842,34 +831,31 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
         Settings initialSettings = Settings.builder().put(useRealMemoryUsageSetting, "true").build();
         ClusterSettings clusterSettings = new ClusterSettings(initialSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
-        try (
-            HierarchyCircuitBreakerService service = new HierarchyCircuitBreakerService(
-                CircuitBreakerMetrics.NOOP,
-                Settings.EMPTY,
-                Collections.emptyList(),
-                clusterSettings
-            )
-        ) {
-            // total.limit defaults to 95% of the JVM heap if use_real_memory is true
-            assertEquals(
-                MemorySizeValue.parseBytesSizeValueOrHeapRatio("95%", totalCircuitBreakerLimitSetting).getBytes(),
-                service.getParentLimit()
-            );
+        HierarchyCircuitBreakerService service = new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            Settings.EMPTY,
+            Collections.emptyList(),
+            clusterSettings
+        );
+        // total.limit defaults to 95% of the JVM heap if use_real_memory is true
+        assertEquals(
+            MemorySizeValue.parseBytesSizeValueOrHeapRatio("95%", totalCircuitBreakerLimitSetting).getBytes(),
+            service.getParentLimit()
+        );
 
-            // total.limit defaults to 70% of the JVM heap if use_real_memory set to false
-            clusterSettings.applySettings(Settings.builder().put(useRealMemoryUsageSetting, false).build());
-            assertEquals(
-                MemorySizeValue.parseBytesSizeValueOrHeapRatio("70%", totalCircuitBreakerLimitSetting).getBytes(),
-                service.getParentLimit()
-            );
+        // total.limit defaults to 70% of the JVM heap if use_real_memory set to false
+        clusterSettings.applySettings(Settings.builder().put(useRealMemoryUsageSetting, false).build());
+        assertEquals(
+            MemorySizeValue.parseBytesSizeValueOrHeapRatio("70%", totalCircuitBreakerLimitSetting).getBytes(),
+            service.getParentLimit()
+        );
 
-            // total.limit defaults to 95% of the JVM heap if use_real_memory set to true
-            clusterSettings.applySettings(Settings.builder().put(useRealMemoryUsageSetting, true).build());
-            assertEquals(
-                MemorySizeValue.parseBytesSizeValueOrHeapRatio("95%", totalCircuitBreakerLimitSetting).getBytes(),
-                service.getParentLimit()
-            );
-        }
+        // total.limit defaults to 95% of the JVM heap if use_real_memory set to true
+        clusterSettings.applySettings(Settings.builder().put(useRealMemoryUsageSetting, true).build());
+        assertEquals(
+            MemorySizeValue.parseBytesSizeValueOrHeapRatio("95%", totalCircuitBreakerLimitSetting).getBytes(),
+            service.getParentLimit()
+        );
     }
 
     public void testSizeBelowMinimumWarning() {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestStateReleasingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestStateReleasingTests.java
@@ -102,19 +102,18 @@ public class TDigestStateReleasingTests extends ESTestCase {
      */
     public <E extends Exception> void testCircuitBreakerTrip(CheckedFunction<CircuitBreaker, TDigestState, E> tDigestStateFactory)
         throws E {
-        try (CrankyCircuitBreakerService circuitBreakerService = new CrankyCircuitBreakerService()) {
-            CircuitBreaker breaker = circuitBreakerService.getBreaker("test");
+        CrankyCircuitBreakerService circuitBreakerService = new CrankyCircuitBreakerService();
+        CircuitBreaker breaker = circuitBreakerService.getBreaker("test");
 
-            try (TDigestState state = tDigestStateFactory.apply(breaker)) {
-                // Add some data to make it trip. It won't work in all digest types
-                for (int i = 0; i < 10; i++) {
-                    state.add(randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true));
-                }
-            } catch (CircuitBreakingException e) {
-                // Expected
-            } finally {
-                assertThat("unreleased bytes", breaker.getUsed(), equalTo(0L));
+        try (TDigestState state = tDigestStateFactory.apply(breaker)) {
+            // Add some data to make it trip. It won't work in all digest types
+            for (int i = 0; i < 10; i++) {
+                state.add(randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true));
             }
+        } catch (CircuitBreakingException e) {
+            // Expected
+        } finally {
+            assertThat("unreleased bytes", breaker.getUsed(), equalTo(0L));
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -671,54 +671,49 @@ public abstract class AggregatorTestCase extends ESTestCase {
                 Releasables.close(context);
             }
         }
-
-        try {
-            if (aggTestConfig.incrementalReduce() && internalAggs.size() > 1) {
-                // sometimes do an incremental reduce
-                int toReduceSize = internalAggs.size();
-                Collections.shuffle(internalAggs, random());
-                int r = randomIntBetween(1, toReduceSize);
-                List<InternalAggregations> toReduce = internalAggs.subList(0, r);
-                AggregationReduceContext reduceContext = new AggregationReduceContext.ForPartial(
-                    bigArraysForReduction,
-                    getMockScriptService(),
-                    () -> false,
-                    builder,
-                    b -> {}
-                );
-                internalAggs = new ArrayList<>(internalAggs.subList(r, toReduceSize));
-                internalAggs.add(InternalAggregations.topLevelReduce(toReduce, reduceContext));
-                for (InternalAggregations internalAggregation : internalAggs) {
-                    assertRoundTrip(internalAggregation.copyResults());
-                }
-            }
-
-            // now do the final reduce
-            MultiBucketConsumer reduceBucketConsumer = new MultiBucketConsumer(
-                maxBucket,
-                new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
-            );
-            AggregationReduceContext reduceContext = new AggregationReduceContext.ForFinal(
+        if (aggTestConfig.incrementalReduce() && internalAggs.size() > 1) {
+            // sometimes do an incremental reduce
+            int toReduceSize = internalAggs.size();
+            Collections.shuffle(internalAggs, random());
+            int r = randomIntBetween(1, toReduceSize);
+            List<InternalAggregations> toReduce = internalAggs.subList(0, r);
+            AggregationReduceContext reduceContext = new AggregationReduceContext.ForPartial(
                 bigArraysForReduction,
                 getMockScriptService(),
                 () -> false,
                 builder,
-                reduceBucketConsumer
+                b -> {}
             );
-
-            @SuppressWarnings("unchecked")
-            A internalAgg = (A) doInternalAggregationsReduce(internalAggs, reduceContext);
-            assertRoundTrip(internalAgg);
-
-            doAssertReducedMultiBucketConsumer(internalAgg, reduceBucketConsumer);
-            assertRoundTrip(internalAgg);
-            if (aggTestConfig.builder instanceof ValuesSourceAggregationBuilder.MetricsAggregationBuilder<?>) {
-                verifyMetricNames((ValuesSourceAggregationBuilder.MetricsAggregationBuilder<?>) aggTestConfig.builder, internalAgg);
+            internalAggs = new ArrayList<>(internalAggs.subList(r, toReduceSize));
+            internalAggs.add(InternalAggregations.topLevelReduce(toReduce, reduceContext));
+            for (InternalAggregations internalAggregation : internalAggs) {
+                assertRoundTrip(internalAggregation.copyResults());
             }
-            return internalAgg;
-        } finally {
-            Releasables.close(breakerService);
         }
+
+        // now do the final reduce
+        MultiBucketConsumer reduceBucketConsumer = new MultiBucketConsumer(
+            maxBucket,
+            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+        );
+        AggregationReduceContext reduceContext = new AggregationReduceContext.ForFinal(
+            bigArraysForReduction,
+            getMockScriptService(),
+            () -> false,
+            builder,
+            reduceBucketConsumer
+        );
+
+        @SuppressWarnings("unchecked")
+        A internalAgg = (A) doInternalAggregationsReduce(internalAggs, reduceContext);
+        assertRoundTrip(internalAgg);
+
+        doAssertReducedMultiBucketConsumer(internalAgg, reduceBucketConsumer);
+        assertRoundTrip(internalAgg);
+        if (aggTestConfig.builder instanceof ValuesSourceAggregationBuilder.MetricsAggregationBuilder<?>) {
+            verifyMetricNames((ValuesSourceAggregationBuilder.MetricsAggregationBuilder<?>) aggTestConfig.builder, internalAgg);
+        }
+        return internalAgg;
     }
 
     private InternalAggregation doReduce(List<InternalAggregation> aggregators, AggregationReduceContext reduceContext) {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
@@ -101,15 +101,13 @@ public class CircuitBreakerTests extends ESTestCase {
     }
 
     private void testMemoryCleared(boolean fail) {
-        try (
-            CircuitBreakerService service = new HierarchyCircuitBreakerService(
-                CircuitBreakerMetrics.NOOP,
-                Settings.EMPTY,
-                Collections.singletonList(EqlTestUtils.circuitBreakerSettings(Settings.EMPTY)),
-                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
-            );
-            var threadPool = createThreadPool()
-        ) {
+        CircuitBreakerService service = new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            Settings.EMPTY,
+            Collections.singletonList(EqlTestUtils.circuitBreakerSettings(Settings.EMPTY)),
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+        try (var threadPool = createThreadPool()) {
             final var esClient = new ESMockClient(threadPool, service.getBreaker(CIRCUIT_BREAKER_NAME));
             CircuitBreaker eqlCircuitBreaker = service.getBreaker(CIRCUIT_BREAKER_NAME);
             IndexResolver indexResolver = new IndexResolver(esClient, "cluster", DefaultDataTypeRegistry.INSTANCE, () -> emptySet());

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
@@ -209,15 +209,13 @@ public class CircuitBreakerTests extends ESTestCase {
         TriFunction<ThreadPool, CircuitBreaker, Integer, ESMockClient> esClientSupplier
     ) {
         final int searchRequestsExpectedCount = 2;
-        try (
-            CircuitBreakerService service = new HierarchyCircuitBreakerService(
-                CircuitBreakerMetrics.NOOP,
-                Settings.EMPTY,
-                breakerSettings(),
-                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
-            );
-            var threadPool = createThreadPool()
-        ) {
+        CircuitBreakerService service = new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            Settings.EMPTY,
+            breakerSettings(),
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+        try (var threadPool = createThreadPool()) {
             final var esClient = esClientSupplier.apply(threadPool, service.getBreaker(CIRCUIT_BREAKER_NAME), searchRequestsExpectedCount);
             CircuitBreaker eqlCircuitBreaker = service.getBreaker(CIRCUIT_BREAKER_NAME);
             QueryClient eqlClient = buildQueryClient(esClient, eqlCircuitBreaker);
@@ -248,16 +246,13 @@ public class CircuitBreakerTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "0%")
             .build();
-
-        try (
-            CircuitBreakerService service = new HierarchyCircuitBreakerService(
-                CircuitBreakerMetrics.NOOP,
-                settings,
-                breakerSettings(),
-                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
-            );
-            var threadPool = createThreadPool()
-        ) {
+        CircuitBreakerService service = new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            settings,
+            breakerSettings(),
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+        try (var threadPool = createThreadPool()) {
             final var esClient = new SuccessfulESMockClient(
                 threadPool,
                 service.getBreaker(CIRCUIT_BREAKER_NAME),


### PR DESCRIPTION
CircuitBreakerService and all its implementations has no lifecycle so we don't need to extend AbstractLifecycleComponent here.
Mainly motivated by wanting to have a singleton CircuitBreakerService for some optimizations in query execution, but also a worthwhile cleanup in isolation I believe.
