### PR TITLE
[8.17] [Gradle] Fix deprecation warning in branchConsistency task (#119587)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -372,7 +372,7 @@ tasks.register("verifyBwcTestsEnabled") {
 
 tasks.register("branchConsistency") {
   description = 'Ensures this branch is internally consistent. For example, that versions constants match released versions.'
-  group 'Verification'
+  group = 'Verification'
   dependsOn ":verifyVersions", ":verifyBwcTestsEnabled"
 }
 


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [Gradle] Fix deprecation warning in branchConsistency task (#119587)