### PR TITLE
[8.15] Fix BwC  synonyms tests (#118691)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,85 +1,85 @@
 tests:
-- class: "org.elasticsearch.upgrades.SearchStatesIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/108991"
-  method: "testCanMatch"
-- class: "org.elasticsearch.upgrades.MlTrainedModelsUpgradeIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/108993"
-  method: "testTrainedModelInference"
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/esql/esql-async-query-api/line_17}
-  issue: https://github.com/elastic/elasticsearch/issues/109260
-- class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/102717"
-  method: "testRequestResetAndAbort"
-- class: "org.elasticsearch.xpack.inference.InferenceCrudIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/109391"
-  method: "testDeleteEndpointWhileReferencedByPipeline"
-- class: "org.elasticsearch.xpack.test.rest.XPackRestIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/109687"
-  method: "test {p0=sql/translate/Translate SQL}"
-- class: "org.elasticsearch.xpack.esql.action.AsyncEsqlQueryActionIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/109944"
-  method: "testBasicAsyncExecution"
-- class: "org.elasticsearch.action.admin.indices.rollover.RolloverIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/110034"
-  method: "testRolloverWithClosedWriteIndex"
-- class: org.elasticsearch.xpack.transform.transforms.TransformIndexerTests
-  method: testMaxPageSearchSizeIsResetToConfiguredValue
-  issue: https://github.com/elastic/elasticsearch/issues/109844
-- class: org.elasticsearch.index.store.FsDirectoryFactoryTests
-  method: testStoreDirectory
-  issue: https://github.com/elastic/elasticsearch/issues/110210
-- class: org.elasticsearch.index.store.FsDirectoryFactoryTests
-  method: testPreload
-  issue: https://github.com/elastic/elasticsearch/issues/110211
-- class: "org.elasticsearch.rest.RestControllerIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/110225"
-- class: org.elasticsearch.upgrades.SecurityIndexRolesMetadataMigrationIT
-  method: testMetadataMigratedAfterUpgrade
-  issue: https://github.com/elastic/elasticsearch/issues/110232
-- class: org.elasticsearch.compute.lucene.ValueSourceReaderTypeConversionTests
-  method: testLoadAll
-  issue: https://github.com/elastic/elasticsearch/issues/110244
-- class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
-  method: testMinVersionAsNewVersion
-  issue: https://github.com/elastic/elasticsearch/issues/95384
-- class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
-  method: testCcsMinimizeRoundtripsIsFalse
-  issue: https://github.com/elastic/elasticsearch/issues/101974
-- class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/110408"
-  method: "testCreateAndRestorePartialSearchableSnapshot"
-- class: "org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/110591"
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test600Interrupt
-  issue: https://github.com/elastic/elasticsearch/issues/111324
-- class: org.elasticsearch.xpack.transform.integration.TransformIT
-  method: testStopWaitForCheckpoint
-  issue: https://github.com/elastic/elasticsearch/issues/106113
-- class: org.elasticsearch.index.mapper.IgnoredSourceFieldMapperTests
-  method: testStoredNestedSubObjectWithNameOverlappingParentName
-  issue: https://github.com/elastic/elasticsearch/issues/112083
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testSnapshotRestore {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/111798
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testDeleteExpiredData_RemovesUnusedState
-  issue: https://github.com/elastic/elasticsearch/issues/116234
-- class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
-  method: testPutE5Small_withPlatformAgnosticVariant
-  issue: https://github.com/elastic/elasticsearch/issues/113983
-- class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
-  method: testPutE5WithTrainedModelAndInference
-  issue: https://github.com/elastic/elasticsearch/issues/114023
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/112746
-- class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
-  method: testFeatureImportanceValues
-  issue: https://github.com/elastic/elasticsearch/issues/116564
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test021InstallPlugin
-  issue: https://github.com/elastic/elasticsearch/issues/116147
+  - class: "org.elasticsearch.upgrades.SearchStatesIT"
+    issue: "https://github.com/elastic/elasticsearch/issues/108991"
+    method: "testCanMatch"
+  - class: "org.elasticsearch.upgrades.MlTrainedModelsUpgradeIT"
+    issue: "https://github.com/elastic/elasticsearch/issues/108993"
+    method: "testTrainedModelInference"
+  - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
+    method: test {yaml=reference/esql/esql-async-query-api/line_17}
+    issue: https://github.com/elastic/elasticsearch/issues/109260
+  - class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
+    issue: "https://github.com/elastic/elasticsearch/issues/102717"
+    method: "testRequestResetAndAbort"
+  - class: "org.elasticsearch.xpack.inference.InferenceCrudIT"
+    issue: "https://github.com/elastic/elasticsearch/issues/109391"
+    method: "testDeleteEndpointWhileReferencedByPipeline"
+  - class: "org.elasticsearch.xpack.test.rest.XPackRestIT"
+    issue: "https://github.com/elastic/elasticsearch/issues/109687"
+    method: "test {p0=sql/translate/Translate SQL}"
+  - class: "org.elasticsearch.xpack.esql.action.AsyncEsqlQueryActionIT"
+    issue: "https://github.com/elastic/elasticsearch/issues/109944"
+    method: "testBasicAsyncExecution"
+  - class: "org.elasticsearch.action.admin.indices.rollover.RolloverIT"
+    issue: "https://github.com/elastic/elasticsearch/issues/110034"
+    method: "testRolloverWithClosedWriteIndex"
+  - class: org.elasticsearch.xpack.transform.transforms.TransformIndexerTests
+    method: testMaxPageSearchSizeIsResetToConfiguredValue
+    issue: https://github.com/elastic/elasticsearch/issues/109844
+  - class: org.elasticsearch.index.store.FsDirectoryFactoryTests
+    method: testStoreDirectory
+    issue: https://github.com/elastic/elasticsearch/issues/110210
+  - class: org.elasticsearch.index.store.FsDirectoryFactoryTests
+    method: testPreload
+    issue: https://github.com/elastic/elasticsearch/issues/110211
+  - class: "org.elasticsearch.rest.RestControllerIT"
+    issue: "https://github.com/elastic/elasticsearch/issues/110225"
+  - class: org.elasticsearch.upgrades.SecurityIndexRolesMetadataMigrationIT
+    method: testMetadataMigratedAfterUpgrade
+    issue: https://github.com/elastic/elasticsearch/issues/110232
+  - class: org.elasticsearch.compute.lucene.ValueSourceReaderTypeConversionTests
+    method: testLoadAll
+    issue: https://github.com/elastic/elasticsearch/issues/110244
+  - class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
+    method: testMinVersionAsNewVersion
+    issue: https://github.com/elastic/elasticsearch/issues/95384
+  - class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
+    method: testCcsMinimizeRoundtripsIsFalse
+    issue: https://github.com/elastic/elasticsearch/issues/101974
+  - class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
+    issue: "https://github.com/elastic/elasticsearch/issues/110408"
+    method: "testCreateAndRestorePartialSearchableSnapshot"
+  - class: "org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT"
+    issue: "https://github.com/elastic/elasticsearch/issues/110591"
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test600Interrupt
+    issue: https://github.com/elastic/elasticsearch/issues/111324
+  - class: org.elasticsearch.xpack.transform.integration.TransformIT
+    method: testStopWaitForCheckpoint
+    issue: https://github.com/elastic/elasticsearch/issues/106113
+  - class: org.elasticsearch.index.mapper.IgnoredSourceFieldMapperTests
+    method: testStoredNestedSubObjectWithNameOverlappingParentName
+    issue: https://github.com/elastic/elasticsearch/issues/112083
+  - class: org.elasticsearch.upgrades.FullClusterRestartIT
+    method: testSnapshotRestore {cluster=UPGRADED}
+    issue: https://github.com/elastic/elasticsearch/issues/111798
+  - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
+    method: testDeleteExpiredData_RemovesUnusedState
+    issue: https://github.com/elastic/elasticsearch/issues/116234
+  - class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
+    method: testPutE5Small_withPlatformAgnosticVariant
+    issue: https://github.com/elastic/elasticsearch/issues/113983
+  - class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
+    method: testPutE5WithTrainedModelAndInference
+    issue: https://github.com/elastic/elasticsearch/issues/114023
+  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+    issue: https://github.com/elastic/elasticsearch/issues/112746
+  - class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
+    method: testFeatureImportanceValues
+    issue: https://github.com/elastic/elasticsearch/issues/116564
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test021InstallPlugin
+    issue: https://github.com/elastic/elasticsearch/issues/116147
 
 # Examples:
 #

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -84,6 +84,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("search/370_profile/fetch nested source", "profile output has changed")
   task.skipTest("search/240_date_nanos/doc value fields are working as expected across date and date_nanos fields", "Fetching docvalues field multiple times is no longer allowed")
   task.skipTest("search/110_field_collapsing/field collapsing and rescore", "#107779 Field collapsing is compatible with rescore in 8.15")
+  task.skipTest("synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set", "Can't work until auto-expand replicas is 0-1 for synonyms index")
 
   task.replaceValueInMatch("_type", "_doc")
   task.addAllowedWarningRegex("\\[types removal\\].*")

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -1,5 +1,4 @@
----
-"Reload analyzers for specific synonym set":
+setup:
   - requires:
       cluster_features: ["gte_v8.10.0"]
       reason: Reloading analyzers for specific synonym set is introduced in 8.10.0
@@ -26,6 +25,14 @@
             - synonyms: "bye => goodbye"
               id: "synonym-rule-2"
 
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
+
   # Create my_index1 with synonym_filter that uses synonyms_set1
   - do:
       indices.create:
@@ -34,7 +41,6 @@
           settings:
             index:
               number_of_shards: 1
-              number_of_replicas: 0
             analysis:
               filter:
                 my_synonym_filter:
@@ -68,7 +74,6 @@
           settings:
             index:
               number_of_shards: 1
-              number_of_replicas: 0
             analysis:
               filter:
                 my_synonym_filter:
@@ -95,8 +100,12 @@
           - '{"index": {"_index": "my_index2", "_id": "2"}}'
           - '{"my_field": "goodbye"}'
 
+---
+"Reload analyzers for specific synonym set":
+# These specific tests can't succeed in BwC, as synonyms auto-expand replicas are 0-all. Replicas can't be associated to
+#  upgraded nodes, and thus we are not able to guarantee that the shards are not failed.
+# This test is skipped for BwC until synonyms index has auto-exapnd replicas set to 0-1.
 
-  # An update of synonyms_set1 must trigger auto-reloading of analyzers only for synonyms_set1
   - do:
       synonyms.put_synonym:
         id: synonyms_set1
@@ -104,12 +113,12 @@
           synonyms_set:
             - synonyms: "hello, salute"
             - synonyms: "ciao => goodbye"
+
   - match: { result: "updated" }
-  - match: { reload_analyzers_details._shards.total: 2 } # shard requests are still sent to 2 indices
-  - match: { reload_analyzers_details._shards.successful: 2 }
-  - length: { reload_analyzers_details.reload_details: 1 } # reload details contain only a single index
-  - match: { reload_analyzers_details.reload_details.0.index: "my_index1" }
-  - match: { reload_analyzers_details.reload_details.0.reloaded_analyzers.0: "my_analyzer1" }
+  - gt: { reload_analyzers_details._shards.total: 0 }
+  - gt: { reload_analyzers_details._shards.successful: 0 }
+  - match: { reload_analyzers_details._shards.failed: 0 }
+
 
   # Confirm that the index analyzers are reloaded for my_index1
   - do:
@@ -121,6 +130,23 @@
               my_field:
                 query: salute
   - match: { hits.total.value: 1 }
+
+---
+"Check analyzer reloaded and non failed shards for bwc tests":
+
+  - do:
+      synonyms.put_synonym:
+        id: synonyms_set1
+        body:
+          synonyms_set:
+            - synonyms: "hello, salute"
+            - synonyms: "ciao => goodbye"
+  - match: { result: "updated" }
+  - gt: { reload_analyzers_details._shards.total: 0 }
+  - gt: { reload_analyzers_details._shards.successful: 0 }
+  - length: { reload_analyzers_details.reload_details: 1 } # reload details contain only a single index
+  - match: { reload_analyzers_details.reload_details.0.index: "my_index1" }
+  - match: { reload_analyzers_details.reload_details.0.reloaded_analyzers.0: "my_analyzer1" }
 
   # Confirm that the index analyzers are still the same for my_index2
   - do:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Fix BwC  synonyms tests (#118691)](https://github.com/elastic/elasticsearch/pull/118691)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)