### PR TITLE
Minor DataStreamsUpgradeIT::testUpgradeDataStream improvements (#119144)

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -176,7 +176,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
 
     public void testUpgradeDataStream() throws Exception {
         String dataStreamName = "reindex_test_data_stream";
-        int numRollovers = 5;
+        int numRollovers = randomIntBetween(0, 5);
         if (CLUSTER_TYPE == ClusterType.OLD) {
             createAndRolloverDataStream(dataStreamName, numRollovers);
         } else if (CLUSTER_TYPE == ClusterType.UPGRADED) {
@@ -271,10 +271,17 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             );
             assertOK(statusResponse);
             assertThat(statusResponseMap.get("complete"), equalTo(true));
+            /*
+             * total_indices_in_data_stream is determined at the beginning of the reindex, and does not take into account the write
+             * index being rolled over
+             */
+            assertThat(statusResponseMap.get("total_indices_in_data_stream"), equalTo(numRollovers + 1));
             if (isOriginalClusterSameMajorVersionAsCurrent()) {
                 // If the original cluster was the same as this one, we don't want any indices reindexed:
+                assertThat(statusResponseMap.get("total_indices_requiring_upgrade"), equalTo(0));
                 assertThat(statusResponseMap.get("successes"), equalTo(0));
             } else {
+                assertThat(statusResponseMap.get("total_indices_requiring_upgrade"), equalTo(numRollovers + 1));
                 assertThat(statusResponseMap.get("successes"), equalTo(numRollovers + 1));
             }
         }, 60, TimeUnit.SECONDS);
@@ -283,7 +290,15 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
         assertOK(cancelResponse);
     }
 
+    /*
+     * Similar to isOriginalClusterCurrent, but returns true if the major versions of the clusters are the same. So true
+     * for 8.6 and 8.17, but false for 7.17 and 8.18.
+     */
     private boolean isOriginalClusterSameMajorVersionAsCurrent() {
+        /*
+         * Since data stream reindex is specifically about upgrading a data stream from one major version to the next, it's ok to use the
+         * deprecated Version.fromString here
+         */
         return Version.fromString(UPGRADE_FROM_VERSION).major == Version.fromString(Build.current().version()).major;
     }
 


### PR DESCRIPTION
This is a collection of a few minor enhancements to DataStreamsUpgradeIT::testUpgradeDataStream:

- It makes the number of rollovers (and therefore backing indices) random from 0-5
- It adds a few additional assertions about the status response
- It fixes a bug where the test would fail if it were running during an upgrade between minor versions (e.g. 9.0->9.1)