### PR TITLE
[8.17] Limit concurrency of third party xpack tests (#119297)

### DIFF
--- a/x-pack/qa/third-party/active-directory/build.gradle
+++ b/x-pack/qa/third-party/active-directory/build.gradle
@@ -29,4 +29,8 @@ tasks.named("test").configure {
   systemProperty 'tests.security.manager', 'false'
   include '**/*IT.class'
   include '**/*Tests.class'
+
+  // Limit how many concurrent docker test fixtures we are running
+  maxParallelForks = 1
+  forkEvery = 1
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Limit concurrency of third party xpack tests (#119297)](https://github.com/elastic/elasticsearch/pull/119297)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)