### PR TITLE
Remove unsupported timeout from rest-api-spec license API

### DIFF
--- a/docs/changelog/118920.yaml
+++ b/docs/changelog/118920.yaml
@@ -1,0 +1,5 @@
+pr: 118920
+summary: Remove unsupported timeout from rest-api-spec license API
+area: Machine Learning
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_trained_model.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_trained_model.json
@@ -26,12 +26,6 @@
       ]
     },
     "params":{
-      "timeout":{
-        "type":"time",
-        "required":false,
-        "description":"Controls the amount of time to wait for the model to be deleted.",
-        "default": "30s"
-      },
       "force":{
         "type":"boolean",
         "required":false,


### PR DESCRIPTION
I noticed it when reviewing https://github.com/elastic/elasticsearch-specification/pull/3297.