### PR TITLE
Clean up lingering tasks after DatafeedJobsIT.

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -11,6 +11,8 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.cancel.TransportCancelTasksAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.ReferenceDocs;
@@ -80,6 +82,10 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
     public void cleanup() {
         updateClusterSettings(Settings.builder().putNull("logger.org.elasticsearch.xpack.ml.datafeed"));
         cleanUp();
+        // Race conditions between closing and killing tasks in these tests,
+        // sometimes result in lingering persistent tasks (such as "_close"),
+        // which cause subsequent tests to fail.
+        client().execute(TransportCancelTasksAction.TYPE, new CancelTasksRequest());
     }
 
     public void testLookbackOnly() throws Exception {


### PR DESCRIPTION
These failures are caused by lingering close tasks, that can be traced back to this IT:
- [[CI] InferenceIngestInputConfigIT testIngestWithInputFields failing](https://github.com/elastic/elasticsearch/issues/118092)
- [[CI] InferenceIngestInputConfigIT testIngestWithMultipleInputFields failing](https://github.com/elastic/elasticsearch/issues/118093)
- [[CI] MlJobIT testUsage failing](https://github.com/elastic/elasticsearch/issues/119659)
- [[CI] MlJobIT testDeleteJob failing](https://github.com/elastic/elasticsearch/issues/119661)
- [[CI] MlJobIT testCreateJobInCustomSharedIndexUpdatesMapping failing](https://github.com/elastic/elasticsearch/issues/119660)
- [[CI] MlJobIT testOpenJob_GivenTimeout_Returns408 failing](https://github.com/elastic/elasticsearch/issues/119810)
- [[CI] MlJobIT testGetJob_GivenJobExists failing](https://github.com/elastic/elasticsearch/issues/119811)

When this is merged and backported, I'll unmute these tests on the 8.x branches.
