### PR TITLE
Fix redundant assignment in QueryStringQueryBuilder

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -268,18 +268,19 @@ public class QueryStringQueryParser extends QueryParser {
             if (allFields && this.field != null && this.field.equals(field)) {
                 // "*" is the default field
                 extractedFields = fieldsAndWeights;
+            } else {
+                boolean multiFields = Regex.isSimpleMatchPattern(field);
+                // Filters unsupported fields if a pattern is requested
+                // Filters metadata fields if all fields are requested
+                extractedFields = resolveMappingField(
+                    context,
+                    field,
+                    1.0f,
+                    allFields == false,
+                    multiFields == false,
+                    quoted ? quoteFieldSuffix : null
+                );
             }
-            boolean multiFields = Regex.isSimpleMatchPattern(field);
-            // Filters unsupported fields if a pattern is requested
-            // Filters metadata fields if all fields are requested
-            extractedFields = resolveMappingField(
-                context,
-                field,
-                1.0f,
-                allFields == false,
-                multiFields == false,
-                quoted ? quoteFieldSuffix : null
-            );
         } else if (quoted && quoteFieldSuffix != null) {
             extractedFields = resolveMappingFields(context, fieldsAndWeights, quoteFieldSuffix);
         } else {


### PR DESCRIPTION
We have a redundant assignment in `QueryStringQueryBuilder` for `extractedFields`:


https://github.com/elastic/elasticsearch/blob/82b1f2a205d8c124be289c11674c55927bf25d14/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java#L268-L282

To fix this we can remove the `extractedFields = fieldsAndWeights` assignment altogether.
However `fieldsAndWeights` already contains the same result of the second assignment.
`fieldsAndWeights` is actually initialised with the exact same value (when the redundant assignment is executed) - see the call to `resolveMappingField`:

https://github.com/elastic/elasticsearch/blob/82b1f2a205d8c124be289c11674c55927bf25d14/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java#L132-L134

When matching all fields I think it was always the intention to just reuse `fieldsAndWeights`, but the redundant assignment and extra computation was added as a regression in https://github.com/elastic/elasticsearch/pull/55158

In the context of a single `query_string` execution, `extractMultiFields` can be called multiple times. Some examples where the redundant assignment is triggered and we end up extracting the fields for wildcard queries multiple times:

- `something OR nothing OR anything` - 3 redundant assignments and recomputing the available fields, instead of relying on the stored `fieldsAndWeights`.
- `*:something AND nothing` - 2 redundant assignments 

This is why I decided to keep the `extractedFields = fieldsAndWeights` assignment and just to make sure we don't call `resolveMappingField` unnecessarily.

