### PR TITLE
Unmute XPackRestIT "ml/data_frame_analytics_cat_apis/Test cat data fr…

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -220,9 +220,6 @@ tests:
   method: testCartesianBoundsBlockLoader
   issue: https://github.com/elastic/elasticsearch/issues/119201
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=ml/data_frame_analytics_cat_apis/Test cat data frame analytics all jobs with header}
-  issue: https://github.com/elastic/elasticsearch/issues/119332
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
   issue: https://github.com/elastic/elasticsearch/issues/119508
 - class: org.elasticsearch.smoketest.MlWithSecurityIT


### PR DESCRIPTION
Unmuting, because of:
> It looks like the failures of this test are caused by something else failing, that has nothing to do with this test and causes many other tests to fail as well.
>
> From the build logs:
> - 3958 tests executed in 19 test classes taking 1h 36s, [2194 failures]
> - 4302 tests executed in 24 test classes taking 1h 36s, [116 failures]
> - 4731 tests executed in 24 test classes taking 1h 38s, [112 failures]

(see [this comment](https://github.com/elastic/elasticsearch/issues/119332#issuecomment-2580514182))

Fixes: https://github.com/elastic/elasticsearch/issues/119332