### PR TITLE
Adjust test mute #119191

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -306,6 +306,7 @@ tests:
   method: testFailureLoadingFields
   issue: https://github.com/elastic/elasticsearch/issues/118000
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: test {yaml=indices.create/20_synthetic_source/create index with use_synthetic_source}
   issue: https://github.com/elastic/elasticsearch/issues/119191
 
 # Examples:


### PR DESCRIPTION
The assertion that trips is related to synthetic recovery source usage, no need to mute the entire test suite.
Relates to #119191