### PR TITLE
ES|QL change point

### DIFF
--- a/docs/changelog/119458.yaml
+++ b/docs/changelog/119458.yaml
@@ -1,0 +1,5 @@
+pr: 119458
+summary: ES|QL change point
+area: Machine Learning
+type: feature
+issues: []

--- a/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Aggregator.java
+++ b/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Aggregator.java
@@ -63,4 +63,8 @@ public @interface Aggregator {
      */
     Class<? extends Exception>[] warnExceptions() default {};
 
+    /**
+     * If {@code true} then the @timestamp LongVector will be appended to the input blocks of the aggregation function.
+     */
+    boolean includeTimestamps() default false;
 }

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -669,6 +669,28 @@ tasks.named('stringTemplates').configure {
     it.outputFile = "org/elasticsearch/compute/aggregation/TopIpAggregator.java"
   }
 
+  File changePointAggregatorInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/aggregation/X-ChangePointAggregator.java.st")
+  template {
+    it.properties = intProperties
+    it.inputFile = changePointAggregatorInputFile
+    it.outputFile = "org/elasticsearch/compute/aggregation/ChangePointIntAggregator.java"
+  }
+  template {
+    it.properties = longProperties
+    it.inputFile = changePointAggregatorInputFile
+    it.outputFile = "org/elasticsearch/compute/aggregation/ChangePointLongAggregator.java"
+  }
+  template {
+    it.properties = floatProperties
+    it.inputFile = changePointAggregatorInputFile
+    it.outputFile = "org/elasticsearch/compute/aggregation/ChangePointFloatAggregator.java"
+  }
+  template {
+    it.properties = doubleProperties
+    it.inputFile = changePointAggregatorInputFile
+    it.outputFile = "org/elasticsearch/compute/aggregation/ChangePointDoubleAggregator.java"
+  }
+
   File multivalueDedupeInputFile = file("src/main/java/org/elasticsearch/compute/operator/mvdedupe/X-MultivalueDedupe.java.st")
   template {
     it.properties = intProperties

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorProcessor.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorProcessor.java
@@ -87,7 +87,14 @@ public class AggregatorProcessor implements Processor {
             );
             if (aggClass.getAnnotation(Aggregator.class) != null) {
                 IntermediateState[] intermediateState = aggClass.getAnnotation(Aggregator.class).value();
-                implementer = new AggregatorImplementer(env.getElementUtils(), aggClass, intermediateState, warnExceptionsTypes);
+                boolean includeTimestamps = aggClass.getAnnotation(Aggregator.class).includeTimestamps();
+                implementer = new AggregatorImplementer(
+                    env.getElementUtils(),
+                    aggClass,
+                    intermediateState,
+                    warnExceptionsTypes,
+                    includeTimestamps
+                );
                 write(aggClass, "aggregator", implementer.sourceFile(), env);
             }
             GroupingAggregatorImplementer groupingAggregatorImplementer = null;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ChangePointDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ChangePointDoubleAggregator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.aggregation.ChangePointStates.GroupingState;
+import org.elasticsearch.compute.aggregation.ChangePointStates.SingleState;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * Change point detection for series of double values.
+ * This class is generated. Edit @{code X-ChangePointAggregator.java.st} instead
+ * of this file.
+ */
+@Aggregator(
+    includeTimestamps = true,
+    value = { @IntermediateState(name = "timestamps", type = "LONG_BLOCK"), @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
+)
+@GroupingAggregator(
+    includeTimestamps = true,
+    value = { @IntermediateState(name = "timestamps", type = "LONG_BLOCK"), @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
+)
+class ChangePointDoubleAggregator {
+
+    public static SingleState initSingle(DriverContext driverContext) {
+        return new SingleState(driverContext.bigArrays());
+    }
+
+    public static void combine(SingleState state, long timestamp, double value) {
+        state.add(timestamp, value);
+    }
+
+    public static void combineIntermediate(SingleState state, LongBlock timestamps, DoubleBlock values) {
+        state.add(timestamps, values);
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(DriverContext driverContext) {
+        return new GroupingState(driverContext.bigArrays());
+    }
+
+    public static void combine(GroupingState current, int groupId, long timestamp, double value) {
+        current.add(groupId, timestamp, value);
+    }
+
+    public static void combineIntermediate(
+        GroupingState current,
+        int groupId,
+        LongBlock timestamps,
+        DoubleBlock values,
+        int otherPosition
+    ) {
+        current.combine(groupId, timestamps, values, otherPosition);
+    }
+
+    public static void combineStates(GroupingState current, int currentGroupId, GroupingState otherState, int otherGroupId) {
+        current.combineState(currentGroupId, otherState, otherGroupId);
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, DriverContext driverContext) {
+        return state.evaluateFinal(selected, driverContext.blockFactory());
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ChangePointFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ChangePointFloatAggregator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.aggregation.ChangePointStates.GroupingState;
+import org.elasticsearch.compute.aggregation.ChangePointStates.SingleState;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * Change point detection for series of float values.
+ * This class is generated. Edit @{code X-ChangePointAggregator.java.st} instead
+ * of this file.
+ */
+@Aggregator(
+    includeTimestamps = true,
+    value = { @IntermediateState(name = "timestamps", type = "LONG_BLOCK"), @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
+)
+@GroupingAggregator(
+    includeTimestamps = true,
+    value = { @IntermediateState(name = "timestamps", type = "LONG_BLOCK"), @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
+)
+class ChangePointFloatAggregator {
+
+    public static SingleState initSingle(DriverContext driverContext) {
+        return new SingleState(driverContext.bigArrays());
+    }
+
+    public static void combine(SingleState state, long timestamp, float value) {
+        state.add(timestamp, value);
+    }
+
+    public static void combineIntermediate(SingleState state, LongBlock timestamps, DoubleBlock values) {
+        state.add(timestamps, values);
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(DriverContext driverContext) {
+        return new GroupingState(driverContext.bigArrays());
+    }
+
+    public static void combine(GroupingState current, int groupId, long timestamp, float value) {
+        current.add(groupId, timestamp, value);
+    }
+
+    public static void combineIntermediate(
+        GroupingState current,
+        int groupId,
+        LongBlock timestamps,
+        DoubleBlock values,
+        int otherPosition
+    ) {
+        current.combine(groupId, timestamps, values, otherPosition);
+    }
+
+    public static void combineStates(GroupingState current, int currentGroupId, GroupingState otherState, int otherGroupId) {
+        current.combineState(currentGroupId, otherState, otherGroupId);
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, DriverContext driverContext) {
+        return state.evaluateFinal(selected, driverContext.blockFactory());
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ChangePointIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ChangePointIntAggregator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.aggregation.ChangePointStates.GroupingState;
+import org.elasticsearch.compute.aggregation.ChangePointStates.SingleState;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * Change point detection for series of int values.
+ * This class is generated. Edit @{code X-ChangePointAggregator.java.st} instead
+ * of this file.
+ */
+@Aggregator(
+    includeTimestamps = true,
+    value = { @IntermediateState(name = "timestamps", type = "LONG_BLOCK"), @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
+)
+@GroupingAggregator(
+    includeTimestamps = true,
+    value = { @IntermediateState(name = "timestamps", type = "LONG_BLOCK"), @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
+)
+class ChangePointIntAggregator {
+
+    public static SingleState initSingle(DriverContext driverContext) {
+        return new SingleState(driverContext.bigArrays());
+    }
+
+    public static void combine(SingleState state, long timestamp, int value) {
+        state.add(timestamp, value);
+    }
+
+    public static void combineIntermediate(SingleState state, LongBlock timestamps, DoubleBlock values) {
+        state.add(timestamps, values);
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(DriverContext driverContext) {
+        return new GroupingState(driverContext.bigArrays());
+    }
+
+    public static void combine(GroupingState current, int groupId, long timestamp, int value) {
+        current.add(groupId, timestamp, value);
+    }
+
+    public static void combineIntermediate(
+        GroupingState current,
+        int groupId,
+        LongBlock timestamps,
+        DoubleBlock values,
+        int otherPosition
+    ) {
+        current.combine(groupId, timestamps, values, otherPosition);
+    }
+
+    public static void combineStates(GroupingState current, int currentGroupId, GroupingState otherState, int otherGroupId) {
+        current.combineState(currentGroupId, otherState, otherGroupId);
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, DriverContext driverContext) {
+        return state.evaluateFinal(selected, driverContext.blockFactory());
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ChangePointLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ChangePointLongAggregator.java
@@ -20,8 +20,9 @@ import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * Change point detection for series of long values.
+ * This class is generated. Edit @{code X-ChangePointAggregator.java.st} instead
+ * of this file.
  */
-// TODO: make .java.st from this to support different types
 @Aggregator(
     includeTimestamps = true,
     value = { @IntermediateState(name = "timestamps", type = "LONG_BLOCK"), @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
@@ -41,11 +42,7 @@ class ChangePointLongAggregator {
     }
 
     public static void combineIntermediate(SingleState state, LongBlock timestamps, DoubleBlock values) {
-        int start = values.getFirstValueIndex(0);
-        int end = start + values.getValueCount(0);
-        for (int i = start; i < end; i++) {
-            state.add(timestamps.getLong(i), values.getDouble(i));
-        }
+        state.add(timestamps, values);
     }
 
     public static Block evaluateFinal(SingleState state, DriverContext driverContext) {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointDoubleAggregatorFunction.java
@@ -1,0 +1,175 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link ChangePointDoubleAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointDoubleAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("timestamps", ElementType.LONG),
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
+
+  private final DriverContext driverContext;
+
+  private final ChangePointStates.SingleState state;
+
+  private final List<Integer> channels;
+
+  public ChangePointDoubleAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      ChangePointStates.SingleState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static ChangePointDoubleAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new ChangePointDoubleAggregatorFunction(driverContext, channels, ChangePointDoubleAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+      return;
+    }
+    DoubleBlock block = page.getBlock(channels.get(0));
+    DoubleVector vector = block.asVector();
+    LongBlock timestampsBlock = page.getBlock(channels.get(1));
+    LongVector timestampsVector = timestampsBlock.asVector();
+    if (timestampsVector == null)  {
+      throw new IllegalStateException("expected @timestamp vector; but got a block");
+    }
+    if (mask.allTrue()) {
+      // No masking
+      if (vector != null) {
+        addRawVector(vector, timestampsVector);
+      } else {
+        addRawBlock(block, timestampsVector);
+      }
+      return;
+    } else {
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, timestampsVector, mask);
+      } else {
+        addRawBlock(block, timestampsVector, mask);
+      }
+    }
+  }
+
+  private void addRawVector(DoubleVector vector, LongVector timestamps) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      ChangePointDoubleAggregator.combine(state, timestamps.getLong(i), vector.getDouble(i));
+    }
+  }
+
+  private void addRawVector(DoubleVector vector, LongVector timestamps, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      ChangePointDoubleAggregator.combine(state, timestamps.getLong(i), vector.getDouble(i));
+    }
+  }
+
+  private void addRawBlock(DoubleBlock block, LongVector timestamps) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ChangePointDoubleAggregator.combine(state, timestamps.getLong(i), block.getDouble(i));
+      }
+    }
+  }
+
+  private void addRawBlock(DoubleBlock block, LongVector timestamps, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ChangePointDoubleAggregator.combine(state, timestamps.getLong(i), block.getDouble(i));
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block timestampsUncast = page.getBlock(channels.get(0));
+    if (timestampsUncast.areAllValuesNull()) {
+      return;
+    }
+    LongBlock timestamps = (LongBlock) timestampsUncast;
+    assert timestamps.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(1));
+    if (valuesUncast.areAllValuesNull()) {
+      return;
+    }
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    ChangePointDoubleAggregator.combineIntermediate(state, timestamps, values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = ChangePointDoubleAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointDoubleAggregatorFunctionSupplier.java
@@ -1,0 +1,39 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link ChangePointDoubleAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final List<Integer> channels;
+
+  public ChangePointDoubleAggregatorFunctionSupplier(List<Integer> channels) {
+    this.channels = channels;
+  }
+
+  @Override
+  public ChangePointDoubleAggregatorFunction aggregator(DriverContext driverContext) {
+    return ChangePointDoubleAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public ChangePointDoubleGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext) {
+    return ChangePointDoubleGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return "change_point of doubles";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointDoubleGroupingAggregatorFunction.java
@@ -1,0 +1,228 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link ChangePointDoubleAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointDoubleGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("timestamps", ElementType.LONG),
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
+
+  private final ChangePointStates.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public ChangePointDoubleGroupingAggregatorFunction(List<Integer> channels,
+      ChangePointStates.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static ChangePointDoubleGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new ChangePointDoubleGroupingAggregatorFunction(channels, ChangePointDoubleAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    DoubleBlock valuesBlock = page.getBlock(channels.get(0));
+    DoubleVector valuesVector = valuesBlock.asVector();
+    LongBlock timestampsBlock = page.getBlock(channels.get(1));
+    LongVector timestampsVector = timestampsBlock.asVector();
+    if (timestampsVector == null)  {
+      throw new IllegalStateException("expected @timestamp vector; but got a block");
+    }
+    if (valuesVector == null) {
+      if (valuesBlock.mayHaveNulls()) {
+        state.enableGroupIdTracking(seenGroupIds);
+      }
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntBlock groupIds) {
+          addRawInput(positionOffset, groupIds, valuesBlock, timestampsVector);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, valuesBlock, timestampsVector);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesVector, timestampsVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesVector, timestampsVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, DoubleBlock values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      if (values.isNull(groupPosition + positionOffset)) {
+        continue;
+      }
+      int valuesStart = values.getFirstValueIndex(groupPosition + positionOffset);
+      int valuesEnd = valuesStart + values.getValueCount(groupPosition + positionOffset);
+      for (int v = valuesStart; v < valuesEnd; v++) {
+        ChangePointDoubleAggregator.combine(state, groupId, timestamps.getLong(v), values.getDouble(v));
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, DoubleVector values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      var valuePosition = groupPosition + positionOffset;
+      ChangePointDoubleAggregator.combine(state, groupId, timestamps.getLong(valuePosition), values.getDouble(valuePosition));
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleBlock values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        if (values.isNull(groupPosition + positionOffset)) {
+          continue;
+        }
+        int valuesStart = values.getFirstValueIndex(groupPosition + positionOffset);
+        int valuesEnd = valuesStart + values.getValueCount(groupPosition + positionOffset);
+        for (int v = valuesStart; v < valuesEnd; v++) {
+          ChangePointDoubleAggregator.combine(state, groupId, timestamps.getLong(v), values.getDouble(v));
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleVector values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        var valuePosition = groupPosition + positionOffset;
+        ChangePointDoubleAggregator.combine(state, groupId, timestamps.getLong(valuePosition), values.getDouble(valuePosition));
+      }
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block timestampsUncast = page.getBlock(channels.get(0));
+    if (timestampsUncast.areAllValuesNull()) {
+      return;
+    }
+    LongBlock timestamps = (LongBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(1));
+    if (valuesUncast.areAllValuesNull()) {
+      return;
+    }
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert timestamps.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      ChangePointDoubleAggregator.combineIntermediate(state, groupId, timestamps, values, groupPosition + positionOffset);
+    }
+  }
+
+  @Override
+  public void addIntermediateRowInput(int groupId, GroupingAggregatorFunction input, int position) {
+    if (input.getClass() != getClass()) {
+      throw new IllegalArgumentException("expected " + getClass() + "; got " + input.getClass());
+    }
+    ChangePointStates.GroupingState inState = ((ChangePointDoubleGroupingAggregatorFunction) input).state;
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    ChangePointDoubleAggregator.combineStates(state, groupId, inState, position);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      DriverContext driverContext) {
+    blocks[offset] = ChangePointDoubleAggregator.evaluateFinal(state, selected, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointFloatAggregatorFunction.java
@@ -1,0 +1,176 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.FloatVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link ChangePointFloatAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointFloatAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("timestamps", ElementType.LONG),
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
+
+  private final DriverContext driverContext;
+
+  private final ChangePointStates.SingleState state;
+
+  private final List<Integer> channels;
+
+  public ChangePointFloatAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      ChangePointStates.SingleState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static ChangePointFloatAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new ChangePointFloatAggregatorFunction(driverContext, channels, ChangePointFloatAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+      return;
+    }
+    FloatBlock block = page.getBlock(channels.get(0));
+    FloatVector vector = block.asVector();
+    LongBlock timestampsBlock = page.getBlock(channels.get(1));
+    LongVector timestampsVector = timestampsBlock.asVector();
+    if (timestampsVector == null)  {
+      throw new IllegalStateException("expected @timestamp vector; but got a block");
+    }
+    if (mask.allTrue()) {
+      // No masking
+      if (vector != null) {
+        addRawVector(vector, timestampsVector);
+      } else {
+        addRawBlock(block, timestampsVector);
+      }
+      return;
+    } else {
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, timestampsVector, mask);
+      } else {
+        addRawBlock(block, timestampsVector, mask);
+      }
+    }
+  }
+
+  private void addRawVector(FloatVector vector, LongVector timestamps) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      ChangePointFloatAggregator.combine(state, timestamps.getLong(i), vector.getFloat(i));
+    }
+  }
+
+  private void addRawVector(FloatVector vector, LongVector timestamps, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      ChangePointFloatAggregator.combine(state, timestamps.getLong(i), vector.getFloat(i));
+    }
+  }
+
+  private void addRawBlock(FloatBlock block, LongVector timestamps) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ChangePointFloatAggregator.combine(state, timestamps.getLong(i), block.getFloat(i));
+      }
+    }
+  }
+
+  private void addRawBlock(FloatBlock block, LongVector timestamps, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ChangePointFloatAggregator.combine(state, timestamps.getLong(i), block.getFloat(i));
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block timestampsUncast = page.getBlock(channels.get(0));
+    if (timestampsUncast.areAllValuesNull()) {
+      return;
+    }
+    LongBlock timestamps = (LongBlock) timestampsUncast;
+    assert timestamps.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(1));
+    if (valuesUncast.areAllValuesNull()) {
+      return;
+    }
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    ChangePointFloatAggregator.combineIntermediate(state, timestamps, values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = ChangePointFloatAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointFloatAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointFloatAggregatorFunctionSupplier.java
@@ -1,0 +1,39 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link ChangePointFloatAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointFloatAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final List<Integer> channels;
+
+  public ChangePointFloatAggregatorFunctionSupplier(List<Integer> channels) {
+    this.channels = channels;
+  }
+
+  @Override
+  public ChangePointFloatAggregatorFunction aggregator(DriverContext driverContext) {
+    return ChangePointFloatAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public ChangePointFloatGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext) {
+    return ChangePointFloatGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return "change_point of floats";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointFloatGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointFloatGroupingAggregatorFunction.java
@@ -1,0 +1,229 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.FloatVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link ChangePointFloatAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointFloatGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("timestamps", ElementType.LONG),
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
+
+  private final ChangePointStates.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public ChangePointFloatGroupingAggregatorFunction(List<Integer> channels,
+      ChangePointStates.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static ChangePointFloatGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new ChangePointFloatGroupingAggregatorFunction(channels, ChangePointFloatAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    FloatBlock valuesBlock = page.getBlock(channels.get(0));
+    FloatVector valuesVector = valuesBlock.asVector();
+    LongBlock timestampsBlock = page.getBlock(channels.get(1));
+    LongVector timestampsVector = timestampsBlock.asVector();
+    if (timestampsVector == null)  {
+      throw new IllegalStateException("expected @timestamp vector; but got a block");
+    }
+    if (valuesVector == null) {
+      if (valuesBlock.mayHaveNulls()) {
+        state.enableGroupIdTracking(seenGroupIds);
+      }
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntBlock groupIds) {
+          addRawInput(positionOffset, groupIds, valuesBlock, timestampsVector);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, valuesBlock, timestampsVector);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesVector, timestampsVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesVector, timestampsVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, FloatBlock values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      if (values.isNull(groupPosition + positionOffset)) {
+        continue;
+      }
+      int valuesStart = values.getFirstValueIndex(groupPosition + positionOffset);
+      int valuesEnd = valuesStart + values.getValueCount(groupPosition + positionOffset);
+      for (int v = valuesStart; v < valuesEnd; v++) {
+        ChangePointFloatAggregator.combine(state, groupId, timestamps.getLong(v), values.getFloat(v));
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, FloatVector values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      var valuePosition = groupPosition + positionOffset;
+      ChangePointFloatAggregator.combine(state, groupId, timestamps.getLong(valuePosition), values.getFloat(valuePosition));
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBlock groups, FloatBlock values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        if (values.isNull(groupPosition + positionOffset)) {
+          continue;
+        }
+        int valuesStart = values.getFirstValueIndex(groupPosition + positionOffset);
+        int valuesEnd = valuesStart + values.getValueCount(groupPosition + positionOffset);
+        for (int v = valuesStart; v < valuesEnd; v++) {
+          ChangePointFloatAggregator.combine(state, groupId, timestamps.getLong(v), values.getFloat(v));
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBlock groups, FloatVector values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        var valuePosition = groupPosition + positionOffset;
+        ChangePointFloatAggregator.combine(state, groupId, timestamps.getLong(valuePosition), values.getFloat(valuePosition));
+      }
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block timestampsUncast = page.getBlock(channels.get(0));
+    if (timestampsUncast.areAllValuesNull()) {
+      return;
+    }
+    LongBlock timestamps = (LongBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(1));
+    if (valuesUncast.areAllValuesNull()) {
+      return;
+    }
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert timestamps.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      ChangePointFloatAggregator.combineIntermediate(state, groupId, timestamps, values, groupPosition + positionOffset);
+    }
+  }
+
+  @Override
+  public void addIntermediateRowInput(int groupId, GroupingAggregatorFunction input, int position) {
+    if (input.getClass() != getClass()) {
+      throw new IllegalArgumentException("expected " + getClass() + "; got " + input.getClass());
+    }
+    ChangePointStates.GroupingState inState = ((ChangePointFloatGroupingAggregatorFunction) input).state;
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    ChangePointFloatAggregator.combineStates(state, groupId, inState, position);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      DriverContext driverContext) {
+    blocks[offset] = ChangePointFloatAggregator.evaluateFinal(state, selected, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointIntAggregatorFunction.java
@@ -1,0 +1,176 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link ChangePointIntAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointIntAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("timestamps", ElementType.LONG),
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
+
+  private final DriverContext driverContext;
+
+  private final ChangePointStates.SingleState state;
+
+  private final List<Integer> channels;
+
+  public ChangePointIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      ChangePointStates.SingleState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static ChangePointIntAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new ChangePointIntAggregatorFunction(driverContext, channels, ChangePointIntAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+      return;
+    }
+    IntBlock block = page.getBlock(channels.get(0));
+    IntVector vector = block.asVector();
+    LongBlock timestampsBlock = page.getBlock(channels.get(1));
+    LongVector timestampsVector = timestampsBlock.asVector();
+    if (timestampsVector == null)  {
+      throw new IllegalStateException("expected @timestamp vector; but got a block");
+    }
+    if (mask.allTrue()) {
+      // No masking
+      if (vector != null) {
+        addRawVector(vector, timestampsVector);
+      } else {
+        addRawBlock(block, timestampsVector);
+      }
+      return;
+    } else {
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, timestampsVector, mask);
+      } else {
+        addRawBlock(block, timestampsVector, mask);
+      }
+    }
+  }
+
+  private void addRawVector(IntVector vector, LongVector timestamps) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      ChangePointIntAggregator.combine(state, timestamps.getLong(i), vector.getInt(i));
+    }
+  }
+
+  private void addRawVector(IntVector vector, LongVector timestamps, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      ChangePointIntAggregator.combine(state, timestamps.getLong(i), vector.getInt(i));
+    }
+  }
+
+  private void addRawBlock(IntBlock block, LongVector timestamps) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ChangePointIntAggregator.combine(state, timestamps.getLong(i), block.getInt(i));
+      }
+    }
+  }
+
+  private void addRawBlock(IntBlock block, LongVector timestamps, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ChangePointIntAggregator.combine(state, timestamps.getLong(i), block.getInt(i));
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block timestampsUncast = page.getBlock(channels.get(0));
+    if (timestampsUncast.areAllValuesNull()) {
+      return;
+    }
+    LongBlock timestamps = (LongBlock) timestampsUncast;
+    assert timestamps.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(1));
+    if (valuesUncast.areAllValuesNull()) {
+      return;
+    }
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    ChangePointIntAggregator.combineIntermediate(state, timestamps, values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = ChangePointIntAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointIntAggregatorFunctionSupplier.java
@@ -1,0 +1,38 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link ChangePointIntAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final List<Integer> channels;
+
+  public ChangePointIntAggregatorFunctionSupplier(List<Integer> channels) {
+    this.channels = channels;
+  }
+
+  @Override
+  public ChangePointIntAggregatorFunction aggregator(DriverContext driverContext) {
+    return ChangePointIntAggregatorFunction.create(driverContext, channels);
+  }
+
+  @Override
+  public ChangePointIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+    return ChangePointIntGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return "change_point of ints";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointIntGroupingAggregatorFunction.java
@@ -1,0 +1,227 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link ChangePointIntAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("timestamps", ElementType.LONG),
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
+
+  private final ChangePointStates.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public ChangePointIntGroupingAggregatorFunction(List<Integer> channels,
+      ChangePointStates.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static ChangePointIntGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new ChangePointIntGroupingAggregatorFunction(channels, ChangePointIntAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    IntBlock valuesBlock = page.getBlock(channels.get(0));
+    IntVector valuesVector = valuesBlock.asVector();
+    LongBlock timestampsBlock = page.getBlock(channels.get(1));
+    LongVector timestampsVector = timestampsBlock.asVector();
+    if (timestampsVector == null)  {
+      throw new IllegalStateException("expected @timestamp vector; but got a block");
+    }
+    if (valuesVector == null) {
+      if (valuesBlock.mayHaveNulls()) {
+        state.enableGroupIdTracking(seenGroupIds);
+      }
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntBlock groupIds) {
+          addRawInput(positionOffset, groupIds, valuesBlock, timestampsVector);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, valuesBlock, timestampsVector);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesVector, timestampsVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesVector, timestampsVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, IntBlock values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      if (values.isNull(groupPosition + positionOffset)) {
+        continue;
+      }
+      int valuesStart = values.getFirstValueIndex(groupPosition + positionOffset);
+      int valuesEnd = valuesStart + values.getValueCount(groupPosition + positionOffset);
+      for (int v = valuesStart; v < valuesEnd; v++) {
+        ChangePointIntAggregator.combine(state, groupId, timestamps.getLong(v), values.getInt(v));
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, IntVector values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      var valuePosition = groupPosition + positionOffset;
+      ChangePointIntAggregator.combine(state, groupId, timestamps.getLong(valuePosition), values.getInt(valuePosition));
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBlock groups, IntBlock values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        if (values.isNull(groupPosition + positionOffset)) {
+          continue;
+        }
+        int valuesStart = values.getFirstValueIndex(groupPosition + positionOffset);
+        int valuesEnd = valuesStart + values.getValueCount(groupPosition + positionOffset);
+        for (int v = valuesStart; v < valuesEnd; v++) {
+          ChangePointIntAggregator.combine(state, groupId, timestamps.getLong(v), values.getInt(v));
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBlock groups, IntVector values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        var valuePosition = groupPosition + positionOffset;
+        ChangePointIntAggregator.combine(state, groupId, timestamps.getLong(valuePosition), values.getInt(valuePosition));
+      }
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block timestampsUncast = page.getBlock(channels.get(0));
+    if (timestampsUncast.areAllValuesNull()) {
+      return;
+    }
+    LongBlock timestamps = (LongBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(1));
+    if (valuesUncast.areAllValuesNull()) {
+      return;
+    }
+    DoubleBlock values = (DoubleBlock) valuesUncast;
+    assert timestamps.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      ChangePointIntAggregator.combineIntermediate(state, groupId, timestamps, values, groupPosition + positionOffset);
+    }
+  }
+
+  @Override
+  public void addIntermediateRowInput(int groupId, GroupingAggregatorFunction input, int position) {
+    if (input.getClass() != getClass()) {
+      throw new IllegalArgumentException("expected " + getClass() + "; got " + input.getClass());
+    }
+    ChangePointStates.GroupingState inState = ((ChangePointIntGroupingAggregatorFunction) input).state;
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    ChangePointIntAggregator.combineStates(state, groupId, inState, position);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      DriverContext driverContext) {
+    blocks[offset] = ChangePointIntAggregator.evaluateFinal(state, selected, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongAggregatorFunction.java
@@ -1,0 +1,173 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link ChangePointLongAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointLongAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("timestamps", ElementType.LONG),
+      new IntermediateStateDesc("values", ElementType.LONG)  );
+
+  private final DriverContext driverContext;
+
+  private final ChangePointLongAggregator.SingleState state;
+
+  private final List<Integer> channels;
+
+  public ChangePointLongAggregatorFunction(DriverContext driverContext, List<Integer> channels,
+      ChangePointLongAggregator.SingleState state) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = state;
+  }
+
+  public static ChangePointLongAggregatorFunction create(DriverContext driverContext,
+      List<Integer> channels) {
+    return new ChangePointLongAggregatorFunction(driverContext, channels, ChangePointLongAggregator.initSingle(driverContext));
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+      return;
+    }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
+    LongBlock timestampsBlock = page.getBlock(channels.get(1));
+    LongVector timestampsVector = timestampsBlock.asVector();
+    if (timestampsVector == null)  {
+      throw new IllegalStateException("expected @timestamp vector; but got a block");
+    }
+    if (mask.allTrue()) {
+      // No masking
+      if (vector != null) {
+        addRawVector(vector, timestampsVector);
+      } else {
+        addRawBlock(block, timestampsVector);
+      }
+      return;
+    } else {
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, timestampsVector, mask);
+      } else {
+        addRawBlock(block, timestampsVector, mask);
+      }
+    }
+  }
+
+  private void addRawVector(LongVector vector, LongVector timestamps) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      ChangePointLongAggregator.combine(state, timestamps.getLong(i), vector.getLong(i));
+    }
+  }
+
+  private void addRawVector(LongVector vector, LongVector timestamps, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      ChangePointLongAggregator.combine(state, timestamps.getLong(i), vector.getLong(i));
+    }
+  }
+
+  private void addRawBlock(LongBlock block, LongVector timestamps) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ChangePointLongAggregator.combine(state, timestamps.getLong(i), block.getLong(i));
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock block, LongVector timestamps, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ChangePointLongAggregator.combine(state, timestamps.getLong(i), block.getLong(i));
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block timestampsUncast = page.getBlock(channels.get(0));
+    if (timestampsUncast.areAllValuesNull()) {
+      return;
+    }
+    LongBlock timestamps = (LongBlock) timestampsUncast;
+    assert timestamps.getPositionCount() == 1;
+    Block valuesUncast = page.getBlock(channels.get(1));
+    if (valuesUncast.areAllValuesNull()) {
+      return;
+    }
+    LongBlock values = (LongBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    ChangePointLongAggregator.combineIntermediate(state, timestamps, values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = ChangePointLongAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
@@ -24,16 +25,16 @@ import org.elasticsearch.compute.operator.DriverContext;
 public final class ChangePointLongAggregatorFunction implements AggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
       new IntermediateStateDesc("timestamps", ElementType.LONG),
-      new IntermediateStateDesc("values", ElementType.LONG)  );
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
 
   private final DriverContext driverContext;
 
-  private final ChangePointLongAggregator.SingleState state;
+  private final ChangePointStates.SingleState state;
 
   private final List<Integer> channels;
 
   public ChangePointLongAggregatorFunction(DriverContext driverContext, List<Integer> channels,
-      ChangePointLongAggregator.SingleState state) {
+      ChangePointStates.SingleState state) {
     this.driverContext = driverContext;
     this.channels = channels;
     this.state = state;
@@ -142,7 +143,7 @@ public final class ChangePointLongAggregatorFunction implements AggregatorFuncti
     if (valuesUncast.areAllValuesNull()) {
       return;
     }
-    LongBlock values = (LongBlock) valuesUncast;
+    DoubleBlock values = (DoubleBlock) valuesUncast;
     assert values.getPositionCount() == 1;
     ChangePointLongAggregator.combineIntermediate(state, timestamps, values);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongAggregatorFunctionSupplier.java
@@ -22,8 +22,8 @@ public final class ChangePointLongAggregatorFunctionSupplier implements Aggregat
   }
 
   @Override
-  public AggregatorFunction aggregator(DriverContext driverContext) {
-    throw new UnsupportedOperationException("non-grouping aggregator is not supported");
+  public ChangePointLongAggregatorFunction aggregator(DriverContext driverContext) {
+    return ChangePointLongAggregatorFunction.create(driverContext, channels);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongAggregatorFunctionSupplier.java
@@ -1,0 +1,38 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link ChangePointLongAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  private final List<Integer> channels;
+
+  public ChangePointLongAggregatorFunctionSupplier(List<Integer> channels) {
+    this.channels = channels;
+  }
+
+  @Override
+  public AggregatorFunction aggregator(DriverContext driverContext) {
+    throw new UnsupportedOperationException("non-grouping aggregator is not supported");
+  }
+
+  @Override
+  public ChangePointLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+    return ChangePointLongGroupingAggregatorFunction.create(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return "change_point of longs";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongGroupingAggregatorFunction.java
@@ -1,0 +1,226 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link ChangePointLongAggregator}.
+ * This class is generated. Do not edit it.
+ */
+public final class ChangePointLongGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("timestamps", ElementType.LONG),
+      new IntermediateStateDesc("values", ElementType.LONG)  );
+
+  private final ChangePointLongAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  public ChangePointLongGroupingAggregatorFunction(List<Integer> channels,
+      ChangePointLongAggregator.GroupingState state, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = state;
+    this.driverContext = driverContext;
+  }
+
+  public static ChangePointLongGroupingAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new ChangePointLongGroupingAggregatorFunction(channels, ChangePointLongAggregator.initGrouping(driverContext), driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    LongBlock valuesBlock = page.getBlock(channels.get(0));
+    LongVector valuesVector = valuesBlock.asVector();
+    LongBlock timestampsBlock = page.getBlock(channels.get(1));
+    LongVector timestampsVector = timestampsBlock.asVector();
+    if (timestampsVector == null)  {
+      throw new IllegalStateException("expected @timestamp vector; but got a block");
+    }
+    if (valuesVector == null) {
+      if (valuesBlock.mayHaveNulls()) {
+        state.enableGroupIdTracking(seenGroupIds);
+      }
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntBlock groupIds) {
+          addRawInput(positionOffset, groupIds, valuesBlock, timestampsVector);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, valuesBlock, timestampsVector);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valuesVector, timestampsVector);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valuesVector, timestampsVector);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, LongBlock values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      if (values.isNull(groupPosition + positionOffset)) {
+        continue;
+      }
+      int valuesStart = values.getFirstValueIndex(groupPosition + positionOffset);
+      int valuesEnd = valuesStart + values.getValueCount(groupPosition + positionOffset);
+      for (int v = valuesStart; v < valuesEnd; v++) {
+        ChangePointLongAggregator.combine(state, groupId, timestamps.getLong(v), values.getLong(v));
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, LongVector values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      var valuePosition = groupPosition + positionOffset;
+      ChangePointLongAggregator.combine(state, groupId, timestamps.getLong(valuePosition), values.getLong(valuePosition));
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBlock groups, LongBlock values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        if (values.isNull(groupPosition + positionOffset)) {
+          continue;
+        }
+        int valuesStart = values.getFirstValueIndex(groupPosition + positionOffset);
+        int valuesEnd = valuesStart + values.getValueCount(groupPosition + positionOffset);
+        for (int v = valuesStart; v < valuesEnd; v++) {
+          ChangePointLongAggregator.combine(state, groupId, timestamps.getLong(v), values.getLong(v));
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBlock groups, LongVector values,
+      LongVector timestamps) {
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        var valuePosition = groupPosition + positionOffset;
+        ChangePointLongAggregator.combine(state, groupId, timestamps.getLong(valuePosition), values.getLong(valuePosition));
+      }
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block timestampsUncast = page.getBlock(channels.get(0));
+    if (timestampsUncast.areAllValuesNull()) {
+      return;
+    }
+    LongBlock timestamps = (LongBlock) timestampsUncast;
+    Block valuesUncast = page.getBlock(channels.get(1));
+    if (valuesUncast.areAllValuesNull()) {
+      return;
+    }
+    LongBlock values = (LongBlock) valuesUncast;
+    assert timestamps.getPositionCount() == values.getPositionCount();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      ChangePointLongAggregator.combineIntermediate(state, groupId, timestamps, values, groupPosition + positionOffset);
+    }
+  }
+
+  @Override
+  public void addIntermediateRowInput(int groupId, GroupingAggregatorFunction input, int position) {
+    if (input.getClass() != getClass()) {
+      throw new IllegalArgumentException("expected " + getClass() + "; got " + input.getClass());
+    }
+    ChangePointLongAggregator.GroupingState inState = ((ChangePointLongGroupingAggregatorFunction) input).state;
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    ChangePointLongAggregator.combineStates(state, groupId, inState, position);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+    state.toIntermediate(blocks, offset, selected, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, IntVector selected,
+      DriverContext driverContext) {
+    blocks[offset] = ChangePointLongAggregator.evaluateFinal(state, selected, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ChangePointLongGroupingAggregatorFunction.java
@@ -10,6 +10,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
@@ -25,16 +26,16 @@ import org.elasticsearch.compute.operator.DriverContext;
 public final class ChangePointLongGroupingAggregatorFunction implements GroupingAggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
       new IntermediateStateDesc("timestamps", ElementType.LONG),
-      new IntermediateStateDesc("values", ElementType.LONG)  );
+      new IntermediateStateDesc("values", ElementType.DOUBLE)  );
 
-  private final ChangePointLongAggregator.GroupingState state;
+  private final ChangePointStates.GroupingState state;
 
   private final List<Integer> channels;
 
   private final DriverContext driverContext;
 
   public ChangePointLongGroupingAggregatorFunction(List<Integer> channels,
-      ChangePointLongAggregator.GroupingState state, DriverContext driverContext) {
+      ChangePointStates.GroupingState state, DriverContext driverContext) {
     this.channels = channels;
     this.state = state;
     this.driverContext = driverContext;
@@ -181,7 +182,7 @@ public final class ChangePointLongGroupingAggregatorFunction implements Grouping
     if (valuesUncast.areAllValuesNull()) {
       return;
     }
-    LongBlock values = (LongBlock) valuesUncast;
+    DoubleBlock values = (DoubleBlock) valuesUncast;
     assert timestamps.getPositionCount() == values.getPositionCount();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int groupId = groups.getInt(groupPosition);
@@ -194,7 +195,7 @@ public final class ChangePointLongGroupingAggregatorFunction implements Grouping
     if (input.getClass() != getClass()) {
       throw new IllegalArgumentException("expected " + getClass() + "; got " + input.getClass());
     }
-    ChangePointLongAggregator.GroupingState inState = ((ChangePointLongGroupingAggregatorFunction) input).state;
+    ChangePointStates.GroupingState inState = ((ChangePointLongGroupingAggregatorFunction) input).state;
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     ChangePointLongAggregator.combineStates(state, groupId, inState, position);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunction.java
@@ -58,24 +58,23 @@ public final class CountDistinctBooleanAggregatorFunction implements AggregatorF
       // Entire page masked away
       return;
     }
+    BooleanBlock block = page.getBlock(channels.get(0));
+    BooleanVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BooleanBlock block = page.getBlock(channels.get(0));
-      BooleanVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BooleanBlock block = page.getBlock(channels.get(0));
-    BooleanVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
@@ -62,24 +62,23 @@ public final class CountDistinctBytesRefAggregatorFunction implements Aggregator
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class CountDistinctDoubleAggregatorFunction implements AggregatorFu
       // Entire page masked away
       return;
     }
