### PR TITLE
[Fleet] Update fleet mappings version

### DIFF
--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -79,11 +79,11 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     private static final int CURRENT_INDEX_VERSION = 7;
     private static final String MAPPING_VERSION_VARIABLE = "fleet.version";
     private static final List<String> ALLOWED_PRODUCTS = List.of("kibana", "fleet");
-    private static final int FLEET_ACTIONS_MAPPINGS_VERSION = 1;
-    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 1;
-    private static final int FLEET_ENROLLMENT_API_KEYS_MAPPINGS_VERSION = 1;
+    private static final int FLEET_ACTIONS_MAPPINGS_VERSION = 2;
+    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 2;
+    private static final int FLEET_ENROLLMENT_API_KEYS_MAPPINGS_VERSION = 2;
     private static final int FLEET_SECRETS_MAPPINGS_VERSION = 1;
-    private static final int FLEET_POLICIES_MAPPINGS_VERSION = 1;
+    private static final int FLEET_POLICIES_MAPPINGS_VERSION = 2;
     private static final int FLEET_POLICIES_LEADER_MAPPINGS_VERSION = 1;
     private static final int FLEET_SERVERS_MAPPINGS_VERSION = 1;
     private static final int FLEET_ARTIFACTS_MAPPINGS_VERSION = 1;


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/kibana/issues/204834

Update mappings version for .fleet systems indices, we made a few change to .fleet indices without updating the mappings version. The consequence of this is the mappings are not updated on stack upgrade.

That PR fix that by increasing the mapping version for those indices.

## How to tests?

I tested the upgrade from an 8.12 Elasticsearch to 8.18 than to that version  with 

```
yarn es  source -E xpack.security.authc.api_key.enabled=true -E xpack.security.authc.token.enabled=true  --source-path=/Users/nchaulet/Workspace/elasticsearch  -E path.data=/tmp/es-data
```

And I was able to verify the .fleet indices have updated mappings, especially the `namespaces: keyword` that is required for Fleet space awareness