### PR TITLE
[Gradle] Fix :docs:yamlRest test cc compatibility

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -178,8 +178,9 @@ testClusters.matching { it.name == "yamlRestTest"}.configureEach {
 }
 
 tasks.named("yamlRestTest").configure {
+  def repoFolder = "${layout.buildDirectory.asFile.get()}/cluster/shared/repo"
   doFirst {
-    delete("${buildDir}/cluster/shared/repo")
+    delete(repoFolder)
   }
 }
 


### PR DESCRIPTION
- reference a Gradle script object from a Groovy closure during execution phase is not allowed