### PR TITLE
[8.17] [DOCS] Link to new API site (#119038)

### DIFF
--- a/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
+++ b/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
@@ -4,6 +4,13 @@
 
 NOTE: {cloud-only}
 
+
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-autoscaling[Autoscaling APIs].
+--
+
 You can use the following APIs to perform {cloud}/ec-autoscaling.html[autoscaling operations].
 
 [discrete]

--- a/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
@@ -7,6 +7,12 @@
 
 NOTE: {cloud-only}
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-autoscaling[Autoscaling APIs].
+--
+
 Delete {cloud}/ec-autoscaling.html[autoscaling] policy.
 
 [[autoscaling-delete-autoscaling-policy-request]]

--- a/docs/reference/autoscaling/apis/get-autoscaling-capacity.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-capacity.asciidoc
@@ -7,6 +7,12 @@
 
 NOTE: {cloud-only}
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-autoscaling[Autoscaling APIs].
+--
+
 Get {cloud}/ec-autoscaling.html[autoscaling] capacity.
 
 [[autoscaling-get-autoscaling-capacity-request]]

--- a/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
@@ -7,6 +7,13 @@
 
 NOTE: {cloud-only}
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-autoscaling[Autoscaling APIs].
+--
+
+
 Get {cloud}/ec-autoscaling.html[autoscaling] policy.
 
 [[autoscaling-get-autoscaling-policy-request]]

--- a/docs/reference/autoscaling/apis/put-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/put-autoscaling-policy.asciidoc
@@ -7,6 +7,12 @@
 
 NOTE: {cloud-only}
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-autoscaling[Autoscaling APIs].
+--
+
 Creates or updates an {cloud}/ec-autoscaling.html[autoscaling] policy.
 
 [[autoscaling-put-autoscaling-policy-request]]

--- a/docs/reference/behavioral-analytics/apis/delete-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/delete-analytics-collection.asciidoc
@@ -8,6 +8,12 @@ beta::[]
 <titleabbrev>Delete Analytics Collection</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-analytics[Behavioral analytics APIs].
+--
+
 ////
 [source,console]
 ----

--- a/docs/reference/behavioral-analytics/apis/index.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/index.asciidoc
@@ -9,6 +9,12 @@ beta::[]
 
 ---
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-analytics[Behavioral analytics APIs].
+--
+
 Use the following APIs to manage tasks and resources related to <<behavioral-analytics-overview,Behavioral Analytics>>:
 
 * <<put-analytics-collection>>

--- a/docs/reference/behavioral-analytics/apis/list-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/list-analytics-collection.asciidoc
@@ -8,6 +8,12 @@ beta::[]
 <titleabbrev>List Analytics Collections</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-analytics[Behavioral analytics APIs].
+--
+
 ////
 [source,console]
 ----

--- a/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
@@ -8,6 +8,12 @@ beta::[]
 <titleabbrev>Post Analytics Collection Event</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-analytics[Behavioral analytics APIs].
+--
+
 ////
 [source,console]
 ----

--- a/docs/reference/behavioral-analytics/apis/put-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/put-analytics-collection.asciidoc
@@ -8,6 +8,12 @@ beta::[]
 <titleabbrev>Put Analytics Collection</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-analytics[Behavioral analytics APIs].
+--
+
 ////
 [source,console]
 ----

--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -1,6 +1,12 @@
 [[cat]]
 == Compact and aligned text (CAT) APIs
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs].
+--
+
 ["float",id="intro"]
 === Introduction
 

--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat aliases</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or the 

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat allocation</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib}

--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>cat anomaly detectors</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib}

--- a/docs/reference/cat/component-templates.asciidoc
+++ b/docs/reference/cat/component-templates.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat component templates</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib}

--- a/docs/reference/cat/count.asciidoc
+++ b/docs/reference/cat/count.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat count</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/datafeeds.asciidoc
+++ b/docs/reference/cat/datafeeds.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>cat {dfeeds}</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/dataframeanalytics.asciidoc
+++ b/docs/reference/cat/dataframeanalytics.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>cat {dfanalytics}</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat fielddata</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/health.asciidoc
+++ b/docs/reference/cat/health.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat health</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib}

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat indices</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib}

--- a/docs/reference/cat/master.asciidoc
+++ b/docs/reference/cat/master.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat master</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/nodeattrs.asciidoc
+++ b/docs/reference/cat/nodeattrs.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat nodeattrs</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>cat nodes</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib}

--- a/docs/reference/cat/pending_tasks.asciidoc
+++ b/docs/reference/cat/pending_tasks.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat pending tasks</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -4,6 +4,11 @@
 <titleabbrev>cat plugins</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
 
 [IMPORTANT]
 ====

--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat recovery</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat repositories</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat segments</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>cat shards</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib}

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat snapshots</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -6,6 +6,12 @@
 
 beta::["The cat task management API is new and should still be considered a beta feature. The API may change in ways that are not backwards compatible.",{es-issue}51628]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat templates</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>cat thread pool</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/trainedmodel.asciidoc
+++ b/docs/reference/cat/trainedmodel.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>cat trained model</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/cat/transforms.asciidoc
+++ b/docs/reference/cat/transforms.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>cat transforms</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cat[Compact and aligned text (CAT) APIs]..
+--
+
 [IMPORTANT]
 ====
 cat APIs are only intended for human consumption using the command line or {kib} 

--- a/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delete auto-follow pattern</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Delete {ccr} <<ccr-auto-follow,auto-follow patterns>>.
 
 [[ccr-delete-auto-follow-pattern-request]]

