### PR TITLE
Improve error handling when parsing retrievers

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/random/RandomRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/random/RandomRankRetrieverBuilder.java
@@ -14,6 +14,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.retriever.RetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverParserContext;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -48,7 +49,8 @@ public class RandomRankRetrieverBuilder extends RetrieverBuilder {
         });
 
     static {
-        PARSER.declareNamedObject(constructorArg(), (p, c, n) -> p.namedObject(RetrieverBuilder.class, n, c), RETRIEVER_FIELD);
+        //PARSER.declareNamedObject(constructorArg(), (p, c, n) -> p.namedObject(RetrieverBuilder.class, n, c), RETRIEVER_FIELD);
+        PARSER.declareField(constructorArg(), RandomRankRetrieverBuilder::parseRetrieverBuilder, RETRIEVER_FIELD, ObjectParser.ValueType.OBJECT);
         PARSER.declareString(optionalConstructorArg(), FIELD_FIELD);
         PARSER.declareInt(optionalConstructorArg(), RANK_WINDOW_SIZE_FIELD);
         PARSER.declareInt(optionalConstructorArg(), SEED_FIELD);
@@ -61,6 +63,22 @@ public class RandomRankRetrieverBuilder extends RetrieverBuilder {
             throw new ParsingException(parser.getTokenLocation(), "unknown retriever [" + RandomRankBuilder.NAME + "]");
         }
         return PARSER.apply(parser, context);
+    }
+
+    private static RetrieverBuilder parseRetrieverBuilder(XContentParser parser, RetrieverParserContext context) throws IOException {
+        assert parser.currentToken() == XContentParser.Token.START_OBJECT;
+        parser.nextToken();
+        if (parser.currentToken() == XContentParser.Token.END_OBJECT) {
+            throw new ParsingException(parser.getTokenLocation(), "empty [" + RETRIEVER_FIELD + "] object");
+        }
+        assert parser.currentToken() == XContentParser.Token.FIELD_NAME;
+        final RetrieverBuilder builder = parser.namedObject(RetrieverBuilder.class, parser.currentName(), context);
+        parser.nextToken();
+        if (parser.currentToken() == XContentParser.Token.FIELD_NAME) {
+            throw new ParsingException(parser.getTokenLocation(), "unexpected field [" + parser.currentName() + "]");
+        }
+        assert parser.currentToken() == XContentParser.Token.END_OBJECT;
+        return builder;
     }
 
     private final RetrieverBuilder retrieverBuilder;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/random/RandomRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/random/RandomRankRetrieverBuilder.java
