### PR TITLE
[8.17] Resolve/cluster should mark remotes as not connected when a security exception is thrown (#119793)

### DIFF
--- a/docs/changelog/119793.yaml
+++ b/docs/changelog/119793.yaml
@@ -1,0 +1,6 @@
+pr: 119793
+summary: Resolve/cluster should mark remotes as not connected when a security exception
+  is thrown
+area: CCS
+type: bug
+issues: []

--- a/docs/reference/indices/resolve-cluster.asciidoc
+++ b/docs/reference/indices/resolve-cluster.asciidoc
@@ -28,8 +28,19 @@ For each cluster in the index expression, information is returned about:
 3. whether there are any indices, aliases or data streams on that cluster that match
    the index expression
 4. whether the search is likely to have errors returned when you do the {ccs} (including any
-   authorization errors if your user does not have permission to query the index)
-5. cluster version information, including the Elasticsearch server version
+   authorization errors if your user does not have permission to query a remote cluster or
+   the indices on that cluster)
+5. (in some cases) cluster version information, including the Elasticsearch server version
+
+[TIP]
+====
+Whenever a security exception is returned for a remote cluster, that remote
+will always be marked as connected=false in the response, since your user does not have
+permissions to access that cluster (or perhaps the remote index) you are querying.
+Once the proper security permissions are obtained, then you can rely on the `connected` field
+in the response to determine whether the remote cluster is available and ready for querying.
+====
+
 
 ////
 [source,console]

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
@@ -9,12 +9,14 @@
 
 package org.elasticsearch.action.admin.indices.resolve;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.CancellableTask;
