### PR TITLE
[8.x] [ML] Add dynamic templates for anomalies results index (#118845)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_mappings.json
@@ -5,7 +5,15 @@
   },
   "dynamic_templates" : [
     {
-      "strings_as_keywords" : {
+      "map_objects": {
+        "match_mapping_type": "object",
+        "mapping": {
+          "type": "object"
+        }
+      }
+    },
+    {
+      "non_objects_as_keywords" : {
         "match" : "*",
         "mapping" : {
           "type" : "keyword"


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Add dynamic templates for anomalies results index (#118845)