### PR TITLE
(Doc+) Split API | add where need to have sufficient disk and how much

### DIFF
--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -121,11 +121,15 @@ newly split index.
 A split operation:
 
 . Creates a new target index with the same definition as the source
-  index, but with a larger number of primary shards.
+  index, but with a larger number of primary shards. Created shards allocate
+  to the same nodes as their correlating source primary shard, so it must
+  already have sufficient disk to host the copy of the data.
 
 . Hard-links segments from the source index into the target index. (If
   the file system doesn't support hard-linking, then all segments are copied
   into the new index, which is a much more time consuming process.)
++
+TIP: Elastic Cloud's backing file systems do not support hard linking.
 
 . Hashes all documents again, after low level files are created, to delete
   documents that belong to a different shard.


### PR DESCRIPTION
👋 howdy, ES Dev! 

Will you kindly confirm for [Split API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html) doc
1. Current doc states ... . My belief is that we're telling customers they need sufficient disk on each node hosting primary shards of the index which are going to be split out. AFAICT the doc does not currently otherwise help users judge which node will "handle the split process" which could randomly be master-only in which case this callout would feel invalid.

    > The node handling the split process must have sufficient free disk space to accommodate a second copy of the existing index. 

2. If Elastic Cloud [hard-link not supported](https://support.elastic.dev/knowledge/view/d2cd7697) (internal link) restriction is ongoing?

TLDR: Can we add expectations about where split api's created primary shards will allocate so users know where to ensure sufficient disk? 

🙏 TIA!
