### PR TITLE
Use unsecure entropy source in docker packaging tests

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
@@ -117,11 +117,7 @@ public class DockerRun {
 
         // Add default java opts
         for (String envVar : List.of("CLI_JAVA_OPTS", "ES_JAVA_OPTS")) {
-            if (this.envVars.containsKey(envVar)) {
-                this.envVars.put(envVar, this.envVars.get(envVar) + " " + DEFAULT_JAVA_OPTS);
-            } else {
-                this.envVars.put(envVar, DEFAULT_JAVA_OPTS);
-            }
+            this.envVars.put(envVar, this.envVars.getOrDefault(envVar, "") + " " + DEFAULT_JAVA_OPTS);
         }
 
         this.envVars.forEach((key, value) -> cmd.add("--env " + key + "=\"" + value + "\""));

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
@@ -116,10 +116,12 @@ public class DockerRun {
         cmd.add("--memory " + memory);
 
         // Add default java opts
-        if (this.envVars.containsKey("CLI_JAVA_OPTS")) {
-            this.envVars.put("CLI_JAVA_OPTS", this.envVars.get("CLI_JAVA_OPTS") + " " + DEFAULT_JAVA_OPTS);
-        } else {
-            this.envVars.put("CLI_JAVA_OPTS", DEFAULT_JAVA_OPTS);
+        for (String envVar : List.of("CLI_JAVA_OPTS", "ES_JAVA_OPTS")) {
+            if (this.envVars.containsKey(envVar)) {
+                this.envVars.put(envVar, this.envVars.get(envVar) + " " + DEFAULT_JAVA_OPTS);
+            } else {
+                this.envVars.put(envVar, DEFAULT_JAVA_OPTS);
+            }
         }
 
         this.envVars.forEach((key, value) -> cmd.add("--env " + key + "=\"" + value + "\""));

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
@@ -29,6 +29,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class DockerRun {
 
+    // Use less secure entropy source to avoid hanging when generating certificates
+    private static final String DEFAULT_JAVA_OPTS = "-Djava.security.egd=file:/dev/urandom";
+
     private Distribution distribution;
     private final Map<String, String> envVars = new HashMap<>();
     private final Map<Path, Path> volumes = new HashMap<>();
@@ -111,6 +114,13 @@ public class DockerRun {
 
         // Limit container memory
         cmd.add("--memory " + memory);
+
+        // Add default java opts
+        if (this.envVars.containsKey("CLI_JAVA_OPTS")) {
+            this.envVars.put("CLI_JAVA_OPTS", this.envVars.get("CLI_JAVA_OPTS") + " " + DEFAULT_JAVA_OPTS);
+        } else {
+            this.envVars.put("CLI_JAVA_OPTS", DEFAULT_JAVA_OPTS);
+        }
 
         this.envVars.forEach((key, value) -> cmd.add("--env " + key + "=\"" + value + "\""));
 


### PR DESCRIPTION
While investigating https://github.com/elastic/elasticsearch/issues/119441 thread dumps indicate [container startup hung up in security auto-configuration](https://gradle-enterprise.elastic.co/s/fqhss6idxlrvo/tests/task/:qa:packaging:destructiveDistroTest.default-dockerWolfi/details/org.elasticsearch.packaging.test.DockerTests/test010Install?focused-exception-line=0-36&top-execution=1) generating certificates. This is likely due to a low source of entropy during these tests as they run serially so there is little other activity on the host machine. This change configures ES to use `/dev/urandom` as the entropy source, which while less secure, should alleviate the problem.