### PR TITLE
Unmuting ReindexDataStreamStatusTests.testEqualsAndHashcode

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -292,9 +292,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/118914
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/118955
-- class: org.elasticsearch.xpack.migrate.task.ReindexDataStreamStatusTests
-  method: testEqualsAndHashcode
-  issue: https://github.com/elastic/elasticsearch/issues/118965
 - class: org.elasticsearch.repositories.blobstore.testkit.analyze.SecureHdfsRepositoryAnalysisRestIT
   issue: https://github.com/elastic/elasticsearch/issues/118970
 


### PR DESCRIPTION
This was fixed by #118957.
Closes #118965