### PR TITLE
Introduce async search API and log activation

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/SubscribableListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/SubscribableListener.java
@@ -266,6 +266,10 @@ public class SubscribableListener<T> implements ActionListener<T> {
         return isDone(state);
     }
 
+    public final boolean isSuccess() {
+        return state instanceof SuccessResult;
+    }
+
     /**
      * @return the result with which this listener completed successfully, or throw the exception with which it failed.
      *

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -292,7 +292,6 @@ final class DefaultSearchContext extends SearchContext {
         ToLongFunction<String> fieldCardinality
     ) {
         return executor instanceof ThreadPoolExecutor tpe
-            && tpe.getQueue().size() <= tpe.getMaximumPoolSize()
             && isParallelCollectionSupportedForResults(resultsType, request.source(), fieldCardinality, enableQueryPhaseParallelCollection)
                 ? tpe.getMaximumPoolSize()
                 : 1;

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -669,66 +669,6 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
         );
     }
 
-    public void testDetermineMaximumNumberOfSlicesWithQueue() {
-        int executorPoolSize = randomIntBetween(1, 100);
-        ThreadPoolExecutor threadPoolExecutor = EsExecutors.newFixed(
-            "test",
-            executorPoolSize,
-            1000,
-            Thread::new,
-            new ThreadContext(Settings.EMPTY),
-            EsExecutors.TaskTrackingConfig.DO_NOT_TRACK
-        );
-        ToLongFunction<String> fieldCardinality = name -> { throw new UnsupportedOperationException(); };
-
-        for (int i = 0; i < executorPoolSize; i++) {
-            assertTrue(threadPoolExecutor.getQueue().offer(() -> {}));
-            assertEquals(
-                executorPoolSize,
-                DefaultSearchContext.determineMaximumNumberOfSlices(
-                    threadPoolExecutor,
-                    createParallelRequest(),
-                    SearchService.ResultsType.DFS,
-                    true,
-                    fieldCardinality
-                )
-            );
-            assertEquals(
-                executorPoolSize,
-                DefaultSearchContext.determineMaximumNumberOfSlices(
-                    threadPoolExecutor,
-                    createParallelRequest(),
-                    SearchService.ResultsType.QUERY,
-                    true,
-                    fieldCardinality
-                )
-            );
-        }
-        for (int i = 0; i < 100; i++) {
-            assertTrue(threadPoolExecutor.getQueue().offer(() -> {}));
-            assertEquals(
-                1,
-                DefaultSearchContext.determineMaximumNumberOfSlices(
-                    threadPoolExecutor,
-                    createParallelRequest(),
-                    SearchService.ResultsType.DFS,
-                    true,
-                    fieldCardinality
-                )
-            );
-            assertEquals(
-                1,
-                DefaultSearchContext.determineMaximumNumberOfSlices(
-                    threadPoolExecutor,
-                    createParallelRequest(),
-                    SearchService.ResultsType.QUERY,
-                    true,
-                    fieldCardinality
-                )
-            );
-        }
-    }
-
     public void testIsParallelCollectionSupportedForResults() {
         SearchSourceBuilder searchSourceBuilderOrNull = randomBoolean() ? null : new SearchSourceBuilder();
         ToLongFunction<String> fieldCardinality = name -> -1;

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceSingleNodeTests.java
@@ -175,6 +175,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 
@@ -2794,10 +2795,11 @@ public class SearchServiceSingleNodeTests extends ESSingleNodeTestCase {
                     final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                     searcher.search(termQuery, new TotalHitCountCollectorManager(searcher.getSlices()));
                     assertBusy(
-                        () -> assertEquals(
+                        () -> assertThat(
                             "DFS supports parallel collection, so the number of slices should be > 1.",
-                            expectedSlices - 1, // one slice executes on the calling thread
-                            executor.getCompletedTaskCount() - priorExecutorTaskCount
+                            executor.getCompletedTaskCount() - priorExecutorTaskCount,
+                            greaterThan(0L)    // one slice executes on the calling thread and we should at least fork once with more
+                            // than a single slice
                         )
                     );
                 }
@@ -2824,10 +2826,10 @@ public class SearchServiceSingleNodeTests extends ESSingleNodeTestCase {
                     final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                     searcher.search(termQuery, new TotalHitCountCollectorManager(searcher.getSlices()));
                     assertBusy(
-                        () -> assertEquals(
-                            "QUERY supports parallel collection when enabled, so the number of slices should be > 1.",
-                            expectedSlices - 1, // one slice executes on the calling thread
-                            executor.getCompletedTaskCount() - priorExecutorTaskCount
+                        () -> assertThat(
+                            "QUERY supports parallel collection when enabled, so the number of extra parallel tasks should be > 0.",
+                            executor.getCompletedTaskCount() - priorExecutorTaskCount,
+                            greaterThan(0L)
                         )
                     );
                 }
@@ -2915,10 +2917,10 @@ public class SearchServiceSingleNodeTests extends ESSingleNodeTestCase {
                         final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                         searcher.search(termQuery, new TotalHitCountCollectorManager(searcher.getSlices()));
                         assertBusy(
-                            () -> assertEquals(
-                                "QUERY supports parallel collection when enabled, so the number of slices should be > 1.",
-                                expectedSlices - 1, // one slice executes on the calling thread
-                                executor.getCompletedTaskCount() - priorExecutorTaskCount
+                            () -> assertThat(
+                                "QUERY supports parallel collection when enabled, so the number of extra parallel tasks should be > 0.",
+                                executor.getCompletedTaskCount() - priorExecutorTaskCount,
+                                greaterThan(0L)
                             )
                         );
                     }


### PR DESCRIPTION
This code here is good to review but lets discuss the motivation first tomorrow maybe :)

This adds an async search API to ContextIndexSearcher that could be used to avoid any blocking on futures in the query phase in a relatively straight-forward and short follow-up.
For now this solves a lot of queuing issues by leveraging the custom execution path this gives us to run tasks using logarithmic activation. We now always slice to up-to thread_count tasks but at max submit thread_count - 1 (the submitting tasks is the remaining search thread) tasks to the search pool. Unlike before, these tasks are only submitted as the pool actually has workers available. This means we decrease latency when tasks are fast by running fewer tasks than before potentially but also eventually get to full parallelism (no matter the queue length, so long as it's not full yet) for things like heavy aggregations. Depending on the relative performance of context switches and task execution this approach self-regulates in a similar manner to how the JDK's fork-join pool works.
