### PR TITLE
[8.16] Fix spike detection for short spikes at the tail of the data. (#119637)

### DIFF
--- a/docs/changelog/119637.yaml
+++ b/docs/changelog/119637.yaml
@@ -1,0 +1,5 @@
+pr: 119637
+summary: Fix spike detection for short spikes at the tail of the data
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/SpikeAndDipDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/SpikeAndDipDetector.java
@@ -58,7 +58,7 @@ final class SpikeAndDipDetector {
         int maxEnd = Math.min(maxStart + extent, values.length);
         double maxSum = sum(values, maxStart, maxEnd, negate);
         for (int start = maxStart + 1; start <= argmax; start++) {
-            if (start + extent >= values.length) {
+            if (start + extent > values.length) {
                 break;
             }
             double average = sum(values, start, start + extent, negate);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/SpikeAndDipDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/SpikeAndDipDetectorTests.java
@@ -184,4 +184,14 @@ public class SpikeAndDipDetectorTests extends ESTestCase {
         assertThat(change, instanceOf(ChangeType.Spike.class));
         assertThat(change.changePoint(), equalTo(10));
     }
+
+    public void testSpikeAtTail() {
+        MlAggsHelper.DoubleBucketValues bucketValues = new MlAggsHelper.DoubleBucketValues(
+            null,
+            new double[] { 2, 2, 2, 2, 3, 2, 2, 2, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 2, 2, 9, 8 }
+        );
+        ChangeType change = new SpikeAndDipDetector(bucketValues).detect(0.01);
+        assertThat(change, instanceOf(ChangeType.Spike.class));
+        assertThat(change.changePoint(), equalTo(27));
+    }
 }


### PR DESCRIPTION
Backports the following commits to 8.16:

- Fix spike detection for short spikes at the tail of the data. (https://github.com/elastic/elasticsearch/pull/119637)