### PR TITLE
[Entitlements] Fix "No SecurityManager when entitlements are enabled"

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
@@ -141,7 +141,7 @@ final class SystemJvmOptions {
 
     @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
     private static Stream<String> maybeAllowSecurityManager(boolean useEntitlements) {
-        if (useEntitlements == false && RuntimeVersionFeature.isSecurityManagerAvailable()) {
+        if (RuntimeVersionFeature.isSecurityManagerAvailable()) {
             // Will become conditional on useEntitlements once entitlements can run without SM
             return Stream.of("-Djava.security.manager=allow");
         }

--- a/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/ExampleSecurityExtension.java
+++ b/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/ExampleSecurityExtension.java
@@ -36,7 +36,8 @@ import static org.elasticsearch.example.role.CustomInMemoryRolesProvider.ROLE_B;
 public class ExampleSecurityExtension implements SecurityExtension {
 
     static {
-        if (RuntimeVersionFeature.isSecurityManagerAvailable()) {
+        final boolean useEntitlements = Boolean.parseBoolean(System.getProperty("es.entitlements.enabled"));
+        if (useEntitlements == false && RuntimeVersionFeature.isSecurityManagerAvailable()) {
             // check that the extension's policy works.
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
                 System.getSecurityManager().checkPropertyAccess("myproperty");


### PR DESCRIPTION
Missing test still using SM even when disabled, plus revert change to SystemJvmOptions to keep allowing the SM. It seems that Hadoop needs that, as it does check if the SM is allowed via `Subject#getSubject`. This is a temp fix, as `Subject#getSubject` is effectively removed from JDK 24 (throws UnsupportedOperationException), but in the meantime allows our tests to run
(in the long run we should update Hadoop after https://github.com/apache/hadoop/pull/7081 has been merged)