### PR TITLE
[8.x] Add rest endpoint for create_from_source_index (#119250)

### DIFF
--- a/docs/changelog/119250.yaml
+++ b/docs/changelog/119250.yaml
@@ -1,0 +1,5 @@
+pr: 119250
+summary: Add rest endpoint for `create_from_source_index`
+area: Data streams
+type: enhancement
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/migrate.create_from.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/migrate.create_from.json
@@ -1,0 +1,37 @@
+{
+  "migrate.create_from":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-reindex.html",
+      "description":"This API creates a destination from a source index. It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values."
+    },
+    "stability":"experimental",
+    "visibility":"private",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_create_from/{source}/{dest}",
+          "methods":[ "PUT", "POST"],
+          "parts":{
+            "source":{
+              "type":"string",
+              "description":"The source index name"
+            },
+            "dest":{
+              "type":"string",
+              "description":"The destination index name"
+            }
+          }
+        }
+      ]
+    },
+    "body":{
+      "description":"The body contains the fields `mappings_override` and `settings_override`.",
+      "required":false
+    }
+  }
+}
+

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigratePlugin.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigratePlugin.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexAction;
 import org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexTransportAction;
 import org.elasticsearch.xpack.migrate.action.ReindexDataStreamTransportAction;
 import org.elasticsearch.xpack.migrate.rest.RestCancelReindexDataStreamAction;
+import org.elasticsearch.xpack.migrate.rest.RestCreateIndexFromSourceAction;
 import org.elasticsearch.xpack.migrate.rest.RestGetMigrationReindexStatusAction;
 import org.elasticsearch.xpack.migrate.rest.RestMigrationReindexAction;
 import org.elasticsearch.xpack.migrate.task.ReindexDataStreamPersistentTaskExecutor;
@@ -77,6 +78,7 @@ public class MigratePlugin extends Plugin implements ActionPlugin, PersistentTas
             handlers.add(new RestMigrationReindexAction());
             handlers.add(new RestGetMigrationReindexStatusAction());
             handlers.add(new RestCancelReindexDataStreamAction());
+            handlers.add(new RestCreateIndexFromSourceAction());
         }
         return handlers;
     }

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
@@ -69,31 +69,31 @@ public class CreateIndexFromSourceTransportAction extends HandledTransportAction
     @Override
     protected void doExecute(Task task, CreateIndexFromSourceAction.Request request, ActionListener<AcknowledgedResponse> listener) {
 
-        IndexMetadata sourceIndex = clusterService.state().getMetadata().index(request.getSourceIndex());
+        IndexMetadata sourceIndex = clusterService.state().getMetadata().index(request.sourceIndex());
 
         if (sourceIndex == null) {
-            listener.onFailure(new IndexNotFoundException(request.getSourceIndex()));
+            listener.onFailure(new IndexNotFoundException(request.sourceIndex()));
             return;
         }
 
-        logger.debug("Creating destination index [{}] for source index [{}]", request.getDestIndex(), request.getSourceIndex());
+        logger.debug("Creating destination index [{}] for source index [{}]", request.destIndex(), request.sourceIndex());
 
         Settings settings = Settings.builder()
             // add source settings
             .put(filterSettings(sourceIndex))
             // add override settings from request
-            .put(request.getSettingsOverride())
+            .put(request.settingsOverride())
             .build();
 
         Map<String, Object> mergeMappings;
         try {
-            mergeMappings = mergeMappings(sourceIndex.mapping(), request.getMappingsOverride());
+            mergeMappings = mergeMappings(sourceIndex.mapping(), request.mappingsOverride());
         } catch (IOException e) {
             listener.onFailure(e);
             return;
         }
 
-        var createIndexRequest = new CreateIndexRequest(request.getDestIndex()).settings(settings);
+        var createIndexRequest = new CreateIndexRequest(request.destIndex()).settings(settings);
         if (mergeMappings.isEmpty() == false) {
             createIndexRequest.mapping(mergeMappings);
         }

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -156,7 +156,7 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
             Map.of()
         );
         request.setParentTask(parentTaskId);
