### PR TITLE
Fix "create index with use_synthetic_source" yaml test.

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -2049,5 +2049,6 @@ create index with use_synthetic_source:
       indices.disk_usage:
         index: test
         run_expensive_tasks: true
+        flush: false
   - gt: { test.fields.field.total_in_bytes: 0 }
   - is_false: test.fields.field._recovery_source

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -2050,5 +2050,5 @@ create index with use_synthetic_source:
         index: test
         run_expensive_tasks: true
         flush: false
-  - gt: { test.fields.field.total_in_bytes: 0 }
+  - gt: { test.store_size_in_bytes: 0 }
   - is_false: test.fields.field._recovery_source

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -2051,4 +2051,4 @@ create index with use_synthetic_source:
         run_expensive_tasks: true
         flush: false
   - gt: { test.store_size_in_bytes: 0 }
-  - is_false: test.fields.field._recovery_source
+  - is_false: test.fields._recovery_source


### PR DESCRIPTION
The `flush` param defaults to `true` and some environments don't support that. Setting `flush` param to `false` to fix this.

```
[2024-12-18T19:51:01,213][INFO ][c.e.e.q.r.ServerlessClientYamlTestSuiteIT] [test] Stash dump on test failure [{
  "stash" : {
    "body" : {
      "_shards" : {
        "total" : 3,
        "successful" : 0,
        "failed" : 3,
        "failures" : [
          {
            "shard" : 0,
            "index" : "test",
            "status" : "BAD_REQUEST",
            "reason" : {
              "type" : "illegal_argument_exception",
              "reason" : "Search engine does not support acquiring last index commit with flush_first"
            }
          }
        ]
      }
    }
  }
}]
```