### PR TITLE
[8.17] [Build] Add 8.16 and 8.17 as base branches for wolfi updates (#118726)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>elastic/renovate-config:only-chainguard",
+    ":disableDependencyDashboard"
+  ],
+  "schedule": [
+    "after 1pm on tuesday"
+  ],
+  "labels": [">non-issue", ":Delivery/Packaging", "Team:Delivery", "auto-merge-without-approval"],
+  "baseBranches": ["main", "8.x", "8.17", "8.16"],
+  "packageRules": [
+    {
+      "groupName": "wolfi (versioned)",
+      "groupSlug": "wolfi-versioned",
+      "description": "Override the `groupSlug` to create a non-special-character branch name",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackagePatterns": [
+        "^docker.elastic.co/wolfi/chainguard-base$"
+      ]
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "Extract Wolfi images from elasticsearch DockerBase configuration",
+      "customType": "regex",
+      "fileMatch": [
+        "build\\-tools\\-internal\\/src\\/main\\/java\\/org\\/elasticsearch\\/gradle\\/internal\\/DockerBase\\.java$"
+      ],
+      "matchStrings": [
+        "\\s*\"?(?<depName>[^\\s:@\"]+)(?::(?<currentValue>[-a-zA-Z0-9.]+))?(?:@(?<currentDigest>sha256:[a-zA-Z0-9]+))?\"?"
+      ],
+      "currentValueTemplate": "{{#if currentValue}}{{{currentValue}}}{{else}}latest{{/if}}",
+      "autoReplaceStringTemplate": "{{{depName}}}{{#if newValue}}:{{{newValue}}}{{/if}}{{#if newDigest}}@{{{newDigest}}}{{/if}}\"",
+      "datasourceTemplate": "docker"
+    }
+  ]
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Build] Add 8.16 and 8.17 as base branches for wolfi updates (#118726)](https://github.com/elastic/elasticsearch/pull/118726)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)