### PR TITLE
[Gradle] Fix deprecation warning in branchConsistency task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -365,7 +365,7 @@ tasks.register("verifyBwcTestsEnabled") {
 
 tasks.register("branchConsistency") {
   description = 'Ensures this branch is internally consistent. For example, that versions constants match released versions.'
-  group 'Verification'
+  group = 'Verification'
   dependsOn ":verifyVersions", ":verifyBwcTestsEnabled"
 }
 


### PR DESCRIPTION
The groovy syntax we use in branchConsistency task was deprecated in gradle 8.12