### PR TITLE
[8.17] Fix CrossClusterEsqlRCSEnrichUnavailableRemotesIT failing tests (#119977)

### DIFF
--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1EnrichUnavailableRemotesIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1EnrichUnavailableRemotesIT.java
@@ -24,11 +24,13 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 public class CrossClusterEsqlRCS1EnrichUnavailableRemotesIT extends AbstractRemoteClusterSecurityTestCase {
     private static final AtomicBoolean SSL_ENABLED_REF = new AtomicBoolean();
@@ -185,8 +187,7 @@ public class CrossClusterEsqlRCS1EnrichUnavailableRemotesIT extends AbstractRemo
             Map<String, ?> failuresMap = (Map<String, ?>) remoteClusterFailures.get(0);
 
             Map<String, ?> reason = (Map<String, ?>) failuresMap.get("reason");
-            assertThat(reason.get("type").toString(), equalTo("connect_transport_exception"));
-            assertThat(reason.get("reason").toString(), containsString("Unable to connect to [my_remote_cluster]"));
+            assertThat(reason.get("type").toString(), oneOf("node_disconnected_exception", "connect_transport_exception"));
         } finally {
             fulfillingCluster.start();
             closeFulfillingClusterClient();
@@ -202,7 +203,11 @@ public class CrossClusterEsqlRCS1EnrichUnavailableRemotesIT extends AbstractRemo
 
             String query = "FROM to-be-enr*,my_remote_cluster:to-be-enr* | ENRICH " + randomFrom(modes) + ":employees-policy | LIMIT 10";
             ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(query)));
-            assertThat(ex.getMessage(), containsString("connect_transport_exception"));
+
+            assertThat(
+                ex.getMessage(),
+                anyOf(containsString("connect_transport_exception"), containsString("node_disconnected_exception"))
+            );
         } finally {
             fulfillingCluster.start();
             closeFulfillingClusterClient();

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS2EnrichUnavailableRemotesIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS2EnrichUnavailableRemotesIT.java
@@ -26,11 +26,13 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 public class CrossClusterEsqlRCS2EnrichUnavailableRemotesIT extends AbstractRemoteClusterSecurityTestCase {
     private static final AtomicReference<Map<String, Object>> API_KEY_MAP_REF = new AtomicReference<>();
@@ -205,8 +207,7 @@ public class CrossClusterEsqlRCS2EnrichUnavailableRemotesIT extends AbstractRemo
             Map<String, ?> failuresMap = (Map<String, ?>) remoteClusterFailures.get(0);
 
             Map<String, ?> reason = (Map<String, ?>) failuresMap.get("reason");
-            assertThat(reason.get("type").toString(), equalTo("connect_transport_exception"));
-            assertThat(reason.get("reason").toString(), containsString("Unable to connect to [my_remote_cluster]"));
+            assertThat(reason.get("type").toString(), oneOf("node_disconnected_exception", "connect_transport_exception"));
         } finally {
             fulfillingCluster.start();
             closeFulfillingClusterClient();
@@ -222,7 +223,10 @@ public class CrossClusterEsqlRCS2EnrichUnavailableRemotesIT extends AbstractRemo
 
             String query = "FROM to-be-enr*,my_remote_cluster:to-be-enr* | ENRICH " + randomFrom(modes) + ":employees-policy | LIMIT 10";
             ResponseException ex = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUser(esqlRequest(query)));
-            assertThat(ex.getMessage(), containsString("connect_transport_exception"));
+            assertThat(
+                ex.getMessage(),
+                anyOf(containsString("connect_transport_exception"), containsString("node_disconnected_exception"))
+            );
         } finally {
             fulfillingCluster.start();
             closeFulfillingClusterClient();


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Fix CrossClusterEsqlRCSEnrichUnavailableRemotesIT failing tests (#119977)