+    DoubleBlock block = page.getBlock(channels.get(0));
+    DoubleVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      DoubleBlock block = page.getBlock(channels.get(0));
-      DoubleVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    DoubleBlock block = page.getBlock(channels.get(0));
-    DoubleVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class CountDistinctFloatAggregatorFunction implements AggregatorFun
       // Entire page masked away
       return;
     }
+    FloatBlock block = page.getBlock(channels.get(0));
+    FloatVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      FloatBlock block = page.getBlock(channels.get(0));
-      FloatVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    FloatBlock block = page.getBlock(channels.get(0));
-    FloatVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class CountDistinctIntAggregatorFunction implements AggregatorFunct
       // Entire page masked away
       return;
     }
+    IntBlock block = page.getBlock(channels.get(0));
+    IntVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      IntBlock block = page.getBlock(channels.get(0));
-      IntVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    IntBlock block = page.getBlock(channels.get(0));
-    IntVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class CountDistinctLongAggregatorFunction implements AggregatorFunc
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxBooleanAggregatorFunction.java
@@ -58,24 +58,23 @@ public final class MaxBooleanAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    BooleanBlock block = page.getBlock(channels.get(0));
+    BooleanVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BooleanBlock block = page.getBlock(channels.get(0));
-      BooleanVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BooleanBlock block = page.getBlock(channels.get(0));
-    BooleanVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxBytesRefAggregatorFunction.java
@@ -61,24 +61,23 @@ public final class MaxBytesRefAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunction.java
@@ -60,24 +60,23 @@ public final class MaxDoubleAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    DoubleBlock block = page.getBlock(channels.get(0));
+    DoubleVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      DoubleBlock block = page.getBlock(channels.get(0));
-      DoubleVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    DoubleBlock block = page.getBlock(channels.get(0));
-    DoubleVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxFloatAggregatorFunction.java
@@ -60,24 +60,23 @@ public final class MaxFloatAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    FloatBlock block = page.getBlock(channels.get(0));
+    FloatVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      FloatBlock block = page.getBlock(channels.get(0));
-      FloatVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    FloatBlock block = page.getBlock(channels.get(0));
-    FloatVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunction.java
@@ -60,24 +60,23 @@ public final class MaxIntAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    IntBlock block = page.getBlock(channels.get(0));
+    IntVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      IntBlock block = page.getBlock(channels.get(0));
-      IntVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    IntBlock block = page.getBlock(channels.get(0));
-    IntVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIpAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIpAggregatorFunction.java
@@ -61,24 +61,23 @@ public final class MaxIpAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunction.java
@@ -60,24 +60,23 @@ public final class MaxLongAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
@@ -61,24 +61,23 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
       // Entire page masked away
       return;
     }
