### PR TITLE
[8.x] Ensure multivalues are sorted in MvJoinKeyOnTheDataNode

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -419,6 +419,7 @@ FROM employees
 | EVAL language_code = emp_no % 10
 | LOOKUP JOIN languages_lookup_non_unique_key ON language_code
 | SORT emp_no
+| EVAL language_name = MV_SORT(language_name)
 | KEEP emp_no, language_code, language_name
 ;
 


### PR DESCRIPTION
This change backports https://github.com/elastic/elasticsearch/pull/119457 into 8.x branch.