### PR TITLE
[7.17] Provide better error message when attempting to run incompatible tests (#119699)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.bwc-test.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.bwc-test.gradle
@@ -52,3 +52,14 @@ plugins.withType(InternalJavaRestTestPlugin) {
 
 tasks.matching { it.name.equals("check") }.configureEach {dependsOn(bwcTestSnapshots) }
 tasks.matching { it.name.equals("test") }.configureEach {enabled = false}
+
+tasks.addRule("incompatible bwc version") { taskName ->
+  def incompatible = BuildParams.bwcVersions.allIndexCompatible - BuildParams.bwcVersions.indexCompatible
+  if (incompatible.any { taskName.startsWith("v${it.toString()}") }) {
+    tasks.register(taskName) {
+      doLast {
+        throw new GradleException("Cannot execute task '$taskName'. Version is unsupported on this platform. Perhaps you need an x86 host?")
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `7.17`:
 - [Provide better error message when attempting to run incompatible tests (#119699)](https://github.com/elastic/elasticsearch/pull/119410)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)