### PR TITLE
[8.x] Add missing timeouts to rest-api-spec SLM APIs (#118958)

### DIFF
--- a/docs/changelog/118958.yaml
+++ b/docs/changelog/118958.yaml
@@ -1,0 +1,5 @@
+pr: 118958
+summary: Add missing timeouts to rest-api-spec SLM APIs
+area: ILM+SLM
+type: bug
+issues: []

--- a/docs/changelog/119447.yaml
+++ b/docs/changelog/119447.yaml
@@ -1,0 +1,5 @@
+pr: 119447
+summary: "[8.x] Add missing timeouts to rest-api-spec SLM APIs"
+area: ILM+SLM
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.delete_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.delete_lifecycle.json
@@ -25,6 +25,15 @@
         }
       ]
     },
-    "params":{}
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_lifecycle.json
@@ -25,6 +25,15 @@
         }
       ]
     },
-    "params":{}
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_retention.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_retention.json
@@ -19,6 +19,15 @@
         }
       ]
     },
-    "params":{}
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_lifecycle.json
@@ -31,6 +31,15 @@
         }
       ]
     },
-    "params":{}
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_stats.json
@@ -19,6 +19,15 @@
         }
       ]
     },
-    "params":{}
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_status.json
@@ -19,6 +19,15 @@
         }
       ]
     },
-    "params":{}
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.put_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.put_lifecycle.json
@@ -26,7 +26,16 @@
         }
       ]
     },
-    "params":{},
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    },
     "body":{
       "description":"The snapshot lifecycle policy definition to register"
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add missing timeouts to rest-api-spec SLM APIs (#118958)](https://github.com/elastic/elasticsearch/pull/118958)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)