### PR TITLE
[Inference API] Fix unique ID message for inference ID matches trained model ID

### DIFF
--- a/docs/changelog/119543.yaml
+++ b/docs/changelog/119543.yaml
@@ -1,0 +1,7 @@
+pr: 119543
+summary: "[Inference API] Fix unique ID message for inference ID matches trained model\
+  \ ID"
+area: Machine Learning
+type: bug
+issues:
+ - 111312

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -281,6 +281,8 @@ public final class Messages {
     public static final String FIELD_CANNOT_BE_NULL = "Field [{0}] cannot be null";
     public static final String MODEL_ID_MATCHES_EXISTING_MODEL_IDS_BUT_MUST_NOT =
         "Model IDs must be unique. Requested model ID [{}] matches existing model IDs but must not.";
+    public static final String INFERENCE_ID_MATCHES_EXISTING_MODEL_IDS_BUT_MUST_NOT =
+        "Inference endpoint IDs must be unique. Requested inference endpoint ID [{}] matches existing trained model ID(s) but must not.";
     public static final String MODEL_ID_DOES_NOT_MATCH_EXISTING_MODEL_IDS_BUT_MUST_FOR_IN_CLUSTER_SERVICE =
         "Requested model ID [{}] does not have a matching trained model and thus cannot be updated.";
     public static final String INFERENCE_ENTITY_NON_EXISTANT_NO_UPDATE = "The inference endpoint [{}] does not exist and cannot be updated";

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
@@ -153,7 +153,7 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
         if ((assignments == null || assignments.isEmpty()) == false) {
             listener.onFailure(
                 ExceptionsHelper.badRequestException(
-                    Messages.MODEL_ID_MATCHES_EXISTING_MODEL_IDS_BUT_MUST_NOT,
+                    Messages.INFERENCE_ID_MATCHES_EXISTING_MODEL_IDS_BUT_MUST_NOT,
                     request.getInferenceEntityId()
                 )
             );

--- a/x-pack/plugin/ml/qa/ml-inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelIdUniquenessIT.java
+++ b/x-pack/plugin/ml/qa/ml-inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelIdUniquenessIT.java
@@ -29,9 +29,10 @@ public class ModelIdUniquenessIT extends InferenceBaseRestTest {
         assertThat(
             e.getMessage(),
             Matchers.containsString(
-                "Model IDs must be unique. Requested model ID [" + modelId + "] matches existing model IDs but must not."
+                "Inference endpoint IDs must be unique. Requested inference endpoint ID ["
+                    + modelId
+                    + "] matches existing trained model ID(s) but must not."
             )
-
         );
     }
 


### PR DESCRIPTION
closes https://github.com/elastic/elasticsearch/issues/111312