-        var errorMessage = String.format(Locale.ROOT, "Could not create index [%s]", request.getDestIndex());
+        var errorMessage = String.format(Locale.ROOT, "Could not create index [%s]", request.destIndex());
         client.execute(CreateIndexFromSourceAction.INSTANCE, request, failIfNotAcknowledged(listener, errorMessage));
     }
 

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestCreateIndexFromSourceAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestCreateIndexFromSourceAction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.migrate.rest;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.migrate.action.CreateIndexFromSourceAction;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.rest.RestRequest.Method.PUT;
+
+public class RestCreateIndexFromSourceAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "create_index_from_source_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(PUT, "/_create_from/{source}/{dest}"), new Route(POST, "/_create_from/{source}/{dest}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        var createRequest = new CreateIndexFromSourceAction.Request(request.param("source"), request.param("dest"));
+        request.applyContentParser(createRequest::fromXContent);
+        return channel -> client.execute(CreateIndexFromSourceAction.INSTANCE, createRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/action/CreateFromSourceIndexRequestTests.java
+++ b/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/action/CreateFromSourceIndexRequestTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.migrate.action;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.migrate.action.CreateIndexFromSourceAction.Request;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
+
+public class CreateFromSourceIndexRequestTests extends AbstractWireSerializingTestCase<Request> {
+
+    public void testToAndFromXContent() throws IOException {
+        var request = createTestInstance();
+
+        boolean humanReadable = randomBoolean();
+        final XContentType xContentType = randomFrom(XContentType.values());
+        BytesReference originalBytes = toShuffledXContent(request, xContentType, EMPTY_PARAMS, humanReadable);
+
+        var parsedRequest = new Request(
+            randomValueOtherThan(request.sourceIndex(), () -> randomAlphanumericOfLength(30)),
+            randomValueOtherThan(request.sourceIndex(), () -> randomAlphanumericOfLength(30))
+        );
+        try (XContentParser xParser = createParser(xContentType.xContent(), originalBytes)) {
+            parsedRequest.fromXContent(xParser);
+        }
+
+        // source and dest won't be equal
+        assertNotEquals(request, parsedRequest);
+        assertNotEquals(request.sourceIndex(), parsedRequest.sourceIndex());
+        assertNotEquals(request.destIndex(), parsedRequest.destIndex());
+
+        // but fields in xcontent will be equal
+        assertEquals(request.settingsOverride(), parsedRequest.settingsOverride());
+        assertEquals(request.mappingsOverride(), parsedRequest.mappingsOverride());
+
+        BytesReference finalBytes = toShuffledXContent(parsedRequest, xContentType, EMPTY_PARAMS, humanReadable);
+        ElasticsearchAssertions.assertToXContentEquivalent(originalBytes, finalBytes, xContentType);
+    }
+
+    @Override
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
+    }
+
+    @Override
+    protected Request createTestInstance() {
+        String source = randomAlphaOfLength(30);
+        String dest = randomAlphaOfLength(30);
+        if (randomBoolean()) {
+            return new Request(source, dest);
+        } else {
+            return new Request(source, dest, randomSettings(), randomMappings());
+        }
+    }
+
+    @Override
+    protected Request mutateInstance(Request instance) throws IOException {
+
+        String sourceIndex = instance.sourceIndex();
+        String destIndex = instance.destIndex();
+        Settings settingsOverride = instance.settingsOverride();
+        Map<String, Object> mappingsOverride = instance.mappingsOverride();
+
+        switch (between(0, 3)) {
+            case 0 -> sourceIndex = randomValueOtherThan(sourceIndex, () -> randomAlphaOfLength(30));
+            case 1 -> destIndex = randomValueOtherThan(destIndex, () -> randomAlphaOfLength(30));
+            case 2 -> settingsOverride = randomValueOtherThan(settingsOverride, CreateFromSourceIndexRequestTests::randomSettings);
+            case 3 -> mappingsOverride = randomValueOtherThan(mappingsOverride, CreateFromSourceIndexRequestTests::randomMappings);
+        }
+        return new Request(sourceIndex, destIndex, settingsOverride, mappingsOverride);
+    }
+
+    public static Map<String, Object> randomMappings() {
+        var randMappings = Map.of("properties", Map.of(randomAlphaOfLength(5), Map.of("type", "keyword")));
+        return randomBoolean() ? Map.of() : Map.of("_doc", randMappings);
+    }
+
+    public static Settings randomSettings() {
+        return randomBoolean() ? Settings.EMPTY : indexSettings(randomIntBetween(1, 10), randomIntBetween(0, 5)).build();
+    }
+}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/30_create_from.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/30_create_from.yml
@@ -1,0 +1,121 @@
+---
+setup:
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: source-index-1
+        ignore_unavailable: true
+  - do:
+      indices.delete:
+        index: dest-index-1
+        ignore_unavailable: true
+
+---
+"Test create from with nonexistent source index":
+  - requires:
+      reason: "migration reindex is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_migration/reindex
+          capabilities: [migration_reindex]
+  - do:
+      catch: /index_not_found_exception/
+      migrate.create_from:
+        source: "does_not_exist"
+        dest: "dest1"
+
+---
+"Test create_from with existing source index":
+  - requires:
+      reason: "migration reindex is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_migration/reindex
+          capabilities: [migration_reindex]
+  - do:
+      indices.create:
+        index: source-index-1
+        body:
+          settings:
+            index:
+              number_of_shards: 3
+              number_of_replicas: 5
+          mappings:
+            dynamic: strict
+            properties:
+              bar:
+                type: text
+  - do:
+      migrate.create_from:
+        source: "source-index-1"
+        dest: "dest-index-1"
+  - do:
+      indices.get_settings:
+        index: dest-index-1
+  - match: { dest-index-1.settings.index.number_of_shards: "3" }
+  - match: { dest-index-1.settings.index.number_of_replicas: "5" }
+  - do:
+      indices.get_mapping:
+        index: dest-index-1
+  - match: {dest-index-1.mappings.properties.bar.type: text}
+
+---
+"Test create_from with existing source index and overrides":
+  - requires:
+      reason: "migration reindex is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_migration/reindex
+          capabilities: [migration_reindex]
+  - do:
+      indices.create:
+        index: source-index-1
+        body:
+          settings:
+            index:
+              number_of_shards: 3
+              number_of_replicas: 5
+          mappings:
+            dynamic: strict
+            properties:
+              bar:
+                type: text
+              foo:
+                type: boolean
+  - do:
+      migrate.create_from:
+        source: "source-index-1"
+        dest: "dest-index-1"
+        body:
+          settings_override:
+            index:
+              number_of_shards: 1
+              default_pipeline: "pipeline-1"
+          mappings_override:
+            dynamic: strict
+            properties:
+              bar:
+                type: keyword
+              baz:
+                type: integer
+  - do:
+      indices.get_settings:
+        index: dest-index-1
+  - match: { dest-index-1.settings.index.number_of_shards: "1" }
+  - match: { dest-index-1.settings.index.number_of_replicas: "5" }
+  - match: { dest-index-1.settings.index.default_pipeline: "pipeline-1" }
+  - do:
+      indices.get_mapping:
+        index: dest-index-1
+  - match: {dest-index-1.mappings.properties.bar.type: keyword}
+  - match: {dest-index-1.mappings.properties.foo.type: boolean}
+  - match: {dest-index-1.mappings.properties.baz.type: integer}
+


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add rest endpoint for create_from_source_index (#119250)