### PR TITLE
Disable SLM history in docs tests

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -130,8 +130,9 @@ testClusters.matching { it.name == "yamlRestTest"}.configureEach {
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.security.authc.api_key.enabled', 'true'
   setting 'xpack.security.authc.token.enabled', 'true'
-  // disable the ILM history for doc tests to avoid potential lingering tasks that'd cause test flakiness
+  // disable the ILM and SLM history for doc tests to avoid potential lingering tasks that'd cause test flakiness
   setting 'indices.lifecycle.history_index_enabled', 'false'
+  setting 'slm.history_index_enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'xpack.security.authc.realms.file.file.order', '0'
   setting 'xpack.security.authc.realms.native.native.order', '1'


### PR DESCRIPTION
The SLM history data stream was causing issues in the docs tests because its presence was flaky and could result in the inability to remove its index template, which in turn resulted in failing tests.

Relates #116788 (I'm not closing it yet because it has been muted on `8.17`, so I have to unmute it there first before I can close the issue).