### PR TITLE
[7.17] [ci] Add oraclelinux-9 to matrix in packaging and platform jobs (#118565)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -12,6 +12,7 @@ steps:
               - opensuse-leap-15
               - oraclelinux-7
               - oraclelinux-8
+              - oraclelinux-9
               - sles-12
               - sles-15
               - ubuntu-1804

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -13,6 +13,7 @@ steps:
               - opensuse-leap-15
               - oraclelinux-7
               - oraclelinux-8
+              - oraclelinux-9
               - sles-12
               - sles-15
               - ubuntu-1804

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -12,6 +12,7 @@ steps:
               - opensuse-leap-15
               - oraclelinux-7
               - oraclelinux-8
+              - oraclelinux-9
               - sles-12
               - sles-15
               - ubuntu-1804

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -15,6 +15,7 @@ steps:
               - opensuse-leap-15
               - oraclelinux-7
               - oraclelinux-8
+              - oraclelinux-9
               - sles-12
               - sles-15
               - ubuntu-1804


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci] Add oraclelinux-9 to matrix in packaging and platform jobs (#118565)](https://github.com/elastic/elasticsearch/pull/118565)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)