### PR TITLE
Enable query rewrites on the coordinator for ESQL

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/QueryBuilderResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/QueryBuilderResolver.java
@@ -59,12 +59,6 @@ public class QueryBuilderResolver {
         ActionListener<Result> listener,
         BiConsumer<LogicalPlan, ActionListener<Result>> callback
     ) {
-        // TODO: remove once SEMANTIC_TEXT_TYPE is enabled outside of snapshots
-        if (false == EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled()) {
-            callback.accept(plan, listener);
-            return;
-        }
-
         if (plan.optimized() == false) {
             listener.onFailure(new IllegalStateException("Expected optimized plan before query builder rewrite."));
             return;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/QueryBuilderResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/QueryBuilderResolver.java
@@ -16,7 +16,6 @@ import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;


### PR DESCRIPTION
Enables full text functions to be translated to query builders on the coordinator.
The functionality was added in https://github.com/elastic/elasticsearch/pull/118676
This change does not enable semantic search in ES|QL.
While this is a requirement for semantic search, this is a general functionality that we can benefit all search functions.
We initially had a conservative approach and added this functionality behind a snapshot, reusing the `SEMANTIC_TEXT_TYPE` capability, but we can take it out of snapshot irrespective of semantic search.