### PR TITLE
[8.x] Remove unused method (#118601)

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/planner/TranslatorHandler.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/planner/TranslatorHandler.java
@@ -12,7 +12,6 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
-import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.util.function.Supplier;
 
@@ -34,5 +33,4 @@ public interface TranslatorHandler {
 
     String nameOf(Expression e);
 
-    Object convert(Object value, DataType dataType);
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlTranslatorHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlTranslatorHandler.java
@@ -17,9 +17,7 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.core.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.core.planner.TranslatorHandler;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
-import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.querydsl.query.SingleValueQuery;
-import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.util.function.Supplier;
 
@@ -28,11 +26,6 @@ public final class EsqlTranslatorHandler implements TranslatorHandler {
     @Override
     public Query asQuery(Expression e) {
         return EsqlExpressionTranslators.toQuery(e, this);
-    }
-
-    @Override
-    public Object convert(Object value, DataType dataType) {
-        return EsqlDataTypeConverter.convert(value, dataType);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Remove unused method (#118601)