### PR TITLE
Improve error message when whitelist resource file is not found

### DIFF
--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistLoader.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistLoader.java
@@ -502,7 +502,7 @@ public final class WhitelistLoader {
         if (stream == null) {
             String msg = "Whitelist file [" + owner.getPackageName().replace(".", "/") + "/" + name + "] not found from owning class [" + owner.getName() + "].";
             if (owner.getModule().isNamed()) {
-                msg += " Check that the file exists and the package [" + owner.getPackageName() + "] is exported " +
+                msg += " Check that the file exists and the package [" + owner.getPackageName() + "] is opened " +
                     "to module " + WhitelistLoader.class.getModule().getName();
             }
             throw new ResourceNotFoundException(msg);

--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistLoader.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistLoader.java
@@ -500,10 +500,19 @@ public final class WhitelistLoader {
     private static InputStream getResourceAsStream(Class<?> owner, String name) {
         InputStream stream = owner.getResourceAsStream(name);
         if (stream == null) {
-            String msg = "Whitelist file [" + owner.getPackageName().replace(".", "/") + "/" + name + "] not found from owning class [" + owner.getName() + "].";
+            String msg = "Whitelist file ["
+                + owner.getPackageName().replace(".", "/")
+                + "/"
+                + name
+                + "] not found from owning class ["
+                + owner.getName()
+                + "].";
             if (owner.getModule().isNamed()) {
-                msg += " Check that the file exists and the package [" + owner.getPackageName() + "] is opened " +
-                    "to module " + WhitelistLoader.class.getModule().getName();
+                msg += " Check that the file exists and the package ["
+                    + owner.getPackageName()
+                    + "] is opened "
+                    + "to module "
+                    + WhitelistLoader.class.getModule().getName();
             }
             throw new ResourceNotFoundException(msg);
         }

--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistLoader.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistLoader.java
@@ -9,8 +9,10 @@
 
 package org.elasticsearch.painless.spi;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.painless.spi.annotation.WhitelistAnnotationParser;
 
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.lang.reflect.Constructor;
@@ -140,7 +142,7 @@ public final class WhitelistLoader {
      * }
      * }
      */
-    public static Whitelist loadFromResourceFiles(Class<?> resource, Map<String, WhitelistAnnotationParser> parsers, String... filepaths) {
+    public static Whitelist loadFromResourceFiles(Class<?> owner, Map<String, WhitelistAnnotationParser> parsers, String... filepaths) {
         List<WhitelistClass> whitelistClasses = new ArrayList<>();
         List<WhitelistMethod> whitelistStatics = new ArrayList<>();
         List<WhitelistClassBinding> whitelistClassBindings = new ArrayList<>();
@@ -153,7 +155,7 @@ public final class WhitelistLoader {
 
             try (
                 LineNumberReader reader = new LineNumberReader(
-                    new InputStreamReader(resource.getResourceAsStream(filepath), StandardCharsets.UTF_8)
+                    new InputStreamReader(getResourceAsStream(owner, filepath), StandardCharsets.UTF_8)
                 )
             ) {
 
@@ -483,14 +485,29 @@ public final class WhitelistLoader {
                 if (javaClassName != null) {
                     throw new IllegalArgumentException("invalid definition: expected closing bracket");
                 }
+            } catch (ResourceNotFoundException e) {
+                throw e; // rethrow
             } catch (Exception exception) {
                 throw new RuntimeException("error in [" + filepath + "] at line [" + number + "]", exception);
             }
         }
 
-        ClassLoader loader = AccessController.doPrivileged((PrivilegedAction<ClassLoader>) resource::getClassLoader);
+        ClassLoader loader = AccessController.doPrivileged((PrivilegedAction<ClassLoader>) owner::getClassLoader);
 
         return new Whitelist(loader, whitelistClasses, whitelistStatics, whitelistClassBindings, Collections.emptyList());
+    }
+
+    private static InputStream getResourceAsStream(Class<?> owner, String name) {
+        InputStream stream = owner.getResourceAsStream(name);
+        if (stream == null) {
+            String msg = "Whitelist file [" + owner.getPackageName().replace(".", "/") + "/" + name + "] not found from owning class [" + owner.getName() + "].";
+            if (owner.getModule().isNamed()) {
+                msg += " Check that the file exists and the package [" + owner.getPackageName() + "] is exported " +
+                    "to module " + WhitelistLoader.class.getModule().getName();
+            }
+            throw new ResourceNotFoundException(msg);
+        }
+        return stream;
     }
 
     private static List<Object> parseWhitelistAnnotations(Map<String, WhitelistAnnotationParser> parsers, String line) {

--- a/modules/lang-painless/spi/src/test/java/org/elasticsearch/painless/WhitelistLoaderTests.java
+++ b/modules/lang-painless/spi/src/test/java/org/elasticsearch/painless/WhitelistLoaderTests.java
@@ -148,7 +148,7 @@ public class WhitelistLoaderTests extends ESTestCase {
             var e = expectThrows(ResourceNotFoundException.class,
                 () -> WhitelistLoader.loadFromResourceFiles(ownerClass, "resource.txt"));
             assertThat(e.getMessage(), equalTo("Whitelist file [p/resource.txt] not found from owning class [p.TestOwner]." +
-                " Check that the file exists and the package [p] is exported to module null"));
+                " Check that the file exists and the package [p] is opened to module null"));
 
             // now check we can actually read it once the package is opened to us
             controller.addOpens(module, "p", WhitelistLoader.class.getModule());

--- a/modules/lang-painless/spi/src/test/java/org/elasticsearch/painless/WhitelistLoaderTests.java
+++ b/modules/lang-painless/spi/src/test/java/org/elasticsearch/painless/WhitelistLoaderTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.painless;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.painless.spi.WhitelistClass;
 import org.elasticsearch.painless.spi.WhitelistLoader;
@@ -17,9 +18,27 @@ import org.elasticsearch.painless.spi.annotation.DeprecatedAnnotation;
 import org.elasticsearch.painless.spi.annotation.NoImportAnnotation;
 import org.elasticsearch.painless.spi.annotation.WhitelistAnnotationParser;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.compiler.InMemoryJavaCompiler;
+import org.elasticsearch.test.jar.JarUtils;
+import org.hamcrest.Matchers;
 
+import java.lang.ModuleLayer.Controller;
+import java.lang.module.Configuration;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReader;
+import java.lang.module.ModuleReference;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class WhitelistLoaderTests extends ESTestCase {
 
@@ -95,5 +114,46 @@ public class WhitelistLoaderTests extends ESTestCase {
         }
 
         assertEquals(3, count);
+    }
+
+    public void testMissingWhitelistResource() {
+        var e = expectThrows(ResourceNotFoundException.class,
+            () -> WhitelistLoader.loadFromResourceFiles(Whitelist.class, "missing.txt"));
+        assertThat(e.getMessage(),
+            equalTo("Whitelist file [org/elasticsearch/painless/spi/missing.txt] not found" +
+                " from owning class [org.elasticsearch.painless.spi.Whitelist]."));
+    }
+
+    public void testMissingWhitelistResourceInModule() throws Exception{
+        Map<String, CharSequence> sources = new HashMap<>();
+        sources.put("module-info", "module m {}");
+        sources.put("p.TestOwner", "package p; public class TestOwner { }");
+        var classToBytes = InMemoryJavaCompiler.compile(sources);
+
+        Path dir = createTempDir(getTestName());
+        Path jar = dir.resolve("m.jar");
+        Map<String, byte[]> jarEntries = new HashMap<>();
+        jarEntries.put("module-info.class", classToBytes.get("module-info"));
+        jarEntries.put("p/TestOwner.class", classToBytes.get("p.TestOwner"));
+        jarEntries.put("p/resource.txt", "# test resource".getBytes());
+        JarUtils.createJarWithEntries(jar, jarEntries);
+
+        try (var loader = JarUtils.loadJar(jar)) {
+            Controller controller = JarUtils.loadModule(jar, loader.classloader(), "m");
+            Module module = controller.layer().findModule("m").orElseThrow();
+
+            Class<?> ownerClass = module.getClassLoader().loadClass("p.TestOwner");
+
+            // first check we get a nice error message when accessing the resource
+            var e = expectThrows(ResourceNotFoundException.class,
+                () -> WhitelistLoader.loadFromResourceFiles(ownerClass, "resource.txt"));
+            assertThat(e.getMessage(), equalTo("Whitelist file [p/resource.txt] not found from owning class [p.TestOwner]." +
+                " Check that the file exists and the package [p] is exported to module null"));
+
+            // now check we can actually read it once the package is opened to us
+            controller.addOpens(module, "p", WhitelistLoader.class.getModule());
+            var whitelist = WhitelistLoader.loadFromResourceFiles(ownerClass, "resource.txt");
+            assertThat(whitelist, notNullValue());
+        }
     }
 }

--- a/modules/lang-painless/spi/src/test/java/org/elasticsearch/painless/WhitelistLoaderTests.java
+++ b/modules/lang-painless/spi/src/test/java/org/elasticsearch/painless/WhitelistLoaderTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.test.compiler.InMemoryJavaCompiler;
 import org.elasticsearch.test.jar.JarUtils;
 
 import java.lang.ModuleLayer.Controller;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -127,7 +128,7 @@ public class WhitelistLoaderTests extends ESTestCase {
         Map<String, byte[]> jarEntries = new HashMap<>();
         jarEntries.put("module-info.class", classToBytes.get("module-info"));
         jarEntries.put("p/TestOwner.class", classToBytes.get("p.TestOwner"));
-        jarEntries.put("p/resource.txt", "# test resource".getBytes());
+        jarEntries.put("p/resource.txt", "# test resource".getBytes(StandardCharsets.UTF_8));
         JarUtils.createJarWithEntries(jar, jarEntries);
 
         try (var loader = JarUtils.loadJar(jar)) {

--- a/modules/lang-painless/spi/src/test/java/org/elasticsearch/painless/WhitelistLoaderTests.java
+++ b/modules/lang-painless/spi/src/test/java/org/elasticsearch/painless/WhitelistLoaderTests.java
@@ -20,24 +20,13 @@ import org.elasticsearch.painless.spi.annotation.WhitelistAnnotationParser;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.compiler.InMemoryJavaCompiler;
 import org.elasticsearch.test.jar.JarUtils;
-import org.hamcrest.Matchers;
 
 import java.lang.ModuleLayer.Controller;
-import java.lang.module.Configuration;
-import java.lang.module.ModuleFinder;
-import java.lang.module.ModuleReader;
-import java.lang.module.ModuleReference;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class WhitelistLoaderTests extends ESTestCase {
@@ -117,14 +106,17 @@ public class WhitelistLoaderTests extends ESTestCase {
     }
 
     public void testMissingWhitelistResource() {
-        var e = expectThrows(ResourceNotFoundException.class,
-            () -> WhitelistLoader.loadFromResourceFiles(Whitelist.class, "missing.txt"));
-        assertThat(e.getMessage(),
-            equalTo("Whitelist file [org/elasticsearch/painless/spi/missing.txt] not found" +
-                " from owning class [org.elasticsearch.painless.spi.Whitelist]."));
+        var e = expectThrows(ResourceNotFoundException.class, () -> WhitelistLoader.loadFromResourceFiles(Whitelist.class, "missing.txt"));
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "Whitelist file [org/elasticsearch/painless/spi/missing.txt] not found"
+                    + " from owning class [org.elasticsearch.painless.spi.Whitelist]."
+            )
+        );
     }
 
-    public void testMissingWhitelistResourceInModule() throws Exception{
+    public void testMissingWhitelistResourceInModule() throws Exception {
         Map<String, CharSequence> sources = new HashMap<>();
         sources.put("module-info", "module m {}");
         sources.put("p.TestOwner", "package p; public class TestOwner { }");
@@ -145,10 +137,14 @@ public class WhitelistLoaderTests extends ESTestCase {
             Class<?> ownerClass = module.getClassLoader().loadClass("p.TestOwner");
 
             // first check we get a nice error message when accessing the resource
-            var e = expectThrows(ResourceNotFoundException.class,
-                () -> WhitelistLoader.loadFromResourceFiles(ownerClass, "resource.txt"));
-            assertThat(e.getMessage(), equalTo("Whitelist file [p/resource.txt] not found from owning class [p.TestOwner]." +
-                " Check that the file exists and the package [p] is opened to module null"));
+            var e = expectThrows(ResourceNotFoundException.class, () -> WhitelistLoader.loadFromResourceFiles(ownerClass, "resource.txt"));
+            assertThat(
+                e.getMessage(),
+                equalTo(
+                    "Whitelist file [p/resource.txt] not found from owning class [p.TestOwner]."
+                        + " Check that the file exists and the package [p] is opened to module null"
+                )
+            );
 
             // now check we can actually read it once the package is opened to us
             controller.addOpens(module, "p", WhitelistLoader.class.getModule());

--- a/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -88,6 +88,7 @@ grant codeBase "${codebase.elasticsearch}" {
 // this is the test-framework, but the jar is horribly named
 grant codeBase "${codebase.framework}" {
   permission java.lang.RuntimePermission "setSecurityManager";
+  permission java.lang.RuntimePermission "createClassLoader";
 };
 
 grant codeBase "${codebase.elasticsearch-rest-client}" {
@@ -129,4 +130,5 @@ grant {
   permission java.nio.file.LinkPermission "symbolic";
   // needed for keystore tests
   permission java.lang.RuntimePermission "accessUserInformation";
+  permission java.lang.RuntimePermission "getClassLoader";
 };

--- a/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.test.jar;
 
-import org.elasticsearch.test.PrivilegedOperations;
 import org.elasticsearch.test.PrivilegedOperations.ClosableURLClassLoader;
 
 import java.io.ByteArrayInputStream;
@@ -17,7 +16,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.module.Configuration;
 import java.lang.module.ModuleFinder;
-import java.lang.module.ModuleReference;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -28,7 +26,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -36,7 +33,6 @@ import java.util.jar.Manifest;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toUnmodifiableMap;
-import static org.hamcrest.Matchers.is;
 
 public final class JarUtils {
 
@@ -107,7 +103,7 @@ public final class JarUtils {
      */
     public static ClosableURLClassLoader loadJar(Path path) {
         try {
-            URL[] urls = new URL[]{ path.toUri().toURL() };
+            URL[] urls = new URL[] { path.toUri().toURL() };
             return new ClosableURLClassLoader(URLClassLoader.newInstance(urls, JarUtils.class.getClassLoader()));
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
@@ -117,8 +113,8 @@ public final class JarUtils {
     public static ModuleLayer.Controller loadModule(Path path, ClassLoader loader, String name) {
         var finder = ModuleFinder.of(path.getParent());
         var cf = Configuration.resolveAndBind(finder, List.of(ModuleLayer.boot().configuration()), ModuleFinder.of(), Set.of(name));
-        return AccessController.doPrivileged((PrivilegedAction<ModuleLayer.Controller>) () ->
-            ModuleLayer.defineModulesWithOneLoader(cf, List.of(ModuleLayer.boot()), loader)
+        return AccessController.doPrivileged(
+            (PrivilegedAction<ModuleLayer.Controller>) () -> ModuleLayer.defineModulesWithOneLoader(cf, List.of(ModuleLayer.boot()), loader)
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
@@ -9,19 +9,34 @@
 
 package org.elasticsearch.test.jar;
 
+import org.elasticsearch.test.PrivilegedOperations;
+import org.elasticsearch.test.PrivilegedOperations.ClosableURLClassLoader;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.module.Configuration;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toUnmodifiableMap;
+import static org.hamcrest.Matchers.is;
 
 public final class JarUtils {
 
@@ -83,6 +98,28 @@ public final class JarUtils {
     public static void createJarWithEntriesUTF(Path jarfile, Map<String, String> entries) throws IOException {
         var map = entries.entrySet().stream().collect(toUnmodifiableMap(Map.Entry::getKey, v -> v.getValue().getBytes(UTF_8)));
         createJarWithEntries(jarfile, map);
+    }
+
+    /**
+     * Creates a class loader for the given jar file.
+     * @param path Path to the jar file to load
+     * @return A URLClassLoader that will load classes from the jar. It should be closed when no longer needed.
+     */
+    public static ClosableURLClassLoader loadJar(Path path) {
+        try {
+            URL[] urls = new URL[]{ path.toUri().toURL() };
+            return new ClosableURLClassLoader(URLClassLoader.newInstance(urls, JarUtils.class.getClassLoader()));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static ModuleLayer.Controller loadModule(Path path, ClassLoader loader, String name) {
+        var finder = ModuleFinder.of(path.getParent());
+        var cf = Configuration.resolveAndBind(finder, List.of(ModuleLayer.boot().configuration()), ModuleFinder.of(), Set.of(name));
+        return AccessController.doPrivileged((PrivilegedAction<ModuleLayer.Controller>) () ->
+            ModuleLayer.defineModulesWithOneLoader(cf, List.of(ModuleLayer.boot()), loader)
+        );
     }
 
     @FunctionalInterface


### PR DESCRIPTION
This commit replaces a NullPointerException that occurs if a whitelist resource is not found with a customized message. Additionally it augments the message with specific actions, especially in the case the owning class is modularized which requires additional work.