### PR TITLE
[DOCS] Adds note on default ELSER and E5 endpoints to service pages

### DIFF
--- a/docs/reference/inference/service-elasticsearch.asciidoc
+++ b/docs/reference/inference/service-elasticsearch.asciidoc
@@ -9,7 +9,8 @@ For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[
 
 Creates an {infer} endpoint to perform an {infer} task with the `elasticsearch` service.
 
-NOTE: If you use the ELSER or the E5 model through the `elasticsearch` service, the API request will automatically download and deploy the model if it isn't downloaded yet.
+NOTE: Your {es} deployment contains <<default-enpoints,preconfigured ELSER and E5 {infer} endpoints>>, you only need to create the enpoints using the API if you want to customize the settings.
+If you use the ELSER or the E5 model through the `elasticsearch` service, the API request will automatically download and deploy the model if it isn't downloaded yet.
 
 
 [discrete]

--- a/docs/reference/inference/service-elasticsearch.asciidoc
+++ b/docs/reference/inference/service-elasticsearch.asciidoc
@@ -9,9 +9,11 @@ For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[
 
 Creates an {infer} endpoint to perform an {infer} task with the `elasticsearch` service.
 
-NOTE: Your {es} deployment contains <<default-enpoints,preconfigured ELSER and E5 {infer} endpoints>>, you only need to create the enpoints using the API if you want to customize the settings.
-If you use the ELSER or the E5 model through the `elasticsearch` service, the API request will automatically download and deploy the model if it isn't downloaded yet.
-
+[NOTE]
+====
+* Your {es} deployment contains <<default-enpoints,preconfigured ELSER and E5 {infer} endpoints>>, you only need to create the enpoints using the API if you want to customize the settings.
+* If you use the ELSER or the E5 model through the `elasticsearch` service, the API request will automatically download and deploy the model if it isn't downloaded yet.
+====
 
 [discrete]
 [[infer-service-elasticsearch-api-request]]

--- a/docs/reference/inference/service-elser.asciidoc
+++ b/docs/reference/inference/service-elser.asciidoc
@@ -10,8 +10,11 @@ For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[
 Creates an {infer} endpoint to perform an {infer} task with the `elser` service.
 You can also deploy ELSER by using the <<infer-service-elasticsearch>>.
 
-NOTE: Your {es} deployment contains <<default-enpoints,a preconfigured ELSER {infer} endpoint>>, you only need to create the enpoint using the API if you want to customize the settings.
-The API request will automatically download and deploy the ELSER model if it isn't already downloaded.
+[NOTE]
+====
+* Your {es} deployment contains <<default-enpoints,a preconfigured ELSER {infer} endpoint>>, you only need to create the enpoint using the API if you want to customize the settings.
+* The API request will automatically download and deploy the ELSER model if it isn't already downloaded.
+====
 
 [WARNING]
 .Deprecated in 8.16

--- a/docs/reference/inference/service-elser.asciidoc
+++ b/docs/reference/inference/service-elser.asciidoc
@@ -10,14 +10,14 @@ For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[
 Creates an {infer} endpoint to perform an {infer} task with the `elser` service.
 You can also deploy ELSER by using the <<infer-service-elasticsearch>>.
 
-NOTE: The API request will automatically download and deploy the ELSER model if
-it isn't already downloaded.
+NOTE: Your {es} deployment contains <<default-enpoints,a preconfigured ELSER {infer} endpoint>>, you only need to create the enpoint using the API if you want to customize the settings.
+The API request will automatically download and deploy the ELSER model if it isn't already downloaded.
 
 [WARNING]
 .Deprecated in 8.16
 ====
-The elser service is deprecated and will be removed in a future release. 
-Use the <<infer-service-elasticsearch>> instead, with model_id included in the service_settings.
+The `elser` service is deprecated and will be removed in a future release. 
+Use the <<infer-service-elasticsearch>> instead, with `model_id` included in the `service_settings`.
 ====
 
 [discrete]


### PR DESCRIPTION
## Overview

From 8.17, the ES deployments contain default ELSER and E5 endpoints. This is stated on the inference API main page. This PR repeats this messaging on the `elasticsearch` and `elser` service pages for better visibility.

### Preview

* [Elasticsearch service](https://elasticsearch_bk_119507.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/infer-service-elasticsearch.html)
* [ELSER service](https://elasticsearch_bk_119507.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/infer-service-elser.html)
