### PR TITLE
Refactor pausable field plugin to have common codebase

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractPauseFieldPlugin.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractPauseFieldPlugin.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.OnScriptError;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.LongFieldScript;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A plugin that provides a script language "pause" that can be used to simulate slow running queries.
+ * See also {@link AbstractPausableIntegTestCase}.
+ */
+public abstract class AbstractPauseFieldPlugin extends Plugin implements ScriptPlugin {
+
+    // Called when the engine enters the execute() method.
+    protected void onStartExecute() {}
+
+    // Called when the engine needs to wait for further execution to be allowed.
+    protected abstract boolean onWait() throws InterruptedException;
+
+    @Override
+    public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+        return new ScriptEngine() {
+            @Override
+            public String getType() {
+                return "pause";
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public <FactoryType> FactoryType compile(
+                String name,
+                String code,
+                ScriptContext<FactoryType> context,
+                Map<String, String> params
+            ) {
+                if (context == LongFieldScript.CONTEXT) {
+                    return (FactoryType) new LongFieldScript.Factory() {
+                        @Override
+                        public LongFieldScript.LeafFactory newFactory(
+                            String fieldName,
+                            Map<String, Object> params,
+                            SearchLookup searchLookup,
+                            OnScriptError onScriptError
+                        ) {
+                            return ctx -> new LongFieldScript(fieldName, params, searchLookup, onScriptError, ctx) {
+                                @Override
+                                public void execute() {
+                                    onStartExecute();
+                                    try {
+                                        assertTrue(onWait());
+                                    } catch (InterruptedException e) {
+                                        throw new AssertionError(e);
+                                    }
+                                    emit(1);
+                                }
+                            };
+                        }
+                    };
+                }
+                throw new IllegalStateException("unsupported type " + context);
+            }
+
+            @Override
+            public Set<ScriptContext<?>> getSupportedContexts() {
+                return Set.of(LongFieldScript.CONTEXT);
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryIT.java
@@ -19,14 +19,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.index.mapper.OnScriptError;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.plugins.ScriptPlugin;
-import org.elasticsearch.script.LongFieldScript;
-import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptEngine;
-import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.test.AbstractMultiClustersTestCase;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.transport.RemoteClusterAware;
@@ -44,7 +38,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -80,7 +73,7 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
         plugins.add(EsqlPluginWithEnterpriseOrTrialLicense.class);
         plugins.add(EsqlAsyncActionIT.LocalStateEsqlAsync.class); // allows the async_search DELETE action
         plugins.add(InternalExchangePlugin.class);
-        plugins.add(PauseFieldPlugin.class);
+        plugins.add(SimplePauseFieldPlugin.class);
         return plugins;
     }
 
@@ -99,64 +92,7 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
 
     @Before
     public void resetPlugin() {
-        PauseFieldPlugin.allowEmitting = new CountDownLatch(1);
-        PauseFieldPlugin.startEmitting = new CountDownLatch(1);
-    }
-
-    public static class PauseFieldPlugin extends Plugin implements ScriptPlugin {
-        public static CountDownLatch startEmitting = new CountDownLatch(1);
-        public static CountDownLatch allowEmitting = new CountDownLatch(1);
-
-        @Override
-        public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
-            return new ScriptEngine() {
-                @Override
-
-                public String getType() {
-                    return "pause";
-                }
-
-                @Override
-                @SuppressWarnings("unchecked")
-                public <FactoryType> FactoryType compile(
-                    String name,
-                    String code,
-                    ScriptContext<FactoryType> context,
-                    Map<String, String> params
-                ) {
-                    if (context == LongFieldScript.CONTEXT) {
-                        return (FactoryType) new LongFieldScript.Factory() {
-                            @Override
-                            public LongFieldScript.LeafFactory newFactory(
-                                String fieldName,
-                                Map<String, Object> params,
-                                SearchLookup searchLookup,
-                                OnScriptError onScriptError
-                            ) {
-                                return ctx -> new LongFieldScript(fieldName, params, searchLookup, onScriptError, ctx) {
-                                    @Override
-                                    public void execute() {
-                                        startEmitting.countDown();
-                                        try {
-                                            assertTrue(allowEmitting.await(30, TimeUnit.SECONDS));
-                                        } catch (InterruptedException e) {
-                                            throw new AssertionError(e);
-                                        }
-                                        emit(1);
-                                    }
-                                };
-                            }
-                        };
-                    }
-                    throw new IllegalStateException("unsupported type " + context);
-                }
-
-                @Override
-                public Set<ScriptContext<?>> getSupportedContexts() {
-                    return Set.of(LongFieldScript.CONTEXT);
-                }
-            };
-        }
+        SimplePauseFieldPlugin.resetPlugin();
     }
 
     /**
@@ -184,7 +120,7 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
         }
 
         // wait until we know that the query against 'remote-b:blocking' has started
-        PauseFieldPlugin.startEmitting.await(30, TimeUnit.SECONDS);
+        SimplePauseFieldPlugin.startEmitting.await(30, TimeUnit.SECONDS);
 
         // wait until the query of 'cluster-a:logs-*' has finished (it is not blocked since we are not searching the 'blocking' index on it)
         assertBusy(() -> {
@@ -234,7 +170,7 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
         }
 
         // allow remoteB query to proceed
-        PauseFieldPlugin.allowEmitting.countDown();
+        SimplePauseFieldPlugin.allowEmitting.countDown();
 
         // wait until both remoteB and local queries have finished
         assertBusy(() -> {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/SimplePauseFieldPlugin.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/SimplePauseFieldPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A plugin that provides a script language "pause" that can be used to simulate slow running queries.
+ * This implementation allows to know when it arrives at execute() via startEmitting and to allow the execution to proceed
+ * via allowEmitting.
+ */
+public class SimplePauseFieldPlugin extends AbstractPauseFieldPlugin {
+    public static CountDownLatch startEmitting = new CountDownLatch(1);
+    public static CountDownLatch allowEmitting = new CountDownLatch(1);
+
+    public static void resetPlugin() {
+        allowEmitting = new CountDownLatch(1);
+        startEmitting = new CountDownLatch(1);
+    }
+
+    @Override
+    public void onStartExecute() {
+        startEmitting.countDown();
+    }
+
+    @Override
+    public boolean onWait() throws InterruptedException {
+        return allowEmitting.await(30, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
Have single class implementing pause field plugin functionality and allow to override start/stop methods. 

Also adds `SimplePauseFieldPlugin` for usage in stand-alone tests that can not inherit `AbstractPausableIntegTestCase`.