### PR TITLE
[8.x] Add ReindexDatastreamIndexAction (#116996)

### DIFF
--- a/docs/changelog/116996.yaml
+++ b/docs/changelog/116996.yaml
@@ -1,0 +1,5 @@
+pr: 116996
+summary: Initial work on `ReindexDatastreamIndexAction`
+area: Data streams
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1656,23 +1656,11 @@ public class MetadataCreateIndexService {
             throw new IllegalStateException("unknown resize type is " + type);
         }
 
-        final Settings.Builder builder = Settings.builder();
+        final Settings.Builder builder;
         if (copySettings) {
-            // copy all settings and non-copyable settings and settings that have already been set (e.g., from the request)
-            for (final String key : sourceMetadata.getSettings().keySet()) {
-                final Setting<?> setting = indexScopedSettings.get(key);
-                if (setting == null) {
-                    assert indexScopedSettings.isPrivateSetting(key) : key;
-                } else if (setting.getProperties().contains(Setting.Property.NotCopyableOnResize)) {
-                    continue;
-                }
-                // do not override settings that have already been set (for example, from the request)
-                if (indexSettingsBuilder.keys().contains(key)) {
-                    continue;
-                }
-                builder.copy(key, sourceMetadata.getSettings());
-            }
+            builder = copySettingsFromSource(true, sourceMetadata.getSettings(), indexScopedSettings, indexSettingsBuilder);
         } else {
+            builder = Settings.builder();
             final Predicate<String> sourceSettingsPredicate = (s) -> (s.startsWith("index.similarity.")
                 || s.startsWith("index.analysis.")
                 || s.startsWith("index.sort.")
@@ -1688,6 +1676,36 @@ public class MetadataCreateIndexService {
         if (sourceMetadata.getSettings().hasValue(IndexMetadata.SETTING_VERSION_COMPATIBILITY)) {
             indexSettingsBuilder.put(IndexMetadata.SETTING_VERSION_COMPATIBILITY, sourceMetadata.getCompatibilityVersion());
         }
+    }
+
+    public static Settings.Builder copySettingsFromSource(
+        boolean copyPrivateSettings,
+        Settings sourceSettings,
+        IndexScopedSettings indexScopedSettings,
+        Settings.Builder indexSettingsBuilder
+    ) {
+        final Settings.Builder builder = Settings.builder();
+        for (final String key : sourceSettings.keySet()) {
+            final Setting<?> setting = indexScopedSettings.get(key);
+            if (setting == null) {
+                assert indexScopedSettings.isPrivateSetting(key) : key;
+                if (copyPrivateSettings == false) {
+                    continue;
+                }
+            } else if (setting.getProperties().contains(Setting.Property.NotCopyableOnResize)) {
+                continue;
+            } else if (setting.isPrivateIndex()) {
+                if (copyPrivateSettings == false) {
+                    continue;
+                }
+            }
+            // do not override settings that have already been set (for example, from the request)
+            if (indexSettingsBuilder.keys().contains(key)) {
+                continue;
+            }
+            builder.copy(key, sourceSettings);
+        }
+        return builder;
     }
 
     /**

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexIT.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.migrate.action;
+
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.FormatNames;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.reindex.ReindexPlugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.migrate.MigratePlugin;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.DEFAULT_TIMESTAMP_FIELD;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ReindexDatastreamIndexIT extends ESIntegTestCase {
+
+    private static final String MAPPING = """
+        {
+          "_doc":{
+            "dynamic":"strict",
+            "properties":{
+              "foo1":{
+                "type":"text"
+              }
+            }
+          }
+        }
+        """;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(MigratePlugin.class, ReindexPlugin.class, MockTransportService.TestPlugin.class, DataStreamsPlugin.class);
+    }
+
+    public void testDestIndexDeletedIfExists() throws Exception {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        // empty source index
+        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        indicesAdmin().create(new CreateIndexRequest(sourceIndex)).get();
+
+        // dest index with docs
+        var destIndex = ReindexDataStreamIndexTransportAction.generateDestIndexName(sourceIndex);
+        indicesAdmin().create(new CreateIndexRequest(destIndex)).actionGet();
+        indexDocs(destIndex, 10);
+        assertHitCount(prepareSearch(destIndex).setSize(0), 10);
+
+        // call reindex
+        client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex)).actionGet();
+
+        // verify that dest still exists, but is now empty
+        assertTrue(indexExists(destIndex));
+        assertHitCount(prepareSearch(destIndex).setSize(0), 0);
+    }
+
+    public void testDestIndexNameSet() throws Exception {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        indicesAdmin().create(new CreateIndexRequest(sourceIndex)).get();
+
+        // call reindex
+        var response = client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex))
+            .actionGet();
+
+        var expectedDestIndexName = ReindexDataStreamIndexTransportAction.generateDestIndexName(sourceIndex);
+        assertEquals(expectedDestIndexName, response.getDestIndex());
+    }
+
+    public void testDestIndexContainsDocs() throws Exception {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        // source index with docs
+        var numDocs = randomIntBetween(1, 100);
+        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        indicesAdmin().create(new CreateIndexRequest(sourceIndex)).get();
+        indexDocs(sourceIndex, numDocs);
+
+        // call reindex
+        var response = client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex))
+            .actionGet();
+        indicesAdmin().refresh(new RefreshRequest(response.getDestIndex())).actionGet();
+
+        // verify that dest contains docs
+        assertHitCount(prepareSearch(response.getDestIndex()).setSize(0), numDocs);
+    }
+
+    public void testSetSourceToReadOnly() throws Exception {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        // empty source index
+        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        indicesAdmin().create(new CreateIndexRequest(sourceIndex)).get();
+
+        // call reindex
+        client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex)).actionGet();
+
+        // assert that write to source fails
+        var indexReq = new IndexRequest(sourceIndex).source(jsonBuilder().startObject().field("field", "1").endObject());
+        assertThrows(ClusterBlockException.class, () -> client().index(indexReq).actionGet());
+        assertHitCount(prepareSearch(sourceIndex).setSize(0), 0);
+    }
+
+    public void testSettingsAddedBeforeReindex() throws Exception {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        // start with a static setting
+        var numShards = randomIntBetween(1, 10);
+        var staticSettings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards).build();
+        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        indicesAdmin().create(new CreateIndexRequest(sourceIndex, staticSettings)).get();
+
+        // update with a dynamic setting
+        var numReplicas = randomIntBetween(0, 10);
+        var dynamicSettings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas).build();
+        indicesAdmin().updateSettings(new UpdateSettingsRequest(dynamicSettings, sourceIndex)).actionGet();
+
+        // call reindex
+        var destIndex = client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex))
+            .actionGet()
+            .getDestIndex();
+
+        // assert both static and dynamic settings set on dest index
+        var settingsResponse = indicesAdmin().getSettings(new GetSettingsRequest().indices(destIndex)).actionGet();
+        assertEquals(numReplicas, Integer.parseInt(settingsResponse.getSetting(destIndex, IndexMetadata.SETTING_NUMBER_OF_REPLICAS)));
+        assertEquals(numShards, Integer.parseInt(settingsResponse.getSetting(destIndex, IndexMetadata.SETTING_NUMBER_OF_SHARDS)));
+    }
+
+    public void testMappingsAddedToDestIndex() throws Exception {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        String mapping = """
+            {
+              "_doc":{
+                "dynamic":"strict",
+                "properties":{
+                  "foo1":{
+                    "type":"text"
+                  }
+                }
+              }
+            }
+            """;
+        indicesAdmin().create(new CreateIndexRequest(sourceIndex).mapping(mapping)).actionGet();
+
+        // call reindex
+        var destIndex = client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex))
+            .actionGet()
+            .getDestIndex();
+
+        var mappingsResponse = indicesAdmin().getMappings(new GetMappingsRequest().indices(sourceIndex, destIndex)).actionGet();
+        Map<String, MappingMetadata> mappings = mappingsResponse.mappings();
+        var destMappings = mappings.get(destIndex).sourceAsMap();
+        var sourceMappings = mappings.get(sourceIndex).sourceAsMap();
+
+        assertEquals(sourceMappings, destMappings);
+        // sanity check specific value from dest mapping
+        assertEquals("text", XContentMapValues.extractValue("properties.foo1.type", destMappings));
+    }
+
+    public void testReadOnlyAddedBack() {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        // Create source index with read-only and/or block-writes
+        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        boolean isReadOnly = randomBoolean();
+        boolean isBlockWrites = randomBoolean();
+        var settings = Settings.builder()
+            .put(IndexMetadata.SETTING_READ_ONLY, isReadOnly)
+            .put(IndexMetadata.SETTING_BLOCKS_WRITE, isBlockWrites)
+            .build();
+        indicesAdmin().create(new CreateIndexRequest(sourceIndex, settings)).actionGet();
+
+        // call reindex
+        var destIndex = client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex))
+            .actionGet()
+            .getDestIndex();
+
+        // assert read-only settings added back to dest index
+        var settingsResponse = indicesAdmin().getSettings(new GetSettingsRequest().indices(destIndex)).actionGet();
+        assertEquals(isReadOnly, Boolean.parseBoolean(settingsResponse.getSetting(destIndex, IndexMetadata.SETTING_READ_ONLY)));
+        assertEquals(isBlockWrites, Boolean.parseBoolean(settingsResponse.getSetting(destIndex, IndexMetadata.SETTING_BLOCKS_WRITE)));
+
+        removeReadOnly(sourceIndex);
+        removeReadOnly(destIndex);
+    }
+
+    public void testSettingsAndMappingsFromTemplate() throws IOException {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        var numShards = randomIntBetween(1, 10);
+        var numReplicas = randomIntBetween(0, 10);
+
+        var settings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas)
+            .build();
+
+        // Create template with settings and mappings
+        var template = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of("logs-*"))
+            .template(new Template(settings, CompressedXContent.fromJSON(MAPPING), null))
+            .build();
+        var request = new TransportPutComposableIndexTemplateAction.Request("logs-template");
+        request.indexTemplate(template);
+        client().execute(TransportPutComposableIndexTemplateAction.TYPE, request).actionGet();
+
+        var sourceIndex = "logs-" + randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        indicesAdmin().create(new CreateIndexRequest(sourceIndex)).actionGet();
+
+        // call reindex
+        var destIndex = client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex))
+            .actionGet()
+            .getDestIndex();
+
+        // verify settings from templates copied to dest index
+        {
+            var settingsResponse = indicesAdmin().getSettings(new GetSettingsRequest().indices(destIndex)).actionGet();
+            assertEquals(numReplicas, Integer.parseInt(settingsResponse.getSetting(destIndex, IndexMetadata.SETTING_NUMBER_OF_REPLICAS)));
+            assertEquals(numShards, Integer.parseInt(settingsResponse.getSetting(destIndex, IndexMetadata.SETTING_NUMBER_OF_SHARDS)));
+        }
+
+        // verify mappings from templates copied to dest index
+        {
+            var mappingsResponse = indicesAdmin().getMappings(new GetMappingsRequest().indices(sourceIndex, destIndex)).actionGet();
+            var destMappings = mappingsResponse.mappings().get(destIndex).sourceAsMap();
+            var sourceMappings = mappingsResponse.mappings().get(sourceIndex).sourceAsMap();
+            assertEquals(sourceMappings, destMappings);
+            // sanity check specific value from dest mapping
+            assertEquals("text", XContentMapValues.extractValue("properties.foo1.type", destMappings));
+        }
+    }
+
+    private static final String TSDB_MAPPING = """
+        {
+          "_doc":{
+            "properties": {
+              "@timestamp" : {
+                "type": "date"
+              },
+              "metricset": {
+                "type": "keyword",
+                "time_series_dimension": true
+              }
+            }
+          }
+        }""";
+
+    private static final String TSDB_DOC = """
+        {
+            "@timestamp": "$time",
+            "metricset": "pod",
+            "k8s": {
+                "pod": {
+                    "name": "dog",
+                    "uid":"df3145b3-0563-4d3b-a0f7-897eb2876ea9",
+                    "ip": "10.10.55.3",
+                    "network": {
+                        "tx": 1434595272,
+                        "rx": 530605511
+                    }
+                }
+            }
+        }
+        """;
+
+    public void testTsdbStartEndSet() throws Exception {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        var templateSettings = Settings.builder().put("index.mode", "time_series");
+        if (randomBoolean()) {
+            templateSettings.put("index.routing_path", "metricset");
+        }
+        var mapping = new CompressedXContent(TSDB_MAPPING);
+
+        // create template
+        var request = new TransportPutComposableIndexTemplateAction.Request("id");
+        request.indexTemplate(
+            ComposableIndexTemplate.builder()
+                .indexPatterns(List.of("k8s*"))
+                .template(new Template(templateSettings.build(), mapping, null))
+                .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate(false, false))
+                .build()
+        );
+        client().execute(TransportPutComposableIndexTemplateAction.TYPE, request).actionGet();
+
+        // index doc
+        Instant time = Instant.now();
+        String backingIndexName;
+        {
+            var indexRequest = new IndexRequest("k8s").opType(DocWriteRequest.OpType.CREATE);
+            indexRequest.source(TSDB_DOC.replace("$time", formatInstant(time)), XContentType.JSON);
+            var indexResponse = client().index(indexRequest).actionGet();
+            backingIndexName = indexResponse.getIndex();
+        }
+
+        var sourceSettings = indicesAdmin().getIndex(new GetIndexRequest().indices(backingIndexName))
+            .actionGet()
+            .getSettings()
+            .get(backingIndexName);
+        Instant startTime = IndexSettings.TIME_SERIES_START_TIME.get(sourceSettings);
+        Instant endTime = IndexSettings.TIME_SERIES_END_TIME.get(sourceSettings);
+
+        // sanity check start/end time on source
+        assertNotNull(startTime);
+        assertNotNull(endTime);
+        assertTrue(endTime.isAfter(startTime));
+
+        // force a rollover so can call reindex and delete
+        var rolloverRequest = new RolloverRequest("k8s", null);
+        var rolloverResponse = indicesAdmin().rolloverIndex(rolloverRequest).actionGet();
+        rolloverResponse.getNewIndex();
+
+        // call reindex on the original backing index
+        var destIndex = client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(backingIndexName))
+            .actionGet()
+            .getDestIndex();
+
+        var destSettings = indicesAdmin().getIndex(new GetIndexRequest().indices(destIndex)).actionGet().getSettings().get(destIndex);
+        var destStart = IndexSettings.TIME_SERIES_START_TIME.get(destSettings);
+        var destEnd = IndexSettings.TIME_SERIES_END_TIME.get(destSettings);
+
+        assertEquals(startTime, destStart);
+        assertEquals(endTime, destEnd);
+    }
+
+    // TODO more logsdb/tsdb specific tests
+    // TODO more data stream specific tests (how are data streams indices are different from regular indices?)
+    // TODO check other IndexMetadata fields that need to be fixed after the fact
+    // TODO what happens if don't have necessary perms for a given index?
+
+    private static void removeReadOnly(String index) {
+        var settings = Settings.builder()
+            .put(IndexMetadata.SETTING_READ_ONLY, false)
+            .put(IndexMetadata.SETTING_BLOCKS_WRITE, false)
+            .build();
+        assertAcked(indicesAdmin().updateSettings(new UpdateSettingsRequest(settings, index)).actionGet());
+    }
+
+    private static void indexDocs(String index, int numDocs) {
+        BulkRequest bulkRequest = new BulkRequest();
+        for (int i = 0; i < numDocs; i++) {
+            String value = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(System.currentTimeMillis());
+            bulkRequest.add(
+                new IndexRequest(index).opType(DocWriteRequest.OpType.CREATE)
+                    .id(i + "")
+                    .source(String.format(Locale.ROOT, "{\"%s\":\"%s\"}", DEFAULT_TIMESTAMP_FIELD, value), XContentType.JSON)
+            );
+        }
+        BulkResponse bulkResponse = client().bulk(bulkRequest).actionGet();
+        assertThat(bulkResponse.getItems().length, equalTo(numDocs));
+        indicesAdmin().refresh(new RefreshRequest(index)).actionGet();
+    }
+
+    private static String formatInstant(Instant instant) {
+        return DateFormatter.forPattern(FormatNames.STRICT_DATE_OPTIONAL_TIME.getName()).format(instant);
+    }
+
+    private static String getIndexUUID(String index) {
+        return indicesAdmin().getIndex(new GetIndexRequest().indices(index))
+            .actionGet()
+            .getSettings()
+            .get(index)
+            .get(IndexMetadata.SETTING_INDEX_UUID);
+    }
+}

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigratePlugin.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigratePlugin.java
@@ -37,6 +37,8 @@ import org.elasticsearch.xpack.migrate.action.CancelReindexDataStreamTransportAc
 import org.elasticsearch.xpack.migrate.action.GetMigrationReindexStatusAction;
 import org.elasticsearch.xpack.migrate.action.GetMigrationReindexStatusTransportAction;
 import org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction;
+import org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexAction;
+import org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexTransportAction;
 import org.elasticsearch.xpack.migrate.action.ReindexDataStreamTransportAction;
 import org.elasticsearch.xpack.migrate.rest.RestCancelReindexDataStreamAction;
 import org.elasticsearch.xpack.migrate.rest.RestGetMigrationReindexStatusAction;
@@ -84,6 +86,7 @@ public class MigratePlugin extends Plugin implements ActionPlugin, PersistentTas
             actions.add(new ActionHandler<>(ReindexDataStreamAction.INSTANCE, ReindexDataStreamTransportAction.class));
             actions.add(new ActionHandler<>(GetMigrationReindexStatusAction.INSTANCE, GetMigrationReindexStatusTransportAction.class));
             actions.add(new ActionHandler<>(CancelReindexDataStreamAction.INSTANCE, CancelReindexDataStreamTransportAction.class));
+            actions.add(new ActionHandler<>(ReindexDataStreamIndexAction.INSTANCE, ReindexDataStreamIndexTransportAction.class));
         }
         return actions;
     }

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamAction.java
@@ -47,7 +47,7 @@ public class ReindexDataStreamAction extends ActionType<ReindexDataStreamAction.
      * The version before which we do not support writes in the _next_ major version of Elasticsearch. For example, Elasticsearch 10.x will
      * not support writing to indices created before version 9.0.0.
      */
-    private static final IndexVersion MINIMUM_WRITEABLE_VERSION_AFTER_UPGRADE = IndexVersions.V_8_0_0;
+    public static final IndexVersion MINIMUM_WRITEABLE_VERSION_AFTER_UPGRADE = IndexVersions.V_8_0_0;
 
     public ReindexDataStreamAction() {
         super(NAME);

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexAction.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.migrate.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class ReindexDataStreamIndexAction extends ActionType<ReindexDataStreamIndexAction.Response> {
+
+    public static final String NAME = "indices:admin/data_stream/index/reindex";
+
+    public static final ActionType<Response> INSTANCE = new ReindexDataStreamIndexAction();
+
+    private ReindexDataStreamIndexAction() {
+        super(NAME);
+    }
+
+    public static class Request extends ActionRequest implements IndicesRequest {
+
+        private final String sourceIndex;
+
+        public Request(String sourceIndex) {
+            this.sourceIndex = sourceIndex;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.sourceIndex = in.readString();
+        }
+
+        public static Request readFrom(StreamInput in) throws IOException {
+            return new Request(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(sourceIndex);
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        public String getSourceIndex() {
+            return sourceIndex;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request request = (Request) o;
+            return Objects.equals(sourceIndex, request.sourceIndex);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(sourceIndex);
+        }
+
+        @Override
+        public String[] indices() {
+            return new String[] { sourceIndex };
+        }
+
+        @Override
+        public IndicesOptions indicesOptions() {
+            return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
+        }
+    }
+
+    public static class Response extends ActionResponse {
+        private final String destIndex;
+
+        public Response(String destIndex) {
+            this.destIndex = destIndex;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            this.destIndex = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(destIndex);
+        }
+
+        public String getDestIndex() {
+            return destIndex;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Response response = (Response) o;
+            return Objects.equals(destIndex, response.destIndex);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(destIndex);
+        }
+    }
+}

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.migrate.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.ReindexAction;
+import org.elasticsearch.index.reindex.ReindexRequest;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+public class ReindexDataStreamIndexTransportAction extends HandledTransportAction<
+    ReindexDataStreamIndexAction.Request,
+    ReindexDataStreamIndexAction.Response> {
+
+    private static final Logger logger = LogManager.getLogger(ReindexDataStreamIndexTransportAction.class);
+
+    private static final Set<String> SETTINGS_TO_ADD_BACK = Set.of(IndexMetadata.SETTING_BLOCKS_WRITE, IndexMetadata.SETTING_READ_ONLY);
+
+    private static final IndicesOptions IGNORE_MISSING_OPTIONS = IndicesOptions.fromOptions(true, true, false, false);
+    private final ClusterService clusterService;
+    private final Client client;
+    private final IndexScopedSettings indexScopedSettings;
+
+    @Inject
+    public ReindexDataStreamIndexTransportAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ActionFilters actionFilters,
+        Client client,
+        IndexScopedSettings indexScopedSettings
+    ) {
+        super(
+            ReindexDataStreamIndexAction.NAME,
+            false,
+            transportService,
+            actionFilters,
+            ReindexDataStreamIndexAction.Request::new,
+            transportService.getThreadPool().executor(ThreadPool.Names.GENERIC)
+        );
+        this.clusterService = clusterService;
+        this.client = client;
+        this.indexScopedSettings = indexScopedSettings;
+    }
+
+    @Override
+    protected void doExecute(
+        Task task,
+        ReindexDataStreamIndexAction.Request request,
+        ActionListener<ReindexDataStreamIndexAction.Response> listener
+    ) {
+        var sourceIndexName = request.getSourceIndex();
+        var destIndexName = generateDestIndexName(sourceIndexName);
+        IndexMetadata sourceIndex = clusterService.state().getMetadata().index(sourceIndexName);
+        Settings settingsBefore = sourceIndex.getSettings();
+
+        var hasOldVersion = ReindexDataStreamAction.getOldIndexVersionPredicate(clusterService.state().metadata());
+        if (hasOldVersion.test(sourceIndex.getIndex()) == false) {
+            logger.warn(
+                "Migrating index [{}] with version [{}] is unnecessary as its version is not before [{}]",
+                sourceIndexName,
+                sourceIndex.getCreationVersion(),
+                ReindexDataStreamAction.MINIMUM_WRITEABLE_VERSION_AFTER_UPGRADE
+            );
+        }
+
+        SubscribableListener.<AcknowledgedResponse>newForked(l -> setBlockWrites(sourceIndexName, l))
+            .<AcknowledgedResponse>andThen(l -> deleteDestIfExists(destIndexName, l))
+            .<CreateIndexResponse>andThen(l -> createIndex(sourceIndex, destIndexName, l))
+            .<BulkByScrollResponse>andThen(l -> reindex(sourceIndexName, destIndexName, l))
+            .<AcknowledgedResponse>andThen(l -> updateSettings(settingsBefore, destIndexName, l))
+            .andThenApply(ignored -> new ReindexDataStreamIndexAction.Response(destIndexName))
+            .addListener(listener);
+    }
+
+    private void setBlockWrites(String sourceIndexName, ActionListener<AcknowledgedResponse> listener) {
+        logger.debug("Setting write block on source index [{}]", sourceIndexName);
+        final Settings readOnlySettings = Settings.builder().put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true).build();
+        var updateSettingsRequest = new UpdateSettingsRequest(readOnlySettings, sourceIndexName);
+        client.admin().indices().updateSettings(updateSettingsRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(AcknowledgedResponse response) {
+                if (response.isAcknowledged()) {
+                    listener.onResponse(null);
+                } else {
+                    var errorMessage = String.format(Locale.ROOT, "Could not set read-only on source index [%s]", sourceIndexName);
+                    listener.onFailure(new ElasticsearchException(errorMessage));
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (e instanceof ClusterBlockException || e.getCause() instanceof ClusterBlockException) {
+                    // It's fine if read-only is already set
+                    listener.onResponse(null);
+                } else {
+                    listener.onFailure(e);
+                }
+            }
+        });
+    }
+
+    private void deleteDestIfExists(String destIndexName, ActionListener<AcknowledgedResponse> listener) {
+        logger.debug("Attempting to delete index [{}]", destIndexName);
+        var deleteIndexRequest = new DeleteIndexRequest(destIndexName).indicesOptions(IGNORE_MISSING_OPTIONS)
+            .masterNodeTimeout(TimeValue.MAX_VALUE);
+        var errorMessage = String.format(Locale.ROOT, "Failed to acknowledge delete of index [%s]", destIndexName);
+        client.admin().indices().delete(deleteIndexRequest, failIfNotAcknowledged(listener, errorMessage));
+    }
+
+    private void createIndex(IndexMetadata sourceIndex, String destIndexName, ActionListener<CreateIndexResponse> listener) {
+        logger.debug("Creating destination index [{}] for source index [{}]", destIndexName, sourceIndex.getIndex().getName());
+
+        // Create destination with subset of source index settings that can be added before reindex
+        var settings = getPreSettings(sourceIndex);
+
+        var sourceMapping = sourceIndex.mapping();
+        Map<String, Object> mapping = sourceMapping != null ? sourceMapping.rawSourceAsMap() : Map.of();
+        var createIndexRequest = new CreateIndexRequest(destIndexName).settings(settings).mapping(mapping);
+
+        var errorMessage = String.format(Locale.ROOT, "Could not create index [%s]", destIndexName);
+        client.admin().indices().create(createIndexRequest, failIfNotAcknowledged(listener, errorMessage));
+    }
+
+    private void reindex(String sourceIndexName, String destIndexName, ActionListener<BulkByScrollResponse> listener) {
+        logger.debug("Reindex to destination index [{}] from source index [{}]", destIndexName, sourceIndexName);
+        var reindexRequest = new ReindexRequest();
+        reindexRequest.setSourceIndices(sourceIndexName);
+        reindexRequest.getSearchRequest().allowPartialSearchResults(false);
+        reindexRequest.getSearchRequest().source().fetchSource(true);
+        reindexRequest.setDestIndex(destIndexName);
+        client.execute(ReindexAction.INSTANCE, reindexRequest, listener);
+    }
+
+    private void updateSettings(Settings settingsBefore, String destIndexName, ActionListener<AcknowledgedResponse> listener) {
+        logger.debug("Adding settings from source index that could not be added before reindex");
+
+        Settings postSettings = getPostSettings(settingsBefore);
+        if (postSettings.isEmpty()) {
+            listener.onResponse(null);
+            return;
+        }
+
+        var updateSettingsRequest = new UpdateSettingsRequest(postSettings, destIndexName);
+        var errorMessage = String.format(Locale.ROOT, "Could not update settings on index [%s]", destIndexName);
+        client.admin().indices().updateSettings(updateSettingsRequest, failIfNotAcknowledged(listener, errorMessage));
+    }
+
+    // Filter source index settings to subset of settings that can be included during reindex.
+    // Similar to the settings filtering done when reindexing for upgrade in Kibana
+    // https://github.com/elastic/kibana/blob/8a8363f02cc990732eb9cbb60cd388643a336bed/x-pack
+    // /plugins/upgrade_assistant/server/lib/reindexing/index_settings.ts#L155
+    private Settings getPreSettings(IndexMetadata sourceIndex) {
+        // filter settings that will be added back later
+        var filtered = sourceIndex.getSettings().filter(settingName -> SETTINGS_TO_ADD_BACK.contains(settingName) == false);
+
+        // filter private and non-copyable settings
+        var builder = MetadataCreateIndexService.copySettingsFromSource(false, filtered, indexScopedSettings, Settings.builder());
+        return builder.build();
+    }
+
+    private Settings getPostSettings(Settings settingsBefore) {
+        return settingsBefore.filter(SETTINGS_TO_ADD_BACK::contains);
+    }
+
+    public static String generateDestIndexName(String sourceIndex) {
+        return "migrated-" + sourceIndex;
+    }
+
+    private static <U extends AcknowledgedResponse> ActionListener<U> failIfNotAcknowledged(
+        ActionListener<U> listener,
+        String errorMessage
+    ) {
+        return listener.delegateFailureAndWrap((delegate, response) -> {
+            if (response.isAcknowledged()) {
+                delegate.onResponse(null);
+            }
+            throw new ElasticsearchException(errorMessage);
+        });
+    }
+}

--- a/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexRequestTests.java
+++ b/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexRequestTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.migrate.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexAction.Request;
+
+public class ReindexDatastreamIndexRequestTests extends AbstractWireSerializingTestCase<Request> {
+    @Override
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
+    }
+
+    @Override
+    protected Request createTestInstance() {
+        return new Request(randomAlphaOfLength(20));
+    }
+
+    @Override
+    protected Request mutateInstance(Request instance) {
+        return new ReindexDataStreamIndexAction.Request(randomValueOtherThan(instance.getSourceIndex(), () -> randomAlphaOfLength(20)));
+    }
+}

--- a/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexResponseTests.java
+++ b/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexResponseTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.migrate.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexAction.Response;
+
+public class ReindexDatastreamIndexResponseTests extends AbstractWireSerializingTestCase<Response> {
+    @Override
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
+    }
+
+    @Override
+    protected Response createTestInstance() {
+        return new Response(randomAlphaOfLength(20));
+    }
+
+    @Override
+    protected Response mutateInstance(Response instance) {
+        return new Response(randomValueOtherThan(instance.getDestIndex(), () -> randomAlphaOfLength(20)));
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -637,6 +637,7 @@ public class Constants {
         "internal:admin/indices/prevalidate_shard_path",
         "internal:index/metadata/migration_version/update",
         new FeatureFlag("reindex_data_stream").isEnabled() ? "indices:admin/migration/reindex_status" : null,
+        new FeatureFlag("reindex_data_stream").isEnabled() ? "indices:admin/data_stream/index/reindex" : null,
         new FeatureFlag("reindex_data_stream").isEnabled() ? "indices:admin/data_stream/reindex" : null,
         new FeatureFlag("reindex_data_stream").isEnabled() ? "indices:admin/data_stream/reindex_cancel" : null,
         "internal:admin/repository/verify",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add ReindexDatastreamIndexAction (#116996)](https://github.com/elastic/elasticsearch/pull/116996)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)