### PR TITLE
[8.17] Add mapping for event_name for OTel logs (#119495)

### DIFF
--- a/docs/changelog/119495.yaml
+++ b/docs/changelog/119495.yaml
@@ -1,0 +1,5 @@
+pr: 119495
+summary: Add mapping for `event_name` for OTel logs
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/logs-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/logs-otel@mappings.yaml
@@ -39,6 +39,8 @@ template:
       log.level:
         type: alias
         path: severity_text
+      event_name:
+        type: keyword
       body:
         type: object
         properties:

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
@@ -105,6 +105,7 @@ Event body:
                 service.name: my-service
             attributes:
               event.name: foo
+            event_name: foo
             body:
               structured:
                 foo:
@@ -119,6 +120,7 @@ Event body:
         index: $datastream-backing-index
   - is_true: $datastream-backing-index
   - match: { .$datastream-backing-index.mappings.properties.body.properties.structured.properties.foo\.bar.type: "keyword" }
+  - match: { .$datastream-backing-index.mappings.properties.event_name.type: "keyword" }
 ---
 Structured log body:
   - do:


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Add mapping for event_name for OTel logs (#119495)