### PR TITLE
Simplify test class hierarchy in old-repository-versions-compatibility

### DIFF
--- a/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/AbstractUpgradeCompatibilityTestCase.java
+++ b/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/AbstractUpgradeCompatibilityTestCase.java
@@ -73,9 +73,11 @@ public abstract class AbstractUpgradeCompatibilityTestCase extends ESRestTestCas
     private static boolean upgradeFailed = false;
 
     private final Version clusterVersion;
+    private final String indexCreatedVersion;
 
-    public AbstractUpgradeCompatibilityTestCase(@Name("cluster") Version clusterVersion) {
+    public AbstractUpgradeCompatibilityTestCase(@Name("cluster") Version clusterVersion, String indexCreatedVersion) {
         this.clusterVersion = clusterVersion;
+        this.indexCreatedVersion = indexCreatedVersion;
     }
 
     @ParametersFactory
@@ -207,5 +209,9 @@ public abstract class AbstractUpgradeCompatibilityTestCase extends ESRestTestCas
                 zipIn.closeEntry();
             }
         }
+    }
+
+    public final void testArchiveIndex() throws Exception {
+        verifyCompatibility(indexCreatedVersion);
     }
 }

--- a/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/archiveindex/ArchiveIndexTestCase.java
+++ b/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/archiveindex/ArchiveIndexTestCase.java
@@ -25,14 +25,14 @@ import static org.elasticsearch.test.rest.ObjectPath.createFromResponse;
  * when deployed ES version 5/6. The cluster then upgrades to version 9, verifying that the archive index
  * is successfully restored.
  */
-public class ArchiveIndexTestCase extends AbstractUpgradeCompatibilityTestCase {
+abstract class ArchiveIndexTestCase extends AbstractUpgradeCompatibilityTestCase {
 
     static {
         clusterConfig = config -> config.setting("xpack.license.self_generated.type", "trial");
     }
 
-    public ArchiveIndexTestCase(Version version) {
-        super(version);
+    protected ArchiveIndexTestCase(Version version, String indexCreatedVersion) {
+        super(version, indexCreatedVersion);
     }
 
     /**

--- a/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/archiveindex/RestoreFromVersion5IT.java
+++ b/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/archiveindex/RestoreFromVersion5IT.java
@@ -12,10 +12,6 @@ import org.elasticsearch.test.cluster.util.Version;
 public class RestoreFromVersion5IT extends ArchiveIndexTestCase {
 
     public RestoreFromVersion5IT(Version version) {
-        super(version);
-    }
-
-    public void testArchiveIndex() throws Exception {
-        verifyCompatibility("5");
+        super(version, "5");
     }
 }

--- a/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/archiveindex/RestoreFromVersion6IT.java
+++ b/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/archiveindex/RestoreFromVersion6IT.java
@@ -12,10 +12,6 @@ import org.elasticsearch.test.cluster.util.Version;
 public class RestoreFromVersion6IT extends ArchiveIndexTestCase {
 
     public RestoreFromVersion6IT(Version version) {
-        super(version);
-    }
-
-    public void testArchiveIndex() throws Exception {
-        verifyCompatibility("6");
+        super(version, "6");
     }
 }

--- a/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/searchablesnapshot/MountFromVersion5IT.java
+++ b/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/searchablesnapshot/MountFromVersion5IT.java
@@ -12,10 +12,6 @@ import org.elasticsearch.test.cluster.util.Version;
 public class MountFromVersion5IT extends SearchableSnapshotTestCase {
 
     public MountFromVersion5IT(Version version) {
-        super(version);
-    }
-
-    public void testSearchableSnapshot() throws Exception {
-        verifyCompatibility("5");
+        super(version, "5");
     }
 }

--- a/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/searchablesnapshot/MountFromVersion6IT.java
+++ b/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/searchablesnapshot/MountFromVersion6IT.java
@@ -12,10 +12,6 @@ import org.elasticsearch.test.cluster.util.Version;
 public class MountFromVersion6IT extends SearchableSnapshotTestCase {
 
     public MountFromVersion6IT(Version version) {
-        super(version);
-    }
-
-    public void testSearchableSnapshot() throws Exception {
-        verifyCompatibility("6");
+        super(version, "6");
     }
 }

--- a/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/searchablesnapshot/SearchableSnapshotTestCase.java
+++ b/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/searchablesnapshot/SearchableSnapshotTestCase.java
@@ -21,14 +21,14 @@ import static org.elasticsearch.test.rest.ObjectPath.createFromResponse;
  * Restores snapshots from old-clusters (version 5/6) and upgrades it to the current version.
  * Test methods are executed after each upgrade.
  */
-public class SearchableSnapshotTestCase extends AbstractUpgradeCompatibilityTestCase {
+abstract class SearchableSnapshotTestCase extends AbstractUpgradeCompatibilityTestCase {
 
     static {
         clusterConfig = config -> config.setting("xpack.license.self_generated.type", "trial");
     }
 
-    public SearchableSnapshotTestCase(Version version) {
-        super(version);
+    protected SearchableSnapshotTestCase(Version version, String indexCreatedVersion) {
+        super(version, indexCreatedVersion);
     }
 
     /**

--- a/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/DocValueOnlyFieldsIT.java
+++ b/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/DocValueOnlyFieldsIT.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 import java.io.IOException;
 
 /**
- * Tests doc-value-based searches against indices imported from clusters older than N-1.
+ * Tests doc-value-based searches against archive indices, imported from clusters older than N-2.
  * We reuse the YAML tests in search/390_doc_values_search.yml but have to do the setup
  * manually here as the setup is done on the old cluster for which we have to use the
  * low-level REST client instead of the YAML set up that only knows how to talk to


### PR DESCRIPTION
The test method does not need to be repeated in every test class, and the two base test classes can be abstract.

Meanwhile I also corrected javadocs on DocValueOnlyFieldsIT that were outdated.