### PR TITLE
[7.17] Disable SLM history in docs tests (#118979)

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -76,6 +76,11 @@ testClusters.matching { it.name == "yamlRestTest"}.configureEach {
   setting 'script.painless.regex.enabled', 'true'
   setting 'xpack.security.enabled', 'false'
   setting 'path.repo', "${buildDir}/cluster/shared/repo"
+
+  // disable the ILM and SLM history for doc tests to avoid potential lingering tasks that'd cause test flakiness
+  setting 'indices.lifecycle.history_index_enabled', 'false'
+  setting 'slm.history_index_enabled', 'false'
+
   Closure configFile = {
     extraConfigFile it, file("src/test/cluster/config/$it")
   }


### PR DESCRIPTION
The SLM history data stream was causing issues in the docs tests because its presence was flaky and could result in the inability to remove its index template, which in turn resulted in failing tests.

Manual backport of https://github.com/elastic/elasticsearch/pull/118979

Fixes #119703