### PR TITLE
[8.16] Add missing timeouts to rest-api-spec ingest APIs (#118844)

### DIFF
--- a/docs/changelog/118844.yaml
+++ b/docs/changelog/118844.yaml
@@ -1,0 +1,5 @@
+pr: 118844
+summary: Add missing timeouts to rest-api-spec ingest APIs
+area: Ingest Node
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_geoip_database.json
@@ -26,6 +26,14 @@
       ]
     },
     "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_ip_location_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_ip_location_database.json
@@ -26,6 +26,14 @@
       ]
     },
     "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
@@ -27,6 +27,14 @@
       ]
     },
     "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
     },
     "body":{
       "description":"The database configuration definition",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_ip_location_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_ip_location_database.json
@@ -27,6 +27,14 @@
       ]
     },
     "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
     },
     "body":{
       "description":"The database configuration definition",


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Add missing timeouts to rest-api-spec ingest APIs (#118844)