### PR TITLE
Don't intern leafName in Mapper.Builder

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -107,9 +107,8 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
         private String leafName;
 
-        @SuppressWarnings("this-escape")
         protected Builder(String leafName) {
-            setLeafName(leafName);
+            this.leafName = leafName;
         }
 
         public final String leafName() {
@@ -120,7 +119,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         public abstract Mapper build(MapperBuilderContext context);
 
         void setLeafName(String leafName) {
-            this.leafName = internFieldName(leafName);
+            this.leafName = leafName;
         }
     }
 


### PR DESCRIPTION
We shouldn't intern in the builder already.
It's redundant since we'll be interning the mapper name when we actually build the mapper instance anyway and introduces a non-trivial slowdown into mapper serialization because we create temporary builders during serialization that never turn into concrete instances.
