### PR TITLE
[8.x] Print thread dump when ES fails to start during Docker packaging tests (#119477)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -206,13 +206,32 @@ public class Docker {
                 ps output:
                 %s
 
-                stdout():
+                Stdout:
                 %s
 
                 Stderr:
+                %s
+
+                Thread dump:
                 %s\
-                """, psOutput, dockerLogs.stdout(), dockerLogs.stderr()));
+                """, psOutput, dockerLogs.stdout(), dockerLogs.stderr(), getThreadDump()));
         }
+    }
+
+    /**
+     * @return output of jstack for currently running Java process
+     */
+    private static String getThreadDump() {
+        try {
+            String pid = dockerShell.run("/usr/share/elasticsearch/jdk/bin/jps | grep -v 'Jps' | awk '{print $1}'").stdout();
+            if (pid.isEmpty() == false) {
+                return dockerShell.run("/usr/share/elasticsearch/jdk/bin/jstack " + Integer.parseInt(pid)).stdout();
+            }
+        } catch (Exception e) {
+            logger.error("Failed to get thread dump", e);
+        }
+
+        return "";
     }
 
     /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Print thread dump when ES fails to start during Docker packaging tests (#119477)](https://github.com/elastic/elasticsearch/pull/119477)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)