### PR TITLE
[8.x] Configure index sorting through index settings for logsdb (#118968)

### DIFF
--- a/docs/changelog/118968.yaml
+++ b/docs/changelog/118968.yaml
@@ -1,0 +1,6 @@
+pr: 118968
+summary: Configure index sorting through index settings for logsdb
+area: Logs
+type: enhancement
+issues:
+ - 118686

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
@@ -10,14 +10,6 @@ setup:
 
 ---
 create logs index:
-  - requires:
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
-
   - do:
       indices.create:
         index: test
@@ -79,14 +71,6 @@ create logs index:
 
 ---
 using default timestamp field mapping:
-  - requires:
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
-
   - do:
       indices.create:
         index: test-timestamp-missing
@@ -111,14 +95,6 @@ using default timestamp field mapping:
 
 ---
 missing hostname field:
-  - requires:
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
-
   - do:
       indices.create:
         index: test-hostname-missing
@@ -150,14 +126,6 @@ missing hostname field:
 
 ---
 missing sort field:
-  - requires:
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
-
   - do:
       catch: bad_request
       indices.create:
@@ -191,14 +159,6 @@ missing sort field:
 
 ---
 non-default sort settings:
-  - requires:
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
-
   - do:
       indices.create:
         index: test-sort
@@ -245,14 +205,10 @@ non-default sort settings:
 ---
 override sort order settings:
   - requires:
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
-
+      cluster_features: [ "index.logsdb_no_host_name_field" ]
+      reason: "Change in default sort config for logsdb"
   - do:
+      catch: bad_request
       indices.create:
         index: test-sort-order
         body:
@@ -279,28 +235,16 @@ override sort order settings:
               message:
                 type: text
 
-  - do:
-      indices.get_settings:
-        index: test-sort-order
-
-  - is_true: test-sort-order
-  - match: { test-sort-order.settings.index.mode: "logsdb" }
-  - match: { test-sort-order.settings.index.sort.field.0: null }
-  - match: { test-sort-order.settings.index.sort.field.1: null }
-  - match: { test-sort-order.settings.index.sort.order.0: "asc" }
-  - match: { test-sort-order.settings.index.sort.order.1: "asc" }
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "index.sort.fields:[] index.sort.order:[asc, asc], size mismatch" }
 
 ---
 override sort missing settings:
   - requires:
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
-
+      cluster_features: [ "index.logsdb_no_host_name_field" ]
+      reason: "Change in default sort config for logsdb"
   - do:
+      catch: bad_request
       indices.create:
         index: test-sort-missing
         body:
@@ -327,28 +271,16 @@ override sort missing settings:
               message:
                 type: text
 
-  - do:
-      indices.get_settings:
-        index: test-sort-missing
-
-  - is_true: test-sort-missing
-  - match: { test-sort-missing.settings.index.mode: "logsdb" }
-  - match: { test-sort-missing.settings.index.sort.field.0: null }
-  - match: { test-sort-missing.settings.index.sort.field.1: null }
-  - match: { test-sort-missing.settings.index.sort.missing.0: "_last" }
-  - match: { test-sort-missing.settings.index.sort.missing.1: "_first" }
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "index.sort.fields:[] index.sort.missing:[_last, _first], size mismatch" }
 
 ---
 override sort mode settings:
   - requires:
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
-
+      cluster_features: [ "index.logsdb_no_host_name_field" ]
+      reason: "Change in default sort config for logsdb"
   - do:
+      catch: bad_request
       indices.create:
         index: test-sort-mode
         body:
@@ -375,16 +307,8 @@ override sort mode settings:
               message:
                 type: text
 
-  - do:
-      indices.get_settings:
-        index: test-sort-mode
-
-  - is_true: test-sort-mode
-  - match: { test-sort-mode.settings.index.mode: "logsdb" }
-  - match: { test-sort-mode.settings.index.sort.field.0: null }
-  - match: { test-sort-mode.settings.index.sort.field.1: null }
-  - match: { test-sort-mode.settings.index.sort.mode.0: "max" }
-  - match: { test-sort-mode.settings.index.sort.mode.1: "max" }
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "index.sort.fields:[] index.sort.mode:[MAX, MAX], size mismatch" }
 
 ---
 override sort field using nested field type in sorting:
@@ -437,12 +361,7 @@ override sort field using nested field type in sorting:
 override sort field using nested field type:
   - requires:
       cluster_features: ["mapper.index_sorting_on_nested"]
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
+      reason: "Support for index sorting on indexes with nested objects required"
 
   - do:
       indices.create:
@@ -476,14 +395,6 @@ override sort field using nested field type:
 
 ---
 routing path not allowed in logs mode:
-  - requires:
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
-
   - do:
       catch: bad_request
       indices.create:
@@ -558,14 +469,6 @@ routing path allowed in logs mode with routing on sort fields:
 
 ---
 start time not allowed in logs mode:
-  - requires:
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
-
   - do:
       catch: bad_request
       indices.create:
@@ -599,14 +502,6 @@ start time not allowed in logs mode:
 
 ---
 end time not allowed in logs mode:
-  - requires:
-      test_runner_features: [ capabilities ]
-      capabilities:
-        - method: PUT
-          path: /{index}
-          capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logsdb' index mode capability required"
-
   - do:
       catch: bad_request
       indices.create:
@@ -686,10 +581,10 @@ ignore dynamic beyond limit logsdb override value:
   - match: { test-ignore-dynamic-override.settings.index.mapping.total_fields.ignore_dynamic_beyond_limit: "false" }
 
 ---
-logsdb with default ignore dynamic beyond limit and default sorting:
+default ignore dynamic beyond limit and default sorting:
   - requires:
-      cluster_features: ["mapper.logsdb_default_ignore_dynamic_beyond_limit"]
-      reason: requires default value for ignore_dynamic_beyond_limit
+      cluster_features: [ "index.logsdb_no_host_name_field" ]
+      reason: "No host.name field injection"
 
   - do:
       indices.create:
@@ -699,19 +594,8 @@ logsdb with default ignore dynamic beyond limit and default sorting:
             index:
               mode: logsdb
               mapping:
-                # NOTE: When the index mode is set to `logsdb`, the `host.name` field is automatically injected if
-                # sort settings are not overridden.
-                # With `subobjects` set to `true` (default), this creates a `host` object field and a nested `name`
-                # keyword field (`host.name`).
-                #
-                # As a result, there are always at least 4 statically mapped fields (`@timestamp`, `host`, `host.name`
-                # and `name`). We cannot use a field limit lower than 4 because these fields are always present.
-                #
-                # Indeed, if `index.mapping.total_fields.ignore_dynamic_beyond_limit` is `true`, any dynamically
-                # mapped fields beyond the limit `index.mapping.total_fields.limit` are ignored, but the statically
-                # mapped fields are always counted.
                 total_fields:
-                  limit: 4
+                  limit: 2
           mappings:
             properties:
               "@timestamp":
@@ -731,9 +615,9 @@ logsdb with default ignore dynamic beyond limit and default sorting:
         refresh: true
         body:
           - '{ "index": { } }'
-          - '{ "@timestamp": "2024-08-13T12:30:00Z", "name": "foo", "host.name": "92f4a67c", "value": 10, "message": "the quick brown fox", "region": "us-west", "pid": 153462 }'
+          - '{ "@timestamp": "2024-08-13T12:30:00Z", "name": "foo", "value": 10, "message": "the quick brown fox", "region": "us-west", "pid": 153462 }'
           - '{ "index": { } }'
-          - '{ "@timestamp": "2024-08-13T12:01:00Z", "name": "bar", "host.name": "24eea278", "value": 20, "message": "jumps over the lazy dog", "region": "us-central", "pid": 674972 }'
+          - '{ "@timestamp": "2024-08-13T12:01:00Z", "name": "bar", "value": 20, "message": "jumps over the lazy dog", "region": "us-central", "pid": 674972 }'
   - match: { errors: false }
 
   - do:
@@ -755,10 +639,68 @@ logsdb with default ignore dynamic beyond limit and default sorting:
   - match: { hits.hits.1._ignored: [ "message", "pid", "region", "value" ] }
 
 ---
-logsdb with default ignore dynamic beyond limit and non-default sorting:
+default ignore dynamic beyond limit and default sorting with hostname:
   - requires:
