### PR TITLE
[8.17] [DOCS] More links to new API site (#119380)

### DIFF
--- a/docs/reference/rest-api/security.asciidoc
+++ b/docs/reference/rest-api/security.asciidoc
@@ -1,6 +1,13 @@
 [role="xpack"]
 [[security-api]]
 == Security APIs
+
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 To use the security APIs, you must set `xpack.security.enabled` to `true` in
 the `elasticsearch.yml` file.
 

--- a/docs/reference/rest-api/security/activate-user-profile.asciidoc
+++ b/docs/reference/rest-api/security/activate-user-profile.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Activate user profile</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 NOTE: The user profile feature is designed only for use by {kib} and
 Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
 users and external applications should not call this API directly. Elastic reserves

--- a/docs/reference/rest-api/security/authenticate.asciidoc
+++ b/docs/reference/rest-api/security/authenticate.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Authenticate</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Enables you to submit a request with a basic auth header to
 authenticate a user and retrieve information about the authenticated user.
 

--- a/docs/reference/rest-api/security/bulk-create-roles.asciidoc
+++ b/docs/reference/rest-api/security/bulk-create-roles.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Bulk create or update roles API</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Bulk adds and updates roles in the native realm.
 
 [[security-api-bulk-put-role-request]]

--- a/docs/reference/rest-api/security/bulk-delete-roles.asciidoc
+++ b/docs/reference/rest-api/security/bulk-delete-roles.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Bulk delete roles API</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Bulk deletes roles in the native realm.
 
 [[security-api-bulk-delete-role-request]]

--- a/docs/reference/rest-api/security/bulk-update-api-keys.asciidoc
+++ b/docs/reference/rest-api/security/bulk-update-api-keys.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Bulk update API keys</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 [[security-api-bulk-update-api-keys-request]]
 ==== {api-request-title}
 

--- a/docs/reference/rest-api/security/change-password.asciidoc
+++ b/docs/reference/rest-api/security/change-password.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Change passwords</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Changes the passwords of users in the native realm and built-in users.
 
 [[security-api-change-password-request]]

--- a/docs/reference/rest-api/security/clear-api-key-cache.asciidoc
+++ b/docs/reference/rest-api/security/clear-api-key-cache.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Clear API key cache</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Evicts a subset of all entries from the API key cache.
 The cache is also automatically cleared on state changes of the security index.
 

--- a/docs/reference/rest-api/security/clear-cache.asciidoc
+++ b/docs/reference/rest-api/security/clear-cache.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Clear cache</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Evicts users from the user cache. You can completely clear
 the cache or evict specific users.
 

--- a/docs/reference/rest-api/security/clear-privileges-cache.asciidoc
+++ b/docs/reference/rest-api/security/clear-privileges-cache.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Clear privileges cache</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Evicts privileges from the native application privilege cache.
 The cache is also automatically cleared for applications that have their privileges updated.
 

--- a/docs/reference/rest-api/security/clear-roles-cache.asciidoc
+++ b/docs/reference/rest-api/security/clear-roles-cache.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Clear roles cache</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Evicts roles from the native role cache. 
 
 [[security-api-clear-role-cache-request]]

--- a/docs/reference/rest-api/security/clear-service-token-caches.asciidoc
+++ b/docs/reference/rest-api/security/clear-service-token-caches.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Clear service account token caches</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Evicts a subset of all entries from the  <<service-accounts,service account>>
 token caches.
 

--- a/docs/reference/rest-api/security/create-api-keys.asciidoc
+++ b/docs/reference/rest-api/security/create-api-keys.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create API keys</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Creates an API key for access without requiring basic authentication.
 
 [[security-api-create-api-key-request]]

--- a/docs/reference/rest-api/security/create-cross-cluster-api-key.asciidoc
+++ b/docs/reference/rest-api/security/create-cross-cluster-api-key.asciidoc
@@ -1,10 +1,15 @@
 [role="xpack"]
 [[security-api-create-cross-cluster-api-key]]
 === Create Cross-Cluster API key API
-
 ++++
 <titleabbrev>Create Cross-Cluster API key</titleabbrev>
 ++++
+
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
 
 Creates an API key of the `cross_cluster` type for the <<remote-clusters-api-key,API key based remote cluster>> access.
 A `cross_cluster` API key cannot be used to authenticate through the REST interface.

--- a/docs/reference/rest-api/security/create-role-mappings.asciidoc
+++ b/docs/reference/rest-api/security/create-role-mappings.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create or update role mappings</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Creates and updates role mappings.
 
 [[security-api-put-role-mapping-request]]

--- a/docs/reference/rest-api/security/create-roles.asciidoc
+++ b/docs/reference/rest-api/security/create-roles.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create or update roles</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Adds and updates roles in the native realm.
 
 [[security-api-put-role-request]]

--- a/docs/reference/rest-api/security/create-service-token.asciidoc
+++ b/docs/reference/rest-api/security/create-service-token.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create service account tokens</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Creates a  <<service-accounts,service accounts>> token for access without requiring basic
 authentication.
 

--- a/docs/reference/rest-api/security/create-users.asciidoc
+++ b/docs/reference/rest-api/security/create-users.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create or update users</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Adds and updates users in the native realm. These users are commonly referred
 to as _native users_.
 

--- a/docs/reference/rest-api/security/delegate-pki-authentication.asciidoc
+++ b/docs/reference/rest-api/security/delegate-pki-authentication.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delegate PKI authentication</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Implements the exchange of an _X509Certificate_ chain into an {es} access
 token.
 

--- a/docs/reference/rest-api/security/delete-app-privileges.asciidoc
+++ b/docs/reference/rest-api/security/delete-app-privileges.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delete application privileges</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Removes <<application-privileges,application privileges>>.
 
 [[security-api-delete-privilege-request]]

--- a/docs/reference/rest-api/security/delete-role-mappings.asciidoc
+++ b/docs/reference/rest-api/security/delete-role-mappings.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delete role mappings</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Removes role mappings.
 
 [[security-api-delete-role-mapping-request]]

--- a/docs/reference/rest-api/security/delete-roles.asciidoc
+++ b/docs/reference/rest-api/security/delete-roles.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delete roles</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Removes roles in the native realm.
 
 [[security-api-delete-role-request]]

--- a/docs/reference/rest-api/security/delete-service-token.asciidoc
+++ b/docs/reference/rest-api/security/delete-service-token.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delete service account token</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Deletes  <<service-accounts,service account>> tokens for a `service` in a
 specified `namespace`.
 

--- a/docs/reference/rest-api/security/delete-users.asciidoc
+++ b/docs/reference/rest-api/security/delete-users.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delete users</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Deletes users from the native realm. 
 
 [[security-api-delete-user-request]]

--- a/docs/reference/rest-api/security/disable-user-profile.asciidoc
+++ b/docs/reference/rest-api/security/disable-user-profile.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Disable user profile</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 NOTE: The user profile feature is designed only for use by {kib} and
 Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
 users and external applications should not call this API directly. Elastic reserves

--- a/docs/reference/rest-api/security/disable-users.asciidoc
+++ b/docs/reference/rest-api/security/disable-users.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Disable users</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Disables users in the native realm. 
 
 

--- a/docs/reference/rest-api/security/enable-user-profile.asciidoc
+++ b/docs/reference/rest-api/security/enable-user-profile.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Enable user profile</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 NOTE: The user profile feature is designed only for use by {kib} and
 Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
 users and external applications should not call this API directly. Elastic reserves

--- a/docs/reference/rest-api/security/enable-users.asciidoc
+++ b/docs/reference/rest-api/security/enable-users.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Enable users</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Enables users in the native realm. 
 
 

--- a/docs/reference/rest-api/security/enroll-kibana.asciidoc
+++ b/docs/reference/rest-api/security/enroll-kibana.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Enroll {kib}</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Enables a {kib} instance to configure itself for communication with a secured {es} cluster.
 
 NOTE: This API is currently intended for internal use only by {kib}.

--- a/docs/reference/rest-api/security/enroll-node.asciidoc
+++ b/docs/reference/rest-api/security/enroll-node.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Enroll node</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Allows a new node to join an existing cluster with security features enabled.
 
 [[security-api-node-enrollment-api-request]]

--- a/docs/reference/rest-api/security/get-api-keys.asciidoc
+++ b/docs/reference/rest-api/security/get-api-keys.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get API key information</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Retrieves information for one or more API keys.
 
 [[security-api-get-api-key-request]]

--- a/docs/reference/rest-api/security/get-app-privileges.asciidoc
+++ b/docs/reference/rest-api/security/get-app-privileges.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get application privileges</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Retrieves <<application-privileges,application privileges>>.
 
 [[security-api-get-privileges-request]]

--- a/docs/reference/rest-api/security/get-builtin-privileges.asciidoc
+++ b/docs/reference/rest-api/security/get-builtin-privileges.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Get builtin privileges</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Retrieves the list of <<privileges-list-cluster,cluster privileges>> and
 <<privileges-list-indices,index privileges>> that are
 available in this version of {es}.

--- a/docs/reference/rest-api/security/get-role-mappings.asciidoc
+++ b/docs/reference/rest-api/security/get-role-mappings.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get role mappings</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Retrieves role mappings.
 
 [[security-api-get-role-mapping-request]]

--- a/docs/reference/rest-api/security/get-roles.asciidoc
+++ b/docs/reference/rest-api/security/get-roles.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get roles</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Retrieves roles in the native realm.
 
 [[security-api-get-role-request]]

--- a/docs/reference/rest-api/security/get-service-accounts.asciidoc
+++ b/docs/reference/rest-api/security/get-service-accounts.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Get service accounts</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Retrieves information about <<service-accounts,service accounts>>.
 
 NOTE: Currently, only the `elastic/fleet-server` service account is available.

--- a/docs/reference/rest-api/security/get-service-credentials.asciidoc
+++ b/docs/reference/rest-api/security/get-service-credentials.asciidoc
@@ -1,10 +1,15 @@
 [role="xpack"]
 [[security-api-get-service-credentials]]
 === Get service account credentials API
-
 ++++
 <titleabbrev>Get service account credentials</titleabbrev>
 ++++
+
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
 
 Retrieves all service credentials for a  <<service-accounts,service account>>.
 

--- a/docs/reference/rest-api/security/get-settings.asciidoc
+++ b/docs/reference/rest-api/security/get-settings.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get Security settings</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Retrieves settings for the security internal indices.
 
 [[security-api-get-settings-prereqs]]

--- a/docs/reference/rest-api/security/get-tokens.asciidoc
+++ b/docs/reference/rest-api/security/get-tokens.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get token</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Creates a bearer token for access without requiring basic authentication.
 
 [[security-api-get-token-request]]

--- a/docs/reference/rest-api/security/get-user-privileges.asciidoc
+++ b/docs/reference/rest-api/security/get-user-privileges.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get user privileges</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Retrieves the <<security-privileges,security privileges>> for the logged in 
 user.
 

--- a/docs/reference/rest-api/security/get-user-profile.asciidoc
+++ b/docs/reference/rest-api/security/get-user-profile.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get user profiles</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 NOTE: The user profile feature is designed only for use by {kib} and
 Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
 users and external applications should not call this API directly. Elastic reserves

--- a/docs/reference/rest-api/security/get-users.asciidoc
+++ b/docs/reference/rest-api/security/get-users.asciidoc
@@ -5,8 +5,13 @@
 <titleabbrev>Get users</titleabbrev>
 ++++
 
-Retrieves information about users in the native realm and built-in users.
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
 
+Retrieves information about users in the native realm and built-in users.
 
 [[security-api-get-user-request]]
 ==== {api-request-title}

--- a/docs/reference/rest-api/security/grant-api-keys.asciidoc
+++ b/docs/reference/rest-api/security/grant-api-keys.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Grant API keys</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Creates an API key on behalf of another user.
 
 [[security-api-grant-api-key-request]]

--- a/docs/reference/rest-api/security/has-privileges-user-profile.asciidoc
+++ b/docs/reference/rest-api/security/has-privileges-user-profile.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Has privileges user profile</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 NOTE: The user profile feature is designed only for use by {kib} and
 Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
 users and external applications should not call this API directly. Elastic reserves

--- a/docs/reference/rest-api/security/has-privileges.asciidoc
+++ b/docs/reference/rest-api/security/has-privileges.asciidoc
@@ -6,6 +6,12 @@
 ++++
 [[security-api-has-privilege]]
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Determines whether the logged in user has a specified list of privileges.
 
 [[security-api-has-privileges-request]]

--- a/docs/reference/rest-api/security/invalidate-api-keys.asciidoc
+++ b/docs/reference/rest-api/security/invalidate-api-keys.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Invalidate API key</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Invalidates one or more API keys.
 
 [[security-api-invalidate-api-key-request]]

--- a/docs/reference/rest-api/security/invalidate-tokens.asciidoc
+++ b/docs/reference/rest-api/security/invalidate-tokens.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Invalidate token</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Invalidates one or more access tokens or refresh tokens.
 
 [[security-api-invalidate-token-request]]

--- a/docs/reference/rest-api/security/oidc-authenticate-api.asciidoc
+++ b/docs/reference/rest-api/security/oidc-authenticate-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>OpenID Connect authenticate</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Submits the response to an oAuth 2.0 authentication request for consumption from
 {es}. Upon successful validation, {es} will respond with an {es} internal Access
 Token and Refresh Token that can be subsequently used for authentication.

--- a/docs/reference/rest-api/security/oidc-logout-api.asciidoc
+++ b/docs/reference/rest-api/security/oidc-logout-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>OpenID Connect logout</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Submits a request to invalidate a refresh token and an access token that was
 generated as a response to a call to `/_security/oidc/authenticate`.
 

--- a/docs/reference/rest-api/security/oidc-prepare-authentication-api.asciidoc
+++ b/docs/reference/rest-api/security/oidc-prepare-authentication-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>OpenID Connect prepare authentication</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Creates an oAuth 2.0 authentication request as a URL string based on the
 configuration of the respective OpenID Connect authentication realm in {es}.
 

--- a/docs/reference/rest-api/security/put-app-privileges.asciidoc
+++ b/docs/reference/rest-api/security/put-app-privileges.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create or update application privileges</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Adds or updates <<application-privileges,application privileges>>.
 
 [[security-api-put-privileges-request]]

--- a/docs/reference/rest-api/security/query-api-key.asciidoc
+++ b/docs/reference/rest-api/security/query-api-key.asciidoc
@@ -1,10 +1,15 @@
 [role="xpack"]
 [[security-api-query-api-key]]
 === Query API key information API
-
 ++++
 <titleabbrev>Query API key information</titleabbrev>
 ++++
+
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
 
 ////
 [source,console]

--- a/docs/reference/rest-api/security/query-role.asciidoc
+++ b/docs/reference/rest-api/security/query-role.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Query Role</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Retrieves roles with <<query-dsl,Query DSL>> in a <<paginate-search-results,paginated>> fashion.
 
 [[security-api-query-role-request]]

--- a/docs/reference/rest-api/security/saml-authenticate-api.asciidoc
+++ b/docs/reference/rest-api/security/saml-authenticate-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>SAML authenticate</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Submits a SAML `Response` message to {es} for consumption.
 
 NOTE: This API is intended for use by custom web applications other than {kib}.

--- a/docs/reference/rest-api/security/saml-complete-logout-api.asciidoc
+++ b/docs/reference/rest-api/security/saml-complete-logout-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>SAML complete logout</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Verifies the logout response sent from the SAML IdP.
 
 NOTE: This API is intended for use by custom web applications other than {kib}.

--- a/docs/reference/rest-api/security/saml-invalidate-api.asciidoc
+++ b/docs/reference/rest-api/security/saml-invalidate-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>SAML invalidate</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Submits a SAML LogoutRequest message to {es} for consumption.
 
 NOTE: This API is intended for use by custom web applications other than {kib}.

--- a/docs/reference/rest-api/security/saml-logout-api.asciidoc
+++ b/docs/reference/rest-api/security/saml-logout-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>SAML logout</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Submits a request to invalidate an access token and refresh token.
 
 NOTE: This API is intended for use by custom web applications other than {kib}.

--- a/docs/reference/rest-api/security/saml-prepare-authentication-api.asciidoc
+++ b/docs/reference/rest-api/security/saml-prepare-authentication-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>SAML prepare authentication</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Creates a SAML authentication request (`<AuthnRequest>`) as a URL string, based on the configuration of the respective SAML realm in {es}.
 
 NOTE: This API is intended for use by custom web applications other than {kib}.

--- a/docs/reference/rest-api/security/saml-sp-metadata.asciidoc
+++ b/docs/reference/rest-api/security/saml-sp-metadata.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>SAML service provider metadata</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Generate SAML metadata for a SAML 2.0 Service Provider.
 
 [[security-api-saml-sp-metadata-request]]

--- a/docs/reference/rest-api/security/ssl.asciidoc
+++ b/docs/reference/rest-api/security/ssl.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>SSL certificate</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 The `certificates` API enables you to retrieve information about the X.509
 certificates that are used to encrypt communications in your {es} cluster.
 

--- a/docs/reference/rest-api/security/suggest-user-profile.asciidoc
+++ b/docs/reference/rest-api/security/suggest-user-profile.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Suggest user profile</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 NOTE: The user profile feature is designed only for use by {kib} and
 Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
 users and external applications should not call this API directly. Elastic reserves

--- a/docs/reference/rest-api/security/update-api-key.asciidoc
+++ b/docs/reference/rest-api/security/update-api-key.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Update API key</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 [[security-api-update-api-key-request]]
 ==== {api-request-title}
 

--- a/docs/reference/rest-api/security/update-cross-cluster-api-key.asciidoc
+++ b/docs/reference/rest-api/security/update-cross-cluster-api-key.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Update Cross-Cluster API key</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Update an existing cross-cluster API Key that is used for <<remote-clusters-api-key,API key based remote cluster>> access.
 
 

--- a/docs/reference/rest-api/security/update-settings.asciidoc
+++ b/docs/reference/rest-api/security/update-settings.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Update Security settings</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 Updates the settings of the security internal indices.
 
 

--- a/docs/reference/rest-api/security/update-user-profile-data.asciidoc
+++ b/docs/reference/rest-api/security/update-user-profile-data.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Update user profile data</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-security[Security APIs].
+--
+
 NOTE: The user profile feature is designed only for use by {kib} and
 Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
 users and external applications should not call this API directly. Elastic reserves

--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -2,6 +2,12 @@
 [[usage-api]]
 == Usage API
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-xpack[Usage APIs].
+--
+
 Provides usage information about the installed {xpack} features.
 
 [discrete]

--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -231,7 +231,8 @@ GET /_xpack/usage
   },
   "eql" : {
     "available" : true,
-    "enabled" : true
+    "enabled" : true,
+    ...
   },
   "esql" : {
     "available" : true,
@@ -529,7 +530,10 @@ GET /_xpack/usage
     "available": true,
     "enabled": false,
     "indices_count": 0,
-    "indices_with_synthetic_source": 0
+    "indices_with_synthetic_source": 0,
+    "num_docs": 0,
+    "size_in_bytes": 0,
+    "has_custom_cutoff_date": false
   }
 }
 ------------------------------------------------------------

