### PR TITLE
Remove unsupported timeout from rest-api-spec license API

### DIFF
--- a/docs/changelog/118919.yaml
+++ b/docs/changelog/118919.yaml
@@ -1,0 +1,5 @@
+pr: 118919
+summary: Remove unsupported timeout from rest-api-spec license API
+area: License
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_trial.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_trial.json
@@ -31,10 +31,6 @@
       "master_timeout": {
         "type": "time",
         "description": "Timeout for processing on master node"
-      },
-      "timeout": {
-        "type": "time",
-        "description": "Timeout for acknowledgement of update from all nodes in cluster"
       }
     }
   }


### PR DESCRIPTION
I noticed it when reviewing https://github.com/elastic/elasticsearch-specification/pull/3297.