### PR TITLE
ESQL: Set LOOKUP JOIN YAML test number of shards to 1

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
@@ -12,8 +12,6 @@ setup:
       indices.create:
         index: test
         body:
-          settings:
-            number_of_shards: 5
           mappings:
             properties:
               key:
@@ -27,6 +25,7 @@ setup:
           settings:
             index:
               mode: lookup
+            number_of_shards: 1
           mappings:
             properties:
               key:


### PR DESCRIPTION
To mitigate https://github.com/elastic/elasticsearch/issues/119035 and https://github.com/elastic/elasticsearch/issues/119036