### PR TITLE
[8.16] Fix BwC  synonyms tests (#118691)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,294 +1,294 @@
 tests:
-- class: "org.elasticsearch.upgrades.SearchStatesIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/108991"
-  method: "testCanMatch"
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/esql/esql-async-query-api/line_17}
-  issue: https://github.com/elastic/elasticsearch/issues/109260
-- class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/102717"
-  method: "testRequestResetAndAbort"
-- class: org.elasticsearch.index.store.FsDirectoryFactoryTests
-  method: testStoreDirectory
-  issue: https://github.com/elastic/elasticsearch/issues/110210
-- class: org.elasticsearch.index.store.FsDirectoryFactoryTests
-  method: testPreload
-  issue: https://github.com/elastic/elasticsearch/issues/110211
-- class: org.elasticsearch.upgrades.SecurityIndexRolesMetadataMigrationIT
-  method: testMetadataMigratedAfterUpgrade
-  issue: https://github.com/elastic/elasticsearch/issues/110232
-- class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
-  method: testMinVersionAsNewVersion
-  issue: https://github.com/elastic/elasticsearch/issues/95384
-- class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
-  method: testCcsMinimizeRoundtripsIsFalse
-  issue: https://github.com/elastic/elasticsearch/issues/101974
-- class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/110408"
-  method: "testCreateAndRestorePartialSearchableSnapshot"
-- class: org.elasticsearch.xpack.security.authz.store.NativePrivilegeStoreCacheTests
-  method: testPopulationOfCacheWhenLoadingPrivilegesForAllApplications
-  issue: https://github.com/elastic/elasticsearch/issues/110789
-- class: org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheFileTests
-  method: testCacheFileCreatedAsSparseFile
-  issue: https://github.com/elastic/elasticsearch/issues/110801
-- class: org.elasticsearch.nativeaccess.VectorSystemPropertyTests
-  method: testSystemPropertyDisabled
-  issue: https://github.com/elastic/elasticsearch/issues/110949
-- class: org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectAuthIT
-  method: testAuthenticateWithImplicitFlow
-  issue: https://github.com/elastic/elasticsearch/issues/111191
-- class: org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectAuthIT
-  method: testAuthenticateWithCodeFlowAndClientPost
-  issue: https://github.com/elastic/elasticsearch/issues/111396
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testSingleDoc {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/111434
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testDataStreams {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/111448
-- class: org.elasticsearch.search.SearchServiceTests
-  issue: https://github.com/elastic/elasticsearch/issues/111529
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testSnapshotRestore {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/111798
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/80_random_rerank_retriever/Random rerank retriever predictably shuffles results}
-  issue: https://github.com/elastic/elasticsearch/issues/111999
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testDeleteJobAfterMissingIndex
-  issue: https://github.com/elastic/elasticsearch/issues/112088
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/112147
-- class: org.elasticsearch.smoketest.WatcherYamlRestIT
-  method: test {p0=watcher/usage/10_basic/Test watcher usage stats output}
-  issue: https://github.com/elastic/elasticsearch/issues/112189
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=ml/inference_processor/Test create processor with missing mandatory fields}
-  issue: https://github.com/elastic/elasticsearch/issues/112191
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testDeleteJobAsync
-  issue: https://github.com/elastic/elasticsearch/issues/112212
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testMultiIndexDelete
-  issue: https://github.com/elastic/elasticsearch/issues/112381
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroidTests
-  method: "testAggregateIntermediate {TestCase=<geo_point> #2}"
-  issue: https://github.com/elastic/elasticsearch/issues/112461
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroidTests
-  method: testAggregateIntermediate {TestCase=<geo_point>}
-  issue: https://github.com/elastic/elasticsearch/issues/112463
-- class: org.elasticsearch.xpack.inference.external.http.RequestBasedTaskRunnerTests
-  method: testLoopOneAtATime
-  issue: https://github.com/elastic/elasticsearch/issues/112471
-- class: org.elasticsearch.ingest.geoip.IngestGeoIpClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/111497
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testPutJob_GivenFarequoteConfig
-  issue: https://github.com/elastic/elasticsearch/issues/112382
-- class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
-  method: test20SecurityNotAutoConfiguredOnReInstallation
-  issue: https://github.com/elastic/elasticsearch/issues/112635
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-  method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
-  issue: https://github.com/elastic/elasticsearch/issues/112642
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-  method: test {case-functions.testUcaseInline1}
-  issue: https://github.com/elastic/elasticsearch/issues/112641
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-  method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
-  issue: https://github.com/elastic/elasticsearch/issues/112640
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-  method: test {case-functions.testUcaseInline3}
-  issue: https://github.com/elastic/elasticsearch/issues/112643
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testDelete_multipleRequest
-  issue: https://github.com/elastic/elasticsearch/issues/112701
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testCreateJobInSharedIndexUpdatesMapping
-  issue: https://github.com/elastic/elasticsearch/issues/112729
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testGetJob_GivenNoSuchJob
-  issue: https://github.com/elastic/elasticsearch/issues/112730
-- class: org.elasticsearch.script.StatsSummaryTests
-  method: testEqualsAndHashCode
-  issue: https://github.com/elastic/elasticsearch/issues/112439
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testDeleteJobAfterMissingAliases
-  issue: https://github.com/elastic/elasticsearch/issues/112823
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testCreateJob_WithClashingFieldMappingsFails
-  issue: https://github.com/elastic/elasticsearch/issues/113046
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-  method: test {case-functions.testUcaseInline1}
-  issue: https://github.com/elastic/elasticsearch/issues/112641
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-  method: test {case-functions.testUcaseInline3}
-  issue: https://github.com/elastic/elasticsearch/issues/112643
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-  method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
-  issue: https://github.com/elastic/elasticsearch/issues/112640
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-  method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
-  issue: https://github.com/elastic/elasticsearch/issues/112642
-- class: org.elasticsearch.xpack.inference.rest.ServerSentEventsRestActionListenerTests
-  method: testResponse
-  issue: https://github.com/elastic/elasticsearch/issues/113148
-- class: org.elasticsearch.packaging.test.WindowsServiceTests
-  method: test30StartStop
-  issue: https://github.com/elastic/elasticsearch/issues/113160
-- class: org.elasticsearch.packaging.test.WindowsServiceTests
-  method: test33JavaChanged
-  issue: https://github.com/elastic/elasticsearch/issues/113177
-- class: org.elasticsearch.xpack.inference.rest.ServerSentEventsRestActionListenerTests
-  method: testErrorMidStream
-  issue: https://github.com/elastic/elasticsearch/issues/113179
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
-  issue: https://github.com/elastic/elasticsearch/issues/108997
-- class: org.elasticsearch.packaging.test.WindowsServiceTests
-  method: test80JavaOptsInEnvVar
-  issue: https://github.com/elastic/elasticsearch/issues/113219
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.AvgTests
-  method: "testFold {TestCase=<double> #2}"
-  issue: https://github.com/elastic/elasticsearch/issues/113225
-- class: org.elasticsearch.packaging.test.WindowsServiceTests
-  method: test81JavaOptsInJvmOptions
-  issue: https://github.com/elastic/elasticsearch/issues/113313
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
-  issue: https://github.com/elastic/elasticsearch/issues/113325
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/ccr/apis/follow/post-resume-follow/line_84}
-  issue: https://github.com/elastic/elasticsearch/issues/113343
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testDeleteJob_TimingStatsDocumentIsDeleted
-  issue: https://github.com/elastic/elasticsearch/issues/113370
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search/500_date_range/from, to, include_lower, include_upper deprecated}
-  issue: https://github.com/elastic/elasticsearch/pull/113286
-- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-  method: testLimitedPrivilege
-  issue: https://github.com/elastic/elasticsearch/issues/113419
-- class: org.elasticsearch.index.mapper.extras.TokenCountFieldMapperTests
-  method: testBlockLoaderFromRowStrideReaderWithSyntheticSource
-  issue: https://github.com/elastic/elasticsearch/issues/113427
-- class: org.elasticsearch.xpack.inference.InferenceCrudIT
-  method: testSupportedStream
-  issue: https://github.com/elastic/elasticsearch/issues/113430
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testOutOfOrderData
-  issue: https://github.com/elastic/elasticsearch/issues/113477
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testCreateJobsWithIndexNameOption
-  issue: https://github.com/elastic/elasticsearch/issues/113528
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search/180_locale_dependent_mapping/Test Index and Search locale dependent mappings / dates}
-  issue: https://github.com/elastic/elasticsearch/issues/113537
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testCantCreateJobWithSameID
-  issue: https://github.com/elastic/elasticsearch/issues/113581
-- class: org.elasticsearch.integration.KibanaUserRoleIntegTests
-  method: testFieldMappings
-  issue: https://github.com/elastic/elasticsearch/issues/113592
-- class: org.elasticsearch.integration.KibanaUserRoleIntegTests
-  method: testSearchAndMSearch
-  issue: https://github.com/elastic/elasticsearch/issues/113593
-- class: org.elasticsearch.xpack.transform.integration.TransformIT
-  method: testStopWaitForCheckpoint
-  issue: https://github.com/elastic/elasticsearch/issues/106113
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search/540_ignore_above_synthetic_source/ignore_above mapping level setting on arrays}
-  issue: https://github.com/elastic/elasticsearch/issues/113648
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testGetJobs_GivenMultipleJobs
-  issue: https://github.com/elastic/elasticsearch/issues/113654
-- class: org.elasticsearch.xpack.ml.integration.MlJobIT
-  method: testGetJobs_GivenSingleJob
-  issue: https://github.com/elastic/elasticsearch/issues/113655
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDateNanosTests
-  issue: https://github.com/elastic/elasticsearch/issues/113661
-- class: org.elasticsearch.search.retriever.RankDocsRetrieverBuilderTests
-  method: testRewrite
-  issue: https://github.com/elastic/elasticsearch/issues/114467
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/esql/esql-across-clusters/line_196}
-  issue: https://github.com/elastic/elasticsearch/issues/114488
-- class: org.elasticsearch.gradle.internal.PublishPluginFuncTest
-  issue: https://github.com/elastic/elasticsearch/issues/114492
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=indices.split/40_routing_partition_size/nested}
-  issue: https://github.com/elastic/elasticsearch/issues/113842
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=indices.split/40_routing_partition_size/more than 1}
-  issue: https://github.com/elastic/elasticsearch/issues/113841
-- class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
-  method: testMinimumVersionSameAsNewVersion
-  issue: https://github.com/elastic/elasticsearch/issues/114593
-- class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
-  method: testMinimumVersionShardDuringPhaseExecution
-  issue: https://github.com/elastic/elasticsearch/issues/114611
-- class: org.elasticsearch.kibana.KibanaThreadPoolIT
-  method: testBlockedThreadPoolsRejectUserRequests
-  issue: https://github.com/elastic/elasticsearch/issues/113939
-- class: org.elasticsearch.xpack.inference.integration.ModelRegistryIT
-  method: testGetModel
-  issue: https://github.com/elastic/elasticsearch/issues/114657
-- class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
-  method: testPutE5WithTrainedModelAndInference
-  issue: https://github.com/elastic/elasticsearch/issues/114023
-- class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
-  method: testPutE5Small_withPlatformAgnosticVariant
-  issue: https://github.com/elastic/elasticsearch/issues/113983
-- class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
-  method: test {yaml=rrf/800_rrf_with_text_similarity_reranker_retriever/explain using rrf retriever and text-similarity}
-  issue: https://github.com/elastic/elasticsearch/issues/114757
-- class: org.elasticsearch.xpack.security.authc.ldap.GroupMappingIT
-  issue: https://github.com/elastic/elasticsearch/issues/115221
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/rest-api/usage/line_38}
-  issue: https://github.com/elastic/elasticsearch/issues/113694
-- class: org.elasticsearch.xpack.enrich.EnrichIT
-  method: testDeleteExistingPipeline
-  issue: https://github.com/elastic/elasticsearch/issues/114775
-- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
-  method: testInferDeploysDefaultE5
-  issue: https://github.com/elastic/elasticsearch/issues/115361
-- class: org.elasticsearch.xpack.inference.rest.ServerSentEventsRestActionListenerTests
-  method: testNoStream
-  issue: https://github.com/elastic/elasticsearch/issues/114788
-- class: org.elasticsearch.xpack.ml.integration.DatafeedJobsRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/111319
-- class: org.elasticsearch.xpack.restart.CoreFullClusterRestartIT
-  method: testSnapshotRestore {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/111799
-- class: org.elasticsearch.search.basic.SearchWhileRelocatingIT
-  method: testSearchAndRelocateConcurrentlyRandomReplicas
-  issue: https://github.com/elastic/elasticsearch/issues/116145
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {categorize.Categorize ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/113055
-- class: org.elasticsearch.xpack.deprecation.DeprecationHttpIT
-  method: testDeprecatedSettingsReturnWarnings
-  issue: https://github.com/elastic/elasticsearch/issues/108628
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {categorize.Categorize SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/113054
-- class: org.elasticsearch.ingest.geoip.EnterpriseGeoIpDownloaderIT
-  method: testEnterpriseDownloaderTask
-  issue: https://github.com/elastic/elasticsearch/issues/115163
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/117027
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/117349
-- class: org.elasticsearch.threadpool.SimpleThreadPoolIT
-  method: testThreadPoolMetrics
-  issue: https://github.com/elastic/elasticsearch/issues/108320
-- class: org.elasticsearch.xpack.esql.plugin.ClusterRequestTests
-  method: testFallbackIndicesOptions
-  issue: https://github.com/elastic/elasticsearch/issues/117937
+  - class: "org.elasticsearch.upgrades.SearchStatesIT"
+    issue: "https://github.com/elastic/elasticsearch/issues/108991"
+    method: "testCanMatch"
+  - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
+    method: test {yaml=reference/esql/esql-async-query-api/line_17}
+    issue: https://github.com/elastic/elasticsearch/issues/109260
+  - class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
+    issue: "https://github.com/elastic/elasticsearch/issues/102717"
+    method: "testRequestResetAndAbort"
+  - class: org.elasticsearch.index.store.FsDirectoryFactoryTests
+    method: testStoreDirectory
+    issue: https://github.com/elastic/elasticsearch/issues/110210
+  - class: org.elasticsearch.index.store.FsDirectoryFactoryTests
+    method: testPreload
+    issue: https://github.com/elastic/elasticsearch/issues/110211
+  - class: org.elasticsearch.upgrades.SecurityIndexRolesMetadataMigrationIT
+    method: testMetadataMigratedAfterUpgrade
+    issue: https://github.com/elastic/elasticsearch/issues/110232
+  - class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
+    method: testMinVersionAsNewVersion
+    issue: https://github.com/elastic/elasticsearch/issues/95384
+  - class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
+    method: testCcsMinimizeRoundtripsIsFalse
+    issue: https://github.com/elastic/elasticsearch/issues/101974
+  - class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
+    issue: "https://github.com/elastic/elasticsearch/issues/110408"
+    method: "testCreateAndRestorePartialSearchableSnapshot"
+  - class: org.elasticsearch.xpack.security.authz.store.NativePrivilegeStoreCacheTests
+    method: testPopulationOfCacheWhenLoadingPrivilegesForAllApplications
+    issue: https://github.com/elastic/elasticsearch/issues/110789
+  - class: org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheFileTests
+    method: testCacheFileCreatedAsSparseFile
+    issue: https://github.com/elastic/elasticsearch/issues/110801
+  - class: org.elasticsearch.nativeaccess.VectorSystemPropertyTests
+    method: testSystemPropertyDisabled
+    issue: https://github.com/elastic/elasticsearch/issues/110949
+  - class: org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectAuthIT
+    method: testAuthenticateWithImplicitFlow
+    issue: https://github.com/elastic/elasticsearch/issues/111191
+  - class: org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectAuthIT
+    method: testAuthenticateWithCodeFlowAndClientPost
+    issue: https://github.com/elastic/elasticsearch/issues/111396
+  - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
+    method: testSingleDoc {cluster=UPGRADED}
+    issue: https://github.com/elastic/elasticsearch/issues/111434
+  - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
+    method: testDataStreams {cluster=UPGRADED}
+    issue: https://github.com/elastic/elasticsearch/issues/111448
+  - class: org.elasticsearch.search.SearchServiceTests
+    issue: https://github.com/elastic/elasticsearch/issues/111529
+  - class: org.elasticsearch.upgrades.FullClusterRestartIT
+    method: testSnapshotRestore {cluster=UPGRADED}
+    issue: https://github.com/elastic/elasticsearch/issues/111798
+  - class: org.elasticsearch.xpack.inference.InferenceRestIT
+    method: test {p0=inference/80_random_rerank_retriever/Random rerank retriever predictably shuffles results}
+    issue: https://github.com/elastic/elasticsearch/issues/111999
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testDeleteJobAfterMissingIndex
+    issue: https://github.com/elastic/elasticsearch/issues/112088
+  - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+    issue: https://github.com/elastic/elasticsearch/issues/112147
+  - class: org.elasticsearch.smoketest.WatcherYamlRestIT
+    method: test {p0=watcher/usage/10_basic/Test watcher usage stats output}
+    issue: https://github.com/elastic/elasticsearch/issues/112189
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=ml/inference_processor/Test create processor with missing mandatory fields}
+    issue: https://github.com/elastic/elasticsearch/issues/112191
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testDeleteJobAsync
+    issue: https://github.com/elastic/elasticsearch/issues/112212
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testMultiIndexDelete
+    issue: https://github.com/elastic/elasticsearch/issues/112381
+  - class: org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroidTests
+    method: "testAggregateIntermediate {TestCase=<geo_point> #2}"
+    issue: https://github.com/elastic/elasticsearch/issues/112461
+  - class: org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroidTests
+    method: testAggregateIntermediate {TestCase=<geo_point>}
+    issue: https://github.com/elastic/elasticsearch/issues/112463
+  - class: org.elasticsearch.xpack.inference.external.http.RequestBasedTaskRunnerTests
+    method: testLoopOneAtATime
+    issue: https://github.com/elastic/elasticsearch/issues/112471
+  - class: org.elasticsearch.ingest.geoip.IngestGeoIpClientYamlTestSuiteIT
+    issue: https://github.com/elastic/elasticsearch/issues/111497
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testPutJob_GivenFarequoteConfig
+    issue: https://github.com/elastic/elasticsearch/issues/112382
+  - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
+    method: test20SecurityNotAutoConfiguredOnReInstallation
+    issue: https://github.com/elastic/elasticsearch/issues/112635
+  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+    method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
+    issue: https://github.com/elastic/elasticsearch/issues/112642
+  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+    method: test {case-functions.testUcaseInline1}
+    issue: https://github.com/elastic/elasticsearch/issues/112641
+  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+    method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
+    issue: https://github.com/elastic/elasticsearch/issues/112640
+  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+    method: test {case-functions.testUcaseInline3}
+    issue: https://github.com/elastic/elasticsearch/issues/112643
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testDelete_multipleRequest
+    issue: https://github.com/elastic/elasticsearch/issues/112701
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testCreateJobInSharedIndexUpdatesMapping
+    issue: https://github.com/elastic/elasticsearch/issues/112729
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testGetJob_GivenNoSuchJob
+    issue: https://github.com/elastic/elasticsearch/issues/112730
+  - class: org.elasticsearch.script.StatsSummaryTests
+    method: testEqualsAndHashCode
+    issue: https://github.com/elastic/elasticsearch/issues/112439
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testDeleteJobAfterMissingAliases
+    issue: https://github.com/elastic/elasticsearch/issues/112823
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testCreateJob_WithClashingFieldMappingsFails
+    issue: https://github.com/elastic/elasticsearch/issues/113046
+  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+    method: test {case-functions.testUcaseInline1}
+    issue: https://github.com/elastic/elasticsearch/issues/112641
+  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+    method: test {case-functions.testUcaseInline3}
+    issue: https://github.com/elastic/elasticsearch/issues/112643
+  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+    method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
+    issue: https://github.com/elastic/elasticsearch/issues/112640
+  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+    method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
+    issue: https://github.com/elastic/elasticsearch/issues/112642
+  - class: org.elasticsearch.xpack.inference.rest.ServerSentEventsRestActionListenerTests
+    method: testResponse
+    issue: https://github.com/elastic/elasticsearch/issues/113148
+  - class: org.elasticsearch.packaging.test.WindowsServiceTests
+    method: test30StartStop
+    issue: https://github.com/elastic/elasticsearch/issues/113160
+  - class: org.elasticsearch.packaging.test.WindowsServiceTests
+    method: test33JavaChanged
+    issue: https://github.com/elastic/elasticsearch/issues/113177
+  - class: org.elasticsearch.xpack.inference.rest.ServerSentEventsRestActionListenerTests
+    method: testErrorMidStream
+    issue: https://github.com/elastic/elasticsearch/issues/113179
+  - class: org.elasticsearch.smoketest.MlWithSecurityIT
+    method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
+    issue: https://github.com/elastic/elasticsearch/issues/108997
+  - class: org.elasticsearch.packaging.test.WindowsServiceTests
+    method: test80JavaOptsInEnvVar
+    issue: https://github.com/elastic/elasticsearch/issues/113219
+  - class: org.elasticsearch.xpack.esql.expression.function.aggregate.AvgTests
+    method: "testFold {TestCase=<double> #2}"
+    issue: https://github.com/elastic/elasticsearch/issues/113225
+  - class: org.elasticsearch.packaging.test.WindowsServiceTests
+    method: test81JavaOptsInJvmOptions
+    issue: https://github.com/elastic/elasticsearch/issues/113313
+  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+    method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
+    issue: https://github.com/elastic/elasticsearch/issues/113325
+  - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
+    method: test {yaml=reference/ccr/apis/follow/post-resume-follow/line_84}
+    issue: https://github.com/elastic/elasticsearch/issues/113343
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testDeleteJob_TimingStatsDocumentIsDeleted
+    issue: https://github.com/elastic/elasticsearch/issues/113370
+  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+    method: test {p0=search/500_date_range/from, to, include_lower, include_upper deprecated}
+    issue: https://github.com/elastic/elasticsearch/pull/113286
+  - class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
+    method: testLimitedPrivilege
+    issue: https://github.com/elastic/elasticsearch/issues/113419
+  - class: org.elasticsearch.index.mapper.extras.TokenCountFieldMapperTests
+    method: testBlockLoaderFromRowStrideReaderWithSyntheticSource
+    issue: https://github.com/elastic/elasticsearch/issues/113427
+  - class: org.elasticsearch.xpack.inference.InferenceCrudIT
+    method: testSupportedStream
+    issue: https://github.com/elastic/elasticsearch/issues/113430
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testOutOfOrderData
+    issue: https://github.com/elastic/elasticsearch/issues/113477
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testCreateJobsWithIndexNameOption
+    issue: https://github.com/elastic/elasticsearch/issues/113528
+  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+    method: test {p0=search/180_locale_dependent_mapping/Test Index and Search locale dependent mappings / dates}
+    issue: https://github.com/elastic/elasticsearch/issues/113537
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testCantCreateJobWithSameID
+    issue: https://github.com/elastic/elasticsearch/issues/113581
+  - class: org.elasticsearch.integration.KibanaUserRoleIntegTests
+    method: testFieldMappings
+    issue: https://github.com/elastic/elasticsearch/issues/113592
+  - class: org.elasticsearch.integration.KibanaUserRoleIntegTests
+    method: testSearchAndMSearch
+    issue: https://github.com/elastic/elasticsearch/issues/113593
+  - class: org.elasticsearch.xpack.transform.integration.TransformIT
+    method: testStopWaitForCheckpoint
+    issue: https://github.com/elastic/elasticsearch/issues/106113
+  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+    method: test {p0=search/540_ignore_above_synthetic_source/ignore_above mapping level setting on arrays}
+    issue: https://github.com/elastic/elasticsearch/issues/113648
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testGetJobs_GivenMultipleJobs
+    issue: https://github.com/elastic/elasticsearch/issues/113654
+  - class: org.elasticsearch.xpack.ml.integration.MlJobIT
+    method: testGetJobs_GivenSingleJob
+    issue: https://github.com/elastic/elasticsearch/issues/113655
+  - class: org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDateNanosTests
+    issue: https://github.com/elastic/elasticsearch/issues/113661
+  - class: org.elasticsearch.search.retriever.RankDocsRetrieverBuilderTests
+    method: testRewrite
+    issue: https://github.com/elastic/elasticsearch/issues/114467
+  - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
+    method: test {yaml=reference/esql/esql-across-clusters/line_196}
+    issue: https://github.com/elastic/elasticsearch/issues/114488
+  - class: org.elasticsearch.gradle.internal.PublishPluginFuncTest
+    issue: https://github.com/elastic/elasticsearch/issues/114492
+  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+    method: test {p0=indices.split/40_routing_partition_size/nested}
+    issue: https://github.com/elastic/elasticsearch/issues/113842
+  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+    method: test {p0=indices.split/40_routing_partition_size/more than 1}
+    issue: https://github.com/elastic/elasticsearch/issues/113841
+  - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
+    method: testMinimumVersionSameAsNewVersion
+    issue: https://github.com/elastic/elasticsearch/issues/114593
+  - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
+    method: testMinimumVersionShardDuringPhaseExecution
+    issue: https://github.com/elastic/elasticsearch/issues/114611
+  - class: org.elasticsearch.kibana.KibanaThreadPoolIT
+    method: testBlockedThreadPoolsRejectUserRequests
+    issue: https://github.com/elastic/elasticsearch/issues/113939
+  - class: org.elasticsearch.xpack.inference.integration.ModelRegistryIT
+    method: testGetModel
+    issue: https://github.com/elastic/elasticsearch/issues/114657
+  - class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
+    method: testPutE5WithTrainedModelAndInference
+    issue: https://github.com/elastic/elasticsearch/issues/114023
+  - class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
+    method: testPutE5Small_withPlatformAgnosticVariant
+    issue: https://github.com/elastic/elasticsearch/issues/113983
+  - class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
+    method: test {yaml=rrf/800_rrf_with_text_similarity_reranker_retriever/explain using rrf retriever and text-similarity}
+    issue: https://github.com/elastic/elasticsearch/issues/114757
+  - class: org.elasticsearch.xpack.security.authc.ldap.GroupMappingIT
+    issue: https://github.com/elastic/elasticsearch/issues/115221
+  - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
+    method: test {yaml=reference/rest-api/usage/line_38}
+    issue: https://github.com/elastic/elasticsearch/issues/113694
+  - class: org.elasticsearch.xpack.enrich.EnrichIT
+    method: testDeleteExistingPipeline
+    issue: https://github.com/elastic/elasticsearch/issues/114775
+  - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
+    method: testInferDeploysDefaultE5
+    issue: https://github.com/elastic/elasticsearch/issues/115361
+  - class: org.elasticsearch.xpack.inference.rest.ServerSentEventsRestActionListenerTests
+    method: testNoStream
+    issue: https://github.com/elastic/elasticsearch/issues/114788
+  - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsRestIT
+    issue: https://github.com/elastic/elasticsearch/issues/111319
+  - class: org.elasticsearch.xpack.restart.CoreFullClusterRestartIT
+    method: testSnapshotRestore {cluster=UPGRADED}
+    issue: https://github.com/elastic/elasticsearch/issues/111799
+  - class: org.elasticsearch.search.basic.SearchWhileRelocatingIT
+    method: testSearchAndRelocateConcurrentlyRandomReplicas
+    issue: https://github.com/elastic/elasticsearch/issues/116145
+  - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+    method: test {categorize.Categorize ASYNC}
+    issue: https://github.com/elastic/elasticsearch/issues/113055
+  - class: org.elasticsearch.xpack.deprecation.DeprecationHttpIT
+    method: testDeprecatedSettingsReturnWarnings
+    issue: https://github.com/elastic/elasticsearch/issues/108628
+  - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+    method: test {categorize.Categorize SYNC}
+    issue: https://github.com/elastic/elasticsearch/issues/113054
+  - class: org.elasticsearch.ingest.geoip.EnterpriseGeoIpDownloaderIT
+    method: testEnterpriseDownloaderTask
+    issue: https://github.com/elastic/elasticsearch/issues/115163
+  - class: org.elasticsearch.xpack.inference.InferenceRestIT
+    method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
+    issue: https://github.com/elastic/elasticsearch/issues/117027
+  - class: org.elasticsearch.xpack.inference.InferenceRestIT
+    method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
+    issue: https://github.com/elastic/elasticsearch/issues/117349
+  - class: org.elasticsearch.threadpool.SimpleThreadPoolIT
+    method: testThreadPoolMetrics
+    issue: https://github.com/elastic/elasticsearch/issues/108320
+  - class: org.elasticsearch.xpack.esql.plugin.ClusterRequestTests
+    method: testFallbackIndicesOptions
+    issue: https://github.com/elastic/elasticsearch/issues/117937
 
 # Examples:
 #

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -247,4 +247,5 @@ tasks.named("precommit").configure {
 tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
   task.skipTest("indices.sort/10_basic/Index Sort", "warning does not exist for compatibility")
   task.skipTest("search/330_fetch_fields/Test search rewrite", "warning does not exist for compatibility")
+  task.skipTest("synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set", "Can't work until auto-expand replicas is 0-1 for synonyms index")
 })

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -1,5 +1,4 @@
----
-"Reload analyzers for specific synonym set":
+setup:
   - requires:
       cluster_features: ["gte_v8.10.0"]
       reason: Reloading analyzers for specific synonym set is introduced in 8.10.0

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -26,6 +26,14 @@
             - synonyms: "bye => goodbye"
               id: "synonym-rule-2"
 
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
+
   # Create my_index1 with synonym_filter that uses synonyms_set1
   - do:
       indices.create:
@@ -34,7 +42,6 @@
           settings:
             index:
               number_of_shards: 1
-              number_of_replicas: 0
             analysis:
               filter:
                 my_synonym_filter:
@@ -68,7 +75,6 @@
           settings:
             index:
               number_of_shards: 1
-              number_of_replicas: 0
             analysis:
               filter:
                 my_synonym_filter:
@@ -95,8 +101,12 @@
           - '{"index": {"_index": "my_index2", "_id": "2"}}'
           - '{"my_field": "goodbye"}'
 
+---
+"Reload analyzers for specific synonym set":
+# These specific tests can't succeed in BwC, as synonyms auto-expand replicas are 0-all. Replicas can't be associated to
+#  upgraded nodes, and thus we are not able to guarantee that the shards are not failed.
+# This test is skipped for BwC until synonyms index has auto-exapnd replicas set to 0-1.
 
-  # An update of synonyms_set1 must trigger auto-reloading of analyzers only for synonyms_set1
   - do:
       synonyms.put_synonym:
         id: synonyms_set1
@@ -104,12 +114,12 @@
           synonyms_set:
             - synonyms: "hello, salute"
             - synonyms: "ciao => goodbye"
+
   - match: { result: "updated" }
-  - match: { reload_analyzers_details._shards.total: 2 } # shard requests are still sent to 2 indices
-  - match: { reload_analyzers_details._shards.successful: 2 }
-  - length: { reload_analyzers_details.reload_details: 1 } # reload details contain only a single index
-  - match: { reload_analyzers_details.reload_details.0.index: "my_index1" }
-  - match: { reload_analyzers_details.reload_details.0.reloaded_analyzers.0: "my_analyzer1" }
+  - gt: { reload_analyzers_details._shards.total: 0 }
+  - gt: { reload_analyzers_details._shards.successful: 0 }
+  - match: { reload_analyzers_details._shards.failed: 0 }
+
 
   # Confirm that the index analyzers are reloaded for my_index1
   - do:
@@ -121,6 +131,23 @@
               my_field:
                 query: salute
   - match: { hits.total.value: 1 }
+
+---
+"Check analyzer reloaded and non failed shards for bwc tests":
+
+  - do:
+      synonyms.put_synonym:
+        id: synonyms_set1
+        body:
+          synonyms_set:
+            - synonyms: "hello, salute"
+            - synonyms: "ciao => goodbye"
+  - match: { result: "updated" }
+  - gt: { reload_analyzers_details._shards.total: 0 }
+  - gt: { reload_analyzers_details._shards.successful: 0 }
+  - length: { reload_analyzers_details.reload_details: 1 } # reload details contain only a single index
+  - match: { reload_analyzers_details.reload_details.0.index: "my_index1" }
+  - match: { reload_analyzers_details.reload_details.0.reloaded_analyzers.0: "my_analyzer1" }
 
   # Confirm that the index analyzers are still the same for my_index2
   - do:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Fix BwC  synonyms tests (#118691)](https://github.com/elastic/elasticsearch/pull/118691)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)