### PR TITLE
[8.17] Add missing timeouts to rest-api-spec shutdown APIs (#118921)

### DIFF
--- a/docs/changelog/118921.yaml
+++ b/docs/changelog/118921.yaml
@@ -1,0 +1,5 @@
+pr: 118921
+summary: Add missing timeouts to rest-api-spec shutdown APIs
+area: Infra/Node Lifecycle
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.delete_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.delete_node.json
@@ -26,6 +26,15 @@
         }
       ]
     },
-    "params":{}
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.put_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.put_node.json
@@ -26,7 +26,16 @@
         }
       ]
     },
-    "params":{},
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    },
     "body":{
       "description":"The shutdown type definition to register",
       "required": true


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Add missing timeouts to rest-api-spec shutdown APIs (#118921)