### PR TITLE
Add missing ProcessBuilder.start entitlements test

### DIFF
--- a/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/RestEntitlementsCheckAction.java
@@ -55,7 +55,7 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
         entry("runtime_exit", deniedToPlugins(RestEntitlementsCheckAction::runtimeExit)),
         entry("runtime_halt", deniedToPlugins(RestEntitlementsCheckAction::runtimeHalt)),
         entry("create_classloader", forPlugins(RestEntitlementsCheckAction::createClassLoader)),
-        // entry("processBuilder_start", deniedToPlugins(RestEntitlementsCheckAction::processBuilder_start)),
+        entry("processBuilder_start", deniedToPlugins(RestEntitlementsCheckAction::processBuilder_start)),
         entry("processBuilder_startPipeline", deniedToPlugins(RestEntitlementsCheckAction::processBuilder_startPipeline))
     );
 
@@ -78,7 +78,11 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
     }
 
     private static void processBuilder_start() {
-        // TODO: processBuilder().start();
+        try {
+            new ProcessBuilder("").start();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     private static void processBuilder_startPipeline() {


### PR DESCRIPTION
Follow-on from #119010.

In that PR, I commented out all the tests for instance methods on the basis that instance methods are hard to test if we're forbidden from creating the required instances. However, my reasoning was flawed for two reasons:

1. we've now lifted the ban on creating those instances, and
2. we were never forbidden from creating a `ProcessBuilder` in the first place.
