### PR TITLE
Ignore CSV tests that require field caps change

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -245,8 +245,6 @@ tests:
 - class: org.elasticsearch.xpack.security.authz.IndicesAndAliasesResolverTests
   method: testBackingIndicesAreNotVisibleWhenNotIncludedByRequestWithoutWildcard
   issue: https://github.com/elastic/elasticsearch/issues/119909
-- class: org.elasticsearch.xpack.esql.CsvTests
-  issue: https://github.com/elastic/elasticsearch/issues/119918
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -270,6 +270,10 @@ public class CsvTests extends ESTestCase {
                 "can't use TERM function in csv tests",
                 testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.TERM_FUNCTION.capabilityName())
             );
+            assumeFalse(
+                "CSV tests cannot correctly handle the field caps change",
+                testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.SEMANTIC_TEXT_FIELD_CAPS.capabilityName())
+            );
             if (Build.current().isSnapshot()) {
                 assertThat(
                     "Capability is not included in the enabled list capabilities on a snapshot build. Spelling mistake?",


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/issues/119918

`semantic_text` fields are now reported as `text` by the field caps which results in failures for CSV tests for non snapshot builds.

This is a quirk of CSV tests that I will need to fix, single-node and multi-node tests should still run the semantic text tests.
From what I tested locally the single and multi node tests should be succesful.

Since this seems to be more of a test problem and not an indicative of a prod bug, the goal is to enable the CSV test suite for now.