### PR TITLE
[8.17] Fix broken anchors (#119802)

### DIFF
--- a/docs/reference/modules/discovery/publishing.asciidoc
+++ b/docs/reference/modules/discovery/publishing.asciidoc
@@ -58,3 +58,16 @@ speed of the storage on each master-eligible node, as well as the reliability
 and latency of the network interconnections between all nodes in the cluster.
 You must therefore ensure that the storage and networking available to the
 nodes in your cluster are good enough to meet your performance goals.
+
+[[dangling-index]]
+==== Dangling indices
+
+When a node joins the cluster, if it finds any shards stored in its local
+data directory that do not already exist in the cluster state, it will consider
+those shards to belong to a "dangling" index. You can list, import or
+delete dangling indices using the <<dangling-indices-api,Dangling indices
+API>>.
+
+NOTE: The API cannot offer any guarantees as to whether the imported data
+truly represents the latest state of the data when the index was still part
+of the cluster.

--- a/docs/reference/modules/gateway.asciidoc
+++ b/docs/reference/modules/gateway.asciidoc
@@ -1,6 +1,7 @@
 [[modules-gateway]]
 === Local gateway settings
 
+[[dangling-indices]]
 The local gateway stores the cluster state and shard data across full
 cluster restarts.
 

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -286,3 +286,22 @@ include::remote-cluster-network.asciidoc[]
 include::network/tracers.asciidoc[]
 
 include::network/threading.asciidoc[]
+
+[[tcp-readiness-port]]
+==== TCP readiness port
+
+preview::[]
+
+If configured, a node can open a TCP port when the node is in a ready state. A node is deemed
+ready when it has successfully joined a cluster. In a single node configuration, the node is
+said to be ready, when it's able to accept requests.
+
+To enable the readiness TCP port, use the `readiness.port` setting. The readiness service will bind to
+all host addresses.
+
+If the node leaves the cluster, or the <<put-shutdown,Shutdown API>> is used to mark the node
+for shutdown, the readiness port is immediately closed.
+
+A successful connection to the readiness TCP port signals that the {es} node is ready. When a client
+connects to the readiness port, the server simply terminates the socket connection. No data is sent back
+to the client. If a client cannot connect to the readiness port, the node is not ready.

--- a/docs/reference/node-roles.asciidoc
+++ b/docs/reference/node-roles.asciidoc
@@ -1,29 +1,18 @@
-[[modules-node]]
-=== Nodes
+[[node-roles-overview]]
+== Node roles
 
 Any time that you start an instance of {es}, you are starting a _node_. A
 collection of connected nodes is called a <<modules-cluster,cluster>>. If you
-are running a single node of {es}, then you have a cluster of one node.
-
-Every node in the cluster can handle <<modules-network,HTTP and transport>>
-traffic by default. The transport layer is used exclusively for communication
-between nodes; the HTTP layer is used by REST clients.
-[[modules-node-description]]
-// tag::modules-node-description-tag[]
-All nodes know about all the other nodes in the cluster and can forward client
+are running a single node of {es}, then you have a cluster of one node. All nodes know about all the other nodes in the cluster and can forward client
 requests to the appropriate node.
-// end::modules-node-description-tag[]
 
-TIP: The performance of an {es} node is often limited by the performance of the underlying storage. 
-Review our recommendations for optimizing your storage for <<indexing-use-faster-hardware,indexing>> and 
-<<search-use-faster-hardware,search>>.
+Each node performs one or more roles. Roles control the behavior of the node in the cluster.
 
-[[node-roles]]
-==== Node roles
+[discrete]
+[[set-node-roles]]
+=== Set node roles
 
-You define a node's roles by setting `node.roles` in `elasticsearch.yml`. If you
-set `node.roles`, the node is only assigned the roles you specify. If you don't
-set `node.roles`, the node is assigned the following roles:
+You define a node's roles by setting `node.roles` in <<settings,`elasticsearch.yml`>>. If you set `node.roles`, the node is only assigned the roles you specify. If you don't set `node.roles`, the node is assigned the following roles:
 
 * `master`
 * `data`
@@ -36,8 +25,6 @@ set `node.roles`, the node is assigned the following roles:
 * `ml`
 * `remote_cluster_client`
 * `transform`
-
-[[coordinating-only-node]]If you leave `node.roles` unset, then the node is considered to be a <<coordinating-only-node-role,coordinating only node>>.
 
 [IMPORTANT]
 ====
@@ -67,40 +54,67 @@ As the cluster grows and in particular if you have large {ml} jobs or
 {ctransforms}, consider separating dedicated master-eligible nodes from
 dedicated data nodes, {ml} nodes, and {transform} nodes.
 
-<<master-node,Master-eligible node>>::
+[discrete]
+[[change-node-role]]
+=== Change the role of a node
 
-A node that has the `master` role, which makes it eligible to be
+Each data node maintains the following data on disk:
+
+* the shard data for every shard allocated to that node,
+* the index metadata corresponding with every shard allocated to that node, and
+* the cluster-wide metadata, such as settings and index templates.
+
+Similarly, each master-eligible node maintains the following data on disk:
+
+* the index metadata for every index in the cluster, and
+* the cluster-wide metadata, such as settings and index templates.
+
+Each node checks the contents of its data path at startup. If it discovers
+unexpected data then it will refuse to start. This is to avoid importing
+unwanted <<dangling-indices,dangling indices>> which can lead
+to a red cluster health. To be more precise, nodes without the `data` role will
+refuse to start if they find any shard data on disk at startup, and nodes
+without both the `master` and `data` roles will refuse to start if they have any
+index metadata on disk at startup.
+
+It is possible to change the roles of a node by adjusting its
+`elasticsearch.yml` file and restarting it. This is known as _repurposing_ a
+node. In order to satisfy the checks for unexpected data described above, you
+must perform some extra steps to prepare a node for repurposing when starting
+the node without the `data` or `master` roles.
+
+* If you want to repurpose a data node by removing the `data` role then you
+  should first use an <<cluster-shard-allocation-filtering,allocation filter>> to safely
+  migrate all the shard data onto other nodes in the cluster.
+
+* If you want to repurpose a node to have neither the `data` nor `master` roles
+  then it is simplest to start a brand-new node with an empty data path and the
+  desired roles. You may find it safest to use an
+  <<cluster-shard-allocation-filtering,allocation filter>> to migrate the shard data elsewhere
+  in the cluster first.
+
+If it is not possible to follow these extra steps then you may be able to use
+the <<node-tool-repurpose,`elasticsearch-node repurpose`>> tool to delete any
+excess data that prevents a node from starting.
+
+[discrete]
+[[node-roles-list]]
+=== Available node roles
+
+The following is a list of the roles that a node can perform in a cluster. A node can have one or more roles.
+
+* <<master-node-role,Master-eligible node>> (`master`): A node that is eligible to be
 <<modules-discovery,elected as the _master_ node>>, which controls the cluster.
 
-<<data-node,Data node>>::
+* <<data-node-role,Data node>> (`data`, `data_content`, `data_hot`, `data_warm`, `data_cold`, `data_frozen`): A node that has one of several data roles. Data nodes hold data and perform data related operations such as CRUD, search, and aggregations. You might use multiple data roles in a cluster so you can implement <<data-tiers,data tiers>>.
 
-A node that has one of several data roles. Data nodes hold data and perform data
-related operations such as CRUD, search, and aggregations. A node with a generic `data` role can fill any of the specialized data node roles.
+* <<node-ingest-node,Ingest node>> (`ingest`): Ingest nodes are able to apply an <<ingest,ingest pipeline>> to a document in order to transform and enrich the document before indexing. With a heavy ingest load, it makes sense to use dedicated ingest nodes and to not include the `ingest` role from nodes that have the `master` or `data` roles.
 
-<<node-ingest-node,Ingest node>>::
+* <<remote-node,Remote-eligible node>> (`remote_cluster_client`): A node that is eligible to act as a remote client.
 
-A node that has the `ingest` role. Ingest nodes are able to apply an
-<<ingest,ingest pipeline>> to a document in order to transform and enrich the
-document before indexing. With a heavy ingest load, it makes sense to use
-dedicated ingest nodes and to not include the `ingest` role from nodes that have
-the `master` or `data` roles.
+* <<ml-node-role,Machine learning node>> (`ml`): A node that can run {ml-features}. If you want to use {ml-features}, there must be at least one {ml} node in your cluster. For more information, see <<ml-settings>> and {ml-docs}/index.html[Machine learning in the {stack}].
 
-<<remote-node,Remote-eligible node>>::
-
-A node that has the `remote_cluster_client` role, which makes it eligible to act
-as a remote client.
-
-<<ml-node,Machine learning node>>::
-
-A node that has the `ml` role. If you want to use {ml-features}, there must be
-at least one {ml} node in your cluster. For more information, see
-<<ml-settings>> and {ml-docs}/index.html[Machine learning in the {stack}].
-
-<<transform-node,{transform-cap} node>>::
-
-A node that has the `transform` role. If you want to use {transforms}, there
-must be at least one {transform} node in your cluster. For more information, see
-<<transform-settings>> and <<transforms>>.
+* <<transform-node-role,{transform-cap} node>> (`transform`): A node that can perform {transforms}. If you want to use {transforms}, there must be at least one {transform} node in your cluster. For more information, see <<transform-settings>> and <<transforms>>.
 
 [NOTE]
 [[coordinating-node]]
@@ -119,13 +133,15 @@ coordinating node reduces each data node's results into a single global
 result set.
 
 Every node is implicitly a coordinating node. This means that a node that has
-an explicit empty list of roles via `node.roles` will only act as a coordinating
+an explicit empty list of roles in the `node.roles` setting will only act as a coordinating
 node, which cannot be disabled. As a result, such a node needs to have enough
 memory and CPU in order to deal with the gather phase.
 
 ===============================================
 
-[[master-node]]
+[discrete]
+
+[[master-node-role]]
 ==== Master-eligible node
 
 The master node is responsible for lightweight cluster-wide actions such as
@@ -143,6 +159,7 @@ cluster metadata is stored. The cluster metadata describes how to read the data
 stored on the data nodes, so if it is lost then the data stored on the data
 nodes cannot be read.
 
+[discrete]
 [[dedicated-master-node]]
 ===== Dedicated master-eligible node
 
@@ -169,6 +186,7 @@ To create a dedicated master-eligible node, set:
 node.roles: [ master ]
 -------------------
 
+[discrete]
 [[voting-only-node]]
 ===== Voting-only master-eligible node
 
@@ -225,7 +243,8 @@ between the elected master node and the other nodes in the cluster. You must
 therefore ensure that the storage and networking available to the nodes in your
 cluster are good enough to meet your performance goals.
 
-[[data-node]]
+[discrete]
+[[data-node-role]]
 ==== Data nodes
 
 Data nodes hold the shards that contain the documents you have indexed. Data
@@ -242,14 +261,15 @@ assign data nodes to specific tiers: `data_content`,`data_hot`, `data_warm`,
 
 If you want to include a node in all tiers, or if your cluster does not use multiple tiers, then you can use the generic `data` role.
 
-include::../how-to/shard-limits.asciidoc[]
+include::{es-ref-dir}/how-to/shard-limits.asciidoc[]
 
 WARNING: If you assign a node to a specific tier using a specialized data role, then you shouldn't also assign it the generic `data` role. The generic `data` role takes precedence over specialized data roles.
 
+[discrete]
 [[generic-data-node]]
 ===== Generic data node
 
-Generic data nodes are included in all content tiers. 
+Generic data nodes are included in all content tiers. A node with a generic `data` role can fill any of the specialized data node roles.
 
 To create a dedicated generic data node, set:
 [source,yaml]
@@ -257,6 +277,7 @@ To create a dedicated generic data node, set:
 node.roles: [ data ]
 ----
 
+[discrete]
 [[data-content-node]]
 ===== Content data node
 
@@ -269,6 +290,7 @@ To create a dedicated content node, set:
 node.roles: [ data_content ]
 ----
 
+[discrete]
 [[data-hot-node]]
 ===== Hot data node
 
@@ -281,6 +303,7 @@ To create a dedicated hot node, set:
 node.roles: [ data_hot ]
 ----
 
+[discrete]
 [[data-warm-node]]
 ===== Warm data node
 
@@ -293,6 +316,7 @@ To create a dedicated warm node, set:
 node.roles: [ data_warm ]
 ----
 
+[discrete]
 [[data-cold-node]]
 ===== Cold data node
 
@@ -305,6 +329,7 @@ To create a dedicated cold node, set:
 node.roles: [ data_cold ]
 ----
 
+[discrete]
 [[data-frozen-node]]
 ===== Frozen data node
 
@@ -317,6 +342,7 @@ To create a dedicated frozen node, set:
 node.roles: [ data_frozen ]
 ----
 
+[discrete]
 [[node-ingest-node]]
 ==== Ingest node
 
@@ -332,7 +358,8 @@ To create a dedicated ingest node, set:
 node.roles: [ ingest ]
 ----
 
-[[coordinating-only-node]]
+[discrete]
+[[coordinating-only-node-role]]
 ==== Coordinating only node
 
 If you take away the ability to be able to handle master duties, to hold data,
@@ -359,6 +386,7 @@ To create a dedicated coordinating node, set:
 node.roles: [ ]
 ----
 
+[discrete]
 [[remote-node]]
 ==== Remote-eligible node
 
@@ -372,7 +400,8 @@ data between clusters using <<xpack-ccr,{ccr}>>.
 node.roles: [ remote_cluster_client ]
 ----
 
-[[ml-node]]
+[discrete]
+[[ml-node-role]]
 ==== [xpack]#Machine learning node#
 
 {ml-cap} nodes run jobs and handle {ml} API requests. For more information, see
@@ -390,7 +419,8 @@ Otherwise, {ccs} fails when used in {ml} jobs or {dfeeds}. If you use {ccs} in
 your {anomaly-jobs}, the `remote_cluster_client` role is also required on all
 master-eligible nodes. Otherwise, the {dfeed} cannot start. See <<remote-node>>.
 
-[[transform-node]]
+[discrete]
+[[transform-node-role]]
 ==== [xpack]#{transform-cap} node#
 
 {transform-cap} nodes run {transforms} and handle {transform} API requests. For
@@ -405,105 +435,3 @@ node.roles: [ transform, remote_cluster_client ]
 
 The `remote_cluster_client` role is optional but strongly recommended.
 Otherwise, {ccs} fails when used in {transforms}. See <<remote-node>>.
-
-[[change-node-role]]
-==== Changing the role of a node
-
-Each data node maintains the following data on disk:
-
-* the shard data for every shard allocated to that node,
-* the index metadata corresponding with every shard allocated to that node, and
-* the cluster-wide metadata, such as settings and index templates.
-
-Similarly, each master-eligible node maintains the following data on disk:
-
-* the index metadata for every index in the cluster, and
-* the cluster-wide metadata, such as settings and index templates.
-
-Each node checks the contents of its data path at startup. If it discovers
-unexpected data then it will refuse to start. This is to avoid importing
-unwanted <<dangling-indices,dangling indices>> which can lead
-to a red cluster health. To be more precise, nodes without the `data` role will
-refuse to start if they find any shard data on disk at startup, and nodes
-without both the `master` and `data` roles will refuse to start if they have any
-index metadata on disk at startup.
-
-It is possible to change the roles of a node by adjusting its
-`elasticsearch.yml` file and restarting it. This is known as _repurposing_ a
-node. In order to satisfy the checks for unexpected data described above, you
-must perform some extra steps to prepare a node for repurposing when starting
-the node without the `data` or `master` roles.
-
-* If you want to repurpose a data node by removing the `data` role then you
-  should first use an <<cluster-shard-allocation-filtering,allocation filter>> to safely
-  migrate all the shard data onto other nodes in the cluster.
-
-* If you want to repurpose a node to have neither the `data` nor `master` roles
-  then it is simplest to start a brand-new node with an empty data path and the
-  desired roles. You may find it safest to use an
-  <<cluster-shard-allocation-filtering,allocation filter>> to migrate the shard data elsewhere
-  in the cluster first.
-
-If it is not possible to follow these extra steps then you may be able to use
-the <<node-tool-repurpose,`elasticsearch-node repurpose`>> tool to delete any
-excess data that prevents a node from starting.
-
-[discrete]
-=== Node data path settings
-
-[[data-path]]
-==== `path.data`
-
-Every data and master-eligible node requires access to a data directory where
-shards and index and cluster metadata will be stored. The `path.data` defaults
-to `$ES_HOME/data` but can be configured in the `elasticsearch.yml` config
-file an absolute path or a path relative to `$ES_HOME` as follows:
-
-[source,yaml]
-----
-path.data:  /var/elasticsearch/data
-----
-
-Like all node settings, it can also be specified on the command line as:
-
-[source,sh]
-----
-./bin/elasticsearch -Epath.data=/var/elasticsearch/data
-----
-
-The contents of the `path.data` directory must persist across restarts, because
-this is where your data is stored. {es} requires the filesystem to act as if it
-were backed by a local disk, but this means that it will work correctly on
-properly-configured remote block devices (e.g. a SAN) and remote filesystems
-(e.g. NFS) as long as the remote storage behaves no differently from local
-storage. You can run multiple {es} nodes on the same filesystem, but each {es}
-node must have its own data path.
-
-TIP: When using the `.zip` or `.tar.gz` distributions, the `path.data` setting
-should be configured to locate the data directory outside the {es} home
-directory, so that the home directory can be deleted without deleting your data!
-The RPM and Debian distributions do this for you already.
-
-// tag::modules-node-data-path-warning-tag[]
-WARNING: Don't modify anything within the data directory or run processes that
-might interfere with its contents. If something other than {es} modifies the
-contents of the data directory, then {es} may fail, reporting corruption or
-other data inconsistencies, or may appear to work correctly having silently
-lost some of your data. Don't attempt to take filesystem backups of the data
-directory; there is no supported way to restore such a backup. Instead, use
-<<snapshot-restore>> to take backups safely. Don't run virus scanners on the
-data directory. A virus scanner can prevent {es} from working correctly and may
-modify the contents of the data directory. The data directory contains no
-executables so a virus scan will only find false positives.
-// end::modules-node-data-path-warning-tag[]
-
-[discrete]
-[[other-node-settings]]
-=== Other node settings
-
-More node settings can be found in <<settings>> and <<important-settings>>,
-including:
-
-* <<cluster-name,`cluster.name`>>
-* <<node-name,`node.name`>>
-* <<modules-network,network settings>>

--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -21,6 +21,7 @@ Where you put the JVM options files depends on the type of installation:
 * Docker: Bind mount custom JVM options files into
 `/usr/share/elasticsearch/config/jvm.options.d/`.
 
+[[readiness-tcp-port]]
 NOTE: Do not modify the root `jvm.options` file. Use files in `jvm.options.d/` instead.
 
 [[jvm-options-syntax]]
@@ -155,23 +156,11 @@ options. We do not recommend using `ES_JAVA_OPTS` in production.
 NOTE: If you are running {es} as a Windows service, you can change the heap size
 using the service manager. See <<windows-service>>.
 
-[[readiness-tcp-port]]
-===== Enable the Elasticsearch TCP readiness port
+[[heap-dump-path-setting]]
+include::important-settings/heap-dump-path.asciidoc[leveloffset=-1]
 
-preview::[]
+[[gc-logging]]
+include::important-settings/gc-logging.asciidoc[leveloffset=-1]
 
-If configured, a node can open a TCP port when the node is in a ready state. A node is deemed
-ready when it has successfully joined a cluster. In a single node configuration, the node is
-said to be ready, when it's able to accept requests.
-
-To enable the readiness TCP port, use the `readiness.port` setting. The readiness service will bind to
-all host addresses.
-
-If the node leaves the cluster, or the <<put-shutdown,Shutdown API>> is used to mark the node
-for shutdown, the readiness port is immediately closed.
-
-A successful connection to the readiness TCP port signals that the {es} node is ready. When a client
-connects to the readiness port, the server simply terminates the socket connection. No data is sent back
-to the client. If a client cannot connect to the readiness port, the node is not ready.
-
-
+[[error-file-path]]
+include::important-settings/error-file.asciidoc[leveloffset=-1]

--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -31,6 +31,7 @@ include::important-settings/discovery-settings.asciidoc[]
 
 include::important-settings/heap-size.asciidoc[]
 
+[[heap-dump-path]]
 include::important-settings/heap-dump-path.asciidoc[]
 
 include::important-settings/gc-logging.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Fix broken anchors (#119802)](https://github.com/elastic/elasticsearch/pull/119802)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)