### PR TITLE
[8.x][ML] Report deprecation for outdated snapshots

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
@@ -26,7 +26,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.elasticsearch.xpack.core.ml.MachineLearningField.MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION;
 import static org.elasticsearch.xpack.core.ml.MachineLearningField.MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION;
 
 public class MlDeprecationChecker implements DeprecationChecker {
@@ -69,7 +68,7 @@ public class MlDeprecationChecker implements DeprecationChecker {
     }
 
     static Optional<DeprecationIssue> checkModelSnapshot(ModelSnapshot modelSnapshot) {
-        if (modelSnapshot.getMinVersion().before(MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION)) {
+        if (modelSnapshot.getMinVersion().before(MIN_REPORTED_SUPPORTED_SNAPSHOT_VERSION)) {
             StringBuilder details = new StringBuilder(
                 String.format(
                     Locale.ROOT,


### PR DESCRIPTION
This PR fixes the constant used to produce deprecated warnings in the Upgrade Assistant in 8.18. It ensures that for all ML model snapshots produced prior to version 8.3 the user can either delete or update them. 

I marked it as a non-issue since it fixes the logic updated in https://github.com/elastic/elasticsearch/pull/118166 and has not been released yet.