### PR TITLE
Unmute synonyms test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -434,9 +434,6 @@ tests:
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/20_metrics_ingest/Test metrics-apm.app-* setting event.ingested via ingest pipeline}
   issue: https://github.com/elastic/elasticsearch/issues/118875
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set}
-  issue: https://github.com/elastic/elasticsearch/issues/116777
 - class: org.elasticsearch.xpack.ml.integration.ForecastIT
   method: testOverflowToDisk
   issue: https://github.com/elastic/elasticsearch/issues/117740


### PR DESCRIPTION
Closes #116777

This test failed on 8.x due to the inability to merge the backport for https://github.com/elastic/elasticsearch/pull/118691 in 8.17 (https://github.com/elastic/elasticsearch/pull/118818) as it was blocked by an unrelated test failure.

