### PR TITLE
[8.x] EQL: add support for partial search results (#116388)

### DIFF
--- a/docs/changelog/116388.yaml
+++ b/docs/changelog/116388.yaml
@@ -1,0 +1,5 @@
+pr: 116388
+summary: Add support for partial shard results
+area: EQL
+type: enhancement
+issues: []

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -88,6 +88,53 @@ request that targets only `bar*` still returns an error.
 +
 Defaults to `true`.
 
+`allow_partial_search_results`::
+(Optional, Boolean)
+
+If `false`, the request returns an error if one or more shards involved in the query are unavailable.
++
+If `true`, the query is executed only on the available shards, ignoring shard request timeouts and
+<<shard-failures,shard failures>>.
++
+Defaults to `false`.
++
+To override the default for this field, set the
+`xpack.eql.default_allow_partial_results` cluster setting to `true`.
+
+
+[IMPORTANT]
+====
+You can also specify this value using the `allow_partial_search_results` request body parameter.
+If both parameters are specified, only the query parameter is used.
+====
+
+
+`allow_partial_sequence_results`::
+(Optional, Boolean)
+
+
+Used together with `allow_partial_search_results=true`, controls the behavior of sequence queries specifically
+(if `allow_partial_search_results=false`, this setting has no effect).
+If `true` and if some shards are unavailable, the sequences are calculated on available shards only.
++
+If `false` and if some shards are unavailable, the query only returns information about the shard failures,
+but no further results.
++
+Defaults to `false`.
++
+Consider that sequences calculated with `allow_partial_search_results=true` can return incorrect results
+(eg. if a <<eql-missing-events, missing event>> clause matches records in unavailable shards)
++
+To override the default for this field, set the
+`xpack.eql.default_allow_partial_sequence_results` cluster setting to `true`.
+
+
+[IMPORTANT]
+====
+You can also specify this value using the `allow_partial_sequence_results` request body parameter.
+If both parameters are specified, only the query parameter is used.
+====
+
 `ccs_minimize_roundtrips`::
 (Optional, Boolean) If `true`, network round-trips between the local and the
 remote cluster are minimized when running cross-cluster search (CCS) requests.

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
@@ -41,6 +41,16 @@
         "type": "time",
         "description": "Update the time interval in which the results (partial or final) for this search will be available",
         "default": "5d"
+      },
+      "allow_partial_search_results": {
+        "type":"boolean",
+        "description":"Control whether the query should keep running in case of shard failures, and return partial results",
+        "default":false
+      },
+      "allow_partial_sequence_results": {
+        "type":"boolean",
+        "description":"Control whether a sequence query should return partial results or no results at all in case of shard failures. This option has effect only if [allow_partial_search_results] is true.",
+        "default":false
       }
     },
     "body":{

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -146,6 +146,7 @@ public class TransportVersions {
     public static final TransportVersion KNN_QUERY_RESCORE_OVERSAMPLE = def(8_806_00_0);
     public static final TransportVersion SEMANTIC_QUERY_LENIENT = def(8_807_00_0);
     public static final TransportVersion ESQL_QUERY_BUILDER_IN_SEARCH_FUNCTIONS = def(8_808_00_0);
+    public static final TransportVersion EQL_ALLOW_PARTIAL_SEARCH_RESULTS = def(8_809_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/BaseEqlSpecTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/BaseEqlSpecTestCase.java
@@ -33,6 +33,9 @@ import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
 public abstract class BaseEqlSpecTestCase extends RemoteClusterAwareEqlRestTestCase {
 
     protected static final String PARAM_FORMATTING = "%2$s";
@@ -52,6 +55,9 @@ public abstract class BaseEqlSpecTestCase extends RemoteClusterAwareEqlRestTestC
      */
     private final int size;
     private final int maxSamplesPerKey;
+    private final Boolean allowPartialSearchResults;
+    private final Boolean allowPartialSequenceResults;
+    private final Boolean expectShardFailures;
 
     @Before
     public void setup() throws Exception {
@@ -104,7 +110,16 @@ public abstract class BaseEqlSpecTestCase extends RemoteClusterAwareEqlRestTestC
             }
 
             results.add(
-                new Object[] { spec.query(), name, spec.expectedEventIds(), spec.joinKeys(), spec.size(), spec.maxSamplesPerKey() }
+                new Object[] {
+                    spec.query(),
+                    name,
+                    spec.expectedEventIds(),
+                    spec.joinKeys(),
+                    spec.size(),
+                    spec.maxSamplesPerKey(),
+                    spec.allowPartialSearchResults(),
+                    spec.allowPartialSequenceResults(),
+                    spec.expectShardFailures() }
             );
         }
 
@@ -118,7 +133,10 @@ public abstract class BaseEqlSpecTestCase extends RemoteClusterAwareEqlRestTestC
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
         this.index = index;
 
@@ -128,6 +146,9 @@ public abstract class BaseEqlSpecTestCase extends RemoteClusterAwareEqlRestTestC
         this.joinKeys = joinKeys;
         this.size = size == null ? -1 : size;
         this.maxSamplesPerKey = maxSamplesPerKey == null ? -1 : maxSamplesPerKey;
+        this.allowPartialSearchResults = allowPartialSearchResults;
+        this.allowPartialSequenceResults = allowPartialSequenceResults;
+        this.expectShardFailures = expectShardFailures;
     }
 
     public void test() throws Exception {
@@ -137,6 +158,7 @@ public abstract class BaseEqlSpecTestCase extends RemoteClusterAwareEqlRestTestC
     private void assertResponse(ObjectPath response) throws Exception {
         List<Map<String, Object>> events = response.evaluate("hits.events");
         List<Map<String, Object>> sequences = response.evaluate("hits.sequences");
+        Object shardFailures = response.evaluate("shard_failures");
 
         if (events != null) {
             assertEvents(events);
@@ -145,6 +167,7 @@ public abstract class BaseEqlSpecTestCase extends RemoteClusterAwareEqlRestTestC
         } else {
             fail("No events or sequences found");
         }
+        assertShardFailures(shardFailures);
     }
 
     protected ObjectPath runQuery(String index, String query) throws Exception {
@@ -163,12 +186,55 @@ public abstract class BaseEqlSpecTestCase extends RemoteClusterAwareEqlRestTestC
         if (maxSamplesPerKey > 0) {
             builder.field("max_samples_per_key", maxSamplesPerKey);
         }
+        boolean allowPartialResultsInBody = randomBoolean();
+        if (allowPartialSearchResults != null) {
+            if (allowPartialResultsInBody) {
+                builder.field("allow_partial_search_results", String.valueOf(allowPartialSearchResults));
+                if (allowPartialSequenceResults != null) {
+                    builder.field("allow_partial_sequence_results", String.valueOf(allowPartialSequenceResults));
+                }
+            } else {
+                // these will be overwritten by the path params, that have higher priority than the query (JSON body) params
+                if (allowPartialSearchResults != null) {
+                    builder.field("allow_partial_search_results", randomBoolean());
+                }
+                if (allowPartialSequenceResults != null) {
+                    builder.field("allow_partial_sequence_results", randomBoolean());
+                }
+            }
+        } else {
+            // Tests that don't specify a setting for these parameters should always pass.
+            // These params should be irrelevant.
+            if (randomBoolean()) {
+                builder.field("allow_partial_search_results", randomBoolean());
+            }
+            if (randomBoolean()) {
+                builder.field("allow_partial_sequence_results", randomBoolean());
+            }
+        }
         builder.endObject();
 
         Request request = new Request("POST", "/" + index + "/_eql/search");
         Boolean ccsMinimizeRoundtrips = ccsMinimizeRoundtrips();
         if (ccsMinimizeRoundtrips != null) {
             request.addParameter("ccs_minimize_roundtrips", ccsMinimizeRoundtrips.toString());
+        }
+        if (allowPartialSearchResults != null) {
+            if (allowPartialResultsInBody == false) {
+                request.addParameter("allow_partial_search_results", String.valueOf(allowPartialSearchResults));
+                if (allowPartialSequenceResults != null) {
+                    request.addParameter("allow_partial_sequence_results", String.valueOf(allowPartialSequenceResults));
+                }
+            }
+        } else {
+            // Tests that don't specify a setting for these parameters should always pass.
+            // These params should be irrelevant.
+            if (randomBoolean()) {
+                request.addParameter("allow_partial_search_results", String.valueOf(randomBoolean()));
+            }
+            if (randomBoolean()) {
+                request.addParameter("allow_partial_sequence_results", String.valueOf(randomBoolean()));
+            }
         }
         int timeout = Math.toIntExact(timeout().millis());
         RequestConfig config = RequestConfig.copy(RequestConfig.DEFAULT)
@@ -180,6 +246,20 @@ public abstract class BaseEqlSpecTestCase extends RemoteClusterAwareEqlRestTestC
         request.setOptions(optionsBuilder.setRequestConfig(config).build());
         request.setJsonEntity(Strings.toString(builder));
         return ObjectPath.createFromResponse(client().performRequest(request));
+    }
+
+    private void assertShardFailures(Object shardFailures) {
+        if (expectShardFailures != null) {
+            if (expectShardFailures) {
+                assertNotNull(shardFailures);
+                List<?> list = (List<?>) shardFailures;
+                assertThat(list.size(), is(greaterThan(0)));
+            } else {
+                assertNull(shardFailures);
+            }
+        } else {
+            assertNull(shardFailures);
+        }
     }
 
     private void assertEvents(List<Map<String, Object>> events) {

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
@@ -52,6 +52,7 @@ import static org.junit.Assert.assertThat;
  */
 public class DataLoader {
     public static final String TEST_INDEX = "endgame-140";
+    public static final String TEST_SHARD_FAILURES_INDEX = "endgame-shard-failures";
     public static final String TEST_EXTRA_INDEX = "extra";
     public static final String TEST_NANOS_INDEX = "endgame-140-nanos";
     public static final String TEST_SAMPLE = "sample1,sample2,sample3";
@@ -103,6 +104,11 @@ public class DataLoader {
         //
         load(client, TEST_MISSING_EVENTS_INDEX, null, null, p);
         load(client, TEST_SAMPLE_MULTI, null, null, p);
+        //
+        // index with a runtime field ("broken", type long) that causes shard failures.
+        // the rest of the mapping is the same as TEST_INDEX
+        //
+        load(client, TEST_SHARD_FAILURES_INDEX, null, DataLoader::timestampToUnixMillis, p);
     }
 
     private static void load(

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlDateNanosSpecTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlDateNanosSpecTestCase.java
@@ -27,9 +27,23 @@ public abstract class EqlDateNanosSpecTestCase extends BaseEqlSpecTestCase {
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
-        this(TEST_NANOS_INDEX, query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+        this(
+            TEST_NANOS_INDEX,
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
     // constructor for multi-cluster tests
@@ -40,9 +54,23 @@ public abstract class EqlDateNanosSpecTestCase extends BaseEqlSpecTestCase {
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
-        super(index, query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+        super(
+            index,
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
     @Override

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlExtraSpecTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlExtraSpecTestCase.java
@@ -27,9 +27,23 @@ public abstract class EqlExtraSpecTestCase extends BaseEqlSpecTestCase {
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
-        this(TEST_EXTRA_INDEX, query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+        this(
+            TEST_EXTRA_INDEX,
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
     // constructor for multi-cluster tests
@@ -40,9 +54,23 @@ public abstract class EqlExtraSpecTestCase extends BaseEqlSpecTestCase {
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
-        super(index, query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+        super(
+            index,
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
     @Override

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlMissingEventsSpecTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlMissingEventsSpecTestCase.java
@@ -27,9 +27,23 @@ public abstract class EqlMissingEventsSpecTestCase extends BaseEqlSpecTestCase {
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
-        this(TEST_MISSING_EVENTS_INDEX, query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+        this(
+            TEST_MISSING_EVENTS_INDEX,
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
     // constructor for multi-cluster tests
@@ -40,9 +54,23 @@ public abstract class EqlMissingEventsSpecTestCase extends BaseEqlSpecTestCase {
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
-        super(index, query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+        super(
+            index,
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
     @Override

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSampleMultipleEntriesTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSampleMultipleEntriesTestCase.java
@@ -21,9 +21,23 @@ public abstract class EqlSampleMultipleEntriesTestCase extends BaseEqlSpecTestCa
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
-        this(TEST_SAMPLE_MULTI, query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+        this(
+            TEST_SAMPLE_MULTI,
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
     public EqlSampleMultipleEntriesTestCase(
@@ -33,9 +47,23 @@ public abstract class EqlSampleMultipleEntriesTestCase extends BaseEqlSpecTestCa
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
-        super(index, query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+        super(
+            index,
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
     @ParametersFactory(shuffle = false, argumentFormatting = PARAM_FORMATTING)

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpec.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpec.java
@@ -30,6 +30,9 @@ public class EqlSpec {
 
     private Integer size;
     private Integer maxSamplesPerKey;
+    private Boolean allowPartialSearchResults;
+    private Boolean allowPartialSequenceResults;
+    private Boolean expectShardFailures;
 
     public String name() {
         return name;
@@ -103,6 +106,30 @@ public class EqlSpec {
         this.maxSamplesPerKey = maxSamplesPerKey;
     }
 
+    public Boolean allowPartialSearchResults() {
+        return allowPartialSearchResults;
+    }
+
+    public void allowPartialSearchResults(Boolean allowPartialSearchResults) {
+        this.allowPartialSearchResults = allowPartialSearchResults;
+    }
+
+    public Boolean allowPartialSequenceResults() {
+        return allowPartialSequenceResults;
+    }
+
+    public void allowPartialSequenceResults(Boolean allowPartialSequenceResults) {
+        this.allowPartialSequenceResults = allowPartialSequenceResults;
+    }
+
+    public Boolean expectShardFailures() {
+        return expectShardFailures;
+    }
+
+    public void expectShardFailures(Boolean expectShardFailures) {
+        this.expectShardFailures = expectShardFailures;
+    }
+
     @Override
     public String toString() {
         String str = "";
@@ -132,7 +159,15 @@ public class EqlSpec {
         if (maxSamplesPerKey != null) {
             str = appendWithComma(str, "max_samples_per_key", "" + maxSamplesPerKey);
         }
-
+        if (allowPartialSearchResults != null) {
+            str = appendWithComma(str, "allow_partial_search_results", String.valueOf(allowPartialSearchResults));
+        }
+        if (allowPartialSequenceResults != null) {
+            str = appendWithComma(str, "allow_partial_sequence_results", String.valueOf(allowPartialSequenceResults));
+        }
+        if (expectShardFailures != null) {
+            str = appendWithComma(str, "expect_shard_failures", String.valueOf(expectShardFailures));
+        }
         return str;
     }
 
@@ -150,12 +185,22 @@ public class EqlSpec {
 
         return Objects.equals(this.query(), that.query())
             && Objects.equals(size, that.size)
-            && Objects.equals(maxSamplesPerKey, that.maxSamplesPerKey);
+            && Objects.equals(maxSamplesPerKey, that.maxSamplesPerKey)
+            && Objects.equals(allowPartialSearchResults, that.allowPartialSearchResults)
+            && Objects.equals(allowPartialSequenceResults, that.allowPartialSequenceResults)
+            && Objects.equals(expectShardFailures, that.expectShardFailures);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.query, size, maxSamplesPerKey);
+        return Objects.hash(
+            this.query,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
     private static String appendWithComma(String str, String name, String append) {

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpecFailingShardsTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpecFailingShardsTestCase.java
@@ -11,11 +11,25 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import java.util.List;
 
-import static org.elasticsearch.test.eql.DataLoader.TEST_SAMPLE;
+import static org.elasticsearch.test.eql.DataLoader.TEST_INDEX;
+import static org.elasticsearch.test.eql.DataLoader.TEST_SHARD_FAILURES_INDEX;
 
-public abstract class EqlSampleTestCase extends BaseEqlSpecTestCase {
+public abstract class EqlSpecFailingShardsTestCase extends BaseEqlSpecTestCase {
 
-    public EqlSampleTestCase(
+    @ParametersFactory(shuffle = false, argumentFormatting = PARAM_FORMATTING)
+    public static List<Object[]> readTestSpecs() throws Exception {
+
+        // Load EQL validation specs
+        return asArray(EqlSpecLoader.load("/test_failing_shards.toml"));
+    }
+
+    @Override
+    protected String tiebreaker() {
+        return "serial_event_id";
+    }
+
+    // constructor for "local" rest tests
+    public EqlSpecFailingShardsTestCase(
         String query,
         String name,
         List<long[]> eventIds,
@@ -27,7 +41,7 @@ public abstract class EqlSampleTestCase extends BaseEqlSpecTestCase {
         Boolean expectShardFailures
     ) {
         this(
-            TEST_SAMPLE,
+            TEST_INDEX + "," + TEST_SHARD_FAILURES_INDEX,
             query,
             name,
             eventIds,
@@ -40,7 +54,8 @@ public abstract class EqlSampleTestCase extends BaseEqlSpecTestCase {
         );
     }
 
-    public EqlSampleTestCase(
+    // constructor for multi-cluster tests
+    public EqlSpecFailingShardsTestCase(
         String index,
         String query,
         String name,
@@ -48,7 +63,7 @@ public abstract class EqlSampleTestCase extends BaseEqlSpecTestCase {
         String[] joinKeys,
         Integer size,
         Integer maxSamplesPerKey,
-        Boolean allowPartialSearchResults,
+        Boolean allowPartialSearch,
         Boolean allowPartialSequenceResults,
         Boolean expectShardFailures
     ) {
@@ -60,30 +75,9 @@ public abstract class EqlSampleTestCase extends BaseEqlSpecTestCase {
             joinKeys,
             size,
             maxSamplesPerKey,
-            allowPartialSearchResults,
+            allowPartialSearch,
             allowPartialSequenceResults,
             expectShardFailures
         );
-    }
-
-    @ParametersFactory(shuffle = false, argumentFormatting = PARAM_FORMATTING)
-    public static List<Object[]> readTestSpecs() throws Exception {
-        return asArray(EqlSpecLoader.load("/test_sample.toml"));
-    }
-
-    @Override
-    protected String tiebreaker() {
-        return null;
-    }
-
-    @Override
-    protected String idField() {
-        return "id";
-    }
-
-    @Override
-    protected int requestFetchSize() {
-        // a more relevant fetch_size value for Samples, from algorithm point of view, so we'll mostly test this value
-        return frequently() ? 2 : super.requestFetchSize();
     }
 }

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpecLoader.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpecLoader.java
@@ -76,6 +76,10 @@ public class EqlSpecLoader {
         return null;
     }
 
+    private static Boolean getBoolean(TomlTable table, String key) {
+        return table.getBoolean(key);
+    }
+
     private static List<EqlSpec> readFromStream(InputStream is, Set<String> uniqueTestNames) throws Exception {
         List<EqlSpec> testSpecs = new ArrayList<>();
 
@@ -90,6 +94,9 @@ public class EqlSpecLoader {
             spec.note(getTrimmedString(table, "note"));
             spec.description(getTrimmedString(table, "description"));
             spec.size(getInteger(table, "size"));
+            spec.allowPartialSearchResults(getBoolean(table, "allow_partial_search_results"));
+            spec.allowPartialSequenceResults(getBoolean(table, "allow_partial_sequence_results"));
+            spec.expectShardFailures(getBoolean(table, "expect_shard_failures"));
 
             List<?> arr = table.getList("tags");
             if (arr != null) {

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpecTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpecTestCase.java
@@ -28,8 +28,29 @@ public abstract class EqlSpecTestCase extends BaseEqlSpecTestCase {
     }
 
     // constructor for "local" rest tests
-    public EqlSpecTestCase(String query, String name, List<long[]> eventIds, String[] joinKeys, Integer size, Integer maxSamplesPerKey) {
-        this(TEST_INDEX, query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+    public EqlSpecTestCase(
+        String query,
+        String name,
+        List<long[]> eventIds,
+        String[] joinKeys,
+        Integer size,
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearch,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
+    ) {
+        this(
+            TEST_INDEX,
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearch,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
     // constructor for multi-cluster tests
@@ -40,8 +61,22 @@ public abstract class EqlSpecTestCase extends BaseEqlSpecTestCase {
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearch,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
-        super(index, query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+        super(
+            index,
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearch,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 }

--- a/x-pack/plugin/eql/qa/common/src/main/resources/data/endgame-shard-failures.data
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/data/endgame-shard-failures.data
@@ -1,0 +1,14 @@
+[
+  {
+    "event_subtype_full": "already_running",
+    "event_type": "process",
+    "event_type_full": "process_event",
+    "opcode": 3,
+    "pid": 0,
+    "process_name": "System Idle Process",
+    "serial_event_id": 10000,
+    "subtype": "create",
+    "timestamp": 117444736000000000,
+    "unique_pid": 1
+  }
+]

--- a/x-pack/plugin/eql/qa/common/src/main/resources/data/endgame-shard-failures.mapping
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/data/endgame-shard-failures.mapping
@@ -1,0 +1,105 @@
+# Text patterns like "[runtime_random_keyword_type]" will get replaced at runtime with a random string type.
+# See DataLoader class for pattern replacements.
+{
+    "runtime":{
+          "broken":{
+            "type": "long",
+            "script": {
+              "lang": "painless",
+              "source": "emit(doc['non_existing'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ENGLISH))"
+            }
+        }
+    },
+    "properties" : {
+        "command_line" : {
+            "type" : "[runtime_random_keyword_type]"
+        },
+        "event_type" : {
+            "type" : "[runtime_random_keyword_type]"
+        },
+        "event" : {
+            "properties" : {
+                "category" : {
+                    "type" : "alias",
+                    "path" : "event_type"
+                },
+                "sequence" : {
+                    "type" : "alias",
+                    "path" : "serial_event_id"
+                }
+            }
+        },
+        "md5" : {
+            "type" : "[runtime_random_keyword_type]"
+        },
+        "parent_process_name": {
+            "type" : "[runtime_random_keyword_type]"
+        },
+        "parent_process_path": {
+            "type" : "[runtime_random_keyword_type]"
+        },
+        "pid" : {
+            "type" : "long"
+        },
+        "ppid" : {
+            "type" : "long"
+        },
+        "process_name": {
+            "type" : "[runtime_random_keyword_type]"
+        },
+        "process_path": {
+            "type" : "[runtime_random_keyword_type]"
+        },
+        "subtype" : {
+            "type" : "[runtime_random_keyword_type]"
+        },
+        "timestamp" : {
+            "type" : "date"
+        },
+        "@timestamp" : {
+            "type" : "date"
+        },
+        "user" : {
+            "type" : "[runtime_random_keyword_type]"
+        },
+        "user_name" : {
+            "type" : "[runtime_random_keyword_type]"
+        },
+        "user_domain": {
+            "type" : "[runtime_random_keyword_type]"
+        },
+        "hostname" : {
+            "type" : "text",
+            "fields" : {
+                "[runtime_random_keyword_type]" : {
+                    "type" : "[runtime_random_keyword_type]",
+                    "ignore_above" : 256
+                }
+            }
+        },
+        "opcode" : {
+            "type" : "long"
+        },
+        "file_name" : {
+            "type" : "text",
+            "fields" : {
+                "[runtime_random_keyword_type]" : {
+                    "type" : "[runtime_random_keyword_type]",
+                    "ignore_above" : 256
+                }
+            }
+        },
+        "file_path" : {
+          "type" : "[runtime_random_keyword_type]"
+        },
+        "serial_event_id" : {
+            "type" : "long"
+        },
+        "source_address" : {
+            "type" : "ip"
+        },
+        "exit_code" : {
+            "type" : "long"
+        }
+    }
+}

--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_failing_shards.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_failing_shards.toml
@@ -1,0 +1,173 @@
+# this query doesn't touch the "broken" field, so it should not fail
+[[queries]]
+name = "eventQueryNoShardFailures"
+query = 'process where serial_event_id == 1'
+allow_partial_search_results = true
+expected_event_ids  = [1]
+expect_shard_failures = false
+
+
+[[queries]]
+name = "eventQueryShardFailures"
+query = 'process where serial_event_id == 1 or broken == 1'
+allow_partial_search_results = true
+expected_event_ids  = [1]
+expect_shard_failures = true
+
+
+[[queries]]
+name = "eventQueryShardFailuresOptionalField"
+query = 'process where serial_event_id == 1 and ?optional_field_default_null == null or broken == 1'
+allow_partial_search_results = true
+expected_event_ids  = [1]
+expect_shard_failures = true
+
+
+[[queries]]
+name = "eventQueryShardFailuresOptionalFieldMatching"
+query = 'process where serial_event_id == 2 and ?subtype == "create" or broken == 1'
+allow_partial_search_results = true
+expected_event_ids  = [2]
+expect_shard_failures = true
+
+
+# this query doesn't touch the "broken" field, so it should not fail
+[[queries]]
+name = "sequenceQueryNoShardFailures"
+query = '''
+sequence
+  [process where serial_event_id == 1]
+  [process where serial_event_id == 2]
+'''
+expected_event_ids  = [1, 2]
+expect_shard_failures = false
+
+
+# this query doesn't touch the "broken" field, so it should not fail
+[[queries]]
+name = "sequenceQueryNoShardFailuresAllowFalse"
+query = '''
+sequence
+  [process where serial_event_id == 1]
+  [process where serial_event_id == 2]
+'''
+allow_partial_search_results = false
+expected_event_ids  = [1, 2]
+expect_shard_failures = false
+
+
+# this query doesn't touch the "broken" field, so it should not fail
+[[queries]]
+name = "sequenceQueryNoShardFailuresAllowTrue"
+query = '''
+sequence
+  [process where serial_event_id == 1]
+  [process where serial_event_id == 2]
+'''
+allow_partial_search_results = true
+expected_event_ids  = [1, 2]
+expect_shard_failures = false
+
+
+[[queries]]
+name = "sequenceQueryMissingShards"
+query = '''
+sequence
+  [process where serial_event_id == 1 or broken == 1]
+  [process where serial_event_id == 2]
+'''
+allow_partial_search_results = true
+expected_event_ids  = []
+expect_shard_failures = true
+
+
+[[queries]]
+name = "sequenceQueryMissingShardsPartialResults"
+query = '''
+sequence
+  [process where serial_event_id == 1 or broken == 1]
+  [process where serial_event_id == 2]
+'''
+allow_partial_search_results = true
+allow_partial_sequence_results = true
+expected_event_ids  = [1, 2]
+expect_shard_failures = true
+
+
+[[queries]]
+name = "sequenceQueryMissingShardsPartialResultsOptional"
+query = '''
+sequence
+  [process where ?serial_event_id == 1 or broken == 1]
+  [process where serial_event_id == 2]
+'''
+allow_partial_search_results = true
+allow_partial_sequence_results = true
+expected_event_ids  = [1, 2]
+expect_shard_failures = true
+
+
+[[queries]]
+name = "sequenceQueryMissingShardsPartialResultsOptional2"
+query = '''
+sequence with maxspan=100000d
+  [process where serial_event_id == 1 and ?subtype == "create" or broken == 1]
+  [process where serial_event_id == 2]
+'''
+allow_partial_search_results = true
+allow_partial_sequence_results = true
+expected_event_ids  = [1, 2]
+expect_shard_failures = true
+
+
+[[queries]]
+name = "sequenceQueryMissingShardsPartialResultsOptionalMissing"
+query = '''
+sequence with maxspan=100000d
+  [process where serial_event_id == 1 and ?subtype == "create"]
+ ![process where broken == 1]
+  [process where serial_event_id == 2]
+'''
+allow_partial_search_results = true
+allow_partial_sequence_results = true
+expected_event_ids  = [1, -1, 2]
+expect_shard_failures = true
+
+
+[[queries]]
+name = "sequenceQueryMissingShardsPartialResultsOptionalMissing2"
+query = '''
+sequence with maxspan=100000d
+  [process where serial_event_id == 1 and ?subtype == "create" or broken == 1]
+ ![process where broken == 1]
+  [process where serial_event_id == 2]
+'''
+allow_partial_search_results = true
+allow_partial_sequence_results = true
+expected_event_ids  = [1, -1, 2]
+expect_shard_failures = true
+
+
+[[queries]]
+name = "sampleQueryMissingShardsPartialResults"
+query = '''
+sample by event_subtype_full
+  [process where serial_event_id == 1 or broken == 1]
+  [process where serial_event_id == 2]
+'''
+allow_partial_search_results = true
+expected_event_ids  = [1, 2]
+expect_shard_failures = true
+
+
+[[queries]]
+name = "sampleQueryMissingShardsPartialResultsOptional"
+query = '''
+sample by event_subtype_full
+  [process where serial_event_id == 1 and ?subtype == "create" or broken == 1]
+  [process where serial_event_id == 2]
+'''
+allow_partial_search_results = true
+expected_event_ids  = [1, 2]
+expect_shard_failures = true
+

--- a/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/EqlSearchIT.java
+++ b/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/EqlSearchIT.java
@@ -407,7 +407,16 @@ public class EqlSearchIT extends ESRestTestCase {
         for (int id : ids) {
             eventIds.add(String.valueOf(id));
         }
-        request.setJsonEntity("{\"query\":\"" + query + "\"}");
+
+        StringBuilder payload = new StringBuilder("{\"query\":\"" + query + "\"");
+        if (randomBoolean()) {
+            payload.append(", \"allow_partial_search_results\": true");
+        }
+        if (randomBoolean()) {
+            payload.append(", \"allow_partial_sequence_results\": true");
+        }
+        payload.append("}");
+        request.setJsonEntity(payload.toString());
         assertResponse(query, eventIds, runEql(client, request));
         testedFunctions.add(functionName);
     }

--- a/x-pack/plugin/eql/qa/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlDateNanosIT.java
+++ b/x-pack/plugin/eql/qa/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlDateNanosIT.java
@@ -37,7 +37,28 @@ public class EqlDateNanosIT extends EqlDateNanosSpecTestCase {
         return REMOTE_CLUSTER.getHttpAddresses();
     }
 
-    public EqlDateNanosIT(String query, String name, List<long[]> eventIds, String[] joinKeys, Integer size, Integer maxSamplesPerKey) {
-        super(remoteClusterIndex(TEST_NANOS_INDEX), query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+    public EqlDateNanosIT(
+        String query,
+        String name,
+        List<long[]> eventIds,
+        String[] joinKeys,
+        Integer size,
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
+    ) {
+        super(
+            remoteClusterIndex(TEST_NANOS_INDEX),
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 }

--- a/x-pack/plugin/eql/qa/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlExtraIT.java
+++ b/x-pack/plugin/eql/qa/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlExtraIT.java
@@ -37,7 +37,28 @@ public class EqlExtraIT extends EqlExtraSpecTestCase {
         return REMOTE_CLUSTER.getHttpAddresses();
     }
 
-    public EqlExtraIT(String query, String name, List<long[]> eventIds, String[] joinKeys, Integer size, Integer maxSamplesPerKey) {
-        super(remoteClusterIndex(TEST_EXTRA_INDEX), query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+    public EqlExtraIT(
+        String query,
+        String name,
+        List<long[]> eventIds,
+        String[] joinKeys,
+        Integer size,
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
+    ) {
+        super(
+            remoteClusterIndex(TEST_EXTRA_INDEX),
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 }

--- a/x-pack/plugin/eql/qa/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSampleIT.java
+++ b/x-pack/plugin/eql/qa/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSampleIT.java
@@ -37,7 +37,28 @@ public class EqlSampleIT extends EqlSampleTestCase {
         return REMOTE_CLUSTER.getHttpAddresses();
     }
 
-    public EqlSampleIT(String query, String name, List<long[]> eventIds, String[] joinKeys, Integer size, Integer maxSamplesPerKey) {
-        super(remoteClusterPattern(TEST_SAMPLE), query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+    public EqlSampleIT(
+        String query,
+        String name,
+        List<long[]> eventIds,
+        String[] joinKeys,
+        Integer size,
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
+    ) {
+        super(
+            remoteClusterPattern(TEST_SAMPLE),
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 }

--- a/x-pack/plugin/eql/qa/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSampleMultipleEntriesIT.java
+++ b/x-pack/plugin/eql/qa/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSampleMultipleEntriesIT.java
@@ -43,8 +43,22 @@ public class EqlSampleMultipleEntriesIT extends EqlSampleMultipleEntriesTestCase
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
-        super(remoteClusterPattern(TEST_SAMPLE_MULTI), query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+        super(
+            remoteClusterPattern(TEST_SAMPLE_MULTI),
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 }

--- a/x-pack/plugin/eql/qa/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSpecIT.java
+++ b/x-pack/plugin/eql/qa/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSpecIT.java
@@ -37,7 +37,28 @@ public class EqlSpecIT extends EqlSpecTestCase {
         return REMOTE_CLUSTER.getHttpAddresses();
     }
 
-    public EqlSpecIT(String query, String name, List<long[]> eventIds, String[] joinKeys, Integer size, Integer maxSamplesPerKey) {
-        super(remoteClusterIndex(TEST_INDEX), query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+    public EqlSpecIT(
+        String query,
+        String name,
+        List<long[]> eventIds,
+        String[] joinKeys,
+        Integer size,
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
+    ) {
+        super(
+            remoteClusterIndex(TEST_INDEX),
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 }

--- a/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlDateNanosIT.java
+++ b/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlDateNanosIT.java
@@ -27,7 +27,27 @@ public class EqlDateNanosIT extends EqlDateNanosSpecTestCase {
         return cluster.getHttpAddresses();
     }
 
-    public EqlDateNanosIT(String query, String name, List<long[]> eventIds, String[] joinKeys, Integer size, Integer maxSamplesPerKey) {
-        super(query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+    public EqlDateNanosIT(
+        String query,
+        String name,
+        List<long[]> eventIds,
+        String[] joinKeys,
+        Integer size,
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
+    ) {
+        super(
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 }

--- a/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlExtraIT.java
+++ b/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlExtraIT.java
@@ -27,7 +27,27 @@ public class EqlExtraIT extends EqlExtraSpecTestCase {
         return cluster.getHttpAddresses();
     }
 
-    public EqlExtraIT(String query, String name, List<long[]> eventIds, String[] joinKeys, Integer size, Integer maxSamplesPerKey) {
-        super(query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+    public EqlExtraIT(
+        String query,
+        String name,
+        List<long[]> eventIds,
+        String[] joinKeys,
+        Integer size,
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
+    ) {
+        super(
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 }

--- a/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlMissingEventsIT.java
+++ b/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlMissingEventsIT.java
@@ -27,8 +27,28 @@ public class EqlMissingEventsIT extends EqlMissingEventsSpecTestCase {
         return cluster.getHttpAddresses();
     }
 
-    public EqlMissingEventsIT(String query, String name, List<long[]> eventIds, String[] joinKeys, Integer size, Integer maxSamplesPerKey) {
-        super(query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+    public EqlMissingEventsIT(
+        String query,
+        String name,
+        List<long[]> eventIds,
+        String[] joinKeys,
+        Integer size,
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
+    ) {
+        super(
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
 }

--- a/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSampleIT.java
+++ b/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSampleIT.java
@@ -27,8 +27,28 @@ public class EqlSampleIT extends EqlSampleTestCase {
         return cluster.getHttpAddresses();
     }
 
-    public EqlSampleIT(String query, String name, List<long[]> eventIds, String[] joinKeys, Integer size, Integer maxSamplesPerKey) {
-        super(query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+    public EqlSampleIT(
+        String query,
+        String name,
+        List<long[]> eventIds,
+        String[] joinKeys,
+        Integer size,
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
+    ) {
+        super(
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
 }

--- a/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSampleMultipleEntriesIT.java
+++ b/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSampleMultipleEntriesIT.java
@@ -33,9 +33,22 @@ public class EqlSampleMultipleEntriesIT extends EqlSampleMultipleEntriesTestCase
         List<long[]> eventIds,
         String[] joinKeys,
         Integer size,
-        Integer maxSamplesPerKey
+        Integer maxSamplesPerKey,
+        Boolean allowPartialSearchResults,
+        Boolean allowPartialSequenceResults,
+        Boolean expectShardFailures
     ) {
-        super(query, name, eventIds, joinKeys, size, maxSamplesPerKey);
+        super(
+            query,
+            name,
+            eventIds,
+            joinKeys,
+            size,
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults,
+            expectShardFailures
+        );
     }
 
 }

--- a/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSpecFailingShardsIT.java
+++ b/x-pack/plugin/eql/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlSpecFailingShardsIT.java
@@ -11,13 +11,13 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
 import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.eql.EqlSpecTestCase;
+import org.elasticsearch.test.eql.EqlSpecFailingShardsTestCase;
 import org.junit.ClassRule;
 
 import java.util.List;
 
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
-public class EqlSpecIT extends EqlSpecTestCase {
+public class EqlSpecFailingShardsIT extends EqlSpecFailingShardsTestCase {
 
     @ClassRule
     public static final ElasticsearchCluster cluster = EqlTestCluster.CLUSTER;
@@ -27,7 +27,7 @@ public class EqlSpecIT extends EqlSpecTestCase {
         return cluster.getHttpAddresses();
     }
 
-    public EqlSpecIT(
+    public EqlSpecFailingShardsIT(
         String query,
         String name,
         List<long[]> eventIds,

--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
@@ -83,6 +83,34 @@ setup:
             id: 123
             valid: true
 
+  - do:
+      indices.create:
+        index:  eql_test_rebel
+        body:
+          mappings:
+            properties:
+              some_keyword:
+                type: keyword
+            runtime:
+              day_of_week:
+                type: keyword
+                script:
+                  source: "throw new IllegalArgumentException(\"rebel shards\")"
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: eql_test_rebel
+              _id:    "1"
+          - event:
+              - category: process
+            "@timestamp": 2020-02-03T12:34:56Z
+            user: SYSTEM
+            id: 123
+            valid: false
+            some_keyword: longer than normal
+
 ---
 # Testing round-trip and the basic shape of the response
 "Execute some EQL.":
@@ -478,3 +506,118 @@ setup:
           query: 'sequence with maxspan=10d [network where user == "ADMIN"] ![network where used == "SYSTEM"]'
   - match: { error.root_cause.0.type: "verification_exception" }
   - match: { error.root_cause.0.reason: "Found 1 problem\nline 1:75: Unknown column [used], did you mean [user]?" }
+
+
+---
+"Execute query shard failures and with allow_partial_search_results":
+  - do:
+      eql.search:
+        index: eql_test*
+        body:
+          query: 'process where user == "SYSTEM" and day_of_week == "Monday"'
+          fields: [{"field":"@timestamp","format":"epoch_millis"},"id","valid","day_of_week"]
+          allow_partial_search_results: true
+
+  - match: {timed_out: false}
+  - match: {hits.total.value: 1}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.events.0._source.user: "SYSTEM"}
+  - match: {hits.events.0._id: "1"}
+  - match: {hits.events.0.fields.@timestamp: ["1580733296000"]}
+  - match: {hits.events.0.fields.id: [123]}
+  - match: {hits.events.0.fields.valid: [false]}
+  - match: {hits.events.0.fields.day_of_week: ["Monday"]}
+  - match: {shard_failures.0.index: "eql_test_rebel"}
+
+
+---
+"Execute query shard failures and with allow_partial_search_results as request param":
+  - do:
+      eql.search:
+        index: eql_test*
+        allow_partial_search_results: true
+        body:
+          query: 'process where user == "SYSTEM" and day_of_week == "Monday"'
+          fields: [{"field":"@timestamp","format":"epoch_millis"},"id","valid","day_of_week"]
+
+  - match: {timed_out: false}
+  - match: {hits.total.value: 1}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.events.0._source.user: "SYSTEM"}
+  - match: {hits.events.0._id: "1"}
+  - match: {hits.events.0.fields.@timestamp: ["1580733296000"]}
+  - match: {hits.events.0.fields.id: [123]}
+  - match: {hits.events.0.fields.valid: [false]}
+  - match: {hits.events.0.fields.day_of_week: ["Monday"]}
+  - match: {shard_failures.0.index: "eql_test_rebel"}
+
+
+---
+"Execute sequence with shard failures and allow_partial_search_results=true":
+  - do:
+      eql.search:
+        index: eql_test*
+        body:
+          query: 'sequence [process where user == "SYSTEM" and day_of_week == "Monday"] [process where user == "SYSTEM" and day_of_week == "Tuesday"]'
+          fields: [{"field":"@timestamp","format":"epoch_millis"},"id","valid","day_of_week"]
+          allow_partial_search_results: true
+
+  - match: {timed_out: false}
+  - match: {hits.total.value: 0}
+  - match: {shard_failures.0.index: "eql_test_rebel"}
+
+
+---
+"Execute sequence with shard failures, allow_partial_search_results=true and allow_partial_sequence_results=true":
+  - do:
+      eql.search:
+        index: eql_test*
+        body:
+          query: 'sequence [process where user == "SYSTEM" and day_of_week == "Monday"] [process where user == "SYSTEM" and day_of_week == "Tuesday"]'
+          fields: [{"field":"@timestamp","format":"epoch_millis"},"id","valid","day_of_week"]
+          allow_partial_search_results: true
+          allow_partial_sequence_results: true
+
+  - match: {timed_out: false}
+  - match: {hits.total.value: 1}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.sequences.0.events.0._source.user: "SYSTEM"}
+  - match: {hits.sequences.0.events.0._id: "1"}
+  - match: {hits.sequences.0.events.0.fields.@timestamp: ["1580733296000"]}
+  - match: {hits.sequences.0.events.0.fields.id: [123]}
+  - match: {hits.sequences.0.events.0.fields.valid: [false]}
+  - match: {hits.sequences.0.events.0.fields.day_of_week: ["Monday"]}
+  - match: {hits.sequences.0.events.1._id: "2"}
+  - match: {hits.sequences.0.events.1.fields.@timestamp: ["1580819696000"]}
+  - match: {hits.sequences.0.events.1.fields.id: [123]}
+  - match: {hits.sequences.0.events.1.fields.valid: [true]}
+  - match: {hits.sequences.0.events.1.fields.day_of_week: ["Tuesday"]}
+  - match: {shard_failures.0.index: "eql_test_rebel"}
+
+
+---
+"Execute sequence with shard failures, allow_partial_search_results=true and allow_partial_sequence_results=true as query params":
+  - do:
+      eql.search:
+        index: eql_test*
+        allow_partial_search_results: true
+        allow_partial_sequence_results: true
+        body:
+          query: 'sequence [process where user == "SYSTEM" and day_of_week == "Monday"] [process where user == "SYSTEM" and day_of_week == "Tuesday"]'
+          fields: [{"field":"@timestamp","format":"epoch_millis"},"id","valid","day_of_week"]
+
+  - match: {timed_out: false}
+  - match: {hits.total.value: 1}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.sequences.0.events.0._source.user: "SYSTEM"}
+  - match: {hits.sequences.0.events.0._id: "1"}
+  - match: {hits.sequences.0.events.0.fields.@timestamp: ["1580733296000"]}
+  - match: {hits.sequences.0.events.0.fields.id: [123]}
+  - match: {hits.sequences.0.events.0.fields.valid: [false]}
+  - match: {hits.sequences.0.events.0.fields.day_of_week: ["Monday"]}
+  - match: {hits.sequences.0.events.1._id: "2"}
+  - match: {hits.sequences.0.events.1.fields.@timestamp: ["1580819696000"]}
+  - match: {hits.sequences.0.events.1.fields.id: [123]}
+  - match: {hits.sequences.0.events.1.fields.valid: [true]}
+  - match: {hits.sequences.0.events.1.fields.day_of_week: ["Tuesday"]}
+  - match: {shard_failures.0.index: "eql_test_rebel"}

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/CCSPartialResultsIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/CCSPartialResultsIT.java
@@ -1,0 +1,613 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.eql.action;
+
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsAction;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.AbstractMultiClustersTestCase;
+import org.elasticsearch.xpack.eql.plugin.EqlPlugin;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class CCSPartialResultsIT extends AbstractMultiClustersTestCase {
+
+    static String REMOTE_CLUSTER = "cluster_a";
+
+    protected Collection<Class<? extends Plugin>> nodePlugins(String cluster) {
+        return Collections.singletonList(LocalStateEQLXPackPlugin.class);
+    }
+
+    protected final Client localClient() {
+        return client(LOCAL_CLUSTER);
+    }
+
+    @Override
+    protected List<String> remoteClusterAlias() {
+        return List.of(REMOTE_CLUSTER);
+    }
+
+    @Override
+    protected boolean reuseClusters() {
+        return false;
+    }
+
+    /**
+     *
+     * @return remote node name
+     */
+    private String createSchema() {
+        final Client remoteClient = client(REMOTE_CLUSTER);
+        final String remoteNode = cluster(REMOTE_CLUSTER).startDataOnlyNode();
+        final String remoteNode2 = cluster(REMOTE_CLUSTER).startDataOnlyNode();
+
+        assertAcked(
+            remoteClient.admin()
+                .indices()
+                .prepareCreate("test-1-remote")
+                .setSettings(
+                    Settings.builder()
+                        .put("index.routing.allocation.require._name", remoteNode)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .build()
+                )
+                .setMapping("@timestamp", "type=date"),
+            TimeValue.timeValueSeconds(60)
+        );
+
+        assertAcked(
+            remoteClient.admin()
+                .indices()
+                .prepareCreate("test-2-remote")
+                .setSettings(
+                    Settings.builder()
+                        .put("index.routing.allocation.require._name", remoteNode2)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .build()
+                )
+                .setMapping("@timestamp", "type=date"),
+            TimeValue.timeValueSeconds(60)
+        );
+
+        for (int i = 0; i < 5; i++) {
+            int val = i * 2;
+            remoteClient.prepareIndex("test-1-remote")
+                .setId(Integer.toString(i))
+                .setSource("@timestamp", 100000 + val, "event.category", "process", "key", "same", "value", val)
+                .get();
+        }
+        for (int i = 0; i < 5; i++) {
+            int val = i * 2 + 1;
+            remoteClient.prepareIndex("test-2-remote")
+                .setId(Integer.toString(i))
+                .setSource("@timestamp", 100000 + val, "event.category", "process", "key", "same", "value", val)
+                .get();
+        }
+
+        remoteClient.admin().indices().prepareRefresh().get();
+        return remoteNode;
+    }
+
+    // ------------------------------------------------------------------------
+    // queries with full cluster (no missing shards)
+    // ------------------------------------------------------------------------
+
+    public void testNoFailures() throws ExecutionException, InterruptedException, IOException {
+        createSchema();
+
+        // event query
+        var request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("process where true")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        EqlSearchResponse response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().events().size(), equalTo(10));
+        for (int i = 0; i < 10; i++) {
+            assertThat(response.hits().events().get(i).toString(), containsString("\"value\" : " + i));
+        }
+        assertThat(response.shardFailures().length, is(0));
+
+        // sequence query on both shards
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 1] [process where value == 2]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        EqlSearchResponse.Sequence sequence = response.hits().sequences().get(0);
+        assertThat(sequence.events().get(0).toString(), containsString("\"value\" : 1"));
+        assertThat(sequence.events().get(1).toString(), containsString("\"value\" : 2"));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sequence query on the available shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 1] [process where value == 3]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        sequence = response.hits().sequences().get(0);
+        assertThat(sequence.events().get(0).toString(), containsString("\"value\" : 1"));
+        assertThat(sequence.events().get(1).toString(), containsString("\"value\" : 3"));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sequence query on the unavailable shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 0] [process where value == 2]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        sequence = response.hits().sequences().get(0);
+        assertThat(sequence.events().get(0).toString(), containsString("\"value\" : 0"));
+        assertThat(sequence.events().get(1).toString(), containsString("\"value\" : 2"));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sequence query with missing event on unavailable shard
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence with maxspan=10s [process where value == 1] ![process where value == 2] [process where value == 3]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sample query on both shards
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 2] [process where value == 1]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        EqlSearchResponse.Sequence sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 2"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 1"));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sample query on the available shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 3] [process where value == 1]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 3"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 1"));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sample query on the unavailable shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 2] [process where value == 0]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 2"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 0"));
+        assertThat(response.shardFailures().length, is(0));
+
+    }
+
+    // ------------------------------------------------------------------------
+    // same queries, with missing shards and allow_partial_search_results=true
+    // and allow_partial_sequence_result=true
+    // ------------------------------------------------------------------------
+
+    public void testAllowPartialSearchAndSequence_event() throws ExecutionException, InterruptedException, IOException {
+        var remoteNode = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        cluster(REMOTE_CLUSTER).stopNode(remoteNode);
+
+        // event query
+        var request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("process where true")
+            .allowPartialSearchResults(true);
+        var response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().events().size(), equalTo(5));
+        for (int i = 0; i < 5; i++) {
+            assertThat(response.hits().events().get(i).toString(), containsString("\"value\" : " + (i * 2 + 1)));
+        }
+        assertThat(response.shardFailures().length, is(1));
+    }
+
+    public void testAllowPartialSearchAndSequence_sequence() throws ExecutionException, InterruptedException, IOException {
+        var remoteNode = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        cluster(REMOTE_CLUSTER).stopNode(remoteNode);
+
+        // sequence query on both shards
+        var request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 1] [process where value == 2]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        var response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the available shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 1] [process where value == 3]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        var sequence = response.hits().sequences().get(0);
+        assertThat(sequence.events().get(0).toString(), containsString("\"value\" : 1"));
+        assertThat(sequence.events().get(1).toString(), containsString("\"value\" : 3"));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the unavailable shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 0] [process where value == 2]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query with missing event on unavailable shard. THIS IS A FALSE POSITIVE
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence with maxspan=10s  [process where value == 1] ![process where value == 2] [process where value == 3]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        sequence = response.hits().sequences().get(0);
+        assertThat(sequence.events().get(0).toString(), containsString("\"value\" : 1"));
+        assertThat(sequence.events().get(2).toString(), containsString("\"value\" : 3"));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+    }
+
+    public void testAllowPartialSearchAndSequence_sample() throws ExecutionException, InterruptedException, IOException {
+        var remoteNode = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        cluster(REMOTE_CLUSTER).stopNode(remoteNode);
+
+        // sample query on both shards
+        var request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 2] [process where value == 1]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        var response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the available shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 3] [process where value == 1]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        var sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 3"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 1"));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the unavailable shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 2] [process where value == 0]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+    }
+
+    // ------------------------------------------------------------------------
+    // same queries, with missing shards and allow_partial_search_results=true
+    // and default allow_partial_sequence_results (ie. false)
+    // ------------------------------------------------------------------------
+
+    public void testAllowPartialSearch_event() throws ExecutionException, InterruptedException, IOException {
+        var remoteNode = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        cluster(REMOTE_CLUSTER).stopNode(remoteNode);
+
+        // event query
+        var request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("process where true")
+            .allowPartialSearchResults(true);
+        var response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().events().size(), equalTo(5));
+        for (int i = 0; i < 5; i++) {
+            assertThat(response.hits().events().get(i).toString(), containsString("\"value\" : " + (i * 2 + 1)));
+        }
+        assertThat(response.shardFailures().length, is(1));
+
+    }
+
+    public void testAllowPartialSearch_sequence() throws ExecutionException, InterruptedException, IOException {
+        var remoteNode = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        cluster(REMOTE_CLUSTER).stopNode(remoteNode);
+
+        // sequence query on both shards
+        var request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 1] [process where value == 2]")
+            .allowPartialSearchResults(true);
+        var response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the available shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 1] [process where value == 3]")
+            .allowPartialSearchResults(true);
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the unavailable shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 0] [process where value == 2]")
+            .allowPartialSearchResults(true);
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query with missing event on unavailable shard. THIS IS A FALSE POSITIVE
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence with maxspan=10s  [process where value == 1] ![process where value == 2] [process where value == 3]")
+            .allowPartialSearchResults(true);
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+    }
+
+    public void testAllowPartialSearch_sample() throws ExecutionException, InterruptedException, IOException {
+        var remoteNode = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        cluster(REMOTE_CLUSTER).stopNode(remoteNode);
+
+        // sample query on both shards
+        var request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 2] [process where value == 1]")
+            .allowPartialSearchResults(true);
+        var response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the available shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 3] [process where value == 1]")
+            .allowPartialSearchResults(true);
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        var sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 3"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 1"));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the unavailable shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 2] [process where value == 0]")
+            .allowPartialSearchResults(true);
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+    }
+
+    // ------------------------------------------------------------------------
+    // same queries, with missing shards and with default xpack.eql.default_allow_partial_results=true
+    // ------------------------------------------------------------------------
+
+    public void testClusterSetting_event() throws ExecutionException, InterruptedException, IOException {
+        var remoteNode = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        cluster(REMOTE_CLUSTER).stopNode(remoteNode);
+
+        cluster(REMOTE_CLUSTER).client()
+            .execute(
+                ClusterUpdateSettingsAction.INSTANCE,
+                new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                    Settings.builder().put(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey(), true)
+                )
+            )
+            .get();
+
+        // event query
+        var request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*").query("process where true");
+        var response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().events().size(), equalTo(5));
+        for (int i = 0; i < 5; i++) {
+            assertThat(response.hits().events().get(i).toString(), containsString("\"value\" : " + (i * 2 + 1)));
+        }
+        assertThat(response.shardFailures().length, is(1));
+
+        localClient().execute(
+            ClusterUpdateSettingsAction.INSTANCE,
+            new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                Settings.builder().putNull(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey())
+            )
+        ).get();
+    }
+
+    public void testClusterSetting_sequence() throws ExecutionException, InterruptedException, IOException {
+        var remoteNode = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        cluster(REMOTE_CLUSTER).stopNode(remoteNode);
+
+        cluster(REMOTE_CLUSTER).client()
+            .execute(
+                ClusterUpdateSettingsAction.INSTANCE,
+                new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                    Settings.builder().put(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey(), true)
+                )
+            )
+            .get();
+        // sequence query on both shards
+        var request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 1] [process where value == 2]");
+        var response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the available shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 1] [process where value == 3]");
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the unavailable shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence [process where value == 0] [process where value == 2]");
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query with missing event on unavailable shard. THIS IS A FALSE POSITIVE
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sequence with maxspan=10s  [process where value == 1] ![process where value == 2] [process where value == 3]");
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        localClient().execute(
+            ClusterUpdateSettingsAction.INSTANCE,
+            new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                Settings.builder().putNull(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey())
+            )
+        ).get();
+    }
+
+    public void testClusterSetting_sample() throws ExecutionException, InterruptedException, IOException {
+        var remoteNode = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        cluster(REMOTE_CLUSTER).stopNode(remoteNode);
+
+        cluster(REMOTE_CLUSTER).client()
+            .execute(
+                ClusterUpdateSettingsAction.INSTANCE,
+                new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                    Settings.builder().put(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey(), true)
+                )
+            )
+            .get();
+
+        // sample query on both shards
+        var request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 2] [process where value == 1]");
+        var response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the available shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 3] [process where value == 1]");
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        var sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 3"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 1"));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the unavailable shard only
+        request = new EqlSearchRequest().indices(REMOTE_CLUSTER + ":test-*")
+            .query("sample by key [process where value == 2] [process where value == 0]");
+        response = localClient().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1-remote"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        localClient().execute(
+            ClusterUpdateSettingsAction.INSTANCE,
+            new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                Settings.builder().putNull(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey())
+            )
+        ).get();
+    }
+}

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/PartialSearchResultsIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/PartialSearchResultsIT.java
@@ -1,0 +1,780 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.eql.action;
+
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsAction;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.SearchService;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
+import org.elasticsearch.xpack.eql.plugin.EqlAsyncGetResultAction;
+import org.elasticsearch.xpack.eql.plugin.EqlPlugin;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+public class PartialSearchResultsIT extends AbstractEqlIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopy(super.nodePlugins(), MockTransportService.TestPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(SearchService.KEEPALIVE_INTERVAL_SETTING.getKey(), TimeValue.timeValueMillis(randomIntBetween(100, 500)))
+            .build();
+    }
+
+    /**
+     *
+     * @return node name where the first index is
+     */
+    private String createSchema() {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        final List<String> dataNodes = internalCluster().clusterService()
+            .state()
+            .nodes()
+            .getDataNodes()
+            .values()
+            .stream()
+            .map(DiscoveryNode::getName)
+            .toList();
+        final String assignedNodeForIndex1 = randomFrom(dataNodes);
+
+        assertAcked(
+            indicesAdmin().prepareCreate("test-1")
+                .setSettings(
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put("index.routing.allocation.include._name", assignedNodeForIndex1)
+                        .build()
+                )
+                .setMapping("@timestamp", "type=date")
+        );
+        assertAcked(
+            indicesAdmin().prepareCreate("test-2")
+                .setSettings(
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put("index.routing.allocation.exclude._name", assignedNodeForIndex1)
+                        .build()
+                )
+                .setMapping("@timestamp", "type=date")
+        );
+
+        for (int i = 0; i < 5; i++) {
+            int val = i * 2;
+            prepareIndex("test-1").setId(Integer.toString(i))
+                .setSource("@timestamp", 100000 + val, "event.category", "process", "key", "same", "value", val)
+                .get();
+        }
+        for (int i = 0; i < 5; i++) {
+            int val = i * 2 + 1;
+            prepareIndex("test-2").setId(Integer.toString(i))
+                .setSource("@timestamp", 100000 + val, "event.category", "process", "key", "same", "value", val)
+                .get();
+        }
+        refresh();
+        return assignedNodeForIndex1;
+    }
+
+    public void testNoFailures() throws Exception {
+        createSchema();
+
+        // ------------------------------------------------------------------------
+        // queries with full cluster (no missing shards)
+        // ------------------------------------------------------------------------
+
+        // event query
+        var request = new EqlSearchRequest().indices("test-*")
+            .query("process where true")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        EqlSearchResponse response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().events().size(), equalTo(10));
+        for (int i = 0; i < 10; i++) {
+            assertThat(response.hits().events().get(i).toString(), containsString("\"value\" : " + i));
+        }
+        assertThat(response.shardFailures().length, is(0));
+
+        // sequence query on both shards
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sequence [process where value == 1] [process where value == 2]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        EqlSearchResponse.Sequence sequence = response.hits().sequences().get(0);
+        assertThat(sequence.events().get(0).toString(), containsString("\"value\" : 1"));
+        assertThat(sequence.events().get(1).toString(), containsString("\"value\" : 2"));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sequence query on the available shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sequence [process where value == 1] [process where value == 3]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        sequence = response.hits().sequences().get(0);
+        assertThat(sequence.events().get(0).toString(), containsString("\"value\" : 1"));
+        assertThat(sequence.events().get(1).toString(), containsString("\"value\" : 3"));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sequence query on the unavailable shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sequence [process where value == 0] [process where value == 2]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        sequence = response.hits().sequences().get(0);
+        assertThat(sequence.events().get(0).toString(), containsString("\"value\" : 0"));
+        assertThat(sequence.events().get(1).toString(), containsString("\"value\" : 2"));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sequence query with missing event on unavailable shard
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sequence with maxspan=10s [process where value == 1] ![process where value == 2] [process where value == 3]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sample query on both shards
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sample by key [process where value == 2] [process where value == 1]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        EqlSearchResponse.Sequence sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 2"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 1"));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sample query on the available shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sample by key [process where value == 3] [process where value == 1]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 3"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 1"));
+        assertThat(response.shardFailures().length, is(0));
+
+        // sample query on the unavailable shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sample by key [process where value == 2] [process where value == 0]")
+            .allowPartialSearchResults(randomBoolean())
+            .allowPartialSequenceResults(randomBoolean());
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 2"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 0"));
+        assertThat(response.shardFailures().length, is(0));
+
+    }
+
+    // ------------------------------------------------------------------------
+    // same queries, with missing shards. Let them fail
+    // allow_partial_sequence_results has no effect if allow_partial_sequence_results is not set to true.
+    // ------------------------------------------------------------------------
+
+    public void testFailures_event() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        // event query
+        shouldFail("process where true");
+
+    }
+
+    public void testFailures_sequence() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        // sequence query on both shards
+        shouldFail("sequence [process where value == 1] [process where value == 2]");
+
+        // sequence query on the available shard only
+        shouldFail("sequence [process where value == 1] [process where value == 3]");
+
+        // sequence query on the unavailable shard only
+        shouldFail("sequence [process where value == 0] [process where value == 2]");
+
+        // sequence query with missing event on unavailable shard.
+        shouldFail("sequence with maxspan=10s  [process where value == 1] ![process where value == 2] [process where value == 3]");
+    }
+
+    public void testFailures_sample() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        // sample query on both shards
+        shouldFail("sample by key [process where value == 2] [process where value == 1]");
+
+        // sample query on the available shard only
+        shouldFail("sample by key [process where value == 3] [process where value == 1]");
+
+        // sample query on the unavailable shard only
+        shouldFail("sample by key [process where value == 2] [process where value == 0]");
+
+    }
+
+    // ------------------------------------------------------------------------
+    // same queries, with missing shards and allow_partial_search_results=true
+    // and allow_partial_sequence_result=true
+    // ------------------------------------------------------------------------
+
+    public void testAllowPartialSearchAndSequenceResults_event() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        // event query
+        var request = new EqlSearchRequest().indices("test-*").query("process where true").allowPartialSearchResults(true);
+        var response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().events().size(), equalTo(5));
+        for (int i = 0; i < 5; i++) {
+            assertThat(response.hits().events().get(i).toString(), containsString("\"value\" : " + (i * 2 + 1)));
+        }
+        assertThat(response.shardFailures().length, is(1));
+
+    }
+
+    public void testAllowPartialSearchAndSequenceResults_sequence() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        // sequence query on both shards
+        var request = new EqlSearchRequest().indices("test-*")
+            .query("sequence [process where value == 1] [process where value == 2]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        var response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the available shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sequence [process where value == 1] [process where value == 3]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        var sequence = response.hits().sequences().get(0);
+        assertThat(sequence.events().get(0).toString(), containsString("\"value\" : 1"));
+        assertThat(sequence.events().get(1).toString(), containsString("\"value\" : 3"));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the unavailable shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sequence [process where value == 0] [process where value == 2]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query with missing event on unavailable shard. THIS IS A FALSE POSITIVE
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sequence with maxspan=10s  [process where value == 1] ![process where value == 2] [process where value == 3]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        sequence = response.hits().sequences().get(0);
+        assertThat(sequence.events().get(0).toString(), containsString("\"value\" : 1"));
+        assertThat(sequence.events().get(2).toString(), containsString("\"value\" : 3"));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+    }
+
+    public void testAllowPartialSearchAndSequenceResults_sample() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        // sample query on both shards
+        var request = new EqlSearchRequest().indices("test-*")
+            .query("sample by key [process where value == 2] [process where value == 1]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        var response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the available shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sample by key [process where value == 3] [process where value == 1]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        var sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 3"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 1"));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the unavailable shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sample by key [process where value == 2] [process where value == 0]")
+            .allowPartialSearchResults(true)
+            .allowPartialSequenceResults(true);
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+    }
+
+    // ------------------------------------------------------------------------
+    // same queries, with missing shards and allow_partial_search_results=true
+    // and default allow_partial_sequence_results (ie. false)
+    // ------------------------------------------------------------------------
+
+    public void testAllowPartialSearchResults_event() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        // event query
+        var request = new EqlSearchRequest().indices("test-*").query("process where true").allowPartialSearchResults(true);
+        var response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().events().size(), equalTo(5));
+        for (int i = 0; i < 5; i++) {
+            assertThat(response.hits().events().get(i).toString(), containsString("\"value\" : " + (i * 2 + 1)));
+        }
+        assertThat(response.shardFailures().length, is(1));
+
+    }
+
+    public void testAllowPartialSearchResults_sequence() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        // sequence query on both shards
+        var request = new EqlSearchRequest().indices("test-*")
+            .query("sequence [process where value == 1] [process where value == 2]")
+            .allowPartialSearchResults(true);
+        var response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the available shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sequence [process where value == 1] [process where value == 3]")
+            .allowPartialSearchResults(true);
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the unavailable shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sequence [process where value == 0] [process where value == 2]")
+            .allowPartialSearchResults(true);
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query with missing event on unavailable shard. THIS IS A FALSE POSITIVE
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sequence with maxspan=10s  [process where value == 1] ![process where value == 2] [process where value == 3]")
+            .allowPartialSearchResults(true);
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+    }
+
+    public void testAllowPartialSearchResults_sample() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        // sample query on both shards
+        var request = new EqlSearchRequest().indices("test-*")
+            .query("sample by key [process where value == 2] [process where value == 1]")
+            .allowPartialSearchResults(true);
+        var response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the available shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sample by key [process where value == 3] [process where value == 1]")
+            .allowPartialSearchResults(true);
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        var sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 3"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 1"));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the unavailable shard only
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sample by key [process where value == 2] [process where value == 0]")
+            .allowPartialSearchResults(true);
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+    }
+
+    // ------------------------------------------------------------------------
+    // same queries, this time async, with missing shards and allow_partial_search_results=true
+    // and default allow_partial_sequence_results (ie. false)
+    // ------------------------------------------------------------------------
+
+    public void testAsyncAllowPartialSearchResults_event() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        // event query
+        var response = runAsync("process where true", true);
+        assertThat(response.hits().events().size(), equalTo(5));
+        for (int i = 0; i < 5; i++) {
+            assertThat(response.hits().events().get(i).toString(), containsString("\"value\" : " + (i * 2 + 1)));
+        }
+        assertThat(response.shardFailures().length, is(1));
+
+    }
+
+    public void testAsyncAllowPartialSearchResults_sequence() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        // sequence query on both shards
+        var response = runAsync("sequence [process where value == 1] [process where value == 2]", true);
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the available shard only
+        response = runAsync("sequence [process where value == 1] [process where value == 3]", true);
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the unavailable shard only
+        response = runAsync("sequence [process where value == 0] [process where value == 2]", true);
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query with missing event on unavailable shard. THIS IS A FALSE POSITIVE
+        response = runAsync(
+            "sequence with maxspan=10s  [process where value == 1] ![process where value == 2] [process where value == 3]",
+            true
+        );
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+    }
+
+    public void testAsyncAllowPartialSearchResults_sample() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+        // sample query on both shards
+        var response = runAsync("sample by key [process where value == 2] [process where value == 1]", true);
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the available shard only
+        response = runAsync("sample by key [process where value == 3] [process where value == 1]", true);
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        var sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 3"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 1"));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the unavailable shard only
+        response = runAsync("sample by key [process where value == 2] [process where value == 0]", true);
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+    }
+
+    // ------------------------------------------------------------------------
+    // same queries, with missing shards and with default xpack.eql.default_allow_partial_results=true
+    // ------------------------------------------------------------------------
+
+    public void testClusterSetting_event() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        client().execute(
+            ClusterUpdateSettingsAction.INSTANCE,
+            new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                Settings.builder().put(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey(), true)
+            )
+        ).get();
+
+        // event query
+        var request = new EqlSearchRequest().indices("test-*").query("process where true");
+        var response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().events().size(), equalTo(5));
+        for (int i = 0; i < 5; i++) {
+            assertThat(response.hits().events().get(i).toString(), containsString("\"value\" : " + (i * 2 + 1)));
+        }
+        assertThat(response.shardFailures().length, is(1));
+
+        client().execute(
+            ClusterUpdateSettingsAction.INSTANCE,
+            new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                Settings.builder().putNull(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey())
+            )
+        ).get();
+    }
+
+    public void testClusterSetting_sequence() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        client().execute(
+            ClusterUpdateSettingsAction.INSTANCE,
+            new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                Settings.builder().put(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey(), true)
+            )
+        ).get();
+        // sequence query on both shards
+        var request = new EqlSearchRequest().indices("test-*").query("sequence [process where value == 1] [process where value == 2]");
+        var response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the available shard only
+        request = new EqlSearchRequest().indices("test-*").query("sequence [process where value == 1] [process where value == 3]");
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query on the unavailable shard only
+        request = new EqlSearchRequest().indices("test-*").query("sequence [process where value == 0] [process where value == 2]");
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sequence query with missing event on unavailable shard. THIS IS A FALSE POSITIVE
+        request = new EqlSearchRequest().indices("test-*")
+            .query("sequence with maxspan=10s  [process where value == 1] ![process where value == 2] [process where value == 3]");
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        client().execute(
+            ClusterUpdateSettingsAction.INSTANCE,
+            new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                Settings.builder().putNull(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey())
+            )
+        ).get();
+    }
+
+    public void testClusterSetting_sample() throws Exception {
+        final String assignedNodeForIndex1 = createSchema();
+        // ------------------------------------------------------------------------
+        // stop one of the nodes, make one of the shards unavailable
+        // ------------------------------------------------------------------------
+
+        internalCluster().stopNode(assignedNodeForIndex1);
+
+        client().execute(
+            ClusterUpdateSettingsAction.INSTANCE,
+            new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                Settings.builder().put(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey(), true)
+            )
+        ).get();
+
+        // sample query on both shards
+        var request = new EqlSearchRequest().indices("test-*").query("sample by key [process where value == 2] [process where value == 1]");
+        var response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the available shard only
+        request = new EqlSearchRequest().indices("test-*").query("sample by key [process where value == 3] [process where value == 1]");
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(1));
+        var sample = response.hits().sequences().get(0);
+        assertThat(sample.events().get(0).toString(), containsString("\"value\" : 3"));
+        assertThat(sample.events().get(1).toString(), containsString("\"value\" : 1"));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        // sample query on the unavailable shard only
+        request = new EqlSearchRequest().indices("test-*").query("sample by key [process where value == 2] [process where value == 0]");
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        assertThat(response.hits().sequences().size(), equalTo(0));
+        assertThat(response.shardFailures().length, is(1));
+        assertThat(response.shardFailures()[0].index(), is("test-1"));
+        assertThat(response.shardFailures()[0].reason(), containsString("NoShardAvailableActionException"));
+
+        client().execute(
+            ClusterUpdateSettingsAction.INSTANCE,
+            new ClusterUpdateSettingsRequest(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS).persistentSettings(
+                Settings.builder().putNull(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey())
+            )
+        ).get();
+    }
+
+    private static EqlSearchResponse runAsync(String query, Boolean allowPartialSearchResults) throws InterruptedException,
+        ExecutionException {
+        EqlSearchRequest request;
+        EqlSearchResponse response;
+        request = new EqlSearchRequest().indices("test-*").query(query).waitForCompletionTimeout(TimeValue.ZERO);
+        if (allowPartialSearchResults != null) {
+            request = request.allowPartialSearchResults(allowPartialSearchResults);
+        }
+        response = client().execute(EqlSearchAction.INSTANCE, request).get();
+        while (response.isRunning()) {
+            GetAsyncResultRequest getResultsRequest = new GetAsyncResultRequest(response.id()).setKeepAlive(TimeValue.timeValueMinutes(10))
+                .setWaitForCompletionTimeout(TimeValue.timeValueMillis(10));
+            response = client().execute(EqlAsyncGetResultAction.INSTANCE, getResultsRequest).get();
+        }
+        return response;
+    }
+
+    private static void shouldFail(String query) throws InterruptedException {
+        EqlSearchRequest request = new EqlSearchRequest().indices("test-*").query(query);
+        if (randomBoolean()) {
+            request = request.allowPartialSearchResults(false);
+        }
+        if (randomBoolean()) {
+            request = request.allowPartialSequenceResults(randomBoolean());
+        }
+        try {
+            client().execute(EqlSearchAction.INSTANCE, request).get();
+            fail();
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), instanceOf(SearchPhaseExecutionException.class));
+        }
+    }
+}

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -63,6 +63,8 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
     private List<FieldAndFormat> fetchFields;
     private Map<String, Object> runtimeMappings = emptyMap();
     private int maxSamplesPerKey = RequestDefaults.MAX_SAMPLES_PER_KEY;
