### PR TITLE
Fix test EsqlNodeFailureIT - use correct exception class

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlNodeFailureIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlNodeFailureIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.action;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.Plugin;
@@ -58,7 +57,7 @@ public class EsqlNodeFailureIT extends AbstractEsqlIntegTestCase {
         docs.add(client().prepareIndex("fail").setSource("foo", 0));
         indexRandom(true, docs);
 
-        ElasticsearchException e = expectThrows(ElasticsearchException.class, () -> run("FROM fail,ok | LIMIT 100").close());
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> run("FROM fail,ok | LIMIT 100").close());
         assertThat(e.getMessage(), equalTo("Accessing failing field"));
     }
 }


### PR DESCRIPTION
This test is muted by https://github.com/elastic/elasticsearch/issues/118000 so CI did not catch its using wrong class. 

Followup to https://github.com/elastic/elasticsearch/pull/119302