### PR TITLE
[8.x] [Build] Update krb5kdc test fixture base image and krb5 library (#119403)

### DIFF
--- a/test/fixtures/krb5kdc-fixture/Dockerfile
+++ b/test/fixtures/krb5kdc-fixture/Dockerfile
@@ -1,9 +1,12 @@
-FROM ubuntu:14.04
-ADD . /fixture
+FROM alpine:3.21.0
+
+ADD src/main/resources /fixture
+RUN apk update && apk add -y --no-cache python3 krb5 krb5-server
+
 RUN echo kerberos.build.elastic.co > /etc/hostname
-RUN bash /fixture/src/main/resources/provision/installkdc.sh
+RUN sh /fixture/provision/installkdc.sh
 
 EXPOSE 88
 EXPOSE 88/udp
 
-CMD sleep infinity
+CMD ["sleep", "infinity"]

--- a/test/fixtures/krb5kdc-fixture/build.gradle
+++ b/test/fixtures/krb5kdc-fixture/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'elasticsearch.deploy-test-fixtures'
 dockerFixtures {
   krb5dc {
     dockerContext = projectDir
-    version = "1.0"
-    baseImages = ["ubuntu:14.04"]
+    version = "1.1"
+    baseImages = ["alpine:3.21.0"]
   }
 }
 

--- a/test/fixtures/krb5kdc-fixture/src/main/java/org/elasticsearch/test/fixtures/krb5kdc/Krb5kDcContainer.java
+++ b/test/fixtures/krb5kdc-fixture/src/main/java/org/elasticsearch/test/fixtures/krb5kdc/Krb5kDcContainer.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public final class Krb5kDcContainer extends DockerEnvironmentAwareTestContainer {
-    public static final String DOCKER_BASE_IMAGE = "docker.elastic.co/elasticsearch-dev/krb5dc-fixture:1.0";
+    public static final String DOCKER_BASE_IMAGE = "docker.elastic.co/elasticsearch-dev/krb5dc-fixture:1.1";
     private final TemporaryFolder temporaryFolder = new TemporaryFolder();
     private final ProvisioningId provisioningId;
     private Path krb5ConfFile;
@@ -39,14 +39,14 @@ public final class Krb5kDcContainer extends DockerEnvironmentAwareTestContainer 
     public enum ProvisioningId {
         HDFS(
             "hdfs",
-            "/fixture/src/main/resources/provision/hdfs.sh",
+            "/fixture/provision/hdfs.sh",
             "/fixture/build/keytabs/hdfs_hdfs.build.elastic.co.keytab",
             "/fixture/build/keytabs/elasticsearch.keytab",
             "hdfs/hdfs.build.elastic.co@BUILD.ELASTIC.CO"
         ),
         PEPPA(
             "peppa",
-            "/fixture/src/main/resources/provision/peppa.sh",
+            "/fixture/provision/peppa.sh",
             "/fixture/build/keytabs/peppa.keytab",
             "/fixture/build/keytabs/HTTP_localhost.keytab",
             "peppa@BUILD.ELASTIC.CO"
@@ -94,7 +94,7 @@ public final class Krb5kDcContainer extends DockerEnvironmentAwareTestContainer 
         withNetworkAliases("kerberos.build.elastic.co", "build.elastic.co");
         withCopyFileToContainer(MountableFile.forHostPath("/dev/urandom"), "/dev/random");
         withExtraHost("kerberos.build.elastic.co", "127.0.0.1");
-        withCommand("bash", provisioningId.scriptPath);
+        withCommand("sh", provisioningId.scriptPath);
     }
 
     @Override
@@ -122,7 +122,7 @@ public final class Krb5kDcContainer extends DockerEnvironmentAwareTestContainer 
             .findFirst();
         String hostPortSpec = bindings.get().getHostPortSpec();
         String s = copyFileFromContainer("/fixture/build/krb5.conf.template", i -> IOUtils.toString(i, StandardCharsets.UTF_8));
-        return s.replace("${MAPPED_PORT}", hostPortSpec);
+        return s.replace("#KDC_DOCKER_HOST", "kdc = 127.0.0.1:" + hostPortSpec);
     }
 
     public Path getKeytab() {

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/addprinc.sh
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/addprinc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the "Elastic License
@@ -24,7 +24,7 @@ PASSWD="$2"
 USER=$(echo $PRINC | tr "/" "_")
 
 VDIR=/fixture
-RESOURCES=$VDIR/src/main/resources
+RESOURCES=$VDIR
 PROV_DIR=$RESOURCES/provision
 ENVPROP_FILE=$RESOURCES/env.properties
 BUILD_DIR=$VDIR/build
@@ -45,16 +45,16 @@ USER_KTAB=$LOCALSTATEDIR/$USER.keytab
 
 if [ -f $USER_KTAB ] && [ -z "$PASSWD" ]; then
   echo "Principal '${PRINC}@${REALM}' already exists. Re-copying keytab..."
-  sudo cp $USER_KTAB $KEYTAB_DIR/$USER.keytab
+  cp $USER_KTAB $KEYTAB_DIR/$USER.keytab
 else
   if [ -z "$PASSWD" ]; then
     echo "Provisioning '${PRINC}@${REALM}' principal and keytab..."
-    sudo kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "addprinc -randkey $USER_PRIN"
-    sudo kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "ktadd -k $USER_KTAB $USER_PRIN"
-    sudo cp $USER_KTAB $KEYTAB_DIR/$USER.keytab
+    kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "addprinc -randkey $USER_PRIN"
+    kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "ktadd -k $USER_KTAB $USER_PRIN"
+    cp $USER_KTAB $KEYTAB_DIR/$USER.keytab
   else
     echo "Provisioning '${PRINC}@${REALM}' principal with password..."
-    sudo kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "addprinc -pw $PASSWD $PRINC"
+    kadmin -p $ADMIN_PRIN -kt $ADMIN_KTAB -q "addprinc -pw $PASSWD $PRINC"
   fi
 fi
 

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/hdfs.sh
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/hdfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/installkdc.sh
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/installkdc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the "Elastic License
@@ -12,8 +12,7 @@ set -e
 # KDC installation steps and considerations based on https://web.mit.edu/kerberos/krb5-latest/doc/admin/install_kdc.html
 # and helpful input from https://help.ubuntu.com/community/Kerberos
 
-VDIR=/fixture
-RESOURCES=$VDIR/src/main/resources
+RESOURCES=/fixture
 PROV_DIR=$RESOURCES/provision
 ENVPROP_FILE=$RESOURCES/env.properties
 LOCALSTATEDIR=/etc
@@ -49,33 +48,11 @@ touch $LOGDIR/kadmin.log
 touch $LOGDIR/krb5kdc.log
 touch $LOGDIR/krb5lib.log
 
-# Update package manager
-apt-get update -qqy
-
-# Installation asks a bunch of questions via debconf. Set the answers ahead of time
-debconf-set-selections <<< "krb5-config krb5-config/read_conf boolean true"
-debconf-set-selections <<< "krb5-config krb5-config/kerberos_servers string $KDC_NAME"
-debconf-set-selections <<< "krb5-config krb5-config/add_servers boolean true"
-debconf-set-selections <<< "krb5-config krb5-config/admin_server string $KDC_NAME"
-debconf-set-selections <<< "krb5-config krb5-config/add_servers_realm string $REALM_NAME"
-debconf-set-selections <<< "krb5-config krb5-config/default_realm string $REALM_NAME"
-debconf-set-selections <<< "krb5-admin-server krb5-admin-server/kadmind boolean true"
-debconf-set-selections <<< "krb5-admin-server krb5-admin-server/newrealm note"
-debconf-set-selections <<< "krb5-kdc krb5-kdc/debconf boolean true"
-debconf-set-selections <<< "krb5-kdc krb5-kdc/purge_data_too boolean false"
-
-# Install krb5 packages
-apt-get install -qqy krb5-{admin-server,kdc}
-
-# /dev/random produces output very slowly on Ubuntu VM's. Install haveged to increase entropy.
-apt-get install -qqy haveged
-haveged
-
 # Create kerberos database with stash file and garbage password
 kdb5_util create -s -r $REALM_NAME -P zyxwvutsrpqonmlk9876
 
 # Set up admin acls
-cat << EOF > /etc/krb5kdc/kadm5.acl
+cat << EOF > /var/lib/krb5kdc/kadm5.acl
 */admin@$REALM_NAME	*
 */*@$REALM_NAME		i
 EOF

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/krb5.conf.template
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/krb5.conf.template
@@ -6,6 +6,7 @@
 # License v3.0 only", or the "Server Side Public License, v 1".
 
 [libdefaults]
+    spake_preauth_groups = edwards25519
     default_realm = ${REALM_NAME}
     dns_canonicalize_hostname = false
     dns_lookup_kdc = false
@@ -25,7 +26,7 @@
 [realms]
     ${REALM_NAME} = {
         kdc = 127.0.0.1:88
-        kdc = 127.0.0.1:${MAPPED_PORT}
+        #KDC_DOCKER_HOST
         admin_server = ${KDC_NAME}:749
         default_domain = ${BUILD_ZONE}
     }

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/peppa.sh
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/peppa.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Build] Update krb5kdc test fixture base image and krb5 library (#119403)](https://github.com/elastic/elasticsearch/pull/119403)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)