### PR TITLE
[8.x] Adjust test mute

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -441,6 +441,7 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/116777
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/119191
+  method: test {yaml=indices.create/20_synthetic_source/create index with use_synthetic_source}
 - class: org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapperTests
   method: testCartesianBoundsBlockLoader
   issue: https://github.com/elastic/elasticsearch/issues/119201


### PR DESCRIPTION
Backporting #119206 to 8.x branch.

The assertion that trips is related to synthetic recovery source usage, no need to mute the entire test suite. Relates to #119191