### PR TITLE
Run template simulation actions on local node

### DIFF
--- a/docs/changelog/120038.yaml
+++ b/docs/changelog/120038.yaml
@@ -1,0 +1,5 @@
+pr: 120038
+summary: Run template simulation actions on local node
+area: Ingest Node
+type: enhancement
+issues: []

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/RestActionCancellationIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/RestActionCancellationIT.java
@@ -18,6 +18,8 @@ import org.elasticsearch.action.admin.indices.recovery.RecoveryAction;
 import org.elasticsearch.action.admin.indices.template.get.GetComponentTemplateAction;
 import org.elasticsearch.action.admin.indices.template.get.GetComposableIndexTemplateAction;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesAction;
+import org.elasticsearch.action.admin.indices.template.post.SimulateIndexTemplateAction;
+import org.elasticsearch.action.admin.indices.template.post.SimulateTemplateAction;
 import org.elasticsearch.action.support.CancellableActionTestPlugin;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
@@ -79,6 +81,21 @@ public class RestActionCancellationIT extends HttpSmokeTestCase {
 
     public void testGetComposableTemplateCancellation() {
         runRestActionCancellationTest(new Request(HttpGet.METHOD_NAME, "/_index_template"), GetComposableIndexTemplateAction.NAME);
+    }
+
+    public void testSimulateTemplateCancellation() {
+        runRestActionCancellationTest(
+            new Request(HttpPost.METHOD_NAME, "/_index_template/_simulate/random_index_template"),
+            SimulateTemplateAction.NAME
+        );
+    }
+
+    public void testSimulateIndexTemplateCancellation() {
+        createIndex("test");
+        runRestActionCancellationTest(
+            new Request(HttpPost.METHOD_NAME, "/_index_template/_simulate_index/test"),
+            SimulateIndexTemplateAction.NAME
+        );
     }
 
     private void runRestActionCancellationTest(Request request, String actionName) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
@@ -12,13 +12,11 @@ package org.elasticsearch.action.admin.indices.template.post;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
-import org.elasticsearch.cluster.metadata.DataStreamGlobalRetention;
 import org.elasticsearch.cluster.metadata.ResettableValue;
 import org.elasticsearch.cluster.metadata.Template;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.UpdateForV10;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -67,27 +65,11 @@ public class SimulateIndexTemplateResponse extends ActionResponse implements ToX
         return rolloverConfiguration;
     }
 
