### PR TITLE
Small for-loop cleanup

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -180,9 +180,7 @@ public class DesiredBalanceReconciler {
                 allocation.clusterInfo(),
                 desiredBalance
             );
-            Map<DiscoveryNode, NodeAllocationStatsAndWeight> nodeToStatsAndWeights = new HashMap<>(
-                nodeIDsToStatsAndWeights.size()
-            );
+            Map<DiscoveryNode, NodeAllocationStatsAndWeight> nodeToStatsAndWeights = new HashMap<>(nodeIDsToStatsAndWeights.size());
             for (var nodeStatsAndWeight : nodeIDsToStatsAndWeights.entrySet()) {
                 var node = allocation.nodes().get(nodeStatsAndWeight.getKey());
                 assert node != null;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -174,22 +174,21 @@ public class DesiredBalanceReconciler {
         }
 
         private void updateDesireBalanceMetrics(AllocationStats allocationStats) {
-            var nodesStatsAndWeights = nodeAllocationStatsAndWeightsCalculator.nodesAllocationStatsAndWeights(
+            var nodeIDsToStatsAndWeights = nodeAllocationStatsAndWeightsCalculator.nodesAllocationStatsAndWeights(
                 allocation.metadata(),
                 allocation.routingNodes(),
                 allocation.clusterInfo(),
                 desiredBalance
             );
-            Map<DiscoveryNode, NodeAllocationStatsAndWeight> filteredNodeAllocationStatsAndWeights = new HashMap<>(
-                nodesStatsAndWeights.size()
+            Map<DiscoveryNode, NodeAllocationStatsAndWeight> nodeToStatsAndWeights = new HashMap<>(
+                nodeIDsToStatsAndWeights.size()
             );
-            for (var nodeStatsAndWeight : nodesStatsAndWeights.entrySet()) {
+            for (var nodeStatsAndWeight : nodeIDsToStatsAndWeights.entrySet()) {
                 var node = allocation.nodes().get(nodeStatsAndWeight.getKey());
-                if (node != null) {
-                    filteredNodeAllocationStatsAndWeights.put(node, nodeStatsAndWeight.getValue());
-                }
+                assert node != null;
+                nodeToStatsAndWeights.put(node, nodeStatsAndWeight.getValue());
             }
-            desiredBalanceMetrics.updateMetrics(allocationStats, desiredBalance.weightsPerNode(), filteredNodeAllocationStatsAndWeights);
+            desiredBalanceMetrics.updateMetrics(allocationStats, desiredBalance.weightsPerNode(), nodeToStatsAndWeights);
         }
 
         private boolean allocateUnassignedInvariant() {


### PR DESCRIPTION
The same RoutingAllocation instance is used to supply the nodes to both maps, so it should be safe to assume that we'll never find a node in one map and not the other. This is purely a transformational for-loop, it is not filtering anything out.