### PR TITLE
ESQL: Add interfaces to distribute the post-analysis verification (#119798)

### DIFF
--- a/docs/changelog/119798.yaml
+++ b/docs/changelog/119798.yaml
@@ -1,0 +1,5 @@
+pr: 119798
+summary: "Add a `PostAnalysisAware,` distribute verification"
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -10,55 +10,28 @@ package org.elasticsearch.xpack.esql.analysis;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.esql.LicenseAware;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisPlanVerificationAware;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
 import org.elasticsearch.xpack.esql.common.Failure;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.capabilities.Unresolvable;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
-import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
-import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.Expressions;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
-import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.expression.predicate.BinaryOperator;
-import org.elasticsearch.xpack.esql.core.expression.predicate.logical.BinaryLogic;
-import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Not;
-import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.UnsupportedAttribute;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.FilteredExpression;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
-import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
-import org.elasticsearch.xpack.esql.expression.function.fulltext.Kql;
-import org.elasticsearch.xpack.esql.expression.function.fulltext.Match;
-import org.elasticsearch.xpack.esql.expression.function.fulltext.QueryString;
-import org.elasticsearch.xpack.esql.expression.function.fulltext.Term;
-import org.elasticsearch.xpack.esql.expression.function.grouping.Categorize;
-import org.elasticsearch.xpack.esql.expression.function.grouping.GroupingFunction;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Neg;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
-import org.elasticsearch.xpack.esql.plan.logical.Enrich;
-import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
-import org.elasticsearch.xpack.esql.plan.logical.Eval;
-import org.elasticsearch.xpack.esql.plan.logical.Filter;
-import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Lookup;
-import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
-import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
-import org.elasticsearch.xpack.esql.plan.logical.Row;
-import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
-import org.elasticsearch.xpack.esql.plan.logical.join.Join;
-import org.elasticsearch.xpack.esql.plan.logical.join.JoinConfig;
 import org.elasticsearch.xpack.esql.stats.FeatureMetric;
 import org.elasticsearch.xpack.esql.stats.Metrics;
 
@@ -66,19 +39,14 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
-import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
-import static org.elasticsearch.xpack.esql.core.type.DataType.NULL;
 
 /**
  * This class is part of the planner. Responsible for failing impossible queries with a human-readable error message.  In particular, this
@@ -103,11 +71,45 @@ public class Verifier {
      */
     Collection<Failure> verify(LogicalPlan plan, BitSet partialMetrics) {
         assert partialMetrics != null;
-        Set<Failure> failures = new LinkedHashSet<>();
-        // alias map, collected during the first iteration for better error messages
-        AttributeMap<Expression> aliases = new AttributeMap<>();
+        Failures failures = new Failures();
 
         // quick verification for unresolved attributes
+        checkUnresolvedAttributes(plan, failures);
+
+        // in case of failures bail-out as all other checks will be redundant
+        if (failures.hasFailures()) {
+            return failures.failures();
+        }
+
+        // collect plan checkers
+        var planCheckers = planCheckers(plan);
+
+        // Concrete verifications
+        plan.forEachDown(p -> {
+            // if the children are unresolved, so will this node; counting it will only add noise
+            if (p.childrenResolved() == false) {
+                return;
+            }
+
+            planCheckers.forEach(c -> c.accept(p, failures));
+
+            checkOperationsOnUnsignedLong(p, failures);
+            checkBinaryComparison(p, failures);
+        });
+
+        if (failures.hasFailures() == false) {
+            licenseCheck(plan, failures);
+        }
+
+        // gather metrics
+        if (failures.hasFailures() == false) {
+            gatherMetrics(plan, partialMetrics);
+        }
+
+        return failures.failures();
+    }
+
+    private static void checkUnresolvedAttributes(LogicalPlan plan, Failures failures) {
         plan.forEachUp(p -> {
             // if the children are unresolved, so will this node; counting it will only add noise
             if (p.childrenResolved() == false) {
@@ -119,7 +121,6 @@ public class Verifier {
             }
             // p is resolved, skip
             else if (p.resolved()) {
-                p.forEachExpressionUp(Alias.class, a -> aliases.put(a.toAttribute(), a.child()));
                 return;
             }
 
@@ -181,390 +182,31 @@ public class Verifier {
                 p.forEachExpression(unresolvedExpressions);
             }
         });
+    }
 
-        // in case of failures bail-out as all other checks will be redundant
-        if (failures.isEmpty() == false) {
-            return failures;
-        }
-
-        // Concrete verifications
+    private static List<BiConsumer<LogicalPlan, Failures>> planCheckers(LogicalPlan plan) {
+        List<BiConsumer<LogicalPlan, Failures>> planCheckers = new ArrayList<>();
+        Consumer<? super Node<?>> collectPlanCheckers = p -> {
+            if (p instanceof PostAnalysisPlanVerificationAware pva) {
+                planCheckers.add(pva.postAnalysisPlanVerification());
+            }
+        };
         plan.forEachDown(p -> {
-            // if the children are unresolved, so will this node; counting it will only add noise
-            if (p.childrenResolved() == false) {
-                return;
-            }
-            checkFilterConditionType(p, failures);
-            checkAggregate(p, failures);
-            checkRegexExtractOnlyOnStrings(p, failures);
+            collectPlanCheckers.accept(p);
+            p.forEachExpression(collectPlanCheckers);
 
-            checkRow(p, failures);
-            checkEvalFields(p, failures);
-
-            checkOperationsOnUnsignedLong(p, failures);
-            checkBinaryComparison(p, failures);
-            checkForSortableDataTypes(p, failures);
-            checkSort(p, failures);
-
-            checkFullTextQueryFunctions(p, failures);
-            checkJoin(p, failures);
-        });
-        checkRemoteEnrich(plan, failures);
-
-        if (failures.isEmpty()) {
-            licenseCheck(plan, failures);
-        }
-
-        // gather metrics
-        if (failures.isEmpty()) {
-            gatherMetrics(plan, partialMetrics);
-        }
-
-        return failures;
-    }
-
-    private void checkSort(LogicalPlan p, Set<Failure> failures) {
-        if (p instanceof OrderBy ob) {
-            ob.order().forEach(o -> {
-                o.forEachDown(Function.class, f -> {
-                    if (f instanceof AggregateFunction) {
-                        failures.add(fail(f, "Aggregate functions are not allowed in SORT [{}]", f.functionName()));
+            if (p instanceof PostAnalysisVerificationAware va) {
+                planCheckers.add((lp, failures) -> {
+                    if (lp.getClass().equals(va.getClass())) {
+                        va.postAnalysisVerification(failures);
                     }
                 });
-            });
-        }
-    }
-
-    private static void checkFilterConditionType(LogicalPlan p, Set<Failure> localFailures) {
-        if (p instanceof Filter f) {
-            Expression condition = f.condition();
-            if (condition.dataType() != BOOLEAN) {
-                localFailures.add(fail(condition, "Condition expression needs to be boolean, found [{}]", condition.dataType()));
             }
-        }
-    }
-
-    private static void checkAggregate(LogicalPlan p, Set<Failure> failures) {
-        if (p instanceof Aggregate agg) {
-            List<Expression> groupings = agg.groupings();
-            AttributeSet groupRefs = new AttributeSet();
-            // check grouping
-            // The grouping can not be an aggregate function
-            groupings.forEach(e -> {
-                e.forEachUp(g -> {
-                    if (g instanceof AggregateFunction af) {
-                        failures.add(fail(g, "cannot use an aggregate [{}] for grouping", af));
-                    } else if (g instanceof GroupingFunction gf) {
-                        gf.children()
-                            .forEach(
-                                c -> c.forEachDown(
-                                    GroupingFunction.class,
-                                    inner -> failures.add(
-                                        fail(
-                                            inner,
-                                            "cannot nest grouping functions; found [{}] inside [{}]",
-                                            inner.sourceText(),
-                                            gf.sourceText()
-                                        )
-                                    )
-                                )
-                            );
-                    }
-                });
-                // keep the grouping attributes (common case)
-                Attribute attr = Expressions.attribute(e);
-                if (attr != null) {
-                    groupRefs.add(attr);
-                }
-                if (e instanceof FieldAttribute f && f.dataType().isCounter()) {
-                    failures.add(fail(e, "cannot group by on [{}] type for grouping [{}]", f.dataType().typeName(), e.sourceText()));
-                }
-            });
-
-            // check aggregates - accept only aggregate functions or expressions over grouping
-            // don't allow the group by itself to avoid duplicates in the output
-            // and since the groups are copied, only look at the declared aggregates
-            List<? extends NamedExpression> aggs = agg.aggregates();
-            aggs.subList(0, aggs.size() - groupings.size()).forEach(e -> {
-                var exp = Alias.unwrap(e);
-                if (exp.foldable()) {
-                    failures.add(fail(exp, "expected an aggregate function but found [{}]", exp.sourceText()));
-                }
-                // traverse the tree to find invalid matches
-                checkInvalidNamedExpressionUsage(exp, groupings, groupRefs, failures, 0);
-            });
-            if (agg.aggregateType() == Aggregate.AggregateType.METRICS) {
-                aggs.forEach(a -> checkRateAggregates(a, 0, failures));
-            } else {
-                agg.forEachExpression(
-                    Rate.class,
-                    r -> failures.add(fail(r, "the rate aggregate[{}] can only be used within the metrics command", r.sourceText()))
-                );
-            }
-            checkCategorizeGrouping(agg, failures);
-        } else {
-            p.forEachExpression(
-                GroupingFunction.class,
-                gf -> failures.add(fail(gf, "cannot use grouping function [{}] outside of a STATS command", gf.sourceText()))
-            );
-        }
-    }
-
-    /**
-     * Check CATEGORIZE grouping function usages.
-     * <p>
-     *     Some of those checks are temporary, until the required syntax or engine changes are implemented.
-     * </p>
-     */
-    private static void checkCategorizeGrouping(Aggregate agg, Set<Failure> failures) {
-        // Forbid CATEGORIZE grouping function with other groupings
-        if (agg.groupings().size() > 1) {
-            agg.groupings().subList(1, agg.groupings().size()).forEach(g -> {
-                g.forEachDown(
-                    Categorize.class,
-                    categorize -> failures.add(
-                        fail(
-                            categorize,
-                            "CATEGORIZE grouping function [{}] can only be in the first grouping expression",
-                            categorize.sourceText()
-                        )
-                    )
-                );
-            });
-        }
-
-        // Forbid CATEGORIZE grouping functions not being top level groupings
-        agg.groupings().forEach(g -> {
-            // Check all CATEGORIZE but the top level one
-            Alias.unwrap(g)
-                .children()
-                .forEach(
-                    child -> child.forEachDown(
-                        Categorize.class,
-                        c -> failures.add(
-                            fail(c, "CATEGORIZE grouping function [{}] can't be used within other expressions", c.sourceText())
-                        )
-                    )
-                );
         });
-
-        // Forbid CATEGORIZE being used in the aggregations, unless it appears as a grouping
-        agg.aggregates()
-            .forEach(
-                a -> a.forEachDown(
-                    AggregateFunction.class,
-                    aggregateFunction -> aggregateFunction.forEachDown(
-                        Categorize.class,
-                        categorize -> failures.add(
-                            fail(categorize, "cannot use CATEGORIZE grouping function [{}] within an aggregation", categorize.sourceText())
-                        )
-                    )
-                )
-            );
-
-        // Forbid CATEGORIZE being referenced as a child of an aggregation function
-        AttributeMap<Categorize> categorizeByAttribute = new AttributeMap<>();
-        agg.groupings().forEach(g -> {
-            g.forEachDown(Alias.class, alias -> {
-                if (alias.child() instanceof Categorize categorize) {
-                    categorizeByAttribute.put(alias.toAttribute(), categorize);
-                }
-            });
-        });
-        agg.aggregates()
-            .forEach(a -> a.forEachDown(AggregateFunction.class, aggregate -> aggregate.forEachDown(Attribute.class, attribute -> {
-                var categorize = categorizeByAttribute.get(attribute);
-                if (categorize != null) {
-                    failures.add(
-                        fail(attribute, "cannot reference CATEGORIZE grouping function [{}] within an aggregation", attribute.sourceText())
-                    );
-                }
-            })));
-        agg.aggregates().forEach(a -> a.forEachDown(FilteredExpression.class, fe -> fe.filter().forEachDown(Attribute.class, attribute -> {
-            var categorize = categorizeByAttribute.get(attribute);
-            if (categorize != null) {
-                failures.add(
-                    fail(
-                        attribute,
-                        "cannot reference CATEGORIZE grouping function [{}] within an aggregation filter",
-                        attribute.sourceText()
-                    )
-                );
-            }
-        })));
+        return planCheckers;
     }
 
-    private static void checkRateAggregates(Expression expr, int nestedLevel, Set<Failure> failures) {
-        if (expr instanceof AggregateFunction) {
-            nestedLevel++;
-        }
-        if (expr instanceof Rate r) {
-            if (nestedLevel != 2) {
-                failures.add(
-                    fail(
-                        expr,
-                        "the rate aggregate [{}] can only be used within the metrics command and inside another aggregate",
-                        r.sourceText()
-                    )
-                );
-            }
-        }
-        for (Expression child : expr.children()) {
-            checkRateAggregates(child, nestedLevel, failures);
-        }
-    }
-
-    // traverse the expression and look either for an agg function or a grouping match
-    // stop either when no children are left, the leafs are literals or a reference attribute is given
-    private static void checkInvalidNamedExpressionUsage(
-        Expression e,
-        List<Expression> groups,
-        AttributeSet groupRefs,
-        Set<Failure> failures,
-        int level
-    ) {
-        // unwrap filtered expression
-        if (e instanceof FilteredExpression fe) {
-            e = fe.delegate();
-            // make sure they work on aggregate functions
-            if (e.anyMatch(AggregateFunction.class::isInstance) == false) {
-                Expression filter = fe.filter();
-                failures.add(fail(filter, "WHERE clause allowed only for aggregate functions, none found in [{}]", fe.sourceText()));
-            }
-            Expression f = fe.filter();
-            // check the filter has to be a boolean term, similar as checkFilterConditionType
-            if (f.dataType() != NULL && f.dataType() != BOOLEAN) {
-                failures.add(fail(f, "Condition expression needs to be boolean, found [{}]", f.dataType()));
-            }
-            // but that the filter doesn't use grouping or aggregate functions
-            fe.filter().forEachDown(c -> {
-                if (c instanceof AggregateFunction af) {
-                    failures.add(
-                        fail(af, "cannot use aggregate function [{}] in aggregate WHERE clause [{}]", af.sourceText(), fe.sourceText())
-                    );
-                }
-                // check the grouping function against the group
-                else if (c instanceof GroupingFunction gf) {
-                    if (c instanceof Categorize
-                        || Expressions.anyMatch(groups, ex -> ex instanceof Alias a && a.child().semanticEquals(gf)) == false) {
-                        failures.add(fail(gf, "can only use grouping function [{}] as part of the BY clause", gf.sourceText()));
-                    }
-                }
-            });
-        }
-        // found an aggregate, constant or a group, bail out
-        if (e instanceof AggregateFunction af) {
-            af.field().forEachDown(AggregateFunction.class, f -> {
-                // rate aggregate is allowed to be inside another aggregate
-                if (f instanceof Rate == false) {
-                    failures.add(fail(f, "nested aggregations [{}] not allowed inside other aggregations [{}]", f, af));
-                }
-            });
-        } else if (e instanceof GroupingFunction gf) {
-            // optimizer will later unroll expressions with aggs and non-aggs with a grouping function into an EVAL, but that will no longer
-            // be verified (by check above in checkAggregate()), so do it explicitly here
-            if (Expressions.anyMatch(groups, ex -> ex instanceof Alias a && a.child().semanticEquals(gf)) == false) {
-                failures.add(fail(gf, "can only use grouping function [{}] as part of the BY clause", gf.sourceText()));
-            } else if (level == 0) {
-                addFailureOnGroupingUsedNakedInAggs(failures, gf, "function");
-            }
-        } else if (e.foldable()) {
-            // don't do anything
-        } else if (groups.contains(e) || groupRefs.contains(e)) {
-            if (level == 0) {
-                addFailureOnGroupingUsedNakedInAggs(failures, e, "key");
-            }
-        }
-        // if a reference is found, mark it as an error
-        else if (e instanceof NamedExpression ne) {
-            boolean foundInGrouping = false;
-            for (Expression g : groups) {
-                if (g.anyMatch(se -> se.semanticEquals(ne))) {
-                    foundInGrouping = true;
-                    failures.add(
-                        fail(
-                            e,
-                            "column [{}] cannot be used as an aggregate once declared in the STATS BY grouping key [{}]",
-                            ne.name(),
-                            g.sourceText()
-                        )
-                    );
-                    break;
-                }
-            }
-            if (foundInGrouping == false) {
-                failures.add(fail(e, "column [{}] must appear in the STATS BY clause or be used in an aggregate function", ne.name()));
-            }
-        }
-        // other keep on going
-        else {
-            for (Expression child : e.children()) {
-                checkInvalidNamedExpressionUsage(child, groups, groupRefs, failures, level + 1);
-            }
-        }
-    }
-
-    private static void addFailureOnGroupingUsedNakedInAggs(Set<Failure> failures, Expression e, String element) {
-        failures.add(
-            fail(e, "grouping {} [{}] cannot be used as an aggregate once declared in the STATS BY clause", element, e.sourceText())
-        );
-    }
-
-    private static void checkRegexExtractOnlyOnStrings(LogicalPlan p, Set<Failure> failures) {
-        if (p instanceof RegexExtract re) {
-            Expression expr = re.input();
-            DataType type = expr.dataType();
-            if (DataType.isString(type) == false) {
-                failures.add(
-                    fail(
-                        expr,
-                        "{} only supports KEYWORD or TEXT values, found expression [{}] type [{}]",
-                        re.getClass().getSimpleName(),
-                        expr.sourceText(),
-                        type
-                    )
-                );
-            }
-        }
-    }
-
-    private static void checkRow(LogicalPlan p, Set<Failure> failures) {
-        if (p instanceof Row row) {
-            row.fields().forEach(a -> {
-                if (DataType.isRepresentable(a.dataType()) == false) {
-                    failures.add(fail(a.child(), "cannot use [{}] directly in a row assignment", a.child().sourceText()));
-                }
-            });
-        }
-    }
-
-    private static void checkEvalFields(LogicalPlan p, Set<Failure> failures) {
-        if (p instanceof Eval eval) {
-            eval.fields().forEach(field -> {
-                // check supported types
-                DataType dataType = field.dataType();
-                if (DataType.isRepresentable(dataType) == false) {
-                    failures.add(
-                        fail(
-                            field,
-                            "EVAL does not support type [{}] as the return data type of expression [{}]",
-                            dataType.typeName(),
-                            field.child().sourceText()
-                        )
-                    );
-                }
-                // check no aggregate functions are used
-                field.forEachDown(AggregateFunction.class, af -> {
-                    if (af instanceof Rate) {
-                        failures.add(fail(af, "aggregate function [{}] not allowed outside METRICS command", af.sourceText()));
-                    } else {
-                        failures.add(fail(af, "aggregate function [{}] not allowed outside STATS command", af.sourceText()));
-                    }
-                });
-            });
-        }
-    }
-
-    private static void checkOperationsOnUnsignedLong(LogicalPlan p, Set<Failure> failures) {
+    private static void checkOperationsOnUnsignedLong(LogicalPlan p, Failures failures) {
         p.forEachExpression(e -> {
             Failure f = null;
 
@@ -580,7 +222,7 @@ public class Verifier {
         });
     }
 
-    private static void checkBinaryComparison(LogicalPlan p, Set<Failure> failures) {
+    private static void checkBinaryComparison(LogicalPlan p, Failures failures) {
         p.forEachExpression(BinaryComparison.class, bc -> {
             Failure f = validateBinaryComparison(bc);
             if (f != null) {
@@ -589,7 +231,7 @@ public class Verifier {
         });
     }
 
-    private void licenseCheck(LogicalPlan plan, Set<Failure> failures) {
+    private void licenseCheck(LogicalPlan plan, Failures failures) {
         Consumer<Node<?>> licenseCheck = n -> {
             if (n instanceof LicenseAware la && la.licenseCheck(licenseState) == false) {
                 failures.add(fail(n, "current license is non-compliant for [{}]", n.sourceText()));
@@ -721,280 +363,6 @@ public class Verifier {
                 childExpressionType.typeName(),
                 neg.sourceText()
             );
-        }
-        return null;
-    }
-
-    /**
-     * Some datatypes are not sortable
-     */
-    private static void checkForSortableDataTypes(LogicalPlan p, Set<Failure> localFailures) {
-        if (p instanceof OrderBy ob) {
-            ob.order().forEach(order -> {
-                if (DataType.isSortable(order.dataType()) == false) {
-                    localFailures.add(fail(order, "cannot sort on " + order.dataType().typeName()));
-                }
-            });
-        }
-    }
-
-    /**
-     * Ensure that no remote enrich is allowed after a reduction or an enrich with coordinator mode.
-     * <p>
-     * TODO:
-     * For Limit and TopN, we can insert the same node after the remote enrich (also needs to move projections around)
-     * to eliminate this limitation. Otherwise, we force users to write queries that might not perform well.
-     * For example, `FROM test | ORDER @timestamp | LIMIT 10 | ENRICH _remote:` doesn't work.
-     * In that case, users have to write it as `FROM test | ENRICH _remote: | ORDER @timestamp | LIMIT 10`,
-     * which is equivalent to bringing all data to the coordinating cluster.
-     * We might consider implementing the actual remote enrich on the coordinating cluster, however, this requires
-     * retaining the originating cluster and restructing pages for routing, which might be complicated.
-     */
-    private static void checkRemoteEnrich(LogicalPlan plan, Set<Failure> failures) {
-        boolean[] agg = { false };
-        boolean[] enrichCoord = { false };
-
-        plan.forEachUp(UnaryPlan.class, u -> {
-            if (u instanceof Aggregate) {
-                agg[0] = true;
-            } else if (u instanceof Enrich enrich && enrich.mode() == Enrich.Mode.COORDINATOR) {
-                enrichCoord[0] = true;
-            }
-            if (u instanceof Enrich enrich && enrich.mode() == Enrich.Mode.REMOTE) {
-                if (agg[0]) {
-                    failures.add(fail(enrich, "ENRICH with remote policy can't be executed after STATS"));
-                }
-                if (enrichCoord[0]) {
-                    failures.add(fail(enrich, "ENRICH with remote policy can't be executed after another ENRICH with coordinator policy"));
-                }
-            }
-        });
-    }
-
-    /**
-     * Checks whether a condition contains a disjunction with a full text search.
-     * If it does, check that every element of the disjunction is a full text search or combinations (AND, OR, NOT) of them.
-     * If not, add a failure to the failures collection.
-     *
-     * @param condition        condition to check for disjunctions of full text searches
-     * @param typeNameProvider provider for the type name to add in the failure message
-     * @param failures         failures collection to add to
-     */
-    private static void checkFullTextSearchDisjunctions(
-        Expression condition,
-        java.util.function.Function<FullTextFunction, String> typeNameProvider,
-        Set<Failure> failures
-    ) {
-        int failuresCount = failures.size();
-        condition.forEachDown(Or.class, or -> {
-            if (failures.size() > failuresCount) {
-                // Exit early if we already have a failures
-                return;
-            }
-            boolean hasFullText = or.anyMatch(FullTextFunction.class::isInstance);
-            if (hasFullText) {
-                boolean hasOnlyFullText = onlyFullTextFunctionsInExpression(or);
-                if (hasOnlyFullText == false) {
-                    failures.add(
-                        fail(
-                            or,
-                            "Invalid condition [{}]. Full text functions can be used in an OR condition, "
-                                + "but only if just full text functions are used in the OR condition",
-                            or.sourceText()
-                        )
-                    );
-                }
-            }
-        });
-    }
-
-    /**
-     * Checks whether an expression contains just full text functions or negations (NOT) and combinations (AND, OR) of full text functions
-     *
-     * @param expression expression to check
-     * @return true if all children are full text functions or negations of full text functions, false otherwise
-     */
-    private static boolean onlyFullTextFunctionsInExpression(Expression expression) {
-        if (expression instanceof FullTextFunction) {
-            return true;
-        } else if (expression instanceof Not) {
-            return onlyFullTextFunctionsInExpression(expression.children().get(0));
-        } else if (expression instanceof BinaryLogic binaryLogic) {
-            return onlyFullTextFunctionsInExpression(binaryLogic.left()) && onlyFullTextFunctionsInExpression(binaryLogic.right());
-        }
-
-        return false;
-    }
-
-    /**
-     * Checks whether an expression contains a full text function as part of it
-     *
-     * @param expression expression to check
-     * @return true if the expression or any of its children is a full text function, false otherwise
-     */
-    private static boolean anyFullTextFunctionsInExpression(Expression expression) {
-        if (expression instanceof FullTextFunction) {
-            return true;
-        }
-
-        for (Expression child : expression.children()) {
-            if (anyFullTextFunctionsInExpression(child)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Checks Joins for invalid usage.
-     *
-     * @param plan root plan to check
-     * @param failures failures found
-     */
-    private static void checkJoin(LogicalPlan plan, Set<Failure> failures) {
-        if (plan instanceof Join join) {
-            JoinConfig config = join.config();
-            for (int i = 0; i < config.leftFields().size(); i++) {
-                Attribute leftField = config.leftFields().get(i);
-                Attribute rightField = config.rightFields().get(i);
-                if (leftField.dataType() != rightField.dataType()) {
-                    failures.add(
-                        fail(
-                            leftField,
-                            "JOIN left field [{}] of type [{}] is incompatible with right field [{}] of type [{}]",
-                            leftField.name(),
-                            leftField.dataType(),
-                            rightField.name(),
-                            rightField.dataType()
-                        )
-                    );
-                }
-            }
-        }
-    }
-
-    /**
-     * Checks full text query functions for invalid usage.
-     *
-     * @param plan root plan to check
-     * @param failures failures found
-     */
-    private static void checkFullTextQueryFunctions(LogicalPlan plan, Set<Failure> failures) {
-        if (plan instanceof Filter f) {
-            Expression condition = f.condition();
-
-            List.of(QueryString.class, Kql.class).forEach(functionClass -> {
-                // Check for limitations of QSTR and KQL function.
-                checkCommandsBeforeExpression(
-                    plan,
-                    condition,
-                    functionClass,
-                    lp -> (lp instanceof Filter || lp instanceof OrderBy || lp instanceof EsRelation),
-                    fullTextFunction -> "[" + fullTextFunction.functionName() + "] " + fullTextFunction.functionType(),
-                    failures
-                );
-            });
-
-            checkCommandsBeforeExpression(
-                plan,
-                condition,
-                Match.class,
-                lp -> (lp instanceof Limit == false) && (lp instanceof Aggregate == false),
-                m -> "[" + m.functionName() + "] " + m.functionType(),
-                failures
-            );
-            checkCommandsBeforeExpression(
-                plan,
-                condition,
-                Term.class,
-                lp -> (lp instanceof Limit == false) && (lp instanceof Aggregate == false),
-                m -> "[" + m.functionName() + "] " + m.functionType(),
-                failures
-            );
-            checkFullTextSearchDisjunctions(condition, ftf -> "[" + ftf.functionName() + "] " + ftf.functionType(), failures);
-            checkFullTextFunctionsParents(condition, failures);
-        } else {
-            plan.forEachExpression(FullTextFunction.class, ftf -> {
-                failures.add(fail(ftf, "[{}] {} is only supported in WHERE commands", ftf.functionName(), ftf.functionType()));
-            });
-        }
-    }
-
-    /**
-     * Checks all commands that exist before a specific type satisfy conditions.
-     *
-     * @param plan plan that contains the condition
-     * @param condition condition to check
-     * @param typeToken type to check for. When a type is found in the condition, all plans before the root plan are checked
-     * @param commandCheck check to perform on each command that precedes the plan that contains the typeToken
-     * @param typeErrorMsgProvider provider for the type name in the error message
-     * @param failures failures to add errors to
-     * @param <E> class of the type to look for
-     */
-    private static <E extends Expression> void checkCommandsBeforeExpression(
-        LogicalPlan plan,
-        Expression condition,
-        Class<E> typeToken,
-        Predicate<LogicalPlan> commandCheck,
-        java.util.function.Function<E, String> typeErrorMsgProvider,
-        Set<Failure> failures
-    ) {
-        condition.forEachDown(typeToken, exp -> {
-            plan.forEachDown(LogicalPlan.class, lp -> {
-                if (commandCheck.test(lp) == false) {
-                    failures.add(
-                        fail(
-                            plan,
-                            "{} cannot be used after {}",
-                            typeErrorMsgProvider.apply(exp),
-                            lp.sourceText().split(" ")[0].toUpperCase(Locale.ROOT)
-                        )
-                    );
-                }
-            });
-        });
-    }
-
-    /**
-     * Checks parents of a full text function to ensure they are allowed
-     * @param condition condition that contains the full text function
-     * @param failures failures to add errors to
-     */
-    private static void checkFullTextFunctionsParents(Expression condition, Set<Failure> failures) {
-        forEachFullTextFunctionParent(condition, (ftf, parent) -> {
-            if ((parent instanceof FullTextFunction == false)
-                && (parent instanceof BinaryLogic == false)
-                && (parent instanceof Not == false)) {
-                failures.add(
-                    fail(
-                        condition,
-                        "Invalid condition [{}]. [{}] {} can't be used with {}",
-                        condition.sourceText(),
-                        ftf.functionName(),
-                        ftf.functionType(),
-                        ((Function) parent).functionName()
-                    )
-                );
-            }
-        });
-    }
-
-    /**
-     * Executes the action on every parent of a FullTextFunction in the condition if it is found
-     *
-     * @param action the action to execute for each parent of a FullTextFunction
-     */
-    private static FullTextFunction forEachFullTextFunctionParent(Expression condition, BiConsumer<FullTextFunction, Expression> action) {
-        if (condition instanceof FullTextFunction ftf) {
-            return ftf;
-        }
-        for (Expression child : condition.children()) {
-            FullTextFunction foundMatchingChild = forEachFullTextFunctionParent(child, action);
-            if (foundMatchingChild != null) {
-                action.accept(foundMatchingChild, condition);
-                return foundMatchingChild;
-            }
         }
         return null;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/PostAnalysisPlanVerificationAware.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/PostAnalysisPlanVerificationAware.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.capabilities;
+
+import org.elasticsearch.xpack.esql.common.Failures;
+import org.elasticsearch.xpack.esql.expression.function.grouping.GroupingFunction;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+
+import java.util.function.BiConsumer;
+
+/**
+ * Interface implemented by expressions or plans that require validation after query plan analysis,
+ * when the indices and references have been resolved, but before the plan is transformed further by optimizations.
+ * The interface is similar to {@link PostAnalysisVerificationAware}, but focused on the tree structure, oftentimes covering semantic
+ * checks.
+ */
+public interface PostAnalysisPlanVerificationAware {
+
+    /**
+     * Allows the implementer to return a consumer that will perform self-validation in the context of the tree structure the implementer
+     * is part of. This usually involves checking the type and configuration of the children or that of the parent.
+     * <p>
+     * It is often more useful to perform the checks as extended as it makes sense, over stopping at the first failure. This will allow the
+     * author to progress faster to a correct query.
+     * </p>
+     * <p>
+     *     Example: a {@link GroupingFunction} instance, which models a function to group documents to aggregate over, can only be used in
+     *     the context of the STATS command, modeled by the {@link Aggregate} class. This is how this verification is performed:
+     *     <pre>
+     *     {@code
+     *      @Override
+     *      public BiConsumer<LogicalPlan, Failures> postAnalysisPlanVerification() {
+     *          return (p, failures) -> {
+     *              if (p instanceof Aggregate == false) {
+     *                  p.forEachExpression(
+     *                      GroupingFunction.class,
+     *                      gf -> failures.add(fail(gf, "cannot use grouping function [{}] outside of a STATS command", gf.sourceText()))
+     *                  );
+     *              }
+     *          };
+     *      }
+     *     }
+     *     </pre>
+     *
+     * @return a consumer that will receive a tree to check and an accumulator of failures found during inspection.
+     */
+    BiConsumer<LogicalPlan, Failures> postAnalysisPlanVerification();
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/PostAnalysisVerificationAware.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/PostAnalysisVerificationAware.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.capabilities;
+
+import org.elasticsearch.xpack.esql.common.Failures;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+
+/**
+ * Interface implemented by expressions or plans that require validation after query plan analysis,
+ * when the indices and references have been resolved, but before the plan is transformed further by optimizations.
+ * The interface is similar to {@link PostAnalysisPlanVerificationAware}, but focused on individual expressions or plans, typically
+ * covering syntactic checks.
+ */
+public interface PostAnalysisVerificationAware {
+
+    /**
+     * Allows the implementer to validate itself. This usually involves checking its internal setup, which often means checking the
+     * parameters it received on construction: their data or syntactic type, class, their count, expressions' structure etc.
+     * The discovered failures are added to the given {@link Failures} object.
+     * <p>
+     * It is often more useful to perform the checks as extended as it makes sense, over stopping at the first failure. This will allow the
+     * author to progress faster to a correct query.
+     * </p>
+     * <p>
+     *     Example: the {@link Filter} class, which models the WHERE command, checks that the expression it filters on - {@code condition}
+     *     - is of a Boolean or NULL type:
+     *     <pre>
+     *     {@code
+     *     @Override
+     *     void postAnalysisVerification(Failures failures) {
+     *          if (condition.dataType() != NULL && condition.dataType() != BOOLEAN) {
+     *              failures.add(fail(condition, "Condition expression needs to be boolean, found [{}]", condition.dataType()));
+     *          }
+     *     }
+     *     }
+     *     </pre>
+     *
+     * @param failures the object to add failures to.
+     */
+    void postAnalysisVerification(Failures failures);
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.esql.expression.function.aggregate;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisPlanVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
@@ -16,19 +18,23 @@ import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 
 /**
  * A type of {@code Function} that takes multiple values and extracts a single value out of them. For example, {@code AVG()}.
  */
-public abstract class AggregateFunction extends Function {
+public abstract class AggregateFunction extends Function implements PostAnalysisPlanVerificationAware {
 
     private final Expression field;
     private final List<? extends Expression> parameters;
@@ -126,5 +132,20 @@ public abstract class AggregateFunction extends Function {
                 && Objects.equals(other.parameters(), parameters());
         }
         return false;
+    }
+
+    @Override
+    public BiConsumer<LogicalPlan, Failures> postAnalysisPlanVerification() {
+        return (p, failures) -> {
+            if (p instanceof OrderBy order) {
+                order.order().forEach(o -> {
+                    o.forEachDown(Function.class, f -> {
+                        if (f instanceof AggregateFunction) {
+                            failures.add(fail(f, "Aggregate functions are not allowed in SORT [{}]", f.functionName()));
+                        }
+                    });
+                });
+            }
+        };
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -9,21 +9,37 @@ package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisPlanVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
+import org.elasticsearch.xpack.esql.core.expression.predicate.logical.BinaryLogic;
+import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.core.planner.ExpressionTranslator;
 import org.elasticsearch.xpack.esql.core.planner.TranslatorHandler;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
 import org.elasticsearch.xpack.esql.core.querydsl.query.TranslationAwareExpressionQuery;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isNotNullAndFoldable;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
@@ -33,7 +49,7 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isStr
  * These functions needs to be pushed down to Lucene queries to be executed - there's no Evaluator for them, but depend on
  * {@link org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizer} to rewrite them into Lucene queries.
  */
-public abstract class FullTextFunction extends Function implements TranslationAware {
+public abstract class FullTextFunction extends Function implements TranslationAware, PostAnalysisPlanVerificationAware {
 
     private final Expression query;
     private final QueryBuilder queryBuilder;
@@ -158,4 +174,210 @@ public abstract class FullTextFunction extends Function implements TranslationAw
     protected abstract ExpressionTranslator<? extends FullTextFunction> translator();
 
     public abstract Expression replaceQueryBuilder(QueryBuilder queryBuilder);
+
+    @Override
+    public BiConsumer<LogicalPlan, Failures> postAnalysisPlanVerification() {
+        return FullTextFunction::checkFullTextQueryFunctions;
+    }
+
+    /**
+     * Checks full text query functions for invalid usage.
+     *
+     * @param plan root plan to check
+     * @param failures failures found
+     */
+    private static void checkFullTextQueryFunctions(LogicalPlan plan, Failures failures) {
+        if (plan instanceof Filter f) {
+            Expression condition = f.condition();
+
+            List.of(QueryString.class, Kql.class).forEach(functionClass -> {
+                // Check for limitations of QSTR and KQL function.
+                checkCommandsBeforeExpression(
+                    plan,
+                    condition,
+                    functionClass,
+                    lp -> (lp instanceof Filter || lp instanceof OrderBy || lp instanceof EsRelation),
+                    fullTextFunction -> "[" + fullTextFunction.functionName() + "] " + fullTextFunction.functionType(),
+                    failures
+                );
+            });
+
+            checkCommandsBeforeExpression(
+                plan,
+                condition,
+                Match.class,
+                lp -> (lp instanceof Limit == false) && (lp instanceof Aggregate == false),
+                m -> "[" + m.functionName() + "] " + m.functionType(),
+                failures
+            );
+            checkCommandsBeforeExpression(
+                plan,
+                condition,
+                Term.class,
+                lp -> (lp instanceof Limit == false) && (lp instanceof Aggregate == false),
+                m -> "[" + m.functionName() + "] " + m.functionType(),
+                failures
+            );
+            checkFullTextSearchDisjunctions(condition, ftf -> "[" + ftf.functionName() + "] " + ftf.functionType(), failures);
+            checkFullTextFunctionsParents(condition, failures);
+        } else {
+            plan.forEachExpression(FullTextFunction.class, ftf -> {
+                failures.add(fail(ftf, "[{}] {} is only supported in WHERE commands", ftf.functionName(), ftf.functionType()));
+            });
+        }
+    }
+
+    /**
+     * Checks whether a condition contains a disjunction with a full text search.
+     * If it does, check that every element of the disjunction is a full text search or combinations (AND, OR, NOT) of them.
+     * If not, add a failure to the failures collection.
+     *
+     * @param condition        condition to check for disjunctions of full text searches
+     * @param typeNameProvider provider for the type name to add in the failure message
+     * @param failures         failures collection to add to
+     */
+    private static void checkFullTextSearchDisjunctions(
+        Expression condition,
+        java.util.function.Function<FullTextFunction, String> typeNameProvider,
+        Failures failures
+    ) {
+        Holder<Boolean> isInvalid = new Holder<>(false);
+        condition.forEachDown(Or.class, or -> {
+            if (isInvalid.get()) {
+                // Exit early if we already have a failures
+                return;
+            }
+            boolean hasFullText = or.anyMatch(FullTextFunction.class::isInstance);
+            if (hasFullText) {
+                boolean hasOnlyFullText = onlyFullTextFunctionsInExpression(or);
+                if (hasOnlyFullText == false) {
+                    isInvalid.set(true);
+                    failures.add(
+                        fail(
+                            or,
+                            "Invalid condition [{}]. Full text functions can be used in an OR condition, "
+                                + "but only if just full text functions are used in the OR condition",
+                            or.sourceText()
+                        )
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * Checks whether an expression contains just full text functions or negations (NOT) and combinations (AND, OR) of full text functions
+     *
+     * @param expression expression to check
+     * @return true if all children are full text functions or negations of full text functions, false otherwise
+     */
+    private static boolean onlyFullTextFunctionsInExpression(Expression expression) {
+        if (expression instanceof FullTextFunction) {
+            return true;
+        } else if (expression instanceof Not) {
+            return onlyFullTextFunctionsInExpression(expression.children().get(0));
+        } else if (expression instanceof BinaryLogic binaryLogic) {
+            return onlyFullTextFunctionsInExpression(binaryLogic.left()) && onlyFullTextFunctionsInExpression(binaryLogic.right());
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks whether an expression contains a full text function as part of it
+     *
+     * @param expression expression to check
+     * @return true if the expression or any of its children is a full text function, false otherwise
+     */
+    private static boolean anyFullTextFunctionsInExpression(Expression expression) {
+        if (expression instanceof FullTextFunction) {
+            return true;
+        }
+
+        for (Expression child : expression.children()) {
+            if (anyFullTextFunctionsInExpression(child)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks all commands that exist before a specific type satisfy conditions.
+     *
+     * @param plan plan that contains the condition
+     * @param condition condition to check
+     * @param typeToken type to check for. When a type is found in the condition, all plans before the root plan are checked
+     * @param commandCheck check to perform on each command that precedes the plan that contains the typeToken
+     * @param typeErrorMsgProvider provider for the type name in the error message
+     * @param failures failures to add errors to
+     * @param <E> class of the type to look for
+     */
+    private static <E extends Expression> void checkCommandsBeforeExpression(
+        LogicalPlan plan,
+        Expression condition,
+        Class<E> typeToken,
+        Predicate<LogicalPlan> commandCheck,
+        java.util.function.Function<E, String> typeErrorMsgProvider,
+        Failures failures
+    ) {
+        condition.forEachDown(typeToken, exp -> {
+            plan.forEachDown(LogicalPlan.class, lp -> {
+                if (commandCheck.test(lp) == false) {
+                    failures.add(
+                        fail(
+                            plan,
+                            "{} cannot be used after {}",
+                            typeErrorMsgProvider.apply(exp),
+                            lp.sourceText().split(" ")[0].toUpperCase(Locale.ROOT)
+                        )
+                    );
+                }
+            });
+        });
+    }
+
+    /**
+     * Checks parents of a full text function to ensure they are allowed
+     * @param condition condition that contains the full text function
+     * @param failures failures to add errors to
+     */
+    private static void checkFullTextFunctionsParents(Expression condition, Failures failures) {
+        forEachFullTextFunctionParent(condition, (ftf, parent) -> {
+            if ((parent instanceof FullTextFunction == false)
+                && (parent instanceof BinaryLogic == false)
+                && (parent instanceof Not == false)) {
+                failures.add(
+                    fail(
+                        condition,
+                        "Invalid condition [{}]. [{}] {} can't be used with {}",
+                        condition.sourceText(),
+                        ftf.functionName(),
+                        ftf.functionType(),
+                        ((Function) parent).functionName()
+                    )
+                );
+            }
+        });
+    }
+
+    /**
+     * Executes the action on every parent of a FullTextFunction in the condition if it is found
+     *
+     * @param action the action to execute for each parent of a FullTextFunction
+     */
+    private static FullTextFunction forEachFullTextFunctionParent(Expression condition, BiConsumer<FullTextFunction, Expression> action) {
+        if (condition instanceof FullTextFunction ftf) {
+            return ftf;
+        }
+        for (Expression child : condition.children()) {
+            FullTextFunction foundMatchingChild = forEachFullTextFunctionParent(child, action);
+            if (foundMatchingChild != null) {
+                action.accept(foundMatchingChild, condition);
+                return foundMatchingChild;
+            }
+        }
+        return null;
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/GroupingFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/GroupingFunction.java
@@ -7,14 +7,21 @@
 
 package org.elasticsearch.xpack.esql.expression.function.grouping;
 
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisPlanVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
-public abstract class GroupingFunction extends Function implements EvaluatorMapper {
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
+
+public abstract class GroupingFunction extends Function implements EvaluatorMapper, PostAnalysisPlanVerificationAware {
 
     protected GroupingFunction(Source source, List<Expression> fields) {
         super(source, fields);
@@ -23,6 +30,18 @@ public abstract class GroupingFunction extends Function implements EvaluatorMapp
     @Override
     public Object fold() {
         return EvaluatorMapper.super.fold();
+    }
+
+    @Override
+    public BiConsumer<LogicalPlan, Failures> postAnalysisPlanVerification() {
+        return (p, failures) -> {
+            if (p instanceof Aggregate == false) {
+                p.forEachExpression(
+                    GroupingFunction.class,
+                    gf -> failures.add(fail(gf, "cannot use grouping function [{}] outside of a STATS command", gf.sourceText()))
+                );
+            }
+        };
     }
 
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
@@ -10,15 +10,24 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.FilteredExpression;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
+import org.elasticsearch.xpack.esql.expression.function.grouping.Categorize;
+import org.elasticsearch.xpack.esql.expression.function.grouping.GroupingFunction;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
 import java.io.IOException;
@@ -26,9 +35,11 @@ import java.util.List;
 import java.util.Objects;
 
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
+import static org.elasticsearch.xpack.esql.plan.logical.Filter.checkFilterConditionDataType;
 
-public class Aggregate extends UnaryPlan {
+public class Aggregate extends UnaryPlan implements PostAnalysisVerificationAware {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         LogicalPlan.class,
         "Aggregate",
@@ -190,5 +201,261 @@ public class Aggregate extends UnaryPlan {
             && Objects.equals(groupings, other.groupings)
             && Objects.equals(aggregates, other.aggregates)
             && Objects.equals(child(), other.child());
+    }
+
+    @Override
+    public void postAnalysisVerification(Failures failures) {
+        AttributeSet groupRefs = new AttributeSet();
+        // check grouping
+        // The grouping can not be an aggregate function
+        groupings.forEach(e -> {
+            e.forEachUp(g -> {
+                if (g instanceof AggregateFunction af) {
+                    failures.add(fail(g, "cannot use an aggregate [{}] for grouping", af));
+                } else if (g instanceof GroupingFunction gf) {
+                    gf.children()
+                        .forEach(
+                            c -> c.forEachDown(
+                                GroupingFunction.class,
+                                inner -> failures.add(
+                                    fail(
+                                        inner,
+                                        "cannot nest grouping functions; found [{}] inside [{}]",
+                                        inner.sourceText(),
+                                        gf.sourceText()
+                                    )
+                                )
+                            )
+                        );
+                }
+            });
+            // keep the grouping attributes (common case)
+            Attribute attr = Expressions.attribute(e);
+            if (attr != null) {
+                groupRefs.add(attr);
+            }
+            if (e instanceof FieldAttribute f && f.dataType().isCounter()) {
+                failures.add(fail(e, "cannot group by on [{}] type for grouping [{}]", f.dataType().typeName(), e.sourceText()));
+            }
+        });
+
+        // check aggregates - accept only aggregate functions or expressions over grouping
+        // don't allow the group by itself to avoid duplicates in the output
+        // and since the groups are copied, only look at the declared aggregates
+        // List<? extends NamedExpression> aggs = agg.aggregates();
+        aggregates.subList(0, aggregates.size() - groupings.size()).forEach(e -> {
+            var exp = Alias.unwrap(e);
+            if (exp.foldable()) {
+                failures.add(fail(exp, "expected an aggregate function but found [{}]", exp.sourceText()));
+            }
+            // traverse the tree to find invalid matches
+            checkInvalidNamedExpressionUsage(exp, groupings, groupRefs, failures, 0);
+        });
+        if (aggregateType() == Aggregate.AggregateType.METRICS) {
+            aggregates.forEach(a -> checkRateAggregates(a, 0, failures));
+        } else {
+            forEachExpression(
+                Rate.class,
+                r -> failures.add(fail(r, "the rate aggregate[{}] can only be used within the metrics command", r.sourceText()))
+            );
+        }
+        checkCategorizeGrouping(failures);
+
+    }
+
+    /**
+     * Check CATEGORIZE grouping function usages.
+     * <p>
+     *     Some of those checks are temporary, until the required syntax or engine changes are implemented.
+     * </p>
+     */
+    private void checkCategorizeGrouping(Failures failures) {
+        // Forbid CATEGORIZE grouping function with other groupings
+        if (groupings.size() > 1) {
+            groupings.subList(1, groupings.size()).forEach(g -> {
+                g.forEachDown(
+                    Categorize.class,
+                    categorize -> failures.add(
+                        fail(
+                            categorize,
+                            "CATEGORIZE grouping function [{}] can only be in the first grouping expression",
+                            categorize.sourceText()
+                        )
+                    )
+                );
+            });
+        }
+
+        // Forbid CATEGORIZE grouping functions not being top level groupings
+        groupings.forEach(g -> {
+            // Check all CATEGORIZE but the top level one
+            Alias.unwrap(g)
+                .children()
+                .forEach(
+                    child -> child.forEachDown(
+                        Categorize.class,
+                        c -> failures.add(
+                            fail(c, "CATEGORIZE grouping function [{}] can't be used within other expressions", c.sourceText())
+                        )
+                    )
+                );
+        });
+
+        // Forbid CATEGORIZE being used in the aggregations, unless it appears as a grouping
+        aggregates.forEach(
+            a -> a.forEachDown(
+                AggregateFunction.class,
+                aggregateFunction -> aggregateFunction.forEachDown(
+                    Categorize.class,
+                    categorize -> failures.add(
+                        fail(categorize, "cannot use CATEGORIZE grouping function [{}] within an aggregation", categorize.sourceText())
+                    )
+                )
+            )
+        );
+
+        // Forbid CATEGORIZE being referenced as a child of an aggregation function
+        AttributeMap<Categorize> categorizeByAttribute = new AttributeMap<>();
+        groupings.forEach(g -> {
+            g.forEachDown(Alias.class, alias -> {
+                if (alias.child() instanceof Categorize categorize) {
+                    categorizeByAttribute.put(alias.toAttribute(), categorize);
+                }
+            });
+        });
+        aggregates.forEach(a -> a.forEachDown(AggregateFunction.class, aggregate -> aggregate.forEachDown(Attribute.class, attribute -> {
+            var categorize = categorizeByAttribute.get(attribute);
+            if (categorize != null) {
+                failures.add(
+                    fail(attribute, "cannot reference CATEGORIZE grouping function [{}] within an aggregation", attribute.sourceText())
+                );
+            }
+        })));
+        aggregates.forEach(a -> a.forEachDown(FilteredExpression.class, fe -> fe.filter().forEachDown(Attribute.class, attribute -> {
+            var categorize = categorizeByAttribute.get(attribute);
+            if (categorize != null) {
+                failures.add(
+                    fail(
+                        attribute,
+                        "cannot reference CATEGORIZE grouping function [{}] within an aggregation filter",
+                        attribute.sourceText()
+                    )
+                );
+            }
+        })));
+    }
+
+    private static void checkRateAggregates(Expression expr, int nestedLevel, Failures failures) {
+        if (expr instanceof AggregateFunction) {
+            nestedLevel++;
+        }
+        if (expr instanceof Rate r) {
+            if (nestedLevel != 2) {
+                failures.add(
+                    fail(
+                        expr,
+                        "the rate aggregate [{}] can only be used within the metrics command and inside another aggregate",
+                        r.sourceText()
+                    )
+                );
+            }
+        }
+        for (Expression child : expr.children()) {
+            checkRateAggregates(child, nestedLevel, failures);
+        }
+    }
+
+    // traverse the expression and look either for an agg function or a grouping match
+    // stop either when no children are left, the leafs are literals or a reference attribute is given
+    private static void checkInvalidNamedExpressionUsage(
+        Expression e,
+        List<Expression> groups,
+        AttributeSet groupRefs,
+        Failures failures,
+        int level
+    ) {
+        // unwrap filtered expression
+        if (e instanceof FilteredExpression fe) {
+            e = fe.delegate();
+            // make sure they work on aggregate functions
+            if (e.anyMatch(AggregateFunction.class::isInstance) == false) {
+                Expression filter = fe.filter();
+                failures.add(fail(filter, "WHERE clause allowed only for aggregate functions, none found in [{}]", fe.sourceText()));
+            }
+            Expression f = fe.filter();
+            // check filter's data type
+            checkFilterConditionDataType(f, failures);
+            // but that the filter doesn't use grouping or aggregate functions
+            fe.filter().forEachDown(c -> {
+                if (c instanceof AggregateFunction af) {
+                    failures.add(
+                        fail(af, "cannot use aggregate function [{}] in aggregate WHERE clause [{}]", af.sourceText(), fe.sourceText())
+                    );
+                }
+                // check the grouping function against the group
+                else if (c instanceof GroupingFunction gf) {
+                    if (c instanceof Categorize
+                        || Expressions.anyMatch(groups, ex -> ex instanceof Alias a && a.child().semanticEquals(gf)) == false) {
+                        failures.add(fail(gf, "can only use grouping function [{}] as part of the BY clause", gf.sourceText()));
+                    }
+                }
+            });
+        }
+        // found an aggregate, constant or a group, bail out
+        if (e instanceof AggregateFunction af) {
+            af.field().forEachDown(AggregateFunction.class, f -> {
+                // rate aggregate is allowed to be inside another aggregate
+                if (f instanceof Rate == false) {
+                    failures.add(fail(f, "nested aggregations [{}] not allowed inside other aggregations [{}]", f, af));
+                }
+            });
+        } else if (e instanceof GroupingFunction gf) {
+            // optimizer will later unroll expressions with aggs and non-aggs with a grouping function into an EVAL, but that will no longer
+            // be verified (by check above in checkAggregate()), so do it explicitly here
+            if (Expressions.anyMatch(groups, ex -> ex instanceof Alias a && a.child().semanticEquals(gf)) == false) {
+                failures.add(fail(gf, "can only use grouping function [{}] as part of the BY clause", gf.sourceText()));
+            } else if (level == 0) {
+                addFailureOnGroupingUsedNakedInAggs(failures, gf, "function");
+            }
+        } else if (e.foldable()) {
+            // don't do anything
+        } else if (groups.contains(e) || groupRefs.contains(e)) {
+            if (level == 0) {
+                addFailureOnGroupingUsedNakedInAggs(failures, e, "key");
+            }
+        }
+        // if a reference is found, mark it as an error
+        else if (e instanceof NamedExpression ne) {
+            boolean foundInGrouping = false;
+            for (Expression g : groups) {
+                if (g.anyMatch(se -> se.semanticEquals(ne))) {
+                    foundInGrouping = true;
+                    failures.add(
+                        fail(
+                            e,
+                            "column [{}] cannot be used as an aggregate once declared in the STATS BY grouping key [{}]",
+                            ne.name(),
+                            g.sourceText()
+                        )
+                    );
+                    break;
+                }
+            }
+            if (foundInGrouping == false) {
+                failures.add(fail(e, "column [{}] must appear in the STATS BY clause or be used in an aggregate function", ne.name()));
+            }
+        }
+        // other keep on going
+        else {
+            for (Expression child : e.children()) {
+                checkInvalidNamedExpressionUsage(child, groups, groupRefs, failures, level + 1);
+            }
+        }
+    }
+
+    private static void addFailureOnGroupingUsedNakedInAggs(Failures failures, Expression e, String element) {
+        failures.add(
+            fail(e, "grouping {} [{}] cannot be used as an aggregate once declared in the STATS BY clause", element, e.sourceText())
+        );
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Enrich.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Enrich.java
@@ -17,6 +17,8 @@ import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisPlanVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -39,11 +41,13 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.core.expression.Expressions.asAttributes;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
-public class Enrich extends UnaryPlan implements GeneratingPlan<Enrich> {
+public class Enrich extends UnaryPlan implements GeneratingPlan<Enrich>, PostAnalysisPlanVerificationAware {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         LogicalPlan.class,
         "Enrich",
@@ -273,5 +277,43 @@ public class Enrich extends UnaryPlan implements GeneratingPlan<Enrich> {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), mode, policyName, matchField, policy, concreteIndices, enrichFields);
+    }
+
+    @Override
+    public BiConsumer<LogicalPlan, Failures> postAnalysisPlanVerification() {
+        return Enrich::checkRemoteEnrich;
+    }
+
+    /**
+     * Ensure that no remote enrich is allowed after a reduction or an enrich with coordinator mode.
+     * <p>
+     * TODO:
+     * For Limit and TopN, we can insert the same node after the remote enrich (also needs to move projections around)
+     * to eliminate this limitation. Otherwise, we force users to write queries that might not perform well.
+     * For example, `FROM test | ORDER @timestamp | LIMIT 10 | ENRICH _remote:` doesn't work.
+     * In that case, users have to write it as `FROM test | ENRICH _remote: | ORDER @timestamp | LIMIT 10`,
+     * which is equivalent to bringing all data to the coordinating cluster.
+     * We might consider implementing the actual remote enrich on the coordinating cluster, however, this requires
+     * retaining the originating cluster and restructing pages for routing, which might be complicated.
+     */
+    private static void checkRemoteEnrich(LogicalPlan plan, Failures failures) {
+        boolean[] agg = { false };
+        boolean[] enrichCoord = { false };
+
+        plan.forEachUp(UnaryPlan.class, u -> {
+            if (u instanceof Aggregate) {
+                agg[0] = true;
+            } else if (u instanceof Enrich enrich && enrich.mode() == Enrich.Mode.COORDINATOR) {
+                enrichCoord[0] = true;
+            }
+            if (u instanceof Enrich enrich && enrich.mode() == Enrich.Mode.REMOTE) {
+                if (agg[0]) {
+                    failures.add(fail(enrich, "ENRICH with remote policy can't be executed after STATS"));
+                }
+                if (enrichCoord[0]) {
+                    failures.add(fail(enrich, "ENRICH with remote policy can't be executed after another ENRICH with coordinator policy"));
+                }
+            }
+        });
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.plan.logical;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -20,6 +22,9 @@ import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.plan.GeneratingPlan;
 
@@ -28,10 +33,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.core.expression.Expressions.asAttributes;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
-public class Eval extends UnaryPlan implements GeneratingPlan<Eval> {
+public class Eval extends UnaryPlan implements GeneratingPlan<Eval>, PostAnalysisVerificationAware {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "Eval", Eval::new);
 
     private final List<Alias> fields;
@@ -160,5 +166,31 @@ public class Eval extends UnaryPlan implements GeneratingPlan<Eval> {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), fields);
+    }
+
+    @Override
+    public void postAnalysisVerification(Failures failures) {
+        fields.forEach(field -> {
+            // check supported types
+            DataType dataType = field.dataType();
+            if (DataType.isRepresentable(dataType) == false) {
+                failures.add(
+                    fail(
+                        field,
+                        "EVAL does not support type [{}] as the return data type of expression [{}]",
+                        dataType.typeName(),
+                        field.child().sourceText()
+                    )
+                );
+            }
+            // check no aggregate functions are used
+            field.forEachDown(AggregateFunction.class, af -> {
+                if (af instanceof Rate) {
+                    failures.add(fail(af, "aggregate function [{}] not allowed outside METRICS command", af.sourceText()));
+                } else {
+                    failures.add(fail(af, "aggregate function [{}] not allowed outside STATS command", af.sourceText()));
+                }
+            });
+        });
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Filter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Filter.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.esql.plan.logical;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -17,12 +19,16 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import java.io.IOException;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
+import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
+import static org.elasticsearch.xpack.esql.core.type.DataType.NULL;
+
 /**
  * A {@code Filter} is a type of Plan that performs filtering of results. In
  * {@code SELECT x FROM y WHERE z ..} the "WHERE" clause is a Filter. A
  * {@code Filter} has a "condition" Expression that does the filtering.
  */
-public class Filter extends UnaryPlan {
+public class Filter extends UnaryPlan implements PostAnalysisVerificationAware {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "Filter", Filter::new);
 
     private final Expression condition;
@@ -97,5 +103,16 @@ public class Filter extends UnaryPlan {
 
     public Filter with(LogicalPlan child, Expression conditionExpr) {
         return new Filter(source(), child, conditionExpr);
+    }
+
+    @Override
+    public void postAnalysisVerification(Failures failures) {
+        checkFilterConditionDataType(condition, failures);
+    }
+
+    public static void checkFilterConditionDataType(Expression expression, Failures failures) {
+        if (expression.dataType() != NULL && expression.dataType() != BOOLEAN) {
+            failures.add(fail(expression, "Condition expression needs to be boolean, found [{}]", expression.dataType()));
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/OrderBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/OrderBy.java
@@ -9,9 +9,12 @@ package org.elasticsearch.xpack.esql.plan.logical;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
@@ -19,7 +22,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class OrderBy extends UnaryPlan {
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
+
+public class OrderBy extends UnaryPlan implements PostAnalysisVerificationAware {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "OrderBy", OrderBy::new);
 
     private final List<Order> order;
@@ -90,5 +95,17 @@ public class OrderBy extends UnaryPlan {
 
         OrderBy other = (OrderBy) obj;
         return Objects.equals(order, other.order) && Objects.equals(child(), other.child());
+    }
+
+    @Override
+    public void postAnalysisVerification(Failures failures) {
+        /**
+         * Some datatypes are not sortable
+         */
+        order.forEach(order -> {
+            if (DataType.isSortable(order.dataType()) == false) {
+                failures.add(fail(order, "cannot sort on " + order.dataType().typeName()));
+            }
+        });
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/RegexExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/RegexExtract.java
@@ -7,20 +7,24 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.plan.GeneratingPlan;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
-public abstract class RegexExtract extends UnaryPlan implements GeneratingPlan<RegexExtract> {
+public abstract class RegexExtract extends UnaryPlan implements GeneratingPlan<RegexExtract>, PostAnalysisVerificationAware {
     protected final Expression input;
     protected final List<Attribute> extractedFields;
 
@@ -92,4 +96,22 @@ public abstract class RegexExtract extends UnaryPlan implements GeneratingPlan<R
     public int hashCode() {
         return Objects.hash(super.hashCode(), input, extractedFields);
     }
+
+    @Override
+    public void postAnalysisVerification(Failures failures) {
+        DataType type = input.dataType();
+        if (DataType.isString(type) == false) {
+            failures.add(
+                fail(
+                    input,
+                    "{} only supports KEYWORD or TEXT values, found expression [{}] type [{}]",
+                    getClass().getSimpleName(),
+                    input.sourceText(),
+                    type
+                )
+            );
+        }
+
+    }
+
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Row.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Row.java
@@ -8,17 +8,22 @@
 package org.elasticsearch.xpack.esql.plan.logical;
 
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.util.List;
 import java.util.Objects;
 
-public class Row extends LeafPlan {
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
+
+public class Row extends LeafPlan implements PostAnalysisVerificationAware {
 
     private final List<Alias> fields;
 
@@ -72,5 +77,14 @@ public class Row extends LeafPlan {
     @Override
     public int hashCode() {
         return Objects.hash(fields);
+    }
+
+    @Override
+    public void postAnalysisVerification(Failures failures) {
+        fields.forEach(a -> {
+            if (DataType.isRepresentable(a.dataType()) == false) {
+                failures.add(fail(a.child(), "cannot use [{}] directly in a row assignment", a.child().sourceText()));
+            }
+        });
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/Join.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/Join.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.plan.logical.join;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
@@ -25,10 +27,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 import static org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes.LEFT;
 
-public class Join extends BinaryPlan {
+public class Join extends BinaryPlan implements PostAnalysisVerificationAware {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "Join", Join::new);
 
     private final JoinConfig config;
@@ -206,5 +209,25 @@ public class Join extends BinaryPlan {
 
         Join other = (Join) obj;
         return config.equals(other.config) && Objects.equals(left(), other.left()) && Objects.equals(right(), other.right());
+    }
+
+    @Override
+    public void postAnalysisVerification(Failures failures) {
+        for (int i = 0; i < config.leftFields().size(); i++) {
+            Attribute leftField = config.leftFields().get(i);
+            Attribute rightField = config.rightFields().get(i);
+            if (leftField.dataType() != rightField.dataType()) {
+                failures.add(
+                    fail(
+                        leftField,
+                        "JOIN left field [{}] of type [{}] is incompatible with right field [{}] of type [{}]",
+                        leftField.name(),
+                        leftField.dataType(),
+                        rightField.name(),
+                        rightField.dataType()
+                    )
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
This adds a PostAnalysisVerificationAware interface that allows an expression, plan or even command to perform post-analysis verifications "locally", vs. having them centralized in the core verifier.

(cherry picked from commit ad264f7bf392a563688b94744e630dfbc7c4aef6)

