### PR TITLE
Broaden index versions tested to cover v7 versions for some analysis tests

### DIFF
--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
@@ -118,7 +118,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         // Test with an index version where lenient should always be false by default
         IndexVersion randomNonLenientIndexVersion = IndexVersionUtils.randomVersionBetween(
             random(),
-            IndexVersions.MINIMUM_COMPATIBLE,
+            IndexVersions.MINIMUM_READONLY_COMPATIBLE,
             IndexVersions.INDEX_SORTING_ON_NESTED
         );
         assertIsNotLenient.accept(randomNonLenientIndexVersion, false);
@@ -177,7 +177,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         // Test with an index version where lenient should always be false by default
         IndexVersion randomNonLenientIndexVersion = IndexVersionUtils.randomVersionBetween(
             random(),
-            IndexVersions.MINIMUM_COMPATIBLE,
+            IndexVersions.MINIMUM_READONLY_COMPATIBLE,
             IndexVersions.INDEX_SORTING_ON_NESTED
         );
         assertIsNotLenient.accept(randomNonLenientIndexVersion, false);
@@ -231,7 +231,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         // Test with an index version where lenient should always be false by default
         IndexVersion randomNonLenientIndexVersion = IndexVersionUtils.randomVersionBetween(
             random(),
-            IndexVersions.MINIMUM_COMPATIBLE,
+            IndexVersions.MINIMUM_READONLY_COMPATIBLE,
             IndexVersions.INDEX_SORTING_ON_NESTED
         );
         assertIsNotLenient.accept(randomNonLenientIndexVersion, false);
@@ -338,7 +338,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
             )
             .put("path.home", createTempDir().toString())
             .put("index.analysis.filter.synonyms.type", "synonym")
@@ -392,7 +392,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
             )
             .put("path.home", createTempDir().toString())
             .build();
@@ -424,7 +424,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
             )
             .put("path.home", createTempDir().toString())
             .putList("common_words", "a", "b")

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/UniqueTokenFilterTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/UniqueTokenFilterTests.java
@@ -124,11 +124,7 @@ public class UniqueTokenFilterTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(
-                    random(),
-                    IndexVersions.MINIMUM_COMPATIBLE,
-                    IndexVersionUtils.getPreviousVersion(IndexVersions.UNIQUE_TOKEN_FILTER_POS_FIX)
-                )
+                IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersions.UNIQUE_TOKEN_FILTER_POS_FIX)
             )
             .build();
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);

--- a/plugins/analysis-phonetic/src/test/java/org/elasticsearch/plugin/analysis/phonetic/AnalysisPhoneticFactoryTests.java
+++ b/plugins/analysis-phonetic/src/test/java/org/elasticsearch/plugin/analysis/phonetic/AnalysisPhoneticFactoryTests.java
@@ -44,7 +44,7 @@ public class AnalysisPhoneticFactoryTests extends AnalysisFactoryTestCase {
         Settings settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
             )
             .put("path.home", createTempDir().toString())
             .build();

--- a/server/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
@@ -55,6 +55,10 @@ public class PreBuiltAnalyzerTests extends ESSingleNodeTestCase {
             PreBuiltAnalyzers.KEYWORD.getAnalyzer(IndexVersion.current()),
             is(PreBuiltAnalyzers.KEYWORD.getAnalyzer(IndexVersions.MINIMUM_COMPATIBLE))
         );
+        assertThat(
+            PreBuiltAnalyzers.KEYWORD.getAnalyzer(IndexVersion.current()),
+            is(PreBuiltAnalyzers.KEYWORD.getAnalyzer(IndexVersions.MINIMUM_READONLY_COMPATIBLE))
+        );
     }
 
     public void testThatInstancesAreCachedAndReused() {

--- a/server/src/test/java/org/elasticsearch/index/similarity/SimilarityServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/similarity/SimilarityServiceTests.java
@@ -74,7 +74,7 @@ public class SimilarityServiceTests extends ESTestCase {
         };
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> SimilarityService.validateSimilarity(IndexVersions.MINIMUM_COMPATIBLE, negativeScoresSim)
+            () -> SimilarityService.validateSimilarity(IndexVersions.MINIMUM_READONLY_COMPATIBLE, negativeScoresSim)
         );
         assertThat(e.getMessage(), Matchers.containsString("Similarities should not return negative scores"));
 
