### PR TITLE
[8.x] ConnectTransportException returns retryable BAD_GATEWAY (#118681)

### DIFF
--- a/docs/changelog/118681.yaml
+++ b/docs/changelog/118681.yaml
@@ -1,0 +1,6 @@
+pr: 118681
+summary: '`ConnectTransportException` returns retryable BAD_GATEWAY'
+area: Network
+type: enhancement
+issues:
+ - 118320

--- a/server/src/main/java/org/elasticsearch/transport/ConnectTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectTransportException.java
@@ -13,6 +13,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
@@ -39,6 +40,18 @@ public class ConnectTransportException extends ActionTransportException {
         if (in.getTransportVersion().before(TransportVersions.V_8_1_0)) {
             in.readOptionalWriteable(DiscoveryNode::new);
         }
+    }
+
+    /**
+     * The ES REST API is a gateway to a single or multiple clusters. If there is an error connecting to other servers, then we should
+     * return a 502 BAD_GATEWAY status code instead of the parent class' 500 INTERNAL_SERVER_ERROR. Clients tend to retry on a 502 but not
+     * on a 500, and retrying may help on a connection error.
+     *
+     * @return a {@link RestStatus#BAD_GATEWAY} code
+     */
+    @Override
+    public final RestStatus status() {
+        return RestStatus.BAD_GATEWAY;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -410,6 +410,7 @@ public class ExceptionSerializationTests extends ESTestCase {
         ex = serialize(new ConnectTransportException(node, "msg", "action", new NullPointerException()));
         assertEquals("[][" + transportAddress + "][action] msg", ex.getMessage());
         assertThat(ex.getCause(), instanceOf(NullPointerException.class));
+        assertEquals(RestStatus.BAD_GATEWAY, ex.status());
     }
 
     public void testSearchPhaseExecutionException() throws IOException {


### PR DESCRIPTION
This will backport the following commits from `main` to `8.x`:
 - [ConnectTransportException returns retryable BAD_GATEWAY (#118681)](https://github.com/elastic/elasticsearch/pull/118681)