### PR TITLE
[8.16] Update docker.elastic.co/wolfi/chainguard-base:latest Docker digest to 1b51ff6 (#117902)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
@@ -27,8 +27,7 @@ public enum DockerBase {
     // Chainguard based wolfi image with latest jdk
     // This is usually updated via renovatebot
     // spotless:off
-    WOLFI(
-        "docker.elastic.co/wolfi/chainguard-base:latest@sha256:90888b190da54062f67f3fef1372eb0ae7d81ea55f5a1f56d748b13e4853d984",
+    WOLFI("docker.elastic.co/wolfi/chainguard-base:latest@sha256:1b51ff6dba78c98d3e02b0cd64a8ce3238c7a40408d21e3af12a329d44db6f23",
         "-wolfi",
         "apk"
     ),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Update docker.elastic.co/wolfi/chainguard-base:latest Docker digest to 1b51ff6 (#117902)](https://github.com/elastic/elasticsearch/pull/117902)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)