### PR TITLE
[8.x] Muting failing test for issue 118806

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -317,6 +317,9 @@ tests:
   - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
     method: testMultipleInferencesTriggeringDownloadAndDeploy
     issue: https://github.com/elastic/elasticsearch/issues/117208
+  - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
+    method: testDeletingAndCreatingSecurityIndexTriggersSynchronization
+    issue: https://github.com/elastic/elasticsearch/issues/118806
 
   # Examples:
   #


### PR DESCRIPTION
This PR mutes test QueryableReservedRolesIT testDeletingAndCreatingSecurityIndexTriggersSynchronization as it's failing for my backport PR repeatedly.

I believe this was already muted on main here: https://github.com/elastic/elasticsearch/issues/118806

I'm not sure if that automatically gets backported to 8.x though 🤔 