### PR TITLE
[ML] Removing unnecessary inference plugin assertion

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -201,8 +201,6 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
         Supplier<DiscoveryNodes> nodesInCluster,
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
-        assert serviceComponents.get() != null : "serviceComponents must be set before retrieving the rest handlers";
-
         var availableRestActions = List.of(
             new RestInferenceAction(),
             new RestStreamInferenceAction(threadPoolSetOnce),


### PR DESCRIPTION
Accidentally left an assert in this PR: https://github.com/elastic/elasticsearch/pull/118999

The assert doesn't currently hurt anything but it's not needed and is checking the wrong variable anyway so I'm remove it.

We don't need to backport this as I've already removed it from the backports for the original PR:
[8.x](https://github.com/elastic/elasticsearch/pull/119218)
[8.17](https://github.com/elastic/elasticsearch/pull/119222)
[8.16](https://github.com/elastic/elasticsearch/pull/119223)