### PR TITLE
[8.x] ESQL: Support union types/multi-index CSV tests (#119273)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -551,11 +551,11 @@ public final class CsvTestUtils {
         }
 
         private static Type bytesRefBlockType(Type actualType) {
-            if (actualType == GEO_POINT || actualType == CARTESIAN_POINT || actualType == GEO_SHAPE || actualType == CARTESIAN_SHAPE) {
-                return actualType;
-            } else {
-                return KEYWORD;
-            }
+            return switch (actualType) {
+                case NULL -> NULL;
+                case GEO_POINT, CARTESIAN_POINT, GEO_SHAPE, CARTESIAN_SHAPE -> actualType;
+                default -> KEYWORD;
+            };
         }
 
         Object convert(String value) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -606,13 +607,20 @@ public class CsvTestsDataLoader {
         }
     }
 
+    public record MultiIndexTestDataset(String indexPattern, List<TestsDataset> datasets) {
+        public static MultiIndexTestDataset of(TestsDataset testsDataset) {
+            return new MultiIndexTestDataset(testsDataset.indexName, List.of(testsDataset));
+        }
+
+    }
+
     public record TestsDataset(
         String indexName,
         String mappingFileName,
         String dataFileName,
         String settingFileName,
         boolean allowSubFields,
-        Map<String, String> typeMapping,
+        @Nullable Map<String, String> typeMapping,
         boolean requiresInferenceEndpoint
     ) {
         public TestsDataset(String indexName, String mappingFileName, String dataFileName) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -445,6 +445,7 @@ count:long  |  message:keyword
 
 multiIndexMissingIpToString
 required_capability: union_types
+required_capability: metadata_fields
 required_capability: union_types_missing_field
 
 FROM sample_data, sample_data_str, missing_ip_sample_data METADATA _index
@@ -479,6 +480,7 @@ sample_data_str        | 2023-10-23T12:15:03.360Z  |  172.21.2.162       |  3450
 
 multiIndexMissingIpToIp
 required_capability: union_types
+required_capability: metadata_fields
 required_capability: union_types_missing_field
 
 FROM sample_data, sample_data_str, missing_ip_sample_data METADATA _index
@@ -1373,9 +1375,6 @@ client_ip:ip | event_duration:long |    message:keyword    |    @timestamp:keywo
 # Once INLINESTATS supports expressions in agg functions and groups, convert the group in the inlinestats
 
 multiIndexIndirectUseOfUnionTypesInSort
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 FROM sample_data, sample_data_ts_long
 | SORT client_ip ASC
 | LIMIT 1
@@ -1386,8 +1385,6 @@ FROM sample_data, sample_data_ts_long
 ;
 
 multiIndexIndirectUseOfUnionTypesInEval
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
 required_capability: union_types
 FROM sample_data, sample_data_ts_long
 | EVAL foo = event_duration > 1232381
@@ -1400,9 +1397,6 @@ FROM sample_data, sample_data_ts_long
 ;
 
 multiIndexIndirectUseOfUnionTypesInRename
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 required_capability: union_types_fix_rename_resolution
 FROM sample_data, sample_data_ts_long
 | RENAME message AS event_message
@@ -1415,9 +1409,6 @@ FROM sample_data, sample_data_ts_long
 ;
 
 multiIndexIndirectUseOfUnionTypesInKeep
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 FROM sample_data, sample_data_ts_long
 | KEEP client_ip, event_duration, message
 | SORT client_ip ASC
@@ -1429,9 +1420,6 @@ client_ip:ip | event_duration:long | message:keyword
 ;
 
 multiIndexIndirectUseOfUnionTypesInWildcardKeep
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 required_capability: union_types_fix_rename_resolution
 FROM sample_data, sample_data_ts_long
 | KEEP *
@@ -1444,9 +1432,6 @@ FROM sample_data, sample_data_ts_long
 ;
 
 multiIndexIndirectUseOfUnionTypesInWildcardKeep2
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 required_capability: union_types_fix_rename_resolution
 FROM sample_data, sample_data_ts_long
 | KEEP *e*
@@ -1460,9 +1445,6 @@ FROM sample_data, sample_data_ts_long
 
 
 multiIndexUseOfUnionTypesInKeep
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 required_capability: union_types_fix_rename_resolution
 FROM sample_data, sample_data_ts_long
 | KEEP @timestamp
@@ -1474,9 +1456,6 @@ null
 ;
 
 multiIndexUseOfUnionTypesInDrop
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 required_capability: union_types_fix_rename_resolution
 FROM sample_data, sample_data_ts_long
 | DROP @timestamp
@@ -1489,9 +1468,6 @@ client_ip:ip | event_duration:long | message:keyword
 ;
 
 multiIndexIndirectUseOfUnionTypesInWildcardDrop
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 required_capability: union_types_fix_rename_resolution
 FROM sample_data, sample_data_ts_long
 | DROP *time*
@@ -1504,9 +1480,6 @@ client_ip:ip | event_duration:long | message:keyword
 ;
 
 multiIndexIndirectUseOfUnionTypesInWhere
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 FROM sample_data, sample_data_ts_long
 | WHERE message == "Disconnected"
 ;
@@ -1517,9 +1490,6 @@ FROM sample_data, sample_data_ts_long
 ;
 
 multiIndexIndirectUseOfUnionTypesInDissect
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 FROM sample_data, sample_data_ts_long
 | DISSECT message "%{foo}"
 | SORT client_ip ASC
@@ -1531,9 +1501,6 @@ FROM sample_data, sample_data_ts_long
 ;
 
 multiIndexIndirectUseOfUnionTypesInGrok
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 FROM sample_data, sample_data_ts_long
 | GROK message "%{WORD:foo}"
 | SORT client_ip ASC
@@ -1545,9 +1512,6 @@ FROM sample_data, sample_data_ts_long
 ;
 
 multiIndexIndirectUseOfUnionTypesInEnrich
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 required_capability: enrich_load
 FROM sample_data, sample_data_ts_long
 | EVAL client_ip = client_ip::keyword
@@ -1561,9 +1525,6 @@ FROM sample_data, sample_data_ts_long
 ;
 
 multiIndexIndirectUseOfUnionTypesInStats
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 FROM sample_data, sample_data_ts_long
 | STATS foo = max(event_duration) BY client_ip
 | SORT client_ip ASC
@@ -1577,9 +1538,6 @@ foo:long | client_ip:ip
 ;
 
 multiIndexIndirectUseOfUnionTypesInInlineStats-Ignore
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 required_capability: inlinestats
 FROM sample_data, sample_data_ts_long
 | INLINESTATS foo = max(event_duration)
@@ -1592,9 +1550,6 @@ FROM sample_data, sample_data_ts_long
 ;
 
 multiIndexIndirectUseOfUnionTypesInLookup-Ignore
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 required_capability: lookup_v4
 FROM sample_data, sample_data_ts_long
 | SORT client_ip ASC
@@ -1608,9 +1563,6 @@ FROM sample_data, sample_data_ts_long
 ;
 
 multiIndexIndirectUseOfUnionTypesInMvExpand
-// TODO: `union_types` is required only because this makes the test skip in the csv tests; better solution:
-// make the csv tests work with multiple indices.
-required_capability: union_types
 FROM sample_data, sample_data_ts_long
 | EVAL foo = MV_APPEND(message, message)
 | SORT client_ip ASC

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -13,22 +13,16 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.logging.HeaderWarning;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.aggregation.GroupingAggregator;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.ElementType;
-import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.LuceneCountOperator;
 import org.elasticsearch.compute.lucene.LuceneOperator;
 import org.elasticsearch.compute.lucene.LuceneSourceOperator;
 import org.elasticsearch.compute.lucene.LuceneTopNSourceOperator;
 import org.elasticsearch.compute.lucene.TimeSeriesSortedSourceOperatorFactory;
 import org.elasticsearch.compute.lucene.ValuesSourceReaderOperator;
-import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.OrdinalsGroupingOperator;
 import org.elasticsearch.compute.operator.SourceOperator;
@@ -384,29 +378,13 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
         }
     }
 
