### PR TITLE
[8.15] Skips synonym test in mixed cluster bwc tests instead of YAML rest compat (#119044)

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -57,6 +57,9 @@ excludeList.add('cluster.desired_nodes/11_old_format/Test node version must have
 excludeList.add('cluster.desired_nodes/11_old_format/Test node version can not be null')
 excludeList.add('cluster.desired_nodes/20_dry_run/Test validation works for dry run updates')
 
+// Can't work until auto-expand replicas is 0-1 for synonyms index
+excludeList.add("synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set")
+
 BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
 
   if (bwcVersion != VersionProperties.getElasticsearchVersion()) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Skips synonym test in mixed cluster bwc tests instead of YAML rest compat (#119044)](https://github.com/elastic/elasticsearch/pull/119044)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)