### PR TITLE
ESQL: Fix writing for LOOKUP status (#119296)

### DIFF
--- a/docs/changelog/119296.yaml
+++ b/docs/changelog/119296.yaml
@@ -1,0 +1,6 @@
+pr: 119296
+summary: Fix writing for LOOKUP status
+area: ES|QL
+type: bug
+issues:
+ - 119086

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -61,6 +61,7 @@ import org.elasticsearch.xpack.esql.action.RestEsqlDeleteAsyncResultAction;
 import org.elasticsearch.xpack.esql.action.RestEsqlGetAsyncResultAction;
 import org.elasticsearch.xpack.esql.action.RestEsqlQueryAction;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupOperator;
+import org.elasticsearch.xpack.esql.enrich.LookupFromIndexOperator;
 import org.elasticsearch.xpack.esql.execution.PlanExecutor;
 import org.elasticsearch.xpack.esql.expression.ExpressionWritables;
 import org.elasticsearch.xpack.esql.plan.PlanWritables;
@@ -192,6 +193,7 @@ public class EsqlPlugin extends Plugin implements ActionPlugin {
         entries.add(SingleValueQuery.ENTRY);
         entries.add(AsyncOperator.Status.ENTRY);
         entries.add(EnrichLookupOperator.Status.ENTRY);
+        entries.add(LookupFromIndexOperator.Status.ENTRY);
 
         entries.addAll(BlockWritables.getNamedWriteables());
         entries.addAll(ExpressionWritables.getNamedWriteables());


### PR DESCRIPTION
This fixes writing the `status` of the LOOKUP operator. It just wasn't registered.

Closes #119086
