### PR TITLE
ESQL: Unmute Esql(Async)SecurityIT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -251,18 +251,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/119179
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/119191
-- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
-  method: testLookupJoinIndexAllowed
-  issue: https://github.com/elastic/elasticsearch/issues/119268
-- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
-  method: testLookupJoinIndexForbidden
-  issue: https://github.com/elastic/elasticsearch/issues/119269
-- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-  method: testLookupJoinIndexForbidden
-  issue: https://github.com/elastic/elasticsearch/issues/119270
-- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-  method: testLookupJoinIndexAllowed
-  issue: https://github.com/elastic/elasticsearch/issues/119271
 - class: org.elasticsearch.xpack.logsdb.qa.LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT
   method: testEsqlTermsAggregationByMethod
   issue: https://github.com/elastic/elasticsearch/issues/119355


### PR DESCRIPTION
Those were fixed in https://github.com/elastic/elasticsearch/pull/119283, but it looks like some CI checks were still running after it got merged, failed, and muted it.

Fixes https://github.com/elastic/elasticsearch/issues/119268
Fixes https://github.com/elastic/elasticsearch/issues/119269
Fixes https://github.com/elastic/elasticsearch/issues/119270
Fixes https://github.com/elastic/elasticsearch/issues/119271