### PR TITLE
[8.17] [Gradle] Make CopyCheckStyleConfTask usage cc compatible in serverless (#119249)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
@@ -134,14 +134,14 @@ public class InternalDistributionArchiveSetupPlugin implements Plugin<Project> {
         });
 
         File pluginsDir = new File(project.getBuildDir(), "plugins-hack/plugins");
-        project.getExtensions().add("pluginsDir", pluginsDir);
+        project.getExtensions().getExtraProperties().set("pluginsDir", pluginsDir);
         project.getTasks().register("createPluginsDir", EmptyDirTask.class, t -> {
             t.setDir(pluginsDir);
             t.setDirMode(0755);
         });
 
         File jvmOptionsDir = new File(project.getBuildDir(), "jvm-options-hack/jvm.options.d");
-        project.getExtensions().add("jvmOptionsDir", jvmOptionsDir);
+        project.getExtensions().getExtraProperties().set("jvmOptionsDir", jvmOptionsDir);
         project.getTasks().register("createJvmOptionsDir", EmptyDirTask.class, t -> {
             t.setDir(jvmOptionsDir);
             t.setDirMode(0750);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
@@ -41,8 +41,8 @@ public class CheckstylePrecommitPlugin extends PrecommitPlugin {
         File checkstyleDir = new File(project.getBuildDir(), "checkstyle");
         File checkstyleSuppressions = new File(checkstyleDir, "checkstyle_suppressions.xml");
         File checkstyleConf = new File(checkstyleDir, "checkstyle.xml");
-        TaskProvider<Task> copyCheckstyleConf = project.getTasks().register("copyCheckstyleConf");
-
+        TaskProvider<CopyCheckStyleConfTask> copyCheckstyleConf = project.getTasks()
+            .register("copyCheckstyleConf", CopyCheckStyleConfTask.class);
         // configure inputs and outputs so up to date works properly
         copyCheckstyleConf.configure(t -> t.getOutputs().files(checkstyleSuppressions, checkstyleConf));
         if ("jar".equals(checkstyleConfUrl.getProtocol())) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CopyCheckStyleConfTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CopyCheckStyleConfTask.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.precommit;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.FileSystemOperations;
+
+import javax.inject.Inject;
+
+public abstract class CopyCheckStyleConfTask extends DefaultTask {
+
+    @Inject
+    public abstract FileSystemOperations getFs();
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Gradle] Make CopyCheckStyleConfTask usage cc compatible in serverless (#119249)](https://github.com/elastic/elasticsearch/pull/119249)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)