### PR TITLE
[8.x] ESQL: Fix AbstractShapeGeometryFieldMapperTests (#119265)

### DIFF
--- a/docs/changelog/119265.yaml
+++ b/docs/changelog/119265.yaml
@@ -1,0 +1,6 @@
+pr: 119265
+summary: Fix `AbstractShapeGeometryFieldMapperTests`
+area: "ES|QL"
+type: bug
+issues:
+ - 119201

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -427,9 +427,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/119191
   method: test {yaml=indices.create/20_synthetic_source/create index with use_synthetic_source}
-- class: org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapperTests
-  method: testCartesianBoundsBlockLoader
-  issue: https://github.com/elastic/elasticsearch/issues/119201
 - class: org.elasticsearch.xpack.ml.integration.InferenceIngestInputConfigIT
   method: testIngestWithInputFields
   issue: https://github.com/elastic/elasticsearch/issues/118092

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -124,7 +124,10 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
 
                     private void read(BinaryDocValues binaryDocValues, int doc, GeometryDocValueReader reader, BytesRefBuilder builder)
                         throws IOException {
-                        binaryDocValues.advanceExact(doc);
+                        if (binaryDocValues.advanceExact(doc) == false) {
+                            builder.appendNull();
+                            return;
+                        }
                         reader.reset(binaryDocValues.binaryValue());
                         var extent = reader.getExtent();
                         // This is rather silly: an extent is already encoded as ints, but we convert it to Rectangle to


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Fix AbstractShapeGeometryFieldMapperTests (#119265)