+    private Boolean allowPartialSearchResults;
+    private Boolean allowPartialSequenceResults;
 
     // Async settings
     private TimeValue waitForCompletionTimeout = null;
@@ -83,6 +85,8 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
     static final String KEY_FETCH_FIELDS = "fields";
     static final String KEY_RUNTIME_MAPPINGS = "runtime_mappings";
     static final String KEY_MAX_SAMPLES_PER_KEY = "max_samples_per_key";
+    static final String KEY_ALLOW_PARTIAL_SEARCH_RESULTS = "allow_partial_search_results";
+    static final String KEY_ALLOW_PARTIAL_SEQUENCE_RESULTS = "allow_partial_sequence_results";
 
     static final ParseField FILTER = new ParseField(KEY_FILTER);
     static final ParseField TIMESTAMP_FIELD = new ParseField(KEY_TIMESTAMP_FIELD);
@@ -97,6 +101,8 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
     static final ParseField RESULT_POSITION = new ParseField(KEY_RESULT_POSITION);
     static final ParseField FETCH_FIELDS_FIELD = SearchSourceBuilder.FETCH_FIELDS_FIELD;
     static final ParseField MAX_SAMPLES_PER_KEY = new ParseField(KEY_MAX_SAMPLES_PER_KEY);
+    static final ParseField ALLOW_PARTIAL_SEARCH_RESULTS = new ParseField(KEY_ALLOW_PARTIAL_SEARCH_RESULTS);
+    static final ParseField ALLOW_PARTIAL_SEQUENCE_RESULTS = new ParseField(KEY_ALLOW_PARTIAL_SEQUENCE_RESULTS);
 
     private static final ObjectParser<EqlSearchRequest, Void> PARSER = objectParser(EqlSearchRequest::new);
 
