### PR TITLE
[Inference API] Unmute upgrade tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -428,24 +428,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.RetrySearchIntegTests
   method: testRetryPointInTime
   issue: https://github.com/elastic/elasticsearch/issues/118514
-- class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
-  method: testOpenAiEmbeddings {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/118156
-- class: org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT
-  method: testHFEmbeddings {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/118197
-- class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
-  method: testOpenAiCompletions {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/118163
-- class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
-  method: testOpenAiCompletions {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/118162
-- class: org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT
-  method: testElser {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/118127
-- class: org.elasticsearch.xpack.application.CohereServiceUpgradeIT
-  method: testCohereEmbeddings {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/116974
 - class: org.elasticsearch.index.engine.RecoverySourcePruneMergePolicyTests
   method: testPruneSome
   issue: https://github.com/elastic/elasticsearch/issues/118728


### PR DESCRIPTION
```
- class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
  method: testOpenAiEmbeddings {upgradedNodes=1}
  issue: https://github.com/elastic/elasticsearch/issues/118156
- class: org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT
  method: testHFEmbeddings {upgradedNodes=1}
  issue: https://github.com/elastic/elasticsearch/issues/118197
- class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
  method: testOpenAiCompletions {upgradedNodes=2}
  issue: https://github.com/elastic/elasticsearch/issues/118163
- class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
  method: testOpenAiCompletions {upgradedNodes=1}
  issue: https://github.com/elastic/elasticsearch/issues/118162
- class: org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT
  method: testElser {upgradedNodes=1}
  issue: https://github.com/elastic/elasticsearch/issues/118127
- class: org.elasticsearch.xpack.application.CohereServiceUpgradeIT
  method: testCohereEmbeddings {upgradedNodes=1}
  issue: https://github.com/elastic/elasticsearch/issues/116974
```