--- a/docs/reference/rest-api/watcher.asciidoc
+++ b/docs/reference/rest-api/watcher.asciidoc
@@ -2,6 +2,12 @@
 [[watcher-api]]
 == Watcher APIs
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 * <<watcher-api-put-watch>>
 * <<watcher-api-get-watch>>
 * <<watcher-api-query-watches>>

--- a/docs/reference/rest-api/watcher/ack-watch.asciidoc
+++ b/docs/reference/rest-api/watcher/ack-watch.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Ack watch</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 <<actions-ack-throttle,Acknowledging a watch>> enables you
 to manually throttle execution of the watch's actions.
 

--- a/docs/reference/rest-api/watcher/activate-watch.asciidoc
+++ b/docs/reference/rest-api/watcher/activate-watch.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Activate watch</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 A watch can be either <<watch-active-state,active or inactive>>. This
 API enables you to activate a currently inactive watch.
 

--- a/docs/reference/rest-api/watcher/deactivate-watch.asciidoc
+++ b/docs/reference/rest-api/watcher/deactivate-watch.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Deactivate watch</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 A watch can be either <<watch-active-state,active or inactive>>. This
 API enables you to deactivate a currently active watch.
 

--- a/docs/reference/rest-api/watcher/delete-watch.asciidoc
+++ b/docs/reference/rest-api/watcher/delete-watch.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delete watch</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 Removes a watch from {watcher}.
 
 [[watcher-api-delete-watch-request]]

