### PR TITLE
Address shape query builders testToQuery failures

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -302,12 +302,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/118414
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
   issue: https://github.com/elastic/elasticsearch/issues/119086
-- class: org.elasticsearch.xpack.spatial.index.query.ShapeQueryBuilderOverShapeTests
-  method: testToQuery
-  issue: https://github.com/elastic/elasticsearch/issues/119090
-- class: org.elasticsearch.xpack.spatial.index.query.GeoShapeQueryBuilderGeoShapeTests
-  method: testToQuery
-  issue: https://github.com/elastic/elasticsearch/issues/119091
 
 # Examples:
 #

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderOverShapeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderOverShapeTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.ShapeType;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
@@ -32,10 +33,18 @@ public class ShapeQueryBuilderOverShapeTests extends ShapeQueryBuilderTests {
     @Override
     protected ShapeRelation getShapeRelation(ShapeType type) {
         SearchExecutionContext context = createSearchExecutionContext();
-        if (type == ShapeType.LINESTRING || type == ShapeType.MULTILINESTRING) {
-            return randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.CONTAINS);
+        if (context.indexVersionCreated().onOrAfter(IndexVersions.V_7_5_0)) { // CONTAINS is only supported from version 7.5
+            if (type == ShapeType.LINESTRING || type == ShapeType.MULTILINESTRING) {
+                return randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.CONTAINS);
+            } else {
+                return randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.WITHIN, ShapeRelation.CONTAINS);
+            }
         } else {
-            return randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.WITHIN, ShapeRelation.CONTAINS);
+            if (type == ShapeType.LINESTRING || type == ShapeType.MULTILINESTRING) {
+                return randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS);
+            } else {
+                return randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.WITHIN);
+            }
         }
     }
 


### PR DESCRIPTION
With broadening of index versions tested in AbstractQueryBuilder, we need to restore compatibility with 7x index versions that has been removed.

Closes #119090 
Closes #119091