### PR TITLE
[8.x] ESQL: Fix match in LOOKUP JOIN YAML test (#118975)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
@@ -1,7 +1,7 @@
 ---
 setup:
   - requires:
-      test_runner_features: [capabilities]
+      test_runner_features: [capabilities, contains]
       capabilities:
         - method: POST
           path: /_query
@@ -75,4 +75,4 @@ non-lookup index:
       catch: "bad_request"
 
   - match: { error.type: "verification_exception" }
-  - match: { error.reason: "Found 1 problem\nline 1:43: invalid [test] resolution in lookup mode to an index in [standard] mode" }
+  - contains: { error.reason: "Found 1 problem\nline 1:43: invalid [test] resolution in lookup mode to an index in [standard] mode" }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Fix match in LOOKUP JOIN YAML test (#118975)