### PR TITLE
Disable entitlements bridge javadoc

### DIFF
--- a/libs/entitlement/bridge/build.gradle
+++ b/libs/entitlement/bridge/build.gradle
@@ -22,3 +22,7 @@ tasks.named('jar').configure {
 tasks.withType(CheckForbiddenApisTask).configureEach {
   replaceSignatureFiles 'jdk-signatures'
 }
+
+tasks.named('javadoc').configure {
+  it.enabled = false
+}


### PR DESCRIPTION
This has problems because of MRJAR.