### PR TITLE
(Doc+) Clarify dimension field requirements for time_series aggregation

### DIFF
--- a/docs/reference/aggregations/bucket/time-series-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/time-series-aggregation.asciidoc
@@ -9,6 +9,18 @@ preview::[]
 The time series aggregation queries data created using a time series index. This is typically data such as metrics
 or other data streams with a time component, and requires creating an index using the time series mode.
 
+[NOTE]
+====
+When you create a time series index, you must:
+
+* Set `index.mode` to `"time_series"`.
+* Specify at least one dimension field by adding `"time_series_dimension": true` in your mapping.
+* Provide a `routing_path` array listing the dimension fields.
+
+These fields ensure that documents sharing the same dimensions are routed to the same shard,
+and they allow the `time_series` aggregation to produce meaningful bucket results.
+====
+
 //////////////////////////
 
 Creating a time series mapping

--- a/docs/reference/aggregations/bucket/time-series-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/time-series-aggregation.asciidoc
@@ -6,19 +6,12 @@
 
 preview::[]
 
-The time series aggregation queries data created using a time series index. This is typically data such as metrics
+The time series aggregation queries data created using a <<tsds,Time series data stream (TSDS)>>. This is typically data such as metrics
 or other data streams with a time component, and requires creating an index using the time series mode.
 
 [NOTE]
 ====
-When you create a time series index, you must:
-
-* Set `index.mode` to `"time_series"`.
-* Specify at least one dimension field by adding `"time_series_dimension": true` in your mapping.
-* Provide a `routing_path` array listing the dimension fields.
-
-These fields ensure that documents sharing the same dimensions are routed to the same shard,
-and they allow the `time_series` aggregation to produce meaningful bucket results.
+Refer to the <<differences-from-regular-data-stream, TSDS documentation>> to learn more about the key differences from regular data streams.
 ====
 
 //////////////////////////


### PR DESCRIPTION
👋 howdy, team!

This PR adds a note explaining that time series indices require:
- index.mode set to "time_series"
- at least one dimension field with time_series_dimension: true
- a routing_path array listing those dimension fields

Without these settings, the time_series aggregation may return empty buckets or behave unexpectedly. By emphasizing the dimension field requirement, we help users configure their time series indices correctly and see meaningful aggregation results.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