--- a/docs/reference/rest-api/watcher/execute-watch.asciidoc
+++ b/docs/reference/rest-api/watcher/execute-watch.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Execute watch</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 Forces the execution of a stored watch.
 
 [[watcher-api-execute-watch-request]]

--- a/docs/reference/rest-api/watcher/get-settings.asciidoc
+++ b/docs/reference/rest-api/watcher/get-settings.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get Watcher settings</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 This API allows a user to retrieve the user-configurable settings for the Watcher internal index (`.watches`). Only a subset of the index settings—those that are user-configurable—will be shown. This includes:
 
 - `index.auto_expand_replicas`

--- a/docs/reference/rest-api/watcher/get-watch.asciidoc
+++ b/docs/reference/rest-api/watcher/get-watch.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get watch</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 Retrieves a watch by its ID.
 
 [[watcher-api-get-watch-request]]

--- a/docs/reference/rest-api/watcher/put-watch.asciidoc
+++ b/docs/reference/rest-api/watcher/put-watch.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create or update watch</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 Either registers a new watch in {watcher} or updates an existing one.
 
 [[watcher-api-put-watch-request]]

--- a/docs/reference/rest-api/watcher/query-watches.asciidoc
+++ b/docs/reference/rest-api/watcher/query-watches.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Query watches</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 Retrieves all registered watches.
 
 [[watcher-api-query-watches-request]]

