### PR TITLE
[8.17] [Inference API] Fix bug checking for e5 or reranker default IDs (#119797)

### DIFF
--- a/docs/changelog/119797.yaml
+++ b/docs/changelog/119797.yaml
@@ -1,0 +1,5 @@
+pr: 119797
+summary: "[Inference API] Fix bug checking for e5 or reranker default IDs"
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -136,7 +136,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         Map<String, Object> config,
         ActionListener<Model> modelListener
     ) {
-        if (inferenceEntityId.equals(DEFAULT_ELSER_ID)) {
+        if (isDefaultId(inferenceEntityId)) {
             modelListener.onFailure(
                 new ElasticsearchStatusException(
                     "[{}] is a reserved inference Id. Cannot create a new inference endpoint with a reserved Id",


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [Inference API] Fix bug checking for e5 or reranker default IDs (#119797)