### PR TITLE
Update Text Similarity Reranker to Properly Handle Aliases

### DIFF
--- a/docs/changelog/120062.yaml
+++ b/docs/changelog/120062.yaml
@@ -1,0 +1,6 @@
+pr: 120062
+summary: Update Text Similarity Reranker to Properly Handle Aliases
+area: Ranking
+type: bug
+issues:
+ - 119617

--- a/server/src/main/java/org/elasticsearch/search/rank/feature/RankFeatureShardPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/feature/RankFeatureShardPhase.java
@@ -83,7 +83,7 @@ public final class RankFeatureShardPhase {
             // FetchSearchResult#shardResult()
             SearchHits hits = fetchSearchResult.hits();
             RankFeatureShardResult featureRankShardResult = (RankFeatureShardResult) rankFeaturePhaseRankShardContext
-                .buildRankFeatureShardResult(hits, searchContext.shardTarget().getShardId().id());
+                .buildRankFeatureShardResult(hits, searchContext.request().shardRequestIndex());
             // save the result in the search context
             // need to add profiling info as well available from fetch
             if (featureRankShardResult != null) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -52,7 +52,8 @@ public class InferenceFeatures implements FeatureSpecification {
             SEMANTIC_MATCH_QUERY_REWRITE_INTERCEPTION_SUPPORTED,
             SEMANTIC_SPARSE_VECTOR_QUERY_REWRITE_INTERCEPTION_SUPPORTED,
             SemanticInferenceMetadataFieldsMapper.EXPLICIT_NULL_FIXES,
-            SEMANTIC_KNN_VECTOR_QUERY_REWRITE_INTERCEPTION_SUPPORTED
+            SEMANTIC_KNN_VECTOR_QUERY_REWRITE_INTERCEPTION_SUPPORTED,
+            TextSimilarityRankRetrieverBuilder.TEXT_SIMILARITY_RERANKER_ALIAS_HANDLING_FIX
         );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -44,6 +44,10 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
         "text_similarity_reranker_retriever_composition_supported",
         true
     );
+    public static final NodeFeature TEXT_SIMILARITY_RERANKER_ALIAS_HANDLING_FIX = new NodeFeature(
+        "text_similarity_reranker_alias_handling_fix",
+        true
+    );
 
     public static final ParseField RETRIEVER_FIELD = new ParseField("retriever");
     public static final ParseField INFERENCE_ID_FIELD = new ParseField("inference_id");

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
@@ -219,6 +219,10 @@ setup:
 
 ---
 "text similarity reranker properly handles aliases":
+  - requires:
+      cluster_features: "text_similarity_reranker_alias_handling_fix"
+      reason: Test for alias handling fix
+
   # Create an empty index that will have an earlier shard index than the index with the desired result when referenced
   # via the alias
   - do:

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
@@ -216,3 +216,78 @@ setup:
   - close_to: { hits.hits.0._explanation.value: { value: 0.4, error: 0.000001 } }
   - match: {hits.hits.0._explanation.description: "/text_similarity_reranker.match.using.inference.endpoint:.\\[my-rerank-model\\].on.document.field:.\\[text\\].*/" }
   - match: {hits.hits.0._explanation.details.0.description: "/weight.*science.*/" }
+
+---
+"text similarity reranker properly handles aliases":
+  # Create an empty index that will have an earlier shard index than the index with the desired result when referenced
+  # via the alias
+  - do:
+      indices.create:
+        index: first-test-index
+        body:
+          mappings:
+            properties:
+              text:
+                type: text
+              topic:
+                type: keyword
+              subtopic:
+                type: keyword
+
+  - do:
+      indices.create:
+        index: second-test-index
+        body:
+          settings:
+            number_of_shards: 2
+            number_of_replicas: 0
+          mappings:
+            properties:
+              text:
+                type: text
+              topic:
+                type: keyword
+              subtopic:
+                type: keyword
+
+  - do:
+      indices.put_alias:
+        index: first-test-index
+        name: test-alias
+
+  - do:
+      indices.put_alias:
+        index: second-test-index
+        name: test-alias
+
+  - do:
+      index:
+        index: second-test-index
+        id: doc_1
+        body:
+          text: "As seen from Earth, a solar eclipse happens when the Moon is directly between the Earth and the Sun."
+          topic: [ "science" ]
+          subtopic: [ "technology" ]
+        refresh: true
+
+  - do:
+      search:
+        index: test-alias
+        body:
+          track_total_hits: true
+          retriever:
+            text_similarity_reranker:
+              retriever:
+                standard:
+                  query:
+                    term:
+                      topic: "science"
+              rank_window_size: 10
+              inference_id: my-rerank-model
+              inference_text: "How often does the moon hide the sun?"
+              field: text
+          size: 10
+
+  - match: { hits.total.value: 1 }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "doc_1" }


### PR DESCRIPTION
Fixes #119617. This bug was caused by the reranker inconsistently using shard indices from the request, resulting in shard index mis-matches when using aliases.