### PR TITLE
[8.x] Add missing parameter to xpack.info rest-api-spec (#118954)

### DIFF
--- a/docs/changelog/118954.yaml
+++ b/docs/changelog/118954.yaml
@@ -1,0 +1,5 @@
+pr: 118954
+summary: Add missing parameter to `xpack.info` rest-api-spec
+area: Infra/REST API
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/xpack.info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/xpack.info.json
@@ -20,6 +20,12 @@
       ]
     },
     "params":{
+      "human":{
+        "type":"boolean",
+        "required":false,
+        "description":"Defines whether additional human-readable information is included in the response. In particular, it adds descriptions and a tag line. The default value is true.",
+        "default":true
+      },
       "categories":{
         "type":"list",
         "description":"Comma-separated list of info categories. Can be any of: build, license, features"


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add missing parameter to xpack.info rest-api-spec (#118954)