### PR TITLE
[Profiling] Remove legacy aggregation_field

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetFlameGraphActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetFlameGraphActionIT.java
@@ -22,7 +22,6 @@ public class GetFlameGraphActionIT extends ProfilingTestCase {
             null,
             null,
             null,
-            null,
             null
         );
         GetFlamegraphResponse response = client().execute(GetFlamegraphAction.INSTANCE, request).get();

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetStackTracesActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetStackTracesActionIT.java
@@ -28,7 +28,6 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
             null,
             null,
             null,
-            null,
             null
         );
         request.setAdjustSampleCount(true);
@@ -68,8 +67,7 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
             null,
             null,
             null,
-            "service.name",
-            null,
+            new String[] { "service.name" },
             null,
             null,
             null,
@@ -117,8 +115,7 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
             // also match an index that does not contain stacktrace ids to ensure it is ignored
             new String[] { "apm-test-*", "apm-legacy-test-*" },
             "transaction.profiler_stack_trace_ids",
-            "transaction.name",
-            null,
+            new String[] { "transaction.name" },
             null,
             null,
             null,
@@ -163,7 +160,6 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
             query,
             new String[] { "apm-test-*" },
             "transaction.profiler_stack_trace_ids",
-            null,
             null,
             null,
             null,
@@ -219,7 +215,6 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
             null,
             null,
             null,
-            null,
             null
         );
         GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();
@@ -242,7 +237,6 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
             null,
             null,
             null,
-            null,
             null
         );
         GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();
@@ -260,7 +254,6 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
             query,
             new String[] { "apm-legacy-test-*" },
             "transaction.profiler_stack_trace_ids",
-            null,
             null,
             null,
             null,

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetTopNFunctionsActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetTopNFunctionsActionIT.java
@@ -25,7 +25,6 @@ public class GetTopNFunctionsActionIT extends ProfilingTestCase {
             null,
             null,
             null,
-            null,
             null
         );
         request.setAdjustSampleCount(true);
