### PR TITLE
Relax profile assertion in single-node rest test

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -312,22 +312,23 @@ public class RestEsqlIT extends RestEsqlTestCase {
             }
             signatures.add(sig);
         }
+        var readProfile = matchesList().item("LuceneSourceOperator")
+            .item("ValuesSourceReaderOperator")
+            .item("AggregationOperator")
+            .item("ExchangeSinkOperator");
+        var mergeProfile = matchesList().item("ExchangeSourceOperator")
+            .item("AggregationOperator")
+            .item("ProjectOperator")
+            .item("LimitOperator")
+            .item("EvalOperator")
+            .item("ProjectOperator")
+            .item("OutputOperator");
+        var emptyReduction = matchesList().item("ExchangeSourceOperator").item("ExchangeSinkOperator");
+        var reduction = matchesList().item("ExchangeSourceOperator").item("AggregationOperator").item("ExchangeSinkOperator");
         assertThat(
             signatures,
-            containsInAnyOrder(
-                matchesList().item("LuceneSourceOperator")
-                    .item("ValuesSourceReaderOperator")
-                    .item("AggregationOperator")
-                    .item("ExchangeSinkOperator"),
-                matchesList().item("ExchangeSourceOperator").item("ExchangeSinkOperator"),
-                matchesList().item("ExchangeSourceOperator")
-                    .item("AggregationOperator")
-                    .item("ProjectOperator")
-                    .item("LimitOperator")
-                    .item("EvalOperator")
-                    .item("ProjectOperator")
-                    .item("OutputOperator")
-            )
+            Matchers.either(containsInAnyOrder(readProfile, reduction, mergeProfile))
+                .or(containsInAnyOrder(readProfile, emptyReduction, mergeProfile))
         );
     }
 


### PR DESCRIPTION
In serverless, the single-node rest tests are run with more than one node, and node-level reduction is enabled if the coordinator and the data node are different. This change relaxes the profile assertion to account for this case.