-      cluster_features: ["mapper.logsdb_default_ignore_dynamic_beyond_limit"]
-      reason: requires default value for ignore_dynamic_beyond_limit
+      cluster_features: [ "index.logsdb_no_host_name_field" ]
+      reason: "No host.name field injection"
+
+  - do:
+      indices.create:
+        index: test-logsdb-default-sort
+        body:
+          settings:
+            index:
+              mode: logsdb
+              mapping:
+                total_fields:
+                  limit: 3
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              host.name:
+                type: keyword
+
+  - do:
+      indices.get_settings:
+        index: test-logsdb-default-sort
+
+  - match: { test-logsdb-default-sort.settings.index.mode: "logsdb" }
+
+  - do:
+      bulk:
+        index: test-logsdb-default-sort
+        refresh: true
+        body:
+          - '{ "index": { } }'
+          - '{ "@timestamp": "2024-08-13T12:30:00Z", "host.name": "foo", "value": 10, "message": "the quick brown fox", "region": "us-west", "pid": 153462 }'
+          - '{ "index": { } }'
+          - '{ "@timestamp": "2024-08-13T12:01:00Z", "host.name": "bar", "value": 20, "message": "jumps over the lazy dog", "region": "us-central", "pid": 674972 }'
+  - match: { errors: false }
+
+  - do:
+      search:
+        index: test-logsdb-default-sort
+        body:
+          query:
+            match_all: {}
+          sort: "@timestamp"
+
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._source.host.name: "bar" }
+  - match: { hits.hits.0._source.value: 20 }
+  - match: { hits.hits.0._source.message: "jumps over the lazy dog" }
+  - match: { hits.hits.0._ignored: [ "message", "pid", "region", "value" ] }
+  - match: { hits.hits.1._source.host.name: "foo" }
+  - match: { hits.hits.1._source.value: 10 }
+  - match: { hits.hits.1._source.message: "the quick brown fox" }
+  - match: { hits.hits.1._ignored: [ "message", "pid", "region", "value" ] }
+
+---
+default ignore dynamic beyond limit and non-default sorting:
+  - requires:
+      cluster_features: [ "index.logsdb_no_host_name_field" ]
+      reason: "No host.name field injection"
 
   - do:
       indices.create:
@@ -770,8 +712,6 @@ logsdb with default ignore dynamic beyond limit and non-default sorting:
               sort.order: [ "desc" ]
               mode: logsdb
               mapping:
-                # NOTE: Here sort settings are overridden and we do not have any additional statically mapped field other
-                # than `name` and `timestamp`. As a result, there are only 2 statically mapped fields.
                 total_fields:
                   limit: 2
           mappings:
@@ -815,109 +755,3 @@ logsdb with default ignore dynamic beyond limit and non-default sorting:
   - match: { hits.hits.1._source.value: 10 }
   - match: { hits.hits.1._source.message: "the quick brown fox" }
   - match: { hits.hits.1._ignored: [ "host", "message", "pid", "region", "value" ] }