--- a/docs/reference/rest-api/watcher/start.asciidoc
+++ b/docs/reference/rest-api/watcher/start.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Start watch service</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 Starts the {watcher} service if it is not already running.
 
 [[watcher-api-start-request]]

--- a/docs/reference/rest-api/watcher/stats.asciidoc
+++ b/docs/reference/rest-api/watcher/stats.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Get {watcher} stats</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 Retrieves the current {watcher} metrics.
 
 [[watcher-api-stats-request]]

--- a/docs/reference/rest-api/watcher/stop.asciidoc
+++ b/docs/reference/rest-api/watcher/stop.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Stop watch service</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 Stops the {watcher} service if it is running.
 
 [[watcher-api-stop-request]]

--- a/docs/reference/rest-api/watcher/update-settings.asciidoc
+++ b/docs/reference/rest-api/watcher/update-settings.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Update Watcher settings</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
+--
+
 This API allows a user to modify the settings for the Watcher internal index (`.watches`). Only a subset of settings are allowed to by modified. This includes:
 
 - `index.auto_expand_replicas`

--- a/docs/reference/searchable-snapshots/apis/clear-cache.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/clear-cache.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Clear cache</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-searchable_snapshots[Searchable snapshots APIs].
+--
+
 experimental::[]
 
 Clears indices and data streams from the shared cache for

