### PR TITLE
ESQL: Fix AbstractShapeGeometryFieldMapperTests

### DIFF
--- a/docs/changelog/119265.yaml
+++ b/docs/changelog/119265.yaml
@@ -1,0 +1,6 @@
+pr: 119265
+summary: Fix `AbstractShapeGeometryFieldMapperTests`
+area: "ES|QL, Geo"
+type: bug
+issues:
+ - 119201

--- a/docs/changelog/119265.yaml
+++ b/docs/changelog/119265.yaml
@@ -1,6 +1,6 @@
 pr: 119265
 summary: Fix `AbstractShapeGeometryFieldMapperTests`
-area: "ES|QL, Geo"
+area: "ES|QL"
 type: bug
 issues:
  - 119201

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -124,7 +124,10 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
 
                     private void read(BinaryDocValues binaryDocValues, int doc, GeometryDocValueReader reader, BytesRefBuilder builder)
                         throws IOException {
-                        binaryDocValues.advanceExact(doc);
+                        if (binaryDocValues.advanceExact(doc) == false) {
+                            builder.appendNull();
+                            return;
+                        }
                         reader.reset(binaryDocValues.binaryValue());
                         var extent = reader.getExtent();
                         // This is rather silly: an extent is already encoded as ints, but we convert it to Rectangle to


### PR DESCRIPTION
Fix a bug in `AbstractShapeGeometryFieldMapperTests` when the directory reader would contain multiple leaves.

Resolves #119201.