### PR TITLE
[8.x] ESQL: Fix MultiClusterSpecIT failing test using :: cast (#119263)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1330,7 +1330,7 @@ emp_no:integer  | first_name:keyword
 
 equalsNullToUpperFolded
 from employees
-| where to_upper(first_name) == null::keyword
+| where to_upper(first_name) == to_string(null)
 | keep emp_no, first_name
 ;
 
@@ -1348,7 +1348,7 @@ emp_no:integer  | first_name:keyword
 
 notEqualsNullToUpperFolded
 from employees
-| where to_upper(first_name) != null::keyword
+| where to_upper(first_name) != to_string(null)
 | keep emp_no, first_name
 ;
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Fix MultiClusterSpecIT failing test using :: cast (#119263)