--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Mount snapshot</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-searchable_snapshots[Searchable snapshots APIs].
+--
+
 Mount a snapshot as a searchable snapshot index.
 
 [[searchable-snapshots-api-mount-request]]

--- a/docs/reference/searchable-snapshots/apis/node-cache-stats.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/node-cache-stats.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Cache stats</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-searchable_snapshots[Searchable snapshots APIs].
+--
+
 Retrieves statistics about the shared cache for <<partially-mounted,partially
 mounted indices>>.
 

--- a/docs/reference/searchable-snapshots/apis/searchable-snapshots-apis.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/searchable-snapshots-apis.asciidoc
@@ -2,6 +2,12 @@
 [[searchable-snapshots-apis]]
 == Searchable snapshots APIs
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-searchable_snapshots[Searchable snapshots APIs].
+--
+
 You can use the following APIs to perform searchable snapshots operations.
 
 * <<searchable-snapshots-api-mount-snapshot,Mount snapshot>>

--- a/docs/reference/searchable-snapshots/apis/shard-stats.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/shard-stats.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Searchable snapshot statistics</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-searchable_snapshots[Searchable snapshots APIs].
+--
+
 experimental::[]
 
 Retrieves statistics about searchable snapshots.

--- a/docs/reference/slm/apis/slm-api.asciidoc
+++ b/docs/reference/slm/apis/slm-api.asciidoc
@@ -2,6 +2,12 @@
 [[snapshot-lifecycle-management-api]]
 == {slm-cap} APIs
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-slm[{slm-cap} APIs].
+--
+
 You use the following APIs to set up policies to automatically take snapshots and 
 control how long they are retained.
 

--- a/docs/reference/slm/apis/slm-delete.asciidoc
+++ b/docs/reference/slm/apis/slm-delete.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delete policy</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-slm[{slm-cap} APIs].
+--
+
 Deletes an existing snapshot lifecycle policy.
 
 [[slm-api-delete-lifecycle-request]]

--- a/docs/reference/slm/apis/slm-execute-retention.asciidoc
+++ b/docs/reference/slm/apis/slm-execute-retention.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Execute snapshot retention policy</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-slm[{slm-cap} APIs].
+--
+
 Deletes any snapshots that are expired according to the policy's retention rules.
 
 [[slm-api-execute-retention-request]]

--- a/docs/reference/slm/apis/slm-execute.asciidoc
+++ b/docs/reference/slm/apis/slm-execute.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Execute snapshot lifecycle policy</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-slm[{slm-cap} APIs].
+--
+
 Immediately creates a snapshot according to the lifecycle policy, 
 without waiting for the scheduled time.
 

