### PR TITLE
[8.x] Nullify sourceAsMap once a search hit is processed (#119734)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -492,6 +492,13 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
     }
 
     /**
+     * Set the cache document as a map to {@code null}.
+     */
+    public void resetSourceAsMap() {
+        sourceAsMap = null;
+    }
+
+    /**
      * The hit field matching the given field name.
      */
     public DocumentField field(String fieldName) {
@@ -728,6 +735,7 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
         if (SearchHit.this.source instanceof RefCounted r) {
             r.decRef();
         }
+        SearchHit.this.sourceAsMap = null;
         SearchHit.this.source = null;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhaseDocsIterator.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhaseDocsIterator.java
@@ -86,7 +86,10 @@ abstract class FetchPhaseDocsIterator {
                     }
                     currentDoc = docs[i].docId;
                     assert searchHits[docs[i].index] == null;
-                    searchHits[docs[i].index] = nextDoc(docs[i].docId);
+                    SearchHit searchHit = nextDoc(docs[i].docId);
+                    // free some memory
+                    searchHit.resetSourceAsMap();
+                    searchHits[docs[i].index] = searchHit;
                 } catch (ContextIndexSearcher.TimeExceededException e) {
                     if (allowPartialResults == false) {
                         purgeSearchHits(searchHits);


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Nullify sourceAsMap once a search hit is processed (#119734)