### PR TITLE
Surface failures when cloning test repo in gradle functional tests

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGitAwareGradleFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGitAwareGradleFuncTest.groovy
@@ -24,7 +24,7 @@ abstract class AbstractGitAwareGradleFuncTest extends AbstractGradleFuncTest {
 
     def setup() {
         remoteGitRepo = new File(setupGitRemote(), '.git')
-        "git clone ${remoteGitRepo.absolutePath} cloned".execute(Collections.emptyList(), testProjectDir.root).waitFor()
+        execute("git clone ${remoteGitRepo.absolutePath} cloned", testProjectDir.root)
         buildFile = new File(testProjectDir.root, 'cloned/build.gradle')
         settingsFile = new File(testProjectDir.root, 'cloned/settings.gradle')
     }


### PR DESCRIPTION
Adding some more debugging to attempt to track down the cause of https://github.com/elastic/elasticsearch/issues/119948. Refactors our test setup here to ensure that any failures to call `git clone` are properly logged.