-    public SimulateIndexTemplateResponse(StreamInput in) throws IOException {
-        super(in);
-        resolvedTemplate = in.readOptionalWriteable(Template::new);
-        if (in.readBoolean()) {
-            int overlappingTemplatesCount = in.readInt();
-            overlappingTemplates = Maps.newMapWithExpectedSize(overlappingTemplatesCount);
-            for (int i = 0; i < overlappingTemplatesCount; i++) {
-                String templateName = in.readString();
-                overlappingTemplates.put(templateName, in.readStringCollectionAsList());
-            }
-        } else {
-            this.overlappingTemplates = null;
-        }
-        rolloverConfiguration = in.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)
-            ? in.readOptionalWriteable(RolloverConfiguration::new)
-            : null;
-        if (in.getTransportVersion().between(TransportVersions.V_8_14_0, TransportVersions.V_8_16_0)) {
-            in.readOptionalWriteable(DataStreamGlobalRetention::read);
-        }
-    }
-
+    /**
+     * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
+     * we no longer need to support calling this action remotely.
+     */
+    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(resolvedTemplate);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateRequestTests.java
@@ -12,45 +12,21 @@ package org.elasticsearch.action.admin.indices.template.post;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
-import org.elasticsearch.cluster.metadata.ComposableIndexTemplateTests;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Template;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.ESTestCase;
 
 import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class SimulateIndexTemplateRequestTests extends AbstractWireSerializingTestCase<SimulateIndexTemplateRequest> {
-
-    @Override
-    protected Writeable.Reader<SimulateIndexTemplateRequest> instanceReader() {
-        return SimulateIndexTemplateRequest::new;
-    }
-
-    @Override
-    protected SimulateIndexTemplateRequest createTestInstance() {
-        SimulateIndexTemplateRequest req = new SimulateIndexTemplateRequest(randomAlphaOfLength(10));
-        TransportPutComposableIndexTemplateAction.Request newTemplateRequest = new TransportPutComposableIndexTemplateAction.Request(
-            randomAlphaOfLength(4)
-        );
-        newTemplateRequest.indexTemplate(ComposableIndexTemplateTests.randomInstance());
-        req.indexTemplateRequest(newTemplateRequest);
-        req.includeDefaults(randomBoolean());
-        return req;
-    }
-
-    @Override
-    protected SimulateIndexTemplateRequest mutateInstance(SimulateIndexTemplateRequest instance) {
-        return randomValueOtherThan(instance, this::createTestInstance);
-    }
+public class SimulateIndexTemplateRequestTests extends ESTestCase {
 
     public void testIndexNameCannotBeNullOrEmpty() {
-        expectThrows(IllegalArgumentException.class, () -> new SimulateIndexTemplateRequest((String) null));
-        expectThrows(IllegalArgumentException.class, () -> new SimulateIndexTemplateRequest(""));
+        expectThrows(IllegalArgumentException.class, () -> new SimulateIndexTemplateRequest(TEST_REQUEST_TIMEOUT, null));
+        expectThrows(IllegalArgumentException.class, () -> new SimulateIndexTemplateRequest(TEST_REQUEST_TIMEOUT, ""));
     }
 
     public void testAddingGlobalTemplateWithHiddenIndexSettingIsIllegal() {
@@ -60,7 +36,7 @@ public class SimulateIndexTemplateRequestTests extends AbstractWireSerializingTe
         TransportPutComposableIndexTemplateAction.Request request = new TransportPutComposableIndexTemplateAction.Request("test");
         request.indexTemplate(globalTemplate);
 
-        SimulateIndexTemplateRequest simulateRequest = new SimulateIndexTemplateRequest("testing");
+        SimulateIndexTemplateRequest simulateRequest = new SimulateIndexTemplateRequest(TEST_REQUEST_TIMEOUT, "testing");
         simulateRequest.indexTemplateRequest(request);
 
         ActionRequestValidationException validationException = simulateRequest.validate();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/post/SimulateTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/post/SimulateTemplateRequestTests.java
@@ -12,49 +12,17 @@ package org.elasticsearch.action.admin.indices.template.post;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
-import org.elasticsearch.cluster.metadata.ComposableIndexTemplateTests;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Template;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.ESTestCase;
 
 import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class SimulateTemplateRequestTests extends AbstractWireSerializingTestCase<SimulateTemplateAction.Request> {
-
-    @Override
-    protected Writeable.Reader<SimulateTemplateAction.Request> instanceReader() {
-        return SimulateTemplateAction.Request::new;
-    }
-
-    @Override
-    protected SimulateTemplateAction.Request createTestInstance() {
-        SimulateTemplateAction.Request req = new SimulateTemplateAction.Request(randomAlphaOfLength(10));
-        TransportPutComposableIndexTemplateAction.Request newTemplateRequest = new TransportPutComposableIndexTemplateAction.Request(
-            randomAlphaOfLength(4)
-        );
-        newTemplateRequest.indexTemplate(ComposableIndexTemplateTests.randomInstance());
-        req.indexTemplateRequest(newTemplateRequest);
-        req.includeDefaults(randomBoolean());
-        return req;
-    }
-
-    @Override
-    protected SimulateTemplateAction.Request mutateInstance(SimulateTemplateAction.Request instance) {
-        return randomValueOtherThan(instance, this::createTestInstance);
-    }
-
-    public void testIndexNameCannotBeNullOrEmpty() {
-        expectThrows(IllegalArgumentException.class, () -> new SimulateTemplateAction.Request((String) null));
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> new SimulateTemplateAction.Request((TransportPutComposableIndexTemplateAction.Request) null)
-        );
-    }
+public class SimulateTemplateRequestTests extends ESTestCase {
 
     public void testAddingGlobalTemplateWithHiddenIndexSettingIsIllegal() {
         Template template = new Template(Settings.builder().put(IndexMetadata.SETTING_INDEX_HIDDEN, true).build(), null, null);
@@ -63,7 +31,7 @@ public class SimulateTemplateRequestTests extends AbstractWireSerializingTestCas
         TransportPutComposableIndexTemplateAction.Request request = new TransportPutComposableIndexTemplateAction.Request("test");
         request.indexTemplate(globalTemplate);
 
-        SimulateTemplateAction.Request simulateRequest = new SimulateTemplateAction.Request("testing");
+        SimulateTemplateAction.Request simulateRequest = new SimulateTemplateAction.Request(TEST_REQUEST_TIMEOUT, "testing");
         simulateRequest.indexTemplateRequest(request);
 
         ActionRequestValidationException validationException = simulateRequest.validate();


### PR DESCRIPTION
The actions `TransportSimulateTemplateAction` and
`TransportSimulateIndexTemplateAction` solely need the cluster state, they can run on any node. Additionally, they need to be cancellable to avoid doing unnecessary work after a client failure or timeout.

As a drive-by, this removes more usages of the trappy default master node timeout.

Relates https://github.com/elastic/elasticsearch/issues/101805
Relates https://github.com/elastic/elasticsearch/issues/107984