### PR TITLE
Create an array-based version of ChunkedToXContentBuilder

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpMetadata.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpMetadata.java
@@ -17,7 +17,7 @@ import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.ingest.geoip.direct.DatabaseConfigurationMetadata;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -91,7 +91,7 @@ public final class IngestGeoIpMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).xContentObjectFields(DATABASES_FIELD.getPreferredName(), databases);
+        return NewChunkedXContentBuilder.xContentObjectFields(DATABASES_FIELD.getPreferredName(), databases);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.support.master.AcknowledgedResponse.ACKNOWLEDGED_KEY;
 import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.chunk;
-import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.ifThen;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.empty;
 import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.object;
 import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.xContentObject;
 
@@ -99,8 +99,8 @@ public class ClusterRerouteResponse extends ActionResponse implements IsAcknowle
         return NewChunkedXContentBuilder.of(
             object(
                 chunk((b, p) -> b.field(ACKNOWLEDGED_KEY, isAcknowledged())),
-                ifThen(emitState(outerParams), xContentObject("state", state.toXContentChunked(outerParams))),
-                ifThen(outerParams.paramAsBoolean("explain", false), explanations)
+                emitState(outerParams) ? xContentObject("state", state.toXContentChunked(outerParams)) : empty(),
+                outerParams.paramAsBoolean("explain", false) ? chunk(explanations) : empty()
             )
         );
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
@@ -32,7 +32,6 @@ import static org.elasticsearch.action.support.master.AcknowledgedResponse.ACKNO
 import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.chunk;
 import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.empty;
 import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.object;
