### PR TITLE
[8.15] Mark the lookup join tests in IndexResolverFieldNamesTests as snapshot-only (#118815)

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
@@ -3353,7 +3353,7 @@ Alejandro
 Amabile
 Anoosh
 Basil
-Bojan
+Brendon
 // end::filterToday
 ;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Mark the lookup join tests in IndexResolverFieldNamesTests as snapshot-only (#118815)](https://github.com/elastic/elasticsearch/pull/118815)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)