+    DoubleBlock block = page.getBlock(channels.get(0));
+    DoubleVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      DoubleBlock block = page.getBlock(channels.get(0));
-      DoubleVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    DoubleBlock block = page.getBlock(channels.get(0));
-    DoubleVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregatorFunction.java
@@ -61,24 +61,23 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
       // Entire page masked away
       return;
     }
+    FloatBlock block = page.getBlock(channels.get(0));
+    FloatVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      FloatBlock block = page.getBlock(channels.get(0));
-      FloatVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    FloatBlock block = page.getBlock(channels.get(0));
-    FloatVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunction.java
@@ -61,24 +61,23 @@ public final class MedianAbsoluteDeviationIntAggregatorFunction implements Aggre
       // Entire page masked away
       return;
     }
+    IntBlock block = page.getBlock(channels.get(0));
+    IntVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      IntBlock block = page.getBlock(channels.get(0));
-      IntVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    IntBlock block = page.getBlock(channels.get(0));
-    IntVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunction.java
@@ -61,24 +61,23 @@ public final class MedianAbsoluteDeviationLongAggregatorFunction implements Aggr
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinBooleanAggregatorFunction.java
@@ -58,24 +58,23 @@ public final class MinBooleanAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    BooleanBlock block = page.getBlock(channels.get(0));
+    BooleanVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BooleanBlock block = page.getBlock(channels.get(0));
-      BooleanVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BooleanBlock block = page.getBlock(channels.get(0));
-    BooleanVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinBytesRefAggregatorFunction.java
@@ -61,24 +61,23 @@ public final class MinBytesRefAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunction.java
@@ -60,24 +60,23 @@ public final class MinDoubleAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    DoubleBlock block = page.getBlock(channels.get(0));
+    DoubleVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      DoubleBlock block = page.getBlock(channels.get(0));
-      DoubleVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    DoubleBlock block = page.getBlock(channels.get(0));
-    DoubleVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinFloatAggregatorFunction.java
@@ -60,24 +60,23 @@ public final class MinFloatAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    FloatBlock block = page.getBlock(channels.get(0));
+    FloatVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      FloatBlock block = page.getBlock(channels.get(0));
-      FloatVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    FloatBlock block = page.getBlock(channels.get(0));
-    FloatVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunction.java
@@ -60,24 +60,23 @@ public final class MinIntAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    IntBlock block = page.getBlock(channels.get(0));
+    IntVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      IntBlock block = page.getBlock(channels.get(0));
-      IntVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    IntBlock block = page.getBlock(channels.get(0));
-    IntVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIpAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIpAggregatorFunction.java
@@ -61,24 +61,23 @@ public final class MinIpAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunction.java
@@ -60,24 +60,23 @@ public final class MinLongAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
       // Entire page masked away
       return;
     }
