### PR TITLE
[8.16] [Gradle] Fix deprecation warning in release tests after 8.12 update (#119608)

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -45,7 +45,7 @@ if (useDra == false) {
         ivy {
           name = 'beats'
           if (useLocalArtifacts) {
-            url getLayout().getBuildDirectory().dir("artifacts").get().asFile
+            url = getLayout().getBuildDirectory().dir("artifacts").get().asFile
             patternLayout {
               artifact '/[organisation]/[module]-[revision]-[classifier].[ext]'
             }


### PR DESCRIPTION
Backports the following commits to 8.16:
 - [Gradle] Fix deprecation warning in release tests after 8.12 update (#119608)