### PR TITLE
Resolve/cluster API supports no index expression

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -149,6 +149,7 @@ public class TransportVersions {
     public static final TransportVersion TRANSFORMS_UPGRADE_MODE = def(8_814_00_0);
     public static final TransportVersion NODE_SHUTDOWN_EPHEMERAL_ID_ADDED = def(8_815_00_0);
     public static final TransportVersion ESQL_CCS_TELEMETRY_STATS = def(8_816_00_0);
+    public static final TransportVersion RESOLVE_CLUSTER_EXTRA_PARAMS = def(8_817_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
@@ -13,7 +13,6 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,6 +29,8 @@ import java.util.Objects;
 public class ResolveClusterActionRequest extends ActionRequest implements IndicesRequest.Replaceable {
 
     public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
+
+    public static final String TRANSPORT_VERSION_ERROR_MESSAGE_PREFIX = "ResolveClusterAction requires at least version";
 
     private String[] names;
     /*
@@ -49,16 +50,25 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
      */
     private boolean localIndicesRequested = false;
     private IndicesOptions indicesOptions;
+    // true if the user did not provide any index expression - they only want cluster level info, not index matching
+    private boolean clusterInfoOnly;
+    // whether this request is being processing on the primary ("local") cluster being queried or on a remote
+    // this is needed when clusterInfoOnly=true since we need to know whether to list out all possible remotes
+    // on a node. (We don't want cross-cluster chaining on remotes that might be configured with their own remotes.)
+    private boolean isQueryingCluster;
 
     public ResolveClusterActionRequest(String[] names) {
-        this(names, DEFAULT_INDICES_OPTIONS);
+        this(names, DEFAULT_INDICES_OPTIONS, false, true);
+        assert names != null && names.length > 0 : "One or more index expressions must be included with this constructor";
     }
 
     @SuppressWarnings("this-escape")
-    public ResolveClusterActionRequest(String[] names, IndicesOptions indicesOptions) {
+    public ResolveClusterActionRequest(String[] names, IndicesOptions indicesOptions, boolean clusterInfoOnly, boolean queryingCluster) {
         this.names = names;
         this.localIndicesRequested = localIndicesPresent(names);
         this.indicesOptions = indicesOptions;
+        this.clusterInfoOnly = clusterInfoOnly;
+        this.isQueryingCluster = queryingCluster;
     }
 
     @SuppressWarnings("this-escape")
@@ -66,7 +76,7 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
         super(in);
         if (in.getTransportVersion().before(TransportVersions.V_8_13_0)) {
             throw new UnsupportedOperationException(
-                "ResolveClusterAction requires at least version "
+                TRANSPORT_VERSION_ERROR_MESSAGE_PREFIX
                     + TransportVersions.V_8_13_0.toReleaseVersion()
                     + " but was "
                     + in.getTransportVersion().toReleaseVersion()
@@ -75,6 +85,13 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
         this.names = in.readStringArray();
         this.indicesOptions = IndicesOptions.readIndicesOptions(in);
         this.localIndicesRequested = localIndicesPresent(names);
+        if (in.getTransportVersion().onOrAfter(TransportVersions.RESOLVE_CLUSTER_EXTRA_PARAMS)) {
+            this.clusterInfoOnly = in.readBoolean();
+            this.isQueryingCluster = in.readBoolean();
+        } else {
+            this.clusterInfoOnly = false;
+            this.isQueryingCluster = false;
+        }
     }
 
     @Override
@@ -90,15 +107,15 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
         }
         out.writeStringArray(names);
         indicesOptions.writeIndicesOptions(out);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.RESOLVE_CLUSTER_EXTRA_PARAMS)) {
+            out.writeBoolean(clusterInfoOnly);
+            out.writeBoolean(isQueryingCluster);
+        }
     }
 
     @Override
     public ActionRequestValidationException validate() {
-        ActionRequestValidationException validationException = null;
-        if (names == null || names.length == 0) {
-            validationException = ValidateActions.addValidationError("no index expressions specified", validationException);
-        }
-        return validationException;
+        return null;
     }
 
     @Override
@@ -119,6 +136,14 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
     @Override
     public String[] indices() {
         return names;
+    }
+
+    public boolean clusterInfoOnly() {
+        return clusterInfoOnly;
+    }
+
+    public boolean queryingCluster() {
+        return isQueryingCluster;
     }
 
     public boolean isLocalIndicesRequested() {
@@ -158,7 +183,11 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
         return new CancellableTask(id, type, action, "", parentTaskId, headers) {
             @Override
             public String getDescription() {
-                return "resolve/cluster for " + Arrays.toString(indices());
+                if (indices().length == 0) {
+                    return "resolve/cluster";
+                } else {
+                    return "resolve/cluster for " + Arrays.toString(indices());
+                }
             }
         };
     }
@@ -170,5 +199,19 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
             }
         }
         return false;
