### PR TITLE
Print thread dump when ES fails to start during Docker packaging tests

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -206,13 +206,32 @@ public class Docker {
                 ps output:
                 %s
 
-                stdout():
+                Stdout:
                 %s
 
                 Stderr:
+                %s
+
+                Thread dump:
                 %s\
-                """, psOutput, dockerLogs.stdout(), dockerLogs.stderr()));
+                """, psOutput, dockerLogs.stdout(), dockerLogs.stderr(), getThreadDump()));
         }
+    }
+
+    /**
+     * @return output of jstack for currently running Java process
+     */
+    private static String getThreadDump() {
+        try {
+            String pid = dockerShell.run("/usr/share/elasticsearch/jdk/bin/jps | grep -v 'Jps' | awk '{print $1}'").stdout();
+            if (pid.isEmpty() == false) {
+                return dockerShell.run("/usr/share/elasticsearch/jdk/bin/jstack " + Integer.parseInt(pid)).stdout();
+            }
+        } catch (Exception e) {
+            logger.error("Failed to get thread dump", e);
+        }
+
+        return "";
     }
 
     /**


### PR DESCRIPTION
Adds additional diagnostics when Elasticsearch fails to start up during Docker packaging tests. This is an attempt to track down the cause of https://github.com/elastic/elasticsearch/issues/119441.

An example of the output [can be seen here](https://gradle-enterprise.elastic.co/s/cjglhvtxvqhem/tests/task/:qa:packaging:destructiveDistroTest.default-docker-aarch64/details/org.elasticsearch.packaging.test.DockerTests/test010Install?focused-exception-line=0-14&top-execution=1).