### PR TITLE
[8.x] [Inference API] Make message content optional in unified API (#118998)

### DIFF
--- a/server/src/main/java/org/elasticsearch/inference/UnifiedCompletionRequest.java
+++ b/server/src/main/java/org/elasticsearch/inference/UnifiedCompletionRequest.java
@@ -122,7 +122,12 @@ public record UnifiedCompletionRequest(
         );
 
         static {
-            PARSER.declareField(constructorArg(), (p, c) -> parseContent(p), new ParseField("content"), ObjectParser.ValueType.VALUE_ARRAY);
+            PARSER.declareField(
+                optionalConstructorArg(),
+                (p, c) -> parseContent(p),
+                new ParseField("content"),
+                ObjectParser.ValueType.VALUE_ARRAY
+            );
             PARSER.declareString(constructorArg(), new ParseField("role"));
             PARSER.declareString(optionalConstructorArg(), new ParseField("name"));
             PARSER.declareString(optionalConstructorArg(), new ParseField("tool_call_id"));
@@ -143,7 +148,7 @@ public record UnifiedCompletionRequest(
 
         public Message(StreamInput in) throws IOException {
             this(
-                in.readNamedWriteable(Content.class),
+                in.readOptionalNamedWriteable(Content.class),
                 in.readString(),
                 in.readOptionalString(),
                 in.readOptionalString(),
@@ -153,7 +158,7 @@ public record UnifiedCompletionRequest(
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeNamedWriteable(content);
+            out.writeOptionalNamedWriteable(content);
             out.writeString(role);
             out.writeOptionalString(name);
             out.writeOptionalString(toolCallId);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/openai/OpenAiUnifiedChatCompletionRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/openai/OpenAiUnifiedChatCompletionRequestEntity.java
@@ -66,7 +66,9 @@ public class OpenAiUnifiedChatCompletionRequestEntity implements ToXContentObjec
             for (UnifiedCompletionRequest.Message message : unifiedRequest.messages()) {
                 builder.startObject();
                 {
-                    if (message.content() instanceof UnifiedCompletionRequest.ContentString contentString) {
+                    if (message.content() == null) {
+                        // content is optional
+                    } else if (message.content() instanceof UnifiedCompletionRequest.ContentString contentString) {
                         builder.field(CONTENT_FIELD, contentString.content());
                     } else if (message.content() instanceof UnifiedCompletionRequest.ContentObjects contentObjects) {
                         builder.startArray(CONTENT_FIELD);
@@ -77,10 +79,6 @@ public class OpenAiUnifiedChatCompletionRequestEntity implements ToXContentObjec
                             builder.endObject();
                         }
                         builder.endArray();
-                    } else {
-                        throw new IllegalArgumentException(
-                            Strings.format("Unsupported message.content class received: %s", message.content().getClass().getSimpleName())
-                        );
                     }
 
                     builder.field(ROLE_FIELD, message.role());


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Inference API] Make message content optional in unified API (#118998)](https://github.com/elastic/elasticsearch/pull/118998)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)