### PR TITLE
[8.x] ESQL: Disable LOOKUP JOIN physical optimizer test on release

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -461,9 +461,6 @@ tests:
 - class: org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT
   method: testElser {upgradedNodes=1}
   issue: https://github.com/elastic/elasticsearch/issues/118127
-- class: org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizerTests
-  method: testVerifierOnMissingReferencesWithBinaryPlans {default}
-  issue: https://github.com/elastic/elasticsearch/issues/118707
 - class: org.elasticsearch.xpack.application.CohereServiceUpgradeIT
   method: testCohereEmbeddings {upgradedNodes=1}
   issue: https://github.com/elastic/elasticsearch/issues/116974

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -2329,6 +2329,8 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     }
 
     public void testVerifierOnMissingReferencesWithBinaryPlans() throws Exception {
+        assumeTrue("Requires LOOKUP JOIN", EsqlCapabilities.Cap.JOIN_LOOKUP_V5.isEnabled());
+
         // Do not assert serialization:
         // This will have a LookupJoinExec, which is not serializable because it doesn't leave the coordinator.
         var plan = physicalPlan("""


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/118752