### PR TITLE
Fix error in QSTR docs

### DIFF
--- a/docs/reference/esql/functions/layout/qstr.asciidoc
+++ b/docs/reference/esql/functions/layout/qstr.asciidoc
@@ -4,7 +4,7 @@
 [[esql-qstr]]
 === `QSTR`
 
-preview::["Do not use `VALUES` on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
+preview::["Do not use on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 
 *Syntax*
 


### PR DESCRIPTION
QSTR docs include by mistake the following tech preview note:

![Screenshot 2025-01-13 at 09 20 44](https://github.com/user-attachments/assets/a6b4f9ed-8cfa-4356-93bd-dbc068a31e31)

`VALUES` should be removed from that description. This is fixed in main by #112792 but not backported to 8.x branches.