--- a/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get auto-follow pattern</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Get {ccr} <<ccr-auto-follow,auto-follow patterns>>.
 
 [[ccr-get-auto-follow-pattern-request]]

--- a/docs/reference/ccr/apis/auto-follow/pause-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/pause-auto-follow-pattern.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Pause auto-follow pattern</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Pauses a {ccr} <<ccr-auto-follow,auto-follow pattern>>.
 
 [[ccr-pause-auto-follow-pattern-request]]

--- a/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create auto-follow pattern</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Creates a {ccr} <<ccr-auto-follow,auto-follow pattern>>.
 
 [[ccr-put-auto-follow-pattern-request]]

--- a/docs/reference/ccr/apis/auto-follow/resume-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/resume-auto-follow-pattern.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Resume auto-follow pattern</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Resumes a {ccr} <<ccr-auto-follow,auto-follow pattern>>.
 
 [[ccr-resume-auto-follow-pattern-request]]

--- a/docs/reference/ccr/apis/ccr-apis.asciidoc
+++ b/docs/reference/ccr/apis/ccr-apis.asciidoc
@@ -2,6 +2,12 @@
 [[ccr-apis]]
 == {ccr-cap} APIs
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 You can use the following APIs to perform <<xpack-ccr,{ccr}>> operations.
 
 [discrete]

--- a/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get follower info</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Retrieves information about all <<xpack-ccr,{ccr}>> follower indices.
 
 [[ccr-get-follow-info-request]]

--- a/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get follower stats</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Get <<xpack-ccr,{ccr}>> follower stats.
 
 [[ccr-get-follow-stats-request]]

--- a/docs/reference/ccr/apis/follow/post-forget-follower.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-forget-follower.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Forget follower</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Removes the <<xpack-ccr,{ccr}>> follower retention leases from the leader.
 
 [[ccr-post-forget-follower-request]]

--- a/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Pause follower</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Pauses a <<xpack-ccr,{ccr}>> follower index.
 
 [[ccr-post-pause-follow-request]]

--- a/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Resume follower</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Resumes a <<xpack-ccr,{ccr}>> follower index.
 
 [[ccr-post-resume-follow-request]]

--- a/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Unfollow</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Converts a <<xpack-ccr,{ccr}>> follower index to a regular index.
 
 [[ccr-post-unfollow-request]]

--- a/docs/reference/ccr/apis/follow/put-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/put-follow.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create follower</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Creates a <<xpack-ccr,{ccr}>> follower index.
 
 [[ccr-put-follow-request]]

--- a/docs/reference/ccr/apis/get-ccr-stats.asciidoc
+++ b/docs/reference/ccr/apis/get-ccr-stats.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Get {ccr-init} stats</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ccr[Cross-cluster replication APIs].
+--
+
 Get <<xpack-ccr,{ccr}>> stats.
 
 [[ccr-get-stats-request]]

--- a/docs/reference/cluster.asciidoc
+++ b/docs/reference/cluster.asciidoc
@@ -1,6 +1,12 @@
 [[cluster]]
 == Cluster APIs
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 ["float",id="cluster-nodes"]
 === Node specification
 

--- a/docs/reference/cluster/allocation-explain.asciidoc
+++ b/docs/reference/cluster/allocation-explain.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Cluster allocation explain</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Provides an explanation for a shard's current <<index-modules-allocation,allocation>>.
 
 [source,console]

--- a/docs/reference/cluster/cluster-info.asciidoc
+++ b/docs/reference/cluster/cluster-info.asciidoc
@@ -7,6 +7,12 @@ experimental::[]
 <titleabbrev>Cluster Info</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Returns cluster information.
 
 [[cluster-info-api-request]]

--- a/docs/reference/cluster/delete-desired-balance.asciidoc
+++ b/docs/reference/cluster/delete-desired-balance.asciidoc
@@ -6,6 +6,12 @@
 
 NOTE: {cloud-only}
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Discards the current <<shards-rebalancing-heuristics,desired balance>> and computes a new desired balance starting from the current allocation of shards.
 This can sometimes help {es} find a desired balance which needs fewer shard movements to achieve, especially if the
 cluster has experienced changes so substantial that the current desired balance is no longer optimal without {es} having

--- a/docs/reference/cluster/delete-desired-nodes.asciidoc
+++ b/docs/reference/cluster/delete-desired-nodes.asciidoc
@@ -6,6 +6,12 @@
 
 NOTE: {cloud-only}
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Delete desired nodes.
 
 [[delete-desired-nodes-request]]

--- a/docs/reference/cluster/get-desired-balance.asciidoc
+++ b/docs/reference/cluster/get-desired-balance.asciidoc
@@ -6,6 +6,12 @@
 
 NOTE: {cloud-only}
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Exposes:
 
 * the <<shards-rebalancing-heuristics,desired balance>> computation and reconciliation stats

--- a/docs/reference/cluster/get-desired-nodes.asciidoc
+++ b/docs/reference/cluster/get-desired-nodes.asciidoc
@@ -6,6 +6,12 @@
 
 NOTE: {cloud-only}
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Get desired nodes.
 
 [[get-desired-nodes-request]]

--- a/docs/reference/cluster/get-settings.asciidoc
+++ b/docs/reference/cluster/get-settings.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Cluster get settings</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Returns cluster-wide settings.
 
 [source,console]

--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Cluster health</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Returns the health status of a cluster.
 
 [[cluster-health-api-request]]

