### PR TITLE
[8.x] Remove unsupported timeout from rest-api-spec license API (#118919)

### DIFF
--- a/docs/changelog/118919.yaml
+++ b/docs/changelog/118919.yaml
@@ -1,0 +1,5 @@
+pr: 118919
+summary: Remove unsupported timeout from rest-api-spec license API
+area: License
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_trial.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_trial.json
@@ -31,10 +31,6 @@
       "master_timeout": {
         "type": "time",
         "description": "Timeout for processing on master node"
-      },
-      "timeout": {
-        "type": "time",
-        "description": "Timeout for acknowledgement of update from all nodes in cluster"
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Remove unsupported timeout from rest-api-spec license API (#118919)