### PR TITLE
[7.17] More verbose logging in `IndicesSegmentsRestCancellationIT` (#113844)

### DIFF
--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/BlockedSearcherRestCancellationTestCase.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/BlockedSearcherRestCancellationTestCase.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Cancellable;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
@@ -38,6 +37,7 @@ import org.elasticsearch.plugins.Plugin;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Semaphore;
@@ -154,7 +154,8 @@ public abstract class BlockedSearcherRestCancellationTestCase extends HttpSmokeT
         public Searcher acquireSearcher(String source, SearcherScope scope, Function<Searcher, Searcher> wrapper) throws EngineException {
             if (blockedSearcherRestCancellationTestCaseLogger.isDebugEnabled()) {
                 blockedSearcherRestCancellationTestCaseLogger.debug(
-                    Strings.format(
+                    String.format(
+                        Locale.ROOT,
                         "in acquireSearcher for shard [%s] on thread [%s], availablePermits=%d",
                         config().getShardId(),
                         Thread.currentThread().getName(),
@@ -173,7 +174,8 @@ public abstract class BlockedSearcherRestCancellationTestCase extends HttpSmokeT
 
             if (blockedSearcherRestCancellationTestCaseLogger.isDebugEnabled()) {
                 blockedSearcherRestCancellationTestCaseLogger.debug(
-                    Strings.format(
+                    String.format(
+                        Locale.ROOT,
                         "continuing in acquireSearcher for shard [%s] on thread [%s], availablePermits=%d",
                         config().getShardId(),
                         Thread.currentThread().getName(),

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/BlockedSearcherRestCancellationTestCase.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/BlockedSearcherRestCancellationTestCase.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.http;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Cancellable;
@@ -30,8 +32,6 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
 import org.elasticsearch.index.translog.TranslogStats;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.logging.Logger;
 import org.elasticsearch.plugins.EnginePlugin;
 import org.elasticsearch.plugins.Plugin;
 

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IndicesSegmentsRestCancellationIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IndicesSegmentsRestCancellationIT.java
@@ -11,12 +11,23 @@ package org.elasticsearch.http;
 import org.apache.http.client.methods.HttpGet;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 
 public class IndicesSegmentsRestCancellationIT extends BlockedSearcherRestCancellationTestCase {
+    @TestIssueLogging(
+        issueUrl = "https://github.com/elastic/elasticsearch/issues/88201",
+        value = "org.elasticsearch.http.BlockedSearcherRestCancellationTestCase:DEBUG"
+            + ",org.elasticsearch.transport.TransportService:TRACE"
+    )
     public void testIndicesSegmentsRestCancellation() throws Exception {
         runTest(new Request(HttpGet.METHOD_NAME, "/_segments"), IndicesSegmentsAction.NAME);
     }
 
+    @TestIssueLogging(
+        issueUrl = "https://github.com/elastic/elasticsearch/issues/88201",
+        value = "org.elasticsearch.http.BlockedSearcherRestCancellationTestCase:DEBUG"
+            + ",org.elasticsearch.transport.TransportService:TRACE"
+    )
     public void testCatSegmentsRestCancellation() throws Exception {
         runTest(new Request(HttpGet.METHOD_NAME, "/_cat/segments"), IndicesSegmentsAction.NAME);
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [More verbose logging in &#x60;IndicesSegmentsRestCancellationIT&#x60; (#113844)](https://github.com/elastic/elasticsearch/pull/113844)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)