### PR TITLE
Fixing DataStreamsUpgradeIT.testUpgradeDataStream when cluster major version is unchanged (#119786)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -309,7 +309,6 @@ tests:
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/116175
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
-<<<<<<< HEAD
   method: testMinimumVersionBetweenNewAndOldVersion
   issue: https://github.com/elastic/elasticsearch/issues/117485
 - class: org.elasticsearch.discovery.ClusterDisruptionIT

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -309,6 +309,7 @@ tests:
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/116175
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
+<<<<<<< HEAD
   method: testMinimumVersionBetweenNewAndOldVersion
   issue: https://github.com/elastic/elasticsearch/issues/117485
 - class: org.elasticsearch.discovery.ClusterDisruptionIT

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -275,18 +275,22 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             );
             assertOK(statusResponse);
             assertThat(statusResponseMap.get("complete"), equalTo(true));
-            // The number of rollovers that will have happened when we call reindex:
-            final int rolloversPerformedByReindex = explicitRolloverOnNewClusterCount == 0 ? 1 : 0;
             final int originalWriteIndex = 1;
-            assertThat(
-                statusResponseMap.get("total_indices_in_data_stream"),
-                equalTo(originalWriteIndex + numRolloversOnOldCluster + explicitRolloverOnNewClusterCount + rolloversPerformedByReindex)
-            );
             if (isOriginalClusterSameMajorVersionAsCurrent()) {
+                assertThat(
+                    statusResponseMap.get("total_indices_in_data_stream"),
+                    equalTo(originalWriteIndex + numRolloversOnOldCluster + explicitRolloverOnNewClusterCount)
+                );
                 // If the original cluster was the same as this one, we don't want any indices reindexed:
                 assertThat(statusResponseMap.get("total_indices_requiring_upgrade"), equalTo(0));
                 assertThat(statusResponseMap.get("successes"), equalTo(0));
             } else {
+                // The number of rollovers that will have happened when we call reindex:
+                final int rolloversPerformedByReindex = explicitRolloverOnNewClusterCount == 0 ? 1 : 0;
+                assertThat(
+                    statusResponseMap.get("total_indices_in_data_stream"),
+                    equalTo(originalWriteIndex + numRolloversOnOldCluster + explicitRolloverOnNewClusterCount + rolloversPerformedByReindex)
+                );
                 /*
                  * total_indices_requiring_upgrade is made up of: (the original write index) + numRolloversOnOldCluster. The number of
                  * rollovers on the upgraded cluster is irrelevant since those will not be reindexed.


### PR DESCRIPTION
If the major version of the cluster has not changed, then no reindex will happen. This means that there will be no rollover performed during that reindex. So we need to not expect `rolloversPerformedByReindex` to be included in the value for `total_indices_in_data_stream`.
Closes #119717 