### PR TITLE
[8.x] Issue S3 web identity token refresh call with sufficient permissions (#119748)

### DIFF
--- a/docs/changelog/119748.yaml
+++ b/docs/changelog/119748.yaml
@@ -1,0 +1,6 @@
+pr: 119748
+summary: Issue S3 web identity token refresh call with sufficient permissions
+area: Snapshot/Restore
+type: bug
+issues:
+ - 119747

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -423,7 +423,7 @@ class S3Service implements Closeable {
                     public void onFileChanged(Path file) {
                         if (file.equals(webIdentityTokenFileSymlink)) {
                             LOGGER.debug("WS web identity token file [{}] changed, updating credentials", file);
-                            credentialsProvider.refresh();
+                            SocketAccess.doPrivilegedVoid(credentialsProvider::refresh);
                         }
                     }
                 });


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Issue S3 web identity token refresh call with sufficient permissions (#119748)