### PR TITLE
[CI] Do not pull latest mutes from base when build is not for PR

### DIFF
--- a/.buildkite/scripts/get-latest-test-mutes.sh
+++ b/.buildkite/scripts/get-latest-test-mutes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ ! "${BUILDKITE_PULL_REQUEST:-}" || "${BUILDKITE_AGENT_META_DATA_PROVIDER:-}" == "k8s" ]]; then
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false"  || "${BUILDKITE_AGENT_META_DATA_PROVIDER:-}" == "k8s" ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
In case when Buildkite pipeline do not run for the PR the env `BUILDKITE_PULL_REQUEST` is set to "false".
In this case we do not want to override the `muted-tests.yml` file with version from main.
