### PR TITLE
Correcting index counts in data stream reindex status (#119658)

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
@@ -19,6 +19,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamAction;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
@@ -60,6 +61,7 @@ public class ReindexDataStreamPersistentTaskExecutor extends PersistentTasksExec
     ) {
         ReindexDataStreamTaskParams params = taskInProgress.getParams();
         return new ReindexDataStreamTask(
+            clusterService,
             params.startTime(),
             params.totalIndices(),
             params.totalIndicesToBeUpgraded(),
@@ -73,7 +75,12 @@ public class ReindexDataStreamPersistentTaskExecutor extends PersistentTasksExec
     }
 
     @Override
-    protected void nodeOperation(AllocatedPersistentTask task, ReindexDataStreamTaskParams params, PersistentTaskState state) {
+    protected void nodeOperation(
+        AllocatedPersistentTask task,
+        ReindexDataStreamTaskParams params,
+        PersistentTaskState persistentTaskState
+    ) {
+        ReindexDataStreamPersistentTaskState state = (ReindexDataStreamPersistentTaskState) persistentTaskState;
         String sourceDataStream = params.getSourceDataStream();
         TaskId taskId = new TaskId(clusterService.localNode().getId(), task.getId());
         GetDataStreamAction.Request request = new GetDataStreamAction.Request(TimeValue.MAX_VALUE, new String[] { sourceDataStream });
@@ -92,33 +99,71 @@ public class ReindexDataStreamPersistentTaskExecutor extends PersistentTasksExec
                         RolloverAction.INSTANCE,
                         rolloverRequest,
                         ActionListener.wrap(
-                            rolloverResponse -> reindexIndices(dataStream, reindexDataStreamTask, reindexClient, sourceDataStream, taskId),
-                            e -> completeFailedPersistentTask(reindexDataStreamTask, e)
+                            rolloverResponse -> reindexIndices(
+                                dataStream,
+                                dataStream.getIndices().size() + 1,
+                                reindexDataStreamTask,
+                                params,
+                                state,
+                                reindexClient,
+                                sourceDataStream,
+                                taskId
+                            ),
+                            e -> completeFailedPersistentTask(reindexDataStreamTask, state, e)
                         )
                     );
                 } else {
-                    reindexIndices(dataStream, reindexDataStreamTask, reindexClient, sourceDataStream, taskId);
+                    reindexIndices(
+                        dataStream,
+                        dataStream.getIndices().size(),
+                        reindexDataStreamTask,
+                        params,
+                        state,
+                        reindexClient,
+                        sourceDataStream,
+                        taskId
+                    );
                 }
             } else {
-                completeFailedPersistentTask(reindexDataStreamTask, new ElasticsearchException("data stream does not exist"));
+                completeFailedPersistentTask(reindexDataStreamTask, state, new ElasticsearchException("data stream does not exist"));
             }
-        }, exception -> completeFailedPersistentTask(reindexDataStreamTask, exception)));
+        }, exception -> completeFailedPersistentTask(reindexDataStreamTask, state, exception)));
     }
 
     private void reindexIndices(
         DataStream dataStream,
+        int totalIndicesInDataStream,
         ReindexDataStreamTask reindexDataStreamTask,
+        ReindexDataStreamTaskParams params,
+        ReindexDataStreamPersistentTaskState state,
         ExecuteWithHeadersClient reindexClient,
         String sourceDataStream,
         TaskId parentTaskId
     ) {
         List<Index> indices = dataStream.getIndices();
         List<Index> indicesToBeReindexed = indices.stream().filter(getReindexRequiredPredicate(clusterService.state().metadata())).toList();
+        final ReindexDataStreamPersistentTaskState updatedState;
+        if (params.totalIndices() != totalIndicesInDataStream
+            || params.totalIndicesToBeUpgraded() != indicesToBeReindexed.size()
+            || (state != null
+                && (state.totalIndices() != null
+                    && state.totalIndicesToBeUpgraded() != null
+                    && (state.totalIndices() != totalIndicesInDataStream
+                        || state.totalIndicesToBeUpgraded() != indicesToBeReindexed.size())))) {
+            updatedState = new ReindexDataStreamPersistentTaskState(
+                totalIndicesInDataStream,
+                indicesToBeReindexed.size(),
+                state == null ? null : state.completionTime()
+            );
+            reindexDataStreamTask.updatePersistentTaskState(updatedState, ActionListener.noop());
+        } else {
+            updatedState = state;
+        }
         reindexDataStreamTask.setPendingIndicesCount(indicesToBeReindexed.size());
         // The CountDownActionListener is 1 more than the number of indices so that the count is not 0 if we have no indices
         CountDownActionListener listener = new CountDownActionListener(indicesToBeReindexed.size() + 1, ActionListener.wrap(response1 -> {
-            completeSuccessfulPersistentTask(reindexDataStreamTask);
-        }, exception -> { completeFailedPersistentTask(reindexDataStreamTask, exception); }));
+            completeSuccessfulPersistentTask(reindexDataStreamTask, updatedState);
+        }, exception -> { completeFailedPersistentTask(reindexDataStreamTask, updatedState, exception); }));
         List<Index> indicesRemaining = Collections.synchronizedList(new ArrayList<>(indicesToBeReindexed));
         final int maxConcurrentIndices = 1;
         for (int i = 0; i < maxConcurrentIndices; i++) {
@@ -190,15 +235,25 @@ public class ReindexDataStreamPersistentTaskExecutor extends PersistentTasksExec
         });
     }
 