+    }
+
+    @Override
+    public String toString() {
+        return "ResolveClusterActionRequest{"
+            + "names="
+            + Arrays.toString(names)
+            + ", localIndicesRequested="
+            + localIndicesRequested
+            + ", clusterInfoOnly="
+            + clusterInfoOnly
+            + ", queryingCluster="
+            + isQueryingCluster
+            + '}';
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
@@ -52,8 +52,8 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
     private IndicesOptions indicesOptions;
     // true if the user did not provide any index expression - they only want cluster level info, not index matching
     private boolean clusterInfoOnly;
-    // whether this request is being processing on the primary ("local") cluster being queried or on a remote
-    // this is needed when clusterInfoOnly=true since we need to know whether to list out all possible remotes
+    // Whether this request is being processed on the primary ("local") cluster being queried or on a remote.
+    // This is needed when clusterInfoOnly=true since we need to know whether to list out all possible remotes
     // on a node. (We don't want cross-cluster chaining on remotes that might be configured with their own remotes.)
     private boolean isQueryingCluster;
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterInfo.java
@@ -22,7 +22,7 @@ public class ResolveClusterInfo implements Writeable {
 
     private final boolean connected;
     private final Boolean skipUnavailable;  // remote clusters don't know their setting, so they put null and querying cluster fills in
-    private final Boolean matchingIndices;  // null means 'unknown' when not connected
+    private final Boolean matchingIndices;  // null means no index expression requested by user or remote cluster was not connected
     private final Build build;
     private final String error;
 
@@ -38,8 +38,14 @@ public class ResolveClusterInfo implements Writeable {
         this(connected, skipUnavailable, matchingIndices, build, null);
     }
 
-    public ResolveClusterInfo(ResolveClusterInfo copyFrom, boolean skipUnavailable) {
-        this(copyFrom.isConnected(), skipUnavailable, copyFrom.getMatchingIndices(), copyFrom.getBuild(), copyFrom.getError());
+    public ResolveClusterInfo(ResolveClusterInfo copyFrom, boolean skipUnavailable, boolean clusterInfoOnly) {
+        this(
+            copyFrom.isConnected(),
+            skipUnavailable,
+            clusterInfoOnly ? null : copyFrom.getMatchingIndices(),
+            copyFrom.getBuild(),
+            clusterInfoOnly ? null : copyFrom.getError()
+        );
     }
 
     private ResolveClusterInfo(boolean connected, Boolean skipUnavailable, Boolean matchingIndices, Build build, String error) {
@@ -48,7 +54,6 @@ public class ResolveClusterInfo implements Writeable {
         this.matchingIndices = matchingIndices;
         this.build = build;
         this.error = error;
-        assert error != null || matchingIndices != null || connected == false : "If matchingIndices is null, connected must be false";
     }
 
     public ResolveClusterInfo(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.injection.guice.Inject;
@@ -51,14 +52,13 @@ import static org.elasticsearch.action.search.TransportSearchHelper.checkCCSVers
 public class TransportResolveClusterAction extends HandledTransportAction<ResolveClusterActionRequest, ResolveClusterActionResponse> {
 
     private static final Logger logger = LogManager.getLogger(TransportResolveClusterAction.class);
-    private static final String TRANSPORT_VERSION_ERROR_MESSAGE = "ResolveClusterAction requires at least Transport Version";
-
     public static final String NAME = "indices:admin/resolve/cluster";
     public static final ActionType<ResolveClusterActionResponse> TYPE = new ActionType<>(NAME);
     public static final RemoteClusterActionType<ResolveClusterActionResponse> REMOTE_TYPE = new RemoteClusterActionType<>(
         NAME,
         ResolveClusterActionResponse::new
     );
+    private static final String DUMMY_IDX = "dummy";
 
     private final Executor searchCoordinationExecutor;
     private final ClusterService clusterService;
@@ -92,15 +92,35 @@ public class TransportResolveClusterAction extends HandledTransportAction<Resolv
         if (ccsCheckCompatibility) {
             checkCCSVersionCompatibility(request);
         }
+
         assert task instanceof CancellableTask;
         final CancellableTask resolveClusterTask = (CancellableTask) task;
         ClusterState clusterState = clusterService.state();
-        Map<String, OriginalIndices> remoteClusterIndices = remoteClusterService.groupIndices(request.indicesOptions(), request.indices());
+
+        Map<String, OriginalIndices> remoteClusterIndices;
+        if (request.clusterInfoOnly() && request.queryingCluster()) {
+            // user does not want to check whether an index expression matches
+            // use "*:*" to 1) discover all the configured remote clusters and 2) specify an index pattern
+            // of "*" for older clusters that do not have/understand the clusterInfoOnly flag on the request
+            remoteClusterIndices = remoteClusterService.groupIndices(request.indicesOptions(), new String[] { "*:" + DUMMY_IDX }, false);
+            if (remoteClusterIndices.isEmpty()) {
+                // no remote clusters are configured on the primary "querying" cluster
+                listener.onResponse(new ResolveClusterActionResponse(Map.of()));
+                return;
+            }
+        } else {
+            remoteClusterIndices = remoteClusterService.groupIndices(request.indicesOptions(), request.indices(), false);
+        }
+
         OriginalIndices localIndices = remoteClusterIndices.remove(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
 
         Map<String, ResolveClusterInfo> clusterInfoMap = new ConcurrentHashMap<>();
         // add local cluster info if in scope of the index-expression from user
-        if (localIndices != null) {
+        if (request.clusterInfoOnly() && request.queryingCluster() == false) {
+            // on the remote cluster if cluster info only is requested (localIndices == null), just return build info
+            ResolveClusterInfo resolveClusterInfo = new ResolveClusterInfo(true, false, null, Build.current());
+            clusterInfoMap.put(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY, resolveClusterInfo);
+        } else if (localIndices != null) {
             try {
                 boolean matchingIndices = hasMatchingIndices(localIndices, request.indicesOptions(), clusterState);
                 clusterInfoMap.put(
@@ -143,7 +163,14 @@ public class TransportResolveClusterAction extends HandledTransportAction<Resolv
                     searchCoordinationExecutor,
                     RemoteClusterService.DisconnectedStrategy.FAIL_IF_DISCONNECTED
                 );
-                var remoteRequest = new ResolveClusterActionRequest(originalIndices.indices(), request.indicesOptions());
+                // // MP TODO: can this ever actually be null now?
+                // String[] remoteIndicesArray = originalIndices.indices() != null ? originalIndices.indices() : new String[0];
+                var remoteRequest = new ResolveClusterActionRequest(
+                    originalIndices.indices(),
+                    request.indicesOptions(),
+                    request.clusterInfoOnly(),
+                    false
+                );
                 // allow cancellation requests to propagate to remote clusters
                 remoteRequest.setParentTask(clusterService.localNode().getId(), task.getId());
 
@@ -156,7 +183,7 @@ public class TransportResolveClusterAction extends HandledTransportAction<Resolv
                         }
                         ResolveClusterInfo info = response.getResolveClusterInfo().get(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
                         if (info != null) {
-                            clusterInfoMap.put(clusterAlias, new ResolveClusterInfo(info, skipUnavailable));
+                            clusterInfoMap.put(clusterAlias, new ResolveClusterInfo(info, skipUnavailable, request.clusterInfoOnly()));
                         }
                         if (resolveClusterTask.isCancelled()) {
                             releaseResourcesOnCancel(clusterInfoMap);
@@ -169,50 +196,41 @@ public class TransportResolveClusterAction extends HandledTransportAction<Resolv
                             releaseResourcesOnCancel(clusterInfoMap);
                             return;
                         }
+
                         if (ExceptionsHelper.isRemoteUnavailableException((failure))) {
                             clusterInfoMap.put(clusterAlias, new ResolveClusterInfo(false, skipUnavailable));
                         } else if (ExceptionsHelper.unwrap(
                             failure,
-                            ElasticsearchSecurityException.class
-                        ) instanceof ElasticsearchSecurityException ese) {
-                            clusterInfoMap.put(clusterAlias, new ResolveClusterInfo(true, skipUnavailable, ese.getMessage()));
-                        } else if (ExceptionsHelper.unwrap(failure, IndexNotFoundException.class) instanceof IndexNotFoundException infe) {
-                            clusterInfoMap.put(clusterAlias, new ResolveClusterInfo(true, skipUnavailable, infe.getMessage()));
+                            ElasticsearchSecurityException.class,
+                            IndexNotFoundException.class
+                        ) instanceof Exception knownCause) {
+                            if (request.clusterInfoOnly()) {
+                                // this error likely due to querying for the DUMMY_IDX on an older cluster that doesn't understand
+                                // the clusterInfoOnly query, so ignore the error and mark it as connected to the remote
+                                clusterInfoMap.put(clusterAlias, new ResolveClusterInfo(true, skipUnavailable));
+                            } else {
+                                clusterInfoMap.put(clusterAlias, new ResolveClusterInfo(true, skipUnavailable, knownCause.getMessage()));
+                            }
                         } else {
                             Throwable cause = ExceptionsHelper.unwrapCause(failure);
                             // when querying an older cluster that does not have the _resolve/cluster endpoint, we will get
                             // this error at the Transport layer BEFORE it sends the request to the remote cluster, since there
                             // are version guards on the Writeables for this Action, namely ResolveClusterActionRequest.writeTo
                             if (cause instanceof UnsupportedOperationException
-                                && cause.getMessage().contains(TRANSPORT_VERSION_ERROR_MESSAGE)) {
+                                && cause.getMessage().contains(ResolveClusterActionRequest.TRANSPORT_VERSION_ERROR_MESSAGE_PREFIX)) {
                                 // Since this cluster does not have _resolve/cluster, we call the _resolve/index
                                 // endpoint to fill in the matching_indices field of the response for that cluster
                                 ResolveIndexAction.Request resolveIndexRequest = new ResolveIndexAction.Request(
                                     originalIndices.indices(),
                                     originalIndices.indicesOptions()
                                 );
-                                ActionListener<ResolveIndexAction.Response> resolveIndexActionListener = new ActionListener<>() {
-                                    @Override
-                                    public void onResponse(ResolveIndexAction.Response response) {
-                                        boolean matchingIndices = response.getIndices().size() > 0
-                                            || response.getAliases().size() > 0
-                                            || response.getDataStreams().size() > 0;
-                                        clusterInfoMap.put(
-                                            clusterAlias,
-                                            new ResolveClusterInfo(true, skipUnavailable, matchingIndices, null)
-                                        );
-                                    }
-
-                                    @Override
-                                    public void onFailure(Exception e) {
-                                        Throwable cause = ExceptionsHelper.unwrapCause(e);
-                                        clusterInfoMap.put(clusterAlias, new ResolveClusterInfo(false, skipUnavailable, cause.toString()));
-                                        logger.warn(
-                                            () -> Strings.format("Failure from _resolve/cluster lookup against cluster %s: ", clusterAlias),
-                                            e
-                                        );
-                                    }
-                                };
+                                ActionListener<ResolveIndexAction.Response> resolveIndexActionListener = createResolveIndexActionListener(
+                                    clusterAlias,
+                                    request.clusterInfoOnly(),
+                                    skipUnavailable,
+                                    clusterInfoMap,
+                                    resolveClusterTask
+                                );
                                 remoteClusterClient.execute(
                                     ResolveIndexAction.REMOTE_TYPE,
                                     resolveIndexRequest,
@@ -232,6 +250,70 @@ public class TransportResolveClusterAction extends HandledTransportAction<Resolv
                         if (resolveClusterTask.isCancelled()) {
                             releaseResourcesOnCancel(clusterInfoMap);
                         }
+                    }
+
+                    /**
+                     * Create an ActionListener to handle responses from calls when falling back to use the resolve/index
+                     * endpoint from older clusters that don't have the resolve/cluster endpoint.
+                     */
+                    private static ActionListener<ResolveIndexAction.Response> createResolveIndexActionListener(
+                        String clusterAlias,
+                        boolean clusterInfoOnly,
+                        boolean skipUnavailable,
+                        Map<String, ResolveClusterInfo> clusterInfoMap,
+                        CancellableTask resolveClusterTask
+                    ) {
+                        ActionListener<ResolveIndexAction.Response> resolveIndexActionListener = new ActionListener<>() {
+                            @Override
+                            public void onResponse(ResolveIndexAction.Response response) {
+                                if (resolveClusterTask.isCancelled()) {
+                                    releaseResourcesOnCancel(clusterInfoMap);
+                                    return;
+                                }
+
+                                Boolean matchingIndices = null;
+                                if (clusterInfoOnly == false) {
+                                    matchingIndices = response.getIndices().size() > 0
+                                        || response.getAliases().size() > 0
+                                        || response.getDataStreams().size() > 0;
+                                }
+                                clusterInfoMap.put(clusterAlias, new ResolveClusterInfo(true, skipUnavailable, matchingIndices, null));
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                if (resolveClusterTask.isCancelled()) {
+                                    releaseResourcesOnCancel(clusterInfoMap);
+                                    return;
+                                }
+
+                                ResolveClusterInfo resolveClusterInfo;
+                                if (ExceptionsHelper.isRemoteUnavailableException((e))) {
+                                    resolveClusterInfo = new ResolveClusterInfo(false, skipUnavailable);
+                                } else if (clusterInfoOnly) {
+                                    resolveClusterInfo = new ResolveClusterInfo(true, skipUnavailable);
+                                } else {
+                                    Throwable knownCause = ExceptionsHelper.unwrap(
+                                        e,
+                                        ElasticsearchSecurityException.class,
+                                        IndexNotFoundException.class
+                                    );
+                                    if (knownCause != null) {
+                                        resolveClusterInfo = new ResolveClusterInfo(true, skipUnavailable, knownCause.getMessage());
+                                    } else {
+                                        // not clear what the error is here, so be safe and mark the cluster as not connected
+                                        String errorMessage = ExceptionsHelper.unwrapCause(e).getMessage();
+                                        resolveClusterInfo = new ResolveClusterInfo(false, skipUnavailable, errorMessage);
+                                        logger.warn(
+                                            () -> Strings.format("Failure from _resolve/index lookup against cluster %s: ", clusterAlias),
+                                            e
+                                        );
+                                    }
+                                }
+                                clusterInfoMap.put(clusterAlias, resolveClusterInfo);
+                            }
+                        };
+                        return resolveIndexActionListener;
                     }
                 };
                 remoteClusterClient.execute(
@@ -253,7 +335,11 @@ public class TransportResolveClusterAction extends HandledTransportAction<Resolv
      * @return true if indices has at least one matching non-closed index or any aliases or data streams match
      * @throws IndexNotFoundException if a (non-wildcarded) index, alias or data stream is requested
      */
-    private boolean hasMatchingIndices(OriginalIndices localIndices, IndicesOptions indicesOptions, ClusterState clusterState) {
+    private boolean hasMatchingIndices(@Nullable OriginalIndices localIndices, IndicesOptions indicesOptions, ClusterState clusterState) {
+        if (localIndices == null) {
+            return false;
+        }
+
         List<ResolveIndexAction.ResolvedIndex> indices = new ArrayList<>();
         List<ResolveIndexAction.ResolvedAlias> aliases = new ArrayList<>();
         List<ResolveIndexAction.ResolvedDataStream> dataStreams = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestResolveClusterAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestResolveClusterAction.java
@@ -34,15 +34,25 @@ public class RestResolveClusterAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/_resolve/cluster/{name}"));
+        return List.of(new Route(GET, "/_resolve/cluster"), new Route(GET, "/_resolve/cluster/{name}"));
     }
 
     @Override
     protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        String[] indexExpressions = Strings.splitStringByCommaToArray(request.param("name"));
+        String[] indexExpressions;
+        boolean clusterInfoOnly;
+        if (request.hasParam("name")) {
+            indexExpressions = Strings.splitStringByCommaToArray(request.param("name"));
+            clusterInfoOnly = false;
+        } else {
+            indexExpressions = new String[0];
+            clusterInfoOnly = true;
+        }
         ResolveClusterActionRequest resolveRequest = new ResolveClusterActionRequest(
             indexExpressions,
-            IndicesOptions.fromRequest(request, ResolveIndexAction.Request.DEFAULT_INDICES_OPTIONS)
+            IndicesOptions.fromRequest(request, ResolveIndexAction.Request.DEFAULT_INDICES_OPTIONS),
+            clusterInfoOnly,
+            true
         );
         return channel -> new RestCancellableNodeClient(client, request.getHttpChannel()).admin()
             .indices()

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -184,11 +184,14 @@ public final class RemoteClusterService extends RemoteClusterAware
     }
 
     /**
-     * TODO: DOCUMENT ME
-     * @param indicesOptions
-     * @param indices
-     * @param returnLocalAll
-     * @return
+     *
+     * @param indicesOptions IndicesOptions to clarify how the index expressions should be parsed/applied
+     * @param indices Multiple index expressions as string[].
+     * @param returnLocalAll whether to support the _all functionality needed by _search
+     *        (See https://github.com/elastic/elasticsearch/pull/33899). If true, and no indices are specified,
+     *        then a Map with one entry for the local cluster with an empty index array is returned.
+     *        If false, an empty map is returned when when no indices are specified.
+     * @return Map keyed by cluster alias having OriginalIndices as the map value parsed from the String[] indices argument
      */
     public Map<String, OriginalIndices> groupIndices(IndicesOptions indicesOptions, String[] indices, boolean returnLocalAll) {
         final Map<String, OriginalIndices> originalIndicesMap = new HashMap<>();
@@ -209,10 +212,11 @@ public final class RemoteClusterService extends RemoteClusterAware
     }
 
     /**
-     * TODO: DOCUMENT ME
+     * If no indices are specified, then a Map with one entry for the local cluster with an empty index array is returned.
+     * For details see {@code groupIndices(IndicesOptions indicesOptions, String[] indices, boolean returnLocalAll)}
      * @param indicesOptions IndicesOptions to clarify how the index expressions should be parsed/applied
      * @param indices Multiple index expressions as string[].
-     * @return
+     * @return Map keyed by cluster alias having OriginalIndices as the map value parsed from the String[] indices argument
      */
     public Map<String, OriginalIndices> groupIndices(IndicesOptions indicesOptions, String[] indices) {
         return groupIndices(indicesOptions, indices, true);

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -183,12 +183,21 @@ public final class RemoteClusterService extends RemoteClusterAware
         return remoteClusters.get(remoteCluster).isNodeConnected(node);
     }
 
-    public Map<String, OriginalIndices> groupIndices(IndicesOptions indicesOptions, String[] indices) {
+    /**
+     * TODO: DOCUMENT ME
+     * @param indicesOptions
+     * @param indices
+     * @param returnLocalAll
+     * @return
+     */
+    public Map<String, OriginalIndices> groupIndices(IndicesOptions indicesOptions, String[] indices, boolean returnLocalAll) {
         final Map<String, OriginalIndices> originalIndicesMap = new HashMap<>();
         final Map<String, List<String>> groupedIndices = groupClusterIndices(getRemoteClusterNames(), indices);
         if (groupedIndices.isEmpty()) {
-            // search on _all in the local cluster if neither local indices nor remote indices were specified
-            originalIndicesMap.put(LOCAL_CLUSTER_GROUP_KEY, new OriginalIndices(Strings.EMPTY_ARRAY, indicesOptions));
+            if (returnLocalAll) {
+                // search on _all in the local cluster if neither local indices nor remote indices were specified
+                originalIndicesMap.put(LOCAL_CLUSTER_GROUP_KEY, new OriginalIndices(Strings.EMPTY_ARRAY, indicesOptions));
+            }
         } else {
             for (Map.Entry<String, List<String>> entry : groupedIndices.entrySet()) {
                 String clusterAlias = entry.getKey();
@@ -197,6 +206,16 @@ public final class RemoteClusterService extends RemoteClusterAware
             }
         }
         return originalIndicesMap;
+    }
+
+    /**
+     * TODO: DOCUMENT ME
+     * @param indicesOptions IndicesOptions to clarify how the index expressions should be parsed/applied
+     * @param indices Multiple index expressions as string[].
+     * @return
+     */
+    public Map<String, OriginalIndices> groupIndices(IndicesOptions indicesOptions, String[] indices) {
+        return groupIndices(indicesOptions, indices, true);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequestTests.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.action.admin.indices.resolve;
 
-import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.ArrayUtils;
@@ -31,19 +30,23 @@ public class ResolveClusterActionRequestTests extends AbstractWireSerializingTes
 
     @Override
     protected ResolveClusterActionRequest createTestInstance() {
-        String[] names = generateRandomStringArray(1, 7, false);
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(
-            randomBoolean(),
-            randomBoolean(),
-            randomBoolean(),
-            randomBoolean(),
-            randomBoolean(),
-            randomBoolean(),
-            randomBoolean(),
-            randomBoolean(),
-            randomBoolean()
-        );
-        return new ResolveClusterActionRequest(names, indicesOptions);
+        if (randomInt(5) == 3) {
+            return new ResolveClusterActionRequest(new String[0], IndicesOptions.DEFAULT, true, randomBoolean());
+        } else {
+            String[] names = generateRandomStringArray(1, 7, false);
+            IndicesOptions indicesOptions = IndicesOptions.fromOptions(
+                randomBoolean(),
+                randomBoolean(),
+                randomBoolean(),
+                randomBoolean(),
+                randomBoolean(),
+                randomBoolean(),
+                randomBoolean(),
+                randomBoolean(),
+                randomBoolean()
+            );
+            return new ResolveClusterActionRequest(names, indicesOptions, false, randomBoolean());
+        }
     }
 
     @Override
@@ -69,12 +72,6 @@ public class ResolveClusterActionRequestTests extends AbstractWireSerializingTes
         Consumer<ResolveClusterActionRequest> mutator = randomFrom(mutators);
         mutator.accept(mutatedInstance);
         return mutatedInstance;
-    }
-
-    public void testValidation() {
-        ResolveClusterActionRequest request = new ResolveClusterActionRequest(new String[0]);
-        ActionRequestValidationException exception = request.validate();
-        assertNotNull(exception);
     }
 
     public void testLocalIndicesPresent() {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionResponseTests.java
@@ -54,11 +54,12 @@ public class ResolveClusterActionResponseTests extends AbstractWireSerializingTe
     }
 
     static ResolveClusterInfo randomResolveClusterInfo() {
-        int val = randomIntBetween(1, 3);
+        int val = randomIntBetween(1, 4);
         return switch (val) {
             case 1 -> new ResolveClusterInfo(false, randomBoolean());
             case 2 -> new ResolveClusterInfo(randomBoolean(), randomBoolean(), randomAlphaOfLength(15));
             case 3 -> new ResolveClusterInfo(randomBoolean(), randomBoolean(), randomBoolean(), Build.current());
+            case 4 -> new ResolveClusterInfo(true, randomBoolean(), null, Build.current());
             default -> throw new UnsupportedOperationException("should not get here");
         };
     }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryIT.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.core.TimeValue.timeValueMillis;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -109,13 +108,13 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
         Boolean requestIncludeMeta = includeCCSMetadata.v1();
         boolean responseExpectMeta = includeCCSMetadata.v2();
 
-        AtomicReference<String> asyncExecutionId = new AtomicReference<>();
+        String asyncExecutionId;
 
         String q = "FROM logs-*,cluster-a:logs-*,remote-b:blocking | STATS total=sum(const) | LIMIT 10";
         try (EsqlQueryResponse resp = runAsyncQuery(q, requestIncludeMeta, null, TimeValue.timeValueMillis(100))) {
             assertTrue(resp.isRunning());
             assertNotNull("async execution id is null", resp.asyncExecutionId());
-            asyncExecutionId.set(resp.asyncExecutionId().get());
+            asyncExecutionId = resp.asyncExecutionId().get();
             // executionInfo may or may not be set on the initial response when there is a relatively low wait_for_completion_timeout
             // so we do not check for it here
         }
@@ -125,7 +124,7 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
 
         // wait until the query of 'cluster-a:logs-*' has finished (it is not blocked since we are not searching the 'blocking' index on it)
         assertBusy(() -> {
-            try (EsqlQueryResponse asyncResponse = getAsyncResponse(asyncExecutionId.get())) {
+            try (EsqlQueryResponse asyncResponse = getAsyncResponse(asyncExecutionId)) {
                 EsqlExecutionInfo executionInfo = asyncResponse.getExecutionInfo();
                 assertNotNull(executionInfo);
                 EsqlExecutionInfo.Cluster clusterA = executionInfo.getCluster("cluster-a");
@@ -138,7 +137,7 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
          *  the query against remote-b should be running (blocked on the PauseFieldPlugin.allowEmitting CountDown)
          *  the query against the local cluster should be running because it has a STATS clause that needs to wait on remote-b
          */
-        try (EsqlQueryResponse asyncResponse = getAsyncResponse(asyncExecutionId.get())) {
+        try (EsqlQueryResponse asyncResponse = getAsyncResponse(asyncExecutionId)) {
             EsqlExecutionInfo executionInfo = asyncResponse.getExecutionInfo();
             assertThat(asyncResponse.isRunning(), is(true));
             assertThat(
@@ -175,7 +174,7 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
 
         // wait until both remoteB and local queries have finished
         assertBusy(() -> {
-            try (EsqlQueryResponse asyncResponse = getAsyncResponse(asyncExecutionId.get())) {
+            try (EsqlQueryResponse asyncResponse = getAsyncResponse(asyncExecutionId)) {
                 EsqlExecutionInfo executionInfo = asyncResponse.getExecutionInfo();
                 assertNotNull(executionInfo);
                 EsqlExecutionInfo.Cluster remoteB = executionInfo.getCluster(REMOTE_CLUSTER_2);
@@ -186,7 +185,7 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
             }
         });
 
-        try (EsqlQueryResponse asyncResponse = getAsyncResponse(asyncExecutionId.get())) {
+        try (EsqlQueryResponse asyncResponse = getAsyncResponse(asyncExecutionId)) {
             EsqlExecutionInfo executionInfo = asyncResponse.getExecutionInfo();
             assertNotNull(executionInfo);
             assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(1L));
@@ -218,7 +217,7 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
             assertThat(local.getFailedShards(), equalTo(0));
             assertThat(local.getFailures().size(), equalTo(0));
         } finally {
-            AcknowledgedResponse acknowledgedResponse = deleteAsyncId(asyncExecutionId.get());
+            AcknowledgedResponse acknowledgedResponse = deleteAsyncId(asyncExecutionId);
             assertThat(acknowledgedResponse.isAcknowledged(), is(true));
         }
     }


### PR DESCRIPTION
This enhancement provides users with the ability to query the _resolve/cluster API endpoint without specifying an index expression to match against. This allows users to quickly test what remote clusters are configured on a cluster and whether they are available for querying. Since the _resolve/cluster endpoint always attempts to make a remote connection on each call (unlike the _remote/info endpoint), this new endpoint provides a convenient and reliable way to check on the availability of remote clusters.

This new endpoint works with clusters from older versions.

The new endpoint takes no index expression:

```
GET _resolve/cluster
```

and returns the same information as before except for the "matching_indices" field. Example response:

```
{
  "remote1": {
    "connected": false,
    "skip_unavailable": true
  },
  "remote2": {
    "connected": true,
    "skip_unavailable": false,
    "version": {
      "number": "8.17.0",
      "build_flavor": "default",
      "minimum_wire_compatibility_version": "7.17.0",
      "minimum_index_compatibility_version": "7.0.0"
    }
  }
}
```