### PR TITLE
Unmute `FullClusterRestartIT.testWatcherWithApiKey`

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -209,7 +209,6 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
     }
 
     @SuppressWarnings("unchecked")
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84700")
     public void testWatcherWithApiKey() throws Exception {
         final Request getWatchStatusRequest = new Request("GET", "/_watcher/watch/watch_with_api_key");
 


### PR DESCRIPTION
This test failure issue was closed due to an absence of activity, but it
was reopened because the `@AwaitsFix` was still present.

We haven't determined with certainty that this test has been fixed, but
unmuting it will tell us if it is still an issue.

Closes #84700