### PR TITLE
Lower _source.mode mapping attribute deprecation issue level.

### DIFF
--- a/docs/changelog/120059.yaml
+++ b/docs/changelog/120059.yaml
@@ -1,0 +1,5 @@
+pr: 120059
+summary: Lower `_source.mode` mapping attribute deprecation issue level
+area: Mapping
+type: bug
+issues: []

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -215,7 +215,7 @@ public class IndexDeprecationChecks {
             }));
             if (useSourceMode[0]) {
                 return new DeprecationIssue(
-                    DeprecationIssue.Level.CRITICAL,
+                    DeprecationIssue.Level.WARNING,
                     SourceFieldMapper.DEPRECATION_WARNING,
                     "https://github.com/elastic/elasticsearch/pull/117172",
                     SourceFieldMapper.DEPRECATION_WARNING,


### PR DESCRIPTION
Changed from CRITICAL to WARNING, this is just for 8.17.x.
The reason is that this deprecation issue is only a critical when upgrading to 9.x. So a warning level makes more sense in 8.17.x