### PR TITLE
[8.x] Enable query rewrites on the coordinator for ESQL (#119667)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/QueryBuilderResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/QueryBuilderResolver.java
@@ -16,7 +16,6 @@ import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
@@ -59,12 +58,6 @@ public class QueryBuilderResolver {
         ActionListener<Result> listener,
         BiConsumer<LogicalPlan, ActionListener<Result>> callback
     ) {
-        // TODO: remove once SEMANTIC_TEXT_TYPE is enabled outside of snapshots
-        if (false == EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled()) {
-            callback.accept(plan, listener);
-            return;
-        }
-
         if (plan.optimized() == false) {
             listener.onFailure(new IllegalStateException("Expected optimized plan before query builder rewrite."));
             return;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Enable query rewrites on the coordinator for ESQL (#119667)