### PR TITLE
[8.x] ESQL: Add simple count all test (#119098)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -931,6 +931,15 @@ null           | 1950
 null           | 1960
 ;
 
+countAllOnly
+from employees | stats c = count()
+;
+
+c:l
+100
+;
+
+
 countFieldNoGrouping
 from employees | where emp_no < 10050 | stats c = count(salary);
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Add simple count all test (#119098)