--- a/docs/reference/slm/apis/slm-get-status.asciidoc
+++ b/docs/reference/slm/apis/slm-get-status.asciidoc
@@ -7,6 +7,12 @@
 <titleabbrev>Get {slm} status</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-slm[{slm-cap} APIs].
+--
+
 Retrieves the status of {slm} ({slm-init}).
 
 [[slm-api-get-status-request]]

--- a/docs/reference/slm/apis/slm-get.asciidoc
+++ b/docs/reference/slm/apis/slm-get.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get policy</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-slm[{slm-cap} APIs].
+--
+
 Retrieves one or more snapshot lifecycle policy definitions and
 information about the latest snapshot attempts.
 

--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -4,8 +4,13 @@
 <titleabbrev>Create or update policy</titleabbrev>
 ++++
 
-Creates or updates a snapshot lifecycle policy.
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-slm[{slm-cap} APIs].
+--
 
+Creates or updates a snapshot lifecycle policy.
 
 [[slm-api-put-request]]
 ==== {api-request-title}

--- a/docs/reference/slm/apis/slm-start.asciidoc
+++ b/docs/reference/slm/apis/slm-start.asciidoc
@@ -1,11 +1,16 @@
 [role="xpack"]
 [[slm-api-start]]
 === Start {slm} API
-
 [subs="attributes"]
 ++++
 <titleabbrev>Start {slm}</titleabbrev>
 ++++
+
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-slm[{slm-cap} APIs].
+--
 
 Turns on {slm} ({slm-init}).
 

--- a/docs/reference/slm/apis/slm-stats.asciidoc
+++ b/docs/reference/slm/apis/slm-stats.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get snapshot lifecycle stats</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-slm[{slm-cap} APIs].
+--
+
 Returns global and policy-level statistics about actions taken by {slm}.
 
 [[slm-api-stats-request]]

--- a/docs/reference/slm/apis/slm-stop.asciidoc
+++ b/docs/reference/slm/apis/slm-stop.asciidoc
@@ -1,11 +1,16 @@
 [role="xpack"]
 [[slm-api-stop]]
 === Stop {slm} API
-
 [subs="attributes"]
 ++++
 <titleabbrev>Stop {slm}</titleabbrev>
 ++++
+
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-slm[{slm-cap} APIs].
+--
 
 Turn off {slm} ({slm-init}).
 

--- a/docs/reference/snapshot-restore/apis/clean-up-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/clean-up-repo-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Clean up snapshot repository</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Triggers the review of a snapshot repository's contents and deletes any stale
 data that is not referenced by existing snapshots. See
 <<snapshots-repository-cleanup>>.

--- a/docs/reference/snapshot-restore/apis/clone-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/clone-snapshot-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Clone snapshot</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Clones part or all of a snapshot into a new snapshot.
 
 [source,console]

--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Create snapshot</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 <<snapshots-take-snapshot,Takes a snapshot>> of a cluster or specified data
 streams and indices.
 

--- a/docs/reference/snapshot-restore/apis/delete-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/delete-repo-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Delete snapshot repository</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Unregisters one or more <<snapshots-register-repository,snapshot repositories>>.
 
 When a repository is unregistered, {es} only removes the reference to the

--- a/docs/reference/snapshot-restore/apis/delete-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/delete-snapshot-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Delete snapshot</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Deletes a <<snapshot-restore,snapshot>>.
 
 ////

--- a/docs/reference/snapshot-restore/apis/get-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-repo-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get snapshot repository</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Gets information about one or more registered
 <<snapshots-register-repository,snapshot repositories>>.
 

--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get snapshot</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Retrieves information about one or more snapshots.
 
 ////

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Get snapshot status</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Retrieves a detailed description of the current state for each shard participating in the snapshot. Note that this API should only be used to obtain detailed shard-level information for ongoing snapshots. If this detail is not needed, or you want to obtain information about one or more existing snapshots, use the <<get-snapshot-api,get snapshot API>>.
 
 ////

--- a/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Create or update snapshot repository</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Registers or updates a <<snapshots-register-repository,snapshot repository>>.
 
 [source,console]

--- a/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Repository analysis</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Analyzes a repository, reporting its performance characteristics and any
 incorrect behaviour found.
 

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Restore snapshot</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Restores a <<snapshot-restore,snapshot>> of a cluster or specified data streams and indices.
 
 ////

--- a/docs/reference/snapshot-restore/apis/snapshot-restore-apis.asciidoc
+++ b/docs/reference/snapshot-restore/apis/snapshot-restore-apis.asciidoc
@@ -1,6 +1,12 @@
 [[snapshot-restore-apis]]
 == Snapshot and restore APIs
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 You can use the following APIs to set up snapshot repositories, manage snapshot
 backups, and restore snapshots to a running cluster.
 

--- a/docs/reference/snapshot-restore/apis/verify-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/verify-repo-api.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Verify snapshot repository</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Checks for common misconfigurations in a snapshot repository. See
 <<snapshots-repository-verification>>.
 

--- a/docs/reference/snapshot-restore/apis/verify-repo-integrity-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/verify-repo-integrity-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Verify repository integrity</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-snapshot[Snapshot and restore APIs].
+--
+
 Verifies the integrity of the contents of a snapshot repository.
 
 ////

