### PR TITLE
Fix semantic text match failure

### DIFF
--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/45_semantic_text_match.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/45_semantic_text_match.yml
@@ -61,6 +61,9 @@ setup:
                 inference_id: sparse-inference-id
               non_inference_field:
                 type: text
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
@@ -73,6 +76,9 @@ setup:
                 inference_id: dense-inference-id
               non_inference_field:
                 type: text
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/45_semantic_text_match.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/45_semantic_text_match.yml
@@ -61,9 +61,6 @@ setup:
                 inference_id: sparse-inference-id
               non_inference_field:
                 type: text
-          settings:
-            number_of_shards: 1
-            number_of_replicas: 0
 
   - do:
       indices.create:
@@ -76,9 +73,6 @@ setup:
                 inference_id: dense-inference-id
               non_inference_field:
                 type: text
-          settings:
-            number_of_shards: 1
-            number_of_replicas: 0
 
   - do:
       indices.create:
@@ -216,8 +210,6 @@ setup:
                 query: "inference test"
 
   - match: { hits.total.value: 2 }
-  - match: { hits.hits.0._id: "doc_1" }
-  - match: { hits.hits.1._id: "doc_2" }
 
   # Test querying multiple indices that either use the same inference ID or combine semantic_text with lexical search
   - do:
@@ -252,9 +244,6 @@ setup:
                 query: "inference test"
 
   - match: { hits.total.value: 3 }
-  - match: { hits.hits.0._id: "doc_1" }
-  - match: { hits.hits.1._id: "doc_3" }
-  - match: { hits.hits.2._id: "doc_2" }
 
 ---
 "Query a field that has no indexed inference results":


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/118727 

Test failures due to different shard counts, this forces the index to one shard so we can check on specific returned documents repeatably. 