### PR TITLE
Renable :qa:ccs-rolling-upgrade-remote-cluster for FIPS

### DIFF
--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -50,8 +50,6 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
       nonInputProperties.systemProperty('tests.rest.cluster', localCluster.map(c -> c.allHttpSocketURI.join(",")))
       nonInputProperties.systemProperty('tests.rest.remote_cluster', remoteCluster.map(c -> c.allHttpSocketURI.join(",")))
     }
-
-    onlyIf("FIPS mode disabled") { buildParams.inFipsJvm == false }
   }
 
   tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {


### PR DESCRIPTION
For undetermined reasons this test is flaky when run in FIPS mode. There is suspicion that the failure is due to some odd test only behavior . This PR re-enables the test now that a) the FIPS libary jar(s) have been updated b) the BWC from main is 8->9 (not 7->8). This un-mute will not be backported to 8.x and will remain muted in the 8.x branch. 🤞 that what ever caused the instability is addressed by the newer versions. If not, we can re-mute this test when running in FIPS mode. The value of this test is not specific to FIPS and if this problems continue, then it is unlikely worth the effort to continue the investigation to why it is flaky when FIPS is enabled.   

closes #96134