### PR TITLE
[8.x] Move SlowLogFieldProvider instantiation to node construction (#117949)

### DIFF
--- a/docs/changelog/117949.yaml
+++ b/docs/changelog/117949.yaml
@@ -1,0 +1,5 @@
+pr: 117949
+summary: Move `SlowLogFieldProvider` instantiation to node construction
+area: Infra/Logging
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -208,8 +208,9 @@ public final class IndexModule {
         this.engineFactory = Objects.requireNonNull(engineFactory);
         // Need to have a mutable arraylist for plugins to add listeners to it
         this.searchOperationListeners = new ArrayList<>(searchOperationListeners);
-        this.searchOperationListeners.add(new SearchSlowLog(indexSettings, slowLogFieldProvider));
-        this.indexOperationListeners.add(new IndexingSlowLog(indexSettings, slowLogFieldProvider));
+        SlowLogFields slowLogFields = slowLogFieldProvider.create(indexSettings);
+        this.searchOperationListeners.add(new SearchSlowLog(indexSettings, slowLogFields));
+        this.indexOperationListeners.add(new IndexingSlowLog(indexSettings, slowLogFields));
         this.directoryFactories = Collections.unmodifiableMap(directoryFactories);
         this.allowExpensiveQueries = allowExpensiveQueries;
         this.expressionResolver = expressionResolver;

--- a/server/src/main/java/org/elasticsearch/index/IndexingSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexingSlowLog.java
@@ -103,7 +103,7 @@ public final class IndexingSlowLog implements IndexingOperationListener {
      * <em>characters</em> of the source.
      */
     private int maxSourceCharsToLog;
-    private final SlowLogFieldProvider slowLogFieldProvider;
+    private final SlowLogFields slowLogFields;
 
     /**
      * Reads how much of the source to log. The user can specify any value they
@@ -125,8 +125,8 @@ public final class IndexingSlowLog implements IndexingOperationListener {
         Property.IndexScope
     );
 
-    IndexingSlowLog(IndexSettings indexSettings, SlowLogFieldProvider slowLogFieldProvider) {
-        this.slowLogFieldProvider = slowLogFieldProvider;
+    IndexingSlowLog(IndexSettings indexSettings, SlowLogFields slowLogFields) {
+        this.slowLogFields = slowLogFields;
         this.index = indexSettings.getIndex();
 
         indexSettings.getScopedSettings().addSettingsUpdateConsumer(INDEX_INDEXING_SLOWLOG_REFORMAT_SETTING, this::setReformat);
@@ -179,47 +179,19 @@ public final class IndexingSlowLog implements IndexingOperationListener {
             final long tookInNanos = result.getTook();
             if (indexWarnThreshold >= 0 && tookInNanos > indexWarnThreshold) {
                 indexLogger.warn(
-                    IndexingSlowLogMessage.of(
-                        this.slowLogFieldProvider.indexSlowLogFields(),
-                        index,
-                        doc,
-                        tookInNanos,
-                        reformat,
-                        maxSourceCharsToLog
-                    )
+                    IndexingSlowLogMessage.of(this.slowLogFields.indexFields(), index, doc, tookInNanos, reformat, maxSourceCharsToLog)
                 );
             } else if (indexInfoThreshold >= 0 && tookInNanos > indexInfoThreshold) {
                 indexLogger.info(
-                    IndexingSlowLogMessage.of(
-                        this.slowLogFieldProvider.indexSlowLogFields(),
-                        index,
-                        doc,
-                        tookInNanos,
-                        reformat,
-                        maxSourceCharsToLog
-                    )
+                    IndexingSlowLogMessage.of(this.slowLogFields.indexFields(), index, doc, tookInNanos, reformat, maxSourceCharsToLog)
                 );
             } else if (indexDebugThreshold >= 0 && tookInNanos > indexDebugThreshold) {
                 indexLogger.debug(
-                    IndexingSlowLogMessage.of(
-                        this.slowLogFieldProvider.indexSlowLogFields(),
-                        index,
-                        doc,
-                        tookInNanos,
-                        reformat,
-                        maxSourceCharsToLog
-                    )
+                    IndexingSlowLogMessage.of(this.slowLogFields.indexFields(), index, doc, tookInNanos, reformat, maxSourceCharsToLog)
                 );
             } else if (indexTraceThreshold >= 0 && tookInNanos > indexTraceThreshold) {
                 indexLogger.trace(
-                    IndexingSlowLogMessage.of(
-                        this.slowLogFieldProvider.indexSlowLogFields(),
-                        index,
-                        doc,
-                        tookInNanos,
-                        reformat,
-                        maxSourceCharsToLog
-                    )
+                    IndexingSlowLogMessage.of(this.slowLogFields.indexFields(), index, doc, tookInNanos, reformat, maxSourceCharsToLog)
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -45,7 +45,7 @@ public final class SearchSlowLog implements SearchOperationListener {
     private static final Logger queryLogger = LogManager.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".query");
     private static final Logger fetchLogger = LogManager.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".fetch");
 
-    private final SlowLogFieldProvider slowLogFieldProvider;
+    private final SlowLogFields slowLogFields;
 
     public static final Setting<Boolean> INDEX_SEARCH_SLOWLOG_INCLUDE_USER_SETTING = Setting.boolSetting(
         INDEX_SEARCH_SLOWLOG_PREFIX + ".include.user",
@@ -126,9 +126,8 @@ public final class SearchSlowLog implements SearchOperationListener {
 
     private static final ToXContent.Params FORMAT_PARAMS = new ToXContent.MapParams(Collections.singletonMap("pretty", "false"));
 
-    public SearchSlowLog(IndexSettings indexSettings, SlowLogFieldProvider slowLogFieldProvider) {
-        slowLogFieldProvider.init(indexSettings);
-        this.slowLogFieldProvider = slowLogFieldProvider;
+    public SearchSlowLog(IndexSettings indexSettings, SlowLogFields slowLogFields) {
+        this.slowLogFields = slowLogFields;
         indexSettings.getScopedSettings()
             .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING, this::setQueryWarnThreshold);
         this.queryWarnThreshold = indexSettings.getValue(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING).nanos();
@@ -159,26 +158,26 @@ public final class SearchSlowLog implements SearchOperationListener {
     @Override
     public void onQueryPhase(SearchContext context, long tookInNanos) {
         if (queryWarnThreshold >= 0 && tookInNanos > queryWarnThreshold) {
-            queryLogger.warn(SearchSlowLogMessage.of(this.slowLogFieldProvider.searchSlowLogFields(), context, tookInNanos));
+            queryLogger.warn(SearchSlowLogMessage.of(this.slowLogFields.searchFields(), context, tookInNanos));
         } else if (queryInfoThreshold >= 0 && tookInNanos > queryInfoThreshold) {
-            queryLogger.info(SearchSlowLogMessage.of(this.slowLogFieldProvider.searchSlowLogFields(), context, tookInNanos));
+            queryLogger.info(SearchSlowLogMessage.of(this.slowLogFields.searchFields(), context, tookInNanos));
         } else if (queryDebugThreshold >= 0 && tookInNanos > queryDebugThreshold) {
-            queryLogger.debug(SearchSlowLogMessage.of(this.slowLogFieldProvider.searchSlowLogFields(), context, tookInNanos));
+            queryLogger.debug(SearchSlowLogMessage.of(this.slowLogFields.searchFields(), context, tookInNanos));
         } else if (queryTraceThreshold >= 0 && tookInNanos > queryTraceThreshold) {
-            queryLogger.trace(SearchSlowLogMessage.of(this.slowLogFieldProvider.searchSlowLogFields(), context, tookInNanos));
+            queryLogger.trace(SearchSlowLogMessage.of(this.slowLogFields.searchFields(), context, tookInNanos));
         }
     }
 
     @Override
     public void onFetchPhase(SearchContext context, long tookInNanos) {
         if (fetchWarnThreshold >= 0 && tookInNanos > fetchWarnThreshold) {
-            fetchLogger.warn(SearchSlowLogMessage.of(this.slowLogFieldProvider.searchSlowLogFields(), context, tookInNanos));
+            fetchLogger.warn(SearchSlowLogMessage.of(this.slowLogFields.searchFields(), context, tookInNanos));
         } else if (fetchInfoThreshold >= 0 && tookInNanos > fetchInfoThreshold) {
-            fetchLogger.info(SearchSlowLogMessage.of(this.slowLogFieldProvider.searchSlowLogFields(), context, tookInNanos));
+            fetchLogger.info(SearchSlowLogMessage.of(this.slowLogFields.searchFields(), context, tookInNanos));
         } else if (fetchDebugThreshold >= 0 && tookInNanos > fetchDebugThreshold) {
-            fetchLogger.debug(SearchSlowLogMessage.of(this.slowLogFieldProvider.searchSlowLogFields(), context, tookInNanos));
+            fetchLogger.debug(SearchSlowLogMessage.of(this.slowLogFields.searchFields(), context, tookInNanos));
         } else if (fetchTraceThreshold >= 0 && tookInNanos > fetchTraceThreshold) {
-            fetchLogger.trace(SearchSlowLogMessage.of(this.slowLogFieldProvider.searchSlowLogFields(), context, tookInNanos));
+            fetchLogger.trace(SearchSlowLogMessage.of(this.slowLogFields.searchFields(), context, tookInNanos));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/SlowLogFields.java
+++ b/server/src/main/java/org/elasticsearch/index/SlowLogFields.java
@@ -9,14 +9,22 @@
 
 package org.elasticsearch.index;
 
+import java.util.Map;
+
 /**
- * Interface for providing additional fields to the slow log from a plugin.
- * Intended to be loaded through SPI.
+ * Fields for the slow log. These may be different each call depending on the state of the system.
  */
-public interface SlowLogFieldProvider {
+public interface SlowLogFields {
+
     /**
-     * Create a field provider with index level settings to be able to listen for updates and set initial values
-     * @param indexSettings settings for the index
+     * Slow log fields for indexing events
+     * @return map of field name to value
      */
-    SlowLogFields create(IndexSettings indexSettings);
+    Map<String, String> indexFields();
+
+    /**
+     * Slow log fields for search events
+     * @return map of field name to value
+     */
+    Map<String, String> searchFields();
 }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesServiceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesServiceBuilder.java
@@ -23,6 +23,8 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.gateway.MetaStateService;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.SlowLogFieldProvider;
+import org.elasticsearch.index.SlowLogFields;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.mapper.MapperMetrics;
@@ -79,6 +81,22 @@ public class IndicesServiceBuilder {
     MapperMetrics mapperMetrics;
     List<SearchOperationListener> searchOperationListener = List.of();
     QueryRewriteInterceptor queryRewriteInterceptor = null;
+    SlowLogFieldProvider slowLogFieldProvider = new SlowLogFieldProvider() {
+        @Override
+        public SlowLogFields create(IndexSettings indexSettings) {
+            return new SlowLogFields() {
+                @Override
+                public Map<String, String> indexFields() {
+                    return Map.of();
+                }
+
+                @Override
+                public Map<String, String> searchFields() {
+                    return Map.of();
+                }
+            };
+        }
+    };
 
     public IndicesServiceBuilder settings(Settings settings) {
         this.settings = settings;
@@ -191,6 +209,11 @@ public class IndicesServiceBuilder {
         return this;
     }
 
+    public IndicesServiceBuilder slowLogFieldProvider(SlowLogFieldProvider slowLogFieldProvider) {
+        this.slowLogFieldProvider = slowLogFieldProvider;
+        return this;
+    }
+
     public IndicesService build() {
         Objects.requireNonNull(settings);
         Objects.requireNonNull(pluginsService);
@@ -216,6 +239,7 @@ public class IndicesServiceBuilder {
         Objects.requireNonNull(snapshotCommitSuppliers);
         Objects.requireNonNull(mapperMetrics);
         Objects.requireNonNull(searchOperationListener);
+        Objects.requireNonNull(slowLogFieldProvider);
 
         // collect engine factory providers from plugins
         engineFactoryProviders = pluginsService.filterPlugins(EnginePlugin.class)

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -113,6 +113,8 @@ import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettingProvider;
 import org.elasticsearch.index.IndexSettingProviders;
 import org.elasticsearch.index.IndexingPressure;
+import org.elasticsearch.index.SlowLogFieldProvider;
+import org.elasticsearch.index.SlowLogFields;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.SourceFieldMetrics;
@@ -808,6 +810,31 @@ class NodeConstruction {
             new ShardSearchPhaseAPMMetrics(telemetryProvider.getMeterRegistry())
         );
 
+        List<? extends SlowLogFieldProvider> slowLogFieldProviders = pluginsService.loadServiceProviders(SlowLogFieldProvider.class);
+        // NOTE: the response of index/search slow log fields below must be calculated dynamically on every call
+        // because the responses may change dynamically at runtime
+        SlowLogFieldProvider slowLogFieldProvider = indexSettings -> {
+            final List<SlowLogFields> fields = new ArrayList<>();
+            for (var provider : slowLogFieldProviders) {
+                fields.add(provider.create(indexSettings));
+            }
+            return new SlowLogFields() {
+                @Override
+                public Map<String, String> indexFields() {
+                    return fields.stream()
+                        .flatMap(f -> f.indexFields().entrySet().stream())
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                }
+
+                @Override
+                public Map<String, String> searchFields() {
+                    return fields.stream()
+                        .flatMap(f -> f.searchFields().entrySet().stream())
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                }
+            };
+        };
+
         IndicesService indicesService = new IndicesServiceBuilder().settings(settings)
             .pluginsService(pluginsService)
             .nodeEnvironment(nodeEnvironment)
@@ -829,6 +856,7 @@ class NodeConstruction {
             .requestCacheKeyDifferentiator(searchModule.getRequestCacheKeyDifferentiator())
             .mapperMetrics(mapperMetrics)
             .searchOperationListeners(searchOperationListeners)
+            .slowLogFieldProvider(slowLogFieldProvider)
             .build();
 
         final var parameters = new IndexSettingProvider.Parameters(clusterService, indicesService::createIndexMapperServiceForValidation);

--- a/server/src/test/java/org/elasticsearch/index/IndexingSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexingSlowLogTests.java
@@ -81,7 +81,7 @@ public class IndexingSlowLogTests extends ESTestCase {
         String uuid = UUIDs.randomBase64UUID();
         IndexMetadata metadata = createIndexMetadata("index-precedence", settings(uuid));
         IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-        IndexingSlowLog log = new IndexingSlowLog(settings, mock(SlowLogFieldProvider.class));
+        IndexingSlowLog log = new IndexingSlowLog(settings, mock(SlowLogFields.class));
 
         ParsedDocument doc = EngineTestCase.createParsedDoc("1", null);
         Engine.Index index = new Engine.Index(Uid.encodeId("doc_id"), randomNonNegativeLong(), doc);
@@ -142,7 +142,7 @@ public class IndexingSlowLogTests extends ESTestCase {
             ),
             Settings.EMPTY
         );
-        IndexingSlowLog log1 = new IndexingSlowLog(index1Settings, mock(SlowLogFieldProvider.class));
+        IndexingSlowLog log1 = new IndexingSlowLog(index1Settings, mock(SlowLogFields.class));
 
         IndexSettings index2Settings = new IndexSettings(
             createIndexMetadata(
@@ -155,7 +155,7 @@ public class IndexingSlowLogTests extends ESTestCase {
             ),
             Settings.EMPTY
         );
-        IndexingSlowLog log2 = new IndexingSlowLog(index2Settings, mock(SlowLogFieldProvider.class));
+        IndexingSlowLog log2 = new IndexingSlowLog(index2Settings, mock(SlowLogFields.class));
 
         ParsedDocument doc = EngineTestCase.createParsedDoc("1", null);
         Engine.Index index = new Engine.Index(Uid.encodeId("doc_id"), randomNonNegativeLong(), doc);
@@ -179,12 +179,12 @@ public class IndexingSlowLogTests extends ESTestCase {
         LoggerContext context = (LoggerContext) LogManager.getContext(false);
 
         IndexSettings index1Settings = new IndexSettings(createIndexMetadata("index1", settings(UUIDs.randomBase64UUID())), Settings.EMPTY);
-        IndexingSlowLog log1 = new IndexingSlowLog(index1Settings, mock(SlowLogFieldProvider.class));
+        IndexingSlowLog log1 = new IndexingSlowLog(index1Settings, mock(SlowLogFields.class));
 
         int numberOfLoggersBefore = context.getLoggers().size();
 
         IndexSettings index2Settings = new IndexSettings(createIndexMetadata("index2", settings(UUIDs.randomBase64UUID())), Settings.EMPTY);
-        IndexingSlowLog log2 = new IndexingSlowLog(index2Settings, mock(SlowLogFieldProvider.class));
+        IndexingSlowLog log2 = new IndexingSlowLog(index2Settings, mock(SlowLogFields.class));
         context = (LoggerContext) LogManager.getContext(false);
 
         int numberOfLoggersAfter = context.getLoggers().size();
@@ -355,7 +355,7 @@ public class IndexingSlowLogTests extends ESTestCase {
                 .build()
         );
         IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-        IndexingSlowLog log = new IndexingSlowLog(settings, mock(SlowLogFieldProvider.class));
+        IndexingSlowLog log = new IndexingSlowLog(settings, mock(SlowLogFields.class));
         assertFalse(log.isReformat());
         settings.updateIndexMetadata(
             newIndexMeta("index", Settings.builder().put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_REFORMAT_SETTING.getKey(), "true").build())
@@ -372,7 +372,7 @@ public class IndexingSlowLogTests extends ESTestCase {
 
         metadata = newIndexMeta("index", Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build());
         settings = new IndexSettings(metadata, Settings.EMPTY);
-        log = new IndexingSlowLog(settings, mock(SlowLogFieldProvider.class));
+        log = new IndexingSlowLog(settings, mock(SlowLogFields.class));
         assertTrue(log.isReformat());
         try {
             settings.updateIndexMetadata(
@@ -405,7 +405,7 @@ public class IndexingSlowLogTests extends ESTestCase {
                 .build()
         );
         IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-        IndexingSlowLog log = new IndexingSlowLog(settings, mock(SlowLogFieldProvider.class));
+        IndexingSlowLog log = new IndexingSlowLog(settings, mock(SlowLogFields.class));
         assertEquals(TimeValue.timeValueMillis(100).nanos(), log.getIndexTraceThreshold());
         assertEquals(TimeValue.timeValueMillis(200).nanos(), log.getIndexDebugThreshold());
         assertEquals(TimeValue.timeValueMillis(300).nanos(), log.getIndexInfoThreshold());
@@ -436,7 +436,7 @@ public class IndexingSlowLogTests extends ESTestCase {
         assertEquals(TimeValue.timeValueMillis(-1).nanos(), log.getIndexWarnThreshold());
 
         settings = new IndexSettings(metadata, Settings.EMPTY);
-        log = new IndexingSlowLog(settings, mock(SlowLogFieldProvider.class));
+        log = new IndexingSlowLog(settings, mock(SlowLogFields.class));
 
         assertEquals(TimeValue.timeValueMillis(-1).nanos(), log.getIndexTraceThreshold());
         assertEquals(TimeValue.timeValueMillis(-1).nanos(), log.getIndexDebugThreshold());

--- a/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
@@ -103,7 +103,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         try (SearchContext ctx = searchContextWithSourceAndTask(createIndex("index"))) {
             String uuid = UUIDs.randomBase64UUID();
             IndexSettings settings = new IndexSettings(createIndexMetadata("index", settings(uuid)), Settings.EMPTY);
-            SearchSlowLog log = new SearchSlowLog(settings, mock(SlowLogFieldProvider.class));
+            SearchSlowLog log = new SearchSlowLog(settings, mock(SlowLogFields.class));
 
             // For this test, when level is not breached, the level below should be used.
             {
@@ -187,7 +187,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                 ),
                 Settings.EMPTY
             );
-            SearchSlowLog log1 = new SearchSlowLog(settings1, mock(SlowLogFieldProvider.class));
+            SearchSlowLog log1 = new SearchSlowLog(settings1, mock(SlowLogFields.class));
 
             IndexSettings settings2 = new IndexSettings(
                 createIndexMetadata(
@@ -200,7 +200,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                 ),
                 Settings.EMPTY
             );
-            SearchSlowLog log2 = new SearchSlowLog(settings2, mock(SlowLogFieldProvider.class));
+            SearchSlowLog log2 = new SearchSlowLog(settings2, mock(SlowLogFields.class));
 
             {
                 // threshold set on WARN only, should not log
@@ -223,7 +223,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
 
         try (SearchContext ctx1 = searchContextWithSourceAndTask(createIndex("index-1"))) {
             IndexSettings settings1 = new IndexSettings(createIndexMetadata("index-1", settings(UUIDs.randomBase64UUID())), Settings.EMPTY);
-            SearchSlowLog log1 = new SearchSlowLog(settings1, mock(SlowLogFieldProvider.class));
+            SearchSlowLog log1 = new SearchSlowLog(settings1, mock(SlowLogFields.class));
             int numberOfLoggersBefore = context.getLoggers().size();
 
             try (SearchContext ctx2 = searchContextWithSourceAndTask(createIndex("index-2"))) {
@@ -231,7 +231,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                     createIndexMetadata("index-2", settings(UUIDs.randomBase64UUID())),
                     Settings.EMPTY
                 );
-                SearchSlowLog log2 = new SearchSlowLog(settings2, mock(SlowLogFieldProvider.class));
+                SearchSlowLog log2 = new SearchSlowLog(settings2, mock(SlowLogFields.class));
 
                 int numberOfLoggersAfter = context.getLoggers().size();
                 assertThat(numberOfLoggersAfter, equalTo(numberOfLoggersBefore));
@@ -323,7 +323,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                 .build()
         );
         IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-        SearchSlowLog log = new SearchSlowLog(settings, mock(SlowLogFieldProvider.class));
+        SearchSlowLog log = new SearchSlowLog(settings, mock(SlowLogFields.class));
         assertEquals(TimeValue.timeValueMillis(100).nanos(), log.getQueryTraceThreshold());
         assertEquals(TimeValue.timeValueMillis(200).nanos(), log.getQueryDebugThreshold());
         assertEquals(TimeValue.timeValueMillis(300).nanos(), log.getQueryInfoThreshold());
@@ -354,7 +354,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         assertEquals(TimeValue.timeValueMillis(-1).nanos(), log.getQueryWarnThreshold());
 
         settings = new IndexSettings(metadata, Settings.EMPTY);
-        log = new SearchSlowLog(settings, mock(SlowLogFieldProvider.class));
+        log = new SearchSlowLog(settings, mock(SlowLogFields.class));
 
         assertEquals(TimeValue.timeValueMillis(-1).nanos(), log.getQueryTraceThreshold());
         assertEquals(TimeValue.timeValueMillis(-1).nanos(), log.getQueryDebugThreshold());
@@ -429,7 +429,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                 .build()
         );
         IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-        SearchSlowLog log = new SearchSlowLog(settings, mock(SlowLogFieldProvider.class));
+        SearchSlowLog log = new SearchSlowLog(settings, mock(SlowLogFields.class));
         assertEquals(TimeValue.timeValueMillis(100).nanos(), log.getFetchTraceThreshold());
         assertEquals(TimeValue.timeValueMillis(200).nanos(), log.getFetchDebugThreshold());
         assertEquals(TimeValue.timeValueMillis(300).nanos(), log.getFetchInfoThreshold());
@@ -460,7 +460,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         assertEquals(TimeValue.timeValueMillis(-1).nanos(), log.getFetchWarnThreshold());
 
         settings = new IndexSettings(metadata, Settings.EMPTY);
-        log = new SearchSlowLog(settings, mock(SlowLogFieldProvider.class));
+        log = new SearchSlowLog(settings, mock(SlowLogFields.class));
 
         assertEquals(TimeValue.timeValueMillis(-1).nanos(), log.getFetchTraceThreshold());
         assertEquals(TimeValue.timeValueMillis(-1).nanos(), log.getFetchDebugThreshold());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/slowlog/SecuritySlowLogFieldProvider.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/slowlog/SecuritySlowLogFieldProvider.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.security.slowlog;
 
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.SlowLogFieldProvider;
+import org.elasticsearch.index.SlowLogFields;
 import org.elasticsearch.xpack.security.Security;
 
 import java.util.Map;
@@ -18,8 +19,36 @@ import static org.elasticsearch.index.SearchSlowLog.INDEX_SEARCH_SLOWLOG_INCLUDE
 
 public class SecuritySlowLogFieldProvider implements SlowLogFieldProvider {
     private final Security plugin;
-    private boolean includeUserInIndexing = false;
-    private boolean includeUserInSearch = false;
+
+    private class SecuritySlowLogFields implements SlowLogFields {
+        private boolean includeUserInIndexing = false;
+        private boolean includeUserInSearch = false;
+
+        SecuritySlowLogFields(IndexSettings indexSettings) {
+            indexSettings.getScopedSettings()
+                .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_INCLUDE_USER_SETTING, newValue -> this.includeUserInSearch = newValue);
+            this.includeUserInSearch = indexSettings.getValue(INDEX_SEARCH_SLOWLOG_INCLUDE_USER_SETTING);
+            indexSettings.getScopedSettings()
+                .addSettingsUpdateConsumer(INDEX_INDEXING_SLOWLOG_INCLUDE_USER_SETTING, newValue -> this.includeUserInIndexing = newValue);
+            this.includeUserInIndexing = indexSettings.getValue(INDEX_INDEXING_SLOWLOG_INCLUDE_USER_SETTING);
+        }
+
+        @Override
+        public Map<String, String> indexFields() {
+            if (includeUserInIndexing) {
+                return plugin.getAuthContextForSlowLog();
+            }
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, String> searchFields() {
+            if (includeUserInSearch) {
+                return plugin.getAuthContextForSlowLog();
+            }
+            return Map.of();
+        }
+    }
 
     public SecuritySlowLogFieldProvider() {
         throw new IllegalStateException("Provider must be constructed using PluginsService");
@@ -30,28 +59,7 @@ public class SecuritySlowLogFieldProvider implements SlowLogFieldProvider {
     }
 
     @Override
-    public void init(IndexSettings indexSettings) {
-        indexSettings.getScopedSettings()
-            .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_INCLUDE_USER_SETTING, newValue -> this.includeUserInSearch = newValue);
-        this.includeUserInSearch = indexSettings.getValue(INDEX_SEARCH_SLOWLOG_INCLUDE_USER_SETTING);
-        indexSettings.getScopedSettings()
-            .addSettingsUpdateConsumer(INDEX_INDEXING_SLOWLOG_INCLUDE_USER_SETTING, newValue -> this.includeUserInIndexing = newValue);
-        this.includeUserInIndexing = indexSettings.getValue(INDEX_INDEXING_SLOWLOG_INCLUDE_USER_SETTING);
-    }
-
-    @Override
-    public Map<String, String> indexSlowLogFields() {
-        if (includeUserInIndexing) {
-            return plugin.getAuthContextForSlowLog();
-        }
-        return Map.of();
-    }
-
-    @Override
-    public Map<String, String> searchSlowLogFields() {
-        if (includeUserInSearch) {
-            return plugin.getAuthContextForSlowLog();
-        }
-        return Map.of();
+    public SlowLogFields create(IndexSettings indexSettings) {
+        return new SecuritySlowLogFields(indexSettings);
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Move SlowLogFieldProvider instantiation to node construction (#117949)