### PR TITLE
[7.17] [ci] Add ubuntu-2404-aarch64 to test matrix in platform-support (#118847)

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -66,6 +66,7 @@ steps:
             image:
               - almalinux-8-aarch64
               - ubuntu-2004-aarch64
+              - ubuntu-2404-aarch64
         agents:
           provider: aws
           imagePrefix: elasticsearch-{{matrix.image}}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci] Add ubuntu-2404-aarch64 to test matrix in platform-support (#118847)](https://github.com/elastic/elasticsearch/pull/118847)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)