### PR TITLE
Fix broken anchors

### DIFF
--- a/docs/reference/modules/discovery/publishing.asciidoc
+++ b/docs/reference/modules/discovery/publishing.asciidoc
@@ -77,7 +77,7 @@ and latency of the network interconnections between all nodes in the cluster.
 You must therefore ensure that the storage and networking available to the
 nodes in your cluster are good enough to meet your performance goals.
 
-[[dangling-indices]]
+[[dangling-index]]
 ==== Dangling indices
 
 When a node joins the cluster, if it finds any shards stored in its local

--- a/docs/reference/modules/gateway.asciidoc
+++ b/docs/reference/modules/gateway.asciidoc
@@ -1,6 +1,7 @@
 [[modules-gateway]]
 === Local gateway settings
 
+[[dangling-indices]]
 The local gateway stores the cluster state and shard data across full
 cluster restarts.
 

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -287,7 +287,7 @@ include::network/tracers.asciidoc[]
 
 include::network/threading.asciidoc[]
 
-[[readiness-tcp-port]]
+[[tcp-readiness-port]]
 ==== TCP readiness port
 
 preview::[]

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -46,6 +46,8 @@ The following additional roles are available:
 
 * `voting_only`
 
+[[coordinating-only-node]]If you leave `node.roles` unset, then the node is considered to be a <<coordinating-only-node-role,coordinating only node>>.
+
 [IMPORTANT]
 ====
 If you set `node.roles`, ensure you specify every node role your cluster needs.

--- a/docs/reference/node-roles.asciidoc
+++ b/docs/reference/node-roles.asciidoc
@@ -359,7 +359,7 @@ node.roles: [ ingest ]
 ----
 
 [discrete]
-[[coordinating-only-node]]
+[[coordinating-only-node-role]]
 ==== Coordinating only node
 
 If you take away the ability to be able to handle master duties, to hold data,

--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -19,6 +19,7 @@ CAUTION: Setting your own JVM options is generally not recommended and could neg
 impact performance and stability. Using the {es}-provided defaults
 is recommended in most circumstances.
 
+[[readiness-tcp-port]]
 NOTE: Do not modify the root `jvm.options` file. Use files in `jvm.options.d/` instead.
 
 [[jvm-options-syntax]]
@@ -153,7 +154,7 @@ options. We do not recommend using `ES_JAVA_OPTS` in production.
 NOTE: If you are running {es} as a Windows service, you can change the heap size
 using the service manager. See <<windows-service>>.
 
-[[heap-dump-path]]
+[[heap-dump-path-setting]]
 include::important-settings/heap-dump-path.asciidoc[leveloffset=-1]
 
 [[gc-logging]]

--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -41,6 +41,7 @@ include::important-settings/discovery-settings.asciidoc[]
 
 include::important-settings/heap-size.asciidoc[]
 
+[[heap-dump-path]]
 include::important-settings/heap-dump-path.asciidoc[]
 
 include::important-settings/gc-logging.asciidoc[]


### PR DESCRIPTION
Puts temp anchors in to get around errors in https://github.com/elastic/elasticsearch/pull/119642 and https://github.com/elastic/elasticsearch/pull/119643