### PR TITLE
[8.x] Limit concurrency of third party xpack tests (#119297)

### DIFF
--- a/x-pack/qa/third-party/active-directory/build.gradle
+++ b/x-pack/qa/third-party/active-directory/build.gradle
@@ -29,4 +29,8 @@ tasks.named("test").configure {
   systemProperty 'tests.security.manager', 'false'
   include '**/*IT.class'
   include '**/*Tests.class'
+
+  // Limit how many concurrent docker test fixtures we are running
+  maxParallelForks = 1
+  forkEvery = 1
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Limit concurrency of third party xpack tests (#119297)