### PR TITLE
(Doc+) Enrich run on ingest+data nodes not coordinating-only

### DIFF
--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -98,7 +98,8 @@ and <<update-enrich-policies, update your enrich policies>>.
 [IMPORTANT]
 ====
 The enrich processor performs several operations and may impact the speed of
-your ingest pipeline.
+your ingest pipeline. We recommend <<modules-node,node roles>> co-locate
+ingest and data roles to minimize remote search operations.
 
 We strongly recommend testing and benchmarking your enrich processors
 before deploying them in production.

--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -98,7 +98,7 @@ and <<update-enrich-policies, update your enrich policies>>.
 [IMPORTANT]
 ====
 The enrich processor performs several operations and may impact the speed of
-your ingest pipeline. We recommend <<modules-node,node roles>> co-locate
+your ingest pipeline. We recommend <<modules-node,node roles>> co-locating
 ingest and data roles to minimize remote search operations.
 
 We strongly recommend testing and benchmarking your enrich processors


### PR DESCRIPTION
👋 howdy, team! I'm not otherwise finding it so documenting https://github.com/elastic/elasticsearch/issues/95969 in ES docs

> Currently we tell users of enrich that they should co-locate the nodes that perform the enrichment (ingest nodes) with the actual enrich data so that enrich operations don't require a remote search operation.