-import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.xContentObject;
 
 /**
  * Response returned after a cluster reroute request
@@ -99,7 +98,7 @@ public class ClusterRerouteResponse extends ActionResponse implements IsAcknowle
         return NewChunkedXContentBuilder.of(
             object(
                 chunk((b, p) -> b.field(ACKNOWLEDGED_KEY, isAcknowledged())),
-                emitState(outerParams) ? xContentObject("state", state.toXContentChunked(outerParams)) : empty(),
+                emitState(outerParams) ? NewChunkedXContentBuilder.object("state", state.toXContentChunked(outerParams)) : empty(),
                 outerParams.paramAsBoolean("explain", false) ? chunk(explanations) : empty()
             )
         );

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -14,13 +14,17 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
 import java.util.Iterator;
+
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.array;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.chunk;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.object;
 
 /**
  * A response of a bulk execution. Holding a response for each item responding (in order) of the
@@ -158,13 +162,13 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).object(ob -> ob.append((b, p) -> {
+        return NewChunkedXContentBuilder.of(object(chunk((b, p) -> {
             b.field(ERRORS, hasFailures());
             b.field(TOOK, tookInMillis);
             if (ingestTookInMillis != BulkResponse.NO_INGEST_TOOK) {
                 b.field(INGEST_TOOK, ingestTookInMillis);
             }
             return b;
-        }).array(ITEMS, Iterators.forArray(responses)));
+        }), array(ITEMS, Iterators.forArray(responses))));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.SimpleRefCounted;
@@ -382,7 +383,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         assert hasReferences();
-        return ChunkedToXContent.builder(params).xContentObject(innerToXContentChunked(params));
+        return NewChunkedXContentBuilder.object(innerToXContentChunked(params));
     }
 
     public Iterator<? extends ToXContent> innerToXContentChunked(ToXContent.Params params) {

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponse.java
@@ -11,13 +11,16 @@ package org.elasticsearch.action.support.nodes;
 
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterName;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.xcontent.ToXContent;
 
 import java.util.Iterator;
 import java.util.List;
+
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.chunk;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.object;
 
 public abstract class BaseNodesXContentResponse<TNodeResponse extends BaseNodeResponse> extends BaseNodesResponse<TNodeResponse>
     implements
@@ -29,12 +32,12 @@ public abstract class BaseNodesXContentResponse<TNodeResponse extends BaseNodeRe
 
     @Override
     public final Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params)
-            .object(
-                ob -> ob.append((b, p) -> RestActions.buildNodesHeader(b, p, this))
-                    .field("cluster_name", getClusterName().value())
-                    .append(xContentChunks(params))
-            );
+        return NewChunkedXContentBuilder.of(
+            object(
+                chunk((b, p) -> RestActions.buildNodesHeader(b, p, this).field("cluster_name", getClusterName().value())),
+                xContentChunks(params)
+            )
+        );
     }
 
     protected abstract Iterator<? extends ToXContent> xContentChunks(ToXContent.Params outerParams);

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterFeatures.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterFeatures.java
@@ -34,6 +34,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.common.collect.Iterators.map;
 import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.array;
 
 /**
@@ -281,11 +282,11 @@ public class ClusterFeatures implements Diffable<ClusterFeatures>, ChunkedToXCon
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return NewChunkedXContentBuilder.of(
-            array(nodeFeatures.entrySet().stream().sorted(Map.Entry.comparingByKey()).iterator(), e -> (builder, p) -> {
+            array(map(nodeFeatures.entrySet().stream().sorted(Map.Entry.comparingByKey()).iterator(), e -> (builder, p) -> {
                 String[] features = e.getValue().toArray(String[]::new);
                 Arrays.sort(features);
                 return builder.startObject().field("node_id", e.getKey()).array("features", features).endObject();
-            })
+            }))
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterFeatures.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterFeatures.java
@@ -13,8 +13,8 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.xcontent.ToXContent;
 
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.array;
 
 /**
  * Stores information on what features are present throughout the cluster
@@ -278,12 +280,13 @@ public class ClusterFeatures implements Diffable<ClusterFeatures>, ChunkedToXCon
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params)
-            .array(nodeFeatures.entrySet().stream().sorted(Map.Entry.comparingByKey()).iterator(), e -> (builder, p) -> {
+        return NewChunkedXContentBuilder.of(
+            array(nodeFeatures.entrySet().stream().sorted(Map.Entry.comparingByKey()).iterator(), e -> (builder, p) -> {
                 String[] features = e.getValue().toArray(String[]::new);
                 Arrays.sort(features);
                 return builder.startObject().field("node_id", e.getKey()).array("features", features).endObject();
-            });
+            })
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -66,6 +66,7 @@ import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.object;
 import static org.elasticsearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 
 /**
@@ -758,8 +759,7 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
 
             // customs
             metrics.contains(Metric.CUSTOMS)
-                ? ChunkedToXContent.builder(outerParams)
-                    .forEach(customs.entrySet().iterator(), (b, e) -> b.xContentObject(e.getKey(), e.getValue()))
+                ? Iterators.flatMap(customs.entrySet().iterator(), e -> object(e.getKey(), e.getValue().toXContentChunked(outerParams)))
                 : Collections.emptyIterator()
         );
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
@@ -17,7 +17,7 @@ import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
@@ -103,7 +103,7 @@ public class ComponentTemplateMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).xContentObjectFields(COMPONENT_TEMPLATE.getPreferredName(), componentTemplates);
+        return NewChunkedXContentBuilder.xContentObjectFields(COMPONENT_TEMPLATE.getPreferredName(), componentTemplates);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
@@ -17,7 +17,7 @@ import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
@@ -104,7 +104,7 @@ public class ComposableIndexTemplateMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).xContentObjectFields(INDEX_TEMPLATE.getPreferredName(), indexTemplates);
+        return NewChunkedXContentBuilder.xContentObjectFields(INDEX_TEMPLATE.getPreferredName(), indexTemplates);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -19,7 +19,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -36,6 +36,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.object;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.xContentObjectFields;
 
 /**
  * Custom {@link Metadata} implementation for storing a map of {@link DataStream}s and their names.
@@ -232,9 +235,10 @@ public class DataStreamMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params)
-            .xContentObjectFields(DATA_STREAM.getPreferredName(), dataStreams)
-            .xContentObject(DATA_STREAM_ALIASES.getPreferredName(), dataStreamAliases.values().iterator());
+        return NewChunkedXContentBuilder.of(
+            xContentObjectFields(DATA_STREAM.getPreferredName(), dataStreams),
+            object(DATA_STREAM_ALIASES.getPreferredName(), dataStreamAliases.values().iterator())
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
@@ -19,7 +19,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.xcontent.ContextParser;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -129,7 +129,7 @@ public final class IndexGraveyard implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).array(TOMBSTONES_FIELD.getPreferredName(), tombstones.iterator());
+        return NewChunkedXContentBuilder.array(TOMBSTONES_FIELD.getPreferredName(), tombstones.iterator());
     }
 
     public static IndexGraveyard fromXContent(final XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
@@ -17,7 +17,7 @@ import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -191,7 +191,7 @@ public class NodesShutdownMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).xContentObjectFields(NODES_FIELD.getPreferredName(), nodes);
+        return NewChunkedXContentBuilder.xContentObjectFields(NODES_FIELD.getPreferredName(), nodes);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocateUnassignedDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocateUnassignedDecision.java
@@ -15,7 +15,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ToXContent;
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.chunk;
 
 /**
  * Represents the allocation decision by an allocator for an unassigned shard.
@@ -296,7 +298,7 @@ public class AllocateUnassignedDecision extends AbstractAllocationDecision {
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         checkDecisionState();
-        return ChunkedToXContent.builder(params).append((builder, p) -> {
+        return NewChunkedXContentBuilder.of(chunk((builder, p) -> {
             builder.field("can_allocate", getAllocationDecision());
             builder.field("allocate_explanation", getExplanation());
             if (targetNode != null) {
@@ -320,7 +322,7 @@ public class AllocateUnassignedDecision extends AbstractAllocationDecision {
                 );
             }
             return builder;
-        }).append(nodeDecisionsToXContentChunked(nodeDecisions));
+        }), nodeDecisionsToXContentChunked(nodeDecisions));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
@@ -14,7 +14,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ToXContent;
 
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.chunk;
 
 /**
  * Represents a decision to move a started shard, either because it is no longer allowed to remain on its current node
@@ -260,7 +262,7 @@ public final class MoveDecision extends AbstractAllocationDecision {
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         checkDecisionState();
-        return ChunkedToXContent.builder(params).append((builder, p) -> {
+        return NewChunkedXContentBuilder.of(chunk((builder, p) -> {
             if (targetNode != null) {
                 builder.startObject("target_node");
                 discoveryNodeToXContent(targetNode, true, builder);
@@ -289,7 +291,7 @@ public final class MoveDecision extends AbstractAllocationDecision {
                 builder.field("move_explanation", getExplanation());
             }
             return builder;
-        }).append(nodeDecisionsToXContentChunked(nodeDecisions));
+        }), nodeDecisionsToXContentChunked(nodeDecisions));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentHelper.java
@@ -50,7 +50,19 @@ public enum ChunkedToXContentHelper {
         return Iterators.single(((builder, params) -> builder.field(name, value)));
     }
 
+    public static Iterator<ToXContent> field(String name, double value) {
+        return Iterators.single(((builder, params) -> builder.field(name, value)));
+    }
+
     public static Iterator<ToXContent> field(String name, String value) {
+        return Iterators.single(((builder, params) -> builder.field(name, value)));
+    }
+
+    public static Iterator<ToXContent> field(String name, Enum<?> value) {
+        return Iterators.single(((builder, params) -> builder.field(name, value)));
+    }
+
+    public static Iterator<ToXContent> field(String name, ToXContent value) {
         return Iterators.single(((builder, params) -> builder.field(name, value)));
     }
 

--- a/server/src/main/java/org/elasticsearch/common/xcontent/NewChunkedXContentBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/NewChunkedXContentBuilder.java
@@ -16,8 +16,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.function.Function;
 
-import static java.util.Collections.emptyIterator;
-
 public class NewChunkedXContentBuilder {
 
     private static Iterator<? extends ToXContent> startObject() {
@@ -44,7 +42,7 @@ public class NewChunkedXContentBuilder {
         return chunk((b, p) -> b.endArray());
     }
 
-    public static Iterator<? extends ToXContent> empty() {
+    public static Iterator<ToXContent> empty() {
         return Collections.emptyIterator();
     }
 
@@ -68,14 +66,6 @@ public class NewChunkedXContentBuilder {
 
     public static Iterator<? extends ToXContent> of(ToXContent... chunks) {
         return Iterators.forArray(chunks);
-    }
-
-    public static Iterator<? extends ToXContent> ifThen(boolean condition, ToXContent content) {
-        return condition ? chunk(content) : emptyIterator();
-    }
-
-    public static Iterator<? extends ToXContent> ifThen(boolean condition, Iterator<? extends ToXContent> content) {
-        return condition ? content : emptyIterator();
     }
 
     public static Iterator<? extends ToXContent> object(ToXContent xContent) {

--- a/server/src/main/java/org/elasticsearch/common/xcontent/NewChunkedXContentBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/NewChunkedXContentBuilder.java
@@ -12,32 +12,44 @@ package org.elasticsearch.common.xcontent;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.xcontent.ToXContent;
 
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.function.Function;
+
+import static java.util.Collections.emptyIterator;
 
 public class NewChunkedXContentBuilder {
 
-    private static ToXContent startObject() {
-        return (b, p) -> b.startObject();
+    private static Iterator<? extends ToXContent> startObject() {
+        return chunk((b, p) -> b.startObject());
     }
 
-    private static ToXContent startObject(String name) {
-        return (b, p) -> b.startObject(name);
+    private static Iterator<? extends ToXContent> startObject(String name) {
+        return chunk((b, p) -> b.startObject(name));
     }
 
-    private static ToXContent endObject() {
-        return (b, p) -> b.endObject();
+    private static Iterator<? extends ToXContent> endObject() {
+        return chunk((b, p) -> b.endObject());
     }
 
-    private static ToXContent startArray() {
-        return (b, p) -> b.startArray();
+    private static Iterator<? extends ToXContent> startArray() {
+        return chunk((b, p) -> b.startArray());
     }
 
-    private static ToXContent startArray(String name) {
-        return (b, p) -> b.startArray(name);
+    private static Iterator<? extends ToXContent> startArray(String name) {
+        return chunk((b, p) -> b.startArray(name));
     }
 
-    private static ToXContent endArray() {
-        return (b, p) -> b.endArray();
+    private static Iterator<? extends ToXContent> endArray() {
+        return chunk((b, p) -> b.endArray());
+    }
+
+    public static Iterator<? extends ToXContent> empty() {
+        return Collections.emptyIterator();
+    }
+
+    public static Iterator<? extends ToXContent> of(Iterator<? extends ToXContent> chunk) {
+        return chunk;
     }
 
     @SafeVarargs
@@ -58,25 +70,57 @@ public class NewChunkedXContentBuilder {
         return Iterators.forArray(chunks);
     }
 
+    public static Iterator<? extends ToXContent> ifThen(boolean condition, ToXContent content) {
+        return condition ? chunk(content) : emptyIterator();
+    }
+
+    public static Iterator<? extends ToXContent> ifThen(boolean condition, Iterator<? extends ToXContent> content) {
+        return condition ? content : emptyIterator();
+    }
+
     public static Iterator<? extends ToXContent> object(ToXContent xContent) {
         return of((b, p) -> xContent.toXContent(b.startObject(), p).endObject());
     }
 
     public static Iterator<? extends ToXContent> object(ToXContent... items) {
-        return of(of(startObject()), of(items), of(endObject()));
+        return of(startObject(), of(items), endObject());
     }
 
     public static Iterator<? extends ToXContent> object(Iterator<? extends ToXContent> items) {
-        return of(of(startObject()), items, of(endObject()));
+        return of(startObject(), items, endObject());
+    }
+
+    public static Iterator<? extends ToXContent> object(String name, Iterator<? extends ToXContent> items) {
+        return of(startObject(name), items, endObject());
     }
 
     @SafeVarargs
     @SuppressWarnings("varargs")
     public static Iterator<? extends ToXContent> object(Iterator<? extends ToXContent>... items) {
-        return of(of(startObject()), of(items), of(endObject()));
+        return of(startObject(), of(items), endObject());
+    }
+
+    public static <T> Iterator<? extends ToXContent> object(String name, Iterator<T> items, Function<? super T, ToXContent> create) {
+        return of(startObject(name), Iterators.map(items, create), endObject());
     }
 
     public static Iterator<? extends ToXContent> array(String name, Iterator<? extends ToXContent> items) {
-        return of(of(startArray(name)), items, of(endArray()));
+        return of(startArray(name), items, endArray());
+    }
+
+    public static <T> Iterator<? extends ToXContent> array(Iterator<T> items, Function<? super T, ToXContent> create) {
+        return of(startArray(), Iterators.map(items, create), endArray());
+    }
+
+    public static <T> Iterator<? extends ToXContent> array(String name, Iterator<T> items, Function<? super T, ToXContent> create) {
+        return of(startArray(name), Iterators.map(items, create), endArray());
+    }
+
+    public static Iterator<? extends ToXContent> xContentObject(String name, Iterator<? extends ToXContent> contents) {
+        return of(startObject(name), contents, endObject());
+    }
+
+    public static <T> Iterator<? extends ToXContent> forEach(Iterator<T> items, Function<T, Iterator<? extends ToXContent>> map) {
+        return Iterators.flatMap(items, map);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/NewChunkedXContentBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/NewChunkedXContentBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.xcontent;
+
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.xcontent.ToXContent;
+
+import java.util.Iterator;
+
+public class NewChunkedXContentBuilder {
+
+    private static ToXContent startObject() {
+        return (b, p) -> b.startObject();
+    }
+
+    private static ToXContent startObject(String name) {
+        return (b, p) -> b.startObject(name);
+    }
+
+    private static ToXContent endObject() {
+        return (b, p) -> b.endObject();
+    }
+
+    private static ToXContent startArray() {
+        return (b, p) -> b.startArray();
+    }
+
+    private static ToXContent startArray(String name) {
+        return (b, p) -> b.startArray(name);
+    }
+
+    private static ToXContent endArray() {
+        return (b, p) -> b.endArray();
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public static Iterator<? extends ToXContent> of(Iterator<? extends ToXContent>... chunks) {
+        return Iterators.concat(chunks);
+    }
+
+    public static Iterator<? extends ToXContent> chunk(ToXContent xContent) {
+        return of(xContent);
+    }
+
+    public static Iterator<? extends ToXContent> of(ToXContent xContent) {
+        return Iterators.single(xContent);
+    }
+
+    public static Iterator<? extends ToXContent> of(ToXContent... chunks) {
+        return Iterators.forArray(chunks);
+    }
+
+    public static Iterator<? extends ToXContent> object(ToXContent xContent) {
+        return of((b, p) -> xContent.toXContent(b.startObject(), p).endObject());
+    }
+
+    public static Iterator<? extends ToXContent> object(ToXContent... items) {
+        return of(of(startObject()), of(items), of(endObject()));
+    }
+
+    public static Iterator<? extends ToXContent> object(Iterator<? extends ToXContent> items) {
+        return of(of(startObject()), items, of(endObject()));
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public static Iterator<? extends ToXContent> object(Iterator<? extends ToXContent>... items) {
+        return of(of(startObject()), of(items), of(endObject()));
+    }
+
+    public static Iterator<? extends ToXContent> array(String name, Iterator<? extends ToXContent> items) {
+        return of(of(startArray(name)), items, of(endArray()));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
@@ -18,7 +18,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
@@ -99,7 +99,7 @@ public final class IngestMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).array(PIPELINES_FIELD.getPreferredName(), pipelines.values().iterator());
+        return NewChunkedXContentBuilder.array(PIPELINES_FIELD.getPreferredName(), pipelines.values().iterator());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
@@ -21,7 +21,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -47,6 +47,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.Metadata.ALL_CONTEXTS;
+import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.field;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.array;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
@@ -552,7 +554,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).field("last_allocation_id", lastAllocationId).array("tasks", tasks.values().iterator());
+        return NewChunkedXContentBuilder.of(field("last_allocation_id", lastAllocationId), array("tasks", tasks.values().iterator()));
     }
 
     public static Builder builder() {

--- a/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
@@ -18,7 +18,7 @@ import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 
@@ -58,7 +58,7 @@ public class FeatureMigrationResults implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).xContentObjectFields(RESULTS_FIELD.getPreferredName(), featureStatuses);
+        return NewChunkedXContentBuilder.xContentObjectFields(RESULTS_FIELD.getPreferredName(), featureStatuses);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCustomMetadata.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCustomMetadata.java
@@ -15,7 +15,7 @@ import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParser;
 
@@ -95,7 +95,7 @@ public abstract class TestCustomMetadata extends AbstractNamedDiffable<Metadata.
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).field("data", getData());
+        return ChunkedToXContentHelper.field("data", getData());
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadata.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadata.java
@@ -16,7 +16,7 @@ import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
@@ -119,7 +119,7 @@ public class AutoscalingMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).xContentObjectFields(POLICIES_FIELD.getPreferredName(), policies);
+        return NewChunkedXContentBuilder.xContentObjectFields(POLICIES_FIELD.getPreferredName(), policies);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
@@ -18,7 +18,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -37,6 +37,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.object;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.xContentObjectFieldObjects;
 
 /**
  * Custom metadata that contains auto follow patterns and what leader indices an auto follow pattern has already followed.
@@ -149,10 +152,11 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<Metadata.Custom> i
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params)
-            .xContentObjectFieldObjects(PATTERNS_FIELD.getPreferredName(), patterns)
-            .object(FOLLOWED_LEADER_INDICES_FIELD.getPreferredName(), followedLeaderIndexUUIDs)
-            .object(HEADERS.getPreferredName(), headers);
+        return NewChunkedXContentBuilder.of(
+            xContentObjectFieldObjects(PATTERNS_FIELD.getPreferredName(), patterns),
+            object(FOLLOWED_LEADER_INDICES_FIELD.getPreferredName(), followedLeaderIndexUUIDs),
+            object(HEADERS.getPreferredName(), headers)
+        );
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichMetadata.java
@@ -13,7 +13,7 @@ import org.elasticsearch.cluster.AbstractNamedDiffable;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
@@ -99,7 +99,7 @@ public final class EnrichMetadata extends AbstractNamedDiffable<Metadata.Custom>
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).xContentObjectFieldObjects(POLICIES.getPreferredName(), policies);
+        return NewChunkedXContentBuilder.xContentObjectFieldObjects(POLICIES.getPreferredName(), policies);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
@@ -17,7 +17,7 @@ import org.elasticsearch.cluster.metadata.Metadata.Custom;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
@@ -33,6 +33,9 @@ import java.util.Objects;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.field;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.xContentObjectFields;
 
 public class IndexLifecycleMetadata implements Metadata.Custom {
     public static final String TYPE = "index_lifecycle";
@@ -116,9 +119,10 @@ public class IndexLifecycleMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params)
-            .xContentObjectFields(POLICIES_FIELD.getPreferredName(), policyMetadatas)
-            .field(OPERATION_MODE_FIELD.getPreferredName(), operationMode);
+        return NewChunkedXContentBuilder.of(
+            xContentObjectFields(POLICIES_FIELD.getPreferredName(), policyMetadatas),
+            field(OPERATION_MODE_FIELD.getPreferredName(), operationMode)
+        );
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/ChatCompletionResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/ChatCompletionResults.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.core.inference.results;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.TaskType;
@@ -50,7 +50,7 @@ public record ChatCompletionResults(List<Result> results) implements InferenceSe
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).array(COMPLETION, results.iterator());
+        return NewChunkedXContentBuilder.array(COMPLETION, results.iterator());
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/InferenceTextEmbeddingByteResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/InferenceTextEmbeddingByteResults.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xcontent.ToXContent;
@@ -62,7 +62,7 @@ public record InferenceTextEmbeddingByteResults(List<InferenceByteEmbedding> emb
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).array(TEXT_EMBEDDING_BYTES, embeddings.iterator());
+        return NewChunkedXContentBuilder.array(TEXT_EMBEDDING_BYTES, embeddings.iterator());
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/InferenceTextEmbeddingFloatResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/InferenceTextEmbeddingFloatResults.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.TaskType;
@@ -103,7 +103,7 @@ public record InferenceTextEmbeddingFloatResults(List<InferenceFloatEmbedding> e
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).array(TEXT_EMBEDDING, embeddings.iterator());
+        return NewChunkedXContentBuilder.array(TEXT_EMBEDDING, embeddings.iterator());
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/RankedDocsResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/RankedDocsResults.java
@@ -11,7 +11,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.inference.InferenceServiceResults;
@@ -178,7 +178,7 @@ public class RankedDocsResults implements InferenceServiceResults {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).array(RERANK, rankedDocs.iterator());
+        return NewChunkedXContentBuilder.array(RERANK, rankedDocs.iterator());
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/SparseEmbeddingResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/SparseEmbeddingResults.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.TaskType;
@@ -72,7 +72,7 @@ public record SparseEmbeddingResults(List<Embedding> embeddings) implements Infe
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).array(SPARSE_EMBEDDING, embeddings.iterator());
+        return NewChunkedXContentBuilder.array(SPARSE_EMBEDDING, embeddings.iterator());
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/ModelAliasMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/ModelAliasMetadata.java
@@ -17,7 +17,7 @@ import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
@@ -93,7 +93,7 @@ public class ModelAliasMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).xContentObjectFields(MODEL_ALIASES.getPreferredName(), modelAliases);
+        return NewChunkedXContentBuilder.xContentObjectFields(MODEL_ALIASES.getPreferredName(), modelAliases);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
@@ -17,7 +17,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
@@ -35,6 +35,9 @@ import java.util.Objects;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.field;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.xContentObjectFields;
 
 /**
  * Custom cluster state metadata that stores all the snapshot lifecycle
@@ -143,10 +146,11 @@ public class SnapshotLifecycleMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params)
-            .xContentObjectFields(POLICIES_FIELD.getPreferredName(), snapshotConfigurations)
-            .field(OPERATION_MODE_FIELD.getPreferredName(), operationMode)
-            .field(STATS_FIELD.getPreferredName(), slmStats);
+        return NewChunkedXContentBuilder.of(
+            xContentObjectFields(POLICIES_FIELD.getPreferredName(), snapshotConfigurations),
+            field(OPERATION_MODE_FIELD.getPreferredName(), operationMode),
+            field(STATS_FIELD.getPreferredName(), slmStats)
+        );
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverProfile.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverProfile.java
@@ -12,8 +12,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ToXContent;
 
@@ -21,6 +21,10 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.field;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.array;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.chunk;
 
 /**
  * Profile results from a single {@link Driver}.
@@ -167,24 +171,20 @@ public class DriverProfile implements Writeable, ChunkedToXContentObject {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).object(ob -> {
-            ob.append((b, p) -> {
-                b.timestampFieldsFromUnixEpochMillis("start_millis", "start", startMillis);
-                b.timestampFieldsFromUnixEpochMillis("stop_millis", "stop", stopMillis);
-                b.field("took_nanos", tookNanos);
-                if (b.humanReadable()) {
-                    b.field("took_time", TimeValue.timeValueNanos(tookNanos));
-                }
-                b.field("cpu_nanos", cpuNanos);
-                if (b.humanReadable()) {
-                    b.field("cpu_time", TimeValue.timeValueNanos(cpuNanos));
-                }
-                b.field("iterations", iterations);
-                return b;
-            });
-            ob.array("operators", operators.iterator());
-            ob.field("sleeps", sleeps);
-        });
+        return NewChunkedXContentBuilder.object(chunk((b, p) -> {
+            b.timestampFieldsFromUnixEpochMillis("start_millis", "start", startMillis);
+            b.timestampFieldsFromUnixEpochMillis("stop_millis", "stop", stopMillis);
+            b.field("took_nanos", tookNanos);
+            if (b.humanReadable()) {
+                b.field("took_time", TimeValue.timeValueNanos(tookNanos));
+            }
+            b.field("cpu_nanos", cpuNanos);
+            if (b.humanReadable()) {
+                b.field("cpu_time", TimeValue.timeValueNanos(cpuNanos));
+            }
+            b.field("iterations", iterations);
+            return b;
+        }), array("operators", operators.iterator()), field("sleeps", sleeps));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
@@ -13,8 +13,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.action.RestActions;
@@ -37,6 +37,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
+
+import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.field;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.object;
 
 /**
  * Holds execution metadata about ES|QL queries for cross-cluster searches in order to display
@@ -233,16 +236,16 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
         if (isCrossClusterSearch() == false || clusterInfo.isEmpty()) {
             return Collections.emptyIterator();
         }
-        return ChunkedToXContent.builder(params).object(b -> {
-            b.field(TOTAL_FIELD.getPreferredName(), clusterInfo.size());
-            b.field(SUCCESSFUL_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.SUCCESSFUL));
-            b.field(RUNNING_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.RUNNING));
-            b.field(SKIPPED_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.SKIPPED));
-            b.field(PARTIAL_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.PARTIAL));
-            b.field(FAILED_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.FAILED));
+        return NewChunkedXContentBuilder.object(
+            field(TOTAL_FIELD.getPreferredName(), clusterInfo.size()),
+            field(SUCCESSFUL_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.SUCCESSFUL)),
+            field(RUNNING_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.RUNNING)),
+            field(SKIPPED_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.SKIPPED)),
+            field(PARTIAL_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.PARTIAL)),
+            field(FAILED_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.FAILED)),
             // each Cluster object defines its own field object name
-            b.xContentObject("details", clusterInfo.values().iterator());
-        });
+            object("details", clusterInfo.values().iterator())
+        );
     }
 
     /**

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetFlamegraphResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetFlamegraphResponse.java
@@ -11,8 +11,8 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
+import org.elasticsearch.common.xcontent.NewChunkedXContentBuilder;
 import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.xcontent.ToXContent;
 
@@ -21,6 +21,11 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import static org.elasticsearch.common.collect.Iterators.flatMap;
+import static org.elasticsearch.common.collect.Iterators.map;
+import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.field;
+import static org.elasticsearch.common.xcontent.NewChunkedXContentBuilder.array;
 
 public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXContentObject {
     private final int size;
@@ -177,29 +182,29 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
     @UpdateForV9(owner = UpdateForV9.Owner.PROFILING) // change casing from Camel Case to Snake Case (requires updates in Kibana as well)
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).object(ob -> {
-            ob.array("Edges", edges.iterator(), (eb, e) -> eb.array(intValues(e.values())));
-            ob.array("FileID", fileIds.toArray(String[]::new));
-            ob.array("FrameType", intValues(frameTypes));
-            ob.array("Inline", inlineFrames.iterator(), e -> (b, p) -> b.value(e));
-            ob.array("ExeFilename", fileNames.toArray(String[]::new));
-            ob.array("AddressOrLine", intValues(addressOrLines));
-            ob.array("FunctionName", functionNames.toArray(String[]::new));
-            ob.array("FunctionOffset", intValues(functionOffsets));
-            ob.array("SourceFilename", sourceFileNames.toArray(String[]::new));
-            ob.array("SourceLine", intValues(sourceLines));
-            ob.array("CountInclusive", longValues(countInclusive));
-            ob.array("CountExclusive", longValues(countExclusive));
-            ob.array("AnnualCO2TonsInclusive", doubleValues(annualCO2TonsInclusive));
-            ob.array("AnnualCO2TonsExclusive", doubleValues(annualCO2TonsExclusive));
-            ob.array("AnnualCostsUSDInclusive", doubleValues(annualCostsUSDInclusive));
-            ob.array("AnnualCostsUSDExclusive", doubleValues(annualCostsUSDExclusive));
-            ob.field("Size", size);
-            ob.field("SamplingRate", samplingRate);
-            ob.field("SelfCPU", selfCPU);
-            ob.field("TotalCPU", totalCPU);
-            ob.field("TotalSamples", totalSamples);
-        });
+        return NewChunkedXContentBuilder.object(
+            array("Edges", flatMap(edges.iterator(), e -> array(intValues(e.values())))),
+            array("FileID", fileIds.toArray(String[]::new)),
+            array("FrameType", intValues(frameTypes)),
+            array("Inline", map(inlineFrames.iterator(), e -> (b, p) -> b.value(e))),
+            array("ExeFilename", fileNames.toArray(String[]::new)),
+            array("AddressOrLine", intValues(addressOrLines)),
+            array("FunctionName", functionNames.toArray(String[]::new)),
+            array("FunctionOffset", intValues(functionOffsets)),
+            array("SourceFilename", sourceFileNames.toArray(String[]::new)),
+            array("SourceLine", intValues(sourceLines)),
+            array("CountInclusive", longValues(countInclusive)),
+            array("CountExclusive", longValues(countExclusive)),
+            array("AnnualCO2TonsInclusive", doubleValues(annualCO2TonsInclusive)),
+            array("AnnualCO2TonsExclusive", doubleValues(annualCO2TonsExclusive)),
+            array("AnnualCostsUSDInclusive", doubleValues(annualCostsUSDInclusive)),
+            array("AnnualCostsUSDExclusive", doubleValues(annualCostsUSDExclusive)),
+            field("Size", size),
+            field("SamplingRate", samplingRate),
+            field("SelfCPU", selfCPU),
+            field("TotalCPU", totalCPU),
+            field("TotalSamples", totalSamples)
+        );
     }
 
     private static Iterator<ToXContent> intValues(Collection<Integer> values) {


### PR DESCRIPTION
Use fixed-size arrays, but the methods and semantics of `ChunkedToXContentBuilder`

Fixes https://github.com/elastic/elasticsearch/issues/118647