### PR TITLE
Render all datatypes in pipetables error output

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.logging.Logger;
@@ -290,7 +291,7 @@ public final class CsvAssert {
         int[] width = new int[headers.size()];
         String[][] printableValues = new String[rows][headers.size()];
         for (int c = 0; c < headers.size(); c++) {
-            width[c] = headers.get(c).length();
+            width[c] = header(headers.get(c), types.get(c)).length();
         }
         for (int r = 0; r < rows; r++) {
             for (int c = 0; c < headers.size(); c++) {
@@ -301,10 +302,10 @@ public final class CsvAssert {
 
         var result = new StringBuilder().append(System.lineSeparator()).append(description).append(System.lineSeparator());
         // headers
-        appendPaddedValue(result, headers.get(0), width[0]);
+        appendPaddedValue(result, header(headers.get(0), types.get(0)), width[0]);
         for (int c = 1; c < width.length; c++) {
             result.append(" | ");
-            appendPaddedValue(result, headers.get(c), width[c]);
+            appendPaddedValue(result, header(headers.get(c), types.get(c)), width[c]);
         }
         result.append(System.lineSeparator());
         // values
@@ -320,6 +321,10 @@ public final class CsvAssert {
             result.append("...").append(System.lineSeparator());
         }
         return result.toString();
+    }
+
+    private static String header(String name, Type type) {
+        return name + ':' + Strings.toLowercaseAscii(type.name());
     }
 
     private static void appendPaddedValue(StringBuilder result, String value, int width) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -197,7 +197,13 @@ public final class CsvAssert {
         for (int row = 0; row < expectedValues.size(); row++) {
             try {
                 if (row >= actualValues.size()) {
-                    dataFailure("Expected more data but no more entries found after [" + row + "]", dataFailures, expected, actualValues);
+                    dataFailure(
+                        "Expected more data but no more entries found after [" + row + "]",
+                        dataFailures,
+                        expected,
+                        actualValues,
+                        valueTransformer
+                    );
                 }
 
                 if (logger != null) {
@@ -209,7 +215,7 @@ public final class CsvAssert {
 
                 for (int column = 0; column < expectedRow.size(); column++) {
                     var expectedType = expected.columnTypes().get(column);
-                    var expectedValue = convertExpectedValue(expectedRow.get(column), expectedType);
+                    var expectedValue = convertExpectedValue(expectedType, expectedRow.get(column));
                     var actualValue = actualRow.get(column);
 
                     var transformedExpected = valueTransformer.apply(expectedType, expectedValue);
@@ -218,7 +224,7 @@ public final class CsvAssert {
                         dataFailures.add(new DataFailure(row, column, transformedExpected, transformedActual));
                     }
                     if (dataFailures.size() > 10) {
-                        dataFailure("", dataFailures, expected, actualValues);
+                        dataFailure("", dataFailures, expected, actualValues, valueTransformer);
                     }
                 }
 
@@ -227,7 +233,8 @@ public final class CsvAssert {
                         "Plan has extra columns, returned [" + actualRow.size() + "], expected [" + expectedRow.size() + "]",
                         dataFailures,
                         expected,
-                        actualValues
+                        actualValues,
+                        valueTransformer
                     );
                 }
             } catch (AssertionError ae) {
@@ -239,10 +246,16 @@ public final class CsvAssert {
             }
         }
         if (dataFailures.isEmpty() == false) {
-            dataFailure("", dataFailures, expected, actualValues);
+            dataFailure("", dataFailures, expected, actualValues, valueTransformer);
         }
         if (expectedValues.size() < actualValues.size()) {
-            dataFailure("Elasticsearch still has data after [" + expectedValues.size() + "] entries", dataFailures, expected, actualValues);
+            dataFailure(
+                "Elasticsearch still has data after [" + expectedValues.size() + "] entries",
+                dataFailures,
+                expected,
+                actualValues,
+                valueTransformer
+            );
         }
     }
 
@@ -250,42 +263,68 @@ public final class CsvAssert {
         String description,
         List<DataFailure> dataFailures,
         ExpectedResults expectedValues,
-        List<List<Object>> actualValues
+        List<List<Object>> actualValues,
+        BiFunction<Type, Object, Object> valueTransformer
     ) {
-        var expected = pipeTable("Expected:", expectedValues.columnNames(), expectedValues.values(), 25);
-        var actual = pipeTable("Actual:", expectedValues.columnNames(), actualValues, 25);
+        var expected = pipeTable(
+            "Expected:",
+            expectedValues.columnNames(),
+            expectedValues.columnTypes(),
+            expectedValues.values(),
+            (type, value) -> valueTransformer.apply(type, convertExpectedValue(type, value))
+        );
+        var actual = pipeTable("Actual:", expectedValues.columnNames(), expectedValues.columnTypes(), actualValues, valueTransformer);
         fail(description + System.lineSeparator() + describeFailures(dataFailures) + actual + expected);
     }
 
-    private static String pipeTable(String description, List<String> headers, List<List<Object>> values, int maxRows) {
+    private static final int MAX_ROWS = 25;
+
+    private static String pipeTable(
+        String description,
+        List<String> headers,
+        List<Type> types,
+        List<List<Object>> values,
+        BiFunction<Type, Object, Object> valueTransformer
+    ) {
+        int rows = Math.min(MAX_ROWS, values.size());
         int[] width = new int[headers.size()];
-        for (int i = 0; i < width.length; i++) {
-            width[i] = headers.get(i).length();
-            for (List<Object> row : values) {
-                width[i] = Math.max(width[i], String.valueOf(row.get(i)).length());
+        String[][] printableValues = new String[rows][headers.size()];
+        for (int c = 0; c < headers.size(); c++) {
+            width[c] = headers.get(c).length();
+        }
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < headers.size(); c++) {
+                printableValues[r][c] = String.valueOf(valueTransformer.apply(types.get(c), values.get(r).get(c)));
+                width[c] = Math.max(width[c], printableValues[r][c].length());
             }
         }
 
         var result = new StringBuilder().append(System.lineSeparator()).append(description).append(System.lineSeparator());
-        for (int c = 0; c < width.length; c++) {
-            appendValue(result, headers.get(c), width[c]);
+        // headers
+        appendPaddedValue(result, headers.get(0), width[0]);
+        for (int c = 1; c < width.length; c++) {
+            result.append(" | ");
+            appendPaddedValue(result, headers.get(c), width[c]);
         }
-        result.append('|').append(System.lineSeparator());
-        for (int r = 0; r < Math.min(maxRows, values.size()); r++) {
-            for (int c = 0; c < width.length; c++) {
-                appendValue(result, values.get(r).get(c), width[c]);
+        result.append(System.lineSeparator());
+        // values
+        for (int r = 0; r < printableValues.length; r++) {
+            appendPaddedValue(result, printableValues[r][0], width[0]);
+            for (int c = 1; c < printableValues[r].length; c++) {
+                result.append(" | ");
+                appendPaddedValue(result, printableValues[r][c], width[c]);
             }
-            result.append('|').append(System.lineSeparator());
+            result.append(System.lineSeparator());
         }
-        if (values.size() > maxRows) {
+        if (values.size() > rows) {
             result.append("...").append(System.lineSeparator());
         }
         return result.toString();
     }
 
-    private static void appendValue(StringBuilder result, Object value, int width) {
-        result.append('|').append(value);
-        for (int i = 0; i < width - String.valueOf(value).length(); i++) {
+    private static void appendPaddedValue(StringBuilder result, String value, int width) {
+        result.append(value);
+        for (int i = 0; i < width - (value != null ? value.length() : 4); i++) {
             result.append(' ');
         }
     }
@@ -341,7 +380,7 @@ public final class CsvAssert {
         };
     }
 
-    private static Object convertExpectedValue(Object expectedValue, Type expectedType) {
+    private static Object convertExpectedValue(Type expectedType, Object expectedValue) {
         if (expectedValue == null) {
             return null;
         }
@@ -355,7 +394,11 @@ public final class CsvAssert {
                 x -> DateFormatter.forPattern("strict_date_optional_time_nanos").formatNanos((long) x)
             );
             case Type.GEO_POINT, Type.GEO_SHAPE -> rebuildExpected(expectedValue, BytesRef.class, x -> GEO.wkbToWkt((BytesRef) x));
-            case Type.CARTESIAN_POINT, Type.CARTESIAN_SHAPE -> rebuildExpected(expectedValue, BytesRef.class, x -> CARTESIAN.wkbToWkt((BytesRef) x));
+            case Type.CARTESIAN_POINT, Type.CARTESIAN_SHAPE -> rebuildExpected(
+                expectedValue,
+                BytesRef.class,
+                x -> CARTESIAN.wkbToWkt((BytesRef) x)
+            );
             case Type.IP -> // convert BytesRef-packed IP to String, allowing subsequent comparison with what's expected
                 rebuildExpected(expectedValue, BytesRef.class, x -> DocValueFormat.IP.format((BytesRef) x));
             case Type.VERSION -> // convert BytesRef-packed Version to String


### PR DESCRIPTION
Some types (such as ip or time) require custom formatting logic and were not correctly rendered in actual/expected comparison table.

This change:
* properly formats such data types
* add data types to the column headers
* removes outer pipes

<details>
  <summary>Prior error output</summary>
    
  ```
java.lang.AssertionError:
Data mismatch:
row 0 column 1:a list containing
row 0 column 1:0: expected "172.21.3.16" but was "172.21.3.15"
Actual:
|@timestamp              |client_ip   |event_duration|message              |
|2023-10-23T13:55:01.543Z|172.21.3.15 |1756467       |Connected to 10.1.0.1|
|2023-10-23T13:53:55.832Z|172.21.3.15 |5033755       |Connection error     |
|2023-10-23T13:52:55.015Z|172.21.3.15 |8268153       |Connection error     |
|2023-10-23T13:51:54.732Z|172.21.3.15 |725448        |Connection error     |
|2023-10-23T13:33:34.937Z|172.21.0.5  |1232382       |Disconnected         |
|2023-10-23T12:27:28.948Z|172.21.2.113|2764889       |Connected to 10.1.0.2|
|2023-10-23T12:15:03.360Z|172.21.2.162|3450233       |Connected to 10.1.0.3|

Expected:
|@timestamp         |client_ip                             |event_duration|message              |
|1698069301543000000|[0 0 0 0 0 0 0 0 0 0 ff ff ac 15 3 10]|1756467       |Connected to 10.1.0.1|
|1698069235832000000|[0 0 0 0 0 0 0 0 0 0 ff ff ac 15 3 f] |5033755       |Connection error     |
|1698069175015000000|[0 0 0 0 0 0 0 0 0 0 ff ff ac 15 3 f] |8268153       |Connection error     |
|1698069114732000000|[0 0 0 0 0 0 0 0 0 0 ff ff ac 15 3 f] |725448        |Connection error     |
|1698068014937000000|[0 0 0 0 0 0 0 0 0 0 ff ff ac 15 0 5] |1232382       |Disconnected         |
|1698064048948000000|[0 0 0 0 0 0 0 0 0 0 ff ff ac 15 2 71]|2764889       |Connected to 10.1.0.2|
|1698063303360000000|[0 0 0 0 0 0 0 0 0 0 ff ff ac 15 2 a2]|3450233       |Connected to 10.1.0.3|
  ```
  
</details>


<details>
  <summary>Updated error output</summary>
    
  ```
java.lang.AssertionError:
Data mismatch:
row 0 column 1:a list containing
row 0 column 1:0: expected "172.21.3.16" but was "172.21.3.15"
Actual:
@timestamp:date_nanos    | client_ip:ip | event_duration:long | message:keyword
2023-10-23T13:55:01.543Z | 172.21.3.15  | 1756467             | Connected to 10.1.0.1
2023-10-23T13:53:55.832Z | 172.21.3.15  | 5033755             | Connection error
2023-10-23T13:52:55.015Z | 172.21.3.15  | 8268153             | Connection error
2023-10-23T13:51:54.732Z | 172.21.3.15  | 725448              | Connection error
2023-10-23T13:33:34.937Z | 172.21.0.5   | 1232382             | Disconnected
2023-10-23T12:27:28.948Z | 172.21.2.113 | 2764889             | Connected to 10.1.0.2
2023-10-23T12:15:03.360Z | 172.21.2.162 | 3450233             | Connected to 10.1.0.3

Expected:
@timestamp:date_nanos    | client_ip:ip | event_duration:long | message:keyword
2023-10-23T13:55:01.543Z | 172.21.3.16  | 1756467             | Connected to 10.1.0.1
2023-10-23T13:53:55.832Z | 172.21.3.15  | 5033755             | Connection error
2023-10-23T13:52:55.015Z | 172.21.3.15  | 8268153             | Connection error
2023-10-23T13:51:54.732Z | 172.21.3.15  | 725448              | Connection error
2023-10-23T13:33:34.937Z | 172.21.0.5   | 1232382             | Disconnected
2023-10-23T12:27:28.948Z | 172.21.2.113 | 2764889             | Connected to 10.1.0.2
2023-10-23T12:15:03.360Z | 172.21.2.162 | 3450233             | Connected to 10.1.0.3
  ```

</details>