### PR TITLE
[8.x] Handle `null` text values in RankedDocsResults.asMap() (#118597)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/RankedDocsResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/RankedDocsResults.java
@@ -139,7 +139,11 @@ public class RankedDocsResults implements InferenceServiceResults {
         }
 
         public Map<String, Object> asMap() {
-            return Map.of(NAME, Map.of(INDEX, index, RELEVANCE_SCORE, relevanceScore, TEXT, text));
+            if (text != null) {
+                return Map.of(NAME, Map.of(INDEX, index, RELEVANCE_SCORE, relevanceScore, TEXT, text));
+            } else {
+                return Map.of(NAME, Map.of(INDEX, index, RELEVANCE_SCORE, relevanceScore));
+            }
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/RankedDocsResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/RankedDocsResultsTests.java
@@ -12,10 +12,12 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.AbstractChunkedBWCSerializationTestCase;
+import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class RankedDocsResultsTests extends AbstractChunkedBWCSerializationTestCase<RankedDocsResults> {
 
@@ -35,6 +37,16 @@ public class RankedDocsResultsTests extends AbstractChunkedBWCSerializationTestC
 
     public static RankedDocsResults.RankedDoc createRandomDoc() {
         return new RankedDocsResults.RankedDoc(randomIntBetween(0, 100), randomFloat(), randomBoolean() ? null : randomAlphaOfLength(10));
+    }
+
+    public void test_asMap() {
+        var index = randomIntBetween(0, 100);
+        var score = randomFloat();
+        var mapNullText = new RankedDocsResults.RankedDoc(index, score, null).asMap();
+        assertThat(mapNullText, Matchers.is(Map.of("ranked_doc", Map.of("index", index, "relevance_score", score))));
+
+        var mapWithText = new RankedDocsResults.RankedDoc(index, score, "Sample text").asMap();
+        assertThat(mapWithText, Matchers.is(Map.of("ranked_doc", Map.of("index", index, "relevance_score", score, "text", "Sample text"))));
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Handle `null` text values in RankedDocsResults.asMap() (#118597)