### PR TITLE
[8.x] [Build] Fix Concurrency issue in buildparams access (#117552)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
@@ -439,7 +439,7 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
         // scm info only added for internal builds
         internalBuild()
         buildFile << """
-            buildParams.getGitOriginProperty().set("https://some-repo.com/repo.git")
+            buildParams.setGitOrigin("https://some-repo.com/repo.git")
             apply plugin:'elasticsearch.java'
             apply plugin:'elasticsearch.publish'
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -132,7 +132,7 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
     public void configureCompile(Project project) {
         project.getExtensions().getExtraProperties().set("compactProfile", "full");
         JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
-        if (buildParams.getJavaToolChainSpec().isPresent()) {
+        if (buildParams.getJavaToolChainSpec().getOrNull() != null) {
             java.toolchain(buildParams.getJavaToolChainSpec().get());
         }
         java.setSourceCompatibility(buildParams.getMinimumRuntimeVersion());

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -13,7 +13,6 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin;
 
 import org.elasticsearch.gradle.OS;
 import org.elasticsearch.gradle.internal.conventions.util.Util;
-import org.elasticsearch.gradle.internal.info.BuildParameterExtension;
 import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
 import org.elasticsearch.gradle.internal.test.ErrorReportingTestListener;
 import org.elasticsearch.gradle.internal.test.SimpleCommandLineArgumentProvider;
@@ -26,7 +25,6 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -55,8 +53,7 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getRootProject().getPlugins().apply(GlobalBuildInfoPlugin.class);
-        Property<BuildParameterExtension> buildParams = loadBuildParams(project);
-
+        var buildParams = loadBuildParams(project);
         project.getPluginManager().apply(GradleTestPolicySetupPlugin.class);
         // for fips mode check
         project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -71,7 +71,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
         project.getPlugins().apply(JvmToolchainsPlugin.class);
         toolChainService = project.getExtensions().getByType(JavaToolchainService.class);
-        BuildParameterExtension buildParams = loadBuildParams(project).get();
+        var buildParams = loadBuildParams(project).get();
         Boolean isCi = buildParams.isCi();
         buildParams.getBwcVersions().forPreviousUnreleased((BwcVersions.UnreleasedVersionInfo unreleasedVersion) -> {
             configureBwcProject(

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
@@ -20,7 +20,6 @@ import org.elasticsearch.gradle.distribution.ElasticsearchDistributionTypes;
 import org.elasticsearch.gradle.internal.distribution.InternalElasticsearchDistributionTypes;
 import org.elasticsearch.gradle.internal.docker.DockerSupportPlugin;
 import org.elasticsearch.gradle.internal.docker.DockerSupportService;
-import org.elasticsearch.gradle.internal.info.BuildParameterExtension;
 import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
 import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.GradleException;
@@ -49,7 +48,7 @@ public class InternalDistributionDownloadPlugin implements Plugin<Project> {
         // this is needed for isInternal
         project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
         project.getRootProject().getPluginManager().apply(DockerSupportPlugin.class);
-        BuildParameterExtension buildParams = loadBuildParams(project).get();
+        var buildParams = loadBuildParams(project).get();
 
         DistributionDownloadPlugin distributionDownloadPlugin = project.getPlugins().apply(DistributionDownloadPlugin.class);
         Provider<DockerSupportService> dockerSupport = GradleUtils.getBuildService(
@@ -61,7 +60,7 @@ public class InternalDistributionDownloadPlugin implements Plugin<Project> {
         );
         registerInternalDistributionResolutions(
             DistributionDownloadPlugin.getRegistrationsContainer(project),
-            buildParams.getBwcVersionsProperty()
+            buildParams.getBwcVersionsProvider()
         );
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestClustersPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestClustersPlugin.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.gradle.internal;
 
 import org.elasticsearch.gradle.VersionProperties;
-import org.elasticsearch.gradle.internal.info.BuildParameterExtension;
 import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
@@ -26,7 +25,7 @@ public class InternalTestClustersPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getPlugins().apply(InternalDistributionDownloadPlugin.class);
         project.getRootProject().getRootProject().getPlugins().apply(GlobalBuildInfoPlugin.class);
-        BuildParameterExtension buildParams = loadBuildParams(project).get();
+        var buildParams = loadBuildParams(project).get();
         project.getRootProject().getPluginManager().apply(InternalReaperPlugin.class);
         TestClustersPlugin testClustersPlugin = project.getPlugins().apply(TestClustersPlugin.class);
         testClustersPlugin.setRuntimeJava(buildParams.getRuntimeJavaHome());

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParameterExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParameterExtension.java
@@ -13,175 +13,58 @@ import org.elasticsearch.gradle.internal.BwcVersions;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Task;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.provider.ProviderFactory;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 import java.io.File;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.atomic.AtomicReference;
 
-public abstract class BuildParameterExtension {
-    private final Provider<Boolean> inFipsJvm;
-    private final Provider<File> runtimeJavaHome;
-    private final Boolean isRuntimeJavaHomeSet;
-    private final List<JavaHome> javaVersions;
-    private final JavaVersion minimumCompilerVersion;
-    private final JavaVersion minimumRuntimeVersion;
-    private final JavaVersion gradleJavaVersion;
-    private final Provider<JavaVersion> runtimeJavaVersion;
-    private final Provider<? extends Action<JavaToolchainSpec>> javaToolChainSpec;
-    private final Provider<String> runtimeJavaDetails;
-    private final String gitRevision;
-    private transient AtomicReference<ZonedDateTime> buildDate = new AtomicReference<>();
-    private final String testSeed;
-    private final Boolean isCi;
-    private final Integer defaultParallel;
-    private final Boolean isSnapshotBuild;
+public interface BuildParameterExtension {
+    String EXTENSION_NAME = "buildParams";
 
-    public BuildParameterExtension(
-        ProviderFactory providers,
-        Provider<File> runtimeJavaHome,
-        Provider<? extends Action<JavaToolchainSpec>> javaToolChainSpec,
-        Provider<JavaVersion> runtimeJavaVersion,
-        boolean isRuntimeJavaHomeSet,
-        Provider<String> runtimeJavaDetails,
-        List<JavaHome> javaVersions,
-        JavaVersion minimumCompilerVersion,
-        JavaVersion minimumRuntimeVersion,
-        JavaVersion gradleJavaVersion,
-        String gitRevision,
-        String gitOrigin,
-        ZonedDateTime buildDate,
-        String testSeed,
-        boolean isCi,
-        int defaultParallel,
-        final boolean isSnapshotBuild,
-        Provider<BwcVersions> bwcVersions
-    ) {
-        this.inFipsJvm = providers.systemProperty("tests.fips.enabled").map(BuildParameterExtension::parseBoolean);
-        this.runtimeJavaHome = runtimeJavaHome;
-        this.javaToolChainSpec = javaToolChainSpec;
-        this.runtimeJavaVersion = runtimeJavaVersion;
-        this.isRuntimeJavaHomeSet = isRuntimeJavaHomeSet;
-        this.runtimeJavaDetails = runtimeJavaDetails;
-        this.javaVersions = javaVersions;
-        this.minimumCompilerVersion = minimumCompilerVersion;
-        this.minimumRuntimeVersion = minimumRuntimeVersion;
-        this.gradleJavaVersion = gradleJavaVersion;
-        this.gitRevision = gitRevision;
-        this.testSeed = testSeed;
-        this.isCi = isCi;
-        this.defaultParallel = defaultParallel;
-        this.isSnapshotBuild = isSnapshotBuild;
-        this.getBwcVersionsProperty().set(bwcVersions);
-        this.getGitOriginProperty().set(gitOrigin);
-    }
+    boolean getInFipsJvm();
 
-    private static boolean parseBoolean(String s) {
-        if (s == null) {
-            return false;
-        }
-        return Boolean.parseBoolean(s);
-    }
+    Provider<File> getRuntimeJavaHome();
 
-    public boolean getInFipsJvm() {
-        return inFipsJvm.getOrElse(false);
-    }
+    void withFipsEnabledOnly(Task task);
 
-    public Provider<File> getRuntimeJavaHome() {
-        return runtimeJavaHome;
-    }
+    Boolean getIsRuntimeJavaHomeSet();
 
-    public void withFipsEnabledOnly(Task task) {
-        task.onlyIf("FIPS mode disabled", task1 -> getInFipsJvm() == false);
-    }
+    List<JavaHome> getJavaVersions();
 
-    public Boolean getIsRuntimeJavaHomeSet() {
-        return isRuntimeJavaHomeSet;
-    }
+    JavaVersion getMinimumCompilerVersion();
 
-    public List<JavaHome> getJavaVersions() {
-        return javaVersions;
-    }
+    JavaVersion getMinimumRuntimeVersion();
 
-    public JavaVersion getMinimumCompilerVersion() {
-        return minimumCompilerVersion;
-    }
+    JavaVersion getGradleJavaVersion();
 
-    public JavaVersion getMinimumRuntimeVersion() {
-        return minimumRuntimeVersion;
-    }
+    Provider<JavaVersion> getRuntimeJavaVersion();
 
-    public JavaVersion getGradleJavaVersion() {
-        return gradleJavaVersion;
-    }
+    Provider<? extends Action<JavaToolchainSpec>> getJavaToolChainSpec();
 
-    public Provider<JavaVersion> getRuntimeJavaVersion() {
-        return runtimeJavaVersion;
-    }
+    Provider<String> getRuntimeJavaDetails();
 
-    public Provider<? extends Action<JavaToolchainSpec>> getJavaToolChainSpec() {
-        return javaToolChainSpec;
-    }
+    String getGitRevision();
 
-    public Provider<String> getRuntimeJavaDetails() {
-        return runtimeJavaDetails;
-    }
+    String getGitOrigin();
 
-    public String getGitRevision() {
-        return gitRevision;
-    }
+    ZonedDateTime getBuildDate();
 
-    public String getGitOrigin() {
-        return getGitOriginProperty().get();
-    }
+    String getTestSeed();
 
-    public ZonedDateTime getBuildDate() {
-        ZonedDateTime value = buildDate.get();
-        if (value == null) {
-            value = ZonedDateTime.now(ZoneOffset.UTC);
-            if (buildDate.compareAndSet(null, value) == false) {
-                // If another thread initialized it first, return the initialized value
-                value = buildDate.get();
-            }
-        }
-        return value;
-    }
+    Boolean isCi();
 
-    public String getTestSeed() {
-        return testSeed;
-    }
+    Integer getDefaultParallel();
 
-    public Boolean isCi() {
-        return isCi;
-    }
+    Boolean isSnapshotBuild();
 
-    public Integer getDefaultParallel() {
-        return defaultParallel;
-    }
+    BwcVersions getBwcVersions();
 
-    public Boolean isSnapshotBuild() {
-        return isSnapshotBuild;
-    }
+    Provider<BwcVersions> getBwcVersionsProvider();
 
-    public BwcVersions getBwcVersions() {
-        return getBwcVersionsProperty().get();
-    }
+    Random getRandom();
 
-    public abstract Property<BwcVersions> getBwcVersionsProperty();
-
-    public abstract Property<String> getGitOriginProperty();
-
-    public Random getRandom() {
-        return new Random(Long.parseUnsignedLong(testSeed.split(":")[0], 16));
-    }
-
-    public Boolean isGraalVmRuntime() {
-        return runtimeJavaDetails.get().toLowerCase().contains("graalvm");
-    }
+    Boolean isGraalVmRuntime();
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/DefaultBuildParameterExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/DefaultBuildParameterExtension.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.info;
+
+import org.elasticsearch.gradle.internal.BwcVersions;
+import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Task;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
+
+import java.io.File;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public abstract class DefaultBuildParameterExtension implements BuildParameterExtension {
+    private final Provider<Boolean> inFipsJvm;
+    private final Provider<File> runtimeJavaHome;
+    private final Boolean isRuntimeJavaHomeSet;
+    private final List<JavaHome> javaVersions;
+    private final JavaVersion minimumCompilerVersion;
+    private final JavaVersion minimumRuntimeVersion;
+    private final JavaVersion gradleJavaVersion;
+    private final Provider<JavaVersion> runtimeJavaVersion;
+    private final Provider<? extends Action<JavaToolchainSpec>> javaToolChainSpec;
+    private final Provider<String> runtimeJavaDetails;
+    private final String gitRevision;
+
+    private transient AtomicReference<ZonedDateTime> buildDate = new AtomicReference<>();
+    private final String testSeed;
+    private final Boolean isCi;
+    private final Integer defaultParallel;
+    private final Boolean isSnapshotBuild;
+
+    // not final for testing
+    private Provider<BwcVersions> bwcVersions;
+    private String gitOrigin;
+
+    public DefaultBuildParameterExtension(
+        ProviderFactory providers,
+        Provider<File> runtimeJavaHome,
+        Provider<? extends Action<JavaToolchainSpec>> javaToolChainSpec,
+        Provider<JavaVersion> runtimeJavaVersion,
+        boolean isRuntimeJavaHomeSet,
+        Provider<String> runtimeJavaDetails,
+        List<JavaHome> javaVersions,
+        JavaVersion minimumCompilerVersion,
+        JavaVersion minimumRuntimeVersion,
+        JavaVersion gradleJavaVersion,
+        String gitRevision,
+        String gitOrigin,
+        String testSeed,
+        boolean isCi,
+        int defaultParallel,
+        final boolean isSnapshotBuild,
+        Provider<BwcVersions> bwcVersions
+    ) {
+        this.inFipsJvm = providers.systemProperty("tests.fips.enabled").map(DefaultBuildParameterExtension::parseBoolean);
+        this.runtimeJavaHome = cache(providers, runtimeJavaHome);
+        this.javaToolChainSpec = cache(providers, javaToolChainSpec);
+        this.runtimeJavaVersion = cache(providers, runtimeJavaVersion);
+        this.isRuntimeJavaHomeSet = isRuntimeJavaHomeSet;
+        this.runtimeJavaDetails = cache(providers, runtimeJavaDetails);
+        this.javaVersions = javaVersions;
+        this.minimumCompilerVersion = minimumCompilerVersion;
+        this.minimumRuntimeVersion = minimumRuntimeVersion;
+        this.gradleJavaVersion = gradleJavaVersion;
+        this.gitRevision = gitRevision;
+        this.testSeed = testSeed;
+        this.isCi = isCi;
+        this.defaultParallel = defaultParallel;
+        this.isSnapshotBuild = isSnapshotBuild;
+        this.bwcVersions = cache(providers, bwcVersions);
+        this.gitOrigin = gitOrigin;
+    }
+
+    // This is a workaround for https://github.com/gradle/gradle/issues/25550
+    private <T> Provider<T> cache(ProviderFactory providerFactory, Provider<T> incomingProvider) {
+        SingleObjectCache<T> cache = new SingleObjectCache<>();
+        return providerFactory.provider(() -> cache.computeIfAbsent(() -> incomingProvider.getOrNull()));
+    }
+
+    private static boolean parseBoolean(String s) {
+        if (s == null) {
+            return false;
+        }
+        return Boolean.parseBoolean(s);
+    }
+
+    @Override
+    public boolean getInFipsJvm() {
+        return inFipsJvm.getOrElse(false);
+    }
+
+    @Override
+    public Provider<File> getRuntimeJavaHome() {
+        return runtimeJavaHome;
+    }
+
+    @Override
+    public void withFipsEnabledOnly(Task task) {
+        task.onlyIf("FIPS mode disabled", task1 -> getInFipsJvm() == false);
+    }
+
+    @Override
+    public Boolean getIsRuntimeJavaHomeSet() {
+        return isRuntimeJavaHomeSet;
+    }
+
+    @Override
+    public List<JavaHome> getJavaVersions() {
+        return javaVersions;
+    }
+
+    @Override
+    public JavaVersion getMinimumCompilerVersion() {
+        return minimumCompilerVersion;
+    }
+
+    @Override
+    public JavaVersion getMinimumRuntimeVersion() {
+        return minimumRuntimeVersion;
+    }
+
+    @Override
+    public JavaVersion getGradleJavaVersion() {
+        return gradleJavaVersion;
+    }
+
+    @Override
+    public Provider<JavaVersion> getRuntimeJavaVersion() {
+        return runtimeJavaVersion;
+    }
+
+    @Override
+    public Provider<? extends Action<JavaToolchainSpec>> getJavaToolChainSpec() {
+        return javaToolChainSpec;
+    }
+
+    @Override
+    public Provider<String> getRuntimeJavaDetails() {
+        return runtimeJavaDetails;
+    }
+
+    @Override
+    public String getGitRevision() {
+        return gitRevision;
+    }
+
+    @Override
+    public String getGitOrigin() {
+        return gitOrigin;
+    }
+
+    @Override
+    public ZonedDateTime getBuildDate() {
+        ZonedDateTime value = buildDate.get();
+        if (value == null) {
+            value = ZonedDateTime.now(ZoneOffset.UTC);
+            if (buildDate.compareAndSet(null, value) == false) {
+                // If another thread initialized it first, return the initialized value
+                value = buildDate.get();
+            }
+        }
+        return value;
+    }
+
+    @Override
+    public String getTestSeed() {
+        return testSeed;
+    }
+
+    @Override
+    public Boolean isCi() {
+        return isCi;
+    }
+
+    @Override
+    public Integer getDefaultParallel() {
+        return defaultParallel;
+    }
+
+    @Override
+    public Boolean isSnapshotBuild() {
+        return isSnapshotBuild;
+    }
+
+    @Override
+    public BwcVersions getBwcVersions() {
+        return bwcVersions.get();
+    }
+
+    @Override
+    public Random getRandom() {
+        return new Random(Long.parseUnsignedLong(testSeed.split(":")[0], 16));
+    }
+
+    @Override
+    public Boolean isGraalVmRuntime() {
+        return runtimeJavaDetails.get().toLowerCase().contains("graalvm");
+    }
+
+    private static class SingleObjectCache<T> {
+        private T instance;
+
+        public T computeIfAbsent(Supplier<T> supplier) {
+            synchronized (this) {
+                if (instance == null) {
+                    instance = supplier.get();
+                }
+                return instance;
+            }
+        }
+
+        public T get() {
+            return instance;
+        }
+    }
+
+    public Provider<BwcVersions> getBwcVersionsProvider() {
+        return bwcVersions;
+    }
+
+    // for testing; not part of public api
+    public void setBwcVersions(Provider<BwcVersions> bwcVersions) {
+        this.bwcVersions = bwcVersions;
+    }
+
+    // for testing; not part of public api
+    public void setGitOrigin(String gitOrigin) {
+        this.gitOrigin = gitOrigin;
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -51,8 +51,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -124,8 +122,10 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         );
         BuildParameterExtension buildParams = project.getExtensions()
             .create(
-                "buildParams",
                 BuildParameterExtension.class,
+                BuildParameterExtension.EXTENSION_NAME,
+                DefaultBuildParameterExtension.class,
+                providers,
                 actualRuntimeJavaHome,
                 resolveToolchainSpecFromEnv(),
                 actualRuntimeJavaHome.map(
@@ -145,7 +145,6 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
                 Jvm.current().getJavaVersion(),
                 gitInfo.getRevision(),
                 gitInfo.getOrigin(),
-                ZonedDateTime.now(ZoneOffset.UTC),
                 getTestSeed(),
                 System.getenv("JENKINS_URL") != null || System.getenv("BUILDKITE_BUILD_URL") != null || System.getProperty("isCI") != null,
                 ParallelDetector.findDefaultParallel(project),

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
@@ -12,12 +12,10 @@ package org.elasticsearch.gradle.internal.precommit;
 import org.elasticsearch.gradle.dependencies.CompileOnlyResolvePlugin;
 import org.elasticsearch.gradle.internal.ExportElasticsearchBuildResourcesTask;
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin;
-import org.elasticsearch.gradle.internal.info.BuildParameterExtension;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.TaskProvider;
 
 import java.io.File;
@@ -34,7 +32,7 @@ public class ThirdPartyAuditPrecommitPlugin extends PrecommitPlugin {
     @Override
     public TaskProvider<? extends Task> createTask(Project project) {
         project.getRootProject().getPlugins().apply(CompileOnlyResolvePlugin.class);
-        Property<BuildParameterExtension> buildParams = loadBuildParams(project);
+        var buildParams = loadBuildParams(project);
 
         project.getPlugins().apply(CompileOnlyResolvePlugin.class);
         project.getConfigurations().create("forbiddenApisCliJar");

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePlugin.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.gradle.internal.snyk;
 
 import org.elasticsearch.gradle.internal.conventions.info.GitInfo;
-import org.elasticsearch.gradle.internal.info.BuildParameterExtension;
 import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -18,7 +17,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.SourceSet;
 
@@ -41,7 +39,7 @@ public class SnykDependencyMonitoringGradlePlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getRootProject().getPlugins().apply(GlobalBuildInfoPlugin.class);
-        Property<BuildParameterExtension> buildParams = loadBuildParams(project);
+        var buildParams = loadBuildParams(project);
 
         var generateTaskProvider = project.getTasks()
             .register("generateSnykDependencyGraph", GenerateSnykDependencyGraph.class, generateSnykDependencyGraph -> {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/TestWithSslPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/TestWithSslPlugin.java
@@ -35,7 +35,7 @@ public class TestWithSslPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         File keyStoreDir = new File(project.getBuildDir(), "keystore");
-        BuildParameterExtension buildParams = project.getRootProject().getExtensions().getByType(BuildParameterExtension.class);
+        var buildParams = project.getRootProject().getExtensions().getByType(BuildParameterExtension.class);
         TaskProvider<ExportElasticsearchBuildResourcesTask> exportKeyStore = project.getTasks()
             .register("copyTestCertificates", ExportElasticsearchBuildResourcesTask.class, (t) -> {
                 t.copy("test/ssl/test-client.crt");

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/info/BuildParameterExtensionSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/info/BuildParameterExtensionSpec.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.info
+
+import spock.lang.Specification
+
+import org.elasticsearch.gradle.internal.BwcVersions
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import static org.junit.Assert.fail
+
+class BuildParameterExtensionSpec extends Specification {
+
+    ProjectBuilder projectBuilder = new ProjectBuilder()
+
+    def "#getterName is cached anc concurrently accessible"() {
+        given:
+        def project = projectBuilder.build()
+        def providers = project.getProviders();
+        def buildParams = extension(project, providers)
+        int numberOfThreads = 10;
+        when:
+        var service = Executors.newFixedThreadPool(numberOfThreads)
+        var latch = new CountDownLatch(numberOfThreads)
+        def testedProvider = buildParams."$getterName"()
+        def futures = (1..numberOfThreads).collect {
+            service.submit(
+                () -> {
+                    try {
+                        testedProvider.get()
+                    } catch (AssertionError e) {
+                        latch.countDown()
+                        Assert.fail("Accessing cached provider more than once")
+                    }
+                    latch.countDown()
+                }
+            )
+        }
+        latch.await(10, TimeUnit.SECONDS)
+
+        then:
+        futures.collect { it.state() }.any() { it == Future.State.FAILED } == false
+
+        where:
+        getterName << [
+            "getRuntimeJavaHome",
+            "getJavaToolChainSpec",
+            "getRuntimeJavaDetails",
+            "getRuntimeJavaVersion",
+            "getBwcVersionsProvider"
+        ]
+    }
+
+    private BuildParameterExtension extension(Project project, ProviderFactory providers) {
+        return project.getExtensions().create(
+            BuildParameterExtension.class, "buildParameters", DefaultBuildParameterExtension.class,
+            providers,
+            providerMock(),
+            providerMock(),
+            providerMock(),
+            true,
+            providerMock(),
+            [
+                Mock(JavaHome),
+                Mock(JavaHome),
+            ],
+            JavaVersion.VERSION_11,
+            JavaVersion.VERSION_11,
+            JavaVersion.VERSION_11,
+            "gitRevision",
+            "gitOrigin",
+            "testSeed",
+            false,
+            5,
+            true,
+            // cannot use Mock here because of the way the provider is used by gradle internal property api
+            providerMock()
+        )
+    }
+
+    private Provider providerMock() {
+        Provider provider = Mock(Provider)
+        AtomicInteger counter = new AtomicInteger(0)
+        provider.getOrNull() >> {
+            println "accessing provider"
+            return counter.get() == 1 ? fail("Accessing cached provider more than once") : counter.incrementAndGet()
+        }
+        provider.get() >> {
+            fail("Accessing cached provider directly")
+        }
+        return provider
+
+    }
+}

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/info/BuildParameterExtensionSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/info/BuildParameterExtensionSpec.groovy
@@ -11,13 +11,13 @@ package org.elasticsearch.gradle.internal.info
 
 import spock.lang.Specification
 
-import org.elasticsearch.gradle.internal.BwcVersions
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert
+import org.junit.Ignore
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -31,6 +31,7 @@ class BuildParameterExtensionSpec extends Specification {
 
     ProjectBuilder projectBuilder = new ProjectBuilder()
 
+    @Ignore
     def "#getterName is cached anc concurrently accessible"() {
         given:
         def project = projectBuilder.build()

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/info/BuildParameterExtensionSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/info/BuildParameterExtensionSpec.groovy
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.gradle.internal.info
 
+import spock.lang.Ignore
 import spock.lang.Specification
 
 import org.gradle.api.JavaVersion
@@ -17,7 +18,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert
-import org.junit.Ignore
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -183,7 +183,7 @@ abstract class AbstractGradleFuncTest extends Specification {
         ]
 
         BwcVersions versions = new BwcVersions(currentVersion, versionList, ['main', '8.x', '8.3', '8.2', '8.1', '7.16'])
-        buildParams.getBwcVersionsProperty().set(versions)
+        buildParams.setBwcVersions(project.provider { versions} )
         """
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Build] Fix Concurrency issue in buildparams access (#117552)](https://github.com/elastic/elasticsearch/pull/117552)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)