@@ -134,6 +140,13 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
             maxSamplesPerKey = in.readInt();
+        }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.EQL_ALLOW_PARTIAL_SEARCH_RESULTS)) {
+            allowPartialSearchResults = in.readOptionalBoolean();
+            allowPartialSequenceResults = in.readOptionalBoolean();
+        } else {
+            allowPartialSearchResults = false;
+            allowPartialSequenceResults = false;
         }
     }
 
@@ -245,6 +258,8 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
             builder.field(KEY_RUNTIME_MAPPINGS, runtimeMappings);
         }
         builder.field(KEY_MAX_SAMPLES_PER_KEY, maxSamplesPerKey);
+        builder.field(KEY_ALLOW_PARTIAL_SEARCH_RESULTS, allowPartialSearchResults);
+        builder.field(KEY_ALLOW_PARTIAL_SEQUENCE_RESULTS, allowPartialSequenceResults);
 
         return builder;
     }
@@ -279,6 +294,8 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         parser.declareField(EqlSearchRequest::fetchFields, EqlSearchRequest::parseFetchFields, FETCH_FIELDS_FIELD, ValueType.VALUE_ARRAY);
         parser.declareObject(EqlSearchRequest::runtimeMappings, (p, c) -> p.map(), SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD);
         parser.declareInt(EqlSearchRequest::maxSamplesPerKey, MAX_SAMPLES_PER_KEY);
