### PR TITLE
Unmute SearchWithRandomIOExceptionsIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -332,9 +332,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {spatial.CentroidFromAirportsAfterIntersectsCompoundPredicateNotIndexedNorDocValues}
   issue: https://github.com/elastic/elasticsearch/issues/116945
-- class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
-  method: testRandomDirectoryIOExceptions
-  issue: https://github.com/elastic/elasticsearch/issues/114824
 - class: org.elasticsearch.xpack.application.CohereServiceUpgradeIT
   method: testRerank {upgradedNodes=1}
   issue: https://github.com/elastic/elasticsearch/issues/116973


### PR DESCRIPTION
The test seems to have been fixed on 8.17 and onward with https://github.com/elastic/elasticsearch/pull/117638
