### PR TITLE
Lookup join on multiple join fields not yet supported

### DIFF
--- a/docs/changelog/118858.yaml
+++ b/docs/changelog/118858.yaml
@@ -1,0 +1,5 @@
+pr: 118858
+summary: Lookup join on multiple join fields not yet supported
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -564,6 +564,11 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
             }
         }
 
+        var matchFieldsCount = joinFields.size();
+        if (matchFieldsCount > 1) {
+            throw new ParsingException(source, "JOIN ON clause only supports one field at the moment, found [{}]", matchFieldsCount);
+        }
+
         return p -> new LookupJoin(source, p, right, joinFields);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ParsingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ParsingTests.java
@@ -114,30 +114,42 @@ public class ParsingTests extends ESTestCase {
 
     public void testJoinOnConstant() {
         assumeTrue("LOOKUP JOIN available as snapshot only", EsqlCapabilities.Cap.JOIN_LOOKUP_V7.isEnabled());
-        assertEquals("1:55: JOIN ON clause only supports fields at the moment, found [123]",
-            error("row languages = 1, gender = \"f\" | lookup join test on 123"));
-        assertEquals("1:55: JOIN ON clause only supports fields at the moment, found [\"abc\"]",
-            error("row languages = 1, gender = \"f\" | lookup join test on \"abc\""));
-        assertEquals("1:55: JOIN ON clause only supports fields at the moment, found [false]",
-            error("row languages = 1, gender = \"f\" | lookup join test on false"));
+        assertEquals(
+            "1:55: JOIN ON clause only supports fields at the moment, found [123]",
+            error("row languages = 1, gender = \"f\" | lookup join test on 123")
+        );
+        assertEquals(
+            "1:55: JOIN ON clause only supports fields at the moment, found [\"abc\"]",
+            error("row languages = 1, gender = \"f\" | lookup join test on \"abc\"")
+        );
+        assertEquals(
+            "1:55: JOIN ON clause only supports fields at the moment, found [false]",
+            error("row languages = 1, gender = \"f\" | lookup join test on false")
+        );
     }
 
     public void testJoinOnMultipleFields() {
         assumeTrue("LOOKUP JOIN available as snapshot only", EsqlCapabilities.Cap.JOIN_LOOKUP_V7.isEnabled());
-        assertEquals("1:35: JOIN ON clause only supports one field at the moment, found [2]",
-            error("row languages = 1, gender = \"f\" | lookup join test on gender, languages"));
+        assertEquals(
+            "1:35: JOIN ON clause only supports one field at the moment, found [2]",
+            error("row languages = 1, gender = \"f\" | lookup join test on gender, languages")
+        );
     }
 
     public void testJoinTwiceOnTheSameField() {
         assumeTrue("LOOKUP JOIN available as snapshot only", EsqlCapabilities.Cap.JOIN_LOOKUP_V7.isEnabled());
-        assertEquals("1:35: JOIN ON clause only supports one field at the moment, found [2]",
-            error("row languages = 1, gender = \"f\" | lookup join test on languages, languages"));
+        assertEquals(
+            "1:35: JOIN ON clause only supports one field at the moment, found [2]",
+            error("row languages = 1, gender = \"f\" | lookup join test on languages, languages")
+        );
     }
 
     public void testJoinTwiceOnTheSameField_TwoLookups() {
         assumeTrue("LOOKUP JOIN available as snapshot only", EsqlCapabilities.Cap.JOIN_LOOKUP_V7.isEnabled());
-        assertEquals("1:80: JOIN ON clause only supports one field at the moment, found [2]",
-            error("row languages = 1, gender = \"f\" | lookup join test on languages | eval x = 1 | lookup join test on gender, gender"));
+        assertEquals(
+            "1:80: JOIN ON clause only supports one field at the moment, found [2]",
+            error("row languages = 1, gender = \"f\" | lookup join test on languages | eval x = 1 | lookup join test on gender, gender")
+        );
     }
 
     private String functionName(EsqlFunctionRegistry registry, Expression functionCall) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ParsingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ParsingTests.java
@@ -111,6 +111,26 @@ public class ParsingTests extends ESTestCase {
         assertEquals("-1:-1: ESQL statement is too large [1000011 characters > 1000000]", error(query.toString()));
     }
 
+    public void testJoinOnConstant() {
+        assertEquals("1:55: JOIN ON clause only supports fields at the moment, found [123]",
+            error("row languages = 1, gender = \"f\" | lookup join test on 123"));
+    }
+
+    public void testJoinOnMultipleFields() {
+        assertEquals("1:35: JOIN ON clause only supports one field at the moment, found [2]",
+            error("row languages = 1, gender = \"f\" | lookup join test on gender, languages"));
+    }
+
+    public void testJoinTwiceOnTheSameField() {
+        assertEquals("1:35: JOIN ON clause only supports one field at the moment, found [2]",
+            error("row languages = 1, gender = \"f\" | lookup join test on languages, languages"));
+    }
+
+    public void testJoinTwiceOnTheSameField_TwoLookups() {
+        assertEquals("1:80: JOIN ON clause only supports one field at the moment, found [2]",
+            error("row languages = 1, gender = \"f\" | lookup join test on languages | eval x = 1 | lookup join test on gender, gender"));
+    }
+
     private String functionName(EsqlFunctionRegistry registry, Expression functionCall) {
         for (FunctionDefinition def : registry.listFunctions()) {
             if (functionCall.getClass().equals(def.clazz())) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ParsingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ParsingTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.LoadMapping;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
@@ -112,21 +113,29 @@ public class ParsingTests extends ESTestCase {
     }
 
     public void testJoinOnConstant() {
+        assumeTrue("LOOKUP JOIN available as snapshot only", EsqlCapabilities.Cap.JOIN_LOOKUP_V7.isEnabled());
         assertEquals("1:55: JOIN ON clause only supports fields at the moment, found [123]",
             error("row languages = 1, gender = \"f\" | lookup join test on 123"));
+        assertEquals("1:55: JOIN ON clause only supports fields at the moment, found [\"abc\"]",
+            error("row languages = 1, gender = \"f\" | lookup join test on \"abc\""));
+        assertEquals("1:55: JOIN ON clause only supports fields at the moment, found [false]",
+            error("row languages = 1, gender = \"f\" | lookup join test on false"));
     }
 
     public void testJoinOnMultipleFields() {
+        assumeTrue("LOOKUP JOIN available as snapshot only", EsqlCapabilities.Cap.JOIN_LOOKUP_V7.isEnabled());
         assertEquals("1:35: JOIN ON clause only supports one field at the moment, found [2]",
             error("row languages = 1, gender = \"f\" | lookup join test on gender, languages"));
     }
 
     public void testJoinTwiceOnTheSameField() {
+        assumeTrue("LOOKUP JOIN available as snapshot only", EsqlCapabilities.Cap.JOIN_LOOKUP_V7.isEnabled());
         assertEquals("1:35: JOIN ON clause only supports one field at the moment, found [2]",
             error("row languages = 1, gender = \"f\" | lookup join test on languages, languages"));
     }
 
     public void testJoinTwiceOnTheSameField_TwoLookups() {
+        assumeTrue("LOOKUP JOIN available as snapshot only", EsqlCapabilities.Cap.JOIN_LOOKUP_V7.isEnabled());
         assertEquals("1:80: JOIN ON clause only supports one field at the moment, found [2]",
             error("row languages = 1, gender = \"f\" | lookup join test on languages | eval x = 1 | lookup join test on gender, gender"));
     }


### PR DESCRIPTION
`lookup join`s shouldn't work on multiple join fields at the moment.
This PR also adds tests for another existent limitation: joining fields must be only actual index fields (not constants for example).