### PR TITLE
[8.x] Change synthetic source logic for constant_keyword to not rely on fallback synthetic source (#119323)

### DIFF
--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.constantkeyword.mapper;
 
+import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -40,6 +41,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.SortedNumericDocValuesSyntheticFieldLoader;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryRewriteContext;
@@ -335,6 +337,12 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
                     + "]"
             );
         }
+
+        if (context.mappingLookup().isSourceSynthetic()) {
+            // Remember which documents had value in source so that it can be correctly
+            // reconstructed in synthetic source
+            context.doc().add(new SortedNumericDocValuesField(fieldType().name(), 1));
+        }
     }
 
     @Override
@@ -344,20 +352,19 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport() {
-        String value = fieldType().value();
+        String const_value = fieldType().value();
 
-        if (value == null) {
+        if (const_value == null) {
             return new SyntheticSourceSupport.Native(SourceLoader.SyntheticFieldLoader.NOTHING);
         }
 
-        /*
-        If there was no value in the document, synthetic source should not have the value too.
-        This is consistent with stored source behavior and is important for scenarios
-        like reindexing into an index that has a different value of this value in the mapping.
+        var loader = new SortedNumericDocValuesSyntheticFieldLoader(fullPath(), leafName(), false) {
+            @Override
+            protected void writeValue(XContentBuilder b, long ignored) throws IOException {
+                b.value(const_value);
+            }
+        };
 
-        In order to do that we use fallback logic which implements exactly such logic (_source only contains value
-        if it was in the original document).
-         */
-        return new SyntheticSourceSupport.Fallback();
+        return new SyntheticSourceSupport.Native(loader);
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
+++ b/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
@@ -59,3 +59,103 @@ constant_keyword:
       hits.hits.0._source:
         kwd: foo
         const_kwd: bar
+
+---
+constant_keyword update value:
+  - requires:
+      cluster_features: [ "mapper.constant_keyword.synthetic_source_write_fix" ]
+      reason: "Behavior fix"
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              const_kwd:
+                type: constant_keyword
+              kwd:
+                type: keyword
+
+  - do:
+      index:
+        index:   test
+        id:      1
+        refresh: true
+        body:
+          kwd: foo
+
+  - do:
+      index:
+        index:   test
+        id:      2
+        refresh: true
+        body:
+          const_kwd: bar
+
+  - do:
+      index:
+        index:   test
+        id:      3
+        refresh: true
+        body:
+          kwd: foo
+
+  - do:
+      index:
+        index:   test
+        id:      4
+        refresh: true
+        body:
+          const_kwd: bar
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            ids:
+              values: [1]
+
+  - match:
+      hits.hits.0._source:
+        kwd: foo
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            ids:
+              values: [2]
+
+  - match:
+      hits.hits.0._source:
+        const_kwd: bar
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            ids:
+              values: [3]
+
+  - match:
+      hits.hits.0._source:
+        kwd: foo
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            ids:
+              values: [4]
+
+  - match:
+      hits.hits.0._source:
+        const_kwd: bar


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Change synthetic source logic for constant_keyword to not rely on fallback synthetic source (#119323)