### PR TITLE
[8.17] chore: deps(ironbank): Bump ubi version to 9.5 (#119203)

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -22,7 +22,7 @@
 <% if (docker_base == 'iron_bank') { %>
 ARG BASE_REGISTRY=registry1.dso.mil
 ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
-ARG BASE_TAG=9.4
+ARG BASE_TAG=9.5
 <% } %>
 
 ################################################################################


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [chore: deps(ironbank): Bump ubi version to 9.5 (#119203)](https://github.com/elastic/elasticsearch/pull/119203)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)