### PR TITLE
Updated preceding method to prevent loss of characters

### DIFF
--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
@@ -92,6 +92,13 @@ public class BoundedBreakIteratorScanner extends BreakIterator {
         } else {
             innerStart = Math.max(mainBreak.preceding(offset), 0);
 
+            char previous = mainBreak.getText().previous();
+            while (previous == '?' || previous == '!') {
+                offset = this.mainBreak.getText().getIndex() - 1;
+                innerStart = Math.max(mainBreak.preceding(offset), 0);
+                previous = mainBreak.getText().previous();
+            }
+
             final long targetEndOffset = (long) offset + Math.max(0, maxLen - (offset - innerStart));
             final int textEndIndex = getText().getEndIndex();
 


### PR DESCRIPTION
Added functionality to the `preceding` method of the BoundedBreakIteratorScanner.java file.  This closes [#60168](https://github.com/elastic/elasticsearch/issues/60168) by preventing the premature setting of the start offset for the `Passage` instance.  The added functionality ensures if either of the stop characters, ‘?’ or ‘!’, is found immediately after the now set `innerStart` value and those characters are not in a position to be considered ‘end of sentence/phrase’ characters, then a loop is run until an appropriate starting offset is found.