### PR TITLE
Optimize mapping usage in LogsdbIndexModeSettingsProvider

### DIFF
--- a/docs/changelog/119935.yaml
+++ b/docs/changelog/119935.yaml
@@ -1,0 +1,7 @@
+pr: 119935
+summary: Optimize `LogsdbIndexModeSettingsProvider#newIndexHasSyntheticSourceUsage(...)`
+  logic
+area: Logs
+type: enhancement
+issues:
+ - 119552

--- a/docs/changelog/119935.yaml
+++ b/docs/changelog/119935.yaml
@@ -3,5 +3,4 @@ summary: Optimize `LogsdbIndexModeSettingsProvider#newIndexHasSyntheticSourceUsa
   logic
 area: Logs
 type: enhancement
-issues:
- - 119552
+issues: []

--- a/docs/changelog/119935.yaml
+++ b/docs/changelog/119935.yaml
@@ -1,6 +1,5 @@
 pr: 119935
-summary: Optimize `LogsdbIndexModeSettingsProvider#newIndexHasSyntheticSourceUsage(...)`
-  logic
+summary: Optimize mapping usage in LogsdbIndexModeSettingsProvider
 area: Logs
 type: enhancement
 issues: []

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
@@ -253,7 +253,8 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
                     && ((FieldMapper) hostName).fieldType().hasDocValues()
                     && (hostName instanceof KeywordFieldMapper || hostName instanceof NumberFieldMapper);
                 sortOnHostName = addHostNameField || hasNameHasDocValues;
-                hasSyntheticSourceUsage = hasSyntheticSourceUsage || mapping.getMetadataMapperByClass(SourceFieldMapper.class).isSynthetic();
+                hasSyntheticSourceUsage = hasSyntheticSourceUsage
+                    || mapping.getMetadataMapperByClass(SourceFieldMapper.class).isSynthetic();
                 return new MappingHints(hasSyntheticSourceUsage, sortOnHostName, addHostNameField);
             }
         } catch (AssertionError | Exception e) {

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
@@ -245,6 +245,8 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
                     if (host instanceof ObjectMapper hostObj) {
                         hostName = hostObj.getMapper("name");
                         addHostNameField = hostName == null;
+                    } else if (host == null || mapping.getRoot().subobjects() == ObjectMapper.Subobjects.DISABLED) {
+                        addHostNameField = true;
                     }
                 }
                 boolean hasNameHasDocValues = hostName != null

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
@@ -253,7 +253,7 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
                     && ((FieldMapper) hostName).fieldType().hasDocValues()
                     && (hostName instanceof KeywordFieldMapper || hostName instanceof NumberFieldMapper);
                 sortOnHostName = addHostNameField || hasNameHasDocValues;
-                hasSyntheticSourceUsage = mapping.getMetadataMapperByClass(SourceFieldMapper.class).isSynthetic();
+                hasSyntheticSourceUsage = hasSyntheticSourceUsage || mapping.getMetadataMapperByClass(SourceFieldMapper.class).isSynthetic();
                 return new MappingHints(hasSyntheticSourceUsage, sortOnHostName, addHostNameField);
             }
         } catch (AssertionError | Exception e) {

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
@@ -238,7 +238,11 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
                 boolean addHostNameField = false;
                 boolean sortOnHostName = false;
 
-                var mapping = mapperService.parseMapping("_doc", MapperService.MergeReason.INDEX_TEMPLATE, combinedTemplateMappings);
+                var mapping = mapperService.parseMapping(
+                    MapperService.SINGLE_MAPPING_NAME,
+                    MapperService.MergeReason.INDEX_TEMPLATE,
+                    combinedTemplateMappings
+                );
                 Mapper hostName = mapping.getRoot().getMapper("host.name");
                 if (hostName == null || hostName instanceof ObjectMapper) {
                     Mapper host = mapping.getRoot().getMapper("host");


### PR DESCRIPTION
Optimize mapping usages in when determining synthetic source usage and assessing whether host.name field can be used for index sorting.

By avoiding to invoke `MapperService#merge(...)` and just relying on the parsed `Mapping` instance from `MapperService#parseMapping(...)` instead. This way a lot of overhead can be prevented, without loss of functionality. 

The other alternative is manually parsing the mapping using map of maps representation, but that could be error prone. If this change mitages most of the regression reported in #119552 (and in elastic/elasticsearch-benchmarks#2232), then the approach in this PR is preferred.

Based on the flame graphs in the mentioned issues, this change should reduce the overhead of `LogsdbIndexModeSettingsProvider#getMappingHints(...)` by half.