### PR TITLE
[Inference API] Fix NPE by getting request once and defaulting to empty list

### DIFF
--- a/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/OpenAiServiceUpgradeIT.java
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/OpenAiServiceUpgradeIT.java
@@ -16,6 +16,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -139,9 +141,11 @@ public class OpenAiServiceUpgradeIT extends InferenceUpgradeTestCase {
 
             assertCompletionInference(oldClusterId);
         } else if (isMixedCluster()) {
-            var configs = (List<Map<String, Object>>) get(testTaskType, oldClusterId).get("endpoints");
+            List<Map<String, Object>> configs = new LinkedList<>();
+            var request = get(testTaskType, oldClusterId);
+            configs.addAll((Collection<? extends Map<String, Object>>) request.getOrDefault("endpoints", List.of()));
             if (oldClusterHasFeature("gte_v" + MODELS_RENAMED_TO_ENDPOINTS) == false) {
-                configs.addAll((List<Map<String, Object>>) get(testTaskType, oldClusterId).get(old_cluster_endpoint_identifier));
+                configs.addAll((List<Map<String, Object>>) request.getOrDefault(old_cluster_endpoint_identifier, List.of()));
                 // in version 8.15, there was a breaking change where "models" was renamed to "endpoints"
             }
             assertEquals("openai", configs.get(0).get("service"));


### PR DESCRIPTION
This fix is basically the same as this one: https://github.com/elastic/elasticsearch/pull/118663

closes https://github.com/elastic/elasticsearch/issues/119029
closes https://github.com/elastic/elasticsearch/issues/119030
