### PR TITLE
[8.17] Skips synonym test in mixed cluster bwc tests instead of YAML rest compat (#119044)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -358,9 +358,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/117937
 - class: org.elasticsearch.xpack.security.authc.kerberos.KerberosAuthenticationIT
   issue: https://github.com/elastic/elasticsearch/issues/118414
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set}
-  issue: https://github.com/elastic/elasticsearch/issues/116777
 - class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
   method: "builds distribution from branches via archives extractedAssemble [bwcDistVersion: 8.1.3, bwcProject: bugfix2, expectedAssembleTaskName:
     extractedAssemble, #3]"

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -64,6 +64,9 @@ excludeList.add('cluster.desired_nodes/20_dry_run/Test validation works for dry 
 // Excluded because they create dot-prefixed indices on older versions
 excludeList.add('indices.resolve_index/20_resolve_system_index/*')
 
+// Can't work until auto-expand replicas is 0-1 for synonyms index
+excludeList.add("synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set")
+
 def clusterPath = getPath()
 buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   if (bwcVersion != VersionProperties.getElasticsearchVersion()) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Skips synonym test in mixed cluster bwc tests instead of YAML rest compat (#119044)](https://github.com/elastic/elasticsearch/pull/119044)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)