### PR TITLE
[8.x] Remove needless use of assertBusy polling Future.isDone (#119078)

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -199,7 +199,6 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         DummyAsyncBulkByScrollAction action = new DummyActionWithoutBackoff();
         action.start();
         assertBusy(() -> assertEquals(testRequest.getMaxRetries() + 1, client.searchAttempts.get()));
-        assertBusy(() -> assertTrue(listener.isDone()));
         ExecutionException e = expectThrows(ExecutionException.class, () -> listener.get());
         assertThat(ExceptionsHelper.stackTrace(e), containsString(EsRejectedExecutionException.class.getSimpleName()));
         assertNull("There shouldn't be a search attempt pending that we didn't reject", client.lastSearch.get());

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -252,11 +252,13 @@ public class CancellableTasksIT extends ESIntegTestCase {
         if (waitForCompletion) {
             assertFalse(cancelFuture.isDone());
         } else {
-            assertBusy(() -> assertTrue(cancelFuture.isDone()));
+            cancelFuture.get();
         }
         allowEntireRequest(rootRequest);
         waitForRootTask(mainTaskFuture, false);
-        cancelFuture.actionGet();
+        if (waitForCompletion) {
+            cancelFuture.actionGet();
+        }
         ensureBansAndCancellationsConsistency();
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -379,11 +379,9 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
             r.incRef();
             l.onResponse(r);
         }));
-        assertBusy(() -> assertTrue(queryFuture.isDone()));
-
         // dfs=true overrides the minimize_roundtrips=true setting and does not minimize roundtrips
         if (skipUnavailable == false && minimizeRoundtrips && dfs == false) {
-            ExecutionException ee = expectThrows(ExecutionException.class, () -> queryFuture.get());
+            ExecutionException ee = expectThrows(ExecutionException.class, queryFuture::get);
             assertNotNull(ee.getCause());
             assertThat(ee.getCause(), instanceOf(RemoteTransportException.class));
             Throwable rootCause = ExceptionsHelper.unwrap(ee.getCause(), IllegalStateException.class);
@@ -622,10 +620,8 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
             r.incRef();
             l.onResponse(r);
         }));
-        assertBusy(() -> assertTrue(queryFuture.isDone()));
-
         if (skipUnavailable == false || minimizeRoundtrips == false) {
-            ExecutionException ee = expectThrows(ExecutionException.class, () -> queryFuture.get());
+            ExecutionException ee = expectThrows(ExecutionException.class, queryFuture::get);
             assertNotNull(ee.getCause());
             Throwable rootCause = ExceptionsHelper.unwrap(ee, IllegalStateException.class);
             assertThat(rootCause.getMessage(), containsString("index corrupted"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -1361,9 +1361,12 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         if (deleteAndAbortAll) {
             awaitNumberOfSnapshotsInProgress(0);
             for (ActionFuture<CreateSnapshotResponse> snapshotFuture : snapshotFutures) {
-                // just check that the futures resolve, whether or not things worked out with the snapshot actually finalizing or failing
-                // due to the abort does not matter
-                assertBusy(() -> assertTrue(snapshotFuture.isDone()));
+                try {
+                    snapshotFuture.get();
+                } catch (ExecutionException e) {
+                    // just check that the futures resolve, whether or not things worked out with the snapshot actually finalizing or
+                    // failing due to the abort does not matter
+                }
             }
             assertThat(getRepositoryData(repoName).getSnapshotIds(), empty());
         } else {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/TransportAnalyzeIndexDiskUsageActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/TransportAnalyzeIndexDiskUsageActionTests.java
@@ -132,7 +132,6 @@ public class TransportAnalyzeIndexDiskUsageActionTests extends ESTestCase {
             assertBusy(() -> assertThat(transportService.getRequestsSentPerNode(), equalTo(expectedRequestCounts)));
             pendingRequests.addAll(transportService.getCapturedRequests(true));
         }
-        assertBusy(future::isDone);
         AnalyzeIndexDiskUsageResponse response = future.actionGet();
         assertThat(response.getTotalShards(), equalTo(numberOfShards));
         assertThat(response.getFailedShards(), equalTo(0));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
@@ -460,8 +460,7 @@ public class ComputeListenerTests extends ESTestCase {
                 }), TimeValue.timeValueNanos(between(0, 100)), threadPool.generic());
             }
         }
-        assertBusy(rootListener::isDone);
-        ExecutionException failure = expectThrows(ExecutionException.class, () -> rootListener.get(1, TimeUnit.SECONDS));
+        ExecutionException failure = expectThrows(ExecutionException.class, () -> rootListener.get(10, TimeUnit.SECONDS));
         Throwable cause = failure.getCause();
         assertNotNull(failure);
         assertThat(cause, instanceOf(CircuitBreakingException.class));


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Remove needless use of assertBusy polling Future.isDone (#119078)