### PR TITLE
[8.x] Fix bbq_hnsw merge file cleanup on random IO exceptions (#119691)

### DIFF
--- a/docs/changelog/119691.yaml
+++ b/docs/changelog/119691.yaml
@@ -1,0 +1,6 @@
+pr: 119691
+summary: Fix `bbq_hnsw` merge file cleanup on random IO exceptions
+area: Vector Search
+type: bug
+issues:
+ - 119392

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsWriter.java
@@ -441,21 +441,27 @@ public class ES818BinaryQuantizedVectorsWriter extends FlatVectorsWriter {
         float cDotC
     ) throws IOException {
         long vectorDataOffset = binarizedVectorData.alignFilePointer(Float.BYTES);
-        final IndexOutput tempQuantizedVectorData = segmentWriteState.directory.createTempOutput(
-            binarizedVectorData.getName(),
-            "temp",
-            segmentWriteState.context
-        );
-        final IndexOutput tempScoreQuantizedVectorData = segmentWriteState.directory.createTempOutput(
-            binarizedVectorData.getName(),
-            "score_temp",
-            segmentWriteState.context
-        );
         IndexInput binarizedDataInput = null;
         IndexInput binarizedScoreDataInput = null;
+        IndexOutput tempQuantizedVectorData = null;
+        IndexOutput tempScoreQuantizedVectorData = null;
         boolean success = false;
         OptimizedScalarQuantizer quantizer = new OptimizedScalarQuantizer(fieldInfo.getVectorSimilarityFunction());
         try {
+            // Since we are opening two files, it's possible that one or the other fails to open
+            // we open them within the try to ensure they are cleaned
+            tempQuantizedVectorData = segmentWriteState.directory.createTempOutput(
+                binarizedVectorData.getName(),
+                "temp",
+                segmentWriteState.context
+            );
+            tempScoreQuantizedVectorData = segmentWriteState.directory.createTempOutput(
+                binarizedVectorData.getName(),
+                "score_temp",
+                segmentWriteState.context
+            );
+            final String tempQuantizedVectorDataName = tempQuantizedVectorData.getName();
+            final String tempScoreQuantizedVectorDataName = tempScoreQuantizedVectorData.getName();
             FloatVectorValues floatVectorValues = KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
             if (fieldInfo.getVectorSimilarityFunction() == COSINE) {
                 floatVectorValues = new NormalizedFloatVectorValues(floatVectorValues);
@@ -514,8 +520,8 @@ public class ES818BinaryQuantizedVectorsWriter extends FlatVectorsWriter {
                 IOUtils.close(finalBinarizedDataInput, finalBinarizedScoreDataInput);
                 IOUtils.deleteFilesIgnoringExceptions(
                     segmentWriteState.directory,
-                    tempQuantizedVectorData.getName(),
-                    tempScoreQuantizedVectorData.getName()
+                    tempQuantizedVectorDataName,
+                    tempScoreQuantizedVectorDataName
                 );
             });
         } finally {
@@ -526,11 +532,12 @@ public class ES818BinaryQuantizedVectorsWriter extends FlatVectorsWriter {
                     binarizedDataInput,
                     binarizedScoreDataInput
                 );
-                IOUtils.deleteFilesIgnoringExceptions(
-                    segmentWriteState.directory,
-                    tempQuantizedVectorData.getName(),
-                    tempScoreQuantizedVectorData.getName()
-                );
+                if (tempQuantizedVectorData != null) {
+                    IOUtils.deleteFilesIgnoringExceptions(segmentWriteState.directory, tempQuantizedVectorData.getName());
+                }
+                if (tempScoreQuantizedVectorData != null) {
+                    IOUtils.deleteFilesIgnoringExceptions(segmentWriteState.directory, tempScoreQuantizedVectorData.getName());
+                }
             }
         }
     }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix bbq_hnsw merge file cleanup on random IO exceptions (#119691)