### PR TITLE
[Build] Add 8.16 and 8.17 as base branches for wolfi updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,8 @@
   "schedule": [
     "after 1pm on tuesday"
   ],
-  "labels": [">non-issue", ":Delivery/Packaging", "Team:Delivery"],
-  "baseBranches": ["main", "8.x"],
+  "labels": [">non-issue", ":Delivery/Packaging", "Team:Delivery", "auto-merge-without-approval"],
+  "baseBranches": ["main", "8.x", "8.17", "8.16"],
   "packageRules": [
     {
       "groupName": "wolfi (versioned)",


### PR DESCRIPTION
Furthermore add auto-merge label to PRs created by renovate