### PR TITLE
ESQL: Fix MultiClusterSpecIT failing test using :: cast

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1317,7 +1317,7 @@ emp_no:integer  | first_name:keyword
 
 equalsNullToUpperFolded
 from employees
-| where to_upper(first_name) == null::keyword
+| where to_upper(first_name) == to_keyword(null)
 | keep emp_no, first_name
 ;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1317,7 +1317,7 @@ emp_no:integer  | first_name:keyword
 
 equalsNullToUpperFolded
 from employees
-| where to_upper(first_name) == to_keyword(null)
+| where to_upper(first_name) == to_string(null)
 | keep emp_no, first_name
 ;
 
@@ -1335,7 +1335,7 @@ emp_no:integer  | first_name:keyword
 
 notEqualsNullToUpperFolded
 from employees
-| where to_upper(first_name) != null::keyword
+| where to_upper(first_name) != to_string(null)
 | keep emp_no, first_name
 ;
 


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/119254
Fixes https://github.com/elastic/elasticsearch/issues/119255

The `x::<type>` cast syntax doesn't exist in older versions, so, if the test doesn't require a modern capability, it may fail.

I'm fixing this in main instead of 8.x just to avoid future conflicts, and because the cast syntax has nothing to do with the test itself.