### PR TITLE
[8.x] Skips synonym test in mixed cluster bwc tests instead of YAML rest compat (#119044)

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -64,6 +64,9 @@ excludeList.add('cluster.desired_nodes/20_dry_run/Test validation works for dry 
 // Excluded because they create dot-prefixed indices on older versions
 excludeList.add('indices.resolve_index/20_resolve_system_index/*')
 
+// Can't work until auto-expand replicas is 0-1 for synonyms index
+excludeList.add("synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set")
+
 def clusterPath = getPath()
 
 buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Skips synonym test in mixed cluster bwc tests instead of YAML rest compat (#119044)](https://github.com/elastic/elasticsearch/pull/119044)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)