### PR TITLE
[8.17] Fix buildscan setup after buildParam rework (#119274)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -94,8 +94,8 @@ develocity {
           link 'Source', "${prBaseUrl}/tree/${System.getenv('BUILDKITE_COMMIT')}"
           link 'Pull Request', "https://github.com/${repository}/pull/${prId}"
         } else {
-          value 'Git Commit ID', gitRevision
-          link 'Source', "https://github.com/${repository}/tree/${gitRevision}"
+          value 'Git Commit ID', gitRevision.get()
+          link 'Source', "https://github.com/${repository}/tree/${gitRevision.get()}"
         }
 
         buildFinished { result ->


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Fix buildscan setup after buildParam rework (#119274)