### PR TITLE
rrf support the window_size parameter to compatible with old version

### DIFF
--- a/docs/changelog/119724.yaml
+++ b/docs/changelog/119724.yaml
@@ -1,0 +1,5 @@
+pr: 119724
+summary: rrf support the window_size parameter to compatible with old version
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/rank/RankBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/RankBuilder.java
@@ -41,7 +41,7 @@ import java.util.function.Predicate;
  */
 public abstract class RankBuilder implements VersionedNamedWriteable, ToXContentObject {
 
-    public static final ParseField RANK_WINDOW_SIZE_FIELD = new ParseField("rank_window_size");
+    public static final ParseField RANK_WINDOW_SIZE_FIELD = new ParseField("rank_window_size", "window_size");
 
     public static final int DEFAULT_RANK_WINDOW_SIZE = SearchService.DEFAULT_SIZE;
 

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/100_rank_rrf.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/100_rank_rrf.yml
@@ -105,6 +105,40 @@ setup:
   - match: { hits.hits.2.fields.keyword.0: "other" }
 
 ---
+"Simple rank with old window_size param":
+
+  - requires:
+      cluster_features: ["gte_v8.16.0"]
+      reason: "deprecation added in 8.16"
+      test_runner_features: warnings
+
+  - do:
+      warnings:
+        - "Deprecated field [rank] used, replaced by [retriever]"
+        - "Deprecated field [window_size] used, expected [rank_window_size] instead"
+      search:
+        index: test
+        body:
+          track_total_hits: false
+          fields: [ "keyword" ]
+          knn:
+            field: vector
+            query_vector: [ 0.0 ]
+            k: 3
+            num_candidates: 3
+          query:
+            term:
+              text: term
+          rank:
+            rrf:
+              window_size: 100
+              rank_constant: 1
+          size: 1
+
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.0.fields.keyword.0: "other" }
+
+---
 "Simple rank with multiple bm25 sub searches":
 
   - requires:


### PR DESCRIPTION
where upgrade from 8.13 to 8.17 or newer version, the java client will failed when use rrf and window_size parameter.

I added the `window_size` parameter back to the deprecated parameters to support upgrades.