### PR TITLE
[8.x] Use unsecure entropy source in docker packaging tests (#119598)

### DIFF
--- a/.ci/scripts/packaging-test.ps1
+++ b/.ci/scripts/packaging-test.ps1
@@ -27,6 +27,6 @@ Remove-Item -Recurse -Force \tmp -ErrorAction Ignore
 New-Item -ItemType directory -Path \tmp
 
 $ErrorActionPreference="Continue"
-& .\gradlew.bat -g "$env:USERPROFILE\.gradle" --parallel --no-watch-fs --no-daemon --scan --console=plain $GradleTasks
+& .\gradlew.bat -g "$env:USERPROFILE\.gradle" --parallel --no-daemon --scan --console=plain $GradleTasks
 
 exit $LastExitCode

--- a/.ci/scripts/packaging-test.ps1
+++ b/.ci/scripts/packaging-test.ps1
@@ -27,6 +27,6 @@ Remove-Item -Recurse -Force \tmp -ErrorAction Ignore
 New-Item -ItemType directory -Path \tmp
 
 $ErrorActionPreference="Continue"
-& .\gradlew.bat -g "$env:USERPROFILE\.gradle" --parallel --no-daemon --scan --console=plain $GradleTasks
+& .\gradlew.bat -g "$env:USERPROFILE\.gradle" --parallel --no-watch-fs --no-daemon --scan --console=plain $GradleTasks
 
 exit $LastExitCode

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
@@ -29,6 +29,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class DockerRun {
 
+    // Use less secure entropy source to avoid hanging when generating certificates
+    private static final String DEFAULT_JAVA_OPTS = "-Djava.security.egd=file:/dev/urandom";
+
     private Distribution distribution;
     private final Map<String, String> envVars = new HashMap<>();
     private final Map<Path, Path> volumes = new HashMap<>();
@@ -111,6 +114,11 @@ public class DockerRun {
 
         // Limit container memory
         cmd.add("--memory " + memory);
+
+        // Add default java opts
+        for (String envVar : List.of("CLI_JAVA_OPTS", "ES_JAVA_OPTS")) {
+            this.envVars.put(envVar, this.envVars.getOrDefault(envVar, "") + " " + DEFAULT_JAVA_OPTS);
+        }
 
         this.envVars.forEach((key, value) -> cmd.add("--env " + key + "=\"" + value + "\""));
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Use unsecure entropy source in docker packaging tests (#119598)