### PR TITLE
Change synthetic source logic for constant_keyword to not rely on fallback synthetic source

### DIFF
--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -348,20 +348,6 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport() {
-        String value = fieldType().value();
-
-        if (value == null) {
-            return new SyntheticSourceSupport.Native(SourceLoader.SyntheticFieldLoader.NOTHING);
-        }
-
-        /*
-        If there was no value in the document, synthetic source should not have the value too.
-        This is consistent with stored source behavior and is important for scenarios
-        like reindexing into an index that has a different value of this value in the mapping.
-
-        In order to do that we use fallback logic which implements exactly such logic (_source only contains value
-        if it was in the original document).
-         */
-        return new SyntheticSourceSupport.Fallback();
+        return new SyntheticSourceSupport.Native(SourceLoader.SyntheticFieldLoader.NOTHING);
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.constantkeyword.mapper;
 
+import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -41,6 +42,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.SortedNumericDocValuesSyntheticFieldLoader;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryRewriteContext;
@@ -339,6 +341,12 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
                     + "]"
             );
         }
+
+        if (context.mappingLookup().isSourceSynthetic()) {
+            // Remember which documents had value in source so that it can be correctly
+            // reconstructed in synthetic source
+            context.doc().add(new SortedNumericDocValuesField(fieldType().name(), 1));
+        }
     }
 
     @Override
@@ -348,6 +356,19 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport() {
-        return new SyntheticSourceSupport.Native(SourceLoader.SyntheticFieldLoader.NOTHING);
+        String const_value = fieldType().value();
+
+        if (const_value == null) {
+            return new SyntheticSourceSupport.Native(SourceLoader.SyntheticFieldLoader.NOTHING);
+        }
+
+        var loader = new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), false) {
+            @Override
+            protected void writeValue(XContentBuilder b, long ignored) throws IOException {
+                b.value(const_value);
+            }
+        };
+
+        return new SyntheticSourceSupport.Native(loader);
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -296,8 +296,22 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport(boolean ignoreMalformed) {
-        assumeTrue("not rendered in synthetic source because the value is constant anyway", false);
-        return null;
+        assertFalse("constant_keyword doesn't support ignore_malformed", ignoreMalformed);
+        String value = randomUnicodeOfLength(5);
+        return new SyntheticSourceSupport() {
+            @Override
+            public SyntheticSourceExample example(int maxValues) {
+                return new SyntheticSourceExample(value, value, b -> {
+                    b.field("type", "constant_keyword");
+                    b.field("value", value);
+                });
+            }
+
+            @Override
+            public List<SyntheticSourceInvalidExample> invalidExample() throws IOException {
+                throw new AssumptionViolatedException("copy_to on constant_keyword not supported");
+            }
+        };
     }
 
     @Override

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -296,22 +296,8 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport(boolean ignoreMalformed) {
-        assertFalse("constant_keyword doesn't support ignore_malformed", ignoreMalformed);
-        String value = randomUnicodeOfLength(5);
-        return new SyntheticSourceSupport() {
-            @Override
-            public SyntheticSourceExample example(int maxValues) {
-                return new SyntheticSourceExample(value, value, b -> {
-                    b.field("type", "constant_keyword");
-                    b.field("value", value);
-                });
-            }
-
-            @Override
-            public List<SyntheticSourceInvalidExample> invalidExample() throws IOException {
-                throw new AssumptionViolatedException("copy_to on constant_keyword not supported");
-            }
-        };
+        assumeTrue("not rendered in synthetic source because the value is constant anyway", false);
+        return null;
     }
 
     @Override

--- a/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
+++ b/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
@@ -59,3 +59,103 @@ constant_keyword:
       hits.hits.0._source:
         kwd: foo
         const_kwd: bar
+
+---
+constant_keyword update value:
+  - requires:
+      cluster_features: [ "mapper.constant_keyword.synthetic_source_write_fix" ]
+      reason: "Behavior fix"
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              const_kwd:
+                type: constant_keyword
+              kwd:
+                type: keyword
+
+  - do:
+      index:
+        index:   test
+        id:      1
+        refresh: true
+        body:
+          kwd: foo
+
+  - do:
+      index:
+        index:   test
+        id:      2
+        refresh: true
+        body:
+          const_kwd: bar
+
+  - do:
+      index:
+        index:   test
+        id:      3
+        refresh: true
+        body:
+          kwd: foo
+
+  - do:
+      index:
+        index:   test
+        id:      4
+        refresh: true
+        body:
+          const_kwd: bar
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            ids:
+              values: [1]
+
+  - match:
+      hits.hits.0._source:
+        kwd: foo
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            ids:
+              values: [2]
+
+  - match:
+      hits.hits.0._source:
+        const_kwd: bar
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            ids:
+              values: [3]
+
+  - match:
+      hits.hits.0._source:
+        kwd: foo
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            ids:
+              values: [4]
+
+  - match:
+      hits.hits.0._source:
+        const_kwd: bar


### PR DESCRIPTION
Compared to new approach fallback synthetic source consumes significantly more space on disk and also requires doing additional work at indexing time. 