### PR TITLE
[8.x] Cleanup swapSourceProvider(...) workaround (#118480)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/lookup/SearchLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SearchLookup.java
@@ -102,14 +102,6 @@ public class SearchLookup implements SourceProvider {
         this.fieldLookupProvider = searchLookup.fieldLookupProvider;
     }
 
-    private SearchLookup(SearchLookup searchLookup, SourceProvider sourceProvider, Set<String> fieldChain) {
-        this.fieldChain = Collections.unmodifiableSet(fieldChain);
-        this.sourceProvider = sourceProvider;
-        this.fieldTypeLookup = searchLookup.fieldTypeLookup;
-        this.fieldDataLookup = searchLookup.fieldDataLookup;
-        this.fieldLookupProvider = searchLookup.fieldLookupProvider;
-    }
-
     /**
      * Creates a copy of the current {@link SearchLookup} that looks fields up in the same way, but also tracks field references
      * in order to detect cycles and prevent resolving fields that depend on more than {@link #MAX_FIELD_CHAIN_DEPTH} other fields.
@@ -153,7 +145,4 @@ public class SearchLookup implements SourceProvider {
         return sourceProvider.getSource(ctx, doc);
     }
 
-    public SearchLookup swapSourceProvider(SourceProvider sourceProvider) {
-        return new SearchLookup(this, sourceProvider, fieldChain);
-    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -33,7 +33,6 @@ import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedLookup;
-import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -342,16 +341,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
 
                 @Override
                 public SearchLookup lookup() {
-                    boolean syntheticSource = SourceFieldMapper.isSynthetic(indexSettings());
-                    var searchLookup = ctx.lookup();
-                    if (syntheticSource) {
-                        // in the context of scripts and when synthetic source is used the search lookup can't always be reused between
-                        // users of SearchLookup. This is only an issue when scripts fallback to _source, but since we can't always
-                        // accurately determine whether a script uses _source, we should do this for all script usages.
-                        // This lookup() method is only invoked for scripts / runtime fields, so it is ok to do here.
-                        searchLookup = searchLookup.swapSourceProvider(ctx.createSourceProvider());
-                    }
-                    return searchLookup;
+                    return ctx.lookup();
                 }
 
                 @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Cleanup swapSourceProvider(...) workaround (#118480)