### PR TITLE
[8.x] Don't cache docker export tasks (#119478)

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -553,6 +553,7 @@ subprojects { Project subProject ->
       inputs.file("${parent.projectDir}/build/markers/${buildTaskName}.marker")
       executable = 'docker'
       outputs.file(tarFile)
+      outputs.doNotCacheIf("Build cache is disabled for export tasks") { true }
       args "save",
         "-o",
         tarFile,


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Don't cache docker export tasks (#119478)