--- a/docs/reference/sql/apis/clear-sql-cursor-api.asciidoc
+++ b/docs/reference/sql/apis/clear-sql-cursor-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Clear SQL cursor</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-sql[SQL APIs].
+--
+
 Clears an <<sql-pagination,SQL search cursor>>.
 
 ////

--- a/docs/reference/sql/apis/delete-async-sql-search-api.asciidoc
+++ b/docs/reference/sql/apis/delete-async-sql-search-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Delete async SQL search</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-sql[SQL APIs].
+--
+
 Deletes an <<sql-async,async SQL search>> or a <<sql-store-searches,stored
 synchronous SQL search>>. If the search is still running, the API cancels it.
 

--- a/docs/reference/sql/apis/get-async-sql-search-api.asciidoc
+++ b/docs/reference/sql/apis/get-async-sql-search-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get async SQL search</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-sql[SQL APIs].
+--
+
 Returns results for an <<sql-async,async SQL search>> or a
 <<sql-store-searches,stored synchronous SQL search>>.
 

--- a/docs/reference/sql/apis/get-async-sql-search-status-api.asciidoc
+++ b/docs/reference/sql/apis/get-async-sql-search-status-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get async SQL search status</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-sql[SQL APIs].
+--
+
 Returns the current status of an <<sql-async,async SQL search>> or a
 <<sql-store-searches,stored synchronous SQL search>>.
 

--- a/docs/reference/sql/apis/sql-apis.asciidoc
+++ b/docs/reference/sql/apis/sql-apis.asciidoc
@@ -2,6 +2,12 @@
 [[sql-apis]]
 == SQL APIs
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-sql[SQL APIs].
+--
+
 {es}'s SQL APIs let you run SQL queries on {es} indices and data streams.
 For an overview of {es}'s SQL features and related tutorials, see <<xpack-sql>>.
 

--- a/docs/reference/sql/apis/sql-search-api.asciidoc
+++ b/docs/reference/sql/apis/sql-search-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>SQL search</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-sql[SQL APIs].
+--
+
 Returns results for an <<sql-rest-overview,SQL search>>.
 
 [source,console]

--- a/docs/reference/sql/apis/sql-translate-api.asciidoc
+++ b/docs/reference/sql/apis/sql-translate-api.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>SQL translate</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-sql[SQL APIs].
+--
+
 Translates an <<sql-search-api,SQL search>> into a <<search-search,search API>>
 request containing <<query-dsl,Query DSL>>. See <<sql-translate>>.
 

--- a/docs/reference/synonyms/apis/delete-synonym-rule.asciidoc
+++ b/docs/reference/synonyms/apis/delete-synonym-rule.asciidoc
@@ -1,9 +1,14 @@
 [[delete-synonym-rule]]
 === Delete synonym rule
-
 ++++
 <titleabbrev>Delete synonym rule</titleabbrev>
 ++++
+
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-synonyms[Synonyms APIs].
+--
 
 Deletes an individual synonym rule from a synonyms set.
 

--- a/docs/reference/synonyms/apis/delete-synonyms-set.asciidoc
+++ b/docs/reference/synonyms/apis/delete-synonyms-set.asciidoc
@@ -1,9 +1,14 @@
 [[delete-synonyms-set]]
 === Delete synonyms set
-
 ++++
 <titleabbrev>Delete synonyms set</titleabbrev>
 ++++
+
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-synonyms[Synonyms APIs].
+--
 
 Deletes a synonyms set.
 

--- a/docs/reference/synonyms/apis/get-synonym-rule.asciidoc
+++ b/docs/reference/synonyms/apis/get-synonym-rule.asciidoc
@@ -1,9 +1,14 @@
 [[get-synonym-rule]]
 === Get synonym rule
-
 ++++
 <titleabbrev>Get synonym rule</titleabbrev>
 ++++
+
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-synonyms[Synonyms APIs].
+--
 
 Retrieves a synonym rule from a synonyms set.
 

--- a/docs/reference/synonyms/apis/get-synonyms-set.asciidoc
+++ b/docs/reference/synonyms/apis/get-synonyms-set.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Get synonyms set</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-synonyms[Synonyms APIs].
+--
+
 Retrieves a synonyms set.
 
 [[get-synonyms-set-request]]

--- a/docs/reference/synonyms/apis/list-synonyms-sets.asciidoc
+++ b/docs/reference/synonyms/apis/list-synonyms-sets.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>List synonyms sets</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-synonyms[Synonyms APIs].
+--
+
 Retrieves a summary of all defined synonyms sets.
 
 This API allows to retrieve the total number of synonyms sets defined.

--- a/docs/reference/synonyms/apis/put-synonym-rule.asciidoc
+++ b/docs/reference/synonyms/apis/put-synonym-rule.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create or update synonym rule</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-synonyms[Synonyms APIs].
+--
+
 Creates or updates a synonym rule for a synonym set.
 
 [[put-synonym-rule-request]]

--- a/docs/reference/synonyms/apis/put-synonyms-set.asciidoc
+++ b/docs/reference/synonyms/apis/put-synonyms-set.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create or update synonyms set</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-synonyms[Synonyms APIs].
+--
+
 Creates or updates a synonyms set.
 
 NOTE: Synonyms sets are limited to a maximum of 10,000 synonym rules per set.