+    DoubleBlock block = page.getBlock(channels.get(0));
+    DoubleVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      DoubleBlock block = page.getBlock(channels.get(0));
-      DoubleVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    DoubleBlock block = page.getBlock(channels.get(0));
-    DoubleVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileFloatAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
       // Entire page masked away
       return;
     }
+    FloatBlock block = page.getBlock(channels.get(0));
+    FloatVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      FloatBlock block = page.getBlock(channels.get(0));
-      FloatVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    FloatBlock block = page.getBlock(channels.get(0));
-    FloatVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class PercentileIntAggregatorFunction implements AggregatorFunction
       // Entire page masked away
       return;
     }
+    IntBlock block = page.getBlock(channels.get(0));
+    IntVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      IntBlock block = page.getBlock(channels.get(0));
-      IntVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    IntBlock block = page.getBlock(channels.get(0));
-    IntVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class PercentileLongAggregatorFunction implements AggregatorFunctio
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/StdDevDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/StdDevDoubleAggregatorFunction.java
@@ -62,24 +62,23 @@ public final class StdDevDoubleAggregatorFunction implements AggregatorFunction 
       // Entire page masked away
       return;
     }
+    DoubleBlock block = page.getBlock(channels.get(0));
+    DoubleVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      DoubleBlock block = page.getBlock(channels.get(0));
-      DoubleVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    DoubleBlock block = page.getBlock(channels.get(0));
-    DoubleVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/StdDevFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/StdDevFloatAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class StdDevFloatAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    FloatBlock block = page.getBlock(channels.get(0));
+    FloatVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      FloatBlock block = page.getBlock(channels.get(0));
-      FloatVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    FloatBlock block = page.getBlock(channels.get(0));
-    FloatVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/StdDevIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/StdDevIntAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class StdDevIntAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    IntBlock block = page.getBlock(channels.get(0));
+    IntVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      IntBlock block = page.getBlock(channels.get(0));
-      IntVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    IntBlock block = page.getBlock(channels.get(0));
-    IntVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/StdDevLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/StdDevLongAggregatorFunction.java
@@ -62,24 +62,23 @@ public final class StdDevLongAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunction.java
@@ -61,24 +61,23 @@ public final class SumDoubleAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    DoubleBlock block = page.getBlock(channels.get(0));
+    DoubleVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      DoubleBlock block = page.getBlock(channels.get(0));
-      DoubleVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    DoubleBlock block = page.getBlock(channels.get(0));
-    DoubleVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumFloatAggregatorFunction.java
@@ -63,24 +63,23 @@ public final class SumFloatAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    FloatBlock block = page.getBlock(channels.get(0));
+    FloatVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      FloatBlock block = page.getBlock(channels.get(0));
-      FloatVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    FloatBlock block = page.getBlock(channels.get(0));
-    FloatVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunction.java
@@ -62,24 +62,23 @@ public final class SumIntAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    IntBlock block = page.getBlock(channels.get(0));
+    IntVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      IntBlock block = page.getBlock(channels.get(0));
-      IntVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    IntBlock block = page.getBlock(channels.get(0));
-    IntVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunction.java
@@ -60,24 +60,23 @@ public final class SumLongAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBooleanAggregatorFunction.java
@@ -63,24 +63,23 @@ public final class TopBooleanAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    BooleanBlock block = page.getBlock(channels.get(0));
+    BooleanVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BooleanBlock block = page.getBlock(channels.get(0));
-      BooleanVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BooleanBlock block = page.getBlock(channels.get(0));
-    BooleanVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBytesRefAggregatorFunction.java
@@ -65,24 +65,23 @@ public final class TopBytesRefAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class TopDoubleAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    DoubleBlock block = page.getBlock(channels.get(0));
+    DoubleVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      DoubleBlock block = page.getBlock(channels.get(0));
-      DoubleVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    DoubleBlock block = page.getBlock(channels.get(0));
-    DoubleVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class TopFloatAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    FloatBlock block = page.getBlock(channels.get(0));
+    FloatVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      FloatBlock block = page.getBlock(channels.get(0));
-      FloatVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    FloatBlock block = page.getBlock(channels.get(0));
-    FloatVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class TopIntAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    IntBlock block = page.getBlock(channels.get(0));
+    IntVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      IntBlock block = page.getBlock(channels.get(0));
-      IntVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    IntBlock block = page.getBlock(channels.get(0));
-    IntVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIpAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIpAggregatorFunction.java
@@ -65,24 +65,23 @@ public final class TopIpAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongAggregatorFunction.java
@@ -64,24 +64,23 @@ public final class TopLongAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesBooleanAggregatorFunction.java
@@ -57,24 +57,23 @@ public final class ValuesBooleanAggregatorFunction implements AggregatorFunction
       // Entire page masked away
       return;
     }
