### PR TITLE
Create balancer summary scaffolding

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/AllocationBalancingRoundSummaryService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/AllocationBalancingRoundSummaryService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.routing.allocation.allocator;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Manages the lifecycle of {@link BalancingSummary} data structures tracking allocation balancing round results. There are many balancing
+ * rounds and this class manages their reporting.
+ *
+ * Summarizing balancer rounds and reporting the results will provide information with which to do a cost-benefit analysis of the work that
+ * the allocation rebalancing performs.
+ */
+public class AllocationBalancingRoundSummaryService {
+
+    /** Value to return if no balancing rounds have occurred in the requested time period. */
+    private final BalancingSummary.CombinedClusterBalancingRoundSummary EMPTY_RESULTS =
+        new BalancingSummary.CombinedClusterBalancingRoundSummary(
+            0,
+            0,
+            new LinkedList<>(),
+            new BalancingSummary.ClusterShardMovements(0, 0, 0, 0, 0),
+            new HashMap<>()
+        );
+
+    /**
+     * A concurrency-safe list of balancing round summaries. Balancer rounds are run and added here serially, so the queue will naturally
+     * progress from newer to older results.
+     */
+    private ConcurrentLinkedQueue<BalancingSummary.BalancingRoundSummary> summaries = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Returns a combined summary of all unreported allocation round summaries: may summarize a single balancer round, multiple, or none.
+     *
+     * @return returns {@link #EMPTY_RESULTS} if there are no unreported balancing rounds.
+     */
+    public BalancingSummary.CombinedClusterBalancingRoundSummary combineSummaries() {
+        // TODO: implement
+        return EMPTY_RESULTS;
+    }
+
+    public void addBalancerRoundSummary(BalancingSummary.BalancingRoundSummary summary) {
+        summaries.add(summary);
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancingSummary.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancingSummary.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.routing.allocation.allocator;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Data structures defining the results of allocation balancing rounds.
+ */
+public class BalancingSummary {
+
+    /**
+     * Holds combined {@link BalancingRoundSummary} results. Essentially holds a list of the balancing events and the summed up changes
+     * across all those events: what allocation work was done across some period of time.
+     *
+     * @param eventsStartTime The earliest start time of all the combined balancing rounds.
+     * @param eventsEndTime The latest end time of all the combined balancing rounds.
+     * @param events A list of all the cluster events that started the balancing rounds.
+     * @param shardMovements The sum of all shard movements across all combined balancing rounds.
+     * @param nodeChanges The total change stats per node in the cluster from the earliest balancing round to the latest one.
+     */
+    record CombinedClusterBalancingRoundSummary(
+        long eventsStartTime,
+        long eventsEndTime,
+        List<ClusterRebalancingEvent> events,
+        ClusterShardMovements shardMovements,
+        Map<String, IndividualNodeRebalancingChangeStats> nodeChanges
+    ) {};
+
+    /**
+     * Summarizes the impact to the cluster as a result of a rebalancing round.
+     *
+     * @param eventStartTime Time at which the desired balance calculation began due to a cluster event.
+     * @param computationEndTime Time at which the new desired balance calculation was finished.
+     * @param event Reports what provoked the rebalancing round. The rebalancer only runs when requested, not on a periodic basis.
+     * @param computationFinishReason Whether the balancing round converged to a final allocation, or exiting early for some reason.
+     * @param shardMovements Lists the total number of shard moves, and breaks down the total into number shards moved by category,
+     *                       like node shutdown
+     * @param nodeChanges A Map of node name to {@link IndividualNodeRebalancingChangeStats} to describe what each node gained and how much
+     *                    work each node performed for the balancing round.
+     */
+    record BalancingRoundSummary(
+        long eventStartTime,
+        long computationEndTime,
+        ClusterRebalancingEvent event,
+        DesiredBalance.ComputationFinishReason computationFinishReason,
+        ClusterShardMovements shardMovements,
+        Map<String, IndividualNodeRebalancingChangeStats> nodeChanges
+    ) {
+        @Override
+        public String toString() {
+            return "BalancingRoundSummary{"
+                + "ClusterRebalancingEvent="
+                + event
+                + ", ClusterShardMovements="
+                + shardMovements
+                + ", NodeChangeStats={"
+                + nodeChanges
+                + "}"
+                + '}';
+        }
+    };
+
+    /**
+     * General cost-benefit information on the node-level. Describes how each node was improved by a balancing round, and how much work that
+     * node did to achieve the shard rebalancing.
+     *
+     * @param nodeWeightBeforeRebalancing
+     * @param nodeWeightAfterRebalancing
+     * @param dataMovedToNodeInMB
+     * @param dataMovedAwayFromNodeInMB
+     */
+    record IndividualNodeRebalancingChangeStats(
+        long nodeWeightBeforeRebalancing,
+        long nodeWeightAfterRebalancing,
+        long dataMovedToNodeInMB,
+        long dataMovedAwayFromNodeInMB
+    ) {
+        @Override
+        public String toString() {
+            return "IndividualNodeRebalancingChangeStats{"
+                + "nodeWeightBeforeRebalancing="
+                + nodeWeightBeforeRebalancing
+                + ", nodeWeightAfterRebalancing="
+                + nodeWeightAfterRebalancing
+                + ", dataMovedToNodeInMB="
+                + dataMovedToNodeInMB
+                + ", dataMovedAwayFromNodeInMB="
+                + dataMovedAwayFromNodeInMB
+                + '}';
+        }
+    };
+
+    /**
+     * Tracks and summarizes the more granular reasons why shards are moved between nodes.
+     *
+     * @param numShardMoves total number of shard moves
+     * @param numAllocationDeciderForcedShardMoves total number of shards that must be moved because they violate an AllocationDecider rule
+     * @param numRebalancingShardMoves total number of shards moved to improve cluster balance and are not otherwise required to move
+     * @param numShutdownForcedShardMoves total number of shards that must move off of a node because it is shutting down
+     * @param numStuckShards total number of shards violating an AllocationDecider on their current node and on every other cluster node
+     */
+    record ClusterShardMovements(
+        long numShardMoves,
+        long numAllocationDeciderForcedShardMoves,
+        long numRebalancingShardMoves,
+        long numShutdownForcedShardMoves,
+        long numStuckShards
+    ) {
+        @Override
+        public String toString() {
+            return "ClusterShardMovements{"
+                + "numShardMoves="
+                + numShardMoves
+                + ", numAllocationDeciderForcedShardMoves="
+                + numAllocationDeciderForcedShardMoves
+                + ", numRebalancingShardMoves="
+                + numRebalancingShardMoves
+                + ", numShutdownForcedShardMoves="
+                + numShutdownForcedShardMoves
+                + ", numStuckShards="
+                + numStuckShards
+                + '}';
+        }
+    };
+
+    /**
+     * The cluster event that initiated a rebalancing round. This will tell us what initiated the balancer doing some amount of rebalancing
+     * work.
+     */
+    enum ClusterRebalancingEvent {
+        // TODO (Dianna): go through the reroute methods and identify the causes -- many reroute methods accept a 'reason' string -- and
+        // replace them with this enum to be saved later in a balancing summary.
+        RerouteCommand,
+        IndexCreation,
+        IndexDeletion,
+        NodeShutdownAndRemoval,
+        NewNodeAdded
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -68,6 +68,10 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
     private volatile boolean resetCurrentDesiredBalance = false;
     private final Set<String> processedNodeShutdowns = new HashSet<>();
     private final DesiredBalanceMetrics desiredBalanceMetrics;
+    /**
+     * Manages balancer round results in order to report metrics on the balancer activity in a configurable manner.
+     */
+    private final AllocationBalancingRoundSummaryService balancerRoundSummaryService;
 
     // stats
     protected final CounterMetric computationsSubmitted = new CounterMetric();
@@ -112,6 +116,7 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
         NodeAllocationStatsAndWeightsCalculator nodeAllocationStatsAndWeightsCalculator
     ) {
         this.desiredBalanceMetrics = new DesiredBalanceMetrics(telemetryProvider.getMeterRegistry());
+        this.balancerRoundSummaryService = new AllocationBalancingRoundSummaryService();
         this.delegateAllocator = delegateAllocator;
         this.threadPool = threadPool;
         this.reconciler = reconciler;


### PR DESCRIPTION
Lays out the balancer summary information that we want to collect and
eventually report. Only the class scaffolding, still needs
implementation.

Relates ES-10341

--------------------

This is the outline of the balancer round summary stats I want to track. I'll need to run around the code to track and collect the desired information: I expect I'll need to collect some metrics during reconcile(), there's already [AllocationStats that tracks some information](https://github.com/elastic/elasticsearch/blob/80e8017bb605db5a7296668485cefb33c49cbae8/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java#L570). ES-10260 outlines what I'm doing in this patch, as well as where I'm headed. Eventually I need to push the metrics from the *SummaryService into the DesiredBalanceMetrics to get pulled by APM (that's a later ticket, ES-10343, but is where things are headed).