### PR TITLE
Remove `RepositoryS3EcsClientYamlTestSuiteIT` mute

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -149,8 +149,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_reset/Test reset running transform}
   issue: https://github.com/elastic/elasticsearch/issues/117473
-- class: org.elasticsearch.repositories.s3.RepositoryS3EcsClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/117525
 - class: org.elasticsearch.search.ccs.CrossClusterIT
   method: testCancel
   issue: https://github.com/elastic/elasticsearch/issues/108061


### PR DESCRIPTION
Removes mute for a test suite that no longer exists.

Closes: https://github.com/elastic/elasticsearch/issues/117525