### PR TITLE
Unmute SearchWithRandomIOExceptionsIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -293,9 +293,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {spatial.CentroidFromAirportsAfterIntersectsCompoundPredicateNotIndexedNorDocValues}
   issue: https://github.com/elastic/elasticsearch/issues/116945
-- class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
-  method: testRandomDirectoryIOExceptions
-  issue: https://github.com/elastic/elasticsearch/issues/114824
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
   issue: https://github.com/elastic/elasticsearch/issues/117027


### PR DESCRIPTION
The test seems to have been fixed on 8.17 and onward with https://github.com/elastic/elasticsearch/pull/117638
