### PR TITLE
Match dot prefix of migrated DS backing index with the source index

### DIFF
--- a/docs/changelog/120042.yaml
+++ b/docs/changelog/120042.yaml
@@ -1,0 +1,5 @@
+pr: 120042
+summary: Match dot prefix of migrated DS backing index with the source index
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
@@ -96,10 +96,24 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
         assertHitCount(prepareSearch(destIndex).setSize(0), 0);
     }
 
-    public void testDestIndexNameSet() throws Exception {
+    public void testDestIndexNameSet_noDotPrefix() throws Exception {
         assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
 
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        indicesAdmin().create(new CreateIndexRequest(sourceIndex)).get();
+
+        // call reindex
+        var response = client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex))
+            .actionGet();
+
+        var expectedDestIndexName = ReindexDataStreamIndexTransportAction.generateDestIndexName(sourceIndex);
+        assertEquals(expectedDestIndexName, response.getDestIndex());
+    }
+
+    public void testDestIndexNameSet_withDotPrefix() throws Exception {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        var sourceIndex = "." + randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         indicesAdmin().create(new CreateIndexRequest(sourceIndex)).get();
 
         // call reindex
@@ -445,5 +459,33 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
             .getSettings()
             .get(index)
             .get(IndexMetadata.SETTING_INDEX_UUID);
+    }
+
+    public void testGenerateDestIndexName_noDotPrefix() {
+        String sourceIndex = "sourceindex";
+        String expectedDestIndex = "migrated-sourceindex";
+        String actualDestIndex = ReindexDataStreamIndexTransportAction.generateDestIndexName(sourceIndex);
+        assertEquals(expectedDestIndex, actualDestIndex);
+    }
+
+    public void testGenerateDestIndexName_withDotPrefix() {
+        String sourceIndex = ".sourceindex";
+        String expectedDestIndex = ".migrated-sourceindex";
+        String actualDestIndex = ReindexDataStreamIndexTransportAction.generateDestIndexName(sourceIndex);
+        assertEquals(expectedDestIndex, actualDestIndex);
+    }
+
+    public void testGenerateDestIndexName_withHyphen() {
+        String sourceIndex = "source-index";
+        String expectedDestIndex = "migrated-source-index";
+        String actualDestIndex = ReindexDataStreamIndexTransportAction.generateDestIndexName(sourceIndex);
+        assertEquals(expectedDestIndex, actualDestIndex);
+    }
+
+    public void testGenerateDestIndexName_withUnderscore() {
+        String sourceIndex = "source_index";
+        String expectedDestIndex = "migrated-source_index";
+        String actualDestIndex = ReindexDataStreamIndexTransportAction.generateDestIndexName(sourceIndex);
+        assertEquals(expectedDestIndex, actualDestIndex);
     }
 }

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -221,8 +221,12 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
         }
     }
 
-    public static String generateDestIndexName(String sourceIndex) {
-        return "migrated-" + sourceIndex;
+    static String generateDestIndexName(String sourceIndex) {
+        String prefix = "migrated-";
+        if (sourceIndex.startsWith(".")) {
+            return "." + prefix + sourceIndex.substring(1);
+        }
+        return prefix + sourceIndex;
     }
 
     private static <U extends AcknowledgedResponse> ActionListener<U> failIfNotAcknowledged(


### PR DESCRIPTION
This PR changes the index naming scheme used in `ReindexDataStreamIndexTransportAction` to match the dot prefix status of newly migrated indices.

If the source index does not start with a `.` then neither will the destination however if the source index does start with a `.` then so will the migrated index. Examples:

|Source|Destination|
|---|---|
|my-index|migrated-my-index|
|.my-index|.migrated-my-index|

Also adds additional tests for the change.

Fixes ES-10506