### PR TITLE
Provide better error message when attempting to run incompatible tests

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.bwc-test.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.bwc-test.gradle
@@ -53,3 +53,14 @@ plugins.withType(InternalJavaRestTestPlugin) {
 
 tasks.matching { it.name.equals("check") }.configureEach { dependsOn(bwcTestSnapshots) }
 tasks.matching { it.name.equals("test") }.configureEach { enabled = false }
+
+tasks.addRule("incompatible bwc version") { taskName ->
+  def incompatible = buildParams.bwcVersions.allIndexCompatible - buildParams.bwcVersions.indexCompatible
+  if (incompatible.any { taskName.startsWith("v${it.toString()}") }) {
+    tasks.register(taskName) {
+      doLast {
+        throw new GradleException("Cannot execute task '$taskName'. Version is unsupported on this platform. Perhaps you need an x86 host?")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Register a `TaskContainer` rule which dynamically registers a task which reports a useful error when attempting to run BWC tests for versions that are unsupported by the current host platform. This is primarily the case for older 7.x versions which don't have aarch64 support. The current behavior is Gradle responds with "that task doesn't exist" but no explanation as to _why_.