### PR TITLE
[8.17] [Gradle] Enable stable configuration cache preview (#119382)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,8 @@ plugins {
   id 'elasticsearch.java-toolchain'
 }
 
+enableFeaturePreview "STABLE_CONFIGURATION_CACHE"
+
 rootProject.name = "elasticsearch"
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [Gradle] Enable stable configuration cache preview (#119382)