### PR TITLE
Fixing ReindexDataStreamStatusTests so that the in progress set max size is not less than min size

### DIFF
--- a/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamEnrichedStatusTests.java
+++ b/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamEnrichedStatusTests.java
@@ -74,7 +74,7 @@ public class ReindexDataStreamEnrichedStatusTests extends AbstractWireSerializin
     }
 
     private Set<String> randomSet(int minSize) {
-        return randomSet(minSize, 100, () -> randomAlphaOfLength(50));
+        return randomSet(minSize, Math.max(minSize, 100), () -> randomAlphaOfLength(50));
     }
 
     private List<Tuple<String, Exception>> randomErrorList() {

--- a/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamStatusTests.java
+++ b/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamStatusTests.java
@@ -70,7 +70,7 @@ public class ReindexDataStreamStatusTests extends AbstractWireSerializingTestCas
     }
 
     private Set<String> randomSet(int minSize) {
-        return randomSet(minSize, 100, () -> randomAlphaOfLength(50));
+        return randomSet(minSize, Math.max(minSize, 100), () -> randomAlphaOfLength(50));
     }
 
     private List<Tuple<String, Exception>> randomErrorList() {


### PR DESCRIPTION
It is currently possible when we mutate a status object that we ask for a random set for the inProgress field where the max size of the set is less than the min size. This fixes that.