--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Nodes hot threads</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Returns the hot threads on each selected node in the cluster.
 
 [[cluster-nodes-hot-threads-api-request]]

--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -4,8 +4,13 @@
 <titleabbrev>Nodes info</titleabbrev>
 ++++
 
-Returns cluster nodes information.
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
 
+Returns cluster nodes information.
 
 [[cluster-nodes-info-api-request]]
 ==== {api-request-title}

--- a/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
+++ b/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Nodes reload secure settings</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Reloads the keystore on nodes in the cluster.
 
 [[cluster-nodes-reload-secure-settings-api-request]]

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Nodes stats</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Returns cluster nodes statistics.
 
 [[cluster-nodes-stats-api-request]]

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -4,8 +4,13 @@
 <titleabbrev>Nodes feature usage</titleabbrev>
 ++++
 
-Returns information on the usage of features.
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
 
+Returns information on the usage of features.
 
 [[cluster-nodes-usage-api-request]]
 ==== {api-request-title}

--- a/docs/reference/cluster/pending.asciidoc
+++ b/docs/reference/cluster/pending.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Pending cluster tasks</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Returns cluster-level changes that have not yet been executed.
 
 

--- a/docs/reference/cluster/prevalidate-node-removal.asciidoc
+++ b/docs/reference/cluster/prevalidate-node-removal.asciidoc
@@ -6,6 +6,12 @@
 
 NOTE: {cloud-only}
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Prevalidate node removal.
 
 [[prevalidate-node-removal-api-request]]

--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -4,8 +4,13 @@
 <titleabbrev>Remote cluster info</titleabbrev>
 ++++
 
-Returns configured remote cluster information.
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
 
+Returns configured remote cluster information.
 
 [[cluster-remote-info-api-request]]
 ==== {api-request-title}

--- a/docs/reference/cluster/reroute.asciidoc
+++ b/docs/reference/cluster/reroute.asciidoc
@@ -4,8 +4,13 @@
 <titleabbrev>Cluster reroute</titleabbrev>
 ++++
 
-Changes the allocation of shards in a cluster.
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
 
+Changes the allocation of shards in a cluster.
 
 [[cluster-reroute-api-request]]
 ==== {api-request-title}

--- a/docs/reference/cluster/state.asciidoc
+++ b/docs/reference/cluster/state.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Cluster state</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Returns an internal representation of the cluster state for debugging or
 diagnostic purposes.
 

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Cluster stats</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Returns cluster statistics.
 
 [[cluster-stats-api-request]]

--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -6,6 +6,12 @@
 
 beta::["The task management API is new and should still be considered a beta feature. The API may change in ways that are not backwards compatible.",{es-issue}51628]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-tasks[task management APIs].
+--
+
 Returns information about the tasks currently executing in the cluster.
 
 [[tasks-api-request]]

--- a/docs/reference/cluster/update-desired-nodes.asciidoc
+++ b/docs/reference/cluster/update-desired-nodes.asciidoc
@@ -6,6 +6,12 @@
 
 NOTE: {cloud-only}
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Creates or updates the desired nodes.
 
 [[update-desired-nodes-request]]

--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -4,8 +4,13 @@
 <titleabbrev>Cluster update settings</titleabbrev>
 ++++
 
-Configures <<dynamic-cluster-setting,dynamic cluster settings>>.
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
 
+Configures <<dynamic-cluster-setting,dynamic cluster settings>>.
 
 [[cluster-update-settings-api-request]]
 ==== {api-request-title}

--- a/docs/reference/cluster/voting-exclusions.asciidoc
+++ b/docs/reference/cluster/voting-exclusions.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Voting configuration exclusions</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-cluster[Cluster APIs].
+--
+
 Adds or removes master-eligible nodes from the
 <<modules-discovery-voting,voting configuration exclusion list>>.
 

--- a/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Cancels a connector sync job.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/check-in-connector-api.asciidoc
+++ b/docs/reference/connector/apis/check-in-connector-api.asciidoc
@@ -6,6 +6,12 @@
 
 preview::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Updates the `last_seen` field of a connector with current timestamp.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/check-in-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/check-in-connector-sync-job-api.asciidoc
@@ -6,6 +6,12 @@
 
 preview::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Checks in a connector sync job (updates `last_seen` to the current time).
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/claim-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/claim-connector-sync-job-api.asciidoc
@@ -6,6 +6,12 @@
 
 preview::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Claims a connector sync job.
 
 The `_claim` endpoint is not intended for direct connector management by users. It is there to support the implementation of services that utilize the https://github.com/elastic/connectors/blob/main/docs/CONNECTOR_PROTOCOL.md[Connector Protocol] to communicate with {es}.

--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -1,6 +1,12 @@
 [[connector-apis]]
 == Connector APIs
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 beta::[]
 
 The connector and sync jobs APIs provide a convenient way to create and manage Elastic <<es-connectors,connectors>>.

--- a/docs/reference/connector/apis/create-connector-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Creates an Elastic connector.
 Connectors are {es} integrations that bring content from third-party data sources, which can be deployed on {ecloud} or hosted on your own infrastructure:
 

--- a/docs/reference/connector/apis/create-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-sync-job-api.asciidoc
@@ -6,6 +6,11 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
 
 Creates a connector sync job.
 

--- a/docs/reference/connector/apis/delete-connector-api.asciidoc
+++ b/docs/reference/connector/apis/delete-connector-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Removes a connector and associated sync jobs.
 This is a destructive action that is not recoverable.
 

