### PR TITLE
Fix serverless idea import

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -10,6 +10,8 @@
 import org.elasticsearch.gradle.util.Pair
 import org.elasticsearch.gradle.util.GradleUtils
 import org.elasticsearch.gradle.internal.test.TestUtil
+import org.elasticsearch.gradle.internal.idea.EnablePreviewFeaturesTask
+import org.elasticsearch.gradle.internal.idea.IdeaXmlUtil
 import org.jetbrains.gradle.ext.JUnit
 
 import java.nio.file.Files
@@ -144,19 +146,10 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
   }
 
   // modifies the idea module config to enable preview features on ':libs:native' module
-  tasks.register("enablePreviewFeatures") {
+  tasks.register("enablePreviewFeatures", EnablePreviewFeaturesTask) {
     group = 'ide'
     description = 'Enables preview features on native library module'
     dependsOn tasks.named("enableExternalConfiguration")
-
-//    ext {
-      def enablePreview = { moduleFile, languageLevel ->
-        IdeaXmlUtil.modifyXml(moduleFile) { xml ->
-          xml.component.find { it.'@name' == 'NewModuleRootManager' }?.'@LANGUAGE_LEVEL' = languageLevel
-        }
-      }
-//    }
-
     doLast {
       enablePreview('.idea/modules/libs/native/elasticsearch.libs.native.main.iml', 'JDK_21_PREVIEW')
       enablePreview('.idea/modules/libs/native/elasticsearch.libs.native.test.iml', 'JDK_21_PREVIEW')
@@ -285,37 +278,6 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
  * @param preface optional front matter to add after the XML declaration
  * but before the XML document, e.g. a doctype or comment
  */
-
-class IdeaXmlUtil {
-  static Node parseXml(Object xmlPath) {
-    File xmlFile = new File(xmlPath)
-    XmlParser xmlParser = new XmlParser(false, true, true)
-    xmlParser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-    Node xml = xmlParser.parse(xmlFile)
-    return xml
-  }
-
-  static void modifyXml(Object xmlPath, Action<? super Node> action, String preface = null) {
-    File xmlFile = new File(xmlPath)
-    if (xmlFile.exists()) {
-      Node xml = parseXml(xmlPath)
-      action.execute(xml)
-
-      xmlFile.withPrintWriter { writer ->
-        def printer = new XmlNodePrinter(writer)
-        printer.namespaceAware = true
-        printer.preserveWhitespace = true
-        writer.write("<?xml version=\"1.0\"?>\n")
-
-        if (preface != null) {
-          writer.write(preface)
-        }
-        printer.print(xml)
-      }
-    }
-  }
-}
-
 
 Pair<File, IncludedBuild> locateElasticsearchWorkspace(Gradle gradle) {
   if (gradle.parent == null) {

--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -270,15 +270,6 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
   }
 }
 
-/**
- * Parses a given XML file, applies a set of changes, and writes those changes back to the original file.
- *
- * @param path Path to existing XML file
- * @param action Action to perform on parsed XML document
- * @param preface optional front matter to add after the XML declaration
- * but before the XML document, e.g. a doctype or comment
- */
-
 Pair<File, IncludedBuild> locateElasticsearchWorkspace(Gradle gradle) {
   if (gradle.parent == null) {
     // See if any of these included builds is the Elasticsearch gradle

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/EnablePreviewFeaturesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/EnablePreviewFeaturesTask.java
@@ -1,0 +1,53 @@
+/*
+ * ELASTICSEARCH CONFIDENTIAL
+ * __________________
+ *
+ * Copyright Elasticsearch B.V. All rights reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Elasticsearch B.V. and its suppliers, if any.
+ * The intellectual and technical concepts contained herein
+ * are proprietary to Elasticsearch B.V. and its suppliers and
+ * may be covered by U.S. and Foreign Patents, patents in
+ * process, and are protected by trade secret or copyright
+ * law.  Dissemination of this information or reproduction of
+ * this material is strictly forbidden unless prior written
+ * permission is obtained from Elasticsearch B.V.
+ */
+
+package org.elasticsearch.gradle.internal.idea;
+
+import groovy.util.Node;
+
+import groovy.util.NodeList;
+
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import java.io.IOException;
+
+public class EnablePreviewFeaturesTask extends DefaultTask {
+
+    public void enablePreview(String moduleFile, String languageLevel) throws IOException, ParserConfigurationException, SAXException {
+        IdeaXmlUtil.modifyXml(moduleFile, xml -> {
+            // Find the 'component' node
+            NodeList nodes = (NodeList) xml.depthFirst();
+            Node componentNode = null;
+            for (Object node : nodes) {
+                Node currentNode = (Node) node;
+                if ("component".equals(currentNode.name()) && "NewModuleRootManager".equals(currentNode.attribute("name"))) {
+                    componentNode = currentNode;
+                    break;
+                }
+            }
+
+            // Add the attribute to the 'component' node
+            if (componentNode != null) {
+                componentNode.attributes().put("LANGUAGE_LEVEL", languageLevel);
+            }
+        });
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/EnablePreviewFeaturesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/EnablePreviewFeaturesTask.java
@@ -1,33 +1,23 @@
 /*
- * ELASTICSEARCH CONFIDENTIAL
- * __________________
- *
- * Copyright Elasticsearch B.V. All rights reserved.
- *
- * NOTICE:  All information contained herein is, and remains
- * the property of Elasticsearch B.V. and its suppliers, if any.
- * The intellectual and technical concepts contained herein
- * are proprietary to Elasticsearch B.V. and its suppliers and
- * may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright
- * law.  Dissemination of this information or reproduction of
- * this material is strictly forbidden unless prior written
- * permission is obtained from Elasticsearch B.V.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.gradle.internal.idea;
 
 import groovy.util.Node;
-
 import groovy.util.NodeList;
 
-import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 import java.io.IOException;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 public class EnablePreviewFeaturesTask extends DefaultTask {
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/IdeaXmlUtil.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/IdeaXmlUtil.java
@@ -1,0 +1,66 @@
+/*
+ * ELASTICSEARCH CONFIDENTIAL
+ * __________________
+ *
+ * Copyright Elasticsearch B.V. All rights reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Elasticsearch B.V. and its suppliers, if any.
+ * The intellectual and technical concepts contained herein
+ * are proprietary to Elasticsearch B.V. and its suppliers and
+ * may be covered by U.S. and Foreign Patents, patents in
+ * process, and are protected by trade secret or copyright
+ * law.  Dissemination of this information or reproduction of
+ * this material is strictly forbidden unless prior written
+ * permission is obtained from Elasticsearch B.V.
+ */
+
+package org.elasticsearch.gradle.internal.idea;
+
+import groovy.util.Node;
+import groovy.util.XmlParser;
+import groovy.xml.XmlNodePrinter;
+
+import org.gradle.api.Action;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+public class IdeaXmlUtil {
+
+    static Node parseXml(String xmlPath) throws IOException, SAXException, ParserConfigurationException {
+        File xmlFile = new File(xmlPath);
+        XmlParser xmlParser = new XmlParser(false, true, true);
+        xmlParser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        Node xml = xmlParser.parse(xmlFile);
+        return xml;
+    }
+
+    static void modifyXml(String xmlPath, Action<? super Node> action) throws IOException, ParserConfigurationException, SAXException {
+        modifyXml(xmlPath, action, null);
+    }
+
+    static void modifyXml(String xmlPath, Action<? super Node> action, String preface) throws IOException, ParserConfigurationException,
+        SAXException {
+        File xmlFile = new File(xmlPath);
+        if (xmlFile.exists()) {
+            Node xml = parseXml(xmlPath);
+            action.execute(xml);
+
+            try (PrintWriter writer = new PrintWriter(xmlFile)) {
+                var printer = new XmlNodePrinter(writer);
+                printer.setNamespaceAware(true);
+                printer.setPreserveWhitespace(true);
+                writer.write("<?xml version=\"1.0\"?>\n");
+                if (preface != null) {
+                    writer.write(preface);
+                }
+                printer.print(xml);
+            }
+        }
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/IdeaXmlUtil.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/IdeaXmlUtil.java
@@ -32,10 +32,26 @@ public class IdeaXmlUtil {
         return xml;
     }
 
+
+    /**
+     * Parses a given XML file, applies a set of changes, and writes those changes back to the original file.
+     *
+     * @param path Path to existing XML file
+     * @param action Action to perform on parsed XML document
+     * but before the XML document, e.g. a doctype or comment
+     */
     static void modifyXml(String xmlPath, Action<? super Node> action) throws IOException, ParserConfigurationException, SAXException {
         modifyXml(xmlPath, action, null);
     }
 
+    /**
+     * Parses a given XML file, applies a set of changes, and writes those changes back to the original file.
+     *
+     * @param path Path to existing XML file
+     * @param action Action to perform on parsed XML document
+     * @param preface optional front matter to add after the XML declaration
+     * but before the XML document, e.g. a doctype or comment
+     */
     static void modifyXml(String xmlPath, Action<? super Node> action, String preface) throws IOException, ParserConfigurationException,
         SAXException {
         File xmlFile = new File(xmlPath);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/IdeaXmlUtil.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/IdeaXmlUtil.java
@@ -32,7 +32,6 @@ public class IdeaXmlUtil {
         return xml;
     }
 
-
     /**
      * Parses a given XML file, applies a set of changes, and writes those changes back to the original file.
      *

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/IdeaXmlUtil.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/idea/IdeaXmlUtil.java
@@ -1,18 +1,10 @@
 /*
- * ELASTICSEARCH CONFIDENTIAL
- * __________________
- *
- * Copyright Elasticsearch B.V. All rights reserved.
- *
- * NOTICE:  All information contained herein is, and remains
- * the property of Elasticsearch B.V. and its suppliers, if any.
- * The intellectual and technical concepts contained herein
- * are proprietary to Elasticsearch B.V. and its suppliers and
- * may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright
- * law.  Dissemination of this information or reproduction of
- * this material is strictly forbidden unless prior written
- * permission is obtained from Elasticsearch B.V.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.gradle.internal.idea;


### PR DESCRIPTION
relying on extra properties turns out problematic in general. This
introduces a typed task that has a util method enablePreview which is used
in the elasticsearch and elasticsearch serverless idea setup