### PR TITLE
backport 8.x Fix release tests for SemanticMatchTestCase (#119022)

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/SemanticMatchTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/SemanticMatchTestCase.java
@@ -22,6 +22,8 @@ import static org.hamcrest.core.StringContains.containsString;
 
 public abstract class SemanticMatchTestCase extends ESRestTestCase {
     public void testWithMultipleInferenceIds() throws IOException {
+        assumeTrue("semantic text capability not available", EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled());
+
         String query = """
             from test-semantic1,test-semantic2
             | where match(semantic_text_field, "something")
@@ -34,6 +36,8 @@ public abstract class SemanticMatchTestCase extends ESRestTestCase {
     }
 
     public void testWithInferenceNotConfigured() {
+        assumeTrue("semantic text capability not available", EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled());
+
         String query = """
             from test-semantic3
             | where match(semantic_text_field, "something")
@@ -46,8 +50,6 @@ public abstract class SemanticMatchTestCase extends ESRestTestCase {
 
     @Before
     public void setUpIndices() throws IOException {
-        assumeTrue("semantic text capability not available", EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled());
-
         var settings = Settings.builder().build();
 
         String mapping1 = """
@@ -83,7 +85,6 @@ public abstract class SemanticMatchTestCase extends ESRestTestCase {
 
     @Before
     public void setUpTextEmbeddingInferenceEndpoint() throws IOException {
-        assumeTrue("semantic text capability not available", EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled());
         Request request = new Request("PUT", "_inference/text_embedding/test_dense_inference");
         request.setJsonEntity("""
                   {
@@ -101,7 +102,6 @@ public abstract class SemanticMatchTestCase extends ESRestTestCase {
 
     @After
     public void wipeData() throws IOException {
-        assumeTrue("semantic text capability not available", EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled());
         adminClient().performRequest(new Request("DELETE", "*"));
 
         try {


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/issues/119041
https://github.com/elastic/elasticsearch/issues/119042

Had to do a manual backport of #119022 due to merge conflicts.
Notice that unlike #119022  I did not need to mute the failing tests that I muted for main since they were already muted in 8.x.