### PR TITLE
Fix conditional for CLOUD_ESS docker namespace

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -366,7 +366,7 @@ private static List<String> generateTags(DockerBase base, Architecture architect
   String image = "elasticsearch${base.suffix}"
 
   String namespace = 'elasticsearch'
-  if (base == base == DockerBase.CLOUD_ESS) {
+  if (base == DockerBase.CLOUD_ESS) {
     namespace += '-ci'
   }
 


### PR DESCRIPTION
<= 8.17 is tagging Cloud ESS images as `docker.elastic.co/elasticsearch-ci/elasticsearch-cloud-ess`
\> 8.17 is tagging images as `docker.elastic.co/elasticsearch/elasticsearch-cloud-ess`

Ported from a recent change at https://github.com/elastic/elasticsearch/pull/119068/files#diff-39ead019dc289b9b901bfa7df8efc01b1f040df71c88919b5fc7a6286b0d6597L369