### PR TITLE
[8.16] Skip operator privilege action test on release builds (#119386)

### DIFF
--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.security.operator;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -165,6 +166,7 @@ public class OperatorPrivilegesIT extends ESRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testEveryActionIsEitherOperatorOnlyOrNonOperator() throws IOException {
+        assumeTrue("Exclude release builds due to maintenance burden around feature flags", Build.current().isSnapshot());
         final String message = "An action should be declared to be either operator-only in ["
             + DefaultOperatorOnlyRegistry.class.getName()
             + "] or non-operator in ["


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Skip operator privilege action test on release builds (#119386)](https://github.com/elastic/elasticsearch/pull/119386)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)