--- a/docs/reference/connector/apis/delete-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/delete-connector-sync-job-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Removes a connector sync job and its associated data.
 This is a destructive action that is not recoverable.
 

--- a/docs/reference/connector/apis/get-connector-api.asciidoc
+++ b/docs/reference/connector/apis/get-connector-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Retrieves the details about a connector.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Retrieves the details about a connector sync job.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
+++ b/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
@@ -7,6 +7,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Returns information about all stored connector sync jobs ordered by their creation date in ascending order.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/list-connectors-api.asciidoc
+++ b/docs/reference/connector/apis/list-connectors-api.asciidoc
@@ -7,6 +7,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Returns information about all created connectors.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/set-connector-sync-job-error-api.asciidoc
+++ b/docs/reference/connector/apis/set-connector-sync-job-error-api.asciidoc
@@ -6,6 +6,12 @@
 
 preview::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Sets a connector sync job error.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/set-connector-sync-job-stats-api.asciidoc
+++ b/docs/reference/connector/apis/set-connector-sync-job-stats-api.asciidoc
@@ -6,6 +6,12 @@
 
 preview::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Sets connector sync job stats.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/update-connector-api-key-id-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-api-key-id-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Updates the `api_key_id` and/or `api_key_secret_id` field(s) of a connector, specifying:
 
 . The ID of the API key used for authorization

--- a/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Updates a connector's `configuration`, allowing for config value updates within a registered configuration schema.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/update-connector-error-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-error-api.asciidoc
@@ -6,6 +6,12 @@
 
 preview::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Updates the `error` field of a connector.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/update-connector-features-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-features-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Manages the `features` of a connector. This endpoint can be used to control the following aspects of a connector:
 
 * document-level security

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Updates the draft `filtering` configuration of a connector and marks the draft validation state as `edited`. The filtering draft is activated once validated by the running Elastic connector service.
 
 The filtering property is used to configure sync rules (both basic and advanced) for a connector. Learn more in the <<es-sync-rules>>.

--- a/docs/reference/connector/apis/update-connector-index-name-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-index-name-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Updates the `index_name` field of a connector, specifying the index where the data ingested by the connector is stored.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/update-connector-last-sync-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-last-sync-api.asciidoc
@@ -6,6 +6,12 @@
 
 preview::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Updates the fields related to the last sync of a connector.
 
 This action is used for analytics and monitoring.

--- a/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
@@ -6,6 +6,11 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
 
 Updates the `name` and `description` fields of a connector.
 

--- a/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Updates the `pipeline` configuration of a connector.
 
 When you create a new connector, the configuration of an <<ingest-pipeline-search-details-generic-reference, ingest pipeline>> is populated with default settings.

--- a/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Updates the `scheduling` configuration of a connector.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/update-connector-service-type-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-service-type-api.asciidoc
@@ -6,6 +6,12 @@
 
 beta::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Updates the `service_type` of a connector.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/connector/apis/update-connector-status-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-status-api.asciidoc
@@ -6,6 +6,12 @@
 
 preview::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-connector[Connector APIs].
+--
+
 Updates the `status` of a connector.
 
 To get started with Connector APIs, check out <<es-connectors-tutorial-api, our tutorial>>.

--- a/docs/reference/data-streams/data-stream-apis.asciidoc
+++ b/docs/reference/data-streams/data-stream-apis.asciidoc
@@ -2,6 +2,12 @@
 [[data-stream-apis]]
 == Data stream APIs
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 The following APIs are available for managing <<data-streams,data streams>>:
 
 * <<indices-create-data-stream>>

--- a/docs/reference/data-streams/lifecycle/apis/delete-lifecycle.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/delete-lifecycle.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Delete Data Stream Lifecycle</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Deletes the <<data-stream-lifecycle,lifecycle>> from a set of data streams.
 
 [[delete-lifecycle-api-prereqs]]

--- a/docs/reference/data-streams/lifecycle/apis/explain-lifecycle.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/explain-lifecycle.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Explain Data Stream Lifecycle</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Retrieves the current <<data-stream-lifecycle,data stream lifecycle>> status for one or more data stream backing indices.
 
 [[explain-lifecycle-api-prereqs]]

--- a/docs/reference/data-streams/lifecycle/apis/get-lifecycle-stats.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/get-lifecycle-stats.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get Data Stream Lifecycle</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Gets stats about the execution of <<data-stream-lifecycle,data stream lifecycle>>.
 
 [[get-lifecycle-stats-api-prereqs]]

--- a/docs/reference/data-streams/lifecycle/apis/get-lifecycle.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/get-lifecycle.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get Data Stream Lifecycle</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Gets the <<data-stream-lifecycle,lifecycle>> of a set of <<data-streams,data streams>>.
 
 [[get-lifecycle-api-prereqs]]

--- a/docs/reference/data-streams/lifecycle/apis/put-lifecycle.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/put-lifecycle.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Put Data Stream Lifecycle</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Configures the data stream <<data-stream-lifecycle,lifecycle>> for the targeted <<data-streams,data streams>>.
 
 [[put-lifecycle-api-prereqs]]

--- a/docs/reference/data-streams/modify-data-streams-api.asciidoc
+++ b/docs/reference/data-streams/modify-data-streams-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Modify data streams</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Performs one or more <<data-streams,data stream>> modification actions in a single atomic
 operation.
 

--- a/docs/reference/data-streams/promote-data-stream-api.asciidoc
+++ b/docs/reference/data-streams/promote-data-stream-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Promote data stream</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 The purpose of the promote <<data-streams,data stream>> API is to turn
 a data stream that is replicated by CCR into a regular
 data stream.

