### PR TITLE
Add rolling upgrade BWC tests for N-2 index compatibility

### DIFF
--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/AbstractIndexCompatibilityTestCase.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/AbstractIndexCompatibilityTestCase.java
@@ -88,7 +88,7 @@ public abstract class AbstractIndexCompatibilityTestCase extends ESRestTestCase 
 
     @After
     public final void deleteSnapshotBlobCache() throws IOException {
-        // TODO Having the .snapshot-blob-cache created can block the upgrades. How is it handled today?
+        // TODO ES-10475: The .snapshot-blob-cache created in legacy version can block upgrades, we should probably delete it automatically
         try {
             var request = new Request("DELETE", "/.snapshot-blob-cache");
             request.setOptions(

--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartIndexCompatibilityTestCase.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartIndexCompatibilityTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene;
+
+import com.carrotsearch.randomizedtesting.TestMethodAndParams;
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
+
+import org.elasticsearch.test.cluster.util.Version;
+
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.test.cluster.util.Version.CURRENT;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Test suite for Lucene indices backward compatibility with N-2 versions after full cluster restart upgrades. The test suite creates a
+ * cluster in N-2 version, then upgrades it to N-1 version and finally upgrades it to the current version. Test methods are executed after
+ * each upgrade.
+ */
+@TestCaseOrdering(FullClusterRestartIndexCompatibilityTestCase.TestCaseOrdering.class)
+public abstract class FullClusterRestartIndexCompatibilityTestCase extends AbstractIndexCompatibilityTestCase {
+
+    private final Version clusterVersion;
+
+    public FullClusterRestartIndexCompatibilityTestCase(@Name("cluster") Version clusterVersion) {
+        this.clusterVersion = clusterVersion;
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() {
+        return Stream.of(VERSION_MINUS_2, VERSION_MINUS_1, CURRENT).map(v -> new Object[] { v }).toList();
+    }
+
+    @Override
+    protected void maybeUpgrade() throws Exception {
+        if (nodesVersions().values().stream().anyMatch(version -> version.before(clusterVersion))) {
+            cluster().upgradeToVersion(clusterVersion);
+            closeClients();
+            initClient();
+        }
+        assertThat(isFullyUpgradedTo(clusterVersion), equalTo(true));
+    }
+
+    /**
+     * Execute the test suite with the parameters provided by the {@link #parameters()} in version order.
+     */
+    public static class TestCaseOrdering implements Comparator<TestMethodAndParams> {
+        @Override
+        public int compare(TestMethodAndParams o1, TestMethodAndParams o2) {
+            var version1 = (Version) o1.getInstanceArguments().get(0);
+            var version2 = (Version) o2.getInstanceArguments().get(0);
+            return version1.compareTo(version2);
+        }
+    }
+}

--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartLuceneIndexCompatibilityIT.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartLuceneIndexCompatibilityIT.java
@@ -23,13 +23,13 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 
-public class LuceneCompatibilityIT extends AbstractLuceneIndexCompatibilityTestCase {
+public class FullClusterRestartLuceneIndexCompatibilityIT extends FullClusterRestartIndexCompatibilityTestCase {
 
     static {
         clusterConfig = config -> config.setting("xpack.license.self_generated.type", "trial");
     }
 
-    public LuceneCompatibilityIT(Version version) {
+    public FullClusterRestartLuceneIndexCompatibilityIT(Version version) {
         super(version);
     }
 
@@ -42,7 +42,7 @@ public class LuceneCompatibilityIT extends AbstractLuceneIndexCompatibilityTestC
         final String index = suffix("index");
         final int numDocs = 1234;
 
-        if (VERSION_MINUS_2.equals(clusterVersion())) {
+        if (isFullyUpgradedTo(VERSION_MINUS_2)) {
             logger.debug("--> registering repository [{}]", repository);
             registerRepository(client(), repository, FsRepository.TYPE, true, repositorySettings());
 
@@ -65,7 +65,7 @@ public class LuceneCompatibilityIT extends AbstractLuceneIndexCompatibilityTestC
             return;
         }
 
-        if (VERSION_MINUS_1.equals(clusterVersion())) {
+        if (isFullyUpgradedTo(VERSION_MINUS_1)) {
             ensureGreen(index);
 
             assertThat(indexVersion(index), equalTo(VERSION_MINUS_2));
@@ -76,7 +76,7 @@ public class LuceneCompatibilityIT extends AbstractLuceneIndexCompatibilityTestC
             return;
         }
 
-        if (VERSION_CURRENT.equals(clusterVersion())) {
+        if (isFullyUpgradedTo(VERSION_CURRENT)) {
             var restoredIndex = suffix("index-restored");
             logger.debug("--> restoring index [{}] as [{}]", index, restoredIndex);
 

--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartSearchableSnapshotIndexCompatibilityIT.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartSearchableSnapshotIndexCompatibilityIT.java
@@ -17,7 +17,7 @@ import org.elasticsearch.test.cluster.util.Version;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class SearchableSnapshotCompatibilityIT extends AbstractLuceneIndexCompatibilityTestCase {
+public class FullClusterRestartSearchableSnapshotIndexCompatibilityIT extends FullClusterRestartIndexCompatibilityTestCase {
 
     static {
         clusterConfig = config -> config.setting("xpack.license.self_generated.type", "trial")
@@ -25,7 +25,7 @@ public class SearchableSnapshotCompatibilityIT extends AbstractLuceneIndexCompat
             .setting("xpack.searchable.snapshot.shared_cache.region_size", "256KB");
     }
 
-    public SearchableSnapshotCompatibilityIT(Version version) {
+    public FullClusterRestartSearchableSnapshotIndexCompatibilityIT(Version version) {
         super(version);
     }
 
@@ -38,7 +38,7 @@ public class SearchableSnapshotCompatibilityIT extends AbstractLuceneIndexCompat
         final String index = suffix("index");
         final int numDocs = 1234;
 
-        if (VERSION_MINUS_2.equals(clusterVersion())) {
+        if (isFullyUpgradedTo(VERSION_MINUS_2)) {
             logger.debug("--> registering repository [{}]", repository);
             registerRepository(client(), repository, FsRepository.TYPE, true, repositorySettings());
 
@@ -61,7 +61,7 @@ public class SearchableSnapshotCompatibilityIT extends AbstractLuceneIndexCompat
             return;
         }
 
-        if (VERSION_MINUS_1.equals(clusterVersion())) {
+        if (isFullyUpgradedTo(VERSION_MINUS_1)) {
             ensureGreen(index);
 
             assertThat(indexVersion(index), equalTo(VERSION_MINUS_2));
@@ -72,7 +72,7 @@ public class SearchableSnapshotCompatibilityIT extends AbstractLuceneIndexCompat
             return;
         }
 
-        if (VERSION_CURRENT.equals(clusterVersion())) {
+        if (isFullyUpgradedTo(VERSION_CURRENT)) {
             var mountedIndex = suffix("index-mounted");
             logger.debug("--> mounting index [{}] as [{}]", index, mountedIndex);
             mountIndex(repository, snapshot, index, randomBoolean(), mountedIndex);
@@ -98,7 +98,7 @@ public class SearchableSnapshotCompatibilityIT extends AbstractLuceneIndexCompat
         final String index = suffix("index");
         final int numDocs = 4321;
 
-        if (VERSION_MINUS_2.equals(clusterVersion())) {
+        if (isFullyUpgradedTo(VERSION_MINUS_2)) {
             logger.debug("--> registering repository [{}]", repository);
             registerRepository(client(), repository, FsRepository.TYPE, true, repositorySettings());
 
@@ -124,7 +124,7 @@ public class SearchableSnapshotCompatibilityIT extends AbstractLuceneIndexCompat
             return;
         }
 
-        if (VERSION_MINUS_1.equals(clusterVersion())) {
+        if (isFullyUpgradedTo(VERSION_MINUS_1)) {
             logger.debug("--> mounting index [{}] as [{}]", index, mountedIndex);
             mountIndex(repository, snapshot, index, randomBoolean(), mountedIndex);
 
@@ -135,7 +135,7 @@ public class SearchableSnapshotCompatibilityIT extends AbstractLuceneIndexCompat
             return;
         }
 
-        if (VERSION_CURRENT.equals(clusterVersion())) {
+        if (isFullyUpgradedTo(VERSION_CURRENT)) {
             ensureGreen(mountedIndex);
 
             assertThat(indexVersion(mountedIndex), equalTo(VERSION_MINUS_2));

--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeIndexCompatibilityTestCase.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeIndexCompatibilityTestCase.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene;
+
+import com.carrotsearch.randomizedtesting.TestMethodAndParams;
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
+
+import org.elasticsearch.test.cluster.util.Version;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.test.cluster.util.Version.CURRENT;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Test suite for Lucene indices backward compatibility with N-2 versions during rolling upgrades. The test suite creates a cluster in N-2
+ * version, then upgrades each node sequentially to N-1 version and finally upgrades each node sequentially to the current version. Test
+ * methods are executed after each node upgrade.
+ */
+@TestCaseOrdering(RollingUpgradeIndexCompatibilityTestCase.TestCaseOrdering.class)
+public abstract class RollingUpgradeIndexCompatibilityTestCase extends AbstractIndexCompatibilityTestCase {
+
+    private final List<Version> nodesVersions;
+
+    public RollingUpgradeIndexCompatibilityTestCase(@Name("cluster") List<Version> nodesVersions) {
+        this.nodesVersions = nodesVersions;
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() {
+        return Stream.of(
+            // Begin on N-2
+            List.of(VERSION_MINUS_2, VERSION_MINUS_2, VERSION_MINUS_2),
+            // Rolling upgrade to VERSION_MINUS_1
+            List.of(VERSION_MINUS_1, VERSION_MINUS_2, VERSION_MINUS_2),
+            List.of(VERSION_MINUS_1, VERSION_MINUS_1, VERSION_MINUS_2),
+            List.of(VERSION_MINUS_1, VERSION_MINUS_1, VERSION_MINUS_1),
+            // Rolling upgrade to CURRENT
+            List.of(CURRENT, VERSION_MINUS_1, VERSION_MINUS_1),
+            List.of(CURRENT, CURRENT, VERSION_MINUS_1),
+            List.of(CURRENT, CURRENT, CURRENT)
+        ).map(nodesVersion -> new Object[] { nodesVersion }).toList();
+    }
+
+    @Override
+    protected void maybeUpgrade() throws Exception {
+        assertThat(nodesVersions, hasSize(NODES));
+
+        for (int i = 0; i < NODES; i++) {
+            var nodeName = cluster().getName(i);
+
+            var expectedNodeVersion = nodesVersions.get(i);
+            assertThat(expectedNodeVersion, notNullValue());
+
+            var currentNodeVersion = nodesVersions().get(nodeName);
+            assertThat(currentNodeVersion, notNullValue());
+            assertThat(currentNodeVersion.onOrBefore(expectedNodeVersion), equalTo(true));
+
+            if (currentNodeVersion.equals(expectedNodeVersion) == false) {
+                closeClients();
+                cluster().upgradeNodeToVersion(i, expectedNodeVersion);
+                initClient();
+            }
+
+            currentNodeVersion = nodesVersions().get(nodeName);
+            assertThat(currentNodeVersion, equalTo(expectedNodeVersion));
+        }
+    }
+
+    /**
+     * Execute the test suite with the parameters provided by the {@link #parameters()} in nodes versions order.
+     */
+    public static class TestCaseOrdering implements Comparator<TestMethodAndParams> {
+        @Override
+        public int compare(TestMethodAndParams o1, TestMethodAndParams o2) {
+            List<?> nodesVersions1 = asInstanceOf(List.class, o1.getInstanceArguments().get(0));
+            assertThat(nodesVersions1, hasSize(NODES));
+            List<?> nodesVersions2 = asInstanceOf(List.class, o2.getInstanceArguments().get(0));
+            assertThat(nodesVersions2, hasSize(NODES));
+            for (int i = 0; i < NODES; i++) {
+                var nodeVersion1 = asInstanceOf(Version.class, nodesVersions1.get(i));
+                var nodeVersion2 = asInstanceOf(Version.class, nodesVersions2.get(i));
+                var result = nodeVersion1.compareTo(nodeVersion2);
+                if (result != 0) {
+                    return result;
+                }
+            }
+            return 0;
+        }
+    }
+}

--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeSearchableSnapshotIndexCompatibilityIT.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeSearchableSnapshotIndexCompatibilityIT.java
@@ -36,7 +36,7 @@ public class RollingUpgradeSearchableSnapshotIndexCompatibilityIT extends Rollin
     /**
      * Creates an index and a snapshot on N-2, then mounts the snapshot during rolling upgrades.
      */
-    public void testSearchableSnapshot() throws Exception {
+    public void testMountSearchableSnapshot() throws Exception {
         final String repository = suffix("repository");
         final String snapshot = suffix("snapshot");
         final String index = suffix("index-rolling-upgrade");

--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeSearchableSnapshotIndexCompatibilityIT.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeSearchableSnapshotIndexCompatibilityIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.repositories.fs.FsRepository;
+import org.elasticsearch.test.cluster.util.Version;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class RollingUpgradeSearchableSnapshotIndexCompatibilityIT extends RollingUpgradeIndexCompatibilityTestCase {
+
+    static {
+        clusterConfig = config -> config.setting("xpack.license.self_generated.type", "trial")
+            .setting("xpack.searchable.snapshot.shared_cache.size", "16MB")
+            .setting("xpack.searchable.snapshot.shared_cache.region_size", "256KB");
+    }
+
+    public RollingUpgradeSearchableSnapshotIndexCompatibilityIT(List<Version> nodesVersion) {
+        super(nodesVersion);
+    }
+
+    /**
+     * Creates an index and a snapshot on N-2, then mounts the snapshot during rolling upgrades.
+     */
+    public void testSearchableSnapshot() throws Exception {
+        final String repository = suffix("repository");
+        final String snapshot = suffix("snapshot");
+        final String index = suffix("index-rolling-upgrade");
+        final var mountedIndex = suffix("index-rolling-upgrade-mounted");
+        final int numDocs = 3145;
+
+        if (isFullyUpgradedTo(VERSION_MINUS_2)) {
+            logger.debug("--> registering repository [{}]", repository);
+            registerRepository(client(), repository, FsRepository.TYPE, true, repositorySettings());
+
+            logger.debug("--> creating index [{}]", index);
+            createIndex(
+                client(),
+                index,
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                    .build()
+            );
+
+            logger.debug("--> indexing [{}] docs in [{}]", numDocs, index);
+            indexDocs(index, numDocs);
+
+            logger.debug("--> creating snapshot [{}]", snapshot);
+            createSnapshot(client(), repository, snapshot, true);
+
+            logger.debug("--> deleting index [{}]", index);
+            deleteIndex(index);
+            return;
+        }
+
+        boolean success = false;
+        try {
+            logger.debug("--> mounting index [{}] as [{}]", index, mountedIndex);
+            mountIndex(repository, snapshot, index, randomBoolean(), mountedIndex);
+
+            ensureGreen(mountedIndex);
+
+            assertThat(indexVersion(mountedIndex), equalTo(VERSION_MINUS_2));
+            assertDocCount(client(), mountedIndex, numDocs);
+
+            logger.debug("--> deleting mounted index [{}]", mountedIndex);
+            deleteIndex(mountedIndex);
+
+            success = true;
+        } finally {
+            if (success == false) {
+                try {
+                    client().performRequest(new Request("DELETE", "/" + mountedIndex));
+                } catch (ResponseException e) {
+                    logger.warn("Failed to delete mounted index [" + mountedIndex + ']', e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates an index and a snapshot on N-2, mounts the snapshot and ensures it remains searchable during rolling upgrades.
+     */
+    public void testSearchableSnapshotUpgrade() throws Exception {
+        final String mountedIndex = suffix("index-rolling-upgraded-mounted");
+        final String repository = suffix("repository");
+        final String snapshot = suffix("snapshot");
+        final String index = suffix("index-rolling-upgraded");
+        final int numDocs = 2143;
+
+        if (isFullyUpgradedTo(VERSION_MINUS_2)) {
+            logger.debug("--> registering repository [{}]", repository);
+            registerRepository(client(), repository, FsRepository.TYPE, true, repositorySettings());
+
+            logger.debug("--> creating index [{}]", index);
+            createIndex(
+                client(),
+                index,
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                    .build()
+            );
+
+            logger.debug("--> indexing [{}] docs in [{}]", numDocs, index);
+            indexDocs(index, numDocs);
+
+            logger.debug("--> creating snapshot [{}]", snapshot);
+            createSnapshot(client(), repository, snapshot, true);
+
+            logger.debug("--> deleting index [{}]", index);
+            deleteIndex(index);
+
+            logger.debug("--> mounting index [{}] as [{}]", index, mountedIndex);
+            mountIndex(repository, snapshot, index, randomBoolean(), mountedIndex);
+        }
+
+        ensureGreen(mountedIndex);
+
+        assertThat(indexVersion(mountedIndex), equalTo(VERSION_MINUS_2));
+        assertDocCount(client(), mountedIndex, numDocs);
+    }
+}


### PR DESCRIPTION
This pull request adds rolling upgrade BWC tests for searchable snapshots in N-2 version, so that they are tested in a mixed versions cluster. 

The tests do not use replicas because it may or may not be assigned depending on which node the primary is assigned on (ie, if the cluster has 1 new node and 2 old node and the primary shard is assigned to the new node, then a replica cannot be assigned until at least another node is upgraded). Please let me know if it is worth the additional complexity.

It also renames the existing full cluster restart BWC tests and mutualizes some common code in  `AbstractIndexCompatibilityTestCase`.

Relates ES-10432