### PR TITLE
ES|QL: skip to_upper/lower tests before v 8.12.x

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1287,7 +1287,7 @@ emp_no:integer  | first_name:keyword
 10001           | Georgi
 ;
 
-equalsToUpperFolded
+equalsToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_upper(first_name) == "Georgi"
 | keep emp_no, first_name
@@ -1296,7 +1296,7 @@ from employees
 emp_no:integer  | first_name:keyword
 ;
 
-negatedEqualsToUpperFolded
+negatedEqualsToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where not(to_upper(first_name) == "Georgi")
 | stats c = count()
@@ -1315,7 +1315,7 @@ from employees
 emp_no:integer  | first_name:keyword
 ;
 
-equalsNullToUpperFolded
+equalsNullToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_upper(first_name) == to_string(null)
 | keep emp_no, first_name
@@ -1333,7 +1333,7 @@ from employees
 emp_no:integer  | first_name:keyword
 ;
 
-notEqualsNullToUpperFolded
+notEqualsNullToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_upper(first_name) != to_string(null)
 | keep emp_no, first_name
@@ -1342,7 +1342,7 @@ from employees
 emp_no:integer  | first_name:keyword
 ;
 
-notEqualsToUpperFolded
+notEqualsToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_upper(first_name) != "Georgi"
 | stats c = count()
@@ -1352,7 +1352,7 @@ c:long
 90
 ;
 
-negatedNotEqualsToUpperFolded
+negatedNotEqualsToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where not(to_upper(first_name) != "Georgi")
 | stats c = count()
@@ -1384,7 +1384,7 @@ emp_no:integer  | first_name:keyword
 10002           | Bezalel
 ;
 
-equalsToLowerFolded
+equalsToLowerFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_lower(first_name) == "Georgi"
 | keep emp_no, first_name
@@ -1393,7 +1393,7 @@ from employees
 emp_no:integer  | first_name:keyword
 ;
 
-notEqualsToLowerFolded
+notEqualsToLowerFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_lower(first_name) != "Georgi"
 | stats c = count()
@@ -1403,7 +1403,7 @@ c:long
 90
 ;
 
-equalsToLowerWithUnico(rn|d)s
+equalsToLowerWithUnico(rn|d)s#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_lower(concat(first_name, "🦄🦄")) != "georgi🦄🦄"
 | stats c = count()


### PR DESCRIPTION
Skipping some BWC tests (to_upper/to_lower) before v 8.12.x, as these functions were not available yet.

Related to: https://github.com/elastic/elasticsearch/issues/119439
Related to: https://github.com/elastic/elasticsearch/issues/119438
Related to: https://github.com/elastic/elasticsearch/issues/119437
Related to: https://github.com/elastic/elasticsearch/issues/119436
Related to: https://github.com/elastic/elasticsearch/issues/119431
Related to: https://github.com/elastic/elasticsearch/issues/119430
Related to: https://github.com/elastic/elasticsearch/issues/119429
