### PR TITLE
Remove default auto_expand_replicas of lookup indices (#120073)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
@@ -171,7 +171,6 @@
         index: test_lookup
 
   - match: { test_lookup.settings.index.number_of_shards: "1"}
-  - match: { test_lookup.settings.index.auto_expand_replicas: "0-all"}
 
 ---
 "Create lookup index with one shard":
@@ -196,7 +195,6 @@
         index: test_lookup
 
   - match: { test_lookup.settings.index.number_of_shards: "1"}
-  - match: { test_lookup.settings.index.auto_expand_replicas: "0-all"}
 
 ---
 "Create lookup index with two shards":

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/LookupIndexModeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/LookupIndexModeIT.java
@@ -49,7 +49,7 @@ public class LookupIndexModeIT extends ESIntegTestCase {
         assertAcked(client().admin().indices().execute(TransportCreateIndexAction.TYPE, createRequest));
         Settings settings = client().admin().indices().prepareGetSettings("hosts").get().getIndexToSettings().get("hosts");
         assertThat(settings.get("index.mode"), equalTo("lookup"));
-        assertThat(settings.get("index.auto_expand_replicas"), equalTo("0-all"));
+        assertNull(settings.get("index.auto_expand_replicas"));
         Map<String, String> allHosts = Map.of(
             "192.168.1.2",
             "Windows",
@@ -141,7 +141,6 @@ public class LookupIndexModeIT extends ESIntegTestCase {
         Settings settings = client().admin().indices().prepareGetSettings("lookup-2").get().getIndexToSettings().get("lookup-2");
         assertThat(settings.get("index.mode"), equalTo("lookup"));
         assertThat(settings.get("index.number_of_shards"), equalTo("1"));
-        assertThat(settings.get("index.auto_expand_replicas"), equalTo("0-all"));
 
         ResizeRequest split = new ResizeRequest("lookup-3", "lookup-1");
         split.setResizeType(ResizeType.SPLIT);

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -623,10 +623,7 @@ public enum IndexMode {
                 }
             }
             if (indexMode == LOOKUP) {
-                return Settings.builder()
-                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all")
-                    .build();
+                return Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).build();
             } else {
                 return Settings.EMPTY;
             }


### PR DESCRIPTION
This change disables auto_expand_replicas on lookup indices to enhance the lookup join user experience. Users can, however, enable this setting at any time to optimize performance.