@@ -30,6 +32,7 @@ import java.util.Objects;
 public class ResolveClusterActionRequest extends ActionRequest implements IndicesRequest.Replaceable {
 
     public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
+    public static final String TRANSPORT_VERSION_ERROR_MESSAGE_PREFIX = "ResolveClusterAction requires at least version";
 
     private String[] names;
     /*
@@ -65,12 +68,7 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
     public ResolveClusterActionRequest(StreamInput in) throws IOException {
         super(in);
         if (in.getTransportVersion().before(TransportVersions.V_8_13_0)) {
-            throw new UnsupportedOperationException(
-                "ResolveClusterAction requires at least version "
-                    + TransportVersions.V_8_13_0.toReleaseVersion()
-                    + " but was "
-                    + in.getTransportVersion().toReleaseVersion()
-            );
+            throw new UnsupportedOperationException(createVersionErrorMessage(in.getTransportVersion()));
         }
         this.names = in.readStringArray();
         this.indicesOptions = IndicesOptions.readIndicesOptions(in);
@@ -81,15 +79,19 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         if (out.getTransportVersion().before(TransportVersions.V_8_13_0)) {
-            throw new UnsupportedOperationException(
-                "ResolveClusterAction requires at least version "
-                    + TransportVersions.V_8_13_0.toReleaseVersion()
-                    + " but was "
-                    + out.getTransportVersion().toReleaseVersion()
-            );
+            throw new UnsupportedOperationException(createVersionErrorMessage(out.getTransportVersion()));
         }
         out.writeStringArray(names);
         indicesOptions.writeIndicesOptions(out);
+    }
+
+    private String createVersionErrorMessage(TransportVersion versionFound) {
+        return Strings.format(
+            "%s %s but was %s",
+            TRANSPORT_VERSION_ERROR_MESSAGE_PREFIX,
+            TransportVersions.V_8_13_0.toReleaseVersion(),
+            versionFound.toReleaseVersion()
+        );
     }
 
     @Override

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS1ResolveClusterIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS1ResolveClusterIT.java
@@ -93,7 +93,9 @@ public class RemoteClusterSecurityRCS1ResolveClusterIT extends AbstractRemoteClu
             assertLocalMatching(responseMap);
 
             Map<String, ?> remoteClusterResponse = (Map<String, ?>) responseMap.get("my_remote_cluster");
-            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(true));
+            // with security exceptions, the remote should be marked as connected=false, since you can't tell whether a security
+            // exception comes from the local cluster (intercepted) or the remote
+            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(false));
             assertThat((String) remoteClusterResponse.get("error"), containsString("unauthorized for user [remote_search_user]"));
 
             // TEST CASE 2: Query cluster -> add user role and user on remote cluster and try resolve again
@@ -171,7 +173,7 @@ public class RemoteClusterSecurityRCS1ResolveClusterIT extends AbstractRemoteClu
             Map<String, Object> responseMap = responseAsMap(response);
             assertThat(responseMap.get(LOCAL_CLUSTER_NAME_REPRESENTATION), nullValue());
             Map<String, ?> remoteClusterResponse = (Map<String, ?>) responseMap.get("my_remote_cluster");
-            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(true));
+            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(false));
             assertThat((String) remoteClusterResponse.get("error"), containsString("unauthorized for user [remote_search_user]"));
             assertThat((String) remoteClusterResponse.get("error"), containsString("on indices [secretindex]"));
         }
@@ -183,7 +185,7 @@ public class RemoteClusterSecurityRCS1ResolveClusterIT extends AbstractRemoteClu
             Map<String, Object> responseMap = responseAsMap(response);
             assertThat(responseMap.get(LOCAL_CLUSTER_NAME_REPRESENTATION), nullValue());
             Map<String, ?> remoteClusterResponse = (Map<String, ?>) responseMap.get("my_remote_cluster");
-            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(true));
+            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(false));
             assertThat((String) remoteClusterResponse.get("error"), containsString("unauthorized for user [remote_search_user]"));
             assertThat((String) remoteClusterResponse.get("error"), containsString("on indices [doesnotexist]"));
         }
@@ -195,6 +197,7 @@ public class RemoteClusterSecurityRCS1ResolveClusterIT extends AbstractRemoteClu
             Map<String, Object> responseMap = responseAsMap(response);
             assertThat(responseMap.get(LOCAL_CLUSTER_NAME_REPRESENTATION), nullValue());
             Map<String, ?> remoteClusterResponse = (Map<String, ?>) responseMap.get("my_remote_cluster");
+            // with IndexNotFoundExceptions, we know that error came from the remote cluster, so we can mark the remote as connected=true
             assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(true));
             assertThat((String) remoteClusterResponse.get("error"), containsString("no such index [index99]"));
         }
@@ -210,7 +213,7 @@ public class RemoteClusterSecurityRCS1ResolveClusterIT extends AbstractRemoteClu
             Map<String, Object> responseMap = responseAsMap(response);
             assertThat(responseMap.get(LOCAL_CLUSTER_NAME_REPRESENTATION), nullValue());
             Map<String, ?> remoteClusterResponse = (Map<String, ?>) responseMap.get("my_remote_cluster");
-            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(true));
+            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(false));
             assertThat((String) remoteClusterResponse.get("error"), containsString("unauthorized for user [remote_search_user]"));
             assertThat((String) remoteClusterResponse.get("error"), containsString("on indices [secretindex]"));
         }

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS2ResolveClusterIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS2ResolveClusterIT.java
@@ -180,7 +180,9 @@ public class RemoteClusterSecurityRCS2ResolveClusterIT extends AbstractRemoteClu
             assertLocalMatching(responseMap);
 
             Map<String, ?> remoteClusterResponse = (Map<String, ?>) responseMap.get("my_remote_cluster");
-            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(true));
+            // with security exceptions, the remote should be marked as connected=false, since you can't tell whether a security
+            // exception comes from the local cluster (intercepted) or the remote
+            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(false));
             assertThat((String) remoteClusterResponse.get("error"), containsString("is unauthorized for user"));
             assertThat(
                 (String) remoteClusterResponse.get("error"),
@@ -261,7 +263,7 @@ public class RemoteClusterSecurityRCS2ResolveClusterIT extends AbstractRemoteClu
             Map<String, Object> responseMap = responseAsMap(response);
             assertThat(responseMap.get(LOCAL_CLUSTER_NAME_REPRESENTATION), nullValue());
             Map<String, ?> remoteClusterResponse = (Map<String, ?>) responseMap.get("my_remote_cluster");
-            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(true));
+            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(false));
             assertThat((String) remoteClusterResponse.get("error"), containsString("is unauthorized for user"));
             assertThat((String) remoteClusterResponse.get("error"), containsString("on indices [secretindex]"));
         }
@@ -273,7 +275,7 @@ public class RemoteClusterSecurityRCS2ResolveClusterIT extends AbstractRemoteClu
             Map<String, Object> responseMap = responseAsMap(response);
             assertThat(responseMap.get(LOCAL_CLUSTER_NAME_REPRESENTATION), nullValue());
             Map<String, ?> remoteClusterResponse = (Map<String, ?>) responseMap.get("my_remote_cluster");
-            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(true));
+            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(false));
             assertThat((String) remoteClusterResponse.get("error"), containsString("is unauthorized for user"));
             assertThat((String) remoteClusterResponse.get("error"), containsString("on indices [doesnotexist]"));
         }
@@ -285,6 +287,7 @@ public class RemoteClusterSecurityRCS2ResolveClusterIT extends AbstractRemoteClu
             Map<String, Object> responseMap = responseAsMap(response);
             assertThat(responseMap.get(LOCAL_CLUSTER_NAME_REPRESENTATION), nullValue());
             Map<String, ?> remoteClusterResponse = (Map<String, ?>) responseMap.get("my_remote_cluster");
+            // with IndexNotFoundExceptions, we know that error came from the remote cluster, so we can mark the remote as connected=true
             assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(true));
             assertThat((Boolean) remoteClusterResponse.get("skip_unavailable"), equalTo(false));
             assertThat((String) remoteClusterResponse.get("error"), containsString("no such index [index99]"));
@@ -301,7 +304,7 @@ public class RemoteClusterSecurityRCS2ResolveClusterIT extends AbstractRemoteClu
             Map<String, Object> responseMap = responseAsMap(response);
             assertThat(responseMap.get(LOCAL_CLUSTER_NAME_REPRESENTATION), nullValue());
             Map<String, ?> remoteClusterResponse = (Map<String, ?>) responseMap.get("my_remote_cluster");
-            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(true));
+            assertThat((Boolean) remoteClusterResponse.get("connected"), equalTo(false));
             assertThat((String) remoteClusterResponse.get("error"), containsString("is unauthorized for user"));
             assertThat((String) remoteClusterResponse.get("error"), containsString("on indices [secretindex]"));
         }


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Resolve/cluster should mark remotes as not connected when a security exception is thrown (#119793)