@@ -49,8 +49,12 @@ public class RandomRankRetrieverBuilder extends RetrieverBuilder {
         });
 
     static {
-        //PARSER.declareNamedObject(constructorArg(), (p, c, n) -> p.namedObject(RetrieverBuilder.class, n, c), RETRIEVER_FIELD);
-        PARSER.declareField(constructorArg(), RandomRankRetrieverBuilder::parseRetrieverBuilder, RETRIEVER_FIELD, ObjectParser.ValueType.OBJECT);
+        PARSER.declareField(
+            constructorArg(),
+            RandomRankRetrieverBuilder::parseRetrieverBuilder,
+            RETRIEVER_FIELD,
+            ObjectParser.ValueType.OBJECT
+        );
         PARSER.declareString(optionalConstructorArg(), FIELD_FIELD);
         PARSER.declareInt(optionalConstructorArg(), RANK_WINDOW_SIZE_FIELD);
         PARSER.declareInt(optionalConstructorArg(), SEED_FIELD);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/random/RandomRankRetrieverBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/random/RandomRankRetrieverBuilderTests.java
@@ -15,12 +15,15 @@ import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.usage.SearchUsage;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
 
 import static org.elasticsearch.search.rank.RankBuilder.DEFAULT_RANK_WINDOW_SIZE;
 
@@ -96,6 +99,58 @@ public class RandomRankRetrieverBuilderTests extends AbstractXContentTestCase<Ra
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
             RandomRankRetrieverBuilder parsed = RandomRankRetrieverBuilder.PARSER.parse(parser, null);
             assertEquals(DEFAULT_RANK_WINDOW_SIZE, parsed.rankWindowSize());
+        }
+    }
+
+    public void testParserEmptyRetriever() throws IOException {
+        String json = """
+            {
+              "retriever": {
+              },
+              "field": "my-field"
+            }""";
+
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            XContentParseException ex = expectThrows(XContentParseException.class, () -> RandomRankRetrieverBuilder.PARSER.parse(parser, null));
+            assertThat(ex.getMessage(), containsString("[random_reranker] failed to parse field [retriever]"));
+            assertThat(ex.getCause().getMessage(), containsString("empty [retriever] object"));
+        }
+    }
+
+    public void testParserWrongRetrieverName() throws IOException {
+        String json = """
+            {
+              "retriever": {
+                "test2": {
+                  "value": "my-test-retriever"
+                }
+              },
+              "field": "my-field"
+            }""";
+
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            XContentParseException ex = expectThrows(XContentParseException.class, () -> RandomRankRetrieverBuilder.PARSER.parse(parser, null));
+            assertThat(ex.getMessage(), containsString("[random_reranker] failed to parse field [retriever]"));
+            assertThat(ex.getCause().getMessage(), containsString("unknown field [test2]"));
+        }
+    }
+
+    public void testExtraContent() throws IOException {
+        String json = """
+            {
+              "retriever": {
+                "test": {
+                  "value": "my-test-retriever"
+                },
+                "field2": "my-field"
+              },
+              "field": "my-field"
+            }""";
+
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            XContentParseException ex = expectThrows(XContentParseException.class, () -> RandomRankRetrieverBuilder.PARSER.parse(parser, null));
+            assertThat(ex.getMessage(), containsString("[random_reranker] failed to parse field [retriever]"));
+            assertThat(ex.getCause().getMessage(), containsString("unexpected field [field2]"));
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/random/RandomRankRetrieverBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/random/RandomRankRetrieverBuilderTests.java
@@ -23,9 +23,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.Matchers.containsString;
-
 import static org.elasticsearch.search.rank.RankBuilder.DEFAULT_RANK_WINDOW_SIZE;
+import static org.hamcrest.Matchers.containsString;
 
 public class RandomRankRetrieverBuilderTests extends AbstractXContentTestCase<RandomRankRetrieverBuilder> {
 
@@ -111,7 +110,10 @@ public class RandomRankRetrieverBuilderTests extends AbstractXContentTestCase<Ra
             }""";
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
-            XContentParseException ex = expectThrows(XContentParseException.class, () -> RandomRankRetrieverBuilder.PARSER.parse(parser, null));
+            XContentParseException ex = expectThrows(
+                XContentParseException.class,
+                () -> RandomRankRetrieverBuilder.PARSER.parse(parser, null)
+            );
             assertThat(ex.getMessage(), containsString("[random_reranker] failed to parse field [retriever]"));
             assertThat(ex.getCause().getMessage(), containsString("empty [retriever] object"));
         }
@@ -129,7 +131,10 @@ public class RandomRankRetrieverBuilderTests extends AbstractXContentTestCase<Ra
             }""";
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
-            XContentParseException ex = expectThrows(XContentParseException.class, () -> RandomRankRetrieverBuilder.PARSER.parse(parser, null));
+            XContentParseException ex = expectThrows(
+                XContentParseException.class,
+                () -> RandomRankRetrieverBuilder.PARSER.parse(parser, null)
+            );
             assertThat(ex.getMessage(), containsString("[random_reranker] failed to parse field [retriever]"));
             assertThat(ex.getCause().getMessage(), containsString("unknown field [test2]"));
         }
@@ -148,7 +153,10 @@ public class RandomRankRetrieverBuilderTests extends AbstractXContentTestCase<Ra
             }""";
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
-            XContentParseException ex = expectThrows(XContentParseException.class, () -> RandomRankRetrieverBuilder.PARSER.parse(parser, null));
+            XContentParseException ex = expectThrows(
+                XContentParseException.class,
+                () -> RandomRankRetrieverBuilder.PARSER.parse(parser, null)
+            );
             assertThat(ex.getMessage(), containsString("[random_reranker] failed to parse field [retriever]"));
             assertThat(ex.getCause().getMessage(), containsString("unexpected field [field2]"));
         }


### PR DESCRIPTION
We are currently using `PARSER#declareNamedObject` to parse the contents of a retriever object. Unfortunately this method does not handle properly if the object is actually empty, or they are other fields after it. Therefore, we are changing here so we are parsing the contents manually to handle properly those cases.