--- a/docs/reference/synonyms/apis/synonyms-apis.asciidoc
+++ b/docs/reference/synonyms/apis/synonyms-apis.asciidoc
@@ -7,6 +7,12 @@
 
 ---
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-synonyms[Synonyms APIs].
+--
+
 The synonyms management API provides a convenient way to define and manage synonyms in an internal system index. Related synonyms can be grouped in a "synonyms set".
 Create as many synonym sets as you need.
 

--- a/docs/reference/text-structure/apis/find-field-structure.asciidoc
+++ b/docs/reference/text-structure/apis/find-field-structure.asciidoc
@@ -2,6 +2,12 @@
 [[find-field-structure]]
 = Find field structure API
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-text_structure[Text structure APIs].
+--
+
 Finds the structure of a field in an Elasticsearch index.
 
 [discrete]

--- a/docs/reference/text-structure/apis/find-message-structure.asciidoc
+++ b/docs/reference/text-structure/apis/find-message-structure.asciidoc
@@ -2,6 +2,12 @@
 [[find-message-structure]]
 = Find messages structure API
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-text_structure[Text structure APIs].
+--
+
 Finds the structure of a list of text messages.
 
 [discrete]

--- a/docs/reference/text-structure/apis/find-structure.asciidoc
+++ b/docs/reference/text-structure/apis/find-structure.asciidoc
@@ -2,6 +2,12 @@
 [[find-structure]]
 = Find text structure API
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-text_structure[Text structure APIs].
+--
+
 Finds the structure of text. The text must
 contain data that is suitable to be ingested into the
 {stack}.

--- a/docs/reference/text-structure/apis/index.asciidoc
+++ b/docs/reference/text-structure/apis/index.asciidoc
@@ -2,6 +2,12 @@
 [[text-structure-apis]]
 == Text structure APIs
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-text_structure[Text structure APIs].
+--
+
 You can use the following APIs to find text structures:
 
 * <<find-field-structure>>

--- a/docs/reference/text-structure/apis/test-grok-pattern.asciidoc
+++ b/docs/reference/text-structure/apis/test-grok-pattern.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Test Grok pattern</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-text_structure[Text structure APIs].
+--
+
 Tests a Grok pattern on lines of text, see also <<grok,Grokking grok>>.
 
 [discrete]

--- a/docs/reference/transform/apis/delete-transform.asciidoc
+++ b/docs/reference/transform/apis/delete-transform.asciidoc
@@ -7,6 +7,12 @@
 <titleabbrev>Delete {transform}</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 Deletes an existing {transform}.
 
 [[delete-transform-request]]

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -7,6 +7,12 @@
 <titleabbrev>Get {transform} statistics</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 Retrieves usage information for {transforms}.
 
 

--- a/docs/reference/transform/apis/get-transform.asciidoc
+++ b/docs/reference/transform/apis/get-transform.asciidoc
@@ -6,6 +6,12 @@
 <titleabbrev>Get {transforms}</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 Retrieves configuration information for {transforms}.
 
 [[get-transform-request]]

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -7,6 +7,12 @@
 <titleabbrev>Preview {transform}</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 Previews a {transform}.
 
 [[preview-transform-request]]

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -7,6 +7,12 @@
 <titleabbrev>Create {transform}</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 Instantiates a {transform}.
 
 [[put-transform-request]]

--- a/docs/reference/transform/apis/reset-transform.asciidoc
+++ b/docs/reference/transform/apis/reset-transform.asciidoc
@@ -8,6 +8,12 @@
 <titleabbrev>Reset {transform}</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 Resets a {transform}.
 
 [[reset-transform-request]]

--- a/docs/reference/transform/apis/schedule-now-transform.asciidoc
+++ b/docs/reference/transform/apis/schedule-now-transform.asciidoc
@@ -8,6 +8,12 @@
 <titleabbrev>Schedule now {transform}</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 Instantly runs a {transform} to process data.
 
 [[schedule-now-transform-request]]

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -7,6 +7,12 @@
 <titleabbrev>Start {transform}</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 Starts a {transform}.
 
 [[start-transform-request]]

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -7,6 +7,12 @@
 <titleabbrev>Stop {transforms}</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 Stops one or more {transforms}.
 
 

--- a/docs/reference/transform/apis/transform-apis.asciidoc
+++ b/docs/reference/transform/apis/transform-apis.asciidoc
@@ -2,6 +2,12 @@
 [[transform-apis]]
 = {transform-cap} APIs
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 * <<put-transform>> 
 * <<delete-transform>>
 * <<get-transform>>

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -7,6 +7,12 @@
 <titleabbrev>Update {transform}</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 Updates certain properties of a {transform}.
 
 [[update-transform-request]]

--- a/docs/reference/transform/apis/upgrade-transforms.asciidoc
+++ b/docs/reference/transform/apis/upgrade-transforms.asciidoc
@@ -7,6 +7,12 @@
 <titleabbrev>Upgrade {transforms}</titleabbrev>
 ++++
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/group/endpoint-transform[{transform-cap} APIs].
+--
+
 Upgrades all {transforms}.
 
 [[upgrade-transforms-request]]


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [DOCS] More links to new API site (#119380)

NOTE: This PR contains an extra commit to fix API example tests for the usage API, which were failing CI checks.