+        parser.declareBoolean(EqlSearchRequest::allowPartialSearchResults, ALLOW_PARTIAL_SEARCH_RESULTS);
+        parser.declareBoolean(EqlSearchRequest::allowPartialSequenceResults, ALLOW_PARTIAL_SEQUENCE_RESULTS);
         return parser;
     }
 
@@ -427,6 +444,24 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         return this;
     }
 
+    public Boolean allowPartialSearchResults() {
+        return allowPartialSearchResults;
+    }
+
+    public EqlSearchRequest allowPartialSearchResults(Boolean val) {
+        this.allowPartialSearchResults = val;
+        return this;
+    }
+
+    public Boolean allowPartialSequenceResults() {
+        return allowPartialSequenceResults;
+    }
+
+    public EqlSearchRequest allowPartialSequenceResults(Boolean val) {
+        this.allowPartialSequenceResults = val;
+        return this;
+    }
+
     private static List<FieldAndFormat> parseFetchFields(XContentParser parser) throws IOException {
         List<FieldAndFormat> result = new ArrayList<>();
         Token token = parser.currentToken();
@@ -470,6 +505,10 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
             out.writeInt(maxSamplesPerKey);
         }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.EQL_ALLOW_PARTIAL_SEARCH_RESULTS)) {
+            out.writeOptionalBoolean(allowPartialSearchResults);
+            out.writeOptionalBoolean(allowPartialSequenceResults);
+        }
     }
 
     @Override
