### PR TITLE
[8.x] tier_preference and creation_date fields in monitoring template (#117851)

### DIFF
--- a/docs/changelog/117851.yaml
+++ b/docs/changelog/117851.yaml
@@ -1,0 +1,5 @@
+pr: 117851
+summary: Addition of `tier_preference`, `creation_date` and `version` fields in Elasticsearch monitoring template
+area: Monitoring
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
@@ -1517,6 +1517,17 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "tier_preference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "creation_date": {
+                  "type": "date"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "recovery": {
                   "properties": {
                     "stop_time": {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -77,7 +77,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 18;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 19;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
Backports the following commits to 8.x:
 - tier_preference and creation_date fields in monitoring template (#117851)