### PR TITLE
[8.x] ES|QL: skip to_upper/lower tests before v 8.12.x (#119448)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1300,7 +1300,7 @@ emp_no:integer  | first_name:keyword
 10001           | Georgi
 ;
 
-equalsToUpperFolded
+equalsToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_upper(first_name) == "Georgi"
 | keep emp_no, first_name
@@ -1309,7 +1309,7 @@ from employees
 emp_no:integer  | first_name:keyword
 ;
 
-negatedEqualsToUpperFolded
+negatedEqualsToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where not(to_upper(first_name) == "Georgi")
 | stats c = count()
@@ -1328,7 +1328,7 @@ from employees
 emp_no:integer  | first_name:keyword
 ;
 
-equalsNullToUpperFolded
+equalsNullToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_upper(first_name) == to_string(null)
 | keep emp_no, first_name
@@ -1346,7 +1346,7 @@ from employees
 emp_no:integer  | first_name:keyword
 ;
 
-notEqualsNullToUpperFolded
+notEqualsNullToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_upper(first_name) != to_string(null)
 | keep emp_no, first_name
@@ -1355,7 +1355,7 @@ from employees
 emp_no:integer  | first_name:keyword
 ;
 
-notEqualsToUpperFolded
+notEqualsToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_upper(first_name) != "Georgi"
 | stats c = count()
@@ -1365,7 +1365,7 @@ c:long
 90
 ;
 
-negatedNotEqualsToUpperFolded
+negatedNotEqualsToUpperFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where not(to_upper(first_name) != "Georgi")
 | stats c = count()
@@ -1397,7 +1397,7 @@ emp_no:integer  | first_name:keyword
 10002           | Bezalel
 ;
 
-equalsToLowerFolded
+equalsToLowerFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_lower(first_name) == "Georgi"
 | keep emp_no, first_name
@@ -1406,7 +1406,7 @@ from employees
 emp_no:integer  | first_name:keyword
 ;
 
-notEqualsToLowerFolded
+notEqualsToLowerFolded#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_lower(first_name) != "Georgi"
 | stats c = count()
@@ -1416,7 +1416,7 @@ c:long
 90
 ;
 
-equalsToLowerWithUnico(rn|d)s
+equalsToLowerWithUnico(rn|d)s#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees
 | where to_lower(concat(first_name, "🦄🦄")) != "georgi🦄🦄"
 | stats c = count()


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ES|QL: skip to_upper/lower tests before v 8.12.x (#119448)