### PR TITLE
[Entitlements] Add "always denied" network access checks

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -15,14 +15,18 @@ import java.io.PrintWriter;
 import java.net.ContentHandlerFactory;
 import java.net.DatagramSocketImplFactory;
 import java.net.FileNameMap;
+import java.net.ProxySelector;
+import java.net.ResponseCache;
 import java.net.SocketImplFactory;
 import java.net.URL;
+import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 import java.util.List;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 
 @SuppressWarnings("unused") // Called from instrumentation code inserted by the Entitlements agent
@@ -167,4 +171,22 @@ public interface EntitlementChecker {
 
     void check$java_net_URLConnection$$setContentHandlerFactory(Class<?> callerClass, ContentHandlerFactory fac);
 
+    ////////////////////
+    //
+    // Network access
+    //
+    void check$java_net_ProxySelector$$setDefault(Class<?> callerClass, ProxySelector ps);
+
+    void check$java_net_ResponseCache$$setDefault(Class<?> callerClass, ResponseCache rc);
+
+    void check$java_net_spi_InetAddressResolverProvider$(Class<?> callerClass);
+
+    void check$java_net_spi_URLStreamHandlerProvider$(Class<?> callerClass);
+
+    void check$java_net_URL$(Class<?> callerClass, String protocol, String host, int port, String file, URLStreamHandler handler);
+
+    void check$java_net_URL$(Class<?> callerClass, URL context, String spec, URLStreamHandler handler);
+
+    // The only implementation of SSLSession#getSessionContext(); unfortunately it's an interface, so we need to check the implementation
+    void check$sun_security_ssl_SSLSessionImpl$getSessionContext(Class<?> callerClass, SSLSession sslSession);
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -18,14 +18,18 @@ import java.io.PrintWriter;
 import java.net.ContentHandlerFactory;
 import java.net.DatagramSocketImplFactory;
 import java.net.FileNameMap;
+import java.net.ProxySelector;
+import java.net.ResponseCache;
 import java.net.SocketImplFactory;
 import java.net.URL;
+import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 import java.util.List;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
@@ -309,5 +313,40 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     @Override
     public void check$javax_net_ssl_SSLContext$$setDefault(Class<?> callerClass, SSLContext context) {
         policyManager.checkChangeJVMGlobalState(callerClass);
+    }
+
+    @Override
+    public void check$java_net_ProxySelector$$setDefault(Class<?> callerClass, ProxySelector ps) {
+        policyManager.checkChangeNetworkHandling(callerClass);
+    }
+
+    @Override
+    public void check$java_net_ResponseCache$$setDefault(Class<?> callerClass, ResponseCache rc) {
+        policyManager.checkChangeNetworkHandling(callerClass);
+    }
+
+    @Override
+    public void check$java_net_spi_InetAddressResolverProvider$(Class<?> callerClass) {
+        policyManager.checkChangeNetworkHandling(callerClass);
+    }
+
+    @Override
+    public void check$java_net_spi_URLStreamHandlerProvider$(Class<?> callerClass) {
+        policyManager.checkChangeNetworkHandling(callerClass);
+    }
+
+    @Override
+    public void check$java_net_URL$(Class<?> callerClass, String protocol, String host, int port, String file, URLStreamHandler handler) {
+        policyManager.checkChangeNetworkHandling(callerClass);
+    }
+
+    @Override
+    public void check$java_net_URL$(Class<?> callerClass, URL context, String spec, URLStreamHandler handler) {
+        policyManager.checkChangeNetworkHandling(callerClass);
+    }
+
+    @Override
+    public void check$sun_security_ssl_SSLSessionImpl$getSessionContext(Class<?> callerClass, SSLSession sslSession) {
+        policyManager.checkReadSensitiveNetworkInformation(callerClass);
     }
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -171,6 +171,20 @@ public class PolicyManager {
         });
     }
 
+    /**
+     * Check for operations that can modify the way network operations are handled
+     */
+    public void checkChangeNetworkHandling(Class<?> callerClass) {
+        checkChangeJVMGlobalState(callerClass);
+    }
+
+    /**
+     * Check for operations that can access sensitive network information, e.g. secrets, tokens or SSL sessions
+     */
+    public void checkReadSensitiveNetworkInformation(Class<?> callerClass) {
+        neverEntitled(callerClass, "access sensitive network information");
+    }
+
     private String operationDescription(String methodName) {
         // TODO: Use a more human-readable description. Perhaps share code with InstrumentationServiceImpl.parseCheckerMethodName
         return methodName.substring(methodName.indexOf('$'));


### PR DESCRIPTION
These are always denied because a) they set global things/they can change the behaviour of how things are handled or b) were are always denied today in our SM configuration.
