### PR TITLE
[Gradle] Enable stable configuration cache preview

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,8 @@ plugins {
   id 'elasticsearch.java-toolchain'
 }
 
+enableFeaturePreview "STABLE_CONFIGURATION_CACHE"
+
 rootProject.name = "elasticsearch"
 
 dependencyResolutionManagement {


### PR DESCRIPTION
The STABLE_CONFIGURATION_CACHE feature flag enables the following:

- tasks using a shared build service without declaring the requirement via the Task.usesService method will emit a deprecation warning.
- when the configuration cache is not enabled but the feature flag is present, deprecations for the following configuration cache requirements are also enabled:
    - Registering build listeners
    - Using task extensions and conventions at execution time