### PR TITLE
ESQL: Unmute MixedClusterEsqlSpecIT suite

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -416,8 +416,6 @@ tests:
 - class: org.elasticsearch.aggregations.bucket.SearchCancellationIT
   method: testCancellationDuringTimeSeriesAggregation
   issue: https://github.com/elastic/elasticsearch/issues/118992
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/119159
 - class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
   method: testSeqNoCASLinearizability
   issue: https://github.com/elastic/elasticsearch/issues/117249


### PR DESCRIPTION
Unmuting a full suite mute.

It should have been fixed here: #119216

Fixes https://github.com/elastic/elasticsearch/issues/119159