### PR TITLE
Disable `TO_UPPER(null)` BWC tests prior to 8.17

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1231,7 +1231,7 @@ a:keyword           | upper:keyword         | lower:keyword
 π/2 + a + B + Λ ºC  | Π/2 + A + B + Λ ºC    | π/2 + a + b + λ ºc
 ;
 
-equalsToUpperPushedDown[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
+equalsToUpperPushedDown#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_upper(first_name) == "GEORGI"
 | keep emp_no, first_name
@@ -1241,7 +1241,7 @@ emp_no:integer  | first_name:keyword
 10001           | Georgi
 ;
 
-equalsToUpperNestedPushedDown[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
+equalsToUpperNestedPushedDown#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_upper(to_upper(to_lower(first_name))) == "GEORGI"
 | keep emp_no, first_name
@@ -1251,7 +1251,7 @@ emp_no:integer  | first_name:keyword
 10001           | Georgi
 ;
 
-negatedEqualsToUpperPushedDown[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
+negatedEqualsToUpperPushedDown#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | sort emp_no
 | where not(to_upper(first_name) == "GEORGI")
@@ -1263,7 +1263,7 @@ emp_no:integer  | first_name:keyword
 10002           | Bezalel
 ;
 
-notEqualsToUpperPushedDown[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
+notEqualsToUpperPushedDown#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | sort emp_no
 | where to_upper(first_name) != "GEORGI"
@@ -1275,7 +1275,7 @@ emp_no:integer  | first_name:keyword
 10002           | Bezalel
 ;
 
-negatedNotEqualsToUpperPushedDown[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
+negatedNotEqualsToUpperPushedDown#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | sort emp_no
 | where not(to_upper(first_name) != "GEORGI")
@@ -1306,7 +1306,7 @@ c:long
 90
 ;
 
-equalsToUpperNullFolded
+equalsToUpperNullFolded#[skip:-8.16.99, reason:function's type corrected in #114334]
 from employees
 | where to_upper(null) == "Georgi"
 | keep emp_no, first_name
@@ -1324,7 +1324,7 @@ from employees
 emp_no:integer  | first_name:keyword
 ;
 
-notEqualsToUpperNullFolded
+notEqualsToUpperNullFolded#[skip:-8.16.99, reason:function's type corrected in #114334]
 from employees
 | where to_upper(null) != "Georgi"
 | keep emp_no, first_name
@@ -1362,7 +1362,7 @@ c:long
 0
 ;
 
-equalsToLowerPushedDown[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
+equalsToLowerPushedDown#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_lower(first_name) == "georgi"
 | keep emp_no, first_name
@@ -1372,7 +1372,7 @@ emp_no:integer  | first_name:keyword
 10001           | Georgi
 ;
 
-notEqualsToLowerPushedDown[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
+notEqualsToLowerPushedDown#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | sort emp_no
 | where to_lower(first_name) != "georgi"


### PR DESCRIPTION
TO_UPPER/TO_LOWER resolution incorrectly returned child's type (that could also be `null`, type `NULL`), instead of KEYWORD/TEXT. So a test like `TO_UPPER(null) == "..."` fails on type mismatch.
This was fixed collaterally by #114334 (8.17.0)

Also, correct some of the tests skipping (that had however no impact, due to testing range).