### PR TITLE
Don't use #getSourceAsMap when reading TopHits in transform

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
@@ -94,7 +94,8 @@ public class Latest extends AbstractCompositeAggFunction {
         }
 
         // We don't use #getSourceAsMap here because we don't want to cache the object as we
-        // only need it here. More over we are modifying the map of maps so it would be incorrect,
+        // only need it here. More over we are modifying the map of maps so we will be holding
+        // the wrong map.
         BytesReference bytes = topHits.getHits().getHits()[0].getSourceRef();
         Map<String, Object> document = XContentHelper.convertToMap(bytes, true).v2();
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.transform.transforms.latest;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -90,7 +92,11 @@ public class Latest extends AbstractCompositeAggFunction {
                 topHits.getHits().getHits().length
             );
         }
-        Map<String, Object> document = topHits.getHits().getHits()[0].getSourceAsMap();
+
+        // We don't use #getSourceAsMap here because we don't want to cache the object as we
+        // only need it here. More over we are modifying the map of maps so it would be incorrect,
+        BytesReference bytes = topHits.getHits().getHits()[0].getSourceRef();
+        Map<String, Object> document = XContentHelper.convertToMap(bytes, true).v2();
 
         // generator to create unique but deterministic document ids, so we
         // - do not create duplicates if we re-run after failure


### PR DESCRIPTION
Using this method will cache the generated object which can increase the memory usage for quite a bit. 