### PR TITLE
[Failure store] Remove feature flag from influencing the serialisation

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -248,30 +248,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizerTests
   method: testSingleMatchOperatorFilterPushdownWithStringValues {default}
   issue: https://github.com/elastic/elasticsearch/issues/119721
-- class: org.elasticsearch.script.mustache.SearchTemplateRequestTests
-  method: testConcurrentSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/119819
-- class: org.elasticsearch.script.mustache.SearchTemplateRequestTests
-  method: testEqualsAndHashcode
-  issue: https://github.com/elastic/elasticsearch/issues/119820
-- class: org.elasticsearch.script.mustache.SearchTemplateRequestTests
-  method: testConcurrentEquals
-  issue: https://github.com/elastic/elasticsearch/issues/119821
-- class: org.elasticsearch.script.mustache.SearchTemplateRequestTests
-  method: testSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/119822
-- class: org.elasticsearch.index.rankeval.RankEvalRequestTests
-  method: testSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/119859
-- class: org.elasticsearch.index.rankeval.RankEvalRequestTests
-  method: testEqualsAndHashcode
-  issue: https://github.com/elastic/elasticsearch/issues/119860
-- class: org.elasticsearch.index.rankeval.RankEvalRequestTests
-  method: testConcurrentSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/119861
-- class: org.elasticsearch.index.rankeval.RankEvalRequestTests
-  method: testConcurrentEquals
-  issue: https://github.com/elastic/elasticsearch/issues/119862
 
 # Examples:
 #

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -884,7 +884,8 @@ public record IndicesOptions(
         if (ignoreUnavailable()) {
             backwardsCompatibleOptions.add(Option.ALLOW_UNAVAILABLE_CONCRETE_TARGETS);
         }
-        if (allowSelectors()) {
+        // Until the feature flag is removed we access the field directly from the gatekeeper options.
+        if (gatekeeperOptions().allowSelectors()) {
             if (out.getTransportVersion()
                 .between(TransportVersions.V_8_14_0, TransportVersions.REPLACE_FAILURE_STORE_OPTIONS_WITH_SELECTOR_SYNTAX)) {
                 backwardsCompatibleOptions.add(Option.ALLOW_FAILURE_INDICES);
@@ -1464,7 +1465,8 @@ public record IndicesOptions(
             + ignoreAliases()
             + ", ignore_throttled="
             + ignoreThrottled()
-            + (DataStream.isFailureStoreFeatureFlagEnabled() ? ", allow_selectors=" + allowSelectors() : "")
+            // Until the feature flag is removed we access the field directly from the gatekeeper options.
+            + (DataStream.isFailureStoreFeatureFlagEnabled() ? ", allow_selectors=" + gatekeeperOptions().allowSelectors() : "")
             + ']';
     }
 }


### PR DESCRIPTION
When serialising the `IndicesOptions` we were using the helper method `IndicesOptions#allowSelectors()` to retrieve the value of the flag `allowSelector` from the `GatekeeperOptions`. 

This helper method is taking into consideration the failure store feature flag to ensure we will not allow selectors unless the feature flag is enabled:
```
public boolean allowSelectors() {
        return DataStream.isFailureStoreFeatureFlagEnabled() && gatekeeperOptions.allowSelectors();
    }
```

This was tripping this test. In this case we do not want the feature flag to influence the serialsation of the object. We only want it to be used during index name expression resolution.

Fixes: #119862
Fixes: #119861 
Fixes: #119860
Fixes: #119859
Fixes: #119822
Fixes: #119821
Fixes: #119820
Fixes: #119819