-    private void completeSuccessfulPersistentTask(ReindexDataStreamTask persistentTask) {
-        persistentTask.allReindexesCompleted(threadPool, getTimeToLive(persistentTask));
+    private void completeSuccessfulPersistentTask(
+        ReindexDataStreamTask persistentTask,
+        @Nullable ReindexDataStreamPersistentTaskState state
+    ) {
+        persistentTask.allReindexesCompleted(threadPool, updateCompletionTimeAndGetTimeToLive(persistentTask, state));
     }
 
-    private void completeFailedPersistentTask(ReindexDataStreamTask persistentTask, Exception e) {
-        persistentTask.taskFailed(threadPool, getTimeToLive(persistentTask), e);
+    private void completeFailedPersistentTask(
+        ReindexDataStreamTask persistentTask,
+        @Nullable ReindexDataStreamPersistentTaskState state,
+        Exception e
+    ) {
+        persistentTask.taskFailed(threadPool, updateCompletionTimeAndGetTimeToLive(persistentTask, state), e);
     }
 
-    private TimeValue getTimeToLive(ReindexDataStreamTask reindexDataStreamTask) {
+    private TimeValue updateCompletionTimeAndGetTimeToLive(
+        ReindexDataStreamTask reindexDataStreamTask,
+        @Nullable ReindexDataStreamPersistentTaskState state
+    ) {
         PersistentTasksCustomMetadata persistentTasksCustomMetadata = clusterService.state()
             .getMetadata()
             .custom(PersistentTasksCustomMetadata.TYPE);
@@ -208,16 +263,23 @@ public class ReindexDataStreamPersistentTaskExecutor extends PersistentTasksExec
         if (persistentTask == null) {
             return TimeValue.timeValueMillis(0);
         }
-        PersistentTaskState state = persistentTask.getState();
         final long completionTime;
         if (state == null) {
             completionTime = threadPool.absoluteTimeInMillis();
             reindexDataStreamTask.updatePersistentTaskState(
-                new ReindexDataStreamPersistentTaskState(completionTime),
+                new ReindexDataStreamPersistentTaskState(null, null, completionTime),
                 ActionListener.noop()
             );
         } else {
-            completionTime = ((ReindexDataStreamPersistentTaskState) state).completionTime();
+            if (state.completionTime() == null) {
+                completionTime = threadPool.absoluteTimeInMillis();
+                reindexDataStreamTask.updatePersistentTaskState(
+                    new ReindexDataStreamPersistentTaskState(state.totalIndices(), state.totalIndicesToBeUpgraded(), completionTime),
+                    ActionListener.noop()
+                );
+            } else {
+                completionTime = state.completionTime();
+            }
         }
         return TimeValue.timeValueMillis(TASK_KEEP_ALIVE_TIME.millis() - (threadPool.absoluteTimeInMillis() - completionTime));
     }

--- a/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskStateTests.java
+++ b/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskStateTests.java
@@ -26,11 +26,32 @@ public class ReindexDataStreamPersistentTaskStateTests extends AbstractXContentS
 
     @Override
     protected ReindexDataStreamPersistentTaskState createTestInstance() {
-        return new ReindexDataStreamPersistentTaskState(randomNonNegativeLong());
+        return new ReindexDataStreamPersistentTaskState(
+            randomBoolean() ? null : randomNonNegativeInt(),
+            randomBoolean() ? null : randomNonNegativeInt(),
+            randomBoolean() ? null : randomNonNegativeLong()
+        );
     }
 
     @Override
     protected ReindexDataStreamPersistentTaskState mutateInstance(ReindexDataStreamPersistentTaskState instance) throws IOException {
-        return new ReindexDataStreamPersistentTaskState(instance.completionTime() + 1);
+        return switch (randomInt(2)) {
+            case 0 -> new ReindexDataStreamPersistentTaskState(
+                instance.totalIndices() == null ? randomNonNegativeInt() : instance.totalIndices() + 1,
+                instance.totalIndicesToBeUpgraded(),
+                instance.completionTime()
+            );
+            case 1 -> new ReindexDataStreamPersistentTaskState(
+                instance.totalIndices(),
+                instance.totalIndicesToBeUpgraded() == null ? randomNonNegativeInt() : instance.totalIndicesToBeUpgraded() + 1,
+                instance.completionTime()
+            );
+            case 2 -> new ReindexDataStreamPersistentTaskState(
+                instance.totalIndices(),
+                instance.totalIndicesToBeUpgraded(),
+                instance.completionTime() == null ? randomNonNegativeLong() : instance.completionTime() + 1
+            );
+            default -> throw new IllegalArgumentException("Should never get here");
+        };
     }
 }

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -250,7 +250,11 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
         }
     }
 