--- a/docs/reference/docs.asciidoc
+++ b/docs/reference/docs.asciidoc
@@ -1,6 +1,12 @@
 [[docs]]
 == Document APIs
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-document[Document APIs].
+--
+
 This section starts with a short introduction to {es}'s <<docs-replication,data
 replication model>>, followed by a detailed description of the following CRUD
 APIs:

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Bulk</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-document[Document APIs].
+--
+
 Performs multiple indexing or delete operations in a single API call.
 This reduces overhead and can greatly increase indexing speed.
 

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Delete</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-document[Document APIs].
+--
+
 Removes a JSON document from the specified index.
 
 [[docs-delete-api-request]]

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-document[Document APIs].
+--
+
 Retrieves the specified JSON document from an index.
 
 [source,console]

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Multi get</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-document[Document APIs].
+--
+
 Retrieves multiple JSON documents by ID. 
 
 [source,console]

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Reindex</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-document[Document APIs].
+--
+
 Copies documents from a source to a destination.
 
 The source can be any existing index, alias, or data stream. The destination

--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Term vectors</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-document[Document APIs].
+--
+
 Retrieves information and statistics for terms in the fields of a particular document. 
 
 [source,console]

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Update by query</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-document[Document APIs].
+--
+
 Updates documents that match the specified query.
 If no query is specified, performs an update on every document in the data stream or index without
 modifying the source, which is useful for picking up mapping changes.

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Update</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-document[Document APIs].
+--
+
 Updates a document using the specified script.
 
 [[docs-update-api-request]]

--- a/docs/reference/eql/delete-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/delete-async-eql-search-api.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Delete async EQL search</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-eql[EQL APIs].
+--
+
 Deletes an <<eql-search-async,async EQL search>> or a
 <<eql-search-store-sync-eql-search,stored synchronous EQL search>>. The API also
 deletes results for the search.

--- a/docs/reference/eql/eql-apis.asciidoc
+++ b/docs/reference/eql/eql-apis.asciidoc
@@ -1,6 +1,12 @@
 [[eql-apis]]
 == EQL APIs
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-eql[EQL APIs].
+--
+
 <<eql,Event Query Language (EQL)>> is a query language for event-based time series data,
 such as logs, metrics, and traces. For an overview of EQL and related tutorials,
 see <<eql>>.

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>EQL search</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-eql[EQL APIs].
+--
+
 Returns search results for an <<eql,Event Query Language (EQL)>> query.
 
 EQL assumes each document in a data stream or index corresponds to an

--- a/docs/reference/eql/get-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/get-async-eql-search-api.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Get async EQL search</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-eql[EQL APIs].
+--
+
 Returns the current status and available results for an <<eql-search-async,async
 EQL search>> or a <<eql-search-store-sync-eql-search,stored synchronous EQL
 search>>.

--- a/docs/reference/eql/get-async-eql-status-api.asciidoc
+++ b/docs/reference/eql/get-async-eql-status-api.asciidoc
@@ -5,6 +5,13 @@
 ++++
 <titleabbrev>Get async EQL search status</titleabbrev>
 ++++
+
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-eql[EQL APIs].
+--
+
 Returns the current status for an <<eql-search-async,async EQL search>> or
 a <<eql-search-store-sync-eql-search,stored synchronous EQL search>>
 without returning results. This is a more lightweight API than

--- a/docs/reference/esql/esql-apis.asciidoc
+++ b/docs/reference/esql/esql-apis.asciidoc
@@ -1,6 +1,14 @@
 [[esql-apis]]
 == {esql} APIs
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-esql[ES|QL APIs].
+--
+
+https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-query
+
 The <<esql,{es} Query Language ({esql})>> provides a powerful way to filter, transform,
 and analyze data stored in {es}, and in the future in other runtimes. For an
 overview of {esql} and related tutorials, see <<esql>>.

--- a/docs/reference/esql/esql-async-query-api.asciidoc
+++ b/docs/reference/esql/esql-async-query-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>{esql} async query API</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-esql[ES|QL APIs].
+--
+
 Runs an async <<esql,{esql} query>>.
 
 The async query API lets you asynchronously execute a query request,

--- a/docs/reference/esql/esql-async-query-delete-api.asciidoc
+++ b/docs/reference/esql/esql-async-query-delete-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>{esql} async query delete API</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-esql[ES|QL APIs].
+--
+
 The <<esql,{esql}>> async query delete API is used to manually delete an async query
 by ID. If the query is still running, the query will be cancelled. Otherwise,
 the stored results are deleted.

--- a/docs/reference/esql/esql-async-query-get-api.asciidoc
+++ b/docs/reference/esql/esql-async-query-get-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>{esql} async query get API</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-esql[ES|QL APIs].
+--
+
 Returns the current status and available results for an <<esql-async-query-api,{esql}
 async query>> or a stored results.
 

--- a/docs/reference/esql/esql-query-api.asciidoc
+++ b/docs/reference/esql/esql-query-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>{esql} query API</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-esql[ES|QL APIs].
+--
+
 Returns search results for an <<esql,ES|QL ({es} query language)>> query.
 
 [source,console]

--- a/docs/reference/features/apis/features-apis.asciidoc
+++ b/docs/reference/features/apis/features-apis.asciidoc
@@ -1,6 +1,12 @@
 [[features-apis]]
 == Features APIs
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-features[Features APIs].
+--
+
 You can use the following APIs to introspect and manage Features provided
 by Elasticsearch and Elasticsearch plugins.
 

