### PR TITLE
Removed forgotten test mute

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -279,9 +279,6 @@ tests:
 - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
   method: testDeletingAndCreatingSecurityIndexTriggersSynchronization
   issue: https://github.com/elastic/elasticsearch/issues/118806
-- class: org.elasticsearch.index.engine.RecoverySourcePruneMergePolicyTests
-  method: testPruneSome
-  issue: https://github.com/elastic/elasticsearch/issues/118728
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/indices/shard-stores/line_150}
   issue: https://github.com/elastic/elasticsearch/issues/118896


### PR DESCRIPTION
The test failure #118728 was fixed by #118944 but test wasn't unmuted.