### PR TITLE
[DOCS][ML] Document the text_expansion task type

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1167,6 +1167,12 @@ tag::inference-config-text-embedding-size[]
 The number of dimensions in the embedding vector produced by the model.
 end::inference-config-text-embedding-size[]
 
+tag::inference-config-text-expansion[]
+The Text expansion task works with Sparse Embedding models to transform an input sequence
+into a vector of weighted tokens. These embeddings capture semantic meanings and
+context and can be used in a <<sparse-vector,sparse vector>> field for powerful insights.
+end::inference-config-text-expansion[]
+
 tag::inference-config-text-similarity[]
 Text similarity takes an input sequence and compares it with another input sequence. This is commonly referred to
 as cross-encoding. This task is useful for ranking document text when comparing it to another provided text input.

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1168,7 +1168,7 @@ The number of dimensions in the embedding vector produced by the model.
 end::inference-config-text-embedding-size[]
 
 tag::inference-config-text-expansion[]
-The Text expansion task works with Sparse Embedding models to transform an input sequence
+The text expansion task works with sparse embedding models to transform an input sequence
 into a vector of weighted tokens. These embeddings capture semantic meanings and
 context and can be used in a <<sparse-vector,sparse vector>> field for powerful insights.
 end::inference-config-text-expansion[]

--- a/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
@@ -395,10 +395,10 @@ the model definition is not supplied.
 (Required, object)
 The default configuration for inference. This can be: `regression`,
 `classification`, `fill_mask`, `ner`, `question_answering`,
-`text_classification`, `text_embedding` or `zero_shot_classification`.
+`text_classification`, `text_embedding`, `text_expansion` or `zero_shot_classification`.
 If `regression` or `classification`, it must match the `target_type` of the
 underlying `definition.trained_model`. If `fill_mask`, `ner`,
-`question_answering`, `text_classification`, or `text_embedding`; the
+`question_answering`, `text_classification`, `text_embedding` or `text_expansion`; the
 `model_type` must be `pytorch`.
 +
 .Properties of `inference_config`
@@ -580,6 +580,25 @@ include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-embedding]
 (Optional, integer)
 include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-embedding-size]
 
+`results_field`::::
+(Optional, string)
+include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+
+`tokenization`::::
+(Optional, object)
+include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization]
++
+Refer to <<tokenization-properties>> to review the properties of the
+`tokenization` object.
+=====
+
+`text_expansion`:::
+(Object, optional)
+include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-text_expansion]
++
+.Properties of text_expansion inference
+[%collapsible%open]
+=====
 `results_field`::::
 (Optional, string)
 include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]

--- a/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
@@ -594,7 +594,7 @@ Refer to <<tokenization-properties>> to review the properties of the
 
 `text_expansion`:::
 (Object, optional)
-include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-text_expansion]
+include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-text-expansion]
 +
 .Properties of text_expansion inference
 [%collapsible%open]

--- a/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
@@ -594,7 +594,7 @@ Refer to <<tokenization-properties>> to review the properties of the
 
 `text_expansion`:::
 (Object, optional)
-include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-text-expansion]
+include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-expansion]
 +
 .Properties of text_expansion inference
 [%collapsible%open]


### PR DESCRIPTION
The `text_expansion` task type is used in the ML trained models APIs for sparse embedding models such as ELSER but in is not documented in the create ml trained models docs.  Now that Eland has been enhanced to support other sparse embedding models (https://github.com/elastic/eland/pull/740) there are other models that a user can upload that use the text_expansion task type. 