@@ -99,7 +99,7 @@ public class SimilarityServiceTests extends ESTestCase {
         };
         e = expectThrows(
             IllegalArgumentException.class,
-            () -> SimilarityService.validateSimilarity(IndexVersions.MINIMUM_COMPATIBLE, decreasingScoresWithFreqSim)
+            () -> SimilarityService.validateSimilarity(IndexVersions.MINIMUM_READONLY_COMPATIBLE, decreasingScoresWithFreqSim)
         );
         assertThat(e.getMessage(), Matchers.containsString("Similarity scores should not decrease when term frequency increases"));
 
@@ -124,7 +124,7 @@ public class SimilarityServiceTests extends ESTestCase {
         };
         e = expectThrows(
             IllegalArgumentException.class,
-            () -> SimilarityService.validateSimilarity(IndexVersions.MINIMUM_COMPATIBLE, increasingScoresWithNormSim)
+            () -> SimilarityService.validateSimilarity(IndexVersions.MINIMUM_READONLY_COMPATIBLE, increasingScoresWithNormSim)
         );
         assertThat(e.getMessage(), Matchers.containsString("Similarity scores should not increase when norm increases"));
     }

--- a/server/src/test/java/org/elasticsearch/script/VectorScoreScriptUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/script/VectorScoreScriptUtilsTests.java
@@ -51,12 +51,12 @@ public class VectorScoreScriptUtilsTests extends ESTestCase {
                 BinaryDenseVectorScriptDocValuesTests.wrap(
                     new float[][] { docVector },
                     ElementType.FLOAT,
-                    IndexVersions.MINIMUM_COMPATIBLE
+                    IndexVersions.MINIMUM_READONLY_COMPATIBLE
                 ),
                 "test",
                 ElementType.FLOAT,
                 dims,
-                IndexVersions.MINIMUM_COMPATIBLE
+                IndexVersions.MINIMUM_READONLY_COMPATIBLE
             ),
             new BinaryDenseVectorDocValuesField(
                 BinaryDenseVectorScriptDocValuesTests.wrap(new float[][] { docVector }, ElementType.FLOAT, IndexVersion.current()),
@@ -303,12 +303,12 @@ public class VectorScoreScriptUtilsTests extends ESTestCase {
                 BinaryDenseVectorScriptDocValuesTests.wrap(
                     new float[][] { docVector },
                     ElementType.FLOAT,
-                    IndexVersions.MINIMUM_COMPATIBLE
+                    IndexVersions.MINIMUM_READONLY_COMPATIBLE
                 ),
                 "field0",
                 ElementType.FLOAT,
                 dims,
-                IndexVersions.MINIMUM_COMPATIBLE
+                IndexVersions.MINIMUM_READONLY_COMPATIBLE
             ),
             new BinaryDenseVectorDocValuesField(
                 BinaryDenseVectorScriptDocValuesTests.wrap(new float[][] { docVector }, ElementType.FLOAT, IndexVersion.current()),

--- a/server/src/test/java/org/elasticsearch/script/field/vectors/DenseVectorTests.java
+++ b/server/src/test/java/org/elasticsearch/script/field/vectors/DenseVectorTests.java
@@ -69,7 +69,11 @@ public class DenseVectorTests extends ESTestCase {
         assertEquals(knn.cosineSimilarity(arrayQV), knn.cosineSimilarity(listQV), 0.001f);
         assertEquals(knn.cosineSimilarity((Object) listQV), knn.cosineSimilarity((Object) arrayQV), 0.001f);
 
-        for (IndexVersion indexVersion : List.of(IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current())) {
+        for (IndexVersion indexVersion : List.of(
+            IndexVersions.MINIMUM_READONLY_COMPATIBLE,
+            IndexVersions.MINIMUM_COMPATIBLE,
+            IndexVersion.current()
+        )) {
             BytesRef value = BinaryDenseVectorScriptDocValuesTests.mockEncodeDenseVector(docVector, ElementType.FLOAT, indexVersion);
             BinaryDenseVector bdv = new BinaryDenseVector(docVector, value, dims, indexVersion);
 


### PR DESCRIPTION
This replaces usages of MINIMUM_COMPATIBLE with MINIMUM_READONLY_COMPATIBLE as a lower bound when randomizing the index version in some tests. This provides more coverage as it relies on readonly versions as opposed to only those that can be written to.