### PR TITLE
Fix NodeJoinExecutorTests#testSuccess

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -301,9 +301,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/116777
 - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectoryRunAsIT
   issue: https://github.com/elastic/elasticsearch/issues/115727
-- class: org.elasticsearch.cluster.coordination.NodeJoinExecutorTests
-  method: testSuccess
-  issue: https://github.com/elastic/elasticsearch/issues/119052
 
 # Examples:
 #

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -467,7 +467,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
             .build();
         metaBuilder.put(indexMetadata, false);
         Metadata metadata = metaBuilder.build();
-        NodeJoinExecutor.ensureIndexCompatibility(IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current(), metadata);
+        NodeJoinExecutor.ensureIndexCompatibility(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current(), metadata);
     }
 
     public static Settings.Builder randomCompatibleVersionSettings() {


### PR DESCRIPTION
This is related to #119013, we can lower the minimum compatible version to read only compatible version to make the test succeed at all times.

Closes #119052
