### PR TITLE
ESQL: Disable one more test failing on pre-8.13 BWC #118760

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -428,9 +428,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.RetrySearchIntegTests
   method: testRetryPointInTime
   issue: https://github.com/elastic/elasticsearch/issues/118514
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {stats.ByDateAndKeywordAndIntWithAlias SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/118668
 - class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
   method: testOpenAiEmbeddings {upgradedNodes=1}
   issue: https://github.com/elastic/elasticsearch/issues/118156

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
@@ -223,7 +223,7 @@ null               | null      | null
 ;
 
 
-// the query is incorrectly physically plan (fails the verification) in pre-8.13.0 versions
+// the query is incorrectly physically planned (fails the verification) in pre-8.13.0 versions
 overwriteName#[skip:-8.12.99]
 from employees | sort emp_no asc | eval full_name = concat(first_name, " ", last_name) | dissect full_name "%{emp_no} %{b}" | keep full_name, emp_no, b | limit 3;
 
@@ -245,7 +245,7 @@ emp_no:integer | first_name:keyword | rest:keyword
 ;
 
 
-// the query is incorrectly physically plan (fails the verification) in pre-8.13.0 versions
+// the query is incorrectly physically planned (fails the verification) in pre-8.13.0 versions
 overwriteNameWhere#[skip:-8.12.99]
 from employees | sort emp_no asc | eval full_name = concat(first_name, " ", last_name) | dissect full_name "%{emp_no} %{b}" | where emp_no == "Bezalel" | keep full_name, emp_no, b | limit 3;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
@@ -199,7 +199,7 @@ null               | null      | null
 ;
 
 
-// the query is incorrectly physically plan (fails the verification) in pre-8.13.0 versions
+// the query is incorrectly physically planned (fails the verification) in pre-8.13.0 versions
 overwriteName#[skip:-8.12.99]
 from employees | sort emp_no asc | eval full_name = concat(first_name, " ", last_name) | grok full_name "%{WORD:emp_no} %{WORD:b}" | keep full_name, emp_no, b | limit 3;
 
@@ -210,7 +210,7 @@ Parto Bamford     | Parto          | Bamford
 ;
 
 
-// the query is incorrectly physically plan (fails the verification) in pre-8.13.0 versions
+// the query is incorrectly physically planned (fails the verification) in pre-8.13.0 versions
 overwriteNameWhere#[skip:-8.12.99]
 from employees | sort emp_no asc | eval full_name = concat(first_name, " ", last_name) | grok full_name "%{WORD:emp_no} %{WORD:b}" | where emp_no == "Bezalel" | keep full_name, emp_no, b | limit 3;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -564,7 +564,7 @@ c:long | gender:keyword | trunk_worked_seconds:long
  0     | null           | 200000000
 ;
 
-// the query is incorrectly physically plan (fails the verification) in pre-8.13.0 versions
+// the query is incorrectly physically planned (fails the verification) in pre-8.13.0 versions
 byStringAndLongWithAlias#[skip:-8.12.99]
 FROM employees
 | EVAL trunk_worked_seconds = avg_worked_seconds / 100000000 * 100000000
@@ -720,7 +720,8 @@ c:long |           d:date         | gender:keyword | languages:integer
      2 | 1987-01-01T00:00:00.000Z | M              | 1
 ;
 
-byDateAndKeywordAndIntWithAlias
+// the query is incorrectly physically planned (fails the verification) in pre-8.13.0 versions
+byDateAndKeywordAndIntWithAlias#[skip:-8.12.99]
 from employees | eval d = date_trunc(1 year, hire_date) | rename gender as g, languages as l, emp_no as e | keep d, g, l, e | stats c = count(e) by d, g, l | sort c desc, d, l desc, g desc | limit 10;
 
 c:long |           d:date         | g:keyword | l:integer


### PR DESCRIPTION
Backports the following commits to 8.x:
* ESQL: Disable one more test failing on pre-8.13 BWC #118760

Re-enable testing this tests too.

Fixes #118668