-
----
-logsdb with default ignore dynamic beyond limit and too low limit:
-  - requires:
-      cluster_features: ["mapper.logsdb_default_ignore_dynamic_beyond_limit"]
-      reason: requires default value for ignore_dynamic_beyond_limit
-
-  - do:
-      catch: bad_request
-      indices.create:
-        index: test-logsdb-low-limit
-        body:
-          settings:
-            index:
-              mode: logsdb
-              mapping:
-                # NOTE: When the index mode is set to `logsdb`, the `host.name` field is automatically injected if
-                # sort settings are not overridden.
-                # With `subobjects` set to `true` (default), this creates a `host` object field and a nested `name`
-                # keyword field (`host.name`).
-                #
-                # As a result, there are always at least 4 statically mapped fields (`@timestamp`, `host`, `host.name`
-                # and `name`). We cannot use a field limit lower than 4 because these fields are always present.
-                #
-                # Indeed, if `index.mapping.total_fields.ignore_dynamic_beyond_limit` is `true`, any dynamically
-                # mapped fields beyond the limit `index.mapping.total_fields.limit` are ignored, but the statically
-                # mapped fields are always counted.
-                total_fields:
-                  limit: 3
-          mappings:
-            properties:
-              "@timestamp":
-                type: date
-              name:
-                type: keyword
-  - match: { error.type: "illegal_argument_exception" }
-  - match: { error.reason: "Limit of total fields [3] has been exceeded" }
-
----
-logsdb with default ignore dynamic beyond limit and subobjects false:
-  - requires:
-      cluster_features: ["mapper.logsdb_default_ignore_dynamic_beyond_limit"]
-      reason: requires default value for ignore_dynamic_beyond_limit
-
-  - do:
-      indices.create:
-        index: test-logsdb-subobjects-false
-        body:
-          settings:
-            index:
-              mode: logsdb
-              mapping:
-                # NOTE: When the index mode is set to `logsdb`, the `host.name` field is automatically injected if
-                # sort settings are not overridden.
-                # With `subobjects` set to `false` anyway, a single `host.name` keyword field is automatically mapped.
-                #
-                # As a result, there are just 3 statically mapped fields (`@timestamp`, `host.name` and `name`).
-                # We cannot use a field limit lower than 3 because these fields are always present.
-                #
-                # Indeed, if `index.mapping.total_fields.ignore_dynamic_beyond_limit` is `true`, any dynamically
-                # mapped fields beyond the limit `index.mapping.total_fields.limit` are ignored, but the statically
-                # mapped fields are always counted.
-                total_fields:
-                  limit: 3
-          mappings:
-            subobjects: false
-            properties:
-              "@timestamp":
-                type: date
-              name:
-                type: keyword
-
-  - do:
-      indices.get_settings:
-        index: test-logsdb-subobjects-false
-
-  - match: { test-logsdb-subobjects-false.settings.index.mode: "logsdb" }
-
-  - do:
-      bulk:
-        index: test-logsdb-subobjects-false
-        refresh: true
-        body:
-          - '{ "index": { } }'
-          - '{ "@timestamp": "2024-08-13T12:30:00Z", "name": "foo", "host.name": "92f4a67c", "value": 10, "message": "the quick brown fox", "region": "us-west", "pid": 153462 }'
-          - '{ "index": { } }'
-          - '{ "@timestamp": "2024-08-13T12:01:00Z", "name": "bar", "host.name": "24eea278", "value": 20, "message": "jumps over the lazy dog", "region": "us-central", "pid": 674972 }'
-  - match: { errors: false }
-
-  - do:
-      search:
-        index: test-logsdb-subobjects-false
-        body:
-          query:
-            match_all: {}
-          sort: "@timestamp"
-
-  - match: { hits.total.value: 2 }
-  - match: { hits.hits.0._source.name: "bar" }
-  - match: { hits.hits.0._source.value: 20 }
-  - match: { hits.hits.0._source.message: "jumps over the lazy dog" }
-  - match: { hits.hits.0._ignored: [ "message", "pid", "region", "value" ] }
-  - match: { hits.hits.1._source.name: "foo" }
-  - match: { hits.hits.1._source.value: 10 }
-  - match: { hits.hits.1._source.message: "the quick brown fox" }
-  - match: { hits.hits.1._ignored: [ "message", "pid", "region", "value" ] }

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -430,6 +430,7 @@ module org.elasticsearch.server {
             org.elasticsearch.repositories.RepositoriesFeatures,
             org.elasticsearch.action.admin.cluster.allocation.AllocationStatsFeatures,
             org.elasticsearch.index.mapper.MapperFeatures,
+            org.elasticsearch.index.IndexFeatures,
             org.elasticsearch.ingest.IngestGeoIpFeatures,
             org.elasticsearch.search.SearchFeatures,
             org.elasticsearch.script.ScriptFeatures,

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -185,6 +185,8 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexSettings.LIFECYCLE_PARSE_ORIGINATION_DATE_SETTING,
         IndexSettings.TIME_SERIES_ES87TSDB_CODEC_ENABLED_SETTING,
         IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS,
+        IndexSettings.LOGSDB_SORT_ON_HOST_NAME,
+        IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD,
         IndexSettings.PREFER_ILM_SETTING,
         DataStreamFailureStoreDefinition.FAILURE_STORE_DEFINITION_VERSION_SETTING,
         FieldMapper.SYNTHETIC_SOURCE_KEEP_INDEX_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/IndexFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexFeatures.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index;
+
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Set;
+
+public class IndexFeatures implements FeatureSpecification {
+
+    @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of();
+    }
+
+    public static final NodeFeature LOGSDB_NO_HOST_NAME_FIELD = new NodeFeature("index.logsdb_no_host_name_field");
+
+    @Override
+    public Set<NodeFeature> getTestFeatures() {
+        return Set.of(LOGSDB_NO_HOST_NAME_FIELD);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -178,7 +178,7 @@ public enum IndexMode {
 
         @Override
         public CompressedXContent getDefaultMapping(final IndexSettings indexSettings) {
-            return DEFAULT_TIME_SERIES_TIMESTAMP_MAPPING;
+            return DEFAULT_MAPPING_TIMESTAMP;
         }
 
         @Override
@@ -260,9 +260,9 @@ public enum IndexMode {
 
         @Override
         public CompressedXContent getDefaultMapping(final IndexSettings indexSettings) {
-            return indexSettings != null && indexSettings.getIndexSortConfig().hasPrimarySortOnField(HOST_NAME)
-                ? DEFAULT_LOGS_TIMESTAMP_MAPPING_WITH_HOSTNAME
-                : DEFAULT_TIME_SERIES_TIMESTAMP_MAPPING;
+            return indexSettings != null && indexSettings.logsdbAddHostNameField()
+                ? DEFAULT_MAPPING_TIMESTAMP_HOSTNAME
+                : DEFAULT_MAPPING_TIMESTAMP;
         }
 
         @Override
@@ -392,7 +392,7 @@ public enum IndexMode {
         }
     };
 
-    private static final String HOST_NAME = "host.name";
+    static final String HOST_NAME = "host.name";
 
     private static void validateRoutingPathSettings(Map<Setting<?>, Object> settings) {
         settingRequiresTimeSeries(settings, IndexMetadata.INDEX_ROUTING_PATH);
@@ -432,14 +432,14 @@ public enum IndexMode {
         });
     }
 
-    private static final CompressedXContent DEFAULT_TIME_SERIES_TIMESTAMP_MAPPING;
+    private static final CompressedXContent DEFAULT_MAPPING_TIMESTAMP;
 
-    private static final CompressedXContent DEFAULT_LOGS_TIMESTAMP_MAPPING_WITH_HOSTNAME;
+    private static final CompressedXContent DEFAULT_MAPPING_TIMESTAMP_HOSTNAME;
 
     static {
         try {
-            DEFAULT_TIME_SERIES_TIMESTAMP_MAPPING = createDefaultMapping(false);
-            DEFAULT_LOGS_TIMESTAMP_MAPPING_WITH_HOSTNAME = createDefaultMapping(true);
+            DEFAULT_MAPPING_TIMESTAMP = createDefaultMapping(false);
+            DEFAULT_MAPPING_TIMESTAMP_HOSTNAME = createDefaultMapping(true);
         } catch (IOException e) {
             throw new AssertionError(e);
         }

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -714,6 +714,22 @@ public final class IndexSettings {
         Property.Final
     );
 
+    public static final Setting<Boolean> LOGSDB_ADD_HOST_NAME_FIELD = Setting.boolSetting(
+        "index.logsdb.add_host_name_field",
+        false,
+        Property.IndexScope,
+        Property.PrivateIndex,
+        Property.Final
+    );
+
+    public static final Setting<Boolean> LOGSDB_SORT_ON_HOST_NAME = Setting.boolSetting(
+        "index.logsdb.sort_on_host_name",
+        false,
+        Property.IndexScope,
+        Property.PrivateIndex,
+        Property.Final
+    );
+
     /**
      * The {@link IndexMode "mode"} of the index.
      */
@@ -836,6 +852,8 @@ public final class IndexSettings {
     private volatile long softDeleteRetentionOperations;
     private final boolean es87TSDBCodecEnabled;
     private final boolean logsdbRouteOnSortFields;
+    private final boolean logsdbSortOnHostName;
+    private final boolean logsdbAddHostNameField;
 
     private volatile long retentionLeaseMillis;
 
@@ -954,6 +972,13 @@ public final class IndexSettings {
     }
 
     /**
+     * Returns <code>true</code> if the index is in logsdb mode and needs a [host.name] keyword field. The default is <code>false</code>
+     */
+    public boolean logsdbAddHostNameField() {
+        return logsdbAddHostNameField;
+    }
+
+    /**
      * Creates a new {@link IndexSettings} instance. The given node settings will be merged with the settings in the metadata
      * while index level settings will overwrite node settings.
      *
@@ -1046,6 +1071,8 @@ public final class IndexSettings {
         sourceKeepMode = scopedSettings.get(Mapper.SYNTHETIC_SOURCE_KEEP_INDEX_SETTING);
         es87TSDBCodecEnabled = scopedSettings.get(TIME_SERIES_ES87TSDB_CODEC_ENABLED_SETTING);
         logsdbRouteOnSortFields = scopedSettings.get(LOGSDB_ROUTE_ON_SORT_FIELDS);
+        logsdbSortOnHostName = scopedSettings.get(LOGSDB_SORT_ON_HOST_NAME);
+        logsdbAddHostNameField = scopedSettings.get(LOGSDB_ADD_HOST_NAME_FIELD);
         skipIgnoredSourceWrite = scopedSettings.get(IgnoredSourceFieldMapper.SKIP_IGNORED_SOURCE_WRITE_SETTING);
         skipIgnoredSourceRead = scopedSettings.get(IgnoredSourceFieldMapper.SKIP_IGNORED_SOURCE_READ_SETTING);
         indexMappingSourceMode = scopedSettings.get(INDEX_MAPPER_SOURCE_MODE_SETTING);

--- a/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
@@ -13,7 +13,6 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.SortedSetSortField;
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Setting;
@@ -103,12 +102,23 @@ public final class IndexSortConfig {
         Setting.Property.ServerlessPublic
     );
 
-    public static final FieldSortSpec[] TIME_SERIES_SORT;
-
+    public static final FieldSortSpec[] TIME_SERIES_SORT, TIMESTAMP_SORT, HOSTNAME_TIMESTAMP_SORT, HOSTNAME_TIMESTAMP_BWC_SORT;
     static {
         FieldSortSpec timeStampSpec = new FieldSortSpec(DataStreamTimestampFieldMapper.DEFAULT_PATH);
         timeStampSpec.order = SortOrder.DESC;
         TIME_SERIES_SORT = new FieldSortSpec[] { new FieldSortSpec(TimeSeriesIdFieldMapper.NAME), timeStampSpec };
+        TIMESTAMP_SORT = new FieldSortSpec[] { timeStampSpec };
+
+        FieldSortSpec hostnameSpec = new FieldSortSpec(IndexMode.HOST_NAME);
+        hostnameSpec.order = SortOrder.ASC;
+        hostnameSpec.missingValue = "_last";
+        hostnameSpec.mode = MultiValueMode.MIN;
+        HOSTNAME_TIMESTAMP_SORT = new FieldSortSpec[] { hostnameSpec, timeStampSpec };
+
+        // Older indexes use ascending ordering for host name and timestamp.
+        HOSTNAME_TIMESTAMP_BWC_SORT = new FieldSortSpec[] {
+            new FieldSortSpec(IndexMode.HOST_NAME),
+            new FieldSortSpec(DataStreamTimestampFieldMapper.DEFAULT_PATH) };
     }
 
     private static String validateMissingValue(String missing) {
@@ -148,26 +158,40 @@ public final class IndexSortConfig {
         this.indexName = indexSettings.getIndex().getName();
         this.indexMode = indexSettings.getMode();
 
-        if (this.indexMode == IndexMode.TIME_SERIES) {
-            this.sortSpecs = TIME_SERIES_SORT;
+        if (indexMode == IndexMode.TIME_SERIES) {
+            sortSpecs = TIME_SERIES_SORT;
             return;
         }
 
         List<String> fields = INDEX_SORT_FIELD_SETTING.get(settings);
-        if (this.indexMode == IndexMode.LOGSDB && fields.isEmpty()) {
-            fields = List.of("host.name", DataStream.TIMESTAMP_FIELD_NAME);
+        if (indexMode == IndexMode.LOGSDB && INDEX_SORT_FIELD_SETTING.exists(settings) == false) {
+            if (INDEX_SORT_ORDER_SETTING.exists(settings)) {
+                var order = INDEX_SORT_ORDER_SETTING.get(settings);
+                throw new IllegalArgumentException("index.sort.fields:" + fields + " index.sort.order:" + order + ", size mismatch");
+            }
+            if (INDEX_SORT_MODE_SETTING.exists(settings)) {
+                var mode = INDEX_SORT_MODE_SETTING.get(settings);
+                throw new IllegalArgumentException("index.sort.fields:" + fields + " index.sort.mode:" + mode + ", size mismatch");
+            }
+            if (INDEX_SORT_MISSING_SETTING.exists(settings)) {
+                var missing = INDEX_SORT_MISSING_SETTING.get(settings);
+                throw new IllegalArgumentException("index.sort.fields:" + fields + " index.sort.missing:" + missing + ", size mismatch");
+            }
+            var version = indexSettings.getIndexVersionCreated();
+            if (version.onOrAfter(IndexVersions.LOGSB_OPTIONAL_SORTING_ON_HOST_NAME)
+                || version.between(IndexVersions.LOGSB_OPTIONAL_SORTING_ON_HOST_NAME_BACKPORT, IndexVersions.UPGRADE_TO_LUCENE_10_0_0)) {
+                sortSpecs = (IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(settings)) ? HOSTNAME_TIMESTAMP_SORT : TIMESTAMP_SORT;
+            } else {
+                sortSpecs = HOSTNAME_TIMESTAMP_BWC_SORT;
+            }
+            return;
         }
-        this.sortSpecs = fields.stream().map(FieldSortSpec::new).toArray(FieldSortSpec[]::new);
+        sortSpecs = fields.stream().map(FieldSortSpec::new).toArray(FieldSortSpec[]::new);
 
         if (INDEX_SORT_ORDER_SETTING.exists(settings)) {
             List<SortOrder> orders = INDEX_SORT_ORDER_SETTING.get(settings);
-            if (this.indexMode == IndexMode.LOGSDB && orders.isEmpty()) {
-                orders = List.of(SortOrder.DESC, SortOrder.DESC);
-            }
             if (orders.size() != sortSpecs.length) {
-                throw new IllegalArgumentException(
-                    "index.sort.field:" + fields + " index.sort.order:" + orders.toString() + ", size mismatch"
-                );
+                throw new IllegalArgumentException("index.sort.field:" + fields + " index.sort.order:" + orders + ", size mismatch");
             }
             for (int i = 0; i < sortSpecs.length; i++) {
                 sortSpecs[i].order = orders.get(i);
@@ -176,9 +200,6 @@ public final class IndexSortConfig {
 
         if (INDEX_SORT_MODE_SETTING.exists(settings)) {
             List<MultiValueMode> modes = INDEX_SORT_MODE_SETTING.get(settings);
-            if (this.indexMode == IndexMode.LOGSDB && modes.isEmpty()) {
-                modes = List.of(MultiValueMode.MIN, MultiValueMode.MIN);
-            }
             if (modes.size() != sortSpecs.length) {
                 throw new IllegalArgumentException("index.sort.field:" + fields + " index.sort.mode:" + modes + ", size mismatch");
             }
@@ -189,9 +210,6 @@ public final class IndexSortConfig {
 
         if (INDEX_SORT_MISSING_SETTING.exists(settings)) {
             List<String> missingValues = INDEX_SORT_MISSING_SETTING.get(settings);
-            if (this.indexMode == IndexMode.LOGSDB && missingValues.isEmpty()) {
-                missingValues = List.of("_first", "_first");
-            }
             if (missingValues.size() != sortSpecs.length) {
                 throw new IllegalArgumentException(
                     "index.sort.field:" + fields + " index.sort.missing:" + missingValues + ", size mismatch"

--- a/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
@@ -178,8 +178,7 @@ public final class IndexSortConfig {
                 throw new IllegalArgumentException("index.sort.fields:" + fields + " index.sort.missing:" + missing + ", size mismatch");
             }
             var version = indexSettings.getIndexVersionCreated();
-            if (version.onOrAfter(IndexVersions.LOGSB_OPTIONAL_SORTING_ON_HOST_NAME)
-                || version.between(IndexVersions.LOGSB_OPTIONAL_SORTING_ON_HOST_NAME_BACKPORT, IndexVersions.UPGRADE_TO_LUCENE_10_0_0)) {
+            if (version.onOrAfter(IndexVersions.LOGSB_OPTIONAL_SORTING_ON_HOST_NAME_BACKPORT)) {
                 sortSpecs = (IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(settings)) ? HOSTNAME_TIMESTAMP_SORT : TIMESTAMP_SORT;
             } else {
                 sortSpecs = HOSTNAME_TIMESTAMP_BWC_SORT;

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -125,6 +125,7 @@ public class IndexVersions {
     public static final IndexVersion USE_SYNTHETIC_SOURCE_FOR_RECOVERY_BACKPORT = def(8_522_00_0, Version.LUCENE_9_12_0);
     public static final IndexVersion UPGRADE_TO_LUCENE_9_12_1 = def(8_523_00_0, Version.LUCENE_9_12_1);
     public static final IndexVersion INFERENCE_METADATA_FIELDS_BACKPORT = def(8_524_00_0, Version.LUCENE_9_12_1);
+    public static final IndexVersion LOGSB_OPTIONAL_SORTING_ON_HOST_NAME_BACKPORT = def(8_525_00_0, Version.LUCENE_9_12_1);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -81,7 +81,7 @@ public final class Mapping implements ToXContentFragment {
     /**
      * Returns the root object for the current mapping
      */
-    RootObjectMapper getRoot() {
+    public RootObjectMapper getRoot() {
         return root;
     }
 

--- a/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -16,6 +16,7 @@ org.elasticsearch.rest.RestFeatures
 org.elasticsearch.indices.IndicesFeatures
 org.elasticsearch.repositories.RepositoriesFeatures
 org.elasticsearch.action.admin.cluster.allocation.AllocationStatsFeatures
+org.elasticsearch.index.IndexFeatures
 org.elasticsearch.index.mapper.MapperFeatures
 org.elasticsearch.ingest.IngestGeoIpFeatures
 org.elasticsearch.search.SearchFeatures

--- a/server/src/test/java/org/elasticsearch/index/LogsIndexModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/LogsIndexModeTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.index.IndexVersionUtils;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -25,9 +26,87 @@ public class LogsIndexModeTests extends ESTestCase {
     public void testDefaultHostNameSortField() {
         final IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", buildSettings());
         assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGSDB));
-        final IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
+        boolean sortOnHostName = randomBoolean();
+        final IndexSettings settings = new IndexSettings(
+            metadata,
+            Settings.builder().put(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.getKey(), sortOnHostName).build()
+        );
+        assertThat(settings.getIndexSortConfig().hasPrimarySortOnField("host.name"), equalTo(sortOnHostName));
+    }
+
+    public void testDefaultHostNameSortFieldAndMapping() {
+        final IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", buildSettings());
+        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGSDB));
+        final IndexSettings settings = new IndexSettings(
+            metadata,
+            Settings.builder()
+                .put(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.getKey(), true)
+                .put(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.getKey(), true)
+                .build()
+        );
         assertThat(settings.getIndexSortConfig().hasPrimarySortOnField("host.name"), equalTo(true));
         assertThat(IndexMode.LOGSDB.getDefaultMapping(settings).string(), containsString("host.name"));
+    }
+
+    public void testDefaultHostNameSortFieldBwc() {
+        final IndexMetadata metadata = IndexMetadata.builder("test")
+            .settings(
+                indexSettings(IndexVersionUtils.getPreviousVersion(IndexVersions.LOGSB_OPTIONAL_SORTING_ON_HOST_NAME), 1, 1).put(
+                    buildSettings()
+                )
+            )
+            .build();
+        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGSDB));
+        final IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
+        assertThat(settings.getIndexSortConfig().hasPrimarySortOnField("host.name"), equalTo(true));
+    }
+
+    public void testDefaultHostNameSortWithOrder() {
+        final IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", buildSettings());
+        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGSDB));
+        var exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new IndexSettings(
+                metadata,
+                Settings.builder()
+                    .put(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.getKey(), randomBoolean())
+                    .put(IndexSortConfig.INDEX_SORT_ORDER_SETTING.getKey(), "desc")
+                    .build()
+            )
+        );
+        assertEquals("index.sort.fields:[] index.sort.order:[desc], size mismatch", exception.getMessage());
+    }
+
+    public void testDefaultHostNameSortWithMode() {
+        final IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", buildSettings());
+        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGSDB));
+        var exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new IndexSettings(
+                metadata,
+                Settings.builder()
+                    .put(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.getKey(), randomBoolean())
+                    .put(IndexSortConfig.INDEX_SORT_MODE_SETTING.getKey(), "MAX")
+                    .build()
+            )
+        );
+        assertEquals("index.sort.fields:[] index.sort.mode:[MAX], size mismatch", exception.getMessage());
+    }
+
+    public void testDefaultHostNameSortWithMissing() {
+        final IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", buildSettings());
+        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGSDB));
+        var exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new IndexSettings(
+                metadata,
+                Settings.builder()
+                    .put(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.getKey(), randomBoolean())
+                    .put(IndexSortConfig.INDEX_SORT_MISSING_SETTING.getKey(), "_first")
+                    .build()
+            )
+        );
+        assertEquals("index.sort.fields:[] index.sort.missing:[_first], size mismatch", exception.getMessage());
     }
 
     public void testCustomSortField() {

--- a/server/src/test/java/org/elasticsearch/index/LogsIndexModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/LogsIndexModeTests.java
@@ -51,7 +51,7 @@ public class LogsIndexModeTests extends ESTestCase {
     public void testDefaultHostNameSortFieldBwc() {
         final IndexMetadata metadata = IndexMetadata.builder("test")
             .settings(
-                indexSettings(IndexVersionUtils.getPreviousVersion(IndexVersions.LOGSB_OPTIONAL_SORTING_ON_HOST_NAME), 1, 1).put(
+                indexSettings(IndexVersionUtils.getPreviousVersion(IndexVersions.LOGSB_OPTIONAL_SORTING_ON_HOST_NAME_BACKPORT), 1, 1).put(
                     buildSettings()
                 )
             )

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
@@ -63,7 +63,7 @@ public class LogsDBPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public Collection<IndexSettingProvider> getAdditionalIndexSettingProviders(IndexSettingProvider.Parameters parameters) {
-	logsdbIndexModeSettingsProvider.init(
+        logsdbIndexModeSettingsProvider.init(
             parameters.mapperServiceFactory(),
             () -> IndexVersion.min(
                 IndexVersion.current(),

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
@@ -63,15 +63,14 @@ public class LogsDBPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public Collection<IndexSettingProvider> getAdditionalIndexSettingProviders(IndexSettingProvider.Parameters parameters) {
-        if (DiscoveryNode.isStateless(settings) == false) {
-            logsdbIndexModeSettingsProvider.init(
-                parameters.mapperServiceFactory(),
-                () -> IndexVersion.min(
-                    IndexVersion.current(),
-                    parameters.clusterService().state().nodes().getMaxDataNodeCompatibleIndexVersion()
-                )
-            );
-        }
+	logsdbIndexModeSettingsProvider.init(
+            parameters.mapperServiceFactory(),
+            () -> IndexVersion.min(
+                IndexVersion.current(),
+                parameters.clusterService().state().nodes().getMaxDataNodeCompatibleIndexVersion()
+            ),
+            DiscoveryNode.isStateless(settings) == false
+        );
         return List.of(logsdbIndexModeSettingsProvider);
     }
 

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
@@ -24,7 +24,11 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexSortConfig;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 
 import java.io.IOException;
@@ -44,6 +48,7 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
     private final SyntheticSourceLicenseService syntheticSourceLicenseService;
     private final SetOnce<CheckedFunction<IndexMetadata, MapperService, IOException>> mapperServiceFactory = new SetOnce<>();
     private final SetOnce<Supplier<IndexVersion>> createdIndexVersion = new SetOnce<>();
+    private final SetOnce<Boolean> supportFallbackToStoredSource = new SetOnce<>();
 
     private volatile boolean isLogsdbEnabled;
 
@@ -56,13 +61,14 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
         this.isLogsdbEnabled = isLogsdbEnabled;
     }
 
-    void init(CheckedFunction<IndexMetadata, MapperService, IOException> factory, Supplier<IndexVersion> indexVersion) {
-        mapperServiceFactory.set(factory);
-        createdIndexVersion.set(indexVersion);
-    }
-
-    private boolean supportFallbackToStoredSource() {
-        return mapperServiceFactory.get() != null;
+    void init(
+        CheckedFunction<IndexMetadata, MapperService, IOException> factory,
+        Supplier<IndexVersion> indexVersion,
+        boolean supportFallbackToStoredSource
+    ) {
+        this.mapperServiceFactory.set(factory);
+        this.createdIndexVersion.set(indexVersion);
+        this.supportFallbackToStoredSource.set(supportFallbackToStoredSource);
     }
 
     @Override
@@ -90,14 +96,14 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
             && resolveIndexMode(settings.get(IndexSettings.MODE.getKey())) == null
             && matchesLogsPattern(dataStreamName)) {
             settingsBuilder = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB.getName());
-            if (supportFallbackToStoredSource()) {
-                settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB.getName()).put(settings).build();
-            }
+            settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB.getName()).put(settings).build();
             isLogsDB = true;
         }
 
+        MappingHints mappingHints = getMappingHints(indexName, templateIndexMode, settings, combinedTemplateMappings);
+
         // Inject stored source mode if synthetic source if not available per licence.
-        if (supportFallbackToStoredSource()) {
+        if (mappingHints.hasSyntheticSourceUsage && supportFallbackToStoredSource.get()) {
             // This index name is used when validating component and index templates, we should skip this check in that case.
             // (See MetadataIndexTemplateService#validateIndexTemplateV2(...) method)
             boolean isTemplateValidation = "validate-index-name".equals(indexName);
@@ -106,11 +112,7 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
                 indexName,
                 dataStreamName
             );
-            if (newIndexHasSyntheticSourceUsage(indexName, templateIndexMode, settings, combinedTemplateMappings)
-                && syntheticSourceLicenseService.fallbackToStoredSource(
-                    isTemplateValidation,
-                    legacyLicensedUsageOfSyntheticSourceAllowed
-                )) {
+            if (syntheticSourceLicenseService.fallbackToStoredSource(isTemplateValidation, legacyLicensedUsageOfSyntheticSourceAllowed)) {
                 LOGGER.debug("creation of index [{}] with synthetic source without it being allowed", indexName);
                 if (settingsBuilder == null) {
                     settingsBuilder = Settings.builder();
@@ -120,6 +122,18 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
         }
 
         if (isLogsDB) {
+            // Inject sorting on [host.name], in addition to [@timestamp].
+            if (mappingHints.sortOnHostName) {
+                if (settingsBuilder == null) {
+                    settingsBuilder = Settings.builder();
+                }
+                if (mappingHints.addHostNameField) {
+                    // Inject keyword field [host.name] too.
+                    settingsBuilder.put(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.getKey(), true);
+                }
+                settingsBuilder.put(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.getKey(), true);
+            }
+
             // Inject routing path matching sort fields.
             if (settings.getAsBoolean(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.getKey(), false)) {
                 List<String> sortFields = new ArrayList<>(settings.getAsList(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey()));
@@ -155,13 +169,17 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
                     if (settingsBuilder == null) {
                         settingsBuilder = Settings.builder();
                     }
-                    settingsBuilder.putList(INDEX_ROUTING_PATH.getKey(), sortFields).build();
+                    settingsBuilder.putList(INDEX_ROUTING_PATH.getKey(), sortFields);
                 }
             }
         }
 
         return settingsBuilder == null ? Settings.EMPTY : settingsBuilder.build();
 
+    }
+
+    record MappingHints(boolean hasSyntheticSourceUsage, boolean sortOnHostName, boolean addHostNameField) {
+        static MappingHints EMPTY = new MappingHints(false, false, false);
     }
 
     private static boolean matchesLogsPattern(final String name) {
@@ -172,7 +190,7 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
         return mode != null ? Enum.valueOf(IndexMode.class, mode.toUpperCase(Locale.ROOT)) : null;
     }
 
-    boolean newIndexHasSyntheticSourceUsage(
+    MappingHints getMappingHints(
         String indexName,
         IndexMode templateIndexMode,
         Settings indexTemplateAndCreateRequestSettings,
@@ -181,12 +199,13 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
         if ("validate-index-name".equals(indexName)) {
             // This index name is used when validating component and index templates, we should skip this check in that case.
             // (See MetadataIndexTemplateService#validateIndexTemplateV2(...) method)
-            return false;
+            return MappingHints.EMPTY;
         }
 
         try {
             var tmpIndexMetadata = buildIndexMetadataForMapperService(indexName, templateIndexMode, indexTemplateAndCreateRequestSettings);
             var indexMode = tmpIndexMetadata.getIndexMode();
+            boolean hasSyntheticSourceUsage = false;
             if (SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.exists(tmpIndexMetadata.getSettings())
                 || indexMode == IndexMode.LOGSDB
                 || indexMode == IndexMode.TIME_SERIES) {
@@ -196,10 +215,18 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
                 // to disabled, because that isn't allowed with logsdb/tsdb. In other words setting index.mapping.source.mode setting to
                 // stored when _source.mode mapping attribute is stored is fine as it has no effect, but avoids creating MapperService.
                 var sourceMode = SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.get(tmpIndexMetadata.getSettings());
-                return sourceMode == SourceFieldMapper.Mode.SYNTHETIC;
+                hasSyntheticSourceUsage = sourceMode == SourceFieldMapper.Mode.SYNTHETIC;
+                if (IndexSortConfig.INDEX_SORT_FIELD_SETTING.get(indexTemplateAndCreateRequestSettings).isEmpty() == false) {
+                    // Custom sort config, no point for further checks on [host.name] field.
+                    return new MappingHints(hasSyntheticSourceUsage, false, false);
+                }
+                if (IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(indexTemplateAndCreateRequestSettings)
+                    && IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(indexTemplateAndCreateRequestSettings)) {
+                    // Settings for adding and sorting on [host.name] are already set, propagate them.
+                    return new MappingHints(hasSyntheticSourceUsage, true, true);
+                }
             }
 
-            // TODO: remove this when _source.mode attribute has been removed:
             try (var mapperService = mapperServiceFactory.get().apply(tmpIndexMetadata)) {
                 // combinedTemplateMappings can be null when creating system indices
                 // combinedTemplateMappings can be empty when creating a normal index that doesn't match any template and without mapping.
@@ -207,14 +234,25 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
                     combinedTemplateMappings = List.of(new CompressedXContent("{}"));
                 }
                 mapperService.merge(MapperService.SINGLE_MAPPING_NAME, combinedTemplateMappings, MapperService.MergeReason.INDEX_TEMPLATE);
-                return mapperService.documentMapper().sourceMapper().isSynthetic();
+                Mapper hostName = mapperService.mappingLookup().getMapper("host.name");
+                hasSyntheticSourceUsage = hasSyntheticSourceUsage || mapperService.documentMapper().sourceMapper().isSynthetic();
+                boolean addHostNameField = IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(indexTemplateAndCreateRequestSettings)
+                    || (hostName == null
+                        && mapperService.mappingLookup().objectMappers().get("host.name") == null
+                        && (mapperService.mappingLookup().getMapper("host") == null
+                            || mapperService.mappingLookup().getMapping().getRoot().subobjects() == ObjectMapper.Subobjects.DISABLED));
+                boolean sortOnHostName = IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(indexTemplateAndCreateRequestSettings)
+                    || addHostNameField
+                    || ((hostName instanceof NumberFieldMapper nfm && nfm.fieldType().hasDocValues())
+                        || (hostName instanceof KeywordFieldMapper kfm && kfm.fieldType().hasDocValues()));
+                return new MappingHints(hasSyntheticSourceUsage, sortOnHostName, addHostNameField);
             }
         } catch (AssertionError | Exception e) {
             // In case invalid mappings or setting are provided, then mapper service creation can fail.
             // In that case it is ok to return false here. The index creation will fail anyway later, so no need to fallback to stored
             // source.
             LOGGER.info(() -> Strings.format("unable to create mapper service for index [%s]", indexName), e);
-            return false;
+            return MappingHints.EMPTY;
         }
     }
 

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProviderTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProviderTests.java
@@ -82,7 +82,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         syntheticSourceLicenseService.setLicenseService(mockLicenseService);
     }
 
-    LogsdbIndexModeSettingsProvider withSyntheticSourceDemotionSupport(boolean enabled) {
+    private LogsdbIndexModeSettingsProvider withSyntheticSourceDemotionSupport(boolean enabled) {
         newMapperServiceCounter.set(0);
         var provider = new LogsdbIndexModeSettingsProvider(
             syntheticSourceLicenseService,
@@ -91,11 +91,37 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         provider.init(im -> {
             newMapperServiceCounter.incrementAndGet();
             return MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName());
-        }, IndexVersion::current);
+        }, IndexVersion::current, true);
         return provider;
     }
 
-    public void testLogsDbDisabled() throws IOException {
+    private Settings generateLogsdbSettings(Settings settings) throws IOException {
+        return generateLogsdbSettings(settings, null);
+    }
+
+    private Settings generateLogsdbSettings(Settings settings, String mapping) throws IOException {
+        Metadata metadata = Metadata.EMPTY_METADATA;
+        var provider = new LogsdbIndexModeSettingsProvider(
+            syntheticSourceLicenseService,
+            Settings.builder().put("cluster.logsdb.enabled", true).build()
+        );
+        provider.init(im -> {
+            newMapperServiceCounter.incrementAndGet();
+            return MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName());
+        }, IndexVersion::current, true);
+        var result = provider.getAdditionalIndexSettings(
+            DataStream.getDefaultBackingIndexName(DATA_STREAM_NAME, 0),
+            DATA_STREAM_NAME,
+            IndexMode.LOGSDB,
+            metadata,
+            Instant.now(),
+            settings,
+            mapping == null ? List.of() : List.of(new CompressedXContent(mapping))
+        );
+        return builder().put(result).build();
+    }
+
+    public void testDisabled() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
             syntheticSourceLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", false).build()
@@ -408,7 +434,8 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
                     }
                 }
                 """;
-            boolean result = provider.newIndexHasSyntheticSourceUsage(indexName, null, settings, List.of(new CompressedXContent(mapping)));
+            boolean result = provider.getMappingHints(indexName, null, settings, List.of(new CompressedXContent(mapping)))
+                .hasSyntheticSourceUsage();
             assertTrue(result);
             assertThat(newMapperServiceCounter.get(), equalTo(1));
             assertWarnings(SourceFieldMapper.DEPRECATION_WARNING);
@@ -444,7 +471,8 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
                     }
                     """;
             }
