### PR TITLE
[8.17] Disable SLM history in docs tests (#118979)

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -130,8 +130,9 @@ testClusters.matching { it.name == "yamlRestTest"}.configureEach {
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.security.authc.api_key.enabled', 'true'
   setting 'xpack.security.authc.token.enabled', 'true'
-  // disable the ILM history for doc tests to avoid potential lingering tasks that'd cause test flakiness
+  // disable the ILM and SLM history for doc tests to avoid potential lingering tasks that'd cause test flakiness
   setting 'indices.lifecycle.history_index_enabled', 'false'
+  setting 'slm.history_index_enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'xpack.security.authc.realms.file.file.order', '0'
   setting 'xpack.security.authc.realms.native.native.order', '1'

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -358,8 +358,6 @@ tests:
     issue: https://github.com/elastic/elasticsearch/issues/117937
   - class: org.elasticsearch.xpack.security.authc.kerberos.KerberosAuthenticationIT
     issue: https://github.com/elastic/elasticsearch/issues/118414
-  - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-    issue: https://github.com/elastic/elasticsearch/issues/116788
 
 # Examples:
 #


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Disable SLM history in docs tests (#118979)

Fixes #116788