### PR TITLE
[8.x] ESQL: Fix EsqlSecurityIT LOOKUP tests not checking snapshot (#119283)

### DIFF
--- a/x-pack/plugin/esql/qa/security/build.gradle
+++ b/x-pack/plugin/esql/qa/security/build.gradle
@@ -5,3 +5,9 @@ apply plugin: 'elasticsearch.internal-test-artifact'
 tasks.named('javaRestTest') {
   usesDefaultDistribution()
 }
+
+dependencies {
+  javaRestTestImplementation project(xpackModule('esql-core'))
+  javaRestTestImplementation project(xpackModule('esql'))
+  javaRestTestImplementation project(xpackModule('esql:qa:server'))
+}

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -26,6 +26,8 @@ import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
 import org.junit.Before;
 import org.junit.ClassRule;
 
@@ -544,6 +546,11 @@ public class EsqlSecurityIT extends ESRestTestCase {
     }
 
     public void testLookupJoinIndexAllowed() throws Exception {
+        assumeTrue(
+            "Requires LOOKUP JOIN capability",
+            EsqlSpecTestCase.hasCapabilities(adminClient(), List.of(EsqlCapabilities.Cap.JOIN_LOOKUP_V9.capabilityName()))
+        );
+
         Response resp = runESQLCommand(
             "metadata1_read2",
             "ROW x = 40.0 | EVAL value = x | LOOKUP JOIN `lookup-user2` ON value | KEEP x, org"
@@ -577,7 +584,12 @@ public class EsqlSecurityIT extends ESRestTestCase {
         assertThat(respMap.get("values"), equalTo(List.of(Arrays.asList(123.0, null))));
     }
 
-    public void testLookupJoinIndexForbidden() {
+    public void testLookupJoinIndexForbidden() throws Exception {
+        assumeTrue(
+            "Requires LOOKUP JOIN capability",
+            EsqlSpecTestCase.hasCapabilities(adminClient(), List.of(EsqlCapabilities.Cap.JOIN_LOOKUP_V9.capabilityName()))
+        );
+
         var resp = expectThrows(
             ResponseException.class,
             () -> runESQLCommand("metadata1_read2", "FROM lookup-user2 | EVAL value = 10.0 | LOOKUP JOIN `lookup-user1` ON value | KEEP x")

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -202,7 +202,7 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         return hasCapabilities(adminClient(), requiredCapabilities);
     }
 
-    protected static boolean hasCapabilities(RestClient client, List<String> requiredCapabilities) throws IOException {
+    public static boolean hasCapabilities(RestClient client, List<String> requiredCapabilities) throws IOException {
         if (requiredCapabilities.isEmpty()) {
             return true;
         }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Fix EsqlSecurityIT LOOKUP tests not checking snapshot (#119283)