### PR TITLE
[8.x] Propagate status codes from shard failures appropriately (#118016)

### DIFF
--- a/docs/changelog/118016.yaml
+++ b/docs/changelog/118016.yaml
@@ -1,0 +1,6 @@
+pr: 118016
+summary: Propagate status codes from shard failures appropriately
+area: Search
+type: enhancement
+issues:
+ - 118482


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Propagate status codes from shard failures appropriately (#118016)