-    static class TypeConvertingBlockLoader implements BlockLoader {
-        protected final BlockLoader delegate;
-        private final EvalOperator.ExpressionEvaluator convertEvaluator;
+    private static class TypeConvertingBlockLoader implements BlockLoader {
+        private final BlockLoader delegate;
+        private final TypeConverter typeConverter;
 
         protected TypeConvertingBlockLoader(BlockLoader delegate, AbstractConvertFunction convertFunction) {
             this.delegate = delegate;
-            DriverContext driverContext1 = new DriverContext(
-                BigArrays.NON_RECYCLING_INSTANCE,
-                new org.elasticsearch.compute.data.BlockFactory(
-                    new NoopCircuitBreaker(CircuitBreaker.REQUEST),
-                    BigArrays.NON_RECYCLING_INSTANCE
-                )
-            );
-            this.convertEvaluator = convertFunction.toEvaluator(e -> driverContext -> new EvalOperator.ExpressionEvaluator() {
-                @Override
-                public org.elasticsearch.compute.data.Block eval(Page page) {
-                    // This is a pass-through evaluator, since it sits directly on the source loading (no prior expressions)
-                    return page.getBlock(0);
-                }
-
-                @Override
-                public void close() {}
-            }).get(driverContext1);
+            this.typeConverter = TypeConverter.fromConvertFunction(convertFunction);
         }
 
         @Override
@@ -417,8 +395,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
 
         @Override
         public Block convert(Block block) {
-            Page page = new Page((org.elasticsearch.compute.data.Block) block);
-            return convertEvaluator.eval(page);
+            return typeConverter.convert((org.elasticsearch.compute.data.Block) block);
         }
 
         @Override
@@ -431,9 +408,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
                 @Override
                 public Block read(BlockFactory factory, Docs docs) throws IOException {
                     Block block = reader.read(factory, docs);
-                    Page page = new Page((org.elasticsearch.compute.data.Block) block);
-                    org.elasticsearch.compute.data.Block converted = convertEvaluator.eval(page);
-                    return converted;
+                    return typeConverter.convert((org.elasticsearch.compute.data.Block) block);
                 }
 
                 @Override
@@ -473,7 +448,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
 
         @Override
         public final String toString() {
-            return "TypeConvertingBlockLoader[delegate=" + delegate + ", convertEvaluator=" + convertEvaluator + "]";
+            return "TypeConvertingBlockLoader[delegate=" + delegate + ", typeConverter=" + typeConverter + "]";
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/TypeConverter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/TypeConverter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.planner;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
+
+class TypeConverter {
+    private final String evaluatorName;
+    private final ExpressionEvaluator convertEvaluator;
+
+    private TypeConverter(String evaluatorName, ExpressionEvaluator convertEvaluator) {
+        this.evaluatorName = evaluatorName;
+        this.convertEvaluator = convertEvaluator;
+    }
+
+    public static TypeConverter fromConvertFunction(AbstractConvertFunction convertFunction) {
+        DriverContext driverContext1 = new DriverContext(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            new org.elasticsearch.compute.data.BlockFactory(
+                new NoopCircuitBreaker(CircuitBreaker.REQUEST),
+                BigArrays.NON_RECYCLING_INSTANCE
+            )
+        );
+        return new TypeConverter(
+            convertFunction.functionName(),
+            convertFunction.toEvaluator(e -> driverContext -> new ExpressionEvaluator() {
+                @Override
+                public org.elasticsearch.compute.data.Block eval(Page page) {
+                    // This is a pass-through evaluator, since it sits directly on the source loading (no prior expressions)
+                    return page.getBlock(0);
+                }
+
+                @Override
+                public void close() {}
+            }).get(driverContext1)
+        );
+    }
+
+    public Block convert(Block block) {
+        return convertEvaluator.eval(new Page(block));
+    }
+
+    @Override
+    public String toString() {
+        return evaluatorName;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -57,6 +57,7 @@ import org.elasticsearch.xpack.esql.analysis.PreAnalyzer;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupService;
 import org.elasticsearch.xpack.esql.enrich.LookupFromIndexService;
 import org.elasticsearch.xpack.esql.enrich.ResolvedEnrichPolicy;
@@ -97,11 +98,15 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.esql.CsvSpecReader.specParser;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.ExpectedResults;
@@ -243,10 +248,6 @@ public class CsvTests extends ESTestCase {
             );
             assumeFalse("can't load metrics in csv tests", testCase.requiredCapabilities.contains(cap(EsqlFeatures.METRICS_SYNTAX)));
             assumeFalse(
-                "multiple indices aren't supported",
-                testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.UNION_TYPES.capabilityName())
-            );
-            assumeFalse(
                 "can't use QSTR function in csv tests",
                 testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.QSTR_FUNCTION.capabilityName())
             );
@@ -314,7 +315,13 @@ public class CsvTests extends ESTestCase {
         } finally {
             Releasables.close(() -> Iterators.map(actualResults.pages().iterator(), p -> p::releaseBlocks));
             // Give the breaker service some time to clear in case we got results before the rest of the driver had cleaned up
-            assertBusy(() -> assertThat(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L)));
+            assertBusy(
+                () -> assertThat(
+                    "Not all circuits were cleaned up",
+                    bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST).getUsed(),
+                    equalTo(0L)
+                )
+            );
         }
     }
 
