### PR TITLE
[8.x] Include full stacktrace in gradle functional test failures (#119900)

### DIFF
--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -107,7 +107,7 @@ abstract class AbstractGradleFuncTest extends Specification {
                                 .forwardOutput()
             ), configurationCacheCompatible,
                 buildApiRestrictionsDisabled)
-        ).withArguments(arguments.collect { it.toString() })
+        ).withArguments(arguments.collect { it.toString() } + "--full-stacktrace")
     }
 
     def assertOutputContains(String givenOutput, String expected) {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Include full stacktrace in gradle functional test failures (#119900)