@@ -42,8 +41,7 @@ public class GetTopNFunctionsActionIT extends ProfilingTestCase {
             null,
             null,
             null,
-            "service.name",
-            null,
+            new String[] { "service.name" },
             null,
             null,
             null,
@@ -70,8 +68,7 @@ public class GetTopNFunctionsActionIT extends ProfilingTestCase {
             // also match an index that does not contain stacktrace ids to ensure it is ignored
             new String[] { "apm-test-*", "apm-legacy-test-*" },
             "transaction.profiler_stack_trace_ids",
-            "transaction.name",
-            null,
+            new String[] { "transaction.name" },
             null,
             null,
             null,

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/SubGroup.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/SubGroup.java
@@ -20,23 +20,21 @@ public class SubGroup implements ToXContentFragment {
     private final String name;
     private Long count;
     @UpdateForV9(owner = UpdateForV9.Owner.PROFILING) // remove legacy XContent rendering
-    private final boolean renderLegacyXContent;
     private final Map<String, SubGroup> subgroups;
 
-    public static SubGroup root(String name, boolean renderLegacyXContent) {
-        return new SubGroup(name, null, renderLegacyXContent, new HashMap<>());
+    public static SubGroup root(String name) {
+        return new SubGroup(name, null, new HashMap<>());
     }
 
-    public SubGroup(String name, Long count, boolean renderLegacyXContent, Map<String, SubGroup> subgroups) {
+    public SubGroup(String name, Long count, Map<String, SubGroup> subgroups) {
         this.name = name;
         this.count = count;
-        this.renderLegacyXContent = renderLegacyXContent;
         this.subgroups = subgroups;
     }
 
     public SubGroup addCount(String name, long count) {
         if (this.subgroups.containsKey(name) == false) {
-            this.subgroups.put(name, new SubGroup(name, count, renderLegacyXContent, new HashMap<>()));
+            this.subgroups.put(name, new SubGroup(name, count, new HashMap<>()));
         } else {
             SubGroup s = this.subgroups.get(name);
             s.count += count;
@@ -46,7 +44,7 @@ public class SubGroup implements ToXContentFragment {
 
     public SubGroup getOrAddChild(String name) {
         if (subgroups.containsKey(name) == false) {
-            this.subgroups.put(name, new SubGroup(name, null, renderLegacyXContent, new HashMap<>()));
+            this.subgroups.put(name, new SubGroup(name, null, new HashMap<>()));
         }
         return this.subgroups.get(name);
     }
@@ -65,32 +63,22 @@ public class SubGroup implements ToXContentFragment {
         for (Map.Entry<String, SubGroup> subGroup : subgroups.entrySet()) {
             copy.put(subGroup.getKey(), subGroup.getValue().copy());
         }
-        return new SubGroup(name, count, renderLegacyXContent, copy);
+        return new SubGroup(name, count, copy);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        if (renderLegacyXContent) {
-            // This assumes that we only have one level of sub groups
-            if (subgroups != null && subgroups.isEmpty() == false) {
-                for (SubGroup subgroup : subgroups.values()) {
-                    builder.field(subgroup.name, subgroup.count);
-                }
-            }
-            return builder;
-        } else {
-            builder.startObject(name);
-            // only the root node has no count
-            if (count != null) {
-                builder.field("count", count);
-            }
-            if (subgroups != null && subgroups.isEmpty() == false) {
-                for (SubGroup subgroup : subgroups.values()) {
-                    subgroup.toXContent(builder, params);
-                }
-            }
-            return builder.endObject();
+        builder.startObject(name);
+        // only the root node has no count
+        if (count != null) {
+            builder.field("count", count);
         }
+        if (subgroups != null && subgroups.isEmpty() == false) {
+            for (SubGroup subgroup : subgroups.values()) {
+                subgroup.toXContent(builder, params);
+            }
+        }
+        return builder.endObject();
     }
 
     @Override

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/SubGroupCollector.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/SubGroupCollector.java
@@ -26,21 +26,15 @@ public final class SubGroupCollector {
     private static final Logger log = LogManager.getLogger(SubGroupCollector.class);
 
     private final String[] aggregationFields;
-    private final boolean legacyAggregationField;
 
-    public static SubGroupCollector attach(
-        AbstractAggregationBuilder<?> parentAggregation,
-        String[] aggregationFields,
-        boolean legacyAggregationField
-    ) {
-        SubGroupCollector c = new SubGroupCollector(aggregationFields, legacyAggregationField);
+    public static SubGroupCollector attach(AbstractAggregationBuilder<?> parentAggregation, String[] aggregationFields) {
+        SubGroupCollector c = new SubGroupCollector(aggregationFields);
         c.addAggregations(parentAggregation);
         return c;
     }
 
-    private SubGroupCollector(String[] aggregationFields, boolean legacyAggregationField) {
+    private SubGroupCollector(String[] aggregationFields) {
         this.aggregationFields = aggregationFields;
-        this.legacyAggregationField = legacyAggregationField;
     }
 
     private boolean hasAggregationFields() {
@@ -68,7 +62,7 @@ public final class SubGroupCollector {
     void collectResults(Bucket bucket, TraceEvent event) {
         if (hasAggregationFields()) {
             if (event.subGroups == null) {
-                event.subGroups = SubGroup.root(aggregationFields[0], legacyAggregationField);
+                event.subGroups = SubGroup.root(aggregationFields[0]);
             }
             collectInternal(bucket.getAggregations(), event.subGroups, 0);
         }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStackTracesAction.java
@@ -255,11 +255,7 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
         CountedTermsAggregationBuilder groupByStackTraceId = new CountedTermsAggregationBuilder("group_by").size(
             MAX_TRACE_EVENTS_RESULT_SIZE
         ).field(request.getStackTraceIdsField());
-        SubGroupCollector subGroups = SubGroupCollector.attach(
-            groupByStackTraceId,
-            request.getAggregationFields(),
-            request.isLegacyAggregationField()
-        );
+        SubGroupCollector subGroups = SubGroupCollector.attach(groupByStackTraceId, request.getAggregationFields());
         RandomSamplerAggregationBuilder randomSampler = new RandomSamplerAggregationBuilder("sample").setSeed(request.hashCode())
             .setProbability(responseBuilder.getSamplingRate())
             .subAggregation(groupByStackTraceId);
@@ -326,11 +322,7 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
             // Especially with high cardinality fields, this makes aggregations really slow.
             .executionHint("map")
             .subAggregation(new SumAggregationBuilder("count").field("Stacktrace.count"));
-        SubGroupCollector subGroups = SubGroupCollector.attach(
-            groupByStackTraceId,
-            request.getAggregationFields(),
-            request.isLegacyAggregationField()
-        );
+        SubGroupCollector subGroups = SubGroupCollector.attach(groupByStackTraceId, request.getAggregationFields());
         client.prepareSearch(eventsIndex.getName())
             .setTrackTotalHits(false)
             .setSize(0)

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/GetStackTracesRequestTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/GetStackTracesRequestTests.java
@@ -51,7 +51,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
             // Expect the default values
             assertNull(request.getIndices());
             assertNull(request.getStackTraceIdsField());
-            assertFalse(request.isLegacyAggregationField());
             assertNull(request.getAggregationFields());
             assertNull(request.getAwsCostFactor());
             assertNull(request.getAzureCostFactor());
@@ -92,7 +91,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
 
             // Expect the default values
             assertNull(request.getRequestedDuration());
-            assertFalse(request.isLegacyAggregationField());
             assertNull(request.getAggregationFields());
             assertNull(request.getAwsCostFactor());
             assertNull(request.getAzureCostFactor());
@@ -111,7 +109,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
                 .field("sample_size", 2000)
                 .field("indices", new String[] {"my-traces"})
                 .field("stacktrace_ids_field", "stacktraces")
-                .field("aggregation_field", "service")
+                .field("aggregation_fields", new String[] {"service"})
                 .startObject("query")
                     .startObject("range")
                         .startObject("@timestamp")
@@ -130,7 +128,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
             assertArrayEquals(new String[] { "my-traces" }, request.getIndices());
             assertEquals("stacktraces", request.getStackTraceIdsField());
             assertArrayEquals(new String[] { "service" }, request.getAggregationFields());
-            assertTrue(request.isLegacyAggregationField());
             // a basic check suffices here
             assertEquals("@timestamp", ((RangeQueryBuilder) request.getQuery()).fieldName());
 
@@ -177,7 +174,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
 
             // Expect the default values
             assertNull(request.getRequestedDuration());
-            assertFalse(request.isLegacyAggregationField());
             assertNull(request.getAwsCostFactor());
             assertNull(request.getAzureCostFactor());
             assertNull(request.getCustomCO2PerKWH());
@@ -231,7 +227,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
             // Expect the default values
             assertNull(request.getIndices());
             assertNull(request.getStackTraceIdsField());
-            assertFalse(request.isLegacyAggregationField());
             assertNull(request.getAggregationFields());
         }
     }
@@ -345,7 +340,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
             null,
             null,
             null,
-            null,
             null
         );
         List<String> validationErrors = request.validate().validationErrors();
@@ -367,7 +361,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
             null,
             null,
             null,
-            null,
             null
         );
         assertNull("Expecting no validation errors", request.validate());
@@ -382,7 +375,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
             null,
             null,
             randomAlphaOfLength(3),
-            null,
             null,
             null,
             null,
@@ -409,56 +401,11 @@ public class GetStackTracesRequestTests extends ESTestCase {
             null,
             null,
             null,
-            null,
             null
         );
         List<String> validationErrors = request.validate().validationErrors();
         assertEquals(1, validationErrors.size());
         assertEquals("[stacktrace_ids_field] is mandatory", validationErrors.get(0));
-    }
-
-    public void testValidateEmptyAggregationField() {
-        GetStackTracesRequest request = new GetStackTracesRequest(
-            null,
-            1.0d,
-            1.0d,
-            1.0d,
-            null,
-            new String[] { randomAlphaOfLength(5) },
-            randomAlphaOfLength(5),
-            "",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
-        List<String> validationErrors = request.validate().validationErrors();
-        assertEquals(1, validationErrors.size());
-        assertEquals("[aggregation_field] must be non-empty", validationErrors.get(0));
-    }
-
-    public void testValidateAggregationFieldAndAggregationFields() {
-        GetStackTracesRequest request = new GetStackTracesRequest(
-            null,
-            1.0d,
-            1.0d,
-            1.0d,
-            null,
-            new String[] { randomAlphaOfLength(5) },
-            randomAlphaOfLength(5),
-            "transaction.name",
-            new String[] { "transaction.name", "service.name" },
-            null,
-            null,
-            null,
-            null,
-            null
-        );
-        List<String> validationErrors = request.validate().validationErrors();
-        assertEquals(1, validationErrors.size());
-        assertEquals("[aggregation_field] must not be set when [aggregation_fields] is also set", validationErrors.get(0));
     }
 
     public void testValidateAggregationFieldsContainsTooFewElements() {
@@ -470,7 +417,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
             null,
             new String[] { randomAlphaOfLength(5) },
             randomAlphaOfLength(5),
-            null,
             new String[] {},
             null,
             null,
@@ -492,7 +438,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
             null,
             new String[] { randomAlphaOfLength(5) },
             randomAlphaOfLength(5),
-            null,
             new String[] { "application", "service", "transaction" },
             null,
             null,
@@ -514,7 +459,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
             null,
             new String[] { randomAlphaOfLength(5) },
             randomAlphaOfLength(5),
-            null,
             new String[] { "service", "service" },
             null,
             null,
@@ -540,7 +484,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
             null,
             null,
             null,
-            null,
             null
         );
         String[] indices = request.indices();
@@ -554,7 +497,6 @@ public class GetStackTracesRequestTests extends ESTestCase {
             1.0d,
             1.0d,
             1.0d,
-            null,
             null,
             null,
             null,

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/GetTopNFunctionsResponseTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/GetTopNFunctionsResponseTests.java
@@ -90,7 +90,7 @@ public class GetTopNFunctionsResponseTests extends ESTestCase {
             22.0d,
             12.0d,
             120.0d,
-            SubGroup.root("transaction.name", false).addCount("basket", 7L)
+            SubGroup.root("transaction.name").addCount("basket", 7L)
         );
         GetTopNFunctionsResponse response = new GetTopNFunctionsResponse(1, 10, 2.2d, 12.0d, List.of(topNFunction));
         response.toXContent(actualResponse, ToXContent.EMPTY_PARAMS);

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/ResamplerTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/ResamplerTests.java
@@ -43,7 +43,6 @@ public class ResamplerTests extends ESTestCase {
             null,
             null,
             null,
-            null,
             null
         );
         request.setAdjustSampleCount(false);
@@ -73,7 +72,6 @@ public class ResamplerTests extends ESTestCase {
             null,
             null,
             null,
-            null,
             null
         );
         request.setAdjustSampleCount(true);
@@ -95,7 +93,6 @@ public class ResamplerTests extends ESTestCase {
             1.0d,
             1.0d,
             1.0d,
-            null,
             null,
             null,
             null,
@@ -136,7 +133,6 @@ public class ResamplerTests extends ESTestCase {
             null,
             null,
             null,
-            null,
             null
         );
 
@@ -158,7 +154,6 @@ public class ResamplerTests extends ESTestCase {
             1.0d,
             1.0d,
             1.0d,
-            null,
             null,
             null,
             null,

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/SubGroupCollectorTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/SubGroupCollectorTests.java
@@ -21,7 +21,7 @@ public class SubGroupCollectorTests extends ESTestCase {
         TermsAggregationBuilder stackTraces = new TermsAggregationBuilder("stacktraces").field("stacktrace.id");
         TraceEvent traceEvent = new TraceEvent("1");
 
-        SubGroupCollector collector = SubGroupCollector.attach(stackTraces, new String[0], false);
+        SubGroupCollector collector = SubGroupCollector.attach(stackTraces, new String[0]);
         assertTrue("Sub aggregations attached", stackTraces.getSubAggregations().isEmpty());
 
         SubGroupCollector.Bucket currentStackTrace = bucket("1", 5);
@@ -34,7 +34,7 @@ public class SubGroupCollectorTests extends ESTestCase {
         TermsAggregationBuilder stackTraces = new TermsAggregationBuilder("stacktraces").field("stacktrace.id");
         TraceEvent traceEvent = new TraceEvent("1");
 
-        SubGroupCollector collector = SubGroupCollector.attach(stackTraces, new String[] { "service.name", "transaction.name" }, false);
+        SubGroupCollector collector = SubGroupCollector.attach(stackTraces, new String[] { "service.name", "transaction.name" });
         assertFalse("No sub aggregations attached", stackTraces.getSubAggregations().isEmpty());
 
         StaticAgg services = new StaticAgg();
@@ -73,7 +73,7 @@ public class SubGroupCollectorTests extends ESTestCase {
         TermsAggregationBuilder stackTraces = new TermsAggregationBuilder("stacktraces").field("stacktrace.id");
         TraceEvent traceEvent = new TraceEvent("1");
 
-        SubGroupCollector collector = SubGroupCollector.attach(stackTraces, new String[] { "service.name" }, false);
+        SubGroupCollector collector = SubGroupCollector.attach(stackTraces, new String[] { "service.name" });
         assertFalse("No sub aggregations attached", stackTraces.getSubAggregations().isEmpty());
 
         StaticAgg services1 = new StaticAgg();

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/SubGroupTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/SubGroupTests.java
@@ -34,25 +34,7 @@ public class SubGroupTests extends ESTestCase {
 
         XContentBuilder actualRequest = XContentFactory.contentBuilder(contentType);
         actualRequest.startObject();
-        SubGroup g = SubGroup.root("transaction.name", false).addCount("basket", 7L);
-        g.toXContent(actualRequest, ToXContent.EMPTY_PARAMS);
-        actualRequest.endObject();
-
-        assertToXContentEquivalent(BytesReference.bytes(expectedRequest), BytesReference.bytes(actualRequest), contentType);
-    }
-
-    public void testRenderLegacyXContent() throws IOException {
-        XContentType contentType = randomFrom(XContentType.values());
-        // tag::noformat
-        XContentBuilder expectedRequest = XContentFactory.contentBuilder(contentType)
-            .startObject()
-                .field("basket", 7L)
-            .endObject();
-        // end::noformat
-
-        XContentBuilder actualRequest = XContentFactory.contentBuilder(contentType);
-        actualRequest.startObject();
-        SubGroup g = SubGroup.root("transaction.name", true).addCount("basket", 7L);
+        SubGroup g = SubGroup.root("transaction.name").addCount("basket", 7L);
         g.toXContent(actualRequest, ToXContent.EMPTY_PARAMS);
         actualRequest.endObject();
 
@@ -60,8 +42,8 @@ public class SubGroupTests extends ESTestCase {
     }
 
     public void testMergeNoCommonRoot() {
-        SubGroup root1 = SubGroup.root("transaction.name", false);
-        SubGroup root2 = SubGroup.root("service.name", false);
+        SubGroup root1 = SubGroup.root("transaction.name");
+        SubGroup root2 = SubGroup.root("service.name");
 
         SubGroup toMerge = root1.copy();
 
@@ -71,7 +53,7 @@ public class SubGroupTests extends ESTestCase {
     }
 
     public void testMergeIdenticalTree() {
-        SubGroup g = SubGroup.root("transaction.name", false);
+        SubGroup g = SubGroup.root("transaction.name");
         g.addCount("basket", 5L);
         g.addCount("checkout", 7L);
 
@@ -84,11 +66,11 @@ public class SubGroupTests extends ESTestCase {
     }
 
     public void testMergeMixedTree() {
-        SubGroup g1 = SubGroup.root("transaction.name", false);
+        SubGroup g1 = SubGroup.root("transaction.name");
         g1.addCount("basket", 5L);
         g1.addCount("checkout", 7L);
 
-        SubGroup g2 = SubGroup.root("transaction.name", false);
+        SubGroup g2 = SubGroup.root("transaction.name");
         g2.addCount("catalog", 8L);
         g2.addCount("basket", 5L);
         g2.addCount("checkout", 2L);

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/TopNFunctionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/TopNFunctionTests.java
@@ -81,7 +81,7 @@ public class TopNFunctionTests extends ESTestCase {
             22.0d,
             12.0d,
             120.0d,
-            SubGroup.root("transaction.name", false).addCount("basket", 7L)
+            SubGroup.root("transaction.name").addCount("basket", 7L)
         );
         topNFunction.toXContent(actualRequest, ToXContent.EMPTY_PARAMS);
 
@@ -116,7 +116,7 @@ public class TopNFunctionTests extends ESTestCase {
             4.0d,
             23.2d,
             12.0d,
-            SubGroup.root("transaction.name", false).addCount("checkout", 4L).addCount("basket", 12L)
+            SubGroup.root("transaction.name").addCount("checkout", 4L).addCount("basket", 12L)
         );
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(topNFunction, (TopNFunction::copy));
     }


### PR DESCRIPTION
Removes support for `aggregation_fields`, which has been replaced by `aggregation_fields`.

Reference: https://github.com/elastic/kibana/issues/204024
Pre-requisite: https://github.com/elastic/kibana/pull/205861