@@ -496,7 +535,9 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
             && Objects.equals(resultPosition, that.resultPosition)
             && Objects.equals(fetchFields, that.fetchFields)
             && Objects.equals(runtimeMappings, that.runtimeMappings)
-            && Objects.equals(maxSamplesPerKey, that.maxSamplesPerKey);
+            && Objects.equals(maxSamplesPerKey, that.maxSamplesPerKey)
+            && Objects.equals(allowPartialSearchResults, that.allowPartialSearchResults)
+            && Objects.equals(allowPartialSequenceResults, that.allowPartialSequenceResults);
     }
 
     @Override
@@ -517,7 +558,9 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
             resultPosition,
             fetchFields,
             runtimeMappings,
-            maxSamplesPerKey
+            maxSamplesPerKey,
+            allowPartialSearchResults,
+            allowPartialSequenceResults
         );
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
@@ -7,8 +7,11 @@
 package org.elasticsearch.xpack.eql.action;
 
 import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -17,6 +20,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.core.Nullable;
@@ -36,6 +40,7 @@ import org.elasticsearch.xpack.ql.async.QlStatusResponse;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -54,6 +59,7 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
     private final String asyncExecutionId;
     private final boolean isRunning;
     private final boolean isPartial;
+    private final ShardSearchFailure[] shardFailures;
 
     private static final class Fields {
         static final String TOOK = "took";
@@ -62,6 +68,7 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         static final String ID = "id";
         static final String IS_RUNNING = "is_running";
         static final String IS_PARTIAL = "is_partial";
+        static final String SHARD_FAILURES = "shard_failures";
     }
 
     private static final ParseField TOOK = new ParseField(Fields.TOOK);
