### PR TITLE
[Entitlements] Reintroduce entitlement check on System.exit

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -37,6 +37,8 @@ public interface EntitlementChecker {
 
     void check$java_lang_Runtime$halt(Class<?> callerClass, Runtime runtime, int status);
 
+    void check$java_lang_System$$exit(Class<?> callerClass, int status);
+
     ////////////////////
     //
     // ClassLoader ctor

--- a/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/RestEntitlementsCheckAction.java
@@ -83,6 +83,7 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
     private static final Map<String, CheckAction> checkActions = Map.ofEntries(
         entry("runtime_exit", deniedToPlugins(RestEntitlementsCheckAction::runtimeExit)),
         entry("runtime_halt", deniedToPlugins(RestEntitlementsCheckAction::runtimeHalt)),
+        entry("system_exit", deniedToPlugins(RestEntitlementsCheckAction::systemExit)),
         entry("create_classloader", forPlugins(RestEntitlementsCheckAction::createClassLoader)),
         entry("processBuilder_start", deniedToPlugins(RestEntitlementsCheckAction::processBuilder_start)),
         entry("processBuilder_startPipeline", deniedToPlugins(RestEntitlementsCheckAction::processBuilder_startPipeline)),
@@ -151,6 +152,11 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
     @SuppressForbidden(reason = "Specifically testing Runtime.halt")
     private static void runtimeHalt() {
         Runtime.getRuntime().halt(123);
+    }
+
+    @SuppressForbidden(reason = "Specifically testing System.exit")
+    private static void systemExit() {
+        System.exit(123);
     }
 
     private static void createClassLoader() {

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -52,6 +52,11 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     }
 
     @Override
+    public void check$java_lang_System$$exit(Class<?> callerClass, int status) {
+        policyManager.checkExitVM(callerClass);
+    }
+
+    @Override
     public void check$java_lang_ClassLoader$(Class<?> callerClass) {
         policyManager.checkCreateClassLoader(callerClass);
     }


### PR DESCRIPTION
As discussed during our sync, we should re-introduce the entitlement check on System.exit.
It's not a contract that System.exit calls Runtime.exit; even if unlikely, its implementation _could_ change in a future JDK release, leaving the method unchecked.
In general, now that we have a way to skip the double-check, we should instrument the whole public surface of the JDK (for the methods we need/want to check of course).
