### PR TITLE
[8.x] Optimized index sorting for OTel logs (#119504)

### DIFF
--- a/docs/changelog/119504.yaml
+++ b/docs/changelog/119504.yaml
@@ -1,0 +1,5 @@
+pr: 119504
+summary: Optimized index sorting for OTel logs
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/logs-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/logs-otel@mappings.yaml
@@ -9,6 +9,7 @@ template:
       mode: logsdb
       sort:
         field: [ "resource.attributes.host.name", "@timestamp" ]
+        order: [ "asc", "desc" ]
   mappings:
     properties:
       attributes:


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Optimized index sorting for OTel logs (#119504)