### PR TITLE
Update rejected-requests.asciidoc

### DIFF
--- a/docs/reference/troubleshooting/common-issues/rejected-requests.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/rejected-requests.asciidoc
@@ -69,7 +69,7 @@ These stats are cumulative from node startup.
 
 Indexing pressure rejections appear as an
 `EsRejectedExecutionException`, and indicate that they were rejected due
-to `coordinating_and_primary_bytes`, `coordinating`, `primary`, or `replica`.
+to `combined_coordinating_and_primary`, `coordinating`, `primary`, or `replica`.
 
 These errors are often related to <<task-queue-backlog,backlogged tasks>>,
 <<docs-bulk,bulk index>> sizing, or the ingest target's


### PR DESCRIPTION
I believe this is a typo, as in our 8.16.1 cluster this field appears to be called `combined_coordinating_and_primary`

```
      "indexing_pressure": {
        "memory": {
          "current": {
            "combined_coordinating_and_primary": "0b",
            "combined_coordinating_and_primary_in_bytes": 0,
            "coordinating": "0b",
            "coordinating_in_bytes": 0,
            "primary": "0b",
            "primary_in_bytes": 0,
            "replica": "0b",
            "replica_in_bytes": 0,
            "all": "0b",
            "all_in_bytes": 0
          },
```