@@ -70,8 +77,10 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
     private static final ParseField ID = new ParseField(Fields.ID);
     private static final ParseField IS_RUNNING = new ParseField(Fields.IS_RUNNING);
     private static final ParseField IS_PARTIAL = new ParseField(Fields.IS_PARTIAL);
+    private static final ParseField SHARD_FAILURES = new ParseField(Fields.SHARD_FAILURES);
 
     private static final InstantiatingObjectParser<EqlSearchResponse, Void> PARSER;
+
     static {
         InstantiatingObjectParser.Builder<EqlSearchResponse, Void> parser = InstantiatingObjectParser.builder(
             "eql/search_response",
@@ -84,11 +93,12 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         parser.declareString(optionalConstructorArg(), ID);
         parser.declareBoolean(constructorArg(), IS_RUNNING);
         parser.declareBoolean(constructorArg(), IS_PARTIAL);
+        parser.declareObjectArray(optionalConstructorArg(), (p, c) -> ShardSearchFailure.EMPTY_ARRAY, SHARD_FAILURES);
         PARSER = parser.build();
     }
 
-    public EqlSearchResponse(Hits hits, long tookInMillis, boolean isTimeout) {
-        this(hits, tookInMillis, isTimeout, null, false, false);
+    public EqlSearchResponse(Hits hits, long tookInMillis, boolean isTimeout, ShardSearchFailure[] shardFailures) {
+        this(hits, tookInMillis, isTimeout, null, false, false, shardFailures);
     }
 
     public EqlSearchResponse(
@@ -97,7 +107,8 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         boolean isTimeout,
         String asyncExecutionId,
         boolean isRunning,
-        boolean isPartial
+        boolean isPartial,
+        ShardSearchFailure[] shardFailures
     ) {
         super();
         this.hits = hits == null ? Hits.EMPTY : hits;
@@ -106,6 +117,7 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         this.asyncExecutionId = asyncExecutionId;
         this.isRunning = isRunning;
         this.isPartial = isPartial;
+        this.shardFailures = shardFailures;
     }
 
     public EqlSearchResponse(StreamInput in) throws IOException {
@@ -116,6 +128,11 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         asyncExecutionId = in.readOptionalString();
         isPartial = in.readBoolean();
         isRunning = in.readBoolean();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.EQL_ALLOW_PARTIAL_SEARCH_RESULTS)) {
+            shardFailures = in.readArray(ShardSearchFailure::readShardSearchFailure, ShardSearchFailure[]::new);
+        } else {
+            shardFailures = ShardSearchFailure.EMPTY_ARRAY;
+        }
     }
 
     public static EqlSearchResponse fromXContent(XContentParser parser) {
@@ -130,6 +147,9 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         out.writeOptionalString(asyncExecutionId);
         out.writeBoolean(isPartial);
         out.writeBoolean(isRunning);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.EQL_ALLOW_PARTIAL_SEARCH_RESULTS)) {
+            out.writeArray(shardFailures);
+        }
     }
 
     @Override
@@ -147,6 +167,13 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         builder.field(IS_RUNNING.getPreferredName(), isRunning);
         builder.field(TOOK.getPreferredName(), tookInMillis);
         builder.field(TIMED_OUT.getPreferredName(), isTimeout);
+        if (CollectionUtils.isEmpty(shardFailures) == false) {
+            builder.startArray(SHARD_FAILURES.getPreferredName());
+            for (ShardOperationFailedException shardFailure : ExceptionsHelper.groupBy(shardFailures)) {
+                shardFailure.toXContent(builder, params);
+            }
+            builder.endArray();
+        }
         hits.toXContent(builder, params);
         return builder;
     }
@@ -178,6 +205,10 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         return isPartial;
     }
 
