### PR TITLE
Remove min_read_only_index_version from XContent node

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -595,7 +595,6 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         builder.endArray();
         builder.field("version", versionInfo.buildVersion().toString());
         builder.field("min_index_version", versionInfo.minIndexVersion());
-        builder.field("min_read_only_index_version", versionInfo.minReadOnlyIndexVersion());
         builder.field("max_index_version", versionInfo.maxIndexVersion());
         builder.endObject();
         return builder;

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
@@ -127,7 +127,6 @@ public class ClusterRerouteResponseTests extends ESTestCase {
                             ],
                             "version": "%s",
                             "min_index_version": %s,
-                            "min_read_only_index_version": %s,
                             "max_index_version": %s
                           }
                         },
@@ -219,7 +218,6 @@ public class ClusterRerouteResponseTests extends ESTestCase {
                 clusterState.getNodes().get("node0").getEphemeralId(),
                 Version.CURRENT,
                 IndexVersions.MINIMUM_COMPATIBLE,
-                IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                 IndexVersion.current(),
                 IndexVersion.current(),
                 IndexVersion.current()

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -213,7 +213,6 @@ public class ClusterStateTests extends ESTestCase {
                               ],
                               "version": "%s",
                               "min_index_version":%s,
-                              "min_read_only_index_version":%s,
                               "max_index_version":%s
                             }
                           },
@@ -390,7 +389,6 @@ public class ClusterStateTests extends ESTestCase {
                     ephemeralId,
                     Version.CURRENT,
                     IndexVersions.MINIMUM_COMPATIBLE,
-                    IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                     IndexVersion.current(),
                     TransportVersion.current(),
                     IndexVersion.current(),
@@ -490,7 +488,6 @@ public class ClusterStateTests extends ESTestCase {
                           ],
                           "version" : "%s",
                           "min_index_version" : %s,
-                          "min_read_only_index_version" : %s,
                           "max_index_version" : %s
                         }
                       },
@@ -666,7 +663,6 @@ public class ClusterStateTests extends ESTestCase {
                 ephemeralId,
                 Version.CURRENT,
                 IndexVersions.MINIMUM_COMPATIBLE,
-                IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                 IndexVersion.current(),
                 TransportVersion.current(),
                 IndexVersion.current(),
@@ -766,7 +762,6 @@ public class ClusterStateTests extends ESTestCase {
                           ],
                           "version" : "%s",
                           "min_index_version" : %s,
-                          "min_read_only_index_version" : %s,
                           "max_index_version" : %s
                         }
                       },
@@ -948,7 +943,6 @@ public class ClusterStateTests extends ESTestCase {
                 ephemeralId,
                 Version.CURRENT,
                 IndexVersions.MINIMUM_COMPATIBLE,
-                IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                 IndexVersion.current(),
                 TransportVersion.current(),
                 IndexVersion.current(),

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
@@ -223,7 +223,6 @@ public class DiscoveryNodeTests extends ESTestCase {
                             ],
                             "version" : "%s",
                             "min_index_version" : %s,
-                            "min_read_only_index_version" : %s,
                             "max_index_version" : %s
                           }
                         }""",
@@ -231,7 +230,6 @@ public class DiscoveryNodeTests extends ESTestCase {
                     withExternalId ? "test-external-id" : "test-name",
                     Version.CURRENT,
                     IndexVersions.MINIMUM_COMPATIBLE,
-                    IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                     IndexVersion.current()
                 )
             )

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -462,7 +462,6 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
             pluginEsBuildVersion,
             Version.CURRENT,
             IndexVersions.MINIMUM_COMPATIBLE,
-            IndexVersions.MINIMUM_READONLY_COMPATIBLE,
             IndexVersion.current(),
             apmIndicesExist };
         final String expectedJson = """
@@ -818,7 +817,6 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
                     ],
                     "version": "%s",
                     "min_index_version":%s,
-                    "min_read_only_index_version":%s,
                     "max_index_version":%s
                   }
                 },


### PR DESCRIPTION
We prefer to remove this information from the API since they are not useful externally, impact the search shard API and may be removed later (which would be a breaking change).

Follow-up #118744