### PR TITLE
[8.16] Expose BwC enrich cache setting in plugin (#119131)

### DIFF
--- a/docs/changelog/119131.yaml
+++ b/docs/changelog/119131.yaml
@@ -1,0 +1,5 @@
+pr: 119131
+summary: Expose BwC enrich cache setting in plugin
+area: Ingest Node
+type: bug
+issues: []

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
@@ -306,7 +306,8 @@ public class EnrichPlugin extends Plugin implements SystemIndexPlugin, IngestPlu
             COORDINATOR_PROXY_MAX_LOOKUPS_PER_REQUEST,
             COORDINATOR_PROXY_QUEUE_CAPACITY,
             ENRICH_MAX_FORCE_MERGE_ATTEMPTS,
-            CACHE_SIZE
+            CACHE_SIZE,
+            CACHE_SIZE_BWC
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Expose BwC enrich cache setting in plugin (#119131)