### PR TITLE
[ML] Add dynamic templates for anomalies results index

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_mappings.json
@@ -5,6 +5,14 @@
   },
   "dynamic_templates" : [
     {
+      "map_objects": {
+        "match_mapping_type": "object",
+        "mapping": {
+          "type": "object"
+        }
+      }
+    },
+    {
       "strings_as_keywords" : {
         "match" : "*",
         "mapping" : {

--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_mappings.json
@@ -13,7 +13,7 @@
       }
     },
     {
-      "strings_as_keywords" : {
+      "non_objects_as_keywords" : {
         "match" : "*",
         "mapping" : {
           "type" : "keyword"


### PR DESCRIPTION
This PR enables the resolution of field names containing "." after the rollover of the anomalies results index. This way, the object parts of the field name, e.g., for an influencer, will indeed have the `object` type and can be resolved in search and filter operations.