+    BooleanBlock block = page.getBlock(channels.get(0));
+    BooleanVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BooleanBlock block = page.getBlock(channels.get(0));
-      BooleanVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BooleanBlock block = page.getBlock(channels.get(0));
-    BooleanVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregatorFunction.java
@@ -59,24 +59,23 @@ public final class ValuesBytesRefAggregatorFunction implements AggregatorFunctio
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesDoubleAggregatorFunction.java
@@ -58,24 +58,23 @@ public final class ValuesDoubleAggregatorFunction implements AggregatorFunction 
       // Entire page masked away
       return;
     }
+    DoubleBlock block = page.getBlock(channels.get(0));
+    DoubleVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      DoubleBlock block = page.getBlock(channels.get(0));
-      DoubleVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    DoubleBlock block = page.getBlock(channels.get(0));
-    DoubleVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesFloatAggregatorFunction.java
@@ -58,24 +58,23 @@ public final class ValuesFloatAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    FloatBlock block = page.getBlock(channels.get(0));
+    FloatVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      FloatBlock block = page.getBlock(channels.get(0));
-      FloatVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    FloatBlock block = page.getBlock(channels.get(0));
-    FloatVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesIntAggregatorFunction.java
@@ -58,24 +58,23 @@ public final class ValuesIntAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    IntBlock block = page.getBlock(channels.get(0));
+    IntVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      IntBlock block = page.getBlock(channels.get(0));
-      IntVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    IntBlock block = page.getBlock(channels.get(0));
-    IntVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesLongAggregatorFunction.java
@@ -58,24 +58,23 @@ public final class ValuesLongAggregatorFunction implements AggregatorFunction {
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointDocValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointDocValuesAggregatorFunction.java
@@ -66,24 +66,23 @@ public final class SpatialCentroidCartesianPointDocValuesAggregatorFunction impl
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointSourceValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointSourceValuesAggregatorFunction.java
@@ -69,24 +69,23 @@ public final class SpatialCentroidCartesianPointSourceValuesAggregatorFunction i
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointDocValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointDocValuesAggregatorFunction.java
@@ -66,24 +66,23 @@ public final class SpatialCentroidGeoPointDocValuesAggregatorFunction implements
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointSourceValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointSourceValuesAggregatorFunction.java
@@ -69,24 +69,23 @@ public final class SpatialCentroidGeoPointSourceValuesAggregatorFunction impleme
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentCartesianPointDocValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentCartesianPointDocValuesAggregatorFunction.java
@@ -65,24 +65,23 @@ public final class SpatialExtentCartesianPointDocValuesAggregatorFunction implem
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentCartesianPointSourceValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentCartesianPointSourceValuesAggregatorFunction.java
@@ -66,24 +66,23 @@ public final class SpatialExtentCartesianPointSourceValuesAggregatorFunction imp
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentCartesianShapeAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentCartesianShapeAggregatorFunction.java
@@ -66,24 +66,23 @@ public final class SpatialExtentCartesianShapeAggregatorFunction implements Aggr
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentGeoPointDocValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentGeoPointDocValuesAggregatorFunction.java
@@ -67,24 +67,23 @@ public final class SpatialExtentGeoPointDocValuesAggregatorFunction implements A
       // Entire page masked away
       return;
     }
+    LongBlock block = page.getBlock(channels.get(0));
+    LongVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      LongBlock block = page.getBlock(channels.get(0));
-      LongVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    LongBlock block = page.getBlock(channels.get(0));
-    LongVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentGeoPointSourceValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentGeoPointSourceValuesAggregatorFunction.java
@@ -68,24 +68,23 @@ public final class SpatialExtentGeoPointSourceValuesAggregatorFunction implement
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentGeoShapeAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentGeoShapeAggregatorFunction.java
@@ -68,24 +68,23 @@ public final class SpatialExtentGeoShapeAggregatorFunction implements Aggregator
       // Entire page masked away
       return;
     }
