### PR TITLE
Conditionally mute synonyms config access test

### DIFF
--- a/modules/analysis-common/build.gradle
+++ b/modules/analysis-common/build.gradle
@@ -37,3 +37,16 @@ artifacts {
 tasks.named("yamlRestCompatTestTransform").configure { task ->
   task.replaceValueInMatch("tokens.0.token", "absenț", "romanian")
 }
+
+tasks.named("yamlRestTest").configure {
+  if (buildParams.getRuntimeJavaVersion().map{ it.majorVersion.toInteger() }.get() >= 24 ||
+    "-Des.entitlements.enabled=true".equals(System.getProperty("tests.jvm.argline"))) {
+    systemProperty 'tests.rest.blacklist',
+      [
+        // this test relies on security manager, which doesn't exist in JDK 24.
+        // and entitlements don't yet replace the functionality.
+        // see https://github.com/elastic/elasticsearch/issues/119130
+        'analysis-common/40_token_filters/stemmer_override file access',
+      ].join(',')
+  }
+}

--- a/modules/analysis-common/build.gradle
+++ b/modules/analysis-common/build.gradle
@@ -43,7 +43,7 @@ tasks.named("yamlRestTest").configure {
     "-Des.entitlements.enabled=true".equals(System.getProperty("tests.jvm.argline"))) {
     systemProperty 'tests.rest.blacklist',
       [
-        // this test relies on security manager, which doesn't exist in JDK 24.
+        // AWAITSFIX: this test relies on security manager, which doesn't exist in JDK 24.
         // and entitlements don't yet replace the functionality.
         // see https://github.com/elastic/elasticsearch/issues/119130
         'analysis-common/40_token_filters/stemmer_override file access',


### PR DESCRIPTION
This synonyms test checks certain config files cannot be accessed. It relies on security manager, which is not enabled in JDK 24. Until the entitlement based replacement is available, this commit mutes the test.

see #119130