### PR TITLE
[8.16] fix: do not let `_resolve/cluster` hang if remote is unresponsive (#119516)

### DIFF
--- a/docs/changelog/119516.yaml
+++ b/docs/changelog/119516.yaml
@@ -1,0 +1,5 @@
+pr: 119516
+summary: "Fix: do not let `_resolve/cluster` hang if remote is unresponsive"
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
@@ -141,7 +141,7 @@ public class TransportResolveClusterAction extends HandledTransportAction<Resolv
                 RemoteClusterClient remoteClusterClient = remoteClusterService.getRemoteClusterClient(
                     clusterAlias,
                     searchCoordinationExecutor,
-                    RemoteClusterService.DisconnectedStrategy.RECONNECT_IF_DISCONNECTED
+                    RemoteClusterService.DisconnectedStrategy.FAIL_IF_DISCONNECTED
                 );
                 var remoteRequest = new ResolveClusterActionRequest(originalIndices.indices(), request.indicesOptions());
                 // allow cancellation requests to propagate to remote clusters


### PR DESCRIPTION
Backports the following commits to 8.16:
 - fix: do not let `_resolve/cluster` hang if remote is unresponsive (#119516)