+    BytesRefBlock block = page.getBlock(channels.get(0));
+    BytesRefVector vector = block.asVector();
     if (mask.allTrue()) {
       // No masking
-      BytesRefBlock block = page.getBlock(channels.get(0));
-      BytesRefVector vector = block.asVector();
       if (vector != null) {
         addRawVector(vector);
       } else {
         addRawBlock(block);
       }
       return;
-    }
-    // Some positions masked away, others kept
-    BytesRefBlock block = page.getBlock(channels.get(0));
-    BytesRefVector vector = block.asVector();
-    if (vector != null) {
-      addRawVector(vector, mask);
     } else {
-      addRawBlock(block, mask);
+      // Some positions masked away, others kept
+      if (vector != null) {
+        addRawVector(vector, mask);
+      } else {
+        addRawBlock(block, mask);
+      }
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ChangePointLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ChangePointLongAggregator.java
@@ -249,8 +249,7 @@ class ChangePointLongAggregator {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
-        }
+        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {}
 
         @Override
         public void close() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ChangePointLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ChangePointLongAggregator.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xpack.core.ml.utils.NamedXContentObjectHelper;
+import org.elasticsearch.xpack.ml.aggs.MlAggsHelper;
+import org.elasticsearch.xpack.ml.aggs.changepoint.ChangePointDetector;
+import org.elasticsearch.xpack.ml.aggs.changepoint.ChangeType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Aggregates field values for long.
+ * TODO: make .java.st from this to support other types
+ * TODO: add "includeTimestamp" to @Aggregator
+ */
+// TODO: add normal @Aggregator
+// @Aggregator({
+// includeTimestamps = true,
+// @IntermediateState(name = "timestamps", type = "LONG_BLOCK"),
+// @IntermediateState(name = "values", type = "LONG_BLOCK") })
+@GroupingAggregator(
+    includeTimestamps = true,
+    value = { @IntermediateState(name = "timestamps", type = "LONG_BLOCK"), @IntermediateState(name = "values", type = "LONG_BLOCK") }
+)
+class ChangePointLongAggregator {
+
+    public static GroupingState initGrouping(DriverContext driverContext) {
+        return new GroupingState(driverContext.bigArrays());
+    }
+
+    public static void combine(GroupingState current, int groupId, long timestamp, long value) {
+        current.add(groupId, timestamp, value);
+    }
+
+    public static void combineIntermediate(GroupingState current, int groupId, LongBlock timestamps, LongBlock values, int otherPosition) {
+        current.combine(groupId, timestamps, values, otherPosition);
+    }
+
+    public static void combineStates(GroupingState current, int currentGroupId, GroupingState otherState, int otherGroupId) {
+        current.combineState(currentGroupId, otherState, otherGroupId);
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, DriverContext driverContext) {
+        return state.evaluateFinal(selected, driverContext.blockFactory());
+    }
+
+    public static class SingleState implements Releasable {
+        private final BigArrays bigArrays;
+        private int count;
+        private LongArray timestamps;
+        private LongArray values;
+
+        private SingleState(BigArrays bigArrays) {
+            this.bigArrays = bigArrays;
+            count = 0;
+            timestamps = bigArrays.newLongArray(0);
+            values = bigArrays.newLongArray(0);
+        }
+
+        void add(long timestamp, long value) {
+            count++;
+            timestamps = bigArrays.grow(timestamps, count);
+            timestamps.set(count - 1, timestamp);
+            values = bigArrays.grow(values, count);
+            values.set(count - 1, value);
+        }
+
+        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            blocks[offset] = toBlock(timestamps, driverContext.blockFactory());
+            blocks[offset + 1] = toBlock(values, driverContext.blockFactory());
+        }
+
+        Block toBlock(LongArray arr, BlockFactory blockFactory) {
+            if (arr.size() == 0) {
+                return blockFactory.newConstantNullBlock(1);
+            }
+            if (values.size() == 1) {
+                return blockFactory.newConstantLongBlockWith(arr.get(0), 1);
+            }
+            try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder((int) arr.size())) {
+                builder.beginPositionEntry();
+                for (int id = 0; id < arr.size(); id++) {
+                    builder.appendLong(arr.get(id));
+                }
+                builder.endPositionEntry();
+                return builder.build();
+            }
+        }
+
+        record TimeAndValue(long timestamp, long value) implements Comparable<TimeAndValue> {
+            @Override
+            public int compareTo(TimeAndValue other) {
+                return Long.compare(timestamp, other.timestamp);
+            }
+        }
+
+        void sort() {
+            // TODO: this is very inefficient and doesn't account for memory!
+            List<TimeAndValue> list = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                list.add(new TimeAndValue(timestamps.get(i), values.get(i)));
+            }
+            Collections.sort(list);
+            for (int i = 0; i < count; i++) {
+                timestamps.set(i, list.get(i).timestamp);
+                values.set(i, list.get(i).value);
+            }
+        }
+
+        @Override
+        public void close() {
+            timestamps.close();
+            values.close();
+        }
+    }
+
+    public static class GroupingState implements Releasable {
+        private final BigArrays bigArrays;
+        private final Map<Integer, SingleState> states;
+
+        private GroupingState(BigArrays bigArrays) {
+            this.bigArrays = bigArrays;
+            states = new HashMap<>();
+        }
+
+        void add(int groupId, long timestamp, long value) {
+            SingleState state = states.computeIfAbsent(groupId, key -> new SingleState(bigArrays));
+            state.add(timestamp, value);
+        }
+
+        void combine(int groupId, LongBlock timestamps, LongBlock values, int otherPosition) {
+            final int valueCount = timestamps.getValueCount(otherPosition);
+            if (valueCount == 0) {
+                return;
+            }
+            final int firstIndex = timestamps.getFirstValueIndex(otherPosition);
+            SingleState state = states.computeIfAbsent(groupId, key -> new SingleState(bigArrays));
+            for (int i = 0; i < valueCount; i++) {
+                state.add(timestamps.getLong(firstIndex + i), values.getLong(firstIndex + i));
+            }
+        }
+
+        void combineState(int groupId, GroupingState otherState, int otherGroupId) {
+            SingleState other = otherState.states.get(otherGroupId);
+            if (other == null) {
+                return;
+            }
+            var state = states.computeIfAbsent(groupId, key -> new SingleState(bigArrays));
+            for (int i = 0; i < other.timestamps.size(); i++) {
+                state.add(state.timestamps.get(i), state.values.get(i));
+            }
+        }
+
+        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+            blocks[offset] = toBlock(s -> s.timestamps, driverContext.blockFactory(), selected);
+            blocks[offset + 1] = toBlock(s -> s.values, driverContext.blockFactory(), selected);
+        }
+
+        public Block evaluateFinal(IntVector selected, BlockFactory blockFactory) {
+            try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())) {
+                for (int s = 0; s < selected.getPositionCount(); s++) {
+                    SingleState state = states.get(selected.getInt(s));
+                    state.sort();
+                    double[] values = new double[state.count];
+                    for (int i = 0; i < state.count; i++) {
+                        values[i] = state.values.get(i);
+                    }
+                    MlAggsHelper.DoubleBucketValues bucketValues = new MlAggsHelper.DoubleBucketValues(null, values);
+                    ChangeType changeType = ChangePointDetector.getChangeType(bucketValues);
+                    try (XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()) {
+                        xContentBuilder.startObject();
+                        NamedXContentObjectHelper.writeNamedObject(xContentBuilder, ToXContent.EMPTY_PARAMS, "type", changeType);
+                        xContentBuilder.endObject();
+                        String xContent = Strings.toString(xContentBuilder);
+                        builder.appendBytesRef(new BytesRef(xContent));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        Block toBlock(Function<SingleState, LongArray> getArray, BlockFactory blockFactory, IntVector selected) {
+            if (states.isEmpty()) {
+                return blockFactory.newConstantNullBlock(selected.getPositionCount());
+            }
+            try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(selected.getPositionCount())) {
+                for (int s = 0; s < selected.getPositionCount(); s++) {
+                    int selectedGroup = selected.getInt(s);
+                    SingleState state = states.get(selectedGroup);
+                    LongArray values = getArray.apply(state);
+                    int count = 0;
+                    long first = 0;
+                    for (int i = 0; i < state.count; i++) {
+                        long value = values.get(i);
+                        switch (count) {
+                            case 0 -> first = value;
+                            case 1 -> {
+                                builder.beginPositionEntry();
+                                builder.appendLong(first);
+                                builder.appendLong(value);
+                            }
+                            default -> builder.appendLong(value);
+                        }
+                        count++;
+                    }
+                    switch (count) {
+                        case 0 -> builder.appendNull();
+                        case 1 -> builder.appendLong(first);
+                        default -> builder.endPositionEntry();
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
+            // noop - we handle the null states inside `toIntermediate` and `evaluateFinal`
+        }
+
+        @Override
+        public void close() {
+            for (SingleState state : states.values()) {
+                state.close();
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ChangePointStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ChangePointStates.java
@@ -124,7 +124,8 @@ public class ChangePointStates {
 
         // TODO: this needs to output multiple columns or a composite object, not a JSON blob.
         private BytesRef getChangePoint() {
-            // TODO: this copying doesn't account for memory
+            // TODO: probably reuse ES|QL sort/orderBy to get results in order
+            // TODO: this copying/sorting doesn't account for memory
             List<TimeAndValue> list = new ArrayList<>(count);
             for (int i = 0; i < count; i++) {
                 list.add(new TimeAndValue(timestamps.get(i), values.get(i)));

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ChangePointStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ChangePointStates.java
@@ -58,6 +58,14 @@ public class ChangePointStates {
             values.set(count - 1, value);
         }
 
+        void add(LongBlock timestamps, DoubleBlock values) {
+            int start = values.getFirstValueIndex(0);
+            int end = start + values.getValueCount(0);
+            for (int i = start; i < end; i++) {
+                add(timestamps.getLong(i), values.getDouble(i));
+            }
+        }
+
         void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toTimestampsBlock(timestamps, driverContext.blockFactory());
             blocks[offset + 1] = toValuesBlock(values, driverContext.blockFactory());

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ChangePointStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ChangePointStates.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xpack.core.ml.utils.NamedXContentObjectHelper;
+import org.elasticsearch.xpack.ml.aggs.MlAggsHelper;
+import org.elasticsearch.xpack.ml.aggs.changepoint.ChangePointDetector;
+import org.elasticsearch.xpack.ml.aggs.changepoint.ChangeType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ChangePointStates {
+
+    public static class SingleState implements Releasable {
+        private final BigArrays bigArrays;
+        private int count;
+        private LongArray timestamps;
+        private DoubleArray values;
+
+        SingleState(BigArrays bigArrays) {
+            this.bigArrays = bigArrays;
+            count = 0;
+            timestamps = bigArrays.newLongArray(0);
+            values = bigArrays.newDoubleArray(0);
+        }
+
+        void add(long timestamp, double value) {
+            count++;
+            timestamps = bigArrays.grow(timestamps, count);
+            timestamps.set(count - 1, timestamp);
+            values = bigArrays.grow(values, count);
+            values.set(count - 1, value);
+        }
+
+        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            blocks[offset] = toTimestampsBlock(timestamps, driverContext.blockFactory());
+            blocks[offset + 1] = toValuesBlock(values, driverContext.blockFactory());
+        }
+
+        Block toTimestampsBlock(LongArray arr, BlockFactory blockFactory) {
+            if (arr.size() == 0) {
+                return blockFactory.newConstantNullBlock(1);
+            }
+            if (values.size() == 1) {
+                return blockFactory.newConstantLongBlockWith(arr.get(0), 1);
+            }
+            try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder((int) arr.size())) {
+                builder.beginPositionEntry();
+                for (int id = 0; id < count; id++) {
+                    builder.appendLong(arr.get(id));
+                }
+                builder.endPositionEntry();
+                return builder.build();
+            }
+        }
+
+        Block toValuesBlock(DoubleArray arr, BlockFactory blockFactory) {
+            if (arr.size() == 0) {
+                return blockFactory.newConstantNullBlock(1);
+            }
+            if (values.size() == 1) {
+                return blockFactory.newConstantDoubleBlockWith(arr.get(0), 1);
+            }
+            try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder((int) arr.size())) {
+                builder.beginPositionEntry();
+                for (int id = 0; id < count; id++) {
+                    builder.appendDouble(arr.get(id));
+                }
+                builder.endPositionEntry();
+                return builder.build();
+            }
+        }
+
+        BytesRef toBytesRef() {
+            // TODO: this copying doesn't account for memory
+            List<TimeAndValue> list = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                list.add(new TimeAndValue(timestamps.get(i), values.get(i)));
+            }
+            Collections.sort(list);
+            double[] values = new double[count];
+            for (int i = 0; i < count; i++) {
+                values[i] = list.get(i).value;
+            }
+            MlAggsHelper.DoubleBucketValues bucketValues = new MlAggsHelper.DoubleBucketValues(null, values);
+            ChangeType changeType = ChangePointDetector.getChangeType(bucketValues);
+            try (XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()) {
+                xContentBuilder.startObject();
+                NamedXContentObjectHelper.writeNamedObject(xContentBuilder, ToXContent.EMPTY_PARAMS, "type", changeType);
+                xContentBuilder.endObject();
+                String xContent = Strings.toString(xContentBuilder);
+                return new BytesRef(xContent);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        void add(LongBlock timestamps, DoubleBlock values, int otherPosition) {
+            final int valueCount = timestamps.getValueCount(otherPosition);
+            final int firstIndex = timestamps.getFirstValueIndex(otherPosition);
+            for (int i = 0; i < valueCount; i++) {
+                add(timestamps.getLong(firstIndex + i), values.getDouble(firstIndex + i));
+            }
+        }
+
+        Block toBlock(BlockFactory blockFactory) {
+            // TODO: this needs to output multiple columns or a composite object, not a JSON blob.
+            return blockFactory.newConstantBytesRefBlockWith(toBytesRef(), 1);
+        }
+
+        record TimeAndValue(long timestamp, double value) implements Comparable<TimeAndValue> {
+            @Override
+            public int compareTo(TimeAndValue other) {
+                return Long.compare(timestamp, other.timestamp);
+            }
+        }
+
+        @Override
+        public void close() {
+            timestamps.close();
+            values.close();
+        }
+    }
+
+    public static class GroupingState implements Releasable {
+        private final BigArrays bigArrays;
+        private final Map<Integer, SingleState> states;
+
+        GroupingState(BigArrays bigArrays) {
+            this.bigArrays = bigArrays;
+            states = new HashMap<>();
+        }
+
+        void add(int groupId, long timestamp, double value) {
+            SingleState state = states.computeIfAbsent(groupId, key -> new SingleState(bigArrays));
+            state.add(timestamp, value);
+        }
+
+        void combine(int groupId, LongBlock timestamps, DoubleBlock values, int otherPosition) {
+            if (timestamps.getValueCount(otherPosition) == 0) {
+                return;
+            }
+            SingleState state = states.computeIfAbsent(groupId, key -> new SingleState(bigArrays));
+            state.add(timestamps, values, otherPosition);
+        }
+
+        void combineState(int groupId, GroupingState otherState, int otherGroupId) {
+            SingleState other = otherState.states.get(otherGroupId);
+            if (other == null) {
+                return;
+            }
+            var state = states.computeIfAbsent(groupId, key -> new SingleState(bigArrays));
+            for (int i = 0; i < other.timestamps.size(); i++) {
+                state.add(state.timestamps.get(i), state.values.get(i));
+            }
+        }
+
+        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+            blocks[offset] = toTimestampsBlock(driverContext.blockFactory(), selected);
+            blocks[offset + 1] = toValuesBlock(driverContext.blockFactory(), selected);
+        }
+
+        Block evaluateFinal(IntVector selected, BlockFactory blockFactory) {
+            // TODO: this needs to output multiple columns or a composite object, not a JSON blob.
+            try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(selected.getPositionCount())) {
+                for (int s = 0; s < selected.getPositionCount(); s++) {
+                    builder.appendBytesRef(states.get(selected.getInt(s)).toBytesRef());
+                }
+                return builder.build();
+            }
+        }
+
+        Block toTimestampsBlock(BlockFactory blockFactory, IntVector selected) {
+            if (states.isEmpty()) {
+                return blockFactory.newConstantNullBlock(selected.getPositionCount());
+            }
+            try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(selected.getPositionCount())) {
+                for (int s = 0; s < selected.getPositionCount(); s++) {
+                    int selectedGroup = selected.getInt(s);
+                    SingleState state = states.get(selectedGroup);
+                    int count = 0;
+                    long first = 0;
+                    for (int i = 0; i < state.count; i++) {
+                        long timestamp = state.timestamps.get(i);
+                        switch (count) {
+                            case 0 -> first = timestamp;
+                            case 1 -> {
+                                builder.beginPositionEntry();
+                                builder.appendLong(first);
+                                builder.appendLong(timestamp);
+                            }
+                            default -> builder.appendLong(timestamp);
+                        }
+                        count++;
+                    }
+                    switch (count) {
+                        case 0 -> builder.appendNull();
+                        case 1 -> builder.appendLong(first);
+                        default -> builder.endPositionEntry();
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        Block toValuesBlock(BlockFactory blockFactory, IntVector selected) {
+            if (states.isEmpty()) {
+                return blockFactory.newConstantNullBlock(selected.getPositionCount());
+            }
+            try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())) {
+                for (int s = 0; s < selected.getPositionCount(); s++) {
+                    int selectedGroup = selected.getInt(s);
+                    SingleState state = states.get(selectedGroup);
+                    int count = 0;
+                    double first = 0;
+                    for (int i = 0; i < state.count; i++) {
+                        double value = state.values.get(i);
+                        switch (count) {
+                            case 0 -> first = value;
+                            case 1 -> {
+                                builder.beginPositionEntry();
+                                builder.appendDouble(first);
+                                builder.appendDouble(value);
+                            }
+                            default -> builder.appendDouble(value);
+                        }
+                        count++;
+                    }
+                    switch (count) {
+                        case 0 -> builder.appendNull();
+                        case 1 -> builder.appendDouble(first);
+                        default -> builder.endPositionEntry();
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {}
+
+        @Override
+        public void close() {
+            for (SingleState state : states.values()) {
+                state.close();
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ChangePointAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ChangePointAggregator.java.st
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.aggregation.ChangePointStates.GroupingState;
+import org.elasticsearch.compute.aggregation.ChangePointStates.SingleState;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * Change point detection for series of $type$ values.
+ * This class is generated. Edit @{code X-ChangePointAggregator.java.st} instead
+ * of this file.
+ */
+@Aggregator(
+    includeTimestamps = true,
+    value = { @IntermediateState(name = "timestamps", type = "LONG_BLOCK"), @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
+)
+@GroupingAggregator(
+    includeTimestamps = true,
+    value = { @IntermediateState(name = "timestamps", type = "LONG_BLOCK"), @IntermediateState(name = "values", type = "DOUBLE_BLOCK") }
+)
+class ChangePoint$Type$Aggregator {
+
+    public static SingleState initSingle(DriverContext driverContext) {
+        return new SingleState(driverContext.bigArrays());
+    }
+
+    public static void combine(SingleState state, long timestamp, $type$ value) {
+        state.add(timestamp, value);
+    }
+
+    public static void combineIntermediate(SingleState state, LongBlock timestamps, DoubleBlock values) {
+        state.add(timestamps, values);
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(DriverContext driverContext) {
+        return new GroupingState(driverContext.bigArrays());
+    }
+
+    public static void combine(GroupingState current, int groupId, long timestamp, $type$ value) {
+        current.add(groupId, timestamp, value);
+    }
+
+    public static void combineIntermediate(
+        GroupingState current,
+        int groupId,
+        LongBlock timestamps,
+        DoubleBlock values,
+        int otherPosition
+    ) {
+        current.combine(groupId, timestamps, values, otherPosition);
+    }
+
+    public static void combineStates(GroupingState current, int currentGroupId, GroupingState otherState, int otherGroupId) {
+        current.combineState(currentGroupId, otherState, otherGroupId);
+    }
+
+    public static Block evaluateFinal(GroupingState state, IntVector selected, DriverContext driverContext) {
+        return state.evaluateFinal(selected, driverContext.blockFactory());
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
@@ -1,4 +1,44 @@
-change point with timestamp argument
+change point stationary with timestamp argument
+# required_capability: change_point
+
+FROM k8s
+  | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute)
+  | STATS cp=CHANGE_POINT(count, timestamp)
+;
+
+cp:keyword
+"{""type"":{""stationary"":{}}}"
+;
+
+
+change point stationary without timestamp argument
+# required_capability: change_point
+
+FROM k8s
+  | STATS count=COUNT() BY @timestamp=BUCKET(@timestamp, 1 minute)
+  | STATS cp=CHANGE_POINT(count)
+;
+
+cp:keyword
+"{""type"":{""stationary"":{}}}"
+;
+
+
+change point spike
+# required_capability: change_point
+
+FROM k8s
+  | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute)
+  | EVAL count = count + CASE(timestamp=="2024-05-10T00:09:00.000Z", 1000, 0)
+  | STATS cp=CHANGE_POINT(count, timestamp)
+;
+
+cp:keyword
+"{""type"":{""spike"":{""p_value"":0.0,""change_point"":9}}}"
+;
+
+
+change point grouping with timestamp argument
 # required_capability: change_point
 
 FROM k8s
@@ -13,7 +53,8 @@ cp:keyword                                                                      
 "{""type"":{""indeterminable"":{""reason"":""not enough buckets to calculate change_point. Requires at least [22]; found [18]""}}}" | staging
 ;
 
-change point without timestamp argument
+
+change point grouping without timestamp argument
 # required_capability: change_point
 
 FROM k8s

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
@@ -1,9 +1,24 @@
-change point
+change point with timestamp argument
 # required_capability: change_point
 
 FROM k8s
   | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute), cluster
   | STATS cp=CHANGE_POINT(count, timestamp) BY cluster
+  | SORT cluster
+;
+
+cp:keyword                                                                                                                          | cluster:keyword
+"{""type"":{""indeterminable"":{""reason"":""not enough buckets to calculate change_point. Requires at least [22]; found [21]""}}}" | prod
+"{""type"":{""stationary"":{}}}"                                                                                                    | qa
+"{""type"":{""indeterminable"":{""reason"":""not enough buckets to calculate change_point. Requires at least [22]; found [18]""}}}" | staging
+;
+
+change point without timestamp argument
+# required_capability: change_point
+
+FROM k8s
+  | STATS count=COUNT() BY @timestamp=BUCKET(@timestamp, 1 minute), cluster
+  | STATS cp=CHANGE_POINT(count) BY cluster
   | SORT cluster
 ;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
@@ -1,0 +1,14 @@
+change point
+# required_capability: change_point
+
+FROM k8s
+  | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute), cluster
+  | STATS cp=CHANGE_POINT(count, timestamp) BY cluster
+  | SORT cluster
+;
+
+cp:keyword                                                                                                                          | cluster:keyword
+"{""type"":{""indeterminable"":{""reason"":""not enough buckets to calculate change_point. Requires at least [22]; found [21]""}}}" | prod
+"{""type"":{""stationary"":{}}}"                                                                                                    | qa
+"{""type"":{""indeterminable"":{""reason"":""not enough buckets to calculate change_point. Requires at least [22]; found [18]""}}}" | staging
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
@@ -24,12 +24,40 @@ cp:keyword
 ;
 
 
-change point spike
+change point spike (long)
 # required_capability: change_point
 
 FROM k8s
   | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute)
   | EVAL count = count + CASE(timestamp=="2024-05-10T00:09:00.000Z", 1000, 0)
+  | STATS cp=CHANGE_POINT(count, timestamp)
+;
+
+cp:keyword
+"{""type"":{""spike"":{""p_value"":0.0,""change_point"":9}}}"
+;
+
+
+change point spike (int)
+# required_capability: change_point
+
+FROM k8s
+  | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute)
+  | EVAL count = TO_INTEGER(count + CASE(timestamp=="2024-05-10T00:09:00.000Z", 1000, 0))
+  | STATS cp=CHANGE_POINT(count, timestamp)
+;
+
+cp:keyword
+"{""type"":{""spike"":{""p_value"":0.0,""change_point"":9}}}"
+;
+
+
+change point spike (double)
+# required_capability: change_point
+
+FROM k8s
+  | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute)
+  | EVAL count = TO_DOUBLE(count + CASE(timestamp=="2024-05-10T00:09:00.000Z", 1000, 0))
   | STATS cp=CHANGE_POINT(count, timestamp)
 ;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/change_point.csv-spec
@@ -1,5 +1,5 @@
 change point stationary with timestamp argument
-# required_capability: change_point
+required_capability: change_point
 
 FROM k8s
   | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute)
@@ -12,7 +12,7 @@ cp:keyword
 
 
 change point stationary without timestamp argument
-# required_capability: change_point
+required_capability: change_point
 
 FROM k8s
   | STATS count=COUNT() BY @timestamp=BUCKET(@timestamp, 1 minute)
@@ -25,7 +25,7 @@ cp:keyword
 
 
 change point spike (long)
-# required_capability: change_point
+required_capability: change_point
 
 FROM k8s
   | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute)
@@ -39,7 +39,7 @@ cp:keyword
 
 
 change point spike (int)
-# required_capability: change_point
+required_capability: change_point
 
 FROM k8s
   | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute)
@@ -53,7 +53,7 @@ cp:keyword
 
 
 change point spike (double)
-# required_capability: change_point
+required_capability: change_point
 
 FROM k8s
   | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute)
@@ -67,7 +67,7 @@ cp:keyword
 
 
 change point grouping with timestamp argument
-# required_capability: change_point
+required_capability: change_point
 
 FROM k8s
   | STATS count=COUNT() BY timestamp=BUCKET(@timestamp, 1 minute), cluster
@@ -83,7 +83,7 @@ cp:keyword                                                                      
 
 
 change point grouping without timestamp argument
-# required_capability: change_point
+required_capability: change_point
 
 FROM k8s
   | STATS count=COUNT() BY @timestamp=BUCKET(@timestamp, 1 minute), cluster

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -600,7 +600,12 @@ public class EsqlCapabilities {
         /**
          * Full text functions can be used in disjunctions
          */
-        FULL_TEXT_FUNCTIONS_DISJUNCTIONS;
+        FULL_TEXT_FUNCTIONS_DISJUNCTIONS,
+
+        /**
+         * Support change point detection function "CHANGE_POINT"
+         */
+        CHANGE_POINT;
 
         private final boolean enabled;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Avg;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.ChangePoint;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinct;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
@@ -427,6 +428,7 @@ public class EsqlFunctionRegistry {
             new FunctionDefinition[] {
                 // The delay() function is for debug/snapshot environments only and should never be enabled in a non-snapshot build.
                 // This is an experimental function and can be removed without notice.
+                def(ChangePoint.class, bi(ChangePoint::new), "change_point"),
                 def(Delay.class, Delay::new, "delay"),
                 def(Kql.class, uni(Kql::new), "kql"),
                 def(Rate.class, Rate::withUnresolvedTimestamp, "rate"),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateWritables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateWritables.java
@@ -16,6 +16,7 @@ public class AggregateWritables {
     public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
         return List.of(
             Avg.ENTRY,
+            ChangePoint.ENTRY,
             Count.ENTRY,
             CountDistinct.ENTRY,
             Max.ENTRY,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ChangePoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ChangePoint.java
@@ -36,6 +36,7 @@ public class ChangePoint extends AggregateFunction implements ToAggregator {
         ChangePoint::new
     );
 
+    // TODO: make "timestamp" field optional
     @FunctionInfo(returnType = { "string" }, description = "...", isAggregation = true)
     public ChangePoint(
         Source source,
@@ -77,6 +78,7 @@ public class ChangePoint extends AggregateFunction implements ToAggregator {
         return new ChangePoint(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
 
+    // TODO: this needs to output multiple columns or a composite object
     @Override
     public DataType dataType() {
         return DataType.KEYWORD;
@@ -103,6 +105,7 @@ public class ChangePoint extends AggregateFunction implements ToAggregator {
         final DataType type = field().dataType();
         return switch (type) {
             case LONG -> new ChangePointLongAggregatorFunctionSupplier(inputChannels);
+            // TODO: support other types
             default -> throw EsqlIllegalArgumentException.illegalDataType(type);
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ChangePoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ChangePoint.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.ChangePointLongAggregatorFunctionSupplier;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.planner.ToAggregator;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
+
+public class ChangePoint extends AggregateFunction implements ToAggregator {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ChangePoint",
+        ChangePoint::new
+    );
+
+    @FunctionInfo(returnType = { "string" }, description = "...", isAggregation = true)
+    public ChangePoint(
+        Source source,
+        @Param(name = "field", type = { "double", "integer", "long" }, description = "field") Expression field,
+        @Param(name = "timestamp", type = { "date_nanos", "datetime", "double", "integer", "long" }) Expression timestamp
+    ) {
+        this(source, field, Literal.TRUE, timestamp);
+    }
+
+    public ChangePoint(Source source, Expression field, Expression filter, Expression timestamp) {
+        super(source, field, filter, List.of(timestamp));
+    }
+
+    private ChangePoint(StreamInput in) throws IOException {
+        super(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(Expression.class),
+            in.readNamedWriteable(Expression.class),
+            in.readNamedWriteableCollectionAsList(Expression.class)
+        );
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    Expression timestamp() {
+        return parameters().get(0);
+    }
+
+    @Override
+    protected NodeInfo<ChangePoint> info() {
+        return NodeInfo.create(this, ChangePoint::new, field(), timestamp());
+    }
+
+    @Override
+    public ChangePoint replaceChildren(List<Expression> newChildren) {
+        return new ChangePoint(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2));
+    }
+
+    @Override
+    public DataType dataType() {
+        return DataType.KEYWORD;
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        return isType(field(), dt -> dt.isNumeric(), sourceText(), FIRST, "numeric").and(
+            isType(timestamp(), dt -> dt.isDate() || dt.isNumeric(), sourceText(), SECOND, "date_nanos or datetime or numeric")
+        );
+    }
+
+    @Override
+    public AggregateFunction withFilter(Expression filter) {
+        return new ChangePoint(source(), field(), filter, timestamp());
+    }
+
+    @Override
+    public AggregatorFunctionSupplier supplier(List<Integer> inputChannels) {
+        // if (inputChannels.size() != 2 && inputChannels.size() != 3) {
+        // throw new IllegalArgumentException("change point requires two for raw input or three channels for partial input; got " +
+        // inputChannels);
+        // }
+        final DataType type = field().dataType();
+        return switch (type) {
+            case LONG -> new ChangePointLongAggregatorFunctionSupplier(inputChannels);
+            default -> throw EsqlIllegalArgumentException.illegalDataType(type);
+        };
+    }
+
+    @Override
+    public String toString() {
+        return "change_point{field=" + field() + ",timestamp=" + timestamp() + "}";
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ChangePoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ChangePoint.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.expression.function.aggregate;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.ChangePointDoubleAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.ChangePointIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.ChangePointLongAggregatorFunctionSupplier;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -102,7 +104,8 @@ public class ChangePoint extends AggregateFunction implements OptionalArgument, 
         final DataType type = field().dataType();
         return switch (type) {
             case LONG -> new ChangePointLongAggregatorFunctionSupplier(inputChannels);
-            // TODO: support other types
+            case INTEGER -> new ChangePointIntAggregatorFunctionSupplier(inputChannels);
+            case DOUBLE -> new ChangePointDoubleAggregatorFunctionSupplier(inputChannels);
             default -> throw EsqlIllegalArgumentException.illegalDataType(type);
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ChangePoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ChangePoint.java
@@ -40,7 +40,7 @@ public class ChangePoint extends AggregateFunction implements OptionalArgument, 
         ChangePoint::new
     );
 
-    @FunctionInfo(returnType = { "string" }, description = "...", isAggregation = true)
+    @FunctionInfo(returnType = { "string" }, description = "Detects spikes, dips, and change points in a metric", isAggregation = true)
     public ChangePoint(
         Source source,
         @Param(name = "field", type = { "double", "integer", "long" }, description = "field") Expression field,
@@ -73,12 +73,16 @@ public class ChangePoint extends AggregateFunction implements OptionalArgument, 
 
     @Override
     protected NodeInfo<ChangePoint> info() {
-        return NodeInfo.create(this, ChangePoint::new, field(), timestamp());
+        return NodeInfo.create(this, ChangePoint::new, field(), filter(), timestamp());
     }
 
     @Override
     public ChangePoint replaceChildren(List<Expression> newChildren) {
-        return new ChangePoint(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2));
+        if (newChildren.size() == 2) {
+            return new ChangePoint(source(), newChildren.get(0), newChildren.get(1));
+        } else {
+            return new ChangePoint(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2));
+        }
     }
 
     // TODO: this needs to output multiple columns or a composite object

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -215,8 +215,7 @@ final class AggregateMapper {
     }
 
     private static Stream<AggDef> groupingAndNonGrouping(Tuple<Class<?>, Tuple<String, String>> tuple) {
-        // TODO: also non-grouping change point
-        if (tuple.v1().isAssignableFrom(Rate.class) || tuple.v1().isAssignableFrom(ChangePoint.class)) {
+        if (tuple.v1().isAssignableFrom(Rate.class)) {
             // rate doesn't support non-grouping aggregations
             return Stream.of(new AggDef(tuple.v1(), tuple.v2().v1(), tuple.v2().v2(), true));
         } else {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -198,7 +198,7 @@ final class AggregateMapper {
         } else if (CountDistinct.class.isAssignableFrom(clazz)) {
             types = Stream.concat(NUMERIC.stream(), Stream.of("Boolean", "BytesRef")).toList();
         } else if (ChangePoint.class.isAssignableFrom(clazz)) {
-            types = List.of("Long");  // TODO: add Int, Double
+            types = List.of("Int", "Long", "Double");
         } else {
             assert false : "unknown aggregate type " + clazz;
             throw new IllegalArgumentException("unknown aggregate type " + clazz);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -176,7 +176,7 @@ public class CsvTests extends ESTestCase {
 
     @ParametersFactory(argumentFormatting = "%2$s.%3$s")
     public static List<Object[]> readScriptSpec() throws Exception {
-        List<URL> urls = classpathResources("/*.csv-spec");
+        List<URL> urls = classpathResources("/change_point.csv-spec");
         assertThat("Not enough specs found " + urls, urls, hasSize(greaterThan(0)));
         return SpecReader.readScriptSpec(urls, specParser());
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -176,7 +176,7 @@ public class CsvTests extends ESTestCase {
 
     @ParametersFactory(argumentFormatting = "%2$s.%3$s")
     public static List<Object[]> readScriptSpec() throws Exception {
-        List<URL> urls = classpathResources("/change_point.csv-spec");
+        List<URL> urls = classpathResources("/*.csv-spec");
         assertThat("Not enough specs found " + urls, urls, hasSize(greaterThan(0)));
         return SpecReader.readScriptSpec(urls, specParser());
     }

--- a/x-pack/plugin/ml/src/main/java/module-info.java
+++ b/x-pack/plugin/ml/src/main/java/module-info.java
@@ -37,7 +37,9 @@ module org.elasticsearch.ml {
 
     exports org.elasticsearch.xpack.ml;
     exports org.elasticsearch.xpack.ml.action;
+    exports org.elasticsearch.xpack.ml.aggs;
     exports org.elasticsearch.xpack.ml.aggs.categorization;
+    exports org.elasticsearch.xpack.ml.aggs.changepoint;
     exports org.elasticsearch.xpack.ml.autoscaling;
     exports org.elasticsearch.xpack.ml.job.categorization;
     exports org.elasticsearch.xpack.ml.notifications;

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -92,7 +92,7 @@ setup:
   - gt: {esql.functions.to_long: $functions_to_long}
   - match: {esql.functions.coalesce: $functions_coalesce}
   # Testing for the entire function set isn't feasbile, so we just check that we return the correct count as an approximation.
-  - length: {esql.functions: 130} # check the "sister" test below for a likely update to the same esql.functions length check
+  - length: {esql.functions: 131} # check the "sister" test below for a likely update to the same esql.functions length check
 
 ---
 "Basic ESQL usage output (telemetry) non-snapshot version":


### PR DESCRIPTION
This PR is adding the [Change point aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-change-point-aggregation.html) to ES|QL.

Note: the current output format is a JSON string, which looks like:
```
change_point
------------
{"type":{"spike":{"p_value":1.1498834457157642E-54,"change_point":7}}}
```

 This should be replaced by multiple columns or so, but that still needs some discussion.