+    public ShardSearchFailure[] shardFailures() {
+        return shardFailures;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -190,12 +221,13 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         return Objects.equals(hits, that.hits)
             && Objects.equals(tookInMillis, that.tookInMillis)
             && Objects.equals(isTimeout, that.isTimeout)
-            && Objects.equals(asyncExecutionId, that.asyncExecutionId);
+            && Objects.equals(asyncExecutionId, that.asyncExecutionId)
+            && Arrays.equals(shardFailures, that.shardFailures);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(hits, tookInMillis, isTimeout, asyncExecutionId);
+        return Objects.hash(hits, tookInMillis, isTimeout, asyncExecutionId, Arrays.hashCode(shardFailures));
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchTask.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchTask.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.eql.action;
 
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.async.AsyncExecutionId;
@@ -39,7 +40,8 @@ public class EqlSearchTask extends StoredAsyncTask<EqlSearchResponse> {
             false,
             getExecutionId().getEncoded(),
             true,
-            true
+            true,
+            ShardSearchFailure.EMPTY_ARRAY
         );
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
@@ -167,7 +167,9 @@ public class ExecutionManager {
             criteria.subList(0, completionStage),
             criteria.get(completionStage),
             matcher,
-            listOfKeys
+            listOfKeys,
+            cfg.allowPartialSearchResults(),
+            cfg.allowPartialSequenceResults()
         );
 
         return w;
@@ -235,7 +237,8 @@ public class ExecutionManager {
             cfg.fetchSize(),
             limit,
             session.circuitBreaker(),
-            cfg.maxSamplesPerKey()
+            cfg.maxSamplesPerKey(),
+            cfg.allowPartialSearchResults()
         );
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/payload/AbstractPayload.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/payload/AbstractPayload.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.eql.execution.payload;
 
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.eql.session.Payload;
 
@@ -14,10 +15,12 @@ public abstract class AbstractPayload implements Payload {
 
     private final boolean timedOut;
     private final TimeValue timeTook;
+    private ShardSearchFailure[] shardFailures;
 
-    protected AbstractPayload(boolean timedOut, TimeValue timeTook) {
+    protected AbstractPayload(boolean timedOut, TimeValue timeTook, ShardSearchFailure[] shardFailures) {
         this.timedOut = timedOut;
         this.timeTook = timeTook;
+        this.shardFailures = shardFailures;
     }
 
     @Override
@@ -28,5 +31,10 @@ public abstract class AbstractPayload implements Payload {
     @Override
     public TimeValue timeTook() {
         return timeTook;
+    }
+
+    @Override
+    public ShardSearchFailure[] shardFailures() {
+        return shardFailures;
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/payload/EventPayload.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/payload/EventPayload.java
@@ -20,7 +20,7 @@ public class EventPayload extends AbstractPayload {
     private final List<Event> values;
 
     public EventPayload(SearchResponse response) {
-        super(response.isTimedOut(), response.getTook());
+        super(response.isTimedOut(), response.getTook(), response.getShardFailures());
 
         SearchHits hits = response.getHits();
         values = new ArrayList<>(hits.getHits().length);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sample/SamplePayload.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sample/SamplePayload.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.eql.execution.sample;
 
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.eql.action.EqlSearchResponse.Event;
@@ -19,8 +20,14 @@ class SamplePayload extends AbstractPayload {
 
     private final List<org.elasticsearch.xpack.eql.action.EqlSearchResponse.Sequence> values;
 
-    SamplePayload(List<Sample> samples, List<List<SearchHit>> docs, boolean timedOut, TimeValue timeTook) {
-        super(timedOut, timeTook);
+    SamplePayload(
+        List<Sample> samples,
+        List<List<SearchHit>> docs,
+        boolean timedOut,
+        TimeValue timeTook,
+        ShardSearchFailure[] shardFailures
+    ) {
+        super(timedOut, timeTook, shardFailures);
         values = new ArrayList<>(samples.size());
 
         for (int i = 0; i < samples.size(); i++) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
@@ -56,38 +56,38 @@ public class PITAwareQueryClient extends BasicQueryClient {
     }
 
     @Override
-    protected void search(SearchRequest search, ActionListener<SearchResponse> listener) {
+    protected void search(SearchRequest search, boolean allowPartialSearchResults, ActionListener<SearchResponse> listener) {
         // no pitId, ask for one
         if (pitId == null) {
-            openPIT(listener, () -> searchWithPIT(search, listener));
+            openPIT(listener, () -> searchWithPIT(search, listener, allowPartialSearchResults), allowPartialSearchResults);
         } else {
-            searchWithPIT(search, listener);
+            searchWithPIT(search, listener, allowPartialSearchResults);
         }
     }
 
-    private void searchWithPIT(SearchRequest request, ActionListener<SearchResponse> listener) {
+    private void searchWithPIT(SearchRequest request, ActionListener<SearchResponse> listener, boolean allowPartialSearchResults) {
         makeRequestPITCompatible(request);
         // get the pid on each response
-        super.search(request, pitListener(SearchResponse::pointInTimeId, listener));
+        super.search(request, allowPartialSearchResults, pitListener(SearchResponse::pointInTimeId, listener));
     }
 
     @Override
-    protected void search(MultiSearchRequest search, ActionListener<MultiSearchResponse> listener) {
+    protected void search(MultiSearchRequest search, boolean allowPartialSearchResults, ActionListener<MultiSearchResponse> listener) {
         // no pitId, ask for one
         if (pitId == null) {
-            openPIT(listener, () -> searchWithPIT(search, listener));
+            openPIT(listener, () -> searchWithPIT(search, allowPartialSearchResults, listener), allowPartialSearchResults);
         } else {
-            searchWithPIT(search, listener);
+            searchWithPIT(search, allowPartialSearchResults, listener);
         }
     }
 
-    private void searchWithPIT(MultiSearchRequest search, ActionListener<MultiSearchResponse> listener) {
+    private void searchWithPIT(MultiSearchRequest search, boolean allowPartialSearchResults, ActionListener<MultiSearchResponse> listener) {
         for (SearchRequest request : search.requests()) {
             makeRequestPITCompatible(request);
         }
 
         // get the pid on each request
-        super.search(search, pitListener(r -> {
+        super.search(search, allowPartialSearchResults, pitListener(r -> {
             // get pid
             for (MultiSearchResponse.Item item : r.getResponses()) {
                 // pick the first non-failing response
@@ -135,9 +135,10 @@ public class PITAwareQueryClient extends BasicQueryClient {
         );
     }
 
-    private <Response> void openPIT(ActionListener<Response> listener, Runnable runnable) {
+    private <Response> void openPIT(ActionListener<Response> listener, Runnable runnable, boolean allowPartialSearchResults) {
         OpenPointInTimeRequest request = new OpenPointInTimeRequest(indices).indicesOptions(IndexResolver.FIELD_CAPS_INDICES_OPTIONS)
-            .keepAlive(keepAlive);
+            .keepAlive(keepAlive)
+            .allowPartialSearchResults(allowPartialSearchResults);
         request.indexFilter(filter);
         client.execute(TransportOpenPointInTimeAction.TYPE, request, listener.delegateFailureAndWrap((l, r) -> {
             pitId = r.getPointInTimeId();

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequencePayload.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequencePayload.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.eql.execution.sequence;
 
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.eql.action.EqlSearchResponse.Event;
@@ -19,8 +20,14 @@ class SequencePayload extends AbstractPayload {
 
     private final List<org.elasticsearch.xpack.eql.action.EqlSearchResponse.Sequence> values;
 
-    SequencePayload(List<Sequence> sequences, List<List<SearchHit>> docs, boolean timedOut, TimeValue timeTook) {
-        super(timedOut, timeTook);
+    SequencePayload(
+        List<Sequence> sequences,
+        List<List<SearchHit>> docs,
+        boolean timedOut,
+        TimeValue timeTook,
+        ShardSearchFailure[] shardFailures
+    ) {
+        super(timedOut, timeTook, shardFailures);
         values = new ArrayList<>(sequences.size());
 
         for (int i = 0; i < sequences.size(); i++) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -41,6 +42,7 @@ import org.elasticsearch.xpack.ql.util.CollectionUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -51,6 +53,7 @@ import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.action.ActionListener.runAfter;
 import static org.elasticsearch.xpack.eql.execution.ExecutionUtils.copySource;
 import static org.elasticsearch.xpack.eql.execution.search.RuntimeUtils.combineFilters;
+import static org.elasticsearch.xpack.eql.util.SearchHitUtils.addShardFailures;
 import static org.elasticsearch.xpack.eql.util.SearchHitUtils.qualifiedIndex;
 
 /**
@@ -103,6 +106,9 @@ public class TumblingWindow implements Executable {
 
     private final boolean hasKeys;
     private final List<List<Attribute>> listOfKeys;
+    private final boolean allowPartialSearchResults;
+    private final boolean allowPartialSequenceResults;
+    private Map<String, ShardSearchFailure> shardFailures = new HashMap<>();
 
     // flag used for DESC sequences to indicate whether
     // the window needs to restart (since the DESC query still has results)
@@ -127,7 +133,10 @@ public class TumblingWindow implements Executable {
         List<SequenceCriterion> criteria,
         SequenceCriterion until,
         SequenceMatcher matcher,
-        List<List<Attribute>> listOfKeys
+        List<List<Attribute>> listOfKeys,
+        boolean allowPartialSearchResults,
+        boolean allowPartialSequenceResults
+
     ) {
         this.client = client;
 
@@ -141,6 +150,8 @@ public class TumblingWindow implements Executable {
         this.hasKeys = baseRequest.keySize() > 0;
         this.restartWindowFromTailQuery = baseRequest.descending();
         this.listOfKeys = listOfKeys;
+        this.allowPartialSearchResults = allowPartialSearchResults;
+        this.allowPartialSequenceResults = allowPartialSequenceResults;
     }
 
     @Override
@@ -158,6 +169,9 @@ public class TumblingWindow implements Executable {
      * Move the window while preserving the same base.
      */
     private void tumbleWindow(int currentStage, ActionListener<Payload> listener) {
+        if (allowPartialSequenceResults == false && shardFailures.isEmpty() == false) {
+            doPayload(listener);
+        }
         if (currentStage > matcher.firstPositiveStage && matcher.hasCandidates() == false) {
             if (restartWindowFromTailQuery) {
                 currentStage = matcher.firstPositiveStage;
@@ -224,6 +238,9 @@ public class TumblingWindow implements Executable {
 
     private void doCheckMissingEvents(List<Sequence> batchToCheck, MultiSearchResponse p, ActionListener<Payload> listener, Runnable next) {
         MultiSearchResponse.Item[] responses = p.getResponses();
+        for (MultiSearchResponse.Item response : responses) {
+            addShardFailures(shardFailures, response.getResponse());
+        }
         int nextResponse = 0;
         for (Sequence sequence : batchToCheck) {
             boolean leading = true;
@@ -316,7 +333,14 @@ public class TumblingWindow implements Executable {
                     }
                     addKeyFilter(i, sequence, builder);
                     RuntimeUtils.combineFilters(builder, range);
-                    result.add(RuntimeUtils.prepareRequest(builder.size(1).trackTotalHits(false), false, Strings.EMPTY_ARRAY));
+                    result.add(
+                        RuntimeUtils.prepareRequest(
+                            builder.size(1).trackTotalHits(false),
+                            false,
+                            allowPartialSearchResults,
+                            Strings.EMPTY_ARRAY
+                        )
+                    );
                 } else {
                     leading = false;
                 }
@@ -361,6 +385,7 @@ public class TumblingWindow implements Executable {
      * Execute the base query.
      */
     private void baseCriterion(int baseStage, SearchResponse r, ActionListener<Payload> listener) {
+        addShardFailures(shardFailures, r);
         SequenceCriterion base = criteria.get(baseStage);
         SearchHits hits = r.getHits();
 
@@ -731,8 +756,10 @@ public class TumblingWindow implements Executable {
 
         log.trace("Sending payload for [{}] sequences", completed.size());
 
-        if (completed.isEmpty()) {
-            listener.onResponse(new EmptyPayload(Type.SEQUENCE, timeTook()));
+        if (completed.isEmpty() || (allowPartialSequenceResults == false && shardFailures.isEmpty() == false)) {
+            listener.onResponse(
+                new EmptyPayload(Type.SEQUENCE, timeTook(), shardFailures.values().toArray(new ShardSearchFailure[shardFailures.size()]))
+            );
             return;
         }
 
@@ -741,7 +768,13 @@ public class TumblingWindow implements Executable {
             if (criteria.get(matcher.firstPositiveStage).descending()) {
                 Collections.reverse(completed);
             }
-            return new SequencePayload(completed, addMissingEventPlaceholders(listOfHits), false, timeTook());
+            return new SequencePayload(
+                completed,
+                addMissingEventPlaceholders(listOfHits),
+                false,
+                timeTook(),
+                shardFailures.values().toArray(new ShardSearchFailure[0])
+            );
         }));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/EqlPlugin.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/EqlPlugin.java
@@ -60,6 +60,20 @@ public class EqlPlugin extends Plugin implements ActionPlugin, CircuitBreakerPlu
         Setting.Property.DeprecatedWarning
     );
 
+    public static final Setting<Boolean> DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS = Setting.boolSetting(
+        "xpack.eql.default_allow_partial_results",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    public static final Setting<Boolean> DEFAULT_ALLOW_PARTIAL_SEQUENCE_RESULTS = Setting.boolSetting(
+        "xpack.eql.default_allow_partial_sequence_results",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     public EqlPlugin() {}
 
     @Override
@@ -86,7 +100,7 @@ public class EqlPlugin extends Plugin implements ActionPlugin, CircuitBreakerPlu
      */
     @Override
     public List<Setting<?>> getSettings() {
-        return List.of(EQL_ENABLED_SETTING);
+        return List.of(EQL_ENABLED_SETTING, DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS, DEFAULT_ALLOW_PARTIAL_SEQUENCE_RESULTS);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/RestEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/RestEqlSearchAction.java
@@ -64,6 +64,12 @@ public class RestEqlSearchAction extends BaseRestHandler {
             }
             eqlRequest.keepOnCompletion(request.paramAsBoolean("keep_on_completion", eqlRequest.keepOnCompletion()));
             eqlRequest.ccsMinimizeRoundtrips(request.paramAsBoolean("ccs_minimize_roundtrips", eqlRequest.ccsMinimizeRoundtrips()));
+            eqlRequest.allowPartialSearchResults(
+                request.paramAsBoolean("allow_partial_search_results", eqlRequest.allowPartialSearchResults())
+            );
+            eqlRequest.allowPartialSequenceResults(
+                request.paramAsBoolean("allow_partial_sequence_results", eqlRequest.allowPartialSequenceResults())
+            );
         }
 
         return channel -> {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.Client;
@@ -145,7 +146,8 @@ public final class TransportEqlSearchAction extends HandledTransportAction<EqlSe
             false,
             task.getExecutionId().getEncoded(),
             true,
-            true
+            true,
+            ShardSearchFailure.EMPTY_ARRAY
         );
     }
 
@@ -232,6 +234,12 @@ public final class TransportEqlSearchAction extends HandledTransportAction<EqlSe
                 request.indicesOptions(),
                 request.fetchSize(),
                 request.maxSamplesPerKey(),
+                request.allowPartialSearchResults() == null
+                    ? defaultAllowPartialSearchResults(clusterService)
+                    : request.allowPartialSearchResults(),
+                request.allowPartialSequenceResults() == null
+                    ? defaultAllowPartialSequenceResults(clusterService)
+                    : request.allowPartialSequenceResults(),
                 clientId,
                 new TaskId(nodeId, task.getId()),
                 task
@@ -256,12 +264,34 @@ public final class TransportEqlSearchAction extends HandledTransportAction<EqlSe
         }
     }
 
+    private static boolean defaultAllowPartialSearchResults(ClusterService clusterService) {
+        if (clusterService.getClusterSettings() == null) {
+            return EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getDefault(Settings.EMPTY);
+        }
+        return clusterService.getClusterSettings().get(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS);
+    }
+
+    private static boolean defaultAllowPartialSequenceResults(ClusterService clusterService) {
+        if (clusterService.getClusterSettings() == null) {
+            return EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEQUENCE_RESULTS.getDefault(Settings.EMPTY);
+        }
+        return clusterService.getClusterSettings().get(EqlPlugin.DEFAULT_ALLOW_PARTIAL_SEQUENCE_RESULTS);
+    }
+
     static EqlSearchResponse createResponse(Results results, AsyncExecutionId id) {
         EqlSearchResponse.Hits hits = new EqlSearchResponse.Hits(results.events(), results.sequences(), results.totalHits());
         if (id != null) {
-            return new EqlSearchResponse(hits, results.tookTime().getMillis(), results.timedOut(), id.getEncoded(), false, false);
+            return new EqlSearchResponse(
+                hits,
+                results.tookTime().getMillis(),
+                results.timedOut(),
+                id.getEncoded(),
+                false,
+                false,
+                results.shardFailures()
+            );
         } else {
-            return new EqlSearchResponse(hits, results.tookTime().getMillis(), results.timedOut());
+            return new EqlSearchResponse(hits, results.tookTime().getMillis(), results.timedOut(), results.shardFailures());
         }
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EmptyPayload.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EmptyPayload.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.eql.session;
 
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.core.TimeValue;
 
 import java.util.List;
@@ -17,14 +18,16 @@ public class EmptyPayload implements Payload {
 
     private final Type type;
     private final TimeValue timeTook;
+    private final ShardSearchFailure[] shardFailures;
 
     public EmptyPayload(Type type) {
-        this(type, TimeValue.ZERO);
+        this(type, TimeValue.ZERO, ShardSearchFailure.EMPTY_ARRAY);
     }
 
-    public EmptyPayload(Type type, TimeValue timeTook) {
+    public EmptyPayload(Type type, TimeValue timeTook, ShardSearchFailure[] shardFailures) {
         this.type = type;
         this.timeTook = timeTook;
+        this.shardFailures = shardFailures;
     }
 
     @Override
@@ -46,4 +49,10 @@ public class EmptyPayload implements Payload {
     public List<?> values() {
         return emptyList();
     }
+
+    @Override
+    public ShardSearchFailure[] shardFailures() {
+        return shardFailures;
+    }
+
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlConfiguration.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlConfiguration.java
@@ -30,6 +30,8 @@ public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
     private final EqlSearchTask task;
     private final int fetchSize;
     private final int maxSamplesPerKey;
+    private final boolean allowPartialSearchResults;
+    private final boolean allowPartialSequenceResults;
 
     @Nullable
     private final QueryBuilder filter;
@@ -50,6 +52,8 @@ public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
         IndicesOptions indicesOptions,
         int fetchSize,
         int maxSamplesPerKey,
+        boolean allowPartialSearchResults,
+        boolean allowPartialSequenceResults,
         String clientId,
         TaskId taskId,
         EqlSearchTask task
@@ -67,6 +71,8 @@ public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
         this.task = task;
         this.fetchSize = fetchSize;
         this.maxSamplesPerKey = maxSamplesPerKey;
+        this.allowPartialSearchResults = allowPartialSearchResults;
+        this.allowPartialSequenceResults = allowPartialSequenceResults;
     }
 
     public String[] indices() {
@@ -87,6 +93,14 @@ public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
 
     public int maxSamplesPerKey() {
         return maxSamplesPerKey;
+    }
+
+    public boolean allowPartialSearchResults() {
+        return allowPartialSearchResults;
+    }
+
+    public boolean allowPartialSequenceResults() {
+        return allowPartialSequenceResults;
     }
 
     public QueryBuilder filter() {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/Payload.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/Payload.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.eql.session;
 
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.core.TimeValue;
 
 import java.util.List;
@@ -29,4 +30,6 @@ public interface Payload {
     TimeValue timeTook();
 
     List<?> values();
+
+    ShardSearchFailure[] shardFailures();
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/util/SearchHitUtils.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/util/SearchHitUtils.java
@@ -7,7 +7,11 @@
 
 package org.elasticsearch.xpack.eql.util;
 
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.search.SearchHit;
+
+import java.util.Map;
 
 import static org.elasticsearch.transport.RemoteClusterAware.buildRemoteIndexName;
 
@@ -15,5 +19,13 @@ public final class SearchHitUtils {
 
     public static String qualifiedIndex(SearchHit hit) {
         return buildRemoteIndexName(hit.getClusterAlias(), hit.getIndex());
+    }
+
+    public static void addShardFailures(Map<String, ShardSearchFailure> shardFailures, SearchResponse r) {
+        if (r.getShardFailures() != null) {
+            for (ShardSearchFailure shardFailure : r.getShardFailures()) {
+                shardFailures.put(shardFailure.toString(), shardFailure);
+            }
+        }
     }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
@@ -51,6 +51,8 @@ public final class EqlTestUtils {
         null,
         123,
         1,
+        false,
+        true,
         "",
         new TaskId("test", 123),
         null
@@ -69,6 +71,8 @@ public final class EqlTestUtils {
             randomIndicesOptions(),
             randomIntBetween(1, 1000),
             randomIntBetween(1, 1000),
+            randomBoolean(),
+            randomBoolean(),
             randomAlphaOfLength(16),
             new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()),
             randomTask()

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
@@ -80,6 +80,8 @@ public class EqlSearchRequestTests extends AbstractBWCSerializationTestCase<EqlS
                 .waitForCompletionTimeout(randomTimeValue())
                 .keepAlive(randomTimeValue())
                 .keepOnCompletion(randomBoolean())
+                .allowPartialSearchResults(randomBoolean())
+                .allowPartialSequenceResults(randomBoolean())
                 .fetchFields(randomFetchFields)
                 .runtimeMappings(randomRuntimeMappings())
                 .resultPosition(randomFrom("tail", "head"))
@@ -136,6 +138,12 @@ public class EqlSearchRequestTests extends AbstractBWCSerializationTestCase<EqlS
         mutatedInstance.runtimeMappings(version.onOrAfter(TransportVersions.V_7_13_0) ? instance.runtimeMappings() : emptyMap());
         mutatedInstance.resultPosition(version.onOrAfter(TransportVersions.V_7_17_8) ? instance.resultPosition() : "tail");
         mutatedInstance.maxSamplesPerKey(version.onOrAfter(TransportVersions.V_8_7_0) ? instance.maxSamplesPerKey() : 1);
+        mutatedInstance.allowPartialSearchResults(
+            version.onOrAfter(TransportVersions.EQL_ALLOW_PARTIAL_SEARCH_RESULTS) ? instance.allowPartialSearchResults() : false
+        );
+        mutatedInstance.allowPartialSequenceResults(
+            version.onOrAfter(TransportVersions.EQL_ALLOW_PARTIAL_SEARCH_RESULTS) ? instance.allowPartialSequenceResults() : false
+        );
 
         return mutatedInstance;
     }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.eql.action;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.document.DocumentField;
@@ -190,7 +191,7 @@ public class EqlSearchResponseTests extends AbstractBWCWireSerializingTestCase<E
             hits = new EqlSearchResponse.Hits(randomEvents(xType), null, totalHits);
         }
         if (randomBoolean()) {
-            return new EqlSearchResponse(hits, randomIntBetween(0, 1001), randomBoolean());
+            return new EqlSearchResponse(hits, randomIntBetween(0, 1001), randomBoolean(), ShardSearchFailure.EMPTY_ARRAY);
         } else {
             return new EqlSearchResponse(
                 hits,
@@ -198,7 +199,8 @@ public class EqlSearchResponseTests extends AbstractBWCWireSerializingTestCase<E
                 randomBoolean(),
                 randomAlphaOfLength(10),
                 randomBoolean(),
-                randomBoolean()
+                randomBoolean(),
+                ShardSearchFailure.EMPTY_ARRAY
             );
         }
     }
@@ -222,7 +224,7 @@ public class EqlSearchResponseTests extends AbstractBWCWireSerializingTestCase<E
             hits = new EqlSearchResponse.Hits(null, seq, totalHits);
         }
         if (randomBoolean()) {
-            return new EqlSearchResponse(hits, randomIntBetween(0, 1001), randomBoolean());
+            return new EqlSearchResponse(hits, randomIntBetween(0, 1001), randomBoolean(), ShardSearchFailure.EMPTY_ARRAY);
         } else {
             return new EqlSearchResponse(
                 hits,
@@ -230,7 +232,8 @@ public class EqlSearchResponseTests extends AbstractBWCWireSerializingTestCase<E
                 randomBoolean(),
                 randomAlphaOfLength(10),
                 randomBoolean(),
-                randomBoolean()
+                randomBoolean(),
+                ShardSearchFailure.EMPTY_ARRAY
             );
         }
     }
@@ -273,7 +276,8 @@ public class EqlSearchResponseTests extends AbstractBWCWireSerializingTestCase<E
             instance.isTimeout(),
             instance.id(),
             instance.isRunning(),
-            instance.isPartial()
+            instance.isPartial(),
+            ShardSearchFailure.EMPTY_ARRAY
         );
     }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/LocalStateEQLXPackPlugin.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/LocalStateEQLXPackPlugin.java
@@ -7,26 +7,41 @@
 
 package org.elasticsearch.xpack.eql.action;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.breaker.BreakerSettings;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.plugins.CircuitBreakerPlugin;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.eql.plugin.EqlPlugin;
 import org.elasticsearch.xpack.ql.plugin.QlPlugin;
 
 import java.nio.file.Path;
 
-public class LocalStateEQLXPackPlugin extends LocalStateCompositeXPackPlugin {
+public class LocalStateEQLXPackPlugin extends LocalStateCompositeXPackPlugin implements CircuitBreakerPlugin {
+
+    private final EqlPlugin eqlPlugin;
 
     public LocalStateEQLXPackPlugin(final Settings settings, final Path configPath) {
         super(settings, configPath);
         LocalStateEQLXPackPlugin thisVar = this;
-        plugins.add(new EqlPlugin() {
+        this.eqlPlugin = new EqlPlugin() {
             @Override
             protected XPackLicenseState getLicenseState() {
                 return thisVar.getLicenseState();
             }
-        });
+        };
+        plugins.add(eqlPlugin);
         plugins.add(new QlPlugin());
     }
 
+    @Override
+    public BreakerSettings getCircuitBreaker(Settings settings) {
+        return eqlPlugin.getCircuitBreaker(settings);
+    }
+
+    @Override
+    public void setCircuitBreaker(CircuitBreaker circuitBreaker) {
+        eqlPlugin.setCircuitBreaker(circuitBreaker);
+    }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/ImplicitTiebreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/ImplicitTiebreakerTests.java
@@ -141,7 +141,15 @@ public class ImplicitTiebreakerTests extends ESTestCase {
             booleanArrayOf(stages, false),
             NOOP_CIRCUIT_BREAKER
         );
-        TumblingWindow window = new TumblingWindow(client, criteria, null, matcher, Collections.emptyList());
+        TumblingWindow window = new TumblingWindow(
+            client,
+            criteria,
+            null,
+            matcher,
+            Collections.emptyList(),
+            randomBoolean(),
+            randomBoolean()
+        );
         window.execute(wrap(p -> {}, ex -> { throw ExceptionsHelper.convertToRuntime(ex); }));
     }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
@@ -277,7 +277,15 @@ public class SequenceSpecTests extends ESTestCase {
         );
 
         QueryClient testClient = new TestQueryClient();
-        TumblingWindow window = new TumblingWindow(testClient, criteria, null, matcher, Collections.emptyList());
+        TumblingWindow window = new TumblingWindow(
+            testClient,
+            criteria,
+            null,
+            matcher,
+            Collections.emptyList(),
+            randomBoolean(),
+            randomBoolean()
+        );
 
         // finally make the assertion at the end of the listener
         window.execute(ActionTestUtils.assertNoFailureListener(this::checkResults));

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
@@ -89,7 +89,7 @@ public class CircuitBreakerTests extends ESTestCase {
 
             @Override
             public void fetchHits(Iterable<List<HitReference>> refs, ActionListener<List<List<SearchHit>>> listener) {}
-        }, mockCriteria(), randomIntBetween(10, 500), new Limit(1000, 0), CIRCUIT_BREAKER, 1);
+        }, mockCriteria(), randomIntBetween(10, 500), new Limit(1000, 0), CIRCUIT_BREAKER, 1, randomBoolean());
 
         CIRCUIT_BREAKER.startBreaking();
         iterator.pushToStack(new SampleIterator.Page(CB_STACK_SIZE_PRECISION - 1));
@@ -144,7 +144,8 @@ public class CircuitBreakerTests extends ESTestCase {
                 randomIntBetween(10, 500),
                 new Limit(1000, 0),
                 eqlCircuitBreaker,
-                1
+                1,
+                randomBoolean()
             );
 
             // unfortunately, mocking an actual result set it extremely complicated

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClientTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClientTests.java
@@ -102,6 +102,8 @@ public class PITAwareQueryClientTests extends ESTestCase {
                 null,
                 123,
                 1,
+                randomBoolean(),
+                randomBoolean(),
                 "",
                 new TaskId("test", 123),
                 new EqlSearchTask(
@@ -168,7 +170,15 @@ public class PITAwareQueryClientTests extends ESTestCase {
             }
 
             SequenceMatcher matcher = new SequenceMatcher(stages, false, TimeValue.MINUS_ONE, null, booleanArrayOf(stages, false), cb);
-            TumblingWindow window = new TumblingWindow(eqlClient, criteria, null, matcher, Collections.emptyList());
+            TumblingWindow window = new TumblingWindow(
+                eqlClient,
+                criteria,
+                null,
+                matcher,
+                Collections.emptyList(),
+                randomBoolean(),
+                randomBoolean()
+            );
             window.execute(wrap(response -> {
                 // do nothing, we don't care about the query results
             }, ex -> { fail("Shouldn't have failed"); }));

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
@@ -146,7 +146,15 @@ public class CircuitBreakerTests extends ESTestCase {
             booleanArrayOf(stages, false),
             CIRCUIT_BREAKER
         );
-        TumblingWindow window = new TumblingWindow(client, criteria, null, matcher, Collections.emptyList());
+        TumblingWindow window = new TumblingWindow(
+            client,
+            criteria,
+            null,
+            matcher,
+            Collections.emptyList(),
+            randomBoolean(),
+            randomBoolean()
+        );
         window.execute(ActionTestUtils.assertNoFailureListener(p -> {}));
 
         CIRCUIT_BREAKER.startBreaking();
@@ -230,7 +238,15 @@ public class CircuitBreakerTests extends ESTestCase {
                 booleanArrayOf(sequenceFiltersCount, false),
                 eqlCircuitBreaker
             );
-            TumblingWindow window = new TumblingWindow(eqlClient, criteria, null, matcher, Collections.emptyList());
+            TumblingWindow window = new TumblingWindow(
+                eqlClient,
+                criteria,
+                null,
+                matcher,
+                Collections.emptyList(),
+                randomBoolean(),
+                randomBoolean()
+            );
             window.execute(ActionListener.noop());
 
             assertTrue(esClient.searchRequestsRemainingCount() == 0); // ensure all the search requests have been asked for
@@ -276,7 +292,15 @@ public class CircuitBreakerTests extends ESTestCase {
                 booleanArrayOf(sequenceFiltersCount, false),
                 eqlCircuitBreaker
             );
-            TumblingWindow window = new TumblingWindow(eqlClient, criteria, null, matcher, Collections.emptyList());
+            TumblingWindow window = new TumblingWindow(
+                eqlClient,
+                criteria,
+                null,
+                matcher,
+                Collections.emptyList(),
+                randomBoolean(),
+                randomBoolean()
+            );
             window.execute(wrap(p -> fail(), ex -> assertTrue(ex instanceof CircuitBreakingException)));
         }
         assertCriticalWarnings("[indices.breaker.total.limit] setting of [0%] is below the recommended minimum of 50.0% of the heap");
@@ -334,6 +358,8 @@ public class CircuitBreakerTests extends ESTestCase {
             null,
             123,
             1,
+            randomBoolean(),
+            randomBoolean(),
             "",
             new TaskId("test", 123),
             new EqlSearchTask(

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/PITFailureTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/PITFailureTests.java
@@ -83,6 +83,8 @@ public class PITFailureTests extends ESTestCase {
                 null,
                 123,
                 1,
+                randomBoolean(),
+                randomBoolean(),
                 "",
                 new TaskId("test", 123),
                 new EqlSearchTask(
@@ -132,7 +134,15 @@ public class PITFailureTests extends ESTestCase {
             );
 
             SequenceMatcher matcher = new SequenceMatcher(1, false, TimeValue.MINUS_ONE, null, booleanArrayOf(1, false), cb);
-            TumblingWindow window = new TumblingWindow(eqlClient, criteria, null, matcher, Collections.emptyList());
+            TumblingWindow window = new TumblingWindow(
+                eqlClient,
+                criteria,
+                null,
+                matcher,
+                Collections.emptyList(),
+                randomBoolean(),
+                randomBoolean()
+            );
             window.execute(
                 wrap(
                     p -> { fail("Search succeeded despite PIT failure"); },


### PR DESCRIPTION
Backports the following commits to 8.x:
 - EQL: add support for partial search results (#116388)