### PR TITLE
[8.16] [ci] Add Alma Linux 9 to matrix in packaging and platform jobs (#118331)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -22,6 +22,7 @@ steps:
               - rhel-8
               - rhel-9
               - almalinux-8
+              - almalinux-9
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -23,6 +23,7 @@ steps:
               - rhel-8
               - rhel-9
               - almalinux-8
+              - almalinux-9
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -22,6 +22,7 @@ steps:
               - rhel-8
               - rhel-9
               - almalinux-8
+              - almalinux-9
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/x-pack/test/smb-fixture/build.gradle
+++ b/x-pack/test/smb-fixture/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'elasticsearch.java'
 apply plugin: 'elasticsearch.cache-test-fixtures'
 
 dependencies {
+  implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+
   api project(':test:fixtures:testcontainer-utils')
   api "junit:junit:${versions.junit}"
   api "org.testcontainers:testcontainers:${versions.testcontainer}"

--- a/x-pack/test/smb-fixture/src/main/java/org/elasticsearch/test/fixtures/smb/SmbTestContainer.java
+++ b/x-pack/test/smb-fixture/src/main/java/org/elasticsearch/test/fixtures/smb/SmbTestContainer.java
@@ -7,12 +7,18 @@
 
 package org.elasticsearch.test.fixtures.smb;
 
+import com.github.dockerjava.api.model.Capability;
+
 import org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTestContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+
+import java.time.Duration;
 
 public final class SmbTestContainer extends DockerEnvironmentAwareTestContainer {
 
-    private static final String DOCKER_BASE_IMAGE = "ubuntu:16.04";
+    private static final String DOCKER_BASE_IMAGE = "ubuntu:24.04";
     public static final int AD_LDAP_PORT = 636;
     public static final int AD_LDAP_GC_PORT = 3269;
 
@@ -20,15 +26,15 @@ public final class SmbTestContainer extends DockerEnvironmentAwareTestContainer 
         super(
             new ImageFromDockerfile("es-smb-fixture").withDockerfileFromBuilder(
                 builder -> builder.from(DOCKER_BASE_IMAGE)
-                    .run("apt-get update -qqy && apt-get install -qqy samba ldap-utils")
+                    .env("TZ", "Etc/UTC")
+                    .run("DEBIAN_FRONTEND=noninteractive apt-get update -qqy && apt-get install -qqy tzdata winbind samba ldap-utils")
                     .copy("fixture/provision/installsmb.sh", "/fixture/provision/installsmb.sh")
                     .copy("fixture/certs/ca.key", "/fixture/certs/ca.key")
                     .copy("fixture/certs/ca.pem", "/fixture/certs/ca.pem")
                     .copy("fixture/certs/cert.pem", "/fixture/certs/cert.pem")
                     .copy("fixture/certs/key.pem", "/fixture/certs/key.pem")
                     .run("chmod +x /fixture/provision/installsmb.sh")
-                    .run("/fixture/provision/installsmb.sh")
-                    .cmd("service samba-ad-dc restart && sleep infinity")
+                    .cmd("/fixture/provision/installsmb.sh && service samba-ad-dc restart && echo Samba started && sleep infinity")
                     .build()
             )
                 .withFileFromClasspath("fixture/provision/installsmb.sh", "/smb/provision/installsmb.sh")
@@ -37,10 +43,20 @@ public final class SmbTestContainer extends DockerEnvironmentAwareTestContainer 
                 .withFileFromClasspath("fixture/certs/cert.pem", "/smb/certs/cert.pem")
                 .withFileFromClasspath("fixture/certs/key.pem", "/smb/certs/key.pem")
         );
-        // addExposedPort(389);
-        // addExposedPort(3268);
+
         addExposedPort(AD_LDAP_PORT);
         addExposedPort(AD_LDAP_GC_PORT);
+
+        setWaitStrategy(
+            new WaitAllStrategy().withStartupTimeout(Duration.ofSeconds(120))
+                .withStrategy(Wait.forLogMessage(".*Samba started.*", 1))
+                .withStrategy(Wait.forListeningPort())
+        );
+
+        getCreateContainerCmdModifiers().add(createContainerCmd -> {
+            createContainerCmd.getHostConfig().withCapAdd(Capability.SYS_ADMIN);
+            return createContainerCmd;
+        });
     }
 
     public String getAdLdapUrl() {

--- a/x-pack/test/smb-fixture/src/main/resources/smb/provision/installsmb.sh
+++ b/x-pack/test/smb-fixture/src/main/resources/smb/provision/installsmb.sh
@@ -21,7 +21,7 @@ cat $SSL_DIR/ca.pem >> /etc/ssl/certs/ca-certificates.crt
 
 mv /etc/samba/smb.conf /etc/samba/smb.conf.orig
 
-samba-tool domain provision --server-role=dc --use-rfc2307 --dns-backend=SAMBA_INTERNAL --realm=AD.TEST.ELASTICSEARCH.COM --domain=ADES --adminpass=Passw0rd --use-ntvfs
+samba-tool domain provision --server-role=dc --use-rfc2307 --dns-backend=SAMBA_INTERNAL --realm=AD.TEST.ELASTICSEARCH.COM --domain=ADES --adminpass=Passw0rd
 
 cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[ci] Add Alma Linux 9 to matrix in packaging and platform jobs (#118331)](https://github.com/elastic/elasticsearch/pull/118331)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)