### PR TITLE
[8.x] Fix semantic text match failure (#118790)

### DIFF
--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/45_semantic_text_match.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/45_semantic_text_match.yml
@@ -210,8 +210,6 @@ setup:
                 query: "inference test"
 
   - match: { hits.total.value: 2 }
-  - match: { hits.hits.0._id: "doc_1" }
-  - match: { hits.hits.1._id: "doc_2" }
 
   # Test querying multiple indices that either use the same inference ID or combine semantic_text with lexical search
   - do:
@@ -246,9 +244,6 @@ setup:
                 query: "inference test"
 
   - match: { hits.total.value: 3 }
-  - match: { hits.hits.0._id: "doc_1" }
-  - match: { hits.hits.1._id: "doc_3" }
-  - match: { hits.hits.2._id: "doc_2" }
 
 ---
 "Query a field that has no indexed inference results":


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix semantic text match failure (#118790)