### PR TITLE
[8.x] [ci] Add ubuntu-2404-aarch64 to test matrix in platform-support (#118847)

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -70,6 +70,7 @@ steps:
             image:
               - almalinux-8-aarch64
               - ubuntu-2004-aarch64
+              - ubuntu-2404-aarch64
             GRADLE_TASK:
               - checkPart1
               - checkPart2


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ci] Add ubuntu-2404-aarch64 to test matrix in platform-support (#118847)