### PR TITLE
[8.17] [DOCS] Update migrate_8_17.asciidoc (#118830)

### DIFF
--- a/docs/reference/migration/migrate_8_17.asciidoc
+++ b/docs/reference/migration/migrate_8_17.asciidoc
@@ -9,9 +9,6 @@ your application to {es} 8.17.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-coming::[8.17.0]
-
-
 [discrete]
 [[breaking-changes-8.17]]
 === Breaking changes


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [DOCS] Update migrate_8_17.asciidoc (#118830)