--- a/docs/reference/features/apis/get-features-api.asciidoc
+++ b/docs/reference/features/apis/get-features-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get features</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-features[Features APIs].
+--
+
 Gets a list of features which can be included in snapshots using the
 <<create-snapshot-api-feature-states,`feature_states` field>> when creating a
 snapshot.

--- a/docs/reference/features/apis/reset-features-api.asciidoc
+++ b/docs/reference/features/apis/reset-features-api.asciidoc
@@ -6,6 +6,12 @@
 
 experimental::[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-features[Features APIs].
+--
+
 Clears all of the state information stored in system indices by {es} features, including the security and machine learning indices.
 
 WARNING: Intended for development and testing use only. Do not reset features on a production cluster.

--- a/docs/reference/fleet/fleet-multi-search.asciidoc
+++ b/docs/reference/fleet/fleet-multi-search.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Fleet multi search</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-fleet[{fleet} APIs].
+--
+
 Executes several <<fleet-search,fleet searches>> with a single API request.
 
 The API follows the same structure as the <<search-multi-search, multi search>> API. However,

--- a/docs/reference/fleet/fleet-search.asciidoc
+++ b/docs/reference/fleet/fleet-search.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Fleet search</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-fleet[{fleet} APIs].
+--
+
 The purpose of the fleet search api is to provide a search api where the search
 will only be executed after provided checkpoint has been processed and is visible
 for searches inside of Elasticsearch.

--- a/docs/reference/fleet/index.asciidoc
+++ b/docs/reference/fleet/index.asciidoc
@@ -2,6 +2,12 @@
 [[fleet-apis]]
 == Fleet APIs
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-fleet[{fleet} APIs].
+--
+
 TIP: For the {kib} {fleet} APIs, see the
 {fleet-guide}/fleet-api-docs.html[Fleet API Documentation].
 

--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -2,6 +2,12 @@
 [[graph-explore-api]]
 == Graph explore API
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-graph[Graph explore APIs].
+--
+
 The graph explore API enables you to extract and summarize information about
 the documents and terms in an {es} data stream or index.
 

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Health</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-health_report[Cluster health APIs].
+--
+
 An API that reports the health status of an {es} cluster.
 
 [[health-api-request]]

--- a/docs/reference/ilm/apis/ilm-api.asciidoc
+++ b/docs/reference/ilm/apis/ilm-api.asciidoc
@@ -1,6 +1,13 @@
 [[index-lifecycle-management-api]]
 == {ilm-cap} APIs
 
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-ilm[{ilm-cap} APIs].
+--
+
+https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-ilm
+
 You use the following APIs to set up policies to automatically manage the index lifecycle.
 For more information about {ilm} ({ilm-init}), see <<index-lifecycle-management>>.
 

--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -1,6 +1,12 @@
 [[indices]]
 == Index APIs
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Index APIs are used to manage individual indices,
 index settings, aliases, mappings, and index templates.
 

--- a/docs/reference/indices/add-alias.asciidoc
+++ b/docs/reference/indices/add-alias.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Create or update alias</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Adds a data stream or index to an <<aliases,alias>>.
 
 [source,console]

--- a/docs/reference/indices/alias-exists.asciidoc
+++ b/docs/reference/indices/alias-exists.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Alias exists</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Checks if an <<aliases,alias>> exists.
 
 [source,console]

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Aliases</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Performs one or more <<aliases,alias>> actions in a single atomic operation.
 
 [source,console]

--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Analyze</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Performs <<analysis,analysis>> on a text string
 and returns the resulting tokens.
 

--- a/docs/reference/indices/apis/unfreeze.asciidoc
+++ b/docs/reference/indices/apis/unfreeze.asciidoc
@@ -17,6 +17,12 @@ You can use this API to unfreeze indices that were frozen in 7.x. Frozen indices
 are not related to the frozen data tier.
 ====
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Unfreezes an index.
 
 [[unfreeze-index-api-request]]

--- a/docs/reference/indices/clearcache.asciidoc
+++ b/docs/reference/indices/clearcache.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Clear cache</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Clears the caches of one or more indices. For data streams, the API clears the
 caches of the stream's backing indices.
 

--- a/docs/reference/indices/clone-index.asciidoc
+++ b/docs/reference/indices/clone-index.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Clone index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Clones an existing index.
 
 [source,console]

--- a/docs/reference/indices/close.asciidoc
+++ b/docs/reference/indices/close.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Close index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Closes an index.
 
 [source,console]

--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create data stream</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Creates a new <<data-streams,data stream>>.
 
 ////

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Create index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Creates a new index.
 
 [source,console]

--- a/docs/reference/indices/dangling-index-delete.asciidoc
+++ b/docs/reference/indices/dangling-index-delete.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Delete dangling index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Deletes a dangling index.
 
 [[dangling-index-delete-api-request]]

--- a/docs/reference/indices/dangling-index-import.asciidoc
+++ b/docs/reference/indices/dangling-index-import.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Import dangling index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Imports a dangling index.
 
 [[dangling-index-import-api-request]]

--- a/docs/reference/indices/dangling-indices-list.asciidoc
+++ b/docs/reference/indices/dangling-indices-list.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>List dangling indices</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Lists dangling indices.
 
 [[dangling-indices-list-api-request]]

--- a/docs/reference/indices/data-stream-stats.asciidoc
+++ b/docs/reference/indices/data-stream-stats.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Data stream stats</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Retrieves statistics for one or more <<data-streams,data streams>>.
 
 ////

--- a/docs/reference/indices/delete-alias.asciidoc
+++ b/docs/reference/indices/delete-alias.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Delete alias</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Removes a data stream or index from an <<aliases,alias>>.
 
 [source,console]

--- a/docs/reference/indices/delete-component-template.asciidoc
+++ b/docs/reference/indices/delete-component-template.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Delete component template</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Deletes an existing component template.
 
 ////

--- a/docs/reference/indices/delete-data-stream.asciidoc
+++ b/docs/reference/indices/delete-data-stream.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delete data stream</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Deletes one or more <<data-streams,data streams>> and their backing
 indices. See <<delete-data-stream>>.
 

--- a/docs/reference/indices/delete-index-template-v1.asciidoc
+++ b/docs/reference/indices/delete-index-template-v1.asciidoc
@@ -9,6 +9,12 @@ templates>>, which are deprecated and will be replaced by the composable
 templates introduced in {es} 7.8. For information about composable templates,
 see <<index-templates>>.
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Deletes a legacy index template.
 
 ////

--- a/docs/reference/indices/delete-index-template.asciidoc
+++ b/docs/reference/indices/delete-index-template.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Delete index template</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Deletes an <<index-templates,index template>>.
 
 ////

--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Delete index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Deletes one or more indices.
 
 [source,console]

--- a/docs/reference/indices/diskusage.asciidoc
+++ b/docs/reference/indices/diskusage.asciidoc
@@ -6,6 +6,12 @@
 
 experimental[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Analyzes the disk usage of each field of an index or data stream.
 This API might not support indices created in previous {es} versions.
 The result of a small index can be inaccurate as some parts of an index

--- a/docs/reference/indices/downsample-data-stream.asciidoc
+++ b/docs/reference/indices/downsample-data-stream.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Downsample</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Aggregates a time series (TSDS) index and stores
 pre-computed statistical summaries (`min`, `max`, `sum`, `value_count` and
 `avg`) for each metric field grouped by a configured time interval. For example,

--- a/docs/reference/indices/field-usage-stats.asciidoc
+++ b/docs/reference/indices/field-usage-stats.asciidoc
@@ -6,6 +6,12 @@
 
 experimental[]
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Returns field usage information for each shard and field
 of an index.
 Field usage statistics are automatically captured when

--- a/docs/reference/indices/flush.asciidoc
+++ b/docs/reference/indices/flush.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Flush</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Flushes one or more data streams or indices.
 
 [source,console]

--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Force merge</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Forces a <<index-modules-merge,merge>> on the shards of one or more indices.
 For data streams, the API forces a merge on the shards of the stream's backing
 indices.

--- a/docs/reference/indices/get-alias.asciidoc
+++ b/docs/reference/indices/get-alias.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get alias</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Retrieves information for one or more <<aliases,aliases>>.
 
 [source,console]

--- a/docs/reference/indices/get-component-template.asciidoc
+++ b/docs/reference/indices/get-component-template.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get component template</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Retrieves information about one or more component templates.
 
 //////////////////////////

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get data stream</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Retrieves information about one or more <<data-streams,data streams>>.
 See <<get-info-about-data-stream>>.
 

--- a/docs/reference/indices/get-field-mapping.asciidoc
+++ b/docs/reference/indices/get-field-mapping.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get field mapping</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Retrieves <<mapping,mapping definitions>> for one or more fields. For data
 streams, the API retrieves field mappings for the stream's backing indices.
 

--- a/docs/reference/indices/get-index-template-v1.asciidoc
+++ b/docs/reference/indices/get-index-template-v1.asciidoc
@@ -8,6 +8,12 @@ IMPORTANT: This documentation is about legacy index templates,
 which are deprecated and will be replaced by the composable templates introduced in {es} 7.8. 
 For information about composable templates, see <<index-templates>>.
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Retrieves information about one or more index templates.
 
 ////

--- a/docs/reference/indices/get-index-template.asciidoc
+++ b/docs/reference/indices/get-index-template.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get index template</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Returns information about one or more index templates.
 
 ////

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Returns information about one or more indices. For data streams, the API
 returns information about the stream's backing indices.
 

--- a/docs/reference/indices/get-mapping.asciidoc
+++ b/docs/reference/indices/get-mapping.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get mapping</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Retrieves <<mapping,mapping definitions>> for one or more indices. For data
 streams, the API retrieves mappings for the stream's backing indices.
 

--- a/docs/reference/indices/get-settings.asciidoc
+++ b/docs/reference/indices/get-settings.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get index settings</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Returns setting information for one or more indices. For data streams, the API
 returns setting information for the stream's backing indices.
 

--- a/docs/reference/indices/index-template-exists-v1.asciidoc
+++ b/docs/reference/indices/index-template-exists-v1.asciidoc
@@ -9,6 +9,12 @@ templates>>, which are deprecated and will be replaced by the composable
 templates introduced in {es} 7.8. For information about composable templates,
 see <<index-templates>>.
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Checks if an <<indices-templates-v1,legacy index template>> exists.
 
 

--- a/docs/reference/indices/indices-exists.asciidoc
+++ b/docs/reference/indices/indices-exists.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Exists</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Checks if a data stream, index, or alias exists.
 
 [source,console]

--- a/docs/reference/indices/migrate-to-data-stream.asciidoc
+++ b/docs/reference/indices/migrate-to-data-stream.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Migrate to data stream</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-data-stream[Data stream APIs].
+--
+
 Converts an <<aliases,index alias>> to a <<data-streams,data stream>>.
 
 ////

--- a/docs/reference/indices/open-close.asciidoc
+++ b/docs/reference/indices/open-close.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Open index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Opens a closed index. For data streams, the API
 opens any closed backing indices.
 

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Create or update component template</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Creates or updates a component template. Component templates are building blocks
 for constructing <<index-templates,index templates>> that specify index
 <<mapping,mappings>>, <<index-modules-settings,settings>>, and

--- a/docs/reference/indices/put-index-template-v1.asciidoc
+++ b/docs/reference/indices/put-index-template-v1.asciidoc
@@ -8,6 +8,12 @@ IMPORTANT: This documentation is about legacy index templates,
 which are deprecated and will be replaced by the composable templates introduced in {es} 7.8.
 For information about composable templates, see <<index-templates>>.
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Creates or updates an index template.
 
 [source,console]

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Create or update index template</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Creates or updates an index template. Index templates define
 <<index-modules-settings,settings>>, <<mapping,mappings>>, and <<aliases,aliases>>
 that can be applied automatically to new indices.

--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Update mapping</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Adds new fields to an existing data stream or index. You can also use this
 API to change the search settings of existing fields.
 

--- a/docs/reference/indices/recovery.asciidoc
+++ b/docs/reference/indices/recovery.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Index recovery</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Returns information about ongoing and completed shard recoveries for one or
 more indices. For data streams, the API returns information for the stream's
 backing indices.

--- a/docs/reference/indices/refresh.asciidoc
+++ b/docs/reference/indices/refresh.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Refresh</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 A refresh makes recent operations performed on one or more indices available for
 search. For data streams, the API runs the refresh operation on the stream's
 backing indices. For more information about the refresh operation, see

--- a/docs/reference/indices/resolve-cluster.asciidoc
+++ b/docs/reference/indices/resolve-cluster.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Resolve cluster</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Resolves the specified index expressions to return information about
 each cluster, including the local cluster, if included.
 

--- a/docs/reference/indices/resolve.asciidoc
+++ b/docs/reference/indices/resolve.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Resolve index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Resolves the specified name(s) and/or index patterns for indices, aliases, and
 data streams. Multiple patterns and remote clusters are supported.
 

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Rollover</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Creates a new index for a <<data-streams,data stream>> or <<aliases,index alias>>.
 
 [source,console]

--- a/docs/reference/indices/segments.asciidoc
+++ b/docs/reference/indices/segments.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Index segments</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Returns low-level information about the https://lucene.apache.org/core/[Lucene]
 segments in index shards. For data streams, the API returns information about
 the stream's backing indices.

--- a/docs/reference/indices/shard-stores.asciidoc
+++ b/docs/reference/indices/shard-stores.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Index shard stores</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Retrieves store information
 about replica shards in one or more indices.
 For data streams, the API retrieves store

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Shrink index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Shrinks an existing index into a new index with fewer primary shards.
 
 

--- a/docs/reference/indices/simulate-index.asciidoc
+++ b/docs/reference/indices/simulate-index.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Simulate index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Returns the index configuration that would be applied to the specified index from an
 existing <<index-templates, index template>>.
 

--- a/docs/reference/indices/simulate-template.asciidoc
+++ b/docs/reference/indices/simulate-template.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Simulate template</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Returns the index configuration that would be applied by a particular
 <<index-templates, index template>>.
 

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Split index</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Splits an existing index into a new index with more primary shards.
 
 [source,console]

--- a/docs/reference/indices/stats.asciidoc
+++ b/docs/reference/indices/stats.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Index stats</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Returns statistics for one or more indices. For data streams, the API retrieves
 statistics for the stream's backing indices.
 

--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Update index settings</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-indices[Index APIs].
+--
+
 Changes a <<index-modules-settings,dynamic index setting>> in real time.
 
 For data streams, index setting changes are applied to all backing indices by

--- a/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delete enrich policy</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-enrich[Enrich APIs].
+--
+
 Deletes an existing <<enrich-policy,enrich policy>> and its
 <<enrich-index,enrich index>>.
 

--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Execute enrich policy</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-enrich[Enrich APIs].
+--
+
 Executes an existing <<enrich-policy,enrich policy>>.
 
 ////

--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get enrich policy</titleabbrev>
 ++++
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-enrich[Enrich APIs].
+--
+
 Returns information about an <<enrich-policy,enrich policy>>.
 
 ////

--- a/docs/reference/ingest/apis/enrich/index.asciidoc
+++ b/docs/reference/ingest/apis/enrich/index.asciidoc
@@ -2,6 +2,12 @@
 [[enrich-apis]]
 == Enrich APIs
 
+..New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-enrich[Enrich APIs].
+--
+
 The following enrich APIs are available for managing <<enrich-policy,enrich
 policies>>:
 

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -5,6 +5,11 @@
 <titleabbrev>Create enrich policy</titleabbrev>
 ++++
 
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-enrich[Enrich APIs].
+--
+
 Creates an enrich policy.
 
 ////

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -6,9 +6,9 @@
 {es} exposes REST APIs that are used by the UI components and can be called
 directly to configure and access {es} features.
 
-[NOTE]
-We are working on including more {es} APIs in this section. Some content might
-not be included yet.
+..New API reference
+[sidebar]
+For the most up-to-date API details, refer to {api-es}[{es} APIs].
 
 * <<api-conventions, API conventions>>
 * <<common-options, Common Options>>


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [DOCS] Link to new API site (#119038)