### PR TITLE
[7.17] [ci] Add ubuntu-2404 to matrix in packaging and platform jobs (#118566)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -18,6 +18,7 @@ steps:
               - ubuntu-1804
               - ubuntu-2004
               - ubuntu-2204
+              - ubuntu-2404
               - rocky-8
               - rocky-9
               - rhel-7

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -19,6 +19,7 @@ steps:
               - ubuntu-1804
               - ubuntu-2004
               - ubuntu-2204
+              - ubuntu-2404
               - rocky-8
               - rocky-9
               - rhel-7

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -18,6 +18,7 @@ steps:
               - ubuntu-1804
               - ubuntu-2004
               - ubuntu-2204
+              - ubuntu-2404
               - rocky-8
               - rocky-9
               - rhel-7

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -21,6 +21,7 @@ steps:
               - ubuntu-1804
               - ubuntu-2004
               - ubuntu-2204
+              - ubuntu-2404
               - rocky-8
               - rocky-9
               - rhel-7


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [ci] Add ubuntu-2404 to matrix in packaging and platform jobs (#118566)