### PR TITLE
Unmuting ReindexDataStreamTransportAction tests after fix was backported

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -384,12 +384,6 @@ tests:
 - class: org.elasticsearch.upgrades.HealthNodeUpgradeIT
   method: testHealthNode {upgradedNodes=2}
   issue: https://github.com/elastic/elasticsearch/issues/118158
-- class: org.elasticsearch.xpack.migrate.action.ReindexDataStreamTransportActionIT
-  method: testNonExistentDataStream
-  issue: https://github.com/elastic/elasticsearch/issues/118275
-- class: org.elasticsearch.xpack.migrate.action.ReindexDataStreamTransportActionIT
-  method: testAlreadyUpToDateDataStream
-  issue: https://github.com/elastic/elasticsearch/issues/118276
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
   method: testInferDeploysDefaultRerank
   issue: https://github.com/elastic/elasticsearch/issues/118184


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/119241 backports the change that enables the feature flag for migration reindexing for XPackRestIT. This fixes a couple of failing tests on 8.x.
Closes #118275
Closes #118276