### PR TITLE
Unmuting data stream reindex yaml rest test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -399,9 +399,6 @@ tests:
 - class: org.elasticsearch.repositories.blobstore.testkit.analyze.MinioRepositoryAnalysisRestIT
   issue: https://github.com/elastic/elasticsearch/issues/118548
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=migrate/10_reindex/Test Reindex With Existing Data Stream}
-  issue: https://github.com/elastic/elasticsearch/issues/118575
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=migrate/20_reindex_status/Test Reindex With Existing Data Stream}
   issue: https://github.com/elastic/elasticsearch/issues/118576
 - class: org.elasticsearch.discovery.ec2.DiscoveryEc2AvailabilityZoneAttributeNoImdsIT


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/119245 backports the change that prevents the global template from being created in yaml rest tests. This fixed https://github.com/elastic/elasticsearch/issues/118575.
Closes #118575
Closes #118576