@@ -329,19 +336,61 @@ public class CsvTests extends ESTestCase {
         CsvAssert.assertResults(expected, actual, ignoreOrder, logger);
     }
 
-    private static IndexResolution loadIndexResolution(String mappingName, String indexName, Map<String, String> typeMapping) {
-        var mapping = new TreeMap<>(loadMapping(mappingName));
-        if ((typeMapping == null || typeMapping.isEmpty()) == false) {
-            for (var entry : typeMapping.entrySet()) {
-                if (mapping.containsKey(entry.getKey())) {
-                    DataType dataType = DataType.fromTypeName(entry.getValue());
-                    EsField field = mapping.get(entry.getKey());
-                    EsField editedField = new EsField(field.getName(), dataType, field.getProperties(), field.isAggregatable());
-                    mapping.put(entry.getKey(), editedField);
-                }
+    private static IndexResolution loadIndexResolution(CsvTestsDataLoader.MultiIndexTestDataset datasets) {
+        var indexNames = datasets.datasets().stream().map(CsvTestsDataLoader.TestsDataset::indexName);
+        Map<String, IndexMode> indexModes = indexNames.collect(Collectors.toMap(x -> x, x -> IndexMode.STANDARD));
+        List<MappingPerIndex> mappings = datasets.datasets()
+            .stream()
+            .map(ds -> new MappingPerIndex(ds.indexName(), createMappingForIndex(ds)))
+            .toList();
+        return IndexResolution.valid(new EsIndex(datasets.indexPattern(), mergeMappings(mappings), indexModes));
+    }
+
+    private static Map<String, EsField> createMappingForIndex(CsvTestsDataLoader.TestsDataset dataset) {
+        var mapping = new TreeMap<>(loadMapping(dataset.mappingFileName()));
+        if (dataset.typeMapping() == null) {
+            return mapping;
+        }
+        for (var entry : dataset.typeMapping().entrySet()) {
+            if (mapping.containsKey(entry.getKey())) {
+                DataType dataType = DataType.fromTypeName(entry.getValue());
+                EsField field = mapping.get(entry.getKey());
+                EsField editedField = new EsField(field.getName(), dataType, field.getProperties(), field.isAggregatable());
+                mapping.put(entry.getKey(), editedField);
             }
         }
-        return IndexResolution.valid(new EsIndex(indexName, mapping, Map.of(indexName, IndexMode.STANDARD)));
+        return mapping;
+    }
+
+    record MappingPerIndex(String index, Map<String, EsField> mapping) {}
+
+    private static Map<String, EsField> mergeMappings(List<MappingPerIndex> mappingsPerIndex) {
+        Map<String, Map<String, EsField>> columnNamesToFieldByIndices = new HashMap<>();
+        for (var mappingPerIndex : mappingsPerIndex) {
+            for (var entry : mappingPerIndex.mapping().entrySet()) {
+                String columnName = entry.getKey();
+                EsField field = entry.getValue();
+                columnNamesToFieldByIndices.computeIfAbsent(columnName, k -> new HashMap<>()).put(mappingPerIndex.index(), field);
+            }
+        }
+
+        return columnNamesToFieldByIndices.entrySet()
+            .stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> mergeFields(e.getKey(), e.getValue())));
+    }
+
+    private static EsField mergeFields(String index, Map<String, EsField> columnNameToField) {
+        var indexFields = columnNameToField.values();
+        if (indexFields.stream().distinct().count() > 1) {
+            var typesToIndices = new HashMap<String, Set<String>>();
+            for (var typeToIndex : columnNameToField.entrySet()) {
+                typesToIndices.computeIfAbsent(typeToIndex.getValue().getDataType().typeName(), k -> new HashSet<>())
+                    .add(typeToIndex.getKey());
+            }
+            return new InvalidMappedField(index, typesToIndices);
+        } else {
+            return indexFields.iterator().next();
+        }
     }
 
     private static EnrichResolution loadEnrichPolicies() {
@@ -351,7 +400,7 @@ public class CsvTests extends ESTestCase {
             CsvTestsDataLoader.TestsDataset sourceIndex = CSV_DATASET_MAP.get(policy.getIndices().get(0));
             // this could practically work, but it's wrong:
             // EnrichPolicyResolution should contain the policy (system) index, not the source index
-            EsIndex esIndex = loadIndexResolution(sourceIndex.mappingFileName(), sourceIndex.indexName(), null).get();
+            EsIndex esIndex = loadIndexResolution(CsvTestsDataLoader.MultiIndexTestDataset.of(sourceIndex.withTypeMapping(Map.of()))).get();
             var concreteIndices = Map.of(RemoteClusterService.LOCAL_CLUSTER_GROUP_KEY, Iterables.get(esIndex.concreteIndices(), 0));
             enrichResolution.addResolvedPolicy(
                 policyConfig.policyName(),
@@ -379,8 +428,8 @@ public class CsvTests extends ESTestCase {
         }
     }
 
-    private LogicalPlan analyzedPlan(LogicalPlan parsed, CsvTestsDataLoader.TestsDataset dataset) {
-        var indexResolution = loadIndexResolution(dataset.mappingFileName(), dataset.indexName(), dataset.typeMapping());
+    private LogicalPlan analyzedPlan(LogicalPlan parsed, CsvTestsDataLoader.MultiIndexTestDataset datasets) {
+        var indexResolution = loadIndexResolution(datasets);
         var enrichPolicies = loadEnrichPolicies();
         var analyzer = new Analyzer(new AnalyzerContext(configuration, functionRegistry, indexResolution, enrichPolicies), TEST_VERIFIER);
         LogicalPlan plan = analyzer.analyze(parsed);
@@ -389,7 +438,7 @@ public class CsvTests extends ESTestCase {
         return plan;
     }
 
-    private static CsvTestsDataLoader.TestsDataset testsDataset(LogicalPlan parsed) {
+    private static CsvTestsDataLoader.MultiIndexTestDataset testDatasets(LogicalPlan parsed) {
         var preAnalysis = new PreAnalyzer().preAnalyze(parsed);
         var indices = preAnalysis.indices;
         if (indices.isEmpty()) {
@@ -397,7 +446,7 @@ public class CsvTests extends ESTestCase {
              * If the data set doesn't matter we'll just grab one we know works.
              * Employees is fine.
              */
-            return CSV_DATASET_MAP.get("employees");
+            return CsvTestsDataLoader.MultiIndexTestDataset.of(CSV_DATASET_MAP.get("employees"));
         } else if (preAnalysis.indices.size() > 1) {
             throw new IllegalArgumentException("unexpected index resolution to multiple entries [" + preAnalysis.indices.size() + "]");
         }
@@ -412,25 +461,35 @@ public class CsvTests extends ESTestCase {
                 }
             }
         } else {
-            var dataset = CSV_DATASET_MAP.get(indexName);
-            datasets.add(dataset);
+            for (String index : indexName.split(",")) {
+                var dataset = CSV_DATASET_MAP.get(index);
+                if (dataset == null) {
+                    throw new IllegalArgumentException("unknown CSV dataset for table [" + index + "]");
+                }
+                datasets.add(dataset);
+            }
         }
         if (datasets.isEmpty()) {
             throw new IllegalArgumentException("unknown CSV dataset for table [" + indexName + "]");
         }
-        // TODO: Support multiple datasets
-        return datasets.get(0);
+        return new CsvTestsDataLoader.MultiIndexTestDataset(indexName, datasets);
     }
 
-    private static TestPhysicalOperationProviders testOperationProviders(CsvTestsDataLoader.TestsDataset dataset) throws Exception {
-        var testData = loadPageFromCsv(CsvTests.class.getResource("/data/" + dataset.dataFileName()), dataset.typeMapping());
-        return new TestPhysicalOperationProviders(testData.v1(), testData.v2());
+    private static TestPhysicalOperationProviders testOperationProviders(CsvTestsDataLoader.MultiIndexTestDataset datasets)
+        throws Exception {
+        var indexResolution = loadIndexResolution(datasets);
+        var indexPages = new ArrayList<TestPhysicalOperationProviders.IndexPage>();
+        for (CsvTestsDataLoader.TestsDataset dataset : datasets.datasets()) {
+            var testData = loadPageFromCsv(CsvTests.class.getResource("/data/" + dataset.dataFileName()), dataset.typeMapping());
+            indexPages.add(new TestPhysicalOperationProviders.IndexPage(dataset.indexName(), testData.v1(), testData.v2()));
+        }
+        return TestPhysicalOperationProviders.create(indexPages);
     }
 
     private ActualResults executePlan(BigArrays bigArrays) throws Exception {
         LogicalPlan parsed = parser.createStatement(testCase.query);
-        var testDataset = testsDataset(parsed);
-        LogicalPlan analyzed = analyzedPlan(parsed, testDataset);
+        var testDatasets = testDatasets(parsed);
+        LogicalPlan analyzed = analyzedPlan(parsed, testDatasets);
 
         EsqlSession session = new EsqlSession(
             getTestName(),
@@ -446,7 +505,7 @@ public class CsvTests extends ESTestCase {
             null,
             EsqlTestUtils.MOCK_QUERY_BUILDER_RESOLVER
         );
-        TestPhysicalOperationProviders physicalOperationProviders = testOperationProviders(testDataset);
+        TestPhysicalOperationProviders physicalOperationProviders = testOperationProviders(testDatasets);
 
         PlainActionFuture<ActualResults> listener = new PlainActionFuture<>();
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
@@ -30,16 +30,22 @@ import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.OrdinalsGroupingOperator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.compute.operator.SourceOperator.SourceOperatorFactory;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.analysis.AnalysisRegistry;
+import org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.plugins.scanners.StablePluginsRegistry;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.TestBlockFactory;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.MultiTypeEsField;
 import org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes;
+import org.elasticsearch.xpack.esql.expression.function.UnsupportedAttribute;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
@@ -48,8 +54,12 @@ import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperat
 import org.elasticsearch.xpack.ml.MachineLearning;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.Random;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
@@ -57,26 +67,33 @@ import java.util.stream.IntStream;
 import static com.carrotsearch.randomizedtesting.generators.RandomNumbers.randomIntBetween;
 import static java.util.stream.Collectors.joining;
 import static org.apache.lucene.tests.util.LuceneTestCase.createTempDir;
-import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.DOC_VALUES;
-import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.NONE;
 
 public class TestPhysicalOperationProviders extends AbstractPhysicalOperationProviders {
+    private final List<IndexPage> indexPages;
 
-    private final Page testData;
-    private final List<String> columnNames;
+    private TestPhysicalOperationProviders(List<IndexPage> indexPages, AnalysisRegistry analysisRegistry) {
+        super(analysisRegistry);
+        this.indexPages = indexPages;
+    }
 
-    public TestPhysicalOperationProviders(Page testData, List<String> columnNames) throws IOException {
-        super(
-            new AnalysisModule(
-                TestEnvironment.newEnvironment(
-                    Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build()
-                ),
-                List.of(new MachineLearning(Settings.EMPTY), new CommonAnalysisPlugin()),
-                new StablePluginsRegistry()
-            ).getAnalysisRegistry()
-        );
-        this.testData = testData;
-        this.columnNames = columnNames;
+    public static TestPhysicalOperationProviders create(List<IndexPage> indexPages) throws IOException {
+        return new TestPhysicalOperationProviders(indexPages, createAnalysisRegistry());
+    }
+
+    public record IndexPage(String index, Page page, List<String> columnNames) {
+        OptionalInt columnIndex(String columnName) {
+            return IntStream.range(0, columnNames.size()).filter(i -> columnNames.get(i).equals(columnName)).findFirst();
+        }
+    }
+
+    private static AnalysisRegistry createAnalysisRegistry() throws IOException {
+        return new AnalysisModule(
+            TestEnvironment.newEnvironment(
+                Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build()
+            ),
+            List.of(new MachineLearning(Settings.EMPTY), new CommonAnalysisPlugin()),
+            new StablePluginsRegistry()
+        ).getAnalysisRegistry();
     }
 
     @Override
@@ -118,13 +135,12 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
             aggregatorFactories,
             groupElementType,
             context.bigArrays(),
-            attrSource.name()
+            attrSource
         );
     }
 
     private class TestSourceOperator extends SourceOperator {
-
-        boolean finished = false;
+        private int index = 0;
         private final DriverContext driverContext;
 
         TestSourceOperator(DriverContext driverContext) {
@@ -133,28 +149,29 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
 
         @Override
         public Page getOutput() {
-            if (finished == false) {
-                finish();
-            }
-
+            var pageIndex = indexPages.get(index);
+            var page = pageIndex.page;
             BlockFactory blockFactory = driverContext.blockFactory();
             DocVector docVector = new DocVector(
-                blockFactory.newConstantIntVector(0, testData.getPositionCount()),
-                blockFactory.newConstantIntVector(0, testData.getPositionCount()),
-                blockFactory.newIntArrayVector(IntStream.range(0, testData.getPositionCount()).toArray(), testData.getPositionCount()),
+                // The shard ID is used to encode the index ID.
+                blockFactory.newConstantIntVector(index, page.getPositionCount()),
+                blockFactory.newConstantIntVector(0, page.getPositionCount()),
+                blockFactory.newIntArrayVector(IntStream.range(0, page.getPositionCount()).toArray(), page.getPositionCount()),
                 true
             );
-            return new Page(docVector.asBlock());
+            var block = docVector.asBlock();
+            index++;
+            return new Page(block);
         }
 
         @Override
         public boolean isFinished() {
-            return finished;
+            return index == indexPages.size();
         }
 
         @Override
         public void finish() {
-            finished = true;
+            index = indexPages.size();
         }
 
         @Override
@@ -177,24 +194,19 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
     }
 
     private class TestFieldExtractOperator implements Operator {
-
+        private final Attribute attribute;
         private Page lastPage;
         boolean finished;
-        String columnName;
-        private final DataType dataType;
-        private final MappedFieldType.FieldExtractPreference extractPreference;
+        private final FieldExtractPreference extractPreference;
 
-        TestFieldExtractOperator(String columnName, DataType dataType, MappedFieldType.FieldExtractPreference extractPreference) {
-            assert columnNames.contains(columnName);
-            this.columnName = columnName;
-            this.dataType = dataType;
+        TestFieldExtractOperator(Attribute attr, FieldExtractPreference extractPreference) {
+            this.attribute = attr;
             this.extractPreference = extractPreference;
         }
 
         @Override
         public void addInput(Page page) {
-            Block block = extractBlockForColumn(page, columnName, dataType, extractPreference);
-            lastPage = page.appendBlock(block);
+            lastPage = page.appendBlock(getBlock(page.getBlock(0), attribute, extractPreference));
         }
 
         @Override
@@ -226,12 +238,12 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
     }
 
     private class TestFieldExtractOperatorFactory implements Operator.OperatorFactory {
-        final Operator op;
-        private String columnName;
+        private final Operator op;
+        private final Attribute attribute;
 
-        TestFieldExtractOperatorFactory(Attribute attr, MappedFieldType.FieldExtractPreference extractPreference) {
-            this.op = new TestFieldExtractOperator(attr.name(), attr.dataType(), extractPreference);
-            this.columnName = attr.name();
+        TestFieldExtractOperatorFactory(Attribute attr, FieldExtractPreference extractPreference) {
+            this.op = new TestFieldExtractOperator(attr, extractPreference);
+            this.attribute = attr;
         }
 
         @Override
@@ -241,27 +253,88 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
 
         @Override
         public String describe() {
-            return "TestFieldExtractOperator(" + columnName + ")";
+            return "TestFieldExtractOperator(" + attribute.name() + ")";
+        }
+    }
+
+    private Block getBlock(DocBlock docBlock, Attribute attribute, FieldExtractPreference extractPreference) {
+        if (attribute instanceof UnsupportedAttribute) {
+            return docBlock.blockFactory().newConstantNullBlock(docBlock.getPositionCount());
+        }
+        return extractBlockForColumn(
+            docBlock,
+            attribute.dataType(),
+            extractPreference,
+            attribute instanceof FieldAttribute fa && fa.field() instanceof MultiTypeEsField multiTypeEsField
+                ? (indexDoc, blockCopier) -> getBlockForMultiType(indexDoc, multiTypeEsField, blockCopier)
+                : (indexDoc, blockCopier) -> extractBlockForSingleDoc(indexDoc, attribute.name(), blockCopier)
+        );
+    }
+
+    private Block getBlockForMultiType(DocBlock indexDoc, MultiTypeEsField multiTypeEsField, TestBlockCopier blockCopier) {
+        var indexId = indexDoc.asVector().shards().getInt(0);
+        var indexPage = indexPages.get(indexId);
+        var conversion = (AbstractConvertFunction) multiTypeEsField.getConversionExpressionForIndex(indexPage.index);
+        Supplier<Block> nulls = () -> indexDoc.blockFactory().newConstantNullBlock(indexDoc.getPositionCount());
+        if (conversion == null) {
+            return nulls.get();
+        }
+        var field = (FieldAttribute) conversion.field();
+        return indexPage.columnIndex(field.fieldName()).isEmpty()
+            ? nulls.get()
+            : TypeConverter.fromConvertFunction(conversion).convert(extractBlockForSingleDoc(indexDoc, field.fieldName(), blockCopier));
+    }
+
+    private Block extractBlockForSingleDoc(DocBlock docBlock, String columnName, TestBlockCopier blockCopier) {
+        var indexId = docBlock.asVector().shards().getInt(0);
+        var indexPage = indexPages.get(indexId);
+        int columnIndex = indexPage.columnIndex(columnName)
+            .orElseThrow(() -> new EsqlIllegalArgumentException("Cannot find column named [{}] in {}", columnName, indexPage.columnNames));
+        var originalData = indexPage.page.getBlock(columnIndex);
+        return blockCopier.copyBlock(originalData);
+    }
+
+    private static void foreachIndexDoc(DocBlock docBlock, Consumer<DocBlock> indexDocConsumer) {
+        var currentIndex = -1;
+        List<Integer> currentList = null;
+        DocVector vector = docBlock.asVector();
+        for (int i = 0; i < docBlock.getPositionCount(); i++) {
+            int indexId = vector.shards().getInt(i);
+            if (indexId != currentIndex) {
+                consumeIndexDoc(indexDocConsumer, vector, currentList);
+                currentList = new ArrayList<>();
+                currentIndex = indexId;
+            }
+            currentList.add(i);
+        }
+        consumeIndexDoc(indexDocConsumer, vector, currentList);
+    }
+
+    private static void consumeIndexDoc(Consumer<DocBlock> indexDocConsumer, DocVector vector, @Nullable List<Integer> currentList) {
+        if (currentList != null) {
+            try (DocVector indexDocVector = vector.filter(currentList.stream().mapToInt(Integer::intValue).toArray())) {
+                indexDocConsumer.accept(indexDocVector.asBlock());
+            }
         }
     }
 
     private class TestHashAggregationOperator extends HashAggregationOperator {
 
-        private final String columnName;
+        private final Attribute attribute;
 
         TestHashAggregationOperator(
             List<GroupingAggregator.Factory> aggregators,
             Supplier<BlockHash> blockHash,
-            String columnName,
+            Attribute attribute,
             DriverContext driverContext
         ) {
             super(aggregators, blockHash, driverContext);
-            this.columnName = columnName;
+            this.attribute = attribute;
         }
 
         @Override
         protected Page wrapPage(Page page) {
-            return page.appendBlock(extractBlockForColumn(page, columnName, null, NONE));
+            return page.appendBlock(getBlock(page.getBlock(0), attribute, FieldExtractPreference.NONE));
         }
     }
 
@@ -270,24 +343,24 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
      * {@link HashAggregationOperator}.
      */
     private class TestOrdinalsGroupingAggregationOperatorFactory implements Operator.OperatorFactory {
-        private int groupByChannel;
-        private List<GroupingAggregator.Factory> aggregators;
-        private ElementType groupElementType;
-        private BigArrays bigArrays;
-        private String columnName;
+        private final int groupByChannel;
+        private final List<GroupingAggregator.Factory> aggregators;
+        private final ElementType groupElementType;
+        private final BigArrays bigArrays;
+        private final Attribute attribute;
 
         TestOrdinalsGroupingAggregationOperatorFactory(
             int channelIndex,
             List<GroupingAggregator.Factory> aggregatorFactories,
             ElementType groupElementType,
             BigArrays bigArrays,
-            String name
+            Attribute attribute
         ) {
             this.groupByChannel = channelIndex;
             this.aggregators = aggregatorFactories;
             this.groupElementType = groupElementType;
             this.bigArrays = bigArrays;
-            this.columnName = name;
+            this.attribute = attribute;
         }
 
         @Override
@@ -302,7 +375,7 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
                     pageSize,
                     false
                 ),
-                columnName,
+                attribute,
                 driverContext
             );
         }
@@ -318,32 +391,34 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
     }
 
     private Block extractBlockForColumn(
-        Page page,
-        String columnName,
+        DocBlock docBlock,
         DataType dataType,
-        MappedFieldType.FieldExtractPreference extractPreference
+        FieldExtractPreference extractPreference,
+        BiFunction<DocBlock, TestBlockCopier, Block> extractBlock
     ) {
-        var columnIndex = -1;
-        // locate the block index corresponding to "columnName"
-        for (int i = 0, size = columnNames.size(); i < size && columnIndex < 0; i++) {
-            if (columnNames.get(i).equals(columnName)) {
-                columnIndex = i;
-            }
+        BlockFactory blockFactory = docBlock.blockFactory();
+        boolean mapToDocValues = shouldMapToDocValues(dataType, extractPreference);
+        try (
+            Block.Builder blockBuilder = mapToDocValues
+                ? blockFactory.newLongBlockBuilder(docBlock.getPositionCount())
+                : blockBuilder(dataType, docBlock.getPositionCount(), TestBlockFactory.getNonBreakingInstance())
+        ) {
+            foreachIndexDoc(docBlock, indexDoc -> {
+                TestBlockCopier blockCopier = mapToDocValues
+                    ? TestSpatialPointStatsBlockCopier.create(indexDoc.asVector().docs(), dataType)
+                    : new TestBlockCopier(indexDoc.asVector().docs());
+                Block blockForIndex = extractBlock.apply(indexDoc, blockCopier);
+                blockBuilder.copyFrom(blockForIndex, 0, blockForIndex.getPositionCount());
+            });
+            var result = blockBuilder.build();
+            assert result.getPositionCount() == docBlock.getPositionCount()
+                : "Expected " + docBlock.getPositionCount() + " rows, got " + result.getPositionCount();
+            return result;
         }
-        if (columnIndex < 0) {
-            throw new EsqlIllegalArgumentException("Cannot find column named [{}] in {}", columnName, columnNames);
-        }
-        DocBlock docBlock = page.getBlock(0);
-        IntVector docIndices = docBlock.asVector().docs();
-        Block originalData = testData.getBlock(columnIndex);
-        var blockCopier = shouldMapToDocValues(dataType, extractPreference)
-            ? TestSpatialPointStatsBlockCopier.create(docIndices, dataType)
-            : new TestBlockCopier(docIndices);
-        return blockCopier.copyBlock(originalData);
     }
 
-    private boolean shouldMapToDocValues(DataType dataType, MappedFieldType.FieldExtractPreference extractPreference) {
-        return extractPreference == DOC_VALUES && DataType.isSpatialPoint(dataType);
+    private boolean shouldMapToDocValues(DataType dataType, FieldExtractPreference extractPreference) {
+        return extractPreference == FieldExtractPreference.DOC_VALUES && DataType.isSpatialPoint(dataType);
     }
 
     private static class TestBlockCopier {
@@ -409,9 +484,9 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
         }
 
         private static TestSpatialPointStatsBlockCopier create(IntVector docIndices, DataType dataType) {
-            Function<BytesRef, Long> encoder = switch (dataType.esType()) {
-                case "geo_point" -> SpatialCoordinateTypes.GEO::wkbAsLong;
-                case "cartesian_point" -> SpatialCoordinateTypes.CARTESIAN::wkbAsLong;
+            Function<BytesRef, Long> encoder = switch (dataType) {
+                case GEO_POINT -> SpatialCoordinateTypes.GEO::wkbAsLong;
+                case CARTESIAN_POINT -> SpatialCoordinateTypes.CARTESIAN::wkbAsLong;
                 default -> throw new IllegalArgumentException("Unsupported spatial data type: " + dataType);
             };
             return new TestSpatialPointStatsBlockCopier(docIndices) {
@@ -421,5 +496,14 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
                 }
             };
         }
+    }
+
+    private static Block.Builder blockBuilder(DataType dataType, int estimatedSize, BlockFactory blockFactory) {
+        ElementType elementType = switch (dataType) {
+            case SHORT -> ElementType.INT;
+            case FLOAT, HALF_FLOAT, SCALED_FLOAT -> ElementType.DOUBLE;
+            default -> PlannerUtils.toElementType(dataType);
+        };
+        return elementType.newBlockBuilder(estimatedSize, blockFactory);
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Support union types/multi-index CSV tests (#119273)