### PR TITLE
Revert "Nullify sourceAsMap once a search hit is processed (#119734)"

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -492,13 +492,6 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
     }
 
     /**
-     * Set the cache document as a map to {@code null}.
-     */
-    public void resetSourceAsMap() {
-        sourceAsMap = null;
-    }
-
-    /**
      * The hit field matching the given field name.
      */
     public DocumentField field(String fieldName) {
@@ -735,7 +728,6 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
         if (SearchHit.this.source instanceof RefCounted r) {
             r.decRef();
         }
-        SearchHit.this.sourceAsMap = null;
         SearchHit.this.source = null;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhaseDocsIterator.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhaseDocsIterator.java
@@ -86,10 +86,7 @@ abstract class FetchPhaseDocsIterator {
                     }
                     currentDoc = docs[i].docId;
                     assert searchHits[docs[i].index] == null;
-                    SearchHit searchHit = nextDoc(docs[i].docId);
-                    // free some memory
-                    searchHit.resetSourceAsMap();
-                    searchHits[docs[i].index] = searchHit;
+                    searchHits[docs[i].index] = nextDoc(docs[i].docId);
                 } catch (ContextIndexSearcher.TimeExceededException e) {
                     if (allowPartialResults == false) {
                         purgeSearchHits(searchHits);


### PR DESCRIPTION
This reverts commit ab77144aa4973c9d90eee63e392ead7cdb11df4e.

We should add more test around this and check the places where we are reading the sourceAsMap from SearchHits.