### PR TITLE
[8.x] Fix off-by-one error in `RecoverySourcePruneMergePolicyTests#testPruneSome`

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
@@ -44,7 +44,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
 
@@ -191,7 +191,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                                     }
                                     assertEquals(i, extra_source.docID());
                                     if (syntheticRecoverySource) {
-                                        assertThat(extra_source.longValue(), greaterThan(10L));
+                                        assertThat(extra_source.longValue(), greaterThanOrEqualTo(10L));
                                     } else {
                                         assertThat(extra_source.longValue(), equalTo(1L));
                                     }


### PR DESCRIPTION
Backports #118944 to 8.x

> The extra_source_size field is set to a value between 10 and 10000 inclusive, so the assertion should be greaterThanOrEqualTo(10) rather than greaterThan(10).
>
> See https://github.com/elastic/elasticsearch/pull/114618
> Resolve https://github.com/elastic/elasticsearch/issues/118728