### PR TITLE
[8.17] [Gradle] Fix configuration cache for validateChangelogs task definition (#116716)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -411,8 +411,11 @@ gradle.projectsEvaluated {
   }
 }
 
-tasks.named("validateChangelogs") {
-  onlyIf { project.gradle.startParameter.taskNames.any { it.startsWith("checkPart") || it == 'functionalTests' } == false }
+tasks.named("validateChangelogs").configure {
+  def triggeredTaskNames = gradle.startParameter.taskNames
+  onlyIf {
+    triggeredTaskNames.any { it.startsWith("checkPart") || it == 'functionalTests' } == false
+  }
 }
 
 tasks.named("precommit") {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Gradle] Fix configuration cache for validateChangelogs task definition (#116716)](https://github.com/elastic/elasticsearch/pull/116716)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)