### PR TITLE
Nullify sourceAsMap once a search hit is processed

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -492,6 +492,13 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
     }
 
     /**
+     * Set the cache document as a map to {@code null}.
+     */
+    public void resetSourceAsMap() {
+        sourceAsMap = null;
+    }
+
+    /**
      * The hit field matching the given field name.
      */
     public DocumentField field(String fieldName) {

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -735,6 +735,7 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
         if (SearchHit.this.source instanceof RefCounted r) {
             r.decRef();
         }
+        SearchHit.this.sourceAsMap = null;
         SearchHit.this.source = null;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhaseDocsIterator.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhaseDocsIterator.java
@@ -86,7 +86,10 @@ abstract class FetchPhaseDocsIterator {
                     }
                     currentDoc = docs[i].docId;
                     assert searchHits[docs[i].index] == null;
-                    searchHits[docs[i].index] = nextDoc(docs[i].docId);
+                    SearchHit searchHit = nextDoc(docs[i].docId);
+                    // free some memory
+                    searchHit.resetSourceAsMap();
+                    searchHits[docs[i].index] = searchHit;
                 } catch (ContextIndexSearcher.TimeExceededException e) {
                     if (allowPartialResults == false) {
                         purgeSearchHits(searchHits);


### PR DESCRIPTION
The sourceAsMap can use a significant amount of memory, still it is only hold for caching. Therefore it might make sense to nullify it once a search hit is processed so we free that memory.