### PR TITLE
[DOCS] Fix link in repository-s3.asciidoc

### DIFF
--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -350,7 +350,7 @@ include::repository-shared-settings.asciidoc[]
     will disable retries altogether. Note that if retries are enabled in the Azure client, each of these retries
     comprises that many client-level retries.
 
-`get_register_retry_delay`
+`get_register_retry_delay`::
 
     (<<time-units,time value>>) Sets the time to wait before trying again if an attempt to read a
     <<repository-s3-linearizable-registers,linearizable register>> fails. Defaults to `5s`.


### PR DESCRIPTION
Fix the formatting for the get_register_retry_delay setting in https://www.elastic.co/guide/en/elasticsearch/reference/master/repository-s3.html#repository-s3-repository