### PR TITLE
Minor DataStreamsUpgradeIT::testUpgradeDataStream improvements

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -274,10 +274,17 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             );
             assertOK(statusResponse);
             assertThat(statusResponseMap.get("complete"), equalTo(true));
+            /*
+             * total_indices_in_data_stream is determined at the beginning of the reindex, and does not take into account the write
+             * index being rolled over
+             */
+            assertThat(statusResponseMap.get("total_indices_in_data_stream"), equalTo(numRollovers + 1));
             if (isOriginalClusterCurrent()) {
                 // If the original cluster was the same as this one, we don't want any indices reindexed:
+                assertThat(statusResponseMap.get("total_indices_requiring_upgrade"), equalTo(0));
                 assertThat(statusResponseMap.get("successes"), equalTo(0));
             } else {
+                assertThat(statusResponseMap.get("total_indices_requiring_upgrade"), equalTo(numRollovers + 1));
                 assertThat(statusResponseMap.get("successes"), equalTo(numRollovers + 1));
             }
         }, 60, TimeUnit.SECONDS);

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -174,7 +174,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
 
     public void testUpgradeDataStream() throws Exception {
         String dataStreamName = "reindex_test_data_stream";
-        int numRollovers = 5;
+        int numRollovers = randomIntBetween(0, 5);
         if (CLUSTER_TYPE == ClusterType.OLD) {
             createAndRolloverDataStream(dataStreamName, numRollovers);
         } else if (CLUSTER_TYPE == ClusterType.UPGRADED) {


### PR DESCRIPTION
This is a collection of a few minor enhancements to DataStreamsUpgradeIT::testUpgradeDataStream:

- It makes the number of rollovers (and therefore backing indices) random from 0-5
- It adds a few additional assertions about the status response
- It fixes a bug where the test would fail if it were running during an upgrade between minor versions (e.g. 9.0->9.1)