### PR TITLE
Construct list manually in AggregatorsReducer#get

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorsReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorsReducer.java
@@ -12,7 +12,10 @@ package org.elasticsearch.search.aggregations;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -54,7 +57,12 @@ public final class AggregatorsReducer implements Releasable {
      * returns the reduced {@link InternalAggregations}.
      */
     public InternalAggregations get() {
-        return InternalAggregations.from(aggByName.values().stream().map(AggregatorReducer::get).toList());
+        final Collection<AggregatorReducer> reducers = aggByName.values();
+        final List<InternalAggregation> aggs = new ArrayList<>(reducers.size());
+        for (AggregatorReducer reducer : reducers) {
+            aggs.add(reducer.get());
+        }
+        return InternalAggregations.from(aggs);
     }
 
     @Override


### PR DESCRIPTION
The reason to replace the current implementation created by default a list with 10 elements which can be wasteful. The new implementation makes sure the final list is the size of the aggregations to reduce.