### PR TITLE
[Transform] Auto-migrate max_page_search_size (#119348)

### DIFF
--- a/docs/changelog/119348.yaml
+++ b/docs/changelog/119348.yaml
@@ -1,0 +1,5 @@
+pr: 119348
+summary: Auto-migrate `max_page_search_size`
+area: Transform
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -89,6 +89,9 @@ public class TransformMessages {
     public static final String INVALID_ID = "Invalid {0}; ''{1}'' can contain lowercase alphanumeric (a-z and 0-9), hyphens or "
         + "underscores; must start and end with alphanumeric";
 
+    public static final String MAX_PAGE_SEARCH_SIZE_MIGRATION =
+        "Automatically migrating [max_page_search_size] from the pivot to the transform setting.";
+
     private TransformMessages() {}
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -615,32 +615,7 @@ public final class TransformConfig implements SimpleDiffable<TransformConfig>, W
 
     private static TransformConfig applyRewriteForUpdate(Builder builder) {
         // 1. Move pivot.max_page_size_search to settings.max_page_size_search
-        if (builder.getPivotConfig() != null && builder.getPivotConfig().getMaxPageSearchSize() != null) {
-
-            // find maxPageSearchSize value
-            Integer maxPageSearchSizeDeprecated = builder.getPivotConfig().getMaxPageSearchSize();
-            Integer maxPageSearchSize = builder.getSettings().getMaxPageSearchSize() != null
-                ? builder.getSettings().getMaxPageSearchSize()
-                : maxPageSearchSizeDeprecated;
-
-            // create a new pivot config but set maxPageSearchSize to null
-            builder.setPivotConfig(
-                new PivotConfig(builder.getPivotConfig().getGroupConfig(), builder.getPivotConfig().getAggregationConfig(), null)
-            );
-            // create new settings with maxPageSearchSize
-            builder.setSettings(
-                new SettingsConfig(
-                    maxPageSearchSize,
-                    builder.getSettings().getDocsPerSecond(),
-                    builder.getSettings().getDatesAsEpochMillis(),
-                    builder.getSettings().getAlignCheckpoints(),
-                    builder.getSettings().getUsePit(),
-                    builder.getSettings().getDeduceMappings(),
-                    builder.getSettings().getNumFailureRetries(),
-                    builder.getSettings().getUnattended()
-                )
-            );
-        }
+        migrateMaxPageSearchSize(builder);
 
         // 2. set dates_as_epoch_millis to true for transforms < 7.11 to keep BWC
         if (builder.getVersion() != null && builder.getVersion().before(TransformConfigVersion.V_7_11_0)) {
@@ -675,6 +650,40 @@ public final class TransformConfig implements SimpleDiffable<TransformConfig>, W
         }
 
         return builder.setVersion(TransformConfigVersion.CURRENT).build();
+    }
+
+    public boolean shouldAutoMigrateMaxPageSearchSize() {
+        return getPivotConfig() != null && getPivotConfig().getMaxPageSearchSize() != null;
+    }
+
+    public static Builder migrateMaxPageSearchSize(Builder builder) {
+        if (builder.getPivotConfig() != null && builder.getPivotConfig().getMaxPageSearchSize() != null) {
+
+            // find maxPageSearchSize value
+            Integer maxPageSearchSizeDeprecated = builder.getPivotConfig().getMaxPageSearchSize();
+            Integer maxPageSearchSize = builder.getSettings().getMaxPageSearchSize() != null
+                ? builder.getSettings().getMaxPageSearchSize()
+                : maxPageSearchSizeDeprecated;
+
+            // create a new pivot config but set maxPageSearchSize to null
+            builder.setPivotConfig(
+                new PivotConfig(builder.getPivotConfig().getGroupConfig(), builder.getPivotConfig().getAggregationConfig(), null)
+            );
+            // create new settings with maxPageSearchSize
+            builder.setSettings(
+                new SettingsConfig(
+                    maxPageSearchSize,
+                    builder.getSettings().getDocsPerSecond(),
+                    builder.getSettings().getDatesAsEpochMillis(),
+                    builder.getSettings().getAlignCheckpoints(),
+                    builder.getSettings().getUsePit(),
+                    builder.getSettings().getDeduceMappings(),
+                    builder.getSettings().getNumFailureRetries(),
+                    builder.getSettings().getUnattended()
+                )
+            );
+        }
+        return builder;
     }
 
     public static Builder builder() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -152,6 +152,14 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
             latestConfig = LatestConfigTests.randomLatestConfig();
         }
 
+        return randomTransformConfigWithSettings(settingsConfig, pivotConfig, latestConfig);
+    }
+
+    public static TransformConfig randomTransformConfigWithSettings(
+        SettingsConfig settingsConfig,
+        PivotConfig pivotConfig,
+        LatestConfig latestConfig
+    ) {
         return new TransformConfig(
             randomAlphaOfLengthBetween(1, 10),
             randomSourceConfig(),

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformOldTransformsIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformOldTransformsIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -56,16 +57,7 @@ public class TransformOldTransformsIT extends TransformSingleNodeTestCase {
 
         // The mapping does not need to actually be the "OLD" mapping, we are testing that the old doc gets deleted, and the new one
         // created.
-        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
-            builder.startObject();
-            builder.field(TransformInternalIndex.DYNAMIC, "false");
-            builder.startObject("properties");
-            builder.startObject(TransformField.INDEX_DOC_TYPE.getPreferredName()).field("type", "keyword").endObject();
-            TransformInternalIndex.addTransformsConfigMappings(builder);
-            builder.endObject();
-            builder.endObject();
-            indicesAdmin().create(new CreateIndexRequest(OLD_INDEX).mapping(builder).origin(ClientHelper.TRANSFORM_ORIGIN)).actionGet();
-        }
+        createTransformIndex();
         String transformIndex = "transform-index";
         createSourceIndex(transformIndex);
         String transformId = "transform-throws-for-old-config";
@@ -106,11 +98,7 @@ public class TransformOldTransformsIT extends TransformSingleNodeTestCase {
               "frequency": "1s",
               "version": "%s"
             }""", transformIndex, transformId, transformVersion);
-        IndexRequest indexRequest = new IndexRequest(OLD_INDEX).id(TransformConfig.documentId(transformId))
-            .source(config, XContentType.JSON)
-            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        DocWriteResponse indexResponse = client().index(indexRequest).actionGet();
-        assertThat(indexResponse.getResult(), is(DocWriteResponse.Result.CREATED));
+        putTransform(transformId, config);
 
         GetTransformAction.Request getTransformRequest = new GetTransformAction.Request(transformId);
         GetTransformAction.Response getTransformResponse = client().execute(GetTransformAction.INSTANCE, getTransformRequest).actionGet();
@@ -155,7 +143,114 @@ public class TransformOldTransformsIT extends TransformSingleNodeTestCase {
         assertTrue(stopTransformActionResponse.isAcknowledged());
     }
 
+    private void createTransformIndex() throws Exception {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.startObject();
+            builder.field(TransformInternalIndex.DYNAMIC, "false");
+            builder.startObject("properties");
+            builder.startObject(TransformField.INDEX_DOC_TYPE.getPreferredName()).field("type", "keyword").endObject();
+            TransformInternalIndex.addTransformsConfigMappings(builder);
+            builder.endObject();
+            builder.endObject();
+            indicesAdmin().create(new CreateIndexRequest(OLD_INDEX).mapping(builder).origin(ClientHelper.TRANSFORM_ORIGIN)).actionGet();
+        }
+    }
+
     private void createSourceIndex(String index) {
         indicesAdmin().create(new CreateIndexRequest(index)).actionGet();
     }
+
+    private void putTransform(String transformId, String config) {
+        IndexRequest indexRequest = new IndexRequest(OLD_INDEX).id(TransformConfig.documentId(transformId))
+            .source(config, XContentType.JSON)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        DocWriteResponse indexResponse = client().index(indexRequest).actionGet();
+        assertThat(indexResponse.getResult(), is(DocWriteResponse.Result.CREATED));
+    }
+
+    public void testUpdateReplacesDeprecatedTransformSettings() throws Exception {
+        var expectedMaxPageSearchSize = 555;
+        var transformId = createTransformWithDeprecatedMaxPageSearchSize(expectedMaxPageSearchSize);
+
+        assertMaxPageSearchSizeInPivotConfig(transformId, expectedMaxPageSearchSize);
+
+        var updateRequest = new UpdateTransformAction.Request(TransformConfigUpdate.EMPTY, transformId, false, TimeValue.THIRTY_SECONDS);
+        client().execute(UpdateTransformAction.INSTANCE, updateRequest).actionGet();
+
+        assertMaxPageSearchSizeInSettings(transformId, expectedMaxPageSearchSize);
+    }
+
+    private String createTransformWithDeprecatedMaxPageSearchSize(int maxPageSearchSize) throws Exception {
+        createTransformIndex();
+        String transformIndex = "transform-index";
+        createSourceIndex(transformIndex);
+        String transformId = "transform-update-fixes-deprecated-settings";
+        String config = Strings.format("""
+            {
+              "dest": {
+                "index": "bar"
+              },
+              "source": {
+                "index": "%s",
+                "query": {
+                  "match_all": {}
+                }
+              },
+              "id": "%s",
+              "doc_type": "data_frame_transform_config",
+              "pivot": {
+                "group_by": {
+                  "reviewer": {
+                    "terms": {
+                      "field": "user_id"
+                    }
+                  }
+                },
+                "aggregations": {
+                  "avg_rating": {
+                    "avg": {
+                      "field": "stars"
+                    }
+                  }
+                },
+                "max_page_search_size": %d
+              },
+              "frequency": "1s",
+              "version": "%s"
+            }""", transformIndex, transformId, maxPageSearchSize, TransformConfigVersion.CURRENT);
+        putTransform(transformId, config);
+        return transformId;
+    }
+
+    private void assertMaxPageSearchSizeInPivotConfig(String transformId, int expectedMaxPageSearchSize) {
+        var getTransformRequest = new GetTransformAction.Request(transformId);
+        var getTransformResponse = client().execute(GetTransformAction.INSTANCE, getTransformRequest).actionGet();
+        var transformConfig = getTransformResponse.getTransformConfigurations().get(0);
+        assertThat(transformConfig.getId(), equalTo(transformId));
+        assertThat(transformConfig.getPivotConfig().getMaxPageSearchSize(), equalTo(expectedMaxPageSearchSize));
+        assertThat(transformConfig.getSettings().getMaxPageSearchSize(), equalTo(null));
+    }
+
+    private void assertMaxPageSearchSizeInSettings(String transformId, int expectedMaxPageSearchSize) {
+        var getTransformRequest = new GetTransformAction.Request(transformId);
+        var getTransformResponse = client().execute(GetTransformAction.INSTANCE, getTransformRequest).actionGet();
+        var transformConfig = getTransformResponse.getTransformConfigurations().get(0);
+        assertThat(transformConfig.getId(), equalTo(transformId));
+        assertThat(transformConfig.getPivotConfig().getMaxPageSearchSize(), equalTo(null));
+        assertThat(transformConfig.getSettings().getMaxPageSearchSize(), equalTo(expectedMaxPageSearchSize));
+    }
+
+    public void testStartReplacesDeprecatedTransformSettings() throws Exception {
+        var expectedMaxPageSearchSize = 1234;
+        var transformId = createTransformWithDeprecatedMaxPageSearchSize(expectedMaxPageSearchSize);
+
+        assertMaxPageSearchSizeInPivotConfig(transformId, expectedMaxPageSearchSize);
+
+        var startTransformRequest = new StartTransformAction.Request(transformId, null, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+        var startTransformActionResponse = client().execute(StartTransformAction.INSTANCE, startTransformRequest).actionGet();
+        assertTrue(startTransformActionResponse.isAcknowledged());
+
+        assertMaxPageSearchSizeInSettings(transformId, expectedMaxPageSearchSize);
+    }
+
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -110,6 +110,7 @@ import org.elasticsearch.xpack.transform.rest.action.RestStartTransformAction;
 import org.elasticsearch.xpack.transform.rest.action.RestStopTransformAction;
 import org.elasticsearch.xpack.transform.rest.action.RestUpdateTransformAction;
 import org.elasticsearch.xpack.transform.rest.action.RestUpgradeTransformsAction;
+import org.elasticsearch.xpack.transform.telemetry.TransformMeterRegistry;
 import org.elasticsearch.xpack.transform.transforms.TransformPersistentTasksExecutor;
 import org.elasticsearch.xpack.transform.transforms.scheduling.TransformScheduler;
 
@@ -138,6 +139,7 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
 
     private final Settings settings;
     private final SetOnce<TransformServices> transformServices = new SetOnce<>();
+    private final SetOnce<TransformConfigAutoMigration> transformConfigAutoMigration = new SetOnce<>();
     private final TransformExtension transformExtension = new DefaultTransformExtension();
 
     public static final Integer DEFAULT_INITIAL_MAX_PAGE_SEARCH_SIZE = Integer.valueOf(500);
@@ -319,7 +321,15 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
 
         transformServices.set(new TransformServices(configManager, checkpointService, auditor, scheduler, transformNode));
 
-        return List.of(transformServices.get(), clusterStateListener, new TransformExtensionHolder(getTransformExtension()));
+        var transformMeterRegistry = TransformMeterRegistry.create(services.telemetryProvider().getMeterRegistry());
+        transformConfigAutoMigration.set(new TransformConfigAutoMigration(configManager, auditor, transformMeterRegistry));
+
+        return List.of(
+            transformServices.get(),
+            clusterStateListener,
+            new TransformExtensionHolder(getTransformExtension()),
+            transformConfigAutoMigration.get()
+        );
     }
 
     @Override
@@ -332,6 +342,7 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
     ) {
         // the transform services should have been created
         assert transformServices.get() != null;
+        assert transformConfigAutoMigration.get() != null;
 
         return List.of(
             new TransformPersistentTasksExecutor(
@@ -341,7 +352,8 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
                 clusterService,
                 settingsModule.getSettings(),
                 getTransformExtension(),
-                expressionResolver
+                expressionResolver,
+                transformConfigAutoMigration.get()
             )
         );
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformConfigAutoMigration.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformConfigAutoMigration.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+import org.elasticsearch.xpack.transform.telemetry.TransformMeterRegistry;
+
+/**
+ * Intended to automatically apply configuration changes as part of `PUT _transform` or during the persistent task's start
+ * in {@link org.elasticsearch.xpack.transform.transforms.TransformPersistentTasksExecutor}.
+ *
+ * This is intentionally separate from {@link org.elasticsearch.xpack.transform.action.TransformUpdater}, which is designed to be called
+ * from `_update` and `_upgrade` and apply potentially breaking changes and a broader set of changes.
+ * This class is more designed for serverless rolling updates to apply a smaller non-breaking subset of changes.
+ */
+public class TransformConfigAutoMigration {
+
+    private static final Logger logger = LogManager.getLogger(TransformConfigAutoMigration.class);
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(TransformConfigAutoMigration.class);
+    private final TransformConfigManager transformConfigManager;
+    private final TransformAuditor auditor;
+    private final TransformMeterRegistry transformMeterRegistry;
+
+    TransformConfigAutoMigration(
+        TransformConfigManager transformConfigManager,
+        TransformAuditor auditor,
+        TransformMeterRegistry transformMeterRegistry
+    ) {
+        this.transformConfigManager = transformConfigManager;
+        this.auditor = auditor;
+        this.transformMeterRegistry = transformMeterRegistry;
+    }
+
+    public TransformConfig migrate(TransformConfig currentConfig) {
+        // most transforms shouldn't need to migrate, so let's exit early
+        if (currentConfig.shouldAutoMigrateMaxPageSearchSize() == false) {
+            return currentConfig;
+        }
+
+        var updatedConfig = TransformConfig.migrateMaxPageSearchSize(new TransformConfig.Builder(currentConfig)).build();
+
+        var validationException = updatedConfig.validate(null);
+        if (validationException == null) {
+            auditor.info(updatedConfig.getId(), TransformMessages.MAX_PAGE_SEARCH_SIZE_MIGRATION);
+            transformMeterRegistry.autoMigrationCount().increment();
+            deprecationLogger.warn(
+                DeprecationCategory.API,
+                TransformField.MAX_PAGE_SEARCH_SIZE.getPreferredName(),
+                TransformMessages.MAX_PAGE_SEARCH_SIZE_MIGRATION
+            );
+            return updatedConfig;
+        } else {
+            logger.atDebug()
+                .withThrowable(validationException)
+                .log(
+                    "Failed to validate auto-migrated Config. Please use the _update API to correct and update "
+                        + "the Transform configuration. Continuing with old config."
+                );
+            return currentConfig;
+        }
+    }
+
+    public void migrateAndSave(TransformConfig currentConfig, ActionListener<TransformConfig> listener) {
+        var updatedConfig = migrate(currentConfig);
+        if (currentConfig == updatedConfig) {
+            listener.onResponse(currentConfig);
+        } else {
+            ActionListener<Boolean> putConfigListener = ActionListener.wrap(r -> listener.onResponse(updatedConfig), e -> {
+                var errorMessage = "Failed to persist auto-migrated Config. Please see Elasticsearch logs. Continuing with old config.";
+                logger.atWarn().withThrowable(e).log(errorMessage);
+                auditor.warning(currentConfig.getId(), errorMessage);
+                listener.onResponse(currentConfig);
+            });
+
+            transformConfigManager.putTransformConfiguration(updatedConfig, putConfigListener);
+        }
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/telemetry/TransformMeterRegistry.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/telemetry/TransformMeterRegistry.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.telemetry;
+
+import org.elasticsearch.telemetry.metric.LongCounter;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+
+import java.util.Objects;
+
+public record TransformMeterRegistry(LongCounter autoMigrationCount) {
+    public TransformMeterRegistry {
+        Objects.requireNonNull(autoMigrationCount);
+    }
+
+    public static TransformMeterRegistry create(MeterRegistry meterRegistry) {
+        return new TransformMeterRegistry(
+            meterRegistry.registerLongCounter(
+                "es.transform.automigration.count.total",
+                "Count of when a Transform is automatically migrated from a deprecated setting or feature",
+                "count"
+            )
+        );
+    }
+
+    public static TransformMeterRegistry noOp() {
+        return new TransformMeterRegistry(LongCounter.NOOP);
+    }
+}

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformConfigAutoMigrationTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformConfigAutoMigrationTests.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.transform.TransformConfigVersion;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.AggregationConfigTests;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfigTests;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfig;
+import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+import org.elasticsearch.xpack.transform.telemetry.TransformMeterRegistry;
+import org.junit.Before;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.action.support.ActionTestUtils.assertNoFailureListener;
+import static org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests.randomTransformConfigWithSettings;
+import static org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfigTests.randomPivotConfig;
+import static org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfigTests.randomPivotConfigWithDeprecatedFields;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+public class TransformConfigAutoMigrationTests extends ESTestCase {
+    private TransformConfigManager transformConfigManager;
+    private TransformAuditor auditor;
+    private TransformConfigAutoMigration autoMigration;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        transformConfigManager = mock();
+        auditor = mock();
+
+        autoMigration = new TransformConfigAutoMigration(transformConfigManager, auditor, TransformMeterRegistry.noOp());
+    }
+
+    protected boolean enableWarningsCheck() {
+        return false;
+    }
+
+    public void testMigrateWithNoDeprecatedSettings() {
+        var config = randomTransformConfigWithNoDeprecatedSettings();
+
+        var updatedConfig = autoMigration.migrate(config);
+
+        assertThat(updatedConfig, sameInstance(config));
+        verifyNoInteractions(auditor);
+    }
+
+    private static TransformConfig randomTransformConfigWithNoDeprecatedSettings() {
+        return randomTransformConfigWithSettings(SettingsConfig.EMPTY, randomPivotConfig(), null);
+    }
+
+    public void testMigrateWithMaxPageSearchSize() {
+        var config = randomTransformConfigWithDeprecatedSettings();
+
+        var updatedConfig = autoMigration.migrate(config);
+
+        assertThatMaxPageSearchSizeMigrated(updatedConfig, config);
+        verify(auditor, only()).info(eq(updatedConfig.getId()), eq(TransformMessages.MAX_PAGE_SEARCH_SIZE_MIGRATION));
+    }
+
+    private static TransformConfig randomTransformConfigWithDeprecatedSettings() {
+        return randomTransformConfigWithSettings(SettingsConfig.EMPTY, randomPivotConfigWithDeprecatedFields(), null);
+    }
+
+    private void assertThatMaxPageSearchSizeMigrated(TransformConfig updatedConfig, TransformConfig originalConfig) {
+        assertThat(updatedConfig, not(sameInstance(originalConfig)));
+        assertThat(updatedConfig.getPivotConfig().getMaxPageSearchSize(), nullValue());
+        assertThat(updatedConfig.getSettings().getMaxPageSearchSize(), equalTo(originalConfig.getPivotConfig().getMaxPageSearchSize()));
+    }
+
+    public void testMigrateWithInvalidMaxPageSearchSize() {
+        var config = randomTransformConfigWithSettings(
+            SettingsConfig.EMPTY,
+            new PivotConfig(
+                GroupConfigTests.randomGroupConfig(TransformConfigVersion.CURRENT),
+                AggregationConfigTests.randomAggregationConfig(),
+                1
+            ),
+            null
+        );
+
+        var updatedConfig = autoMigration.migrate(config);
+
+        assertThat(updatedConfig, sameInstance(config));
+        verifyNoInteractions(auditor);
+    }
+
+    public void testMigrateAndSaveWithNoChanges() throws InterruptedException {
+        var originalConfig = randomTransformConfigWithNoDeprecatedSettings();
+
+        testMigration(originalConfig, updatedConfig -> {
+            assertThat(updatedConfig, sameInstance(originalConfig));
+            verifyNoInteractions(transformConfigManager);
+            verifyNoInteractions(auditor);
+        });
+    }
+
+    private void testMigration(TransformConfig config, CheckedConsumer<TransformConfig, Exception> updatedConfigListener)
+        throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        autoMigration.migrateAndSave(config, ActionListener.runAfter(assertNoFailureListener(updatedConfigListener), latch::countDown));
+        assertTrue(latch.await(1, TimeUnit.SECONDS));
+    }
+
+    public void testMigrateAndSaveSuccess() throws InterruptedException {
+        doAnswer(ans -> {
+            ActionListener<Boolean> listener = ans.getArgument(1);
+            listener.onResponse(true);
+            return null;
+        }).when(transformConfigManager).putTransformConfiguration(any(), any());
+        var originalConfig = randomTransformConfigWithDeprecatedSettings();
+
+        testMigration(originalConfig, updatedConfig -> {
+            assertThatMaxPageSearchSizeMigrated(updatedConfig, originalConfig);
+            verify(auditor, only()).info(eq(updatedConfig.getId()), eq(TransformMessages.MAX_PAGE_SEARCH_SIZE_MIGRATION));
+        });
+    }
+
+    public void testMigrateAndSaveWithErrors() throws InterruptedException {
+        doAnswer(ans -> {
+            ActionListener<Boolean> listener = ans.getArgument(1);
+            listener.onFailure(new IllegalStateException("This is a failure"));
+            return null;
+        }).when(transformConfigManager).putTransformConfiguration(any(), any());
+        var originalConfig = randomTransformConfigWithDeprecatedSettings();
+
+        testMigration(originalConfig, updatedConfig -> {
+            assertThat(updatedConfig, sameInstance(originalConfig));
+            verify(auditor).info(eq(updatedConfig.getId()), eq(TransformMessages.MAX_PAGE_SEARCH_SIZE_MIGRATION));
+            verify(auditor).warning(
+                eq(originalConfig.getId()),
+                eq("Failed to persist auto-migrated Config. Please see Elasticsearch logs. Continuing with old config.")
+            );
+        });
+    }
+
+    public void testMigrateWithMaxPageSearchSizeInBothLocations() {
+        var settingsMaxPageSearchSize = 555;
+        var settingsConfig = new SettingsConfig.Builder(SettingsConfig.EMPTY).setMaxPageSearchSize(settingsMaxPageSearchSize).build();
+
+        var pivotConfigMaxPageSearchSize = 1234;
+        var pivotConfig = new PivotConfig(
+            GroupConfigTests.randomGroupConfig(TransformConfigVersion.CURRENT),
+            AggregationConfigTests.randomAggregationConfig(),
+            pivotConfigMaxPageSearchSize
+        );
+
+        var originalConfig = randomTransformConfigWithSettings(settingsConfig, pivotConfig, null);
+
+        var updatedConfig = autoMigration.migrate(originalConfig);
+
+        assertThat(updatedConfig, not(sameInstance(originalConfig)));
+        assertThat(updatedConfig.getPivotConfig().getMaxPageSearchSize(), nullValue());
+        assertThat(updatedConfig.getSettings().getMaxPageSearchSize(), equalTo(settingsMaxPageSearchSize));
+        verify(auditor, only()).info(eq(updatedConfig.getId()), eq(TransformMessages.MAX_PAGE_SEARCH_SIZE_MIGRATION));
+    }
+}


### PR DESCRIPTION
`max_page_search_size` had been deprecated in Pivot and migrated to Settings in ES 7.x.  We are removing the key in Pivot in 9.x.  It is still possible to create Pivots with `max_page_search_size`, though a deprecation is logged.  To prep for its removal, this change automatically migrates `max_page_search_size` from Pivot to Settings as if the user called `_update`.

- `PUT _transform` with `max_page_search_size` in Pivot will migrate the value to Settings as part of the Transform's creation.  The user will receive an additional deprecation warning informing of this migration.
- Existing transforms with `max_page_search_size` in Pivot will migrate the value to Settings as part of node assignment during start. Transform Messages and Elasticsearch logs will record this event so users will know what happened.