-            boolean result = provider.newIndexHasSyntheticSourceUsage(indexName, null, settings, List.of(new CompressedXContent(mapping)));
+            boolean result = provider.getMappingHints(indexName, null, settings, List.of(new CompressedXContent(mapping)))
+                .hasSyntheticSourceUsage();
             assertFalse(result);
             assertThat(newMapperServiceCounter.get(), equalTo(2));
             if (withSourceMode) {
@@ -471,7 +499,8 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
             """;
         Settings settings = Settings.EMPTY;
         LogsdbIndexModeSettingsProvider provider = withSyntheticSourceDemotionSupport(false);
-        boolean result = provider.newIndexHasSyntheticSourceUsage(indexName, null, settings, List.of(new CompressedXContent(mapping)));
+        boolean result = provider.getMappingHints(indexName, null, settings, List.of(new CompressedXContent(mapping)))
+            .hasSyntheticSourceUsage();
         assertFalse(result);
     }
 
@@ -492,30 +521,27 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         LogsdbIndexModeSettingsProvider provider = withSyntheticSourceDemotionSupport(false);
         {
             Settings settings = Settings.builder().put("index.mode", "logsdb").build();
-            boolean result = provider.newIndexHasSyntheticSourceUsage(indexName, null, settings, List.of(new CompressedXContent(mapping)));
+            boolean result = provider.getMappingHints(indexName, null, settings, List.of(new CompressedXContent(mapping)))
+                .hasSyntheticSourceUsage();
             assertTrue(result);
-            assertThat(newMapperServiceCounter.get(), equalTo(0));
-        }
-        {
-            Settings settings = Settings.builder().put("index.mode", "logsdb").build();
-            boolean result = provider.newIndexHasSyntheticSourceUsage(indexName, null, settings, List.of());
-            assertTrue(result);
-            assertThat(newMapperServiceCounter.get(), equalTo(0));
-        }
-        {
-            boolean result = provider.newIndexHasSyntheticSourceUsage(indexName, null, Settings.EMPTY, List.of());
-            assertFalse(result);
             assertThat(newMapperServiceCounter.get(), equalTo(1));
         }
         {
-            boolean result = provider.newIndexHasSyntheticSourceUsage(
-                indexName,
-                null,
-                Settings.EMPTY,
-                List.of(new CompressedXContent(mapping))
-            );
-            assertFalse(result);
+            Settings settings = Settings.builder().put("index.mode", "logsdb").build();
+            boolean result = provider.getMappingHints(indexName, null, settings, List.of()).hasSyntheticSourceUsage();
+            assertTrue(result);
             assertThat(newMapperServiceCounter.get(), equalTo(2));
+        }
+        {
+            boolean result = provider.getMappingHints(indexName, null, Settings.EMPTY, List.of()).hasSyntheticSourceUsage();
+            assertFalse(result);
+            assertThat(newMapperServiceCounter.get(), equalTo(3));
+        }
+        {
+            boolean result = provider.getMappingHints(indexName, null, Settings.EMPTY, List.of(new CompressedXContent(mapping)))
+                .hasSyntheticSourceUsage();
+            assertFalse(result);
+            assertThat(newMapperServiceCounter.get(), equalTo(4));
         }
     }
 
@@ -537,25 +563,22 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         LogsdbIndexModeSettingsProvider provider = withSyntheticSourceDemotionSupport(false);
         {
             Settings settings = Settings.builder().put("index.mode", "time_series").put("index.routing_path", "my_field").build();
-            boolean result = provider.newIndexHasSyntheticSourceUsage(indexName, null, settings, List.of(new CompressedXContent(mapping)));
+            boolean result = provider.getMappingHints(indexName, null, settings, List.of(new CompressedXContent(mapping)))
+                .hasSyntheticSourceUsage();
             assertTrue(result);
         }
         {
             Settings settings = Settings.builder().put("index.mode", "time_series").put("index.routing_path", "my_field").build();
-            boolean result = provider.newIndexHasSyntheticSourceUsage(indexName, null, settings, List.of());
+            boolean result = provider.getMappingHints(indexName, null, settings, List.of()).hasSyntheticSourceUsage();
             assertTrue(result);
         }
         {
-            boolean result = provider.newIndexHasSyntheticSourceUsage(indexName, null, Settings.EMPTY, List.of());
+            boolean result = provider.getMappingHints(indexName, null, Settings.EMPTY, List.of()).hasSyntheticSourceUsage();
             assertFalse(result);
         }
         {
-            boolean result = provider.newIndexHasSyntheticSourceUsage(
-                indexName,
-                null,
-                Settings.EMPTY,
-                List.of(new CompressedXContent(mapping))
-            );
+            boolean result = provider.getMappingHints(indexName, null, Settings.EMPTY, List.of(new CompressedXContent(mapping)))
+                .hasSyntheticSourceUsage();
             assertFalse(result);
         }
     }
@@ -580,7 +603,8 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
                     }
                 }
                 """;
-            boolean result = provider.newIndexHasSyntheticSourceUsage(indexName, null, settings, List.of(new CompressedXContent(mapping)));
+            boolean result = provider.getMappingHints(indexName, null, settings, List.of(new CompressedXContent(mapping)))
+                .hasSyntheticSourceUsage();
             assertFalse(result);
             assertThat(newMapperServiceCounter.get(), equalTo(1));
         }
