### PR TITLE
Mark Query Role API as public in Serverless

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestQueryRoleAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestQueryRoleAction.java
@@ -34,7 +34,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public final class RestQueryRoleAction extends NativeRoleBaseRestHandler {
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Makes [`Query Role API`](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-query-role.html) available in Serverless.

Related specification update PR:

- https://github.com/elastic/elasticsearch-specification/pull/3316