### PR TITLE
Improve collection of SearchHits in ML module

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.inference.InferenceResults;
@@ -240,7 +241,7 @@ public class InferenceRunner {
         Map<String, Object> resultsMap = new LinkedHashMap<>(results.asMap());
         resultsMap.put(DestinationIndex.IS_TRAINING, false);
 
-        Map<String, Object> source = new LinkedHashMap<>(hit.getSourceAsMap());
+        Map<String, Object> source = XContentHelper.convertToMap(hit.getSourceRef(), true).v2();
         source.put(resultField, resultsMap);
         IndexRequest indexRequest = new IndexRequest(hit.getIndex());
         indexRequest.id(hit.getId());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
@@ -25,7 +25,6 @@ import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.tasks.TaskId;
@@ -129,7 +130,7 @@ class DataFrameRowsJoiner implements AutoCloseable {
     }
 
     private IndexRequest createIndexRequest(RowResults result, SearchHit hit) {
-        Map<String, Object> source = new LinkedHashMap<>(hit.getSourceAsMap());
+        Map<String, Object> source = XContentHelper.convertToMap(hit.getSourceRef(), true).v2();
         source.putAll(result.getResults());
         IndexRequest indexRequest = new IndexRequest(hit.getIndex());
         indexRequest.id(hit.getId());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -1016,11 +1016,12 @@ public class TrainedModelProvider {
                 long totalHitCount = response.getHits().getTotalHits().value() + foundResourceIds.size();
                 Set<String> foundFromDocs = new HashSet<>();
                 for (SearchHit hit : response.getHits().getHits()) {
-                    Map<String, Object> docSource = hit.getSourceAsMap();
+                    BytesReference docSource = hit.getSourceRef();
                     if (docSource == null) {
                         continue;
                     }
-                    Object idValue = docSource.get(TrainedModelConfig.MODEL_ID.getPreferredName());
+                    Map<String, Object> docSourceAsMap = XContentHelper.convertToMap(docSource, false).v2();
+                    Object idValue = docSourceAsMap.get(TrainedModelConfig.MODEL_ID.getPreferredName());
                     if (idValue instanceof String) {
                         foundFromDocs.add(idValue.toString());
                     }


### PR DESCRIPTION
The method `SearchHit#getSourceAsMap` currently hodls a reference to the generated map and therefore increments the memory usage of the process. If we are not calling again this method, this is wasteful. Therefore I propose here is to manually create the source as map in the code to avoid the extra memory usage, more over ssd in some cases we might be processing thousand of hits.