### PR TITLE
Add random index settings and mappings updates in N-2 BWC tests

### DIFF
--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartSearchableSnapshotIndexCompatibilityIT.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartSearchableSnapshotIndexCompatibilityIT.java
@@ -82,6 +82,9 @@ public class FullClusterRestartSearchableSnapshotIndexCompatibilityIT extends Fu
             assertThat(indexVersion(mountedIndex), equalTo(VERSION_MINUS_2));
             assertDocCount(client(), mountedIndex, numDocs);
 
+            updateRandomIndexSettings(mountedIndex);
+            updateRandomMappings(mountedIndex);
+
             logger.debug("--> adding replica to test peer-recovery");
             updateIndexSettings(mountedIndex, Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1));
             ensureGreen(mountedIndex);
@@ -130,6 +133,9 @@ public class FullClusterRestartSearchableSnapshotIndexCompatibilityIT extends Fu
 
             ensureGreen(mountedIndex);
 
+            updateRandomIndexSettings(mountedIndex);
+            updateRandomMappings(mountedIndex);
+
             assertThat(indexVersion(mountedIndex), equalTo(VERSION_MINUS_2));
             assertDocCount(client(), mountedIndex, numDocs);
             return;
@@ -140,6 +146,9 @@ public class FullClusterRestartSearchableSnapshotIndexCompatibilityIT extends Fu
 
             assertThat(indexVersion(mountedIndex), equalTo(VERSION_MINUS_2));
             assertDocCount(client(), mountedIndex, numDocs);
+
+            updateRandomIndexSettings(mountedIndex);
+            updateRandomMappings(mountedIndex);
 
             logger.debug("--> adding replica to test peer-recovery");
             updateIndexSettings(mountedIndex, Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1));

--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeSearchableSnapshotIndexCompatibilityIT.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeSearchableSnapshotIndexCompatibilityIT.java
@@ -76,6 +76,9 @@ public class RollingUpgradeSearchableSnapshotIndexCompatibilityIT extends Rollin
 
             ensureGreen(mountedIndex);
 
+            updateRandomIndexSettings(mountedIndex);
+            updateRandomMappings(mountedIndex);
+
             assertThat(indexVersion(mountedIndex), equalTo(VERSION_MINUS_2));
             assertDocCount(client(), mountedIndex, numDocs);
 
@@ -133,6 +136,9 @@ public class RollingUpgradeSearchableSnapshotIndexCompatibilityIT extends Rollin
         }
 
         ensureGreen(mountedIndex);
+
+        updateRandomIndexSettings(mountedIndex);
+        updateRandomMappings(mountedIndex);
 
         assertThat(indexVersion(mountedIndex), equalTo(VERSION_MINUS_2));
         assertDocCount(client(), mountedIndex, numDocs);


### PR DESCRIPTION
This is to test that metadata writes are not blocked.

Relates ES-10434