### PR TITLE
Fix check exit for specialized JDK 23 entitlements

### DIFF
--- a/docs/changelog/118907.yaml
+++ b/docs/changelog/118907.yaml
@@ -1,0 +1,5 @@
+pr: 118907
+summary: Fix check exit for specialized JDK 23 entitlements
+area: Infra/Plugins
+type: bug
+issues: []

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -21,7 +21,8 @@ import java.net.URLStreamHandlerFactory;
  * The trampoline module loads this object via SPI.
  */
 public class ElasticsearchEntitlementChecker implements EntitlementChecker {
-    private final PolicyManager policyManager;
+
+    protected final PolicyManager policyManager;
 
     public ElasticsearchEntitlementChecker(PolicyManager policyManager) {
         this.policyManager = policyManager;

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -193,9 +193,9 @@ public class PolicyManager {
                 return callerModule;
             }
         }
-        int framesToSkip = 1  // getCallingClass (this method)
-            + 1  // the checkXxx method
-            + 1  // the runtime config method
+        int framesToSkip = 1  // requestingModule (this method)
+            + 1  // the checkEntitlementPresent method
+            + 1  // the check[EntitlementType] method
             + 1  // the instrumented method
         ;
         Optional<Module> module = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)

--- a/libs/entitlement/src/main23/java/org/elasticsearch/entitlement/runtime/api/Java23ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main23/java/org/elasticsearch/entitlement/runtime/api/Java23ElasticsearchEntitlementChecker.java
@@ -12,6 +12,11 @@ package org.elasticsearch.entitlement.runtime.api;
 import org.elasticsearch.entitlement.bridge.Java23EntitlementChecker;
 import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
 
+/**
+ * When adding checks specific to JDK 23, do NOT add super calls.
+ * We depend on a specific number of stack frames for entitlement checking
+ * in PolicyManager#requestingModule(Class).
+ */
 public class Java23ElasticsearchEntitlementChecker extends ElasticsearchEntitlementChecker implements Java23EntitlementChecker {
 
     public Java23ElasticsearchEntitlementChecker(PolicyManager policyManager) {
@@ -21,6 +26,8 @@ public class Java23ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
     @Override
     public void check$$exit(Class<?> callerClass, Runtime runtime, int status) {
         // TODO: this is just an example, we shouldn't really override a method implemented in the superclass
-        super.check$$exit(callerClass, runtime, status);
+        // We cannot call super here or it adds an unexpected extra stack frame that we do not skip
+        // during our entitlement check in PolicyManager#requestingModule(Class<?>)
+        policyManager.checkExitVM(callerClass);
     }
 }


### PR DESCRIPTION
We expect exactly 4 stack frames for our entitlement checks when fetching the module we want to check the policy for. When adding entitlement checks for specific JDK versions we cannot call `super` or we increase that number to 5 stack frames which causes entitlement failures. This removes the `super` call and instead calls call policy manager directly.