-    private void upgradeDataStream(String dataStreamName, int numRollovers) throws Exception {
+    private void upgradeDataStream(String dataStreamName, int numRolloversOnOldCluster) throws Exception {
+        final int explicitRolloverOnNewClusterCount = randomIntBetween(0, 2);
+        for (int i = 0; i < explicitRolloverOnNewClusterCount; i++) {
+            rollover(dataStreamName);
+        }
         Request reindexRequest = new Request("POST", "/_migration/reindex");
         reindexRequest.setJsonEntity(Strings.format("""
             {
@@ -271,18 +275,27 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             );
             assertOK(statusResponse);
             assertThat(statusResponseMap.get("complete"), equalTo(true));
-            /*
-             * total_indices_in_data_stream is determined at the beginning of the reindex, and does not take into account the write
-             * index being rolled over
-             */
-            assertThat(statusResponseMap.get("total_indices_in_data_stream"), equalTo(numRollovers + 1));
+            // The number of rollovers that will have happened when we call reindex:
+            final int rolloversPerformedByReindex = explicitRolloverOnNewClusterCount == 0 ? 1 : 0;
+            final int originalWriteIndex = 1;
+            assertThat(
+                statusResponseMap.get("total_indices_in_data_stream"),
+                equalTo(originalWriteIndex + numRolloversOnOldCluster + explicitRolloverOnNewClusterCount + rolloversPerformedByReindex)
+            );
             if (isOriginalClusterSameMajorVersionAsCurrent()) {
                 // If the original cluster was the same as this one, we don't want any indices reindexed:
                 assertThat(statusResponseMap.get("total_indices_requiring_upgrade"), equalTo(0));
                 assertThat(statusResponseMap.get("successes"), equalTo(0));
             } else {
-                assertThat(statusResponseMap.get("total_indices_requiring_upgrade"), equalTo(numRollovers + 1));
-                assertThat(statusResponseMap.get("successes"), equalTo(numRollovers + 1));
+                /*
+                 * total_indices_requiring_upgrade is made up of: (the original write index) + numRolloversOnOldCluster. The number of
+                 * rollovers on the upgraded cluster is irrelevant since those will not be reindexed.
+                 */
+                assertThat(
+                    statusResponseMap.get("total_indices_requiring_upgrade"),
+                    equalTo(originalWriteIndex + numRolloversOnOldCluster)
+                );
+                assertThat(statusResponseMap.get("successes"), equalTo(numRolloversOnOldCluster + 1));
             }
         }, 60, TimeUnit.SECONDS);
         Request cancelRequest = new Request("POST", "_migration/reindex/" + dataStreamName + "/_cancel");


### PR DESCRIPTION
We currently put the number of total number of indices and the total number of indices to be reindexed into the params of the data stream reindex task. However, if the write index needs to be upgraded then we do a rollover, which will change the total number of indices. Or if some external force changes the number of indices in the data stream, we don't pick that up. This is reported in the get-status API for the reindex task.
This change makes it so that we account for changes to the number of backing indices in the data stream.