### PR TITLE
[8.x] Add missing ES|QL, data stream, inference, and PKI security specifications (#119472)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_delete.json
@@ -1,0 +1,27 @@
+{
+  "esql.async_query_delete": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-delete-api.html",
+      "description": "Delete an async query request given its ID."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_query/async/{id}",
+          "methods": ["DELETE"],
+          "parts": {
+            "id": {
+              "type": "string",
+              "description": "The async query ID"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle_stats.json
@@ -1,0 +1,21 @@
+{
+  "indices.get_data_lifecycle_stats": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle-stats.html",
+      "description": "Get data stream lifecycle statistics."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_lifecycle/stats",
+          "methods": ["GET"]
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.update.json
@@ -1,0 +1,45 @@
+{
+  "inference.update": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-inference-api.html",
+      "description": "Update inference"
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_inference/{inference_id}/_update",
+          "methods": ["POST"],
+          "parts": {
+            "inference_id": {
+              "type": "string",
+              "description": "The inference Id"
+            }
+          }
+        },
+        {
+          "path": "/_inference/{task_type}/{inference_id}/_update",
+          "methods": ["POST"],
+          "parts": {
+            "task_type": {
+              "type": "string",
+              "description": "The task type"
+            },
+            "inference_id": {
+              "type": "string",
+              "description": "The inference Id"
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "The inference endpoint's task and service settings"
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.delegate_pki.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.delegate_pki.json
@@ -1,0 +1,26 @@
+{
+  "security.delegate_pki": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delegate-pki-authentication.html",
+      "description": "Delegate PKI authentication."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_security/delegate_pki",
+          "methods": ["POST"]
+        }
+      ]
+    },
+    "params": {},
+    "body": {
+      "description":"The X509Certificate chain.",
+      "required":true
+    }
+  }
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add missing ES|QL, data stream, inference, and PKI security specifications (#119472)