@@ -596,7 +620,8 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
                     }
                 }
                 """;
-            boolean result = provider.newIndexHasSyntheticSourceUsage(indexName, null, settings, List.of(new CompressedXContent(mapping)));
+            boolean result = provider.getMappingHints(indexName, null, settings, List.of(new CompressedXContent(mapping)))
+                .hasSyntheticSourceUsage();
             assertFalse(result);
             assertThat(newMapperServiceCounter.get(), equalTo(2));
         }
@@ -628,7 +653,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
             List.of()
         );
         assertThat(result.size(), equalTo(0));
-        assertThat(newMapperServiceCounter.get(), equalTo(0));
+        assertThat(newMapperServiceCounter.get(), equalTo(1));
 
         syntheticSourceLicenseService.setSyntheticSourceFallback(true);
         result = provider.getAdditionalIndexSettings(
@@ -642,7 +667,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         );
         assertThat(result.size(), equalTo(1));
         assertEquals(SourceFieldMapper.Mode.STORED, SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.get(result));
-        assertThat(newMapperServiceCounter.get(), equalTo(0));
+        assertThat(newMapperServiceCounter.get(), equalTo(2));
 
         result = provider.getAdditionalIndexSettings(
             DataStream.getDefaultBackingIndexName(dataStreamName, 2),
@@ -655,7 +680,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         );
         assertThat(result.size(), equalTo(1));
         assertEquals(SourceFieldMapper.Mode.STORED, SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.get(result));
-        assertThat(newMapperServiceCounter.get(), equalTo(0));
+        assertThat(newMapperServiceCounter.get(), equalTo(3));
 
         result = provider.getAdditionalIndexSettings(
             DataStream.getDefaultBackingIndexName(dataStreamName, 2),
@@ -666,9 +691,11 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
             settings,
             List.of()
         );
-        assertThat(result.size(), equalTo(1));
+        assertThat(result.size(), equalTo(3));
         assertEquals(SourceFieldMapper.Mode.STORED, SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.get(result));
-        assertThat(newMapperServiceCounter.get(), equalTo(0));
+        assertTrue(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertTrue(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertThat(newMapperServiceCounter.get(), equalTo(4));
     }
 
     public void testGetAdditionalIndexSettingsDowngradeFromSyntheticSourceFileMatch() throws IOException {
@@ -719,9 +746,11 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
             settings,
             List.of()
         );
-        assertThat(result.size(), equalTo(2));
+        assertThat(result.size(), equalTo(4));
         assertEquals(SourceFieldMapper.Mode.STORED, SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.get(result));
         assertEquals(IndexMode.LOGSDB, IndexSettings.MODE.get(result));
+        assertTrue(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertTrue(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
 
         result = provider.getAdditionalIndexSettings(
             DataStream.getDefaultBackingIndexName(dataStreamName, 2),
@@ -735,7 +764,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         assertThat(result.size(), equalTo(0));
     }
 
-    public void testLogsdbRoutingPathOnSortFields() throws Exception {
+    public void testRoutingPathOnSortFields() throws Exception {
         var settings = Settings.builder()
             .put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "host,message")
             .put(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.getKey(), true)
@@ -744,7 +773,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), contains("host", "message"));
     }
 
-    public void testLogsdbRoutingPathOnSortFieldsFilterTimestamp() throws Exception {
+    public void testRoutingPathOnSortFieldsFilterTimestamp() throws Exception {
         var settings = Settings.builder()
             .put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "host,message,@timestamp")
             .put(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.getKey(), true)
@@ -753,7 +782,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), contains("host", "message"));
     }
 
-    public void testLogsdbRoutingPathOnSortSingleField() throws Exception {
+    public void testRoutingPathOnSortSingleField() throws Exception {
         var settings = Settings.builder()
             .put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "host")
             .put(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.getKey(), true)
@@ -770,7 +799,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         );
     }
 
-    public void testLogsdbExplicitRoutingPathMatchesSortFields() throws Exception {
+    public void testExplicitRoutingPathMatchesSortFields() throws Exception {
         var settings = Settings.builder()
             .put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB)
             .put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "host,message,@timestamp")
@@ -781,7 +810,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         assertTrue(result.isEmpty());
     }
 
-    public void testLogsdbExplicitRoutingPathDoesNotMatchSortFields() throws Exception {
+    public void testExplicitRoutingPathDoesNotMatchSortFields() throws Exception {
         var settings = Settings.builder()
             .put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "host,message,@timestamp")
             .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "host,message,foo")
@@ -800,21 +829,227 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         );
     }
 
-    private Settings generateLogsdbSettings(Settings settings) throws IOException {
-        Metadata metadata = Metadata.EMPTY_METADATA;
-        var provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
-            Settings.builder().put("cluster.logsdb.enabled", true).build()
-        );
-        var result = provider.getAdditionalIndexSettings(
-            DataStream.getDefaultBackingIndexName(DATA_STREAM_NAME, 0),
-            DATA_STREAM_NAME,
-            IndexMode.LOGSDB,
-            metadata,
-            Instant.now(),
-            settings,
-            List.of()
-        );
-        return builder().put(result).build();
+    public void testSortAndHostNamePropagateValue() throws Exception {
+        var settings = Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB)
+            .put(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.getKey(), true)
+            .put(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.getKey(), true)
+            .build();
+        Settings result = generateLogsdbSettings(settings);
+        assertTrue(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertTrue(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertEquals(0, newMapperServiceCounter.get());
+    }
+
+    public void testSortAndHostNameWithCustomSortConfig() throws Exception {
+        var settings = Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB)
+            .put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "foo,bar")
+            .build();
+        Settings result = generateLogsdbSettings(settings);
+        assertFalse(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertFalse(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertEquals(0, newMapperServiceCounter.get());
+    }
+
+    public void testSortAndHostNameKeyword() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB).build();
+        var mappings = """
+            {
+                "_doc": {
+                    "properties": {
+                        "@timestamp": {
+                            "type": "date"
+                        },
+                        "host.name": {
+                            "type": "keyword"
+                        }
+                    }
+                }
+            }
+            """;
+        Settings result = generateLogsdbSettings(settings, mappings);
+        assertTrue(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertFalse(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertEquals(1, newMapperServiceCounter.get());
+    }
+
+    public void testSortAndHostNameKeywordNoDocvalues() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB).build();
+        var mappings = """
+            {
+                "_doc": {
+                    "properties": {
+                        "@timestamp": {
+                            "type": "date"
+                        },
+                        "host.name": {
+                            "type": "keyword",
+                            "doc_values": false
+                        }
+                    }
+                }
+            }
+            """;
+        Settings result = generateLogsdbSettings(settings, mappings);
+        assertFalse(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertFalse(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertEquals(1, newMapperServiceCounter.get());
+    }
+
+    public void testSortAndHostNameInteger() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB).build();
+        var mappings = """
+            {
+                "_doc": {
+                    "properties": {
+                        "@timestamp": {
+                            "type": "date"
+                        },
+                        "host.name": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+            """;
+        Settings result = generateLogsdbSettings(settings, mappings);
+        assertTrue(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertFalse(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertEquals(1, newMapperServiceCounter.get());
+    }
+
+    public void testSortAndHostNameIntegerNoDocvalues() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB).build();
+        var mappings = """
+            {
+                "_doc": {
+                    "properties": {
+                        "@timestamp": {
+                            "type": "date"
+                        },
+                        "host.name": {
+                            "type": "integer",
+                            "doc_values": false
+                        }
+                    }
+                }
+            }
+            """;
+        Settings result = generateLogsdbSettings(settings, mappings);
+        assertFalse(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertFalse(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertEquals(1, newMapperServiceCounter.get());
+    }
+
+    public void testSortAndHostNameBoolean() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB).build();
+        var mappings = """
+            {
+                "_doc": {
+                    "properties": {
+                        "@timestamp": {
+                            "type": "date"
+                        },
+                        "host.name": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+            """;
+        Settings result = generateLogsdbSettings(settings, mappings);
+        assertFalse(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertFalse(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertEquals(1, newMapperServiceCounter.get());
+    }
+
+    public void testSortAndHostObject() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB).build();
+        var mappings = """
+            {
+                "_doc": {
+                    "properties": {
+                        "@timestamp": {
+                            "type": "date"
+                        },
+                        "host": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+            """;
+        Settings result = generateLogsdbSettings(settings, mappings);
+        assertTrue(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertTrue(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertEquals(1, newMapperServiceCounter.get());
+    }
+
+    public void testSortAndHostField() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB).build();
+        var mappings = """
+            {
+                "_doc": {
+                    "properties": {
+                        "@timestamp": {
+                            "type": "date"
+                        },
+                        "host": {
+                            "type": "keyword"
+                        }
+                    }
+                }
+            }
+            """;
+        Settings result = generateLogsdbSettings(settings, mappings);
+        assertFalse(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertFalse(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertEquals(1, newMapperServiceCounter.get());
+    }
+
+    public void testSortAndHostFieldSubobjectsFalse() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB).build();
+        var mappings = """
+            {
+                "_doc": {
+                    "subobjects": false,
+                    "properties": {
+                        "@timestamp": {
+                            "type": "date"
+                        },
+                        "host": {
+                            "type": "keyword"
+                        }
+                    }
+                }
+            }
+            """;
+        Settings result = generateLogsdbSettings(settings, mappings);
+        assertTrue(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertTrue(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertEquals(1, newMapperServiceCounter.get());
+    }
+
+    public void testSortAndHostNameObject() throws Exception {
+        var settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB).build();
+        var mappings = """
+            {
+                "_doc": {
+                    "properties": {
+                        "@timestamp": {
+                            "type": "date"
+                        },
+                        "host.name.sub": {
+                            "type": "keyword"
+                        }
+                    }
+                }
+            }
+            """;
+        Settings result = generateLogsdbSettings(settings, mappings);
+        assertFalse(IndexSettings.LOGSDB_SORT_ON_HOST_NAME.get(result));
+        assertFalse(IndexSettings.LOGSDB_ADD_HOST_NAME_FIELD.get(result));
+        assertEquals(1, newMapperServiceCounter.get());
     }
 }

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LogsdbIndexSettingsProviderLegacyLicenseTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LogsdbIndexSettingsProviderLegacyLicenseTests.java
@@ -52,7 +52,8 @@ public class LogsdbIndexSettingsProviderLegacyLicenseTests extends ESTestCase {
         provider = new LogsdbIndexModeSettingsProvider(syntheticSourceLicenseService, Settings.EMPTY);
         provider.init(
             im -> MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName()),
-            IndexVersion::current
+            IndexVersion::current,
+            true
         );
     }
 
@@ -113,7 +114,8 @@ public class LogsdbIndexSettingsProviderLegacyLicenseTests extends ESTestCase {
         provider = new LogsdbIndexModeSettingsProvider(syntheticSourceLicenseService, Settings.EMPTY);
         provider.init(
             im -> MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName()),
-            IndexVersion::current
+            IndexVersion::current,
+            true
         );
 
         Settings settings = Settings.builder().put(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "SYNTHETIC").build();

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/30_logsdb_default_mapping.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/30_logsdb_default_mapping.yml
@@ -73,6 +73,44 @@ create logsdb data stream with host.name as keyword and timestamp as date:
   - is_true: acknowledged
 
 ---
+create logsdb data stream with host.name as integer and timestamp as date:
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+  - requires:
+      cluster_features: [ "mapper.keyword_normalizer_synthetic_source" ]
+      reason: support for normalizer on keyword fields
+
+  - do:
+      cluster.put_component_template:
+        name: "logsdb-mappings"
+        body:
+          template:
+            settings:
+              mode: "logsdb"
+            mappings:
+              properties:
+                host.name:
+                  type: "integer"
+                "@timestamp":
+                  type: "date"
+
+  - do:
+      indices.put_index_template:
+        name: "logsdb-index-template"
+        body:
+          index_patterns: ["logsdb"]
+          data_stream: {}
+          composed_of: ["logsdb-mappings"]
+      allowed_warnings:
+        - "index template [logsdb-index-template] has index patterns [logsdb] matching patterns from existing older templates [global] with patterns (global => [*]); this template [logsdb-index-template] will take precedence during new index creation"
+
+  - do:
+      indices.create_data_stream:
+        name: "logsdb"
+
+  - is_true: acknowledged
+
+---
 create logsdb data stream with host as keyword:
   - requires:
       test_runner_features: [ "allowed_warnings" ]
@@ -103,12 +141,10 @@ create logsdb data stream with host as keyword:
         - "index template [logsdb-index-template] has index patterns [logsdb] matching patterns from existing older templates [global] with patterns (global => [*]); this template [logsdb-index-template] will take precedence during new index creation"
 
   - do:
-      catch: bad_request
       indices.create_data_stream:
         name: "logsdb"
 
-  - match: { error.type: "mapper_parsing_exception" }
-  - match: { error.reason: "Failed to parse mapping: can't merge a non object mapping [host] with an object mapping" }
+  - is_true: acknowledged
 
 ---
 create logsdb data stream with host as text and multi fields:
@@ -148,12 +184,10 @@ create logsdb data stream with host as text and multi fields:
         - "index template [logsdb-index-template] has index patterns [logsdb] matching patterns from existing older templates [global] with patterns (global => [*]); this template [logsdb-index-template] will take precedence during new index creation"
 
   - do:
-      catch: bad_request
       indices.create_data_stream:
         name: "logsdb"
 
-  - match: { error.type: "mapper_parsing_exception" }
-  - match: { error.reason: "Failed to parse mapping: can't merge a non object mapping [host] with an object mapping" }
+  - is_true: acknowledged
 
 ---
 create logsdb data stream with host as text:
@@ -189,12 +223,10 @@ create logsdb data stream with host as text:
         - "index template [logsdb-index-template] has index patterns [logsdb] matching patterns from existing older templates [global] with patterns (global => [*]); this template [logsdb-index-template] will take precedence during new index creation"
 
   - do:
-      catch: bad_request
       indices.create_data_stream:
         name: "logsdb"
 
-  - match: { error.type: "mapper_parsing_exception" }
-  - match: { error.reason: "Failed to parse mapping: can't merge a non object mapping [host] with an object mapping" }
+  - is_true: acknowledged
 
 ---
 create logsdb data stream with host as text and name as double:
@@ -233,12 +265,10 @@ create logsdb data stream with host as text and name as double:
         - "index template [logsdb-index-template] has index patterns [logsdb] matching patterns from existing older templates [global] with patterns (global => [*]); this template [logsdb-index-template] will take precedence during new index creation"
 
   - do:
-      catch: bad_request
       indices.create_data_stream:
         name: "logsdb"
 
-  - match: { error.type: "mapper_parsing_exception" }
-  - match: { error.reason: "Failed to parse mapping: can't merge a non object mapping [host] with an object mapping" }
+  - is_true: acknowledged
 
 ---
 create logsdb data stream with timestamp object mapping:
@@ -388,7 +418,7 @@ create logsdb data stream with custom sorting and host object:
   - match: { .$backing_index.mappings.properties.host.properties.ip.type: ip }
   - match: { .$backing_index.mappings.properties.host.properties.hostname.type: keyword }
   - match: { .$backing_index.mappings.properties.host.properties.region.type: keyword }
-  - match: { .$backing_index.mappings.properties.host.properties.name.type: integer } # Overrides LogsDB injected
+  - match: { .$backing_index.mappings.properties.host.properties.name.type: integer }
 
 ---
 create logsdb data stream with custom sorting and dynamically mapped host.name:
@@ -647,8 +677,8 @@ create logsdb data stream with custom sorting and missing host.name field mappin
           template:
             settings:
               index:
-                sort.field: [ host.name, host.hostname ]
-                sort.order: [ desc, desc ]
+                sort.field: [ host.hostname ]
+                sort.order: [ desc ]
                 mode: logsdb
             mappings:
               properties:
@@ -677,8 +707,7 @@ create logsdb data stream with custom sorting and missing host.name field mappin
 
   - match: { .$backing_index.mappings.properties.@timestamp.type: date }
   - match: { .$backing_index.mappings.properties.host.properties.hostname.type: keyword }
-  - match: { .$backing_index.mappings.properties.host.properties.name.type: keyword }
-  - match: { .$backing_index.mappings.properties.host.properties.name.ignore_above: 1024 }
+  - match: { .$backing_index.mappings.properties.host.properties.name: null }
 
 ---
 create logsdb data stream with custom sorting and host.name field without doc values:
@@ -797,12 +826,21 @@ create logsdb data stream with no sorting and host.name as text:
   - is_true: acknowledged
 
   - do:
-      catch: bad_request
       indices.create_data_stream:
         name: logsdb-non-keyword
+  - is_true: acknowledged
 
-  - match: { error.type: "illegal_argument_exception" }
-  - match: { error.reason: "docvalues not found for index sort field:[host.name]" }
+  - do:
+      indices.get_data_stream:
+        name: logsdb-non-keyword
+
+  - set: { data_streams.0.indices.0.index_name: backing_index }
+  - do:
+      indices.get_mapping:
+        index: $backing_index
+
+  - match: { .$backing_index.mappings.properties.@timestamp.type: date }
+  - match: { .$backing_index.mappings.properties.host.properties.name.type: text }
 
 ---
 create logsdb data stream without index sorting and ignore_above on host.name:
@@ -963,12 +1001,21 @@ create logsdb data stream with multi-fields on host.name and no sorting:
           data_stream: {}
 
   - do:
-      catch: bad_request
       indices.create_data_stream:
         name: logsdb-no-sort-multi-fields
+  - is_true: acknowledged
 
-  - match: { error.type: "illegal_argument_exception" }
-  - match: { error.reason: "docvalues not found for index sort field:[host.name]" }
+  - do:
+      indices.get_data_stream:
+        name: logsdb-no-sort-multi-fields
+
+  - set: { data_streams.0.indices.0.index_name: backing_index }
+  - do:
+      indices.get_mapping:
+        index: $backing_index
+
+  - match: { .$backing_index.mappings.properties.@timestamp.type: date }
+  - match: { .$backing_index.mappings.properties.host.properties.name.type: text }
 
 ---
 create logsdb data stream with custom empty sorting:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Configure index sorting through index settings for logsdb (#118968)](https://github.com/elastic/elasticsearch/pull/118968)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)