### PR TITLE
fix: do not let `_resolve/cluster` hang if remote is unresponsive

### DIFF
--- a/docs/changelog/119516.yaml
+++ b/docs/changelog/119516.yaml
@@ -1,0 +1,5 @@
+pr: 119516
+summary: "Fix: do not let `_resolve/cluster` hang if remote is unresponsive"
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
@@ -141,7 +141,7 @@ public class TransportResolveClusterAction extends HandledTransportAction<Resolv
                 RemoteClusterClient remoteClusterClient = remoteClusterService.getRemoteClusterClient(
                     clusterAlias,
                     searchCoordinationExecutor,
-                    RemoteClusterService.DisconnectedStrategy.RECONNECT_IF_DISCONNECTED
+                    RemoteClusterService.DisconnectedStrategy.FAIL_IF_DISCONNECTED
                 );
                 var remoteRequest = new ResolveClusterActionRequest(originalIndices.indices(), request.indicesOptions());
                 // allow cancellation requests to propagate to remote clusters


### PR DESCRIPTION
Previously, `_resolve/cluster` would wait for a response from a remote as part of the connection strategy. If the remote were to be unresponsive, this API would wait until `netty` would terminate the connection with a handshake exception. The threshold for terminating the connection is `10s`. This means that the API would wait for `10s` before determining that the remote is unresponsive. After an internal discussion, this is now replaced with a fail fast strategy where a response is sent back to the user immediately rather than waiting for a connection termination.