### PR TITLE
Limit ByteSizeUnit to 2 decimals

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/bytes/BytesArrayReadLongBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/bytes/BytesArrayReadLongBenchmark.java
@@ -47,7 +47,7 @@ public class BytesArrayReadLongBenchmark {
     @Setup
     public void initResults() throws IOException {
         final BytesStreamOutput tmp = new BytesStreamOutput();
-        final long bytes = new ByteSizeValue(dataMb, ByteSizeUnit.MB).getBytes();
+        final long bytes = ByteSizeValue.of(dataMb, ByteSizeUnit.MB).getBytes();
         for (int i = 0; i < bytes / 8; i++) {
             tmp.writeLong(i);
         }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/bytes/PagedBytesReferenceReadLongBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/bytes/PagedBytesReferenceReadLongBenchmark.java
@@ -47,7 +47,7 @@ public class PagedBytesReferenceReadLongBenchmark {
     @Setup
     public void initResults() throws IOException {
         final BytesStreamOutput tmp = new BytesStreamOutput();
-        final long bytes = new ByteSizeValue(dataMb, ByteSizeUnit.MB).getBytes();
+        final long bytes = ByteSizeValue.of(dataMb, ByteSizeUnit.MB).getBytes();
         for (int i = 0; i < bytes / 8; i++) {
             tmp.writeLong(i);
         }

--- a/docs/changelog/120142.yaml
+++ b/docs/changelog/120142.yaml
@@ -6,7 +6,8 @@ issues: []
 breaking:
   title: Limit `ByteSizeUnit` to 2 decimals
   area: Infra/Core
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  details: In the past, byte values like `1.25 mb` were allowed but deprecated. Now, values with up to two decimal places are allowed,
+    unless the unit is bytes, in which case no decimals are allowed. Values with too many decimal places result in an error.
+  impact: Values with more than two decimal places, like `0.123 mb` will be rejected as an error,
+    where in the past, they'd be accepted with a deprecation warning.
   notable: false

--- a/docs/changelog/120142.yaml
+++ b/docs/changelog/120142.yaml
@@ -1,0 +1,12 @@
+pr: 120142
+summary: Limit `ByteSizeUnit` to 2 decimals
+area: Infra/Core
+type: breaking
+issues: []
+breaking:
+  title: Limit `ByteSizeUnit` to 2 decimals
+  area: Infra/Core
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users
+  notable: false

--- a/docs/changelog/120142.yaml
+++ b/docs/changelog/120142.yaml
@@ -5,7 +5,7 @@ type: breaking
 issues: []
 breaking:
   title: Limit `ByteSizeUnit` to 2 decimals
-  area: Infra/Core
+  area: Cluster and node setting
   details: In the past, byte values like `1.25 mb` were allowed but deprecated. Now, values with up to two decimal places are allowed,
     unless the unit is bytes, in which case no decimals are allowed. Values with too many decimal places result in an error.
   impact: Values with more than two decimal places, like `0.123 mb` will be rejected as an error,

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/BytesProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/BytesProcessorTests.java
@@ -77,9 +77,6 @@ public class BytesProcessorTests extends AbstractStringProcessorTestCase<Long> {
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, "1.1kb");
         Processor processor = newProcessor(fieldName, randomBoolean(), fieldName);
         processor.execute(ingestDocument);
-        assertThat(ingestDocument.getFieldValue(fieldName, expectedResultType()), equalTo(1126L));
-        assertWarnings(
-            "Fractional bytes values are deprecated. Use non-fractional bytes values instead: [1.1kb] found for setting " + "[Ingest Field]"
-        );
+        assertThat(ingestDocument.getFieldValue(fieldName, expectedResultType()), equalTo(1127L));
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -438,7 +438,7 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
             public Future<HttpResponse> answer(InvocationOnMock invocationOnMock) throws Throwable {
                 HeapBufferedAsyncResponseConsumer consumer = (HeapBufferedAsyncResponseConsumer) invocationOnMock.getArguments()[1];
                 FutureCallback callback = (FutureCallback) invocationOnMock.getArguments()[3];
-                assertEquals(new ByteSizeValue(100, ByteSizeUnit.MB).bytesAsInt(), consumer.getBufferLimit());
+                assertEquals(ByteSizeValue.of(100, ByteSizeUnit.MB).bytesAsInt(), consumer.getBufferLimit());
                 callback.failed(tooLong);
                 return null;
             }

--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -90,7 +90,7 @@ public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryInteg
     protected Settings repositorySettings(String repoName) {
         Settings.Builder settingsBuilder = Settings.builder()
             .put(super.repositorySettings(repoName))
-            .put(AzureRepository.Repository.MAX_SINGLE_PART_UPLOAD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.MB))
+            .put(AzureRepository.Repository.MAX_SINGLE_PART_UPLOAD_SIZE_SETTING.getKey(), ByteSizeValue.of(1, ByteSizeUnit.MB))
             .put(AzureRepository.Repository.CONTAINER_SETTING.getKey(), "container")
             .put(AzureStorageSettings.ACCOUNT_SETTING.getKey(), "test")
             .put(AzureRepository.Repository.DELETION_BATCH_SIZE_SETTING.getKey(), randomIntBetween(5, 256))

--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
@@ -115,7 +115,7 @@ public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyReposi
                 Settings.builder()
                     .put("container", System.getProperty("test.azure.container"))
                     .put("base_path", System.getProperty("test.azure.base") + randomAlphaOfLength(8))
-                    .put("max_single_part_upload_size", new ByteSizeValue(1, ByteSizeUnit.MB))
+                    .put("max_single_part_upload_size", ByteSizeValue.of(1, ByteSizeUnit.MB))
             )
             .get();
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -107,8 +107,8 @@ public class AzureBlobStore implements BlobStore {
     private static final Logger logger = LogManager.getLogger(AzureBlobStore.class);
     // See https://learn.microsoft.com/en-us/rest/api/storageservices/blob-batch#request-body
     public static final int MAX_ELEMENTS_PER_BATCH = 256;
-    private static final long DEFAULT_READ_CHUNK_SIZE = new ByteSizeValue(32, ByteSizeUnit.MB).getBytes();
-    private static final int DEFAULT_UPLOAD_BUFFERS_SIZE = (int) new ByteSizeValue(64, ByteSizeUnit.KB).getBytes();
+    private static final long DEFAULT_READ_CHUNK_SIZE = ByteSizeValue.of(32, ByteSizeUnit.MB).getBytes();
+    private static final int DEFAULT_UPLOAD_BUFFERS_SIZE = (int) ByteSizeValue.of(64, ByteSizeUnit.KB).getBytes();
 
     private final AzureStorageService service;
     private final BigArrays bigArrays;

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -81,7 +81,7 @@ public class AzureRepository extends MeteredBlobStoreRepository {
         );
         public static final Setting<Boolean> READONLY_SETTING = Setting.boolSetting(READONLY_SETTING_KEY, false, Property.NodeScope);
         // see ModelHelper.BLOB_DEFAULT_MAX_SINGLE_UPLOAD_SIZE
-        private static final ByteSizeValue DEFAULT_MAX_SINGLE_UPLOAD_SIZE = new ByteSizeValue(256, ByteSizeUnit.MB);
+        private static final ByteSizeValue DEFAULT_MAX_SINGLE_UPLOAD_SIZE = ByteSizeValue.of(256, ByteSizeUnit.MB);
         public static final Setting<ByteSizeValue> MAX_SINGLE_PART_UPLOAD_SIZE_SETTING = Setting.byteSizeSetting(
             "max_single_part_upload_size",
             DEFAULT_MAX_SINGLE_UPLOAD_SIZE,

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
@@ -37,7 +37,7 @@ public class AzureStorageService {
      * The maximum size of a BlockBlob block.
      * See https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs
      */
-    public static final ByteSizeValue MAX_BLOCK_SIZE = new ByteSizeValue(100, ByteSizeUnit.MB);
+    public static final ByteSizeValue MAX_BLOCK_SIZE = ByteSizeValue.of(100, ByteSizeUnit.MB);
 
     /**
      * The maximum number of blocks.

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AbstractAzureServerTestCase.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AbstractAzureServerTestCase.java
@@ -165,7 +165,7 @@ public abstract class AbstractAzureServerTestCase extends ESTestCase {
                 .put(CONTAINER_SETTING.getKey(), CONTAINER)
                 .put(ACCOUNT_SETTING.getKey(), clientName)
                 .put(LOCATION_MODE_SETTING.getKey(), locationMode)
-                .put(MAX_SINGLE_PART_UPLOAD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.MB))
+                .put(MAX_SINGLE_PART_UPLOAD_SIZE_SETTING.getKey(), ByteSizeValue.of(1, ByteSizeUnit.MB))
                 .build()
         );
 

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositorySettingsTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositorySettingsTests.java
@@ -133,7 +133,7 @@ public class AzureRepositorySettingsTests extends ESTestCase {
         // chunk size in settings
         int size = randomIntBetween(1, 256);
         azureRepository = azureRepository(Settings.builder().put("chunk_size", size + "mb").build());
-        assertEquals(new ByteSizeValue(size, ByteSizeUnit.MB), azureRepository.chunkSize());
+        assertEquals(ByteSizeValue.of(size, ByteSizeUnit.MB), azureRepository.chunkSize());
 
         // zero bytes is not allowed
         IllegalArgumentException e = expectThrows(

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -143,7 +143,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
             Settings.builder().put("chunk_size", size + "mb").build()
         );
         chunkSize = GoogleCloudStorageRepository.getSetting(GoogleCloudStorageRepository.CHUNK_SIZE, repositoryMetadata);
-        assertEquals(new ByteSizeValue(size, ByteSizeUnit.MB), chunkSize);
+        assertEquals(ByteSizeValue.of(size, ByteSizeUnit.MB), chunkSize);
 
         // zero bytes is not allowed
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
@@ -83,7 +83,7 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         final String key = "es.repository_gcs.large_blob_threshold_byte_size";
         final String largeBlobThresholdByteSizeProperty = System.getProperty(key);
         if (largeBlobThresholdByteSizeProperty == null) {
-            LARGE_BLOB_THRESHOLD_BYTE_SIZE = Math.toIntExact(new ByteSizeValue(5, ByteSizeUnit.MB).getBytes());
+            LARGE_BLOB_THRESHOLD_BYTE_SIZE = Math.toIntExact(ByteSizeValue.of(5, ByteSizeUnit.MB).getBytes());
         } else {
             final int largeBlobThresholdByteSize;
             try {

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -40,7 +40,7 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
      * Maximum allowed object size in GCS.
      * @see <a href="https://cloud.google.com/storage/quotas#objects">GCS documentation</a> for details.
      */
-    static final ByteSizeValue MAX_CHUNK_SIZE = new ByteSizeValue(5, ByteSizeUnit.TB);
+    static final ByteSizeValue MAX_CHUNK_SIZE = ByteSizeValue.of(5, ByteSizeUnit.TB);
 
     static final String TYPE = "gcs";
 

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -129,7 +129,7 @@ class S3BlobContainer extends AbstractBlobContainer {
     @Override
     public long readBlobPreferredLength() {
         // This container returns streams that must be fully consumed, so we tell consumers to make bounded requests.
-        return new ByteSizeValue(32, ByteSizeUnit.MB).getBytes();
+        return ByteSizeValue.of(32, ByteSizeUnit.MB).getBytes();
     }
 
     /**

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -99,13 +99,13 @@ class S3Repository extends MeteredBlobStoreRepository {
     /**
      * Maximum size of files that can be uploaded using a single upload request.
      */
-    static final ByteSizeValue MAX_FILE_SIZE = new ByteSizeValue(5, ByteSizeUnit.GB);
+    static final ByteSizeValue MAX_FILE_SIZE = ByteSizeValue.of(5, ByteSizeUnit.GB);
 
     /**
      * Minimum size of parts that can be uploaded using the Multipart Upload API.
      * (see http://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html)
      */
-    static final ByteSizeValue MIN_PART_SIZE_USING_MULTIPART = new ByteSizeValue(5, ByteSizeUnit.MB);
+    static final ByteSizeValue MIN_PART_SIZE_USING_MULTIPART = ByteSizeValue.of(5, ByteSizeUnit.MB);
 
     /**
      * Maximum size of parts that can be uploaded using the Multipart Upload API.
@@ -116,7 +116,7 @@ class S3Repository extends MeteredBlobStoreRepository {
     /**
      * Maximum size of files that can be uploaded using the Multipart Upload API.
      */
-    static final ByteSizeValue MAX_FILE_SIZE_USING_MULTIPART = new ByteSizeValue(5, ByteSizeUnit.TB);
+    static final ByteSizeValue MAX_FILE_SIZE_USING_MULTIPART = ByteSizeValue.of(5, ByteSizeUnit.TB);
 
     /**
      * Minimum threshold below which the chunk is uploaded using a single request. Beyond this threshold,
@@ -137,7 +137,7 @@ class S3Repository extends MeteredBlobStoreRepository {
     static final Setting<ByteSizeValue> CHUNK_SIZE_SETTING = Setting.byteSizeSetting(
         "chunk_size",
         MAX_FILE_SIZE_USING_MULTIPART,
-        new ByteSizeValue(5, ByteSizeUnit.MB),
+        ByteSizeValue.of(5, ByteSizeUnit.MB),
         MAX_FILE_SIZE_USING_MULTIPART
     );
 

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -335,7 +335,7 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
     public void testWriteLargeBlob() throws Exception {
         final boolean useTimeout = rarely();
         final TimeValue readTimeout = useTimeout ? TimeValue.timeValueMillis(randomIntBetween(100, 500)) : null;
-        final ByteSizeValue bufferSize = new ByteSizeValue(5, ByteSizeUnit.MB);
+        final ByteSizeValue bufferSize = ByteSizeValue.of(5, ByteSizeUnit.MB);
         final BlobContainer blobContainer = createBlobContainer(null, readTimeout, true, bufferSize);
 
         final int parts = randomIntBetween(1, 5);
@@ -436,7 +436,7 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
     public void testWriteLargeBlobStreaming() throws Exception {
         final boolean useTimeout = rarely();
         final TimeValue readTimeout = useTimeout ? TimeValue.timeValueMillis(randomIntBetween(100, 500)) : null;
-        final ByteSizeValue bufferSize = new ByteSizeValue(5, ByteSizeUnit.MB);
+        final ByteSizeValue bufferSize = ByteSizeValue.of(5, ByteSizeUnit.MB);
         final BlobContainer blobContainer = createBlobContainer(null, readTimeout, true, bufferSize);
 
         final int parts = randomIntBetween(1, 5);

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
@@ -93,8 +93,8 @@ public class S3RepositoryTests extends ESTestCase {
     private Settings bufferAndChunkSettings(long buffer, long chunk) {
         return Settings.builder()
             .put(S3Repository.BUCKET_SETTING.getKey(), "bucket")
-            .put(S3Repository.BUFFER_SIZE_SETTING.getKey(), new ByteSizeValue(buffer, ByteSizeUnit.MB).getStringRep())
-            .put(S3Repository.CHUNK_SIZE_SETTING.getKey(), new ByteSizeValue(chunk, ByteSizeUnit.MB).getStringRep())
+            .put(S3Repository.BUFFER_SIZE_SETTING.getKey(), ByteSizeValue.of(buffer, ByteSizeUnit.MB).getStringRep())
+            .put(S3Repository.CHUNK_SIZE_SETTING.getKey(), ByteSizeValue.of(chunk, ByteSizeUnit.MB).getStringRep())
             .build();
     }
 

--- a/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobStore.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobStore.java
@@ -33,7 +33,7 @@ public class URLBlobStore implements BlobStore {
 
     static final Setting<ByteSizeValue> BUFFER_SIZE_SETTING = Setting.byteSizeSetting(
         "repositories.uri.buffer_size",
-        new ByteSizeValue(100, ByteSizeUnit.KB),
+        ByteSizeValue.of(100, ByteSizeUnit.KB),
         Setting.Property.NodeScope
     );
 

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
@@ -42,7 +42,7 @@ import static org.hamcrest.Matchers.hasSize;
 @ClusterScope(scope = Scope.TEST, supportsDedicatedMasters = false, numClientNodes = 0, numDataNodes = 1)
 public class Netty4HttpRequestSizeLimitIT extends ESNetty4IntegTestCase {
 
-    private static final ByteSizeValue LIMIT = new ByteSizeValue(2, ByteSizeUnit.KB);
+    private static final ByteSizeValue LIMIT = ByteSizeValue.of(2, ByteSizeUnit.KB);
 
     @Override
     protected boolean addMockHttpTransport() {

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -96,7 +96,7 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings));
-        builder.put(HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH.getKey(), new ByteSizeValue(50, ByteSizeUnit.MB));
+        builder.put(HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH.getKey(), ByteSizeValue.of(50, ByteSizeUnit.MB));
         return builder.build();
     }
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Plugin.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Plugin.java
@@ -57,7 +57,7 @@ public class Netty4Plugin extends Plugin implements NetworkPlugin {
     );
     public static final Setting<ByteSizeValue> SETTING_HTTP_NETTY_RECEIVE_PREDICTOR_SIZE = byteSizeSetting(
         "http.netty.receive_predictor_size",
-        new ByteSizeValue(64, ByteSizeUnit.KB),
+        ByteSizeValue.of(64, ByteSizeUnit.KB),
         Setting.Property.NodeScope
     );
     public static final Setting<Integer> WORKER_COUNT = new Setting<>(
@@ -68,7 +68,7 @@ public class Netty4Plugin extends Plugin implements NetworkPlugin {
     );
     private static final Setting<ByteSizeValue> NETTY_RECEIVE_PREDICTOR_SIZE = byteSizeSetting(
         "transport.netty.receive_predictor_size",
-        new ByteSizeValue(64, ByteSizeUnit.KB),
+        ByteSizeValue.of(64, ByteSizeUnit.KB),
         Setting.Property.NodeScope
     );
     public static final Setting<ByteSizeValue> NETTY_RECEIVE_PREDICTOR_MAX = byteSizeSetting(

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -316,7 +316,7 @@ public class RolloverIT extends ESIntegTestCase {
         final RolloverResponse response = indicesAdmin().prepareRolloverIndex("test_alias")
             .setConditions(
                 RolloverConditions.newBuilder()
-                    .addMaxIndexSizeCondition(new ByteSizeValue(10, ByteSizeUnit.MB))
+                    .addMaxIndexSizeCondition(ByteSizeValue.of(10, ByteSizeUnit.MB))
                     .addMaxIndexAgeCondition(TimeValue.timeValueHours(4))
             )
             .get();
@@ -330,7 +330,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(
             conditions,
             containsInAnyOrder(
-                new MaxSizeCondition(new ByteSizeValue(10, ByteSizeUnit.MB)).toString(),
+                new MaxSizeCondition(ByteSizeValue.of(10, ByteSizeUnit.MB)).toString(),
                 new MaxAgeCondition(TimeValue.timeValueHours(4)).toString()
             )
         );
@@ -447,7 +447,7 @@ public class RolloverIT extends ESIntegTestCase {
             final RolloverResponse response = indicesAdmin().prepareRolloverIndex("test_alias")
                 .setConditions(
                     RolloverConditions.newBuilder()
-                        .addMaxIndexSizeCondition(new ByteSizeValue(randomIntBetween(100, 50 * 1024), ByteSizeUnit.MB))
+                        .addMaxIndexSizeCondition(ByteSizeValue.of(randomIntBetween(100, 50 * 1024), ByteSizeUnit.MB))
                 )
                 .get();
             assertThat(response.getOldIndex(), equalTo("test-1"));
@@ -459,7 +459,7 @@ public class RolloverIT extends ESIntegTestCase {
 
         // A small max_size
         {
-            ByteSizeValue maxSizeValue = new ByteSizeValue(randomIntBetween(1, 20), ByteSizeUnit.BYTES);
+            ByteSizeValue maxSizeValue = ByteSizeValue.of(randomIntBetween(1, 20), ByteSizeUnit.BYTES);
             long beforeTime = client().threadPool().absoluteTimeInMillis() - 1000L;
             final RolloverResponse response = indicesAdmin().prepareRolloverIndex("test_alias")
                 .setConditions(RolloverConditions.newBuilder().addMaxIndexSizeCondition(maxSizeValue))
@@ -482,7 +482,7 @@ public class RolloverIT extends ESIntegTestCase {
             final RolloverResponse response = indicesAdmin().prepareRolloverIndex("test_alias")
                 .setConditions(
                     RolloverConditions.newBuilder()
-                        .addMaxIndexSizeCondition(new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES))
+                        .addMaxIndexSizeCondition(ByteSizeValue.of(randomNonNegativeLong(), ByteSizeUnit.BYTES))
                         .addMinIndexDocsCondition(1L)
                 )
                 .get();
@@ -512,7 +512,7 @@ public class RolloverIT extends ESIntegTestCase {
             final RolloverResponse response = indicesAdmin().prepareRolloverIndex("test_alias")
                 .setConditions(
                     RolloverConditions.newBuilder()
-                        .addMaxPrimaryShardSizeCondition(new ByteSizeValue(randomIntBetween(100, 50 * 1024), ByteSizeUnit.MB))
+                        .addMaxPrimaryShardSizeCondition(ByteSizeValue.of(randomIntBetween(100, 50 * 1024), ByteSizeUnit.MB))
                 )
                 .get();
             assertThat(response.getOldIndex(), equalTo("test-1"));
@@ -524,7 +524,7 @@ public class RolloverIT extends ESIntegTestCase {
 
         // A small max_primary_shard_size
         {
-            ByteSizeValue maxPrimaryShardSizeCondition = new ByteSizeValue(randomIntBetween(1, 20), ByteSizeUnit.BYTES);
+            ByteSizeValue maxPrimaryShardSizeCondition = ByteSizeValue.of(randomIntBetween(1, 20), ByteSizeUnit.BYTES);
             long beforeTime = client().threadPool().absoluteTimeInMillis() - 1000L;
             final RolloverResponse response = indicesAdmin().prepareRolloverIndex("test_alias")
                 .setConditions(RolloverConditions.newBuilder().addMaxPrimaryShardSizeCondition(maxPrimaryShardSizeCondition))
@@ -547,7 +547,7 @@ public class RolloverIT extends ESIntegTestCase {
             final RolloverResponse response = indicesAdmin().prepareRolloverIndex("test_alias")
                 .setConditions(
                     RolloverConditions.newBuilder()
-                        .addMaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES))
+                        .addMaxPrimaryShardSizeCondition(ByteSizeValue.of(randomNonNegativeLong(), ByteSizeUnit.BYTES))
                         .addMinIndexDocsCondition(1L)
                 )
                 .get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessor2IT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessor2IT.java
@@ -53,7 +53,7 @@ public class BulkProcessor2IT extends ESIntegTestCase {
             // let's make sure that the bulk action limit trips, one single execution will index all the documents
             .setBulkActions(numDocs)
             .setFlushInterval(TimeValue.timeValueHours(24))
-            .setBulkSize(new ByteSizeValue(1, ByteSizeUnit.GB))
+            .setBulkSize(ByteSizeValue.of(1, ByteSizeUnit.GB))
             .build();
         try {
 
@@ -89,7 +89,7 @@ public class BulkProcessor2IT extends ESIntegTestCase {
             .setBulkActions(bulkActions)
             // set interval and size to high values
             .setFlushInterval(TimeValue.timeValueHours(24))
-            .setBulkSize(new ByteSizeValue(1, ByteSizeUnit.GB))
+            .setBulkSize(ByteSizeValue.of(1, ByteSizeUnit.GB))
             .build();
         try {
 
@@ -134,7 +134,7 @@ public class BulkProcessor2IT extends ESIntegTestCase {
             // let's make sure that the bulk action limit trips, one single execution will index all the documents
             .setBulkActions(numDocs)
             .setFlushInterval(TimeValue.timeValueHours(24))
-            .setBulkSize(new ByteSizeValue(randomIntBetween(1, 10), RandomPicks.randomFrom(random(), ByteSizeUnit.values())))
+            .setBulkSize(ByteSizeValue.of(randomIntBetween(1, 10), RandomPicks.randomFrom(random(), ByteSizeUnit.values())))
             .build();
 
         MultiGetRequestBuilder multiGetRequestBuilder = indexDocs(client(), processor, numDocs);
@@ -169,7 +169,7 @@ public class BulkProcessor2IT extends ESIntegTestCase {
             .setBulkActions(bulkActions)
             // set interval and size to high values
             .setFlushInterval(TimeValue.timeValueHours(24))
-            .setBulkSize(new ByteSizeValue(1, ByteSizeUnit.GB))
+            .setBulkSize(ByteSizeValue.of(1, ByteSizeUnit.GB))
             .build();
         try {
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorIT.java
@@ -55,7 +55,7 @@ public class BulkProcessorIT extends ESIntegTestCase {
                 .setConcurrentRequests(randomIntBetween(0, 1))
                 .setBulkActions(numDocs)
                 .setFlushInterval(TimeValue.timeValueHours(24))
-                .setBulkSize(new ByteSizeValue(1, ByteSizeUnit.GB))
+                .setBulkSize(ByteSizeValue.of(1, ByteSizeUnit.GB))
                 .build()
         ) {
 
@@ -83,7 +83,7 @@ public class BulkProcessorIT extends ESIntegTestCase {
                 .setConcurrentRequests(randomIntBetween(0, 10))
                 .setBulkActions(numDocs + randomIntBetween(1, 100))
                 .setFlushInterval(TimeValue.timeValueHours(24))
-                .setBulkSize(new ByteSizeValue(1, ByteSizeUnit.GB))
+                .setBulkSize(ByteSizeValue.of(1, ByteSizeUnit.GB))
                 .build()
         ) {
 
@@ -115,7 +115,7 @@ public class BulkProcessorIT extends ESIntegTestCase {
                 .setConcurrentRequests(randomIntBetween(0, 10))
                 .setBulkActions(numDocs + randomIntBetween(1, 100))
                 .setFlushInterval(TimeValue.timeValueHours(24))
-                .setBulkSize(new ByteSizeValue(1, ByteSizeUnit.GB))
+                .setBulkSize(ByteSizeValue.of(1, ByteSizeUnit.GB))
                 .setFlushCondition(flushEnabled::get)
                 .build()
         ) {
@@ -159,7 +159,7 @@ public class BulkProcessorIT extends ESIntegTestCase {
                 .setBulkActions(bulkActions)
                 // set interval and size to high values
                 .setFlushInterval(TimeValue.timeValueHours(24))
-                .setBulkSize(new ByteSizeValue(1, ByteSizeUnit.GB))
+                .setBulkSize(ByteSizeValue.of(1, ByteSizeUnit.GB))
                 .build()
         ) {
 
@@ -202,7 +202,7 @@ public class BulkProcessorIT extends ESIntegTestCase {
             .setConcurrentRequests(randomIntBetween(0, 1))
             .setBulkActions(numDocs)
             .setFlushInterval(TimeValue.timeValueHours(24))
-            .setBulkSize(new ByteSizeValue(randomIntBetween(1, 10), RandomPicks.randomFrom(random(), ByteSizeUnit.values())))
+            .setBulkSize(ByteSizeValue.of(randomIntBetween(1, 10), RandomPicks.randomFrom(random(), ByteSizeUnit.values())))
             .build();
 
         MultiGetRequestBuilder multiGetRequestBuilder = indexDocs(client(), processor, numDocs);
@@ -250,7 +250,7 @@ public class BulkProcessorIT extends ESIntegTestCase {
                 .setBulkActions(bulkActions)
                 // set interval and size to high values
                 .setFlushInterval(TimeValue.timeValueHours(24))
-                .setBulkSize(new ByteSizeValue(1, ByteSizeUnit.GB))
+                .setBulkSize(ByteSizeValue.of(1, ByteSizeUnit.GB))
                 .build()
         ) {
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.equalTo;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
 
-    private static final long FLOOD_STAGE_BYTES = new ByteSizeValue(10, ByteSizeUnit.KB).getBytes();
+    private static final long FLOOD_STAGE_BYTES = ByteSizeValue.of(10, ByteSizeUnit.KB).getBytes();
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -60,7 +60,7 @@ import static org.hamcrest.Matchers.is;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
 
-    private static final long WATERMARK_BYTES = new ByteSizeValue(10, ByteSizeUnit.KB).getBytes();
+    private static final long WATERMARK_BYTES = ByteSizeValue.of(10, ByteSizeUnit.KB).getBytes();
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -98,7 +98,6 @@ import static org.elasticsearch.cluster.routing.TestShardRouting.shardRoutingBui
 import static org.elasticsearch.index.shard.IndexShardTestCase.closeShardNoCheck;
 import static org.elasticsearch.index.shard.IndexShardTestCase.getTranslog;
 import static org.elasticsearch.index.shard.IndexShardTestCase.recoverFromStore;
-import static org.elasticsearch.indices.cluster.AbstractIndicesClusterStateServiceTestCase.awaitIndexShardCloseAsyncTasks;
 import static org.elasticsearch.test.LambdaMatchers.falseWith;
 import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -332,7 +331,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
                 Settings.builder()
                     .put(
                         IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(),
-                        new ByteSizeValue(135 /* size of the operation + one generation header&footer*/, ByteSizeUnit.BYTES)
+                        ByteSizeValue.of(135 /* size of the operation + one generation header&footer*/, ByteSizeUnit.BYTES)
                     )
                     .build()
             )
@@ -372,7 +371,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         indicesAdmin().prepareUpdateSettings("test")
             .setSettings(
                 Settings.builder()
-                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(size, ByteSizeUnit.BYTES))
+                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), ByteSizeValue.of(size, ByteSizeUnit.BYTES))
                     .build()
             )
             .get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
@@ -604,7 +604,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
     private static void disableTranslogFlush(String index) {
         updateIndexSettings(
             Settings.builder()
-                .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB)),
+                .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), ByteSizeValue.of(1, ByteSizeUnit.PB)),
             index
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -155,7 +155,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
                     // no checkindex - we corrupt shards on purpose
                     .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false)
                     // no translog based flush - it might change the .liv / segments.N files
-                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB))
+                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), ByteSizeValue.of(1, ByteSizeUnit.PB))
             )
         );
         ensureGreen();
@@ -269,7 +269,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
                     .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false) // no checkindex - we corrupt shards on
                                                                                               // purpose
                     // no translog based flush - it might change the .liv / segments.N files
-                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB))
+                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), ByteSizeValue.of(1, ByteSizeUnit.PB))
             )
         );
         ensureGreen();
@@ -544,7 +544,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
                     // no checkindex - we corrupt shards on purpose
                     .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false)
                     // no translog based flush - it might change the .liv / segments.N files
-                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB))
+                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), ByteSizeValue.of(1, ByteSizeUnit.PB))
             )
         );
         ensureGreen();
@@ -612,7 +612,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
                     // no checkindex - we corrupt shards on purpose
                     .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false)
                     // no translog based flush - it might change the .liv / segments.N files
-                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB))
+                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), ByteSizeValue.of(1, ByteSizeUnit.PB))
             )
         );
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
@@ -54,7 +54,7 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
             prepareCreate("test").setSettings(
                 indexSettings(1, 0).put("index.refresh_interval", "-1")
                     .put(MockEngineSupport.DISABLE_FLUSH_ON_CLOSE.getKey(), true) // never flush - always recover from translog
-                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB))
+                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), ByteSizeValue.of(1, ByteSizeUnit.PB))
             )
         );
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -332,7 +332,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
     }
 
     public void testLimitsRequestSize() {
-        ByteSizeValue inFlightRequestsLimit = new ByteSizeValue(8, ByteSizeUnit.KB);
+        ByteSizeValue inFlightRequestsLimit = ByteSizeValue.of(8, ByteSizeUnit.KB);
         if (noopBreakerUsed()) {
             logger.info("--> noop breakers used, skipping test");
             return;

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -256,7 +256,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     public Settings.Builder createRecoverySettingsChunkPerSecond(long chunkSizeBytes) {
         return Settings.builder()
             // Set the chunk size in bytes
-            .put(RecoverySettings.INDICES_RECOVERY_CHUNK_SIZE.getKey(), new ByteSizeValue(chunkSizeBytes, ByteSizeUnit.BYTES))
+            .put(RecoverySettings.INDICES_RECOVERY_CHUNK_SIZE.getKey(), ByteSizeValue.of(chunkSizeBytes, ByteSizeUnit.BYTES))
             // Set one chunk of bytes per second.
             .put(RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), chunkSizeBytes, ByteSizeUnit.BYTES);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -270,7 +270,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             IndexService indexService = service.indexService(resolveIndex("test"));
             if (indexService != null) {
                 assertEquals(indexService.getIndexSettings().getRefreshInterval().millis(), -1);
-                assertEquals(indexService.getIndexSettings().getFlushThresholdSize(new ByteSizeValue(1, ByteSizeUnit.TB)).getBytes(), 1024);
+                assertEquals(indexService.getIndexSettings().getFlushThresholdSize(ByteSizeValue.of(1, ByteSizeUnit.TB)).getBytes(), 1024);
                 assertEquals(indexService.getIndexSettings().getGenerationThresholdSize().getBytes(), 4096);
             }
         }
@@ -281,7 +281,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             IndexService indexService = service.indexService(resolveIndex("test"));
             if (indexService != null) {
                 assertEquals(indexService.getIndexSettings().getRefreshInterval().millis(), 1000);
-                assertEquals(indexService.getIndexSettings().getFlushThresholdSize(new ByteSizeValue(1, ByteSizeUnit.TB)).getBytes(), 1024);
+                assertEquals(indexService.getIndexSettings().getFlushThresholdSize(ByteSizeValue.of(1, ByteSizeUnit.TB)).getBytes(), 1024);
                 assertEquals(indexService.getIndexSettings().getGenerationThresholdSize().getBytes(), 4096);
             }
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -74,7 +74,7 @@ public class CloseIndexIT extends ESIntegTestCase {
             .put(super.indexSettings())
             .put(
                 IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(),
-                new ByteSizeValue(randomIntBetween(1, 4096), ByteSizeUnit.KB)
+                ByteSizeValue.of(randomIntBetween(1, 4096), ByteSizeUnit.KB)
             )
             .build();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/TruncatedRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/TruncatedRecoveryIT.java
@@ -63,10 +63,7 @@ public class TruncatedRecoveryIT extends ESIntegTestCase {
     public void testCancelRecoveryAndResume() throws Exception {
         updateClusterSettings(
             Settings.builder()
-                .put(
-                    RecoverySettings.INDICES_RECOVERY_CHUNK_SIZE.getKey(),
-                    new ByteSizeValue(randomIntBetween(50, 300), ByteSizeUnit.BYTES)
-                )
+                .put(RecoverySettings.INDICES_RECOVERY_CHUNK_SIZE.getKey(), ByteSizeValue.of(randomIntBetween(50, 300), ByteSizeUnit.BYTES))
         );
 
         NodesStatsResponse nodeStats = clusterAdmin().prepareNodesStats().get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/fs/FsBlobStoreRepositoryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/fs/FsBlobStoreRepositoryIT.java
@@ -21,7 +21,7 @@ public class FsBlobStoreRepositoryIT extends ESFsBasedRepositoryIntegTestCase {
         final Settings.Builder settings = Settings.builder().put("compress", randomBoolean()).put("location", randomRepoPath());
         if (randomBoolean()) {
             long size = 1 << randomInt(10);
-            settings.put("chunk_size", new ByteSizeValue(size, ByteSizeUnit.KB));
+            settings.put("chunk_size", ByteSizeValue.of(size, ByteSizeUnit.KB));
         }
         return settings.build();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
@@ -497,7 +497,7 @@ public class SnapshotShutdownIT extends AbstractSnapshotIntegTestCase {
         final String nodeForRemovalId = internalCluster().getInstance(NodeEnvironment.class, nodeForRemoval).nodeId();
         final var indexName = randomIdentifier();
         createIndexWithContent(indexName, indexSettings(numShards, 0).put(REQUIRE_NODE_NAME_SETTING, nodeForRemoval).build());
-        indexAllShardsToAnEqualOrGreaterMinimumSize(indexName, new ByteSizeValue(2, ByteSizeUnit.KB).getBytes());
+        indexAllShardsToAnEqualOrGreaterMinimumSize(indexName, ByteSizeValue.of(2, ByteSizeUnit.KB).getBytes());
 
         // Start the snapshot with blocking in place on the data node not to allow shard snapshots to finish yet.
         final var clusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -157,6 +157,7 @@ public class TransportVersions {
     public static final TransportVersion ELASTIC_INFERENCE_SERVICE_UNIFIED_CHAT_COMPLETIONS_INTEGRATION = def(8_822_00_0);
     public static final TransportVersion KQL_QUERY_TECH_PREVIEW = def(8_823_00_0);
     public static final TransportVersion ESQL_PROFILE_ROWS_PROCESSED = def(8_824_00_0);
+    public static final TransportVersion BYTE_SIZE_VALUE_ALWAYS_USES_BYTES = def(8_825_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
@@ -84,7 +84,7 @@ public class BulkProcessor implements Closeable {
         private final Runnable onClose;
         private int concurrentRequests = 1;
         private int bulkActions = 1000;
-        private ByteSizeValue bulkSize = new ByteSizeValue(5, ByteSizeUnit.MB);
+        private ByteSizeValue bulkSize = ByteSizeValue.of(5, ByteSizeUnit.MB);
         private TimeValue flushInterval = null;
         private BackoffPolicy backoffPolicy = BackoffPolicy.exponentialBackoff();
         private String globalIndex;

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor2.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor2.java
@@ -76,8 +76,8 @@ public class BulkProcessor2 implements Closeable {
         private final Listener listener;
         private final ThreadPool threadPool;
         private int maxRequestsInBulk = 1000;
-        private ByteSizeValue maxBulkSizeInBytes = new ByteSizeValue(5, ByteSizeUnit.MB);
-        private ByteSizeValue maxBytesInFlight = new ByteSizeValue(50, ByteSizeUnit.MB);
+        private ByteSizeValue maxBulkSizeInBytes = ByteSizeValue.of(5, ByteSizeUnit.MB);
+        private ByteSizeValue maxBytesInFlight = ByteSizeValue.of(50, ByteSizeUnit.MB);
         private TimeValue flushInterval = null;
         private int maxNumberOfRetries = 3;
 

--- a/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -87,19 +87,19 @@ public final class HttpTransportSettings {
     );
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_CONTENT_LENGTH = Setting.byteSizeSetting(
         "http.max_content_length",
-        new ByteSizeValue(100, ByteSizeUnit.MB),
+        ByteSizeValue.of(100, ByteSizeUnit.MB),
         ByteSizeValue.ZERO,
         ByteSizeValue.ofBytes(Integer.MAX_VALUE),
         Property.NodeScope
     );
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_CHUNK_SIZE = Setting.byteSizeSetting(
         "http.max_chunk_size",
-        new ByteSizeValue(8, ByteSizeUnit.KB),
+        ByteSizeValue.of(8, ByteSizeUnit.KB),
         Property.NodeScope
     );
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_HEADER_SIZE = Setting.byteSizeSetting(
         "http.max_header_size",
-        new ByteSizeValue(16, ByteSizeUnit.KB),
+        ByteSizeValue.of(16, ByteSizeUnit.KB),
         Property.NodeScope
     );
     public static final Setting<Integer> SETTING_HTTP_MAX_WARNING_HEADER_COUNT = intSetting(
@@ -115,7 +115,7 @@ public final class HttpTransportSettings {
     );
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_INITIAL_LINE_LENGTH = Setting.byteSizeSetting(
         "http.max_initial_line_length",
-        new ByteSizeValue(4, ByteSizeUnit.KB),
+        ByteSizeValue.of(4, ByteSizeUnit.KB),
         Property.NodeScope
     );
 

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -353,7 +353,7 @@ public final class IndexSettings {
          * Prevent the translog from growing over 10GB or 20% of the recommended shard size of 50GB. This helps bound the maximum disk usage
          * overhead of translogs.
          */
-        new ByteSizeValue(10, ByteSizeUnit.GB),
+        ByteSizeValue.of(10, ByteSizeUnit.GB),
         /*
          * An empty translog occupies 55 bytes on disk. If the flush threshold is below this, the flush thread
          * can get stuck in an infinite loop as the shouldPeriodicallyFlush can still be true after flushing.
@@ -385,7 +385,7 @@ public final class IndexSettings {
      */
     public static final Setting<ByteSizeValue> INDEX_FLUSH_AFTER_MERGE_THRESHOLD_SIZE_SETTING = Setting.byteSizeSetting(
         "index.flush_after_merge",
-        new ByteSizeValue(512, ByteSizeUnit.MB),
+        ByteSizeValue.of(512, ByteSizeUnit.MB),
         ByteSizeValue.ZERO, // always flush after merge
         ByteSizeValue.ofBytes(Long.MAX_VALUE), // never flush after merge
         Property.Dynamic,
@@ -398,7 +398,7 @@ public final class IndexSettings {
      */
     public static final Setting<ByteSizeValue> INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING = Setting.byteSizeSetting(
         "index.translog.generation_threshold_size",
-        new ByteSizeValue(64, ByteSizeUnit.MB),
+        ByteSizeValue.of(64, ByteSizeUnit.MB),
         /*
          * An empty translog occupies 55 bytes on disk. If the generation threshold is
          * below this, the flush thread can get stuck in an infinite loop repeatedly
@@ -1431,7 +1431,7 @@ public final class IndexSettings {
         }
         assert onePercentOfTotalDiskSpace > Translog.DEFAULT_HEADER_SIZE_IN_BYTES;
         if (onePercentOfTotalDiskSpace < flushThresholdSize.getBytes()) {
-            return new ByteSizeValue(onePercentOfTotalDiskSpace, ByteSizeUnit.BYTES);
+            return ByteSizeValue.of(onePercentOfTotalDiskSpace, ByteSizeUnit.BYTES);
         } else {
             return flushThresholdSize;
         }

--- a/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
@@ -116,9 +116,9 @@ public final class MergePolicyConfig {
     private final ByteSizeValue defaultMaxTimeBasedMergedSegment;
 
     public static final double DEFAULT_EXPUNGE_DELETES_ALLOWED = 10d;
-    public static final ByteSizeValue DEFAULT_FLOOR_SEGMENT = new ByteSizeValue(2, ByteSizeUnit.MB);
+    public static final ByteSizeValue DEFAULT_FLOOR_SEGMENT = ByteSizeValue.of(2, ByteSizeUnit.MB);
     public static final int DEFAULT_MAX_MERGE_AT_ONCE = 10;
-    public static final ByteSizeValue DEFAULT_MAX_MERGED_SEGMENT = new ByteSizeValue(5, ByteSizeUnit.GB);
+    public static final ByteSizeValue DEFAULT_MAX_MERGED_SEGMENT = ByteSizeValue.of(5, ByteSizeUnit.GB);
     public static final Setting<ByteSizeValue> DEFAULT_MAX_MERGED_SEGMENT_SETTING = Setting.byteSizeSetting(
         "indices.merge.policy.max_merged_segment",
         DEFAULT_MAX_MERGED_SEGMENT,
@@ -131,7 +131,7 @@ public final class MergePolicyConfig {
      * of merging fewer segments together than the merge factor, which in-turn increases write amplification. So we set an arbitrarily high
      * roof that serves as a protection that we expect to never hit.
      */
-    public static final ByteSizeValue DEFAULT_MAX_TIME_BASED_MERGED_SEGMENT = new ByteSizeValue(100, ByteSizeUnit.GB);
+    public static final ByteSizeValue DEFAULT_MAX_TIME_BASED_MERGED_SEGMENT = ByteSizeValue.of(100, ByteSizeUnit.GB);
     public static final Setting<ByteSizeValue> DEFAULT_MAX_TIME_BASED_MERGED_SEGMENT_SETTING = Setting.byteSizeSetting(
         "indices.merge.policy.max_time_based_merged_segment",
         DEFAULT_MAX_TIME_BASED_MERGED_SEGMENT,

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -266,7 +266,7 @@ public class InternalEngine extends Engine {
                 );
                 assert translog.getGeneration() != null;
                 this.translog = translog;
-                this.totalDiskSpace = new ByteSizeValue(Environment.getFileStore(translog.location()).getTotalSpace(), ByteSizeUnit.BYTES);
+                this.totalDiskSpace = ByteSizeValue.of(Environment.getFileStore(translog.location()).getTotalSpace(), ByteSizeUnit.BYTES);
                 this.lastCommittedSegmentInfos = store.readLastCommittedSegmentsInfo();
                 this.softDeletesPolicy = newSoftDeletesPolicy();
                 this.combinedDeletionPolicy = new CombinedDeletionPolicy(

--- a/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
@@ -49,7 +49,7 @@ public class PrimaryReplicaSyncer {
     private final TransportService transportService;
     private final SyncAction syncAction;
 
-    public static final ByteSizeValue DEFAULT_CHUNK_SIZE = new ByteSizeValue(512, ByteSizeUnit.KB);
+    public static final ByteSizeValue DEFAULT_CHUNK_SIZE = ByteSizeValue.of(512, ByteSizeUnit.KB);
 
     private volatile ByteSizeValue chunkSize = DEFAULT_CHUNK_SIZE;
 

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogConfig.java
@@ -25,7 +25,7 @@ import java.nio.file.Path;
  */
 public final class TranslogConfig {
 
-    public static final ByteSizeValue DEFAULT_BUFFER_SIZE = new ByteSizeValue(1, ByteSizeUnit.MB);
+    public static final ByteSizeValue DEFAULT_BUFFER_SIZE = ByteSizeValue.of(1, ByteSizeUnit.MB);
     public static final ByteSizeValue EMPTY_TRANSLOG_BUFFER_SIZE = ByteSizeValue.ofBytes(10);
     public static final OperationListener NOOP_OPERATION_LISTENER = (d, s, l) -> {};
 

--- a/server/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
@@ -56,7 +56,7 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
      * to set a floor on the actual size in bytes (default: 48 MB). */
     public static final Setting<ByteSizeValue> MIN_INDEX_BUFFER_SIZE_SETTING = Setting.byteSizeSetting(
         "indices.memory.min_index_buffer_size",
-        new ByteSizeValue(48, ByteSizeUnit.MB),
+        ByteSizeValue.of(48, ByteSizeUnit.MB),
         ByteSizeValue.ZERO,
         ByteSizeValue.ofBytes(Long.MAX_VALUE),
         Property.NodeScope

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -201,7 +201,7 @@ public class RecoverySettings {
         return s -> Setting.parseDouble(s, 0d, 1d, key, false);
     }
 
-    static final ByteSizeValue DEFAULT_MAX_BYTES_PER_SEC = new ByteSizeValue(40L, ByteSizeUnit.MB);
+    static final ByteSizeValue DEFAULT_MAX_BYTES_PER_SEC = ByteSizeValue.of(40L, ByteSizeUnit.MB);
 
     public static final Setting<ByteSizeValue> INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING = Setting.byteSizeSetting(
         "indices.recovery.max_bytes_per_sec",
@@ -227,16 +227,16 @@ public class RecoverySettings {
              */
             final ByteSizeValue totalPhysicalMemory = TOTAL_PHYSICAL_MEMORY_OVERRIDING_TEST_SETTING.get(s);
             final ByteSizeValue maxBytesPerSec;
-            if (totalPhysicalMemory.compareTo(new ByteSizeValue(4, ByteSizeUnit.GB)) <= 0) {
-                maxBytesPerSec = new ByteSizeValue(40, ByteSizeUnit.MB);
-            } else if (totalPhysicalMemory.compareTo(new ByteSizeValue(8, ByteSizeUnit.GB)) <= 0) {
-                maxBytesPerSec = new ByteSizeValue(60, ByteSizeUnit.MB);
-            } else if (totalPhysicalMemory.compareTo(new ByteSizeValue(16, ByteSizeUnit.GB)) <= 0) {
-                maxBytesPerSec = new ByteSizeValue(90, ByteSizeUnit.MB);
-            } else if (totalPhysicalMemory.compareTo(new ByteSizeValue(32, ByteSizeUnit.GB)) <= 0) {
-                maxBytesPerSec = new ByteSizeValue(125, ByteSizeUnit.MB);
+            if (totalPhysicalMemory.compareTo(ByteSizeValue.of(4, ByteSizeUnit.GB)) <= 0) {
+                maxBytesPerSec = ByteSizeValue.of(40, ByteSizeUnit.MB);
+            } else if (totalPhysicalMemory.compareTo(ByteSizeValue.of(8, ByteSizeUnit.GB)) <= 0) {
+                maxBytesPerSec = ByteSizeValue.of(60, ByteSizeUnit.MB);
+            } else if (totalPhysicalMemory.compareTo(ByteSizeValue.of(16, ByteSizeUnit.GB)) <= 0) {
+                maxBytesPerSec = ByteSizeValue.of(90, ByteSizeUnit.MB);
+            } else if (totalPhysicalMemory.compareTo(ByteSizeValue.of(32, ByteSizeUnit.GB)) <= 0) {
+                maxBytesPerSec = ByteSizeValue.of(125, ByteSizeUnit.MB);
             } else {
-                maxBytesPerSec = new ByteSizeValue(250, ByteSizeUnit.MB);
+                maxBytesPerSec = ByteSizeValue.of(250, ByteSizeUnit.MB);
             }
             return maxBytesPerSec.getStringRep();
         },
@@ -397,7 +397,7 @@ public class RecoverySettings {
         Property.NodeScope
     );
 
-    public static final ByteSizeValue DEFAULT_CHUNK_SIZE = new ByteSizeValue(512, ByteSizeUnit.KB);
+    public static final ByteSizeValue DEFAULT_CHUNK_SIZE = ByteSizeValue.of(512, ByteSizeUnit.KB);
 
     /**
      * The maximum allowable size, in bytes, for buffering source documents during recovery.

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -102,14 +102,14 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         }
 
         public void setEffectiveWatermarks(final DiskThresholdSettings masterThresholdSettings, boolean isDedicatedFrozenNode) {
-            lowWatermarkFreeSpace = masterThresholdSettings.getFreeBytesThresholdLowStage(new ByteSizeValue(total, ByteSizeUnit.BYTES));
-            highWatermarkFreeSpace = masterThresholdSettings.getFreeBytesThresholdHighStage(new ByteSizeValue(total, ByteSizeUnit.BYTES));
+            lowWatermarkFreeSpace = masterThresholdSettings.getFreeBytesThresholdLowStage(ByteSizeValue.of(total, ByteSizeUnit.BYTES));
+            highWatermarkFreeSpace = masterThresholdSettings.getFreeBytesThresholdHighStage(ByteSizeValue.of(total, ByteSizeUnit.BYTES));
             floodStageWatermarkFreeSpace = masterThresholdSettings.getFreeBytesThresholdFloodStage(
-                new ByteSizeValue(total, ByteSizeUnit.BYTES)
+                ByteSizeValue.of(total, ByteSizeUnit.BYTES)
             );
             if (isDedicatedFrozenNode) {
                 frozenFloodStageWatermarkFreeSpace = masterThresholdSettings.getFreeBytesThresholdFrozenFloodStage(
-                    new ByteSizeValue(total, ByteSizeUnit.BYTES)
+                    ByteSizeValue.of(total, ByteSizeUnit.BYTES)
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -261,7 +261,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     public static final Setting<ByteSizeValue> MAX_ASYNC_SEARCH_RESPONSE_SIZE_SETTING = Setting.byteSizeSetting(
         "search.max_async_search_response_size",
-        new ByteSizeValue(10, ByteSizeUnit.MB),
+        ByteSizeValue.of(10, ByteSizeUnit.MB),
         Property.Dynamic,
         Property.NodeScope
     );

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -649,7 +649,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler, 
     static int getMaxSnapshotThreadPoolSize(int allocatedProcessors, final ByteSizeValue maxHeapSize) {
         // While on larger data nodes, larger snapshot threadpool size improves snapshotting on high latency blob stores,
         // smaller instances can run into OOM issues and need a smaller snapshot threadpool size.
-        if (maxHeapSize.compareTo(new ByteSizeValue(750, ByteSizeUnit.MB)) < 0) {
+        if (maxHeapSize.compareTo(ByteSizeValue.of(750, ByteSizeUnit.MB)) < 0) {
             return halfAllocatedProcessorsMaxFive(allocatedProcessors);
         }
         return 10;

--- a/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
@@ -40,11 +40,11 @@ public class InboundDecoder implements Releasable {
     private final ChannelType channelType;
 
     public InboundDecoder(Recycler<BytesRef> recycler) {
-        this(recycler, new ByteSizeValue(2, ByteSizeUnit.GB), ChannelType.MIX);
+        this(recycler, ByteSizeValue.of(2, ByteSizeUnit.GB), ChannelType.MIX);
     }
 
     public InboundDecoder(Recycler<BytesRef> recycler, ChannelType channelType) {
-        this(recycler, new ByteSizeValue(2, ByteSizeUnit.GB), channelType);
+        this(recycler, ByteSizeValue.of(2, ByteSizeUnit.GB), channelType);
     }
 
     public InboundDecoder(Recycler<BytesRef> recycler, ByteSizeValue maxHeaderSize, ChannelType channelType) {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterPortSettings.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterPortSettings.java
@@ -135,9 +135,9 @@ public class RemoteClusterPortSettings {
 
     public static final Setting<ByteSizeValue> MAX_REQUEST_HEADER_SIZE = Setting.byteSizeSetting(
         REMOTE_CLUSTER_PREFIX + "max_request_header_size",
-        new ByteSizeValue(64, ByteSizeUnit.KB), // should cover typical querying user/key authn serialized to the fulfilling cluster
-        new ByteSizeValue(64, ByteSizeUnit.BYTES), // toBytes must be higher than fixed header length
-        new ByteSizeValue(2, ByteSizeUnit.GB), // toBytes must be lower than INT_MAX (>2 GB)
+        ByteSizeValue.of(64, ByteSizeUnit.KB), // should cover typical querying user/key authn serialized to the fulfilling cluster
+        ByteSizeValue.of(64, ByteSizeUnit.BYTES), // toBytes must be higher than fixed header length
+        ByteSizeValue.of(2, ByteSizeUnit.GB), // toBytes must be lower than INT_MAX (>2 GB)
         Setting.Property.NodeScope
     );
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverConditionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverConditionsTests.java
@@ -84,22 +84,22 @@ public class RolloverConditionsTests extends AbstractXContentSerializingTestCase
         switch (between(0, 9)) {
             case 0 -> maxSize = randomValueOtherThan(maxSize, () -> {
                 ByteSizeUnit maxSizeUnit = randomFrom(ByteSizeUnit.values());
-                return new ByteSizeValue(randomNonNegativeLong() / maxSizeUnit.toBytes(1), maxSizeUnit);
+                return ByteSizeValue.of(randomNonNegativeLong() / maxSizeUnit.toBytes(1), maxSizeUnit);
             });
             case 1 -> maxPrimaryShardSize = randomValueOtherThan(maxPrimaryShardSize, () -> {
                 ByteSizeUnit maxPrimaryShardSizeUnit = randomFrom(ByteSizeUnit.values());
-                return new ByteSizeValue(randomNonNegativeLong() / maxPrimaryShardSizeUnit.toBytes(1), maxPrimaryShardSizeUnit);
+                return ByteSizeValue.of(randomNonNegativeLong() / maxPrimaryShardSizeUnit.toBytes(1), maxPrimaryShardSizeUnit);
             });
             case 2 -> maxAge = randomValueOtherThan(maxAge, () -> randomPositiveTimeValue());
             case 3 -> maxDocs = maxDocs == null ? randomNonNegativeLong() : maxDocs + 1;
             case 4 -> maxPrimaryShardDocs = maxPrimaryShardDocs == null ? randomNonNegativeLong() : maxPrimaryShardDocs + 1;
             case 5 -> minSize = randomValueOtherThan(minSize, () -> {
                 ByteSizeUnit minSizeUnit = randomFrom(ByteSizeUnit.values());
-                return new ByteSizeValue(randomNonNegativeLong() / minSizeUnit.toBytes(1), minSizeUnit);
+                return ByteSizeValue.of(randomNonNegativeLong() / minSizeUnit.toBytes(1), minSizeUnit);
             });
             case 6 -> minPrimaryShardSize = randomValueOtherThan(minPrimaryShardSize, () -> {
                 ByteSizeUnit minPrimaryShardSizeUnit = randomFrom(ByteSizeUnit.values());
-                return new ByteSizeValue(randomNonNegativeLong() / minPrimaryShardSizeUnit.toBytes(1), minPrimaryShardSizeUnit);
+                return ByteSizeValue.of(randomNonNegativeLong() / minPrimaryShardSizeUnit.toBytes(1), minPrimaryShardSizeUnit);
             });
             case 7 -> minAge = randomValueOtherThan(minAge, () -> randomPositiveTimeValue());
             case 8 -> minDocs = minDocs == null ? randomNonNegativeLong() : minDocs + 1;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTests.java
@@ -67,7 +67,7 @@ public class ResizeRequestTests extends AbstractWireSerializingTestCase<ResizeRe
         }
         {
             ResizeRequest request = new ResizeRequest("target", "source");
-            request.setMaxPrimaryShardSize(new ByteSizeValue(100, ByteSizeUnit.MB));
+            request.setMaxPrimaryShardSize(ByteSizeValue.of(100, ByteSizeUnit.MB));
             String actualRequestBody = Strings.toString(request);
             assertEquals("""
                 {"settings":{},"aliases":{},"max_primary_shard_size":"100mb"}""", actualRequestBody);

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessor2Tests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessor2Tests.java
@@ -175,7 +175,7 @@ public class BulkProcessor2Tests extends ESTestCase {
             countingListener(requestCount, successCount, failureCount, docCount, exceptionRef),
             maxBatchSize,
             ByteSizeValue.ofBytes(Integer.MAX_VALUE),
-            new ByteSizeValue(50, ByteSizeUnit.MB),
+            ByteSizeValue.of(50, ByteSizeUnit.MB),
             null,
             threadPool
         );
@@ -280,7 +280,7 @@ public class BulkProcessor2Tests extends ESTestCase {
             countingListener(requestCount, successCount, failureCount, docCount, exceptionRef),
             maxBatchSize,
             ByteSizeValue.ofBytes(Integer.MAX_VALUE),
-            new ByteSizeValue(50, ByteSizeUnit.MB),
+            ByteSizeValue.of(50, ByteSizeUnit.MB),
             TimeValue.timeValueMillis(simulateWorkTimeInMillis * 2),
             threadPool
         );

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
@@ -98,7 +98,7 @@ public class BulkProcessorTests extends ESTestCase {
                 emptyListener(),
                 1,
                 bulkSize,
-                new ByteSizeValue(5, ByteSizeUnit.MB),
+                ByteSizeValue.of(5, ByteSizeUnit.MB),
                 flushInterval,
                 threadPool,
                 () -> {},

--- a/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
@@ -62,7 +62,7 @@ public class MemorySizeSettingsTests extends ESTestCase {
     public void testCircuitBreakerSettings() {
         // default is chosen based on actual heap size
         double defaultTotalPercentage;
-        if (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() < new ByteSizeValue(1, ByteSizeUnit.GB).getBytes()) {
+        if (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() < ByteSizeValue.of(1, ByteSizeUnit.GB).getBytes()) {
             defaultTotalPercentage = 0.95d;
         } else {
             defaultTotalPercentage = 0.7d;

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -70,8 +70,8 @@ public class SettingTests extends ESTestCase {
     public void testByteSizeSettingMinValue() {
         final Setting<ByteSizeValue> byteSizeValueSetting = Setting.byteSizeSetting(
             "a.byte.size",
-            new ByteSizeValue(100, ByteSizeUnit.MB),
-            new ByteSizeValue(20_000_000, ByteSizeUnit.BYTES),
+            ByteSizeValue.of(100, ByteSizeUnit.MB),
+            ByteSizeValue.of(20_000_000, ByteSizeUnit.BYTES),
             ByteSizeValue.ofBytes(Integer.MAX_VALUE)
         );
         final long value = 20_000_000 - randomIntBetween(1, 1024);
@@ -84,8 +84,8 @@ public class SettingTests extends ESTestCase {
     public void testByteSizeSettingMaxValue() {
         final Setting<ByteSizeValue> byteSizeValueSetting = Setting.byteSizeSetting(
             "a.byte.size",
-            new ByteSizeValue(100, ByteSizeUnit.MB),
-            new ByteSizeValue(16, ByteSizeUnit.MB),
+            ByteSizeValue.of(100, ByteSizeUnit.MB),
+            ByteSizeValue.of(16, ByteSizeUnit.MB),
             ByteSizeValue.ofBytes(Integer.MAX_VALUE)
         );
         final long value = (1L << 31) - 1 + randomIntBetween(1, 1024);

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -659,7 +659,7 @@ public class SettingsTests extends ESTestCase {
             "key",
             ByteSizeValue.parseBytesSizeValue(randomIntBetween(1, 16) + "k", "key")
         );
-        final ByteSizeValue expected = new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES);
+        final ByteSizeValue expected = ByteSizeValue.of(randomNonNegativeLong(), ByteSizeUnit.BYTES);
         final Settings settings = Settings.builder().put("key", expected).build();
         /*
          * Previously we would internally convert the byte size value to a string using a method that tries to be smart about the units

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.common.unit;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
@@ -228,38 +229,11 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     }
 
     @Override
-    protected ByteSizeValue mutateInstance(final ByteSizeValue instance) {
-        final long instanceSize = instance.getSize();
-        final ByteSizeUnit instanceUnit = instance.getUnit();
-        final long mutateSize;
-        final ByteSizeUnit mutateUnit;
-        switch (between(0, 1)) {
-            case 0 -> {
-                final long unitBytes = instanceUnit.toBytes(1);
-                mutateSize = randomValueOtherThan(instanceSize, () -> randomNonNegativeLong() / unitBytes);
-                mutateUnit = instanceUnit;
-            }
-            case 1 -> {
-                mutateUnit = randomValueOtherThan(instanceUnit, () -> randomFrom(ByteSizeUnit.values()));
-                final long newUnitBytes = mutateUnit.toBytes(1);
-                /*
-                 * If size is zero we can not reuse zero because zero with any unit will be equal to zero with any other
-                 * unit so in this case we need to randomize a new size. Additionally, if the size unit pair is such that
-                 * the representation would be such that the number of represented bytes would exceed Long.Max_VALUE, we
-                 * have to randomize a new size too.
-                 */
-                if (instanceSize == 0 || instanceSize >= Long.MAX_VALUE / newUnitBytes) {
-                    mutateSize = randomValueOtherThanMany(
-                        v -> v == instanceSize && v >= Long.MAX_VALUE / newUnitBytes,
-                        () -> randomNonNegativeLong() / newUnitBytes
-                    );
-                } else {
-                    mutateSize = instanceSize;
-                }
-            }
-            default -> throw new AssertionError("Invalid randomisation branch");
-        }
-        return ByteSizeValue.of(mutateSize, mutateUnit);
+    protected ByteSizeValue mutateInstance(final ByteSizeValue original) {
+        return new ByteSizeValue(
+            randomValueOtherThan(original.getSizeInBytes(), ESTestCase::randomNonNegativeLong),
+            randomFrom(ByteSizeUnit.values())
+        );
     }
 
     public void testParse() {
@@ -518,11 +492,11 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
 
         ByteSizeValue equalityResult = ByteSizeValue.min(ByteSizeValue.of(1024, ByteSizeUnit.MB), ByteSizeValue.of(1, ByteSizeUnit.GB));
         assertThat(equalityResult, is(ByteSizeValue.of(1024, ByteSizeUnit.MB)));
-        assertThat(equalityResult.getUnit(), is(ByteSizeUnit.MB));
+        assertThat(equalityResult.getDesiredUnit(), is(ByteSizeUnit.MB));
 
         equalityResult = ByteSizeValue.min(ByteSizeValue.of(1, ByteSizeUnit.GB), ByteSizeValue.of(1024, ByteSizeUnit.MB));
         assertThat(equalityResult, is(ByteSizeValue.of(1, ByteSizeUnit.GB)));
-        assertThat(equalityResult.getUnit(), is(ByteSizeUnit.GB));
+        assertThat(equalityResult.getDesiredUnit(), is(ByteSizeUnit.GB));
 
         String exceptionMessage = "one of the arguments has -1 bytes";
         Exception e = expectThrows(IllegalArgumentException.class, () -> ByteSizeValue.min(ByteSizeValue.MINUS_ONE, ByteSizeValue.ONE));

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -295,7 +295,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
             if (unit == ByteSizeUnit.BYTES) {
                 continue;
             }
-            for (int tenths = 5; tenths <= 5; tenths++) { // No other tenths values work!
+            for (int tenths = 1; tenths <= 9; tenths++) {
                 checkFractionRoundTrip("23." + tenths + unit.getSuffix());
             }
         }
@@ -303,11 +303,6 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
 
     private void checkFractionRoundTrip(String fractionalValue) {
         assertEquals(fractionalValue, ByteSizeValue.parseBytesSizeValue(fractionalValue, "test").toString());
-        assertWarnings(
-            "Fractional bytes values are deprecated. Use non-fractional bytes values instead: ["
-                + fractionalValue
-                + "] found for setting [test]"
-        );
     }
 
     public void testGetBytesAsInt() {

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -23,24 +23,24 @@ import static org.hamcrest.Matchers.is;
 
 public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSizeValue> {
     public void testActualPeta() {
-        MatcherAssert.assertThat(new ByteSizeValue(4, ByteSizeUnit.PB).getBytes(), equalTo(4503599627370496L));
+        MatcherAssert.assertThat(ByteSizeValue.of(4, ByteSizeUnit.PB).getBytes(), equalTo(4503599627370496L));
     }
 
     public void testActualTera() {
-        MatcherAssert.assertThat(new ByteSizeValue(4, ByteSizeUnit.TB).getBytes(), equalTo(4398046511104L));
+        MatcherAssert.assertThat(ByteSizeValue.of(4, ByteSizeUnit.TB).getBytes(), equalTo(4398046511104L));
     }
 
     public void testActual() {
-        MatcherAssert.assertThat(new ByteSizeValue(4, ByteSizeUnit.GB).getBytes(), equalTo(4294967296L));
+        MatcherAssert.assertThat(ByteSizeValue.of(4, ByteSizeUnit.GB).getBytes(), equalTo(4294967296L));
     }
 
     public void testSimple() {
-        assertThat(ByteSizeUnit.BYTES.toBytes(10), is(new ByteSizeValue(10, ByteSizeUnit.BYTES).getBytes()));
-        assertThat(ByteSizeUnit.KB.toKB(10), is(new ByteSizeValue(10, ByteSizeUnit.KB).getKb()));
-        assertThat(ByteSizeUnit.MB.toMB(10), is(new ByteSizeValue(10, ByteSizeUnit.MB).getMb()));
-        assertThat(ByteSizeUnit.GB.toGB(10), is(new ByteSizeValue(10, ByteSizeUnit.GB).getGb()));
-        assertThat(ByteSizeUnit.TB.toTB(10), is(new ByteSizeValue(10, ByteSizeUnit.TB).getTb()));
-        assertThat(ByteSizeUnit.PB.toPB(10), is(new ByteSizeValue(10, ByteSizeUnit.PB).getPb()));
+        assertThat(ByteSizeUnit.BYTES.toBytes(10), is(ByteSizeValue.of(10, ByteSizeUnit.BYTES).getBytes()));
+        assertThat(ByteSizeUnit.KB.toKB(10), is(ByteSizeValue.of(10, ByteSizeUnit.KB).getKb()));
+        assertThat(ByteSizeUnit.MB.toMB(10), is(ByteSizeValue.of(10, ByteSizeUnit.MB).getMb()));
+        assertThat(ByteSizeUnit.GB.toGB(10), is(ByteSizeValue.of(10, ByteSizeUnit.GB).getGb()));
+        assertThat(ByteSizeUnit.TB.toTB(10), is(ByteSizeValue.of(10, ByteSizeUnit.TB).getTb()));
+        assertThat(ByteSizeUnit.PB.toPB(10), is(ByteSizeValue.of(10, ByteSizeUnit.PB).getPb()));
     }
 
     public void testToIntBytes() {
@@ -60,13 +60,13 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     }
 
     public void testToString() {
-        assertThat("10b", is(new ByteSizeValue(10, ByteSizeUnit.BYTES).toString()));
-        assertThat("1.5kb", is(new ByteSizeValue((long) (1024 * 1.5), ByteSizeUnit.BYTES).toString()));
-        assertThat("1.5mb", is(new ByteSizeValue((long) (1024 * 1.5), ByteSizeUnit.KB).toString()));
-        assertThat("1.5gb", is(new ByteSizeValue((long) (1024 * 1.5), ByteSizeUnit.MB).toString()));
-        assertThat("1.5tb", is(new ByteSizeValue((long) (1024 * 1.5), ByteSizeUnit.GB).toString()));
-        assertThat("1.5pb", is(new ByteSizeValue((long) (1024 * 1.5), ByteSizeUnit.TB).toString()));
-        assertThat("1536pb", is(new ByteSizeValue((long) (1024 * 1.5), ByteSizeUnit.PB).toString()));
+        assertThat("10b", is(ByteSizeValue.of(10, ByteSizeUnit.BYTES).toString()));
+        assertThat("1.5kb", is(ByteSizeValue.of((long) (1024 * 1.5), ByteSizeUnit.BYTES).toString()));
+        assertThat("1.5mb", is(ByteSizeValue.of((long) (1024 * 1.5), ByteSizeUnit.KB).toString()));
+        assertThat("1.5gb", is(ByteSizeValue.of((long) (1024 * 1.5), ByteSizeUnit.MB).toString()));
+        assertThat("1.5tb", is(ByteSizeValue.of((long) (1024 * 1.5), ByteSizeUnit.GB).toString()));
+        assertThat("1.5pb", is(ByteSizeValue.of((long) (1024 * 1.5), ByteSizeUnit.TB).toString()));
+        assertThat("1536pb", is(ByteSizeValue.of((long) (1024 * 1.5), ByteSizeUnit.PB).toString()));
     }
 
     public void testParsing() {
@@ -155,8 +155,8 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     public void testCompareEquality() {
         ByteSizeUnit randomUnit = randomFrom(ByteSizeUnit.values());
         long firstRandom = randomNonNegativeLong() / randomUnit.toBytes(1);
-        ByteSizeValue firstByteValue = new ByteSizeValue(firstRandom, randomUnit);
-        ByteSizeValue secondByteValue = new ByteSizeValue(firstRandom, randomUnit);
+        ByteSizeValue firstByteValue = ByteSizeValue.of(firstRandom, randomUnit);
+        ByteSizeValue secondByteValue = ByteSizeValue.of(firstRandom, randomUnit);
         assertEquals(0, firstByteValue.compareTo(secondByteValue));
     }
 
@@ -164,8 +164,8 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
         ByteSizeUnit unit = randomFrom(ByteSizeUnit.values());
         long firstRandom = randomNonNegativeLong() / unit.toBytes(1);
         long secondRandom = randomValueOtherThan(firstRandom, () -> randomNonNegativeLong() / unit.toBytes(1));
-        ByteSizeValue firstByteValue = new ByteSizeValue(firstRandom, unit);
-        ByteSizeValue secondByteValue = new ByteSizeValue(secondRandom, unit);
+        ByteSizeValue firstByteValue = ByteSizeValue.of(firstRandom, unit);
+        ByteSizeValue secondByteValue = ByteSizeValue.of(secondRandom, unit);
         assertEquals(firstRandom > secondRandom, firstByteValue.compareTo(secondByteValue) > 0);
         assertEquals(secondRandom > firstRandom, secondByteValue.compareTo(firstByteValue) > 0);
     }
@@ -173,8 +173,8 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     public void testCompareUnits() {
         long number = randomLongBetween(1, Long.MAX_VALUE / ByteSizeUnit.PB.toBytes(1));
         ByteSizeUnit randomUnit = randomValueOtherThan(ByteSizeUnit.PB, () -> randomFrom(ByteSizeUnit.values()));
-        ByteSizeValue firstByteValue = new ByteSizeValue(number, randomUnit);
-        ByteSizeValue secondByteValue = new ByteSizeValue(number, ByteSizeUnit.PB);
+        ByteSizeValue firstByteValue = ByteSizeValue.of(number, randomUnit);
+        ByteSizeValue secondByteValue = ByteSizeValue.of(number, ByteSizeUnit.PB);
         assertTrue(firstByteValue.compareTo(secondByteValue) < 0);
         assertTrue(secondByteValue.compareTo(firstByteValue) > 0);
     }
@@ -183,7 +183,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
         // Make sure a value of > Long.MAX_VALUE bytes throws an exception
         ByteSizeUnit unit = randomValueOtherThan(ByteSizeUnit.BYTES, () -> randomFrom(ByteSizeUnit.values()));
         long size = (long) randomDouble() * unit.toBytes(1) + (Long.MAX_VALUE - unit.toBytes(1));
-        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> new ByteSizeValue(size, unit));
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> ByteSizeValue.of(size, unit));
         assertEquals(
             "Values greater than " + Long.MAX_VALUE + " bytes are not supported: " + size + unit.getSuffix(),
             exception.getMessage()
@@ -192,19 +192,19 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
         // Make sure for units other than BYTES a size of -1 throws an exception
         ByteSizeUnit unit2 = randomValueOtherThan(ByteSizeUnit.BYTES, () -> randomFrom(ByteSizeUnit.values()));
         long size2 = -1L;
-        exception = expectThrows(IllegalArgumentException.class, () -> new ByteSizeValue(size2, unit2));
+        exception = expectThrows(IllegalArgumentException.class, () -> ByteSizeValue.of(size2, unit2));
         assertEquals("Values less than -1 bytes are not supported: " + size2 + unit2.getSuffix(), exception.getMessage());
 
         // Make sure for any unit a size < -1 throws an exception
         ByteSizeUnit unit3 = randomFrom(ByteSizeUnit.values());
         long size3 = -1L * randomNonNegativeLong() - 1L;
-        exception = expectThrows(IllegalArgumentException.class, () -> new ByteSizeValue(size3, unit3));
+        exception = expectThrows(IllegalArgumentException.class, () -> ByteSizeValue.of(size3, unit3));
         assertEquals("Values less than -1 bytes are not supported: " + size3 + unit3.getSuffix(), exception.getMessage());
     }
 
     public void testConversionHashCode() {
-        ByteSizeValue firstValue = new ByteSizeValue(randomIntBetween(0, Integer.MAX_VALUE), ByteSizeUnit.GB);
-        ByteSizeValue secondValue = new ByteSizeValue(firstValue.getBytes(), ByteSizeUnit.BYTES);
+        ByteSizeValue firstValue = ByteSizeValue.of(randomIntBetween(0, Integer.MAX_VALUE), ByteSizeUnit.GB);
+        ByteSizeValue secondValue = ByteSizeValue.of(firstValue.getBytes(), ByteSizeUnit.BYTES);
         assertEquals(firstValue.hashCode(), secondValue.hashCode());
     }
 
@@ -216,7 +216,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
             if (size > Long.MAX_VALUE / unit.toBytes(1)) {
                 throw new AssertionError();
             }
-            return new ByteSizeValue(size, unit);
+            return ByteSizeValue.of(size, unit);
         } else {
             return ByteSizeValue.ofBytes(randomNonNegativeLong());
         }
@@ -259,7 +259,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
             }
             default -> throw new AssertionError("Invalid randomisation branch");
         }
-        return new ByteSizeValue(mutateSize, mutateUnit);
+        return ByteSizeValue.of(mutateSize, mutateUnit);
     }
 
     public void testParse() {
@@ -338,7 +338,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
 
     public void testGetBytesAsInt() {
         for (int i = 0; i < NUMBER_OF_TEST_RUNS; i++) {
-            ByteSizeValue instance = new ByteSizeValue(randomIntBetween(1, 1000), randomFrom(ByteSizeUnit.values()));
+            ByteSizeValue instance = ByteSizeValue.of(randomIntBetween(1, 1000), randomFrom(ByteSizeUnit.values()));
             long bytesValue = instance.getBytes();
             if (bytesValue > Integer.MAX_VALUE) {
                 IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> instance.bytesAsInt());
@@ -376,7 +376,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     private void testOf(ByteSizeUnit unit, Function<Long, ByteSizeValue> byteSizeValueFunction) {
         for (int i = 0; i < NUMBER_OF_TEST_RUNS; i++) {
             long size = randomIntBetween(1, 1000);
-            ByteSizeValue expected = new ByteSizeValue(size, unit);
+            ByteSizeValue expected = ByteSizeValue.of(size, unit);
             ByteSizeValue actual = byteSizeValueFunction.apply(size);
             assertThat(actual, equalTo(expected));
         }
@@ -389,27 +389,27 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
         assertThat(ByteSizeValue.add(ByteSizeValue.ofBytes(100L), ByteSizeValue.ONE), is(ByteSizeValue.ofBytes(101L)));
         assertThat(ByteSizeValue.add(ByteSizeValue.ofBytes(100L), ByteSizeValue.ofBytes(2L)), is(ByteSizeValue.ofBytes(102L)));
         assertThat(
-            ByteSizeValue.add(new ByteSizeValue(8, ByteSizeUnit.KB), new ByteSizeValue(4, ByteSizeUnit.KB)),
+            ByteSizeValue.add(ByteSizeValue.of(8, ByteSizeUnit.KB), ByteSizeValue.of(4, ByteSizeUnit.KB)),
             is(ByteSizeValue.ofBytes(12288L))
         );
         assertThat(
-            ByteSizeValue.add(new ByteSizeValue(8, ByteSizeUnit.MB), new ByteSizeValue(4, ByteSizeUnit.MB)),
+            ByteSizeValue.add(ByteSizeValue.of(8, ByteSizeUnit.MB), ByteSizeValue.of(4, ByteSizeUnit.MB)),
             is(ByteSizeValue.ofBytes(12582912L))
         );
         assertThat(
-            ByteSizeValue.add(new ByteSizeValue(8, ByteSizeUnit.GB), new ByteSizeValue(4, ByteSizeUnit.GB)),
+            ByteSizeValue.add(ByteSizeValue.of(8, ByteSizeUnit.GB), ByteSizeValue.of(4, ByteSizeUnit.GB)),
             is(ByteSizeValue.ofBytes(12884901888L))
         );
         assertThat(
-            ByteSizeValue.add(new ByteSizeValue(8, ByteSizeUnit.TB), new ByteSizeValue(4, ByteSizeUnit.TB)),
+            ByteSizeValue.add(ByteSizeValue.of(8, ByteSizeUnit.TB), ByteSizeValue.of(4, ByteSizeUnit.TB)),
             is(ByteSizeValue.ofBytes(13194139533312L))
         );
         assertThat(
-            ByteSizeValue.add(new ByteSizeValue(8, ByteSizeUnit.PB), new ByteSizeValue(4, ByteSizeUnit.PB)),
+            ByteSizeValue.add(ByteSizeValue.of(8, ByteSizeUnit.PB), ByteSizeValue.of(4, ByteSizeUnit.PB)),
             is(ByteSizeValue.ofBytes(13510798882111488L))
         );
         assertThat(
-            ByteSizeValue.add(new ByteSizeValue(8, ByteSizeUnit.PB), new ByteSizeValue(4, ByteSizeUnit.GB)),
+            ByteSizeValue.add(ByteSizeValue.of(8, ByteSizeUnit.PB), ByteSizeValue.of(4, ByteSizeUnit.GB)),
             is(ByteSizeValue.ofBytes(9007203549708288L))
         );
 
@@ -437,27 +437,27 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
         assertThat(ByteSizeValue.subtract(ByteSizeValue.ofBytes(100L), ByteSizeValue.ONE), is(ByteSizeValue.ofBytes(99L)));
         assertThat(ByteSizeValue.subtract(ByteSizeValue.ofBytes(100L), ByteSizeValue.ofBytes(2L)), is(ByteSizeValue.ofBytes(98L)));
         assertThat(
-            ByteSizeValue.subtract(new ByteSizeValue(8, ByteSizeUnit.KB), new ByteSizeValue(4, ByteSizeUnit.KB)),
+            ByteSizeValue.subtract(ByteSizeValue.of(8, ByteSizeUnit.KB), ByteSizeValue.of(4, ByteSizeUnit.KB)),
             is(ByteSizeValue.ofBytes(4096L))
         );
         assertThat(
-            ByteSizeValue.subtract(new ByteSizeValue(8, ByteSizeUnit.MB), new ByteSizeValue(4, ByteSizeUnit.MB)),
+            ByteSizeValue.subtract(ByteSizeValue.of(8, ByteSizeUnit.MB), ByteSizeValue.of(4, ByteSizeUnit.MB)),
             is(ByteSizeValue.ofBytes(4194304L))
         );
         assertThat(
-            ByteSizeValue.subtract(new ByteSizeValue(8, ByteSizeUnit.GB), new ByteSizeValue(4, ByteSizeUnit.GB)),
+            ByteSizeValue.subtract(ByteSizeValue.of(8, ByteSizeUnit.GB), ByteSizeValue.of(4, ByteSizeUnit.GB)),
             is(ByteSizeValue.ofBytes(4294967296L))
         );
         assertThat(
-            ByteSizeValue.subtract(new ByteSizeValue(8, ByteSizeUnit.TB), new ByteSizeValue(4, ByteSizeUnit.TB)),
+            ByteSizeValue.subtract(ByteSizeValue.of(8, ByteSizeUnit.TB), ByteSizeValue.of(4, ByteSizeUnit.TB)),
             is(ByteSizeValue.ofBytes(4398046511104L))
         );
         assertThat(
-            ByteSizeValue.subtract(new ByteSizeValue(8, ByteSizeUnit.PB), new ByteSizeValue(4, ByteSizeUnit.PB)),
+            ByteSizeValue.subtract(ByteSizeValue.of(8, ByteSizeUnit.PB), ByteSizeValue.of(4, ByteSizeUnit.PB)),
             is(ByteSizeValue.ofBytes(4503599627370496L))
         );
         assertThat(
-            ByteSizeValue.subtract(new ByteSizeValue(8, ByteSizeUnit.PB), new ByteSizeValue(4, ByteSizeUnit.GB)),
+            ByteSizeValue.subtract(ByteSizeValue.of(8, ByteSizeUnit.PB), ByteSizeValue.of(4, ByteSizeUnit.GB)),
             is(ByteSizeValue.ofBytes(9007194959773696L))
         );
 
@@ -492,36 +492,36 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
         assertThat(ByteSizeValue.min(ByteSizeValue.ofBytes(2L), ByteSizeValue.ofBytes(100L)), is(ByteSizeValue.ofBytes(2L)));
 
         assertThat(
-            ByteSizeValue.min(new ByteSizeValue(8, ByteSizeUnit.KB), new ByteSizeValue(4, ByteSizeUnit.KB)),
-            is(new ByteSizeValue(4, ByteSizeUnit.KB))
+            ByteSizeValue.min(ByteSizeValue.of(8, ByteSizeUnit.KB), ByteSizeValue.of(4, ByteSizeUnit.KB)),
+            is(ByteSizeValue.of(4, ByteSizeUnit.KB))
         );
         assertThat(
-            ByteSizeValue.min(new ByteSizeValue(4, ByteSizeUnit.MB), new ByteSizeValue(8, ByteSizeUnit.MB)),
-            is(new ByteSizeValue(4, ByteSizeUnit.MB))
+            ByteSizeValue.min(ByteSizeValue.of(4, ByteSizeUnit.MB), ByteSizeValue.of(8, ByteSizeUnit.MB)),
+            is(ByteSizeValue.of(4, ByteSizeUnit.MB))
         );
         assertThat(
-            ByteSizeValue.min(new ByteSizeValue(16, ByteSizeUnit.GB), new ByteSizeValue(15, ByteSizeUnit.GB)),
-            is(new ByteSizeValue(15, ByteSizeUnit.GB))
+            ByteSizeValue.min(ByteSizeValue.of(16, ByteSizeUnit.GB), ByteSizeValue.of(15, ByteSizeUnit.GB)),
+            is(ByteSizeValue.of(15, ByteSizeUnit.GB))
         );
         assertThat(
-            ByteSizeValue.min(new ByteSizeValue(90, ByteSizeUnit.TB), new ByteSizeValue(91, ByteSizeUnit.TB)),
-            is(new ByteSizeValue(90, ByteSizeUnit.TB))
+            ByteSizeValue.min(ByteSizeValue.of(90, ByteSizeUnit.TB), ByteSizeValue.of(91, ByteSizeUnit.TB)),
+            is(ByteSizeValue.of(90, ByteSizeUnit.TB))
         );
         assertThat(
-            ByteSizeValue.min(new ByteSizeValue(2, ByteSizeUnit.PB), new ByteSizeValue(1, ByteSizeUnit.PB)),
-            is(new ByteSizeValue(1, ByteSizeUnit.PB))
+            ByteSizeValue.min(ByteSizeValue.of(2, ByteSizeUnit.PB), ByteSizeValue.of(1, ByteSizeUnit.PB)),
+            is(ByteSizeValue.of(1, ByteSizeUnit.PB))
         );
         assertThat(
-            ByteSizeValue.min(new ByteSizeValue(1, ByteSizeUnit.PB), new ByteSizeValue(1, ByteSizeUnit.GB)),
-            is(new ByteSizeValue(1, ByteSizeUnit.GB))
+            ByteSizeValue.min(ByteSizeValue.of(1, ByteSizeUnit.PB), ByteSizeValue.of(1, ByteSizeUnit.GB)),
+            is(ByteSizeValue.of(1, ByteSizeUnit.GB))
         );
 
-        ByteSizeValue equalityResult = ByteSizeValue.min(new ByteSizeValue(1024, ByteSizeUnit.MB), new ByteSizeValue(1, ByteSizeUnit.GB));
-        assertThat(equalityResult, is(new ByteSizeValue(1024, ByteSizeUnit.MB)));
+        ByteSizeValue equalityResult = ByteSizeValue.min(ByteSizeValue.of(1024, ByteSizeUnit.MB), ByteSizeValue.of(1, ByteSizeUnit.GB));
+        assertThat(equalityResult, is(ByteSizeValue.of(1024, ByteSizeUnit.MB)));
         assertThat(equalityResult.getUnit(), is(ByteSizeUnit.MB));
 
-        equalityResult = ByteSizeValue.min(new ByteSizeValue(1, ByteSizeUnit.GB), new ByteSizeValue(1024, ByteSizeUnit.MB));
-        assertThat(equalityResult, is(new ByteSizeValue(1, ByteSizeUnit.GB)));
+        equalityResult = ByteSizeValue.min(ByteSizeValue.of(1, ByteSizeUnit.GB), ByteSizeValue.of(1024, ByteSizeUnit.MB));
+        assertThat(equalityResult, is(ByteSizeValue.of(1, ByteSizeUnit.GB)));
         assertThat(equalityResult.getUnit(), is(ByteSizeUnit.GB));
 
         String exceptionMessage = "one of the arguments has -1 bytes";

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -316,11 +316,19 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
         assertEquals("failed to parse setting [test] with value [notANumber" + unitSuffix + "]", exception.getMessage());
     }
 
-    public void testParseFractionalNumber() throws IOException {
-        ByteSizeUnit unit = randomValueOtherThan(ByteSizeUnit.BYTES, () -> randomFrom(ByteSizeUnit.values()));
-        String fractionalValue = "23.5" + unit.getSuffix();
-        ByteSizeValue instance = ByteSizeValue.parseBytesSizeValue(fractionalValue, "test");
-        assertEquals(fractionalValue, instance.toString());
+    public void testParseFractionalNumber() {
+        for (var unit : ByteSizeUnit.values()) {
+            if (unit == ByteSizeUnit.BYTES) {
+                continue;
+            }
+            for (int tenths = 5; tenths <= 5; tenths++) { // No other tenths values work!
+                checkFractionRoundTrip("23." + tenths + unit.getSuffix());
+            }
+        }
+    }
+
+    private void checkFractionRoundTrip(String fractionalValue) {
+        assertEquals(fractionalValue, ByteSizeValue.parseBytesSizeValue(fractionalValue, "test").toString());
         assertWarnings(
             "Fractional bytes values are deprecated. Use non-fractional bytes values instead: ["
                 + fractionalValue

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -558,6 +558,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
             checkTransportRoundTrip(ByteSizeValue.ZERO, tv);
             checkTransportRoundTrip(ByteSizeValue.MINUS_ONE, tv);
             for (var unit : ByteSizeUnit.values()) {
+                // Try increasing values until we exceed Long.MAX_VALUE and it wraps around negative
                 for (long bytes = unit.toBytes(1); bytes > 0; bytes *= 10) {
                     checkTransportRoundTrip(new ByteSizeValue(bytes, unit), tv);
                 }

--- a/server/src/test/java/org/elasticsearch/common/unit/RelativeByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/RelativeByteSizeValueTests.java
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.is;
 public class RelativeByteSizeValueTests extends ESTestCase {
 
     public void testDeserialization() throws IOException {
-        final var origin1 = new RelativeByteSizeValue(new ByteSizeValue(between(0, 2048), randomFrom(ByteSizeUnit.values())));
+        final var origin1 = new RelativeByteSizeValue(ByteSizeValue.of(between(0, 2048), randomFrom(ByteSizeUnit.values())));
         final var origin2 = new RelativeByteSizeValue(new RatioValue(randomDoubleBetween(0.0, 100.0, true)));
         final RelativeByteSizeValue target1, target2;
 
@@ -63,7 +63,7 @@ public class RelativeByteSizeValueTests extends ESTestCase {
     }
 
     public void testAbsolute() {
-        ByteSizeValue value = new ByteSizeValue(between(0, 100), randomFrom(ByteSizeUnit.values()));
+        ByteSizeValue value = ByteSizeValue.of(between(0, 100), randomFrom(ByteSizeUnit.values()));
         RelativeByteSizeValue parsed = RelativeByteSizeValue.parseRelativeByteSizeValue(value.getStringRep(), "test");
         assertThat(parsed.getAbsolute(), equalTo(value));
         assertThat(parsed.isAbsolute(), is(true));

--- a/server/src/test/java/org/elasticsearch/common/unit/RelativeByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/RelativeByteSizeValueTests.java
@@ -39,7 +39,9 @@ public class RelativeByteSizeValueTests extends ESTestCase {
         assertNull(origin1.getRatio());
         assertNull(target1.getRatio());
         assertEquals(origin1.getAbsolute(), target1.getAbsolute());
-        assertEquals(origin1.getAbsolute().getUnit(), target1.getAbsolute().getUnit());
+        ByteSizeValue byteSizeValue = target1.getAbsolute();
+        ByteSizeValue byteSizeValue1 = origin1.getAbsolute();
+        assertEquals(byteSizeValue1.getDesiredUnit(), byteSizeValue.getDesiredUnit());
 
         assertFalse(origin2.isAbsolute());
         assertFalse(target2.isAbsolute());

--- a/server/src/test/java/org/elasticsearch/common/unit/RelativeByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/RelativeByteSizeValueTests.java
@@ -39,9 +39,7 @@ public class RelativeByteSizeValueTests extends ESTestCase {
         assertNull(origin1.getRatio());
         assertNull(target1.getRatio());
         assertEquals(origin1.getAbsolute(), target1.getAbsolute());
-        ByteSizeValue byteSizeValue = target1.getAbsolute();
-        ByteSizeValue byteSizeValue1 = origin1.getAbsolute();
-        assertEquals(byteSizeValue1.getDesiredUnit(), byteSizeValue.getDesiredUnit());
+        assertEquals(origin1.getAbsolute().getDesiredUnit(), target1.getAbsolute().getDesiredUnit());
 
         assertFalse(origin2.isAbsolute());
         assertFalse(target2.isAbsolute());

--- a/server/src/test/java/org/elasticsearch/common/util/BitArrayTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BitArrayTests.java
@@ -106,7 +106,7 @@ public class BitArrayTests extends ESTestCase {
     }
 
     public void testClearingDoesntAllocate() {
-        ByteSizeValue max = new ByteSizeValue(1, ByteSizeUnit.KB);
+        ByteSizeValue max = ByteSizeValue.of(1, ByteSizeUnit.KB);
         MockBigArrays bigArrays = new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), max);
         try (BitArray bitArray = new BitArray(1, bigArrays)) {
             bitArray.clear(100000000);

--- a/server/src/test/java/org/elasticsearch/index/MergePolicyConfigTests.java
+++ b/server/src/test/java/org/elasticsearch/index/MergePolicyConfigTests.java
@@ -164,19 +164,19 @@ public class MergePolicyConfigTests extends ESTestCase {
                 Settings.builder()
                     .put(
                         MergePolicyConfig.INDEX_MERGE_POLICY_FLOOR_SEGMENT_SETTING.getKey(),
-                        new ByteSizeValue(MergePolicyConfig.DEFAULT_FLOOR_SEGMENT.getMb() + 1, ByteSizeUnit.MB)
+                        ByteSizeValue.of(MergePolicyConfig.DEFAULT_FLOOR_SEGMENT.getMb() + 1, ByteSizeUnit.MB)
                     )
                     .build()
             )
         );
         assertEquals(
             ((TieredMergePolicy) indexSettings.getMergePolicy(false)).getFloorSegmentMB(),
-            new ByteSizeValue(MergePolicyConfig.DEFAULT_FLOOR_SEGMENT.getMb() + 1, ByteSizeUnit.MB).getMbFrac(),
+            ByteSizeValue.of(MergePolicyConfig.DEFAULT_FLOOR_SEGMENT.getMb() + 1, ByteSizeUnit.MB).getMbFrac(),
             0.001
         );
         assertEquals(
             ((LogByteSizeMergePolicy) indexSettings.getMergePolicy(true)).getMinMergeMB(),
-            new ByteSizeValue(MergePolicyConfig.DEFAULT_FLOOR_SEGMENT.getMb() + 1, ByteSizeUnit.MB).getMbFrac(),
+            ByteSizeValue.of(MergePolicyConfig.DEFAULT_FLOOR_SEGMENT.getMb() + 1, ByteSizeUnit.MB).getMbFrac(),
             0.001
         );
 
@@ -303,12 +303,12 @@ public class MergePolicyConfigTests extends ESTestCase {
         );
         assertEquals(
             ((TieredMergePolicy) indexSettings.getMergePolicy(false)).getFloorSegmentMB(),
-            new ByteSizeValue(MergePolicyConfig.DEFAULT_FLOOR_SEGMENT.getMb(), ByteSizeUnit.MB).getMbFrac(),
+            ByteSizeValue.of(MergePolicyConfig.DEFAULT_FLOOR_SEGMENT.getMb(), ByteSizeUnit.MB).getMbFrac(),
             0.00
         );
         assertEquals(
             ((LogByteSizeMergePolicy) indexSettings.getMergePolicy(true)).getMinMergeMB(),
-            new ByteSizeValue(MergePolicyConfig.DEFAULT_FLOOR_SEGMENT.getMb(), ByteSizeUnit.MB).getMbFrac(),
+            ByteSizeValue.of(MergePolicyConfig.DEFAULT_FLOOR_SEGMENT.getMb(), ByteSizeUnit.MB).getMbFrac(),
             0.00
         );
         assertEquals(

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -290,8 +290,8 @@ public class TranslogTests extends ESTestCase {
     private TranslogConfig getTranslogConfig(final Path path, final Settings settings, OperationListener listener) {
         final ByteSizeValue bufferSize = randomFrom(
             TranslogConfig.DEFAULT_BUFFER_SIZE,
-            new ByteSizeValue(8, ByteSizeUnit.KB),
-            new ByteSizeValue(10 + randomInt(128 * 1024), ByteSizeUnit.BYTES)
+            ByteSizeValue.of(8, ByteSizeUnit.KB),
+            ByteSizeValue.of(10 + randomInt(128 * 1024), ByteSizeUnit.BYTES)
         );
 
         final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings);
@@ -1395,7 +1395,7 @@ public class TranslogTests extends ESTestCase {
             temp.getTranslogPath(),
             temp.getIndexSettings(),
             temp.getBigArrays(),
-            new ByteSizeValue(1, ByteSizeUnit.KB),
+            ByteSizeValue.of(1, ByteSizeUnit.KB),
             randomBoolean() ? DiskIoBufferPool.INSTANCE : RANDOMIZING_IO_BUFFERS,
             TranslogConfig.NOOP_OPERATION_LISTENER,
             true
@@ -4080,7 +4080,7 @@ public class TranslogTests extends ESTestCase {
             translogDir,
             IndexSettingsModule.newIndexSettings(shardId.getIndex(), Settings.EMPTY),
             NON_RECYCLING_INSTANCE,
-            new ByteSizeValue(1, ByteSizeUnit.KB),
+            ByteSizeValue.of(1, ByteSizeUnit.KB),
             randomBoolean() ? DiskIoBufferPool.INSTANCE : RANDOMIZING_IO_BUFFERS,
             TranslogConfig.NOOP_OPERATION_LISTENER,
             false

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -237,7 +237,7 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
             Settings.builder().put("indices.memory.index_buffer_size", "0.001%").put("indices.memory.min_index_buffer_size", "6mb").build()
         );
 
-        assertThat(controller.indexingBufferSize(), equalTo(new ByteSizeValue(6, ByteSizeUnit.MB).getBytes()));
+        assertThat(controller.indexingBufferSize(), equalTo(ByteSizeValue.of(6, ByteSizeUnit.MB).getBytes()));
     }
 
     public void testNegativeMinIndexBufferSize() {
@@ -289,7 +289,7 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
             Settings.builder().put("indices.memory.index_buffer_size", "90%").put("indices.memory.max_index_buffer_size", "6mb").build()
         );
 
-        assertThat(controller.indexingBufferSize(), equalTo(new ByteSizeValue(6, ByteSizeUnit.MB).getBytes()));
+        assertThat(controller.indexingBufferSize(), equalTo(ByteSizeValue.of(6, ByteSizeUnit.MB).getBytes()));
     }
 
     public void testThrottling() throws Exception {

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -211,19 +211,19 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
         CircuitBreaker requestCircuitBreaker = service.getBreaker(CircuitBreaker.REQUEST);
         CircuitBreaker fieldDataCircuitBreaker = service.getBreaker(CircuitBreaker.FIELDDATA);
 
-        assertEquals(new ByteSizeValue(200, ByteSizeUnit.MB).getBytes(), service.stats().getStats(CircuitBreaker.PARENT).getLimit());
-        assertEquals(new ByteSizeValue(150, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getLimit());
-        assertEquals(new ByteSizeValue(150, ByteSizeUnit.MB).getBytes(), fieldDataCircuitBreaker.getLimit());
+        assertEquals(ByteSizeValue.of(200, ByteSizeUnit.MB).getBytes(), service.stats().getStats(CircuitBreaker.PARENT).getLimit());
+        assertEquals(ByteSizeValue.of(150, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getLimit());
+        assertEquals(ByteSizeValue.of(150, ByteSizeUnit.MB).getBytes(), fieldDataCircuitBreaker.getLimit());
 
-        fieldDataCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should not break");
-        assertEquals(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), fieldDataCircuitBreaker.getUsed(), 0.0);
-        requestCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should not break");
-        assertEquals(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getUsed(), 0.0);
-        requestCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should not break");
-        assertEquals(new ByteSizeValue(100, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getUsed(), 0.0);
+        fieldDataCircuitBreaker.addEstimateBytesAndMaybeBreak(ByteSizeValue.of(50, ByteSizeUnit.MB).getBytes(), "should not break");
+        assertEquals(ByteSizeValue.of(50, ByteSizeUnit.MB).getBytes(), fieldDataCircuitBreaker.getUsed(), 0.0);
+        requestCircuitBreaker.addEstimateBytesAndMaybeBreak(ByteSizeValue.of(50, ByteSizeUnit.MB).getBytes(), "should not break");
+        assertEquals(ByteSizeValue.of(50, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getUsed(), 0.0);
+        requestCircuitBreaker.addEstimateBytesAndMaybeBreak(ByteSizeValue.of(50, ByteSizeUnit.MB).getBytes(), "should not break");
+        assertEquals(ByteSizeValue.of(100, ByteSizeUnit.MB).getBytes(), requestCircuitBreaker.getUsed(), 0.0);
         CircuitBreakingException exception = expectThrows(
             CircuitBreakingException.class,
-            () -> requestCircuitBreaker.addEstimateBytesAndMaybeBreak(new ByteSizeValue(50, ByteSizeUnit.MB).getBytes(), "should break")
+            () -> requestCircuitBreaker.addEstimateBytesAndMaybeBreak(ByteSizeValue.of(50, ByteSizeUnit.MB).getBytes(), "should break")
         );
         assertThat(exception.getMessage(), containsString("[parent] Data too large, data for [should break] would be"));
         assertThat(exception.getMessage(), containsString("which is larger than the limit of [209715200/200mb]"));
@@ -733,7 +733,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
         );
 
         long parentLimitBytes = service.getParentLimit();
-        assertEquals(new ByteSizeValue(100, ByteSizeUnit.BYTES).getBytes(), parentLimitBytes);
+        assertEquals(ByteSizeValue.of(100, ByteSizeUnit.BYTES).getBytes(), parentLimitBytes);
 
         CircuitBreaker breaker = service.getBreaker(CircuitBreaker.REQUEST);
         MultiBucketConsumerService.MultiBucketConsumer multiBucketConsumer = new MultiBucketConsumerService.MultiBucketConsumer(
@@ -800,7 +800,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
     }
 
     private static long mb(long size) {
-        return new ByteSizeValue(size, ByteSizeUnit.MB).getBytes();
+        return ByteSizeValue.of(size, ByteSizeUnit.MB).getBytes();
     }
 
     public void testUpdatingUseRealMemory() {

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -83,7 +83,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 
 public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
-    private static final ByteSizeValue SNAPSHOT_FILE_PART_SIZE = new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES);
+    private static final ByteSizeValue SNAPSHOT_FILE_PART_SIZE = ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES);
 
     public void testWriteFileChunksConcurrently() throws Exception {
         IndexShard sourceShard = newStartedShard(true);
@@ -454,7 +454,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
             @Override
             public int getReadSnapshotFileBufferSizeForRepo(String repository) {
-                return (int) new ByteSizeValue(128, ByteSizeUnit.KB).getBytes();
+                return (int) ByteSizeValue.of(128, ByteSizeUnit.KB).getBytes();
             }
         };
 
@@ -526,7 +526,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
             @Override
             public int getReadSnapshotFileBufferSizeForRepo(String repository) {
-                return (int) new ByteSizeValue(128, ByteSizeUnit.KB).getBytes();
+                return (int) ByteSizeValue.of(128, ByteSizeUnit.KB).getBytes();
             }
         };
 
@@ -636,7 +636,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
             @Override
             public int getReadSnapshotFileBufferSizeForRepo(String repository) {
-                return (int) new ByteSizeValue(128, ByteSizeUnit.KB).getBytes();
+                return (int) ByteSizeValue.of(128, ByteSizeUnit.KB).getBytes();
             }
         };
 
@@ -699,7 +699,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
             @Override
             public int getReadSnapshotFileBufferSizeForRepo(String repository) {
-                return (int) new ByteSizeValue(128, ByteSizeUnit.KB).getBytes();
+                return (int) ByteSizeValue.of(128, ByteSizeUnit.KB).getBytes();
             }
         };
 
@@ -713,7 +713,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         BlobStoreIndexShardSnapshot.FileInfo fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
             "name",
             storeFileMetadata,
-            new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)
+            ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES)
         );
 
         recoveryTarget.incRef();

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySettingsTests.java
@@ -423,7 +423,7 @@ public class RecoverySettingsTests extends ESTestCase {
                     .withMemory(ByteSizeValue.ofBytes(randomLongBetween(1L, ByteSizeUnit.GB.toBytes(4L))))
                     .build()
                     .getMaxBytesPerSec(),
-                equalTo(new ByteSizeValue(40, ByteSizeUnit.MB))
+                equalTo(ByteSizeValue.of(40, ByteSizeUnit.MB))
             );
         }
         {
@@ -433,7 +433,7 @@ public class RecoverySettingsTests extends ESTestCase {
                     .withMemory(ByteSizeValue.ofBytes(randomLongBetween(ByteSizeUnit.GB.toBytes(4L) + 1L, ByteSizeUnit.GB.toBytes(8L))))
                     .build()
                     .getMaxBytesPerSec(),
-                equalTo(new ByteSizeValue(60, ByteSizeUnit.MB))
+                equalTo(ByteSizeValue.of(60, ByteSizeUnit.MB))
             );
         }
         {
@@ -443,7 +443,7 @@ public class RecoverySettingsTests extends ESTestCase {
                     .withMemory(ByteSizeValue.ofBytes(randomLongBetween(ByteSizeUnit.GB.toBytes(8L) + 1L, ByteSizeUnit.GB.toBytes(16L))))
                     .build()
                     .getMaxBytesPerSec(),
-                equalTo(new ByteSizeValue(90, ByteSizeUnit.MB))
+                equalTo(ByteSizeValue.of(90, ByteSizeUnit.MB))
             );
         }
         {
@@ -453,7 +453,7 @@ public class RecoverySettingsTests extends ESTestCase {
                     .withMemory(ByteSizeValue.ofBytes(randomLongBetween(ByteSizeUnit.GB.toBytes(16L) + 1L, ByteSizeUnit.GB.toBytes(32L))))
                     .build()
                     .getMaxBytesPerSec(),
-                equalTo(new ByteSizeValue(125, ByteSizeUnit.MB))
+                equalTo(ByteSizeValue.of(125, ByteSizeUnit.MB))
             );
         }
         {
@@ -463,7 +463,7 @@ public class RecoverySettingsTests extends ESTestCase {
                     .withMemory(ByteSizeValue.ofBytes(randomLongBetween(ByteSizeUnit.GB.toBytes(32L) + 1L, ByteSizeUnit.TB.toBytes(4L))))
                     .build()
                     .getMaxBytesPerSec(),
-                equalTo(new ByteSizeValue(250, ByteSizeUnit.MB))
+                equalTo(ByteSizeValue.of(250, ByteSizeUnit.MB))
             );
         }
     }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -1686,7 +1686,7 @@ public class RecoverySourceHandlerTests extends MapperServiceTestCase {
             0
         );
 
-        ByteSizeValue partSize = new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES);
+        ByteSizeValue partSize = ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES);
 
         List<StoreFileMetadata> filesToRecoverFromSource = sourceFiles.subList(0, sourceFileCount);
         List<StoreFileMetadata> filesToRecoverFromSnapshot = sourceFiles.subList(sourceFileCount, sourceFiles.size());

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -486,13 +486,13 @@ public abstract class ESIntegTestCase extends ESTestCase {
         if (random.nextBoolean()) {
             builder.put(
                 IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(),
-                new ByteSizeValue(RandomNumbers.randomIntBetween(random, 1, 300), ByteSizeUnit.MB)
+                ByteSizeValue.of(RandomNumbers.randomIntBetween(random, 1, 300), ByteSizeUnit.MB)
             );
         }
         if (random.nextBoolean()) {
-            builder.put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB)); // just
-                                                                                                                                    // don't
-                                                                                                                                    // flush
+            builder.put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), ByteSizeValue.of(1, ByteSizeUnit.PB)); // just
+                                                                                                                                   // don't
+                                                                                                                                   // flush
         }
         if (random.nextBoolean()) {
             builder.put(

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -574,12 +574,12 @@ public final class InternalTestCluster extends TestCluster {
             if (random.nextInt(10) == 0) { // do something crazy slow here
                 builder.put(
                     RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(),
-                    new ByteSizeValue(RandomNumbers.randomIntBetween(random, 1, 10), ByteSizeUnit.MB)
+                    ByteSizeValue.of(RandomNumbers.randomIntBetween(random, 1, 10), ByteSizeUnit.MB)
                 );
             } else {
                 builder.put(
                     RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(),
-                    new ByteSizeValue(RandomNumbers.randomIntBetween(random, 10, 200), ByteSizeUnit.MB)
+                    ByteSizeValue.of(RandomNumbers.randomIntBetween(random, 10, 200), ByteSizeUnit.MB)
                 );
             }
         }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
@@ -359,7 +359,7 @@ public class TopMetricsAggregatorTests extends AggregatorTestCase {
     public void testTonsOfBucketsTriggersBreaker() throws IOException {
         // Build a "simple" circuit breaker that trips at 20k
         CircuitBreakerService breaker = mock(CircuitBreakerService.class);
-        ByteSizeValue max = new ByteSizeValue(20, ByteSizeUnit.KB);
+        ByteSizeValue max = ByteSizeValue.of(20, ByteSizeUnit.KB);
         when(breaker.getBreaker(CircuitBreaker.REQUEST)).thenReturn(new MockBigArrays.LimitedBreaker(CircuitBreaker.REQUEST, max));
 
         // Collect some buckets with it

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AbstractFrozenAutoscalingIntegTestCase.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AbstractFrozenAutoscalingIntegTestCase.java
@@ -73,7 +73,7 @@ public abstract class AbstractFrozenAutoscalingIntegTestCase extends AbstractSna
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put(SELF_GENERATED_LICENSE_TYPE.getKey(), "trial");
         if (DiscoveryNode.hasRole(otherSettings, DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE)) {
-            builder.put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(10, ByteSizeUnit.MB));
+            builder.put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.of(10, ByteSizeUnit.MB));
         }
         return builder.build();
     }

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/shards/FrozenShardsDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/shards/FrozenShardsDeciderServiceTests.java
@@ -68,7 +68,7 @@ public class FrozenShardsDeciderServiceTests extends AutoscalingTestCase {
         );
         assertThat(defaultSettingsResult.reason().summary(), equalTo("shard count [" + (shards * (replicas + 1) + "]")));
 
-        ByteSizeValue memoryPerShard = new ByteSizeValue(
+        ByteSizeValue memoryPerShard = ByteSizeValue.of(
             randomLongBetween(0, 1000),
             randomFrom(ByteSizeUnit.BYTES, ByteSizeUnit.KB, ByteSizeUnit.MB)
         );

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -813,7 +813,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
     }
 
     public void testCacheSizeChanges() throws IOException {
-        ByteSizeValue val1 = new ByteSizeValue(randomIntBetween(1, 5), ByteSizeUnit.MB);
+        ByteSizeValue val1 = ByteSizeValue.of(randomIntBetween(1, 5), ByteSizeUnit.MB);
         Settings settings = Settings.builder()
             .put(NODE_NAME_SETTING.getKey(), "node")
             .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), val1.getStringRep())
@@ -834,7 +834,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             assertEquals(val1.getBytes(), cacheService.getStats().size());
         }
 
-        ByteSizeValue val2 = new ByteSizeValue(randomIntBetween(1, 5), ByteSizeUnit.MB);
+        ByteSizeValue val2 = ByteSizeValue.of(randomIntBetween(1, 5), ByteSizeUnit.MB);
         settings = Settings.builder()
             .put(settings)
             .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), val2.getStringRep())

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
@@ -120,7 +120,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
     ) throws IOException {
         final ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .masterNodeTimeout(TimeValue.MAX_VALUE);
-        final String chunkSize = new ByteSizeValue(randomFrom(4, 128, 1024), ByteSizeUnit.KB).getStringRep();
+        final String chunkSize = ByteSizeValue.of(randomFrom(4, 128, 1024), ByteSizeUnit.KB).getStringRep();
         settingsRequest.persistentSettings(Settings.builder().put(CcrSettings.RECOVERY_CHUNK_SIZE.getKey(), chunkSize));
         assertAcked(followerClient().admin().cluster().updateSettings(settingsRequest).actionGet());
 

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/FollowerFailOverIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/FollowerFailOverIT.java
@@ -92,10 +92,10 @@ public class FollowerFailOverIT extends CcrIntegTestCase {
         availableDocs.release(between(100, 200));
         PutFollowAction.Request follow = putFollow(leaderIndex, followerIndex);
         follow.getParameters().setMaxReadRequestOperationCount(randomIntBetween(32, 2048));
-        follow.getParameters().setMaxReadRequestSize(new ByteSizeValue(randomIntBetween(1, 4096), ByteSizeUnit.KB));
+        follow.getParameters().setMaxReadRequestSize(ByteSizeValue.of(randomIntBetween(1, 4096), ByteSizeUnit.KB));
         follow.getParameters().setMaxOutstandingReadRequests(randomIntBetween(1, 10));
         follow.getParameters().setMaxWriteRequestOperationCount(randomIntBetween(32, 2048));
-        follow.getParameters().setMaxWriteRequestSize(new ByteSizeValue(randomIntBetween(1, 4096), ByteSizeUnit.KB));
+        follow.getParameters().setMaxWriteRequestSize(ByteSizeValue.of(randomIntBetween(1, 4096), ByteSizeUnit.KB));
         follow.getParameters().setMaxOutstandingWriteRequests(randomIntBetween(1, 10));
         logger.info("--> follow request {}", Strings.toString(follow));
         followerClient().execute(PutFollowAction.INSTANCE, follow).get();
@@ -153,10 +153,10 @@ public class FollowerFailOverIT extends CcrIntegTestCase {
 
         PutFollowAction.Request followRequest = putFollow("index1", "index2");
         followRequest.getParameters().setMaxReadRequestOperationCount(randomIntBetween(32, 2048));
-        followRequest.getParameters().setMaxReadRequestSize(new ByteSizeValue(randomIntBetween(1, 4096), ByteSizeUnit.KB));
+        followRequest.getParameters().setMaxReadRequestSize(ByteSizeValue.of(randomIntBetween(1, 4096), ByteSizeUnit.KB));
         followRequest.getParameters().setMaxOutstandingReadRequests(randomIntBetween(1, 10));
         followRequest.getParameters().setMaxWriteRequestOperationCount(randomIntBetween(32, 2048));
-        followRequest.getParameters().setMaxWriteRequestSize(new ByteSizeValue(randomIntBetween(1, 4096), ByteSizeUnit.KB));
+        followRequest.getParameters().setMaxWriteRequestSize(ByteSizeValue.of(randomIntBetween(1, 4096), ByteSizeUnit.KB));
         followRequest.getParameters().setMaxOutstandingWriteRequests(randomIntBetween(1, 10));
         followRequest.waitForActiveShards(ActiveShardCount.ALL);
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
@@ -150,7 +150,7 @@ public class IndexFollowingIT extends CcrIntegTestCase {
             .setMasterNodeTimeout(TimeValue.MAX_VALUE)
             .setPersistentSettings(
                 Settings.builder()
-                    .put(CcrSettings.RECOVERY_CHUNK_SIZE.getKey(), new ByteSizeValue(randomIntBetween(1, 1000), ByteSizeUnit.KB))
+                    .put(CcrSettings.RECOVERY_CHUNK_SIZE.getKey(), ByteSizeValue.of(randomIntBetween(1, 1000), ByteSizeUnit.KB))
             )
             .get();
 
@@ -667,7 +667,7 @@ public class IndexFollowingIT extends CcrIntegTestCase {
         }
 
         PutFollowAction.Request followRequest = putFollow("index1", "index2");
-        followRequest.getParameters().setMaxReadRequestSize(new ByteSizeValue(randomIntBetween(1, 1024), ByteSizeUnit.BYTES));
+        followRequest.getParameters().setMaxReadRequestSize(ByteSizeValue.of(randomIntBetween(1, 1024), ByteSizeUnit.BYTES));
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
 
         final Map<ShardId, Long> firstBatchNumDocsPerShard = new HashMap<>();

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrSettings.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrSettings.java
@@ -60,7 +60,7 @@ public final class CcrSettings {
      */
     public static final Setting<ByteSizeValue> RECOVERY_MAX_BYTES_PER_SECOND = Setting.byteSizeSetting(
         "ccr.indices.recovery.max_bytes_per_sec",
-        new ByteSizeValue(40, ByteSizeUnit.MB),
+        ByteSizeValue.of(40, ByteSizeUnit.MB),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -70,9 +70,9 @@ public final class CcrSettings {
      */
     public static final Setting<ByteSizeValue> RECOVERY_CHUNK_SIZE = Setting.byteSizeSetting(
         "ccr.indices.recovery.chunk_size",
-        new ByteSizeValue(1, ByteSizeUnit.MB),
-        new ByteSizeValue(1, ByteSizeUnit.KB),
-        new ByteSizeValue(1, ByteSizeUnit.GB),
+        ByteSizeValue.of(1, ByteSizeUnit.MB),
+        ByteSizeValue.of(1, ByteSizeUnit.KB),
+        ByteSizeValue.of(1, ByteSizeUnit.GB),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -68,12 +68,12 @@ import static org.elasticsearch.xpack.ccr.Ccr.CCR_THREAD_POOL_NAME;
 
 public class TransportResumeFollowAction extends AcknowledgedTransportMasterNodeAction<ResumeFollowAction.Request> {
 
-    static final ByteSizeValue DEFAULT_MAX_READ_REQUEST_SIZE = new ByteSizeValue(32, ByteSizeUnit.MB);
+    static final ByteSizeValue DEFAULT_MAX_READ_REQUEST_SIZE = ByteSizeValue.of(32, ByteSizeUnit.MB);
     static final ByteSizeValue DEFAULT_MAX_WRITE_REQUEST_SIZE = ByteSizeValue.ofBytes(Long.MAX_VALUE);
     private static final TimeValue DEFAULT_MAX_RETRY_DELAY = new TimeValue(500);
     private static final int DEFAULT_MAX_OUTSTANDING_WRITE_REQUESTS = 9;
     private static final int DEFAULT_MAX_WRITE_BUFFER_COUNT = Integer.MAX_VALUE;
-    private static final ByteSizeValue DEFAULT_MAX_WRITE_BUFFER_SIZE = new ByteSizeValue(512, ByteSizeUnit.MB);
+    private static final ByteSizeValue DEFAULT_MAX_WRITE_BUFFER_SIZE = ByteSizeValue.of(512, ByteSizeUnit.MB);
     private static final int DEFAULT_MAX_READ_REQUEST_OPERATION_COUNT = 5120;
     private static final int DEFAULT_MAX_WRITE_REQUEST_OPERATION_COUNT = 5120;
     private static final int DEFAULT_MAX_OUTSTANDING_READ_REQUESTS = 12;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestShardChangesAction.java
@@ -59,7 +59,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestShardChangesAction extends BaseRestHandler {
 
     private static final long DEFAULT_FROM_SEQ_NO = 0L;
-    private static final ByteSizeValue DEFAULT_MAX_BATCH_SIZE = new ByteSizeValue(32, ByteSizeUnit.MB);
+    private static final ByteSizeValue DEFAULT_MAX_BATCH_SIZE = ByteSizeValue.of(32, ByteSizeUnit.MB);
     private static final TimeValue DEFAULT_POLL_TIMEOUT = new TimeValue(1, TimeUnit.MINUTES);
     private static final int DEFAULT_MAX_OPERATIONS_COUNT = 1024;
     private static final int DEFAULT_TIMEOUT_SECONDS = 60;

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ResumeFollowActionRequestTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ResumeFollowActionRequestTests.java
@@ -69,7 +69,7 @@ public class ResumeFollowActionRequestTests extends AbstractXContentSerializingT
             followParameters.setMaxOutstandingWriteRequests(randomIntBetween(1, Integer.MAX_VALUE));
         }
         if (randomBoolean()) {
-            followParameters.setMaxReadRequestSize(new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES));
+            followParameters.setMaxReadRequestSize(ByteSizeValue.of(randomNonNegativeLong(), ByteSizeUnit.BYTES));
         }
         if (randomBoolean()) {
             followParameters.setMaxWriteBufferCount(randomIntBetween(1, Integer.MAX_VALUE));

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
@@ -67,7 +67,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
                 min,
                 size,
                 indexShard.getHistoryUUID(),
-                new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)
+                ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES)
             );
             final List<Long> seenSeqNos = Arrays.stream(operations).map(Translog.Operation::seqNo).collect(Collectors.toList());
             final List<Long> expectedSeqNos = LongStream.rangeClosed(min, max).boxed().collect(Collectors.toList());
@@ -84,7 +84,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
                     numWrites,
                     numWrites + 1,
                     indexShard.getHistoryUUID(),
-                    new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)
+                    ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES)
                 )
             );
             final String message = String.format(
@@ -103,7 +103,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
             numWrites - 10,
             numWrites + 10,
             indexShard.getHistoryUUID(),
-            new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)
+            ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES)
         );
         assertThat(operations.length, equalTo(10));
 
@@ -116,7 +116,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
                 0,
                 10,
                 "different-history-uuid",
-                new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)
+                ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES)
             )
         );
         assertThat(
@@ -136,7 +136,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
                     fromSeqNo,
                     batchSize,
                     indexShard.getHistoryUUID(),
-                    new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)
+                    ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES)
                 )
             );
             assertThat(
@@ -159,7 +159,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
                 0,
                 1,
                 indexShard.getHistoryUUID(),
-                new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)
+                ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES)
             )
         );
     }
@@ -179,7 +179,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
             0,
             randomIntBetween(100, 500),
             indexShard.getHistoryUUID(),
-            new ByteSizeValue(256, ByteSizeUnit.BYTES)
+            ByteSizeValue.of(256, ByteSizeUnit.BYTES)
         );
         assertThat(operations.length, equalTo(8));
         assertThat(operations[0].seqNo(), equalTo(0L));

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskRandomTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskRandomTests.java
@@ -105,7 +105,7 @@ public class ShardFollowNodeTaskRandomTests extends ESTestCase {
             TransportResumeFollowAction.DEFAULT_MAX_READ_REQUEST_SIZE,
             TransportResumeFollowAction.DEFAULT_MAX_READ_REQUEST_SIZE,
             10240,
-            new ByteSizeValue(512, ByteSizeUnit.MB),
+            ByteSizeValue.of(512, ByteSizeUnit.MB),
             TimeValue.timeValueMillis(10),
             TimeValue.timeValueMillis(10),
             Collections.emptyMap()

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskTests.java
@@ -139,7 +139,7 @@ public class ShardFollowNodeTaskTests extends ESTestCase {
         params.maxReadRequestOperationCount = 64;
         params.maxOutstandingReadRequests = 1;
         params.maxOutstandingWriteRequests = 0; // need to set outstandingWrites to 0, other the write buffer gets flushed immediately
-        params.maxWriteBufferSize = new ByteSizeValue(1, ByteSizeUnit.KB);
+        params.maxWriteBufferSize = ByteSizeValue.of(1, ByteSizeUnit.KB);
         ShardFollowNodeTask task = createShardFollowTask(params);
         startTask(task, 63, -1);
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -340,7 +340,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                         fromSeqNo,
                         numOps,
                         leadingPrimary.getHistoryUUID(),
-                        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES)
+                        ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES)
                     );
 
                     IndexShard followingPrimary = followerGroup.getPrimary();
@@ -405,7 +405,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
         Future<Void> recoveryFuture = null;
         Settings settings = Settings.builder()
             .put(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey(), true)
-            .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(between(1, 1000), ByteSizeUnit.KB))
+            .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), ByteSizeValue.of(between(1, 1000), ByteSizeUnit.KB))
             .build();
         IndexMetadata indexMetadata = buildIndexMetadata(between(0, 1), settings, indexMapping);
         try (ReplicationGroup group = new ReplicationGroup(indexMetadata) {
@@ -505,7 +505,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
     private ReplicationGroup createFollowGroup(ReplicationGroup leaderGroup, int replicas) throws IOException {
         final Settings settings = Settings.builder()
             .put(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey(), true)
-            .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(between(1, 1000), ByteSizeUnit.KB))
+            .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), ByteSizeValue.of(between(1, 1000), ByteSizeUnit.KB))
             .build();
         IndexMetadata indexMetadata = buildIndexMetadata(replicas, settings, indexMapping);
         return new ReplicationGroup(indexMetadata) {
@@ -573,10 +573,10 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
             between(1, 64),
             between(1, 8),
             between(1, 4),
-            new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
-            new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+            ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+            ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES),
             10240,
-            new ByteSizeValue(512, ByteSizeUnit.MB),
+            ByteSizeValue.of(512, ByteSizeUnit.MB),
             TimeValue.timeValueMillis(10),
             TimeValue.timeValueMillis(10),
             Collections.emptyMap()

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportActivateAutoFollowPatternActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportActivateAutoFollowPatternActionTests.java
@@ -120,10 +120,10 @@ public class TransportActivateAutoFollowPatternActionTests extends ESTestCase {
             randomIntBetween(1, 100),
             randomIntBetween(1, 100),
             randomIntBetween(1, 100),
-            new ByteSizeValue(randomIntBetween(1, 100), randomFrom(ByteSizeUnit.values())),
-            new ByteSizeValue(randomIntBetween(1, 100), randomFrom(ByteSizeUnit.values())),
+            ByteSizeValue.of(randomIntBetween(1, 100), randomFrom(ByteSizeUnit.values())),
+            ByteSizeValue.of(randomIntBetween(1, 100), randomFrom(ByteSizeUnit.values())),
             randomIntBetween(1, 100),
-            new ByteSizeValue(randomIntBetween(1, 100), randomFrom(ByteSizeUnit.values())),
+            ByteSizeValue.of(randomIntBetween(1, 100), randomFrom(ByteSizeUnit.values())),
             TimeValue.timeValueSeconds(randomIntBetween(30, 600)),
             TimeValue.timeValueSeconds(randomIntBetween(30, 600))
         );

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportFollowStatsActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportFollowStatsActionTests.java
@@ -86,7 +86,7 @@ public class TransportFollowStatsActionTests extends ESTestCase {
             TransportResumeFollowAction.DEFAULT_MAX_READ_REQUEST_SIZE,
             TransportResumeFollowAction.DEFAULT_MAX_READ_REQUEST_SIZE,
             10240,
-            new ByteSizeValue(512, ByteSizeUnit.MB),
+            ByteSizeValue.of(512, ByteSizeUnit.MB),
             TimeValue.timeValueMillis(10),
             TimeValue.timeValueMillis(10),
             Collections.emptyMap()

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowActionTests.java
@@ -88,7 +88,7 @@ public class TransportUnfollowActionTests extends ESTestCase {
             TransportResumeFollowAction.DEFAULT_MAX_READ_REQUEST_SIZE,
             TransportResumeFollowAction.DEFAULT_MAX_READ_REQUEST_SIZE,
             10240,
-            new ByteSizeValue(512, ByteSizeUnit.MB),
+            ByteSizeValue.of(512, ByteSizeUnit.MB),
             TimeValue.timeValueMillis(10),
             TimeValue.timeValueMillis(10),
             Collections.emptyMap()

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PauseFollowerIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PauseFollowerIndexStepTests.java
@@ -165,10 +165,10 @@ public class PauseFollowerIndexStepTests extends AbstractUnfollowIndexStepTestCa
                     1024,
                     1,
                     1,
-                    new ByteSizeValue(32, ByteSizeUnit.MB),
-                    new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+                    ByteSizeValue.of(32, ByteSizeUnit.MB),
+                    ByteSizeValue.of(Long.MAX_VALUE, ByteSizeUnit.BYTES),
                     10240,
-                    new ByteSizeValue(512, ByteSizeUnit.MB),
+                    ByteSizeValue.of(512, ByteSizeUnit.MB),
                     TimeValue.timeValueMillis(10),
                     TimeValue.timeValueMillis(10),
                     Map.of()

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
@@ -60,20 +60,20 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
         Step.StepKey stepKey = randomStepKey();
         Step.StepKey nextStepKey = randomStepKey();
         ByteSizeUnit maxSizeUnit = randomFrom(ByteSizeUnit.values());
-        ByteSizeValue maxSize = randomBoolean() ? null : new ByteSizeValue(randomNonNegativeLong() / maxSizeUnit.toBytes(1), maxSizeUnit);
+        ByteSizeValue maxSize = randomBoolean() ? null : ByteSizeValue.of(randomNonNegativeLong() / maxSizeUnit.toBytes(1), maxSizeUnit);
         ByteSizeUnit maxPrimaryShardSizeUnit = randomFrom(ByteSizeUnit.values());
         ByteSizeValue maxPrimaryShardSize = randomBoolean()
             ? null
-            : new ByteSizeValue(randomNonNegativeLong() / maxPrimaryShardSizeUnit.toBytes(1), maxPrimaryShardSizeUnit);
+            : ByteSizeValue.of(randomNonNegativeLong() / maxPrimaryShardSizeUnit.toBytes(1), maxPrimaryShardSizeUnit);
         Long maxDocs = randomBoolean() ? null : randomNonNegativeLong();
         TimeValue maxAge = (maxDocs == null && maxSize == null || randomBoolean()) ? randomPositiveTimeValue() : null;
         Long maxPrimaryShardDocs = randomBoolean() ? null : randomNonNegativeLong();
         ByteSizeUnit minSizeUnit = randomFrom(ByteSizeUnit.values());
-        ByteSizeValue minSize = randomBoolean() ? null : new ByteSizeValue(randomNonNegativeLong() / minSizeUnit.toBytes(1), minSizeUnit);
+        ByteSizeValue minSize = randomBoolean() ? null : ByteSizeValue.of(randomNonNegativeLong() / minSizeUnit.toBytes(1), minSizeUnit);
         ByteSizeUnit minPrimaryShardSizeUnit = randomFrom(ByteSizeUnit.values());
         ByteSizeValue minPrimaryShardSize = randomBoolean()
             ? null
-            : new ByteSizeValue(randomNonNegativeLong() / minPrimaryShardSizeUnit.toBytes(1), minPrimaryShardSizeUnit);
+            : ByteSizeValue.of(randomNonNegativeLong() / minPrimaryShardSizeUnit.toBytes(1), minPrimaryShardSizeUnit);
         Long minDocs = randomBoolean() ? null : randomNonNegativeLong();
         TimeValue minAge = (minDocs == null || randomBoolean()) ? randomPositiveTimeValue() : null;
         Long minPrimaryShardDocs = randomBoolean() ? null : randomNonNegativeLong();
@@ -115,22 +115,22 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
             case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> maxSize = randomValueOtherThan(maxSize, () -> {
                 ByteSizeUnit maxSizeUnit = randomFrom(ByteSizeUnit.values());
-                return new ByteSizeValue(randomNonNegativeLong() / maxSizeUnit.toBytes(1), maxSizeUnit);
+                return ByteSizeValue.of(randomNonNegativeLong() / maxSizeUnit.toBytes(1), maxSizeUnit);
             });
             case 3 -> maxPrimaryShardSize = randomValueOtherThan(maxPrimaryShardSize, () -> {
                 ByteSizeUnit maxPrimaryShardSizeUnit = randomFrom(ByteSizeUnit.values());
-                return new ByteSizeValue(randomNonNegativeLong() / maxPrimaryShardSizeUnit.toBytes(1), maxPrimaryShardSizeUnit);
+                return ByteSizeValue.of(randomNonNegativeLong() / maxPrimaryShardSizeUnit.toBytes(1), maxPrimaryShardSizeUnit);
             });
             case 4 -> maxAge = randomValueOtherThan(maxAge, () -> randomPositiveTimeValue());
             case 5 -> maxDocs = randomValueOtherThan(maxDocs, ESTestCase::randomNonNegativeLong);
             case 6 -> maxPrimaryShardDocs = randomValueOtherThan(maxPrimaryShardDocs, ESTestCase::randomNonNegativeLong);
             case 7 -> minSize = randomValueOtherThan(minSize, () -> {
                 ByteSizeUnit minSizeUnit = randomFrom(ByteSizeUnit.values());
-                return new ByteSizeValue(randomNonNegativeLong() / minSizeUnit.toBytes(1), minSizeUnit);
+                return ByteSizeValue.of(randomNonNegativeLong() / minSizeUnit.toBytes(1), minSizeUnit);
             });
             case 8 -> minPrimaryShardSize = randomValueOtherThan(minPrimaryShardSize, () -> {
                 ByteSizeUnit minPrimaryShardSizeUnit = randomFrom(ByteSizeUnit.values());
-                return new ByteSizeValue(randomNonNegativeLong() / minPrimaryShardSizeUnit.toBytes(1), minPrimaryShardSizeUnit);
+                return ByteSizeValue.of(randomNonNegativeLong() / minPrimaryShardSizeUnit.toBytes(1), minPrimaryShardSizeUnit);
             });
             case 9 -> minAge = randomValueOtherThan(minAge, () -> randomPositiveTimeValue());
             case 10 -> minDocs = randomValueOtherThan(minDocs, ESTestCase::randomNonNegativeLong);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/ForecastJobActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/ForecastJobActionRequestTests.java
@@ -34,7 +34,7 @@ public class ForecastJobActionRequestTests extends AbstractXContentSerializingTe
         }
         if (randomBoolean()) {
             request.setMaxModelMemory(
-                randomLongBetween(new ByteSizeValue(1, ByteSizeUnit.MB).getBytes(), new ByteSizeValue(499, ByteSizeUnit.MB).getBytes())
+                randomLongBetween(ByteSizeValue.of(1, ByteSizeUnit.MB).getBytes(), ByteSizeValue.of(499, ByteSizeUnit.MB).getBytes())
             );
         }
         return request;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
@@ -165,7 +165,7 @@ public class DataFrameAnalyticsConfigTests extends AbstractBWCSerializationTestC
             );
         }
         if (randomBoolean()) {
-            builder.setModelMemoryLimit(new ByteSizeValue(randomIntBetween(1, 16), randomFrom(ByteSizeUnit.MB, ByteSizeUnit.GB)));
+            builder.setModelMemoryLimit(ByteSizeValue.of(randomIntBetween(1, 16), randomFrom(ByteSizeUnit.MB, ByteSizeUnit.GB)));
         }
         if (randomBoolean()) {
             builder.setDescription(randomAlphaOfLength(20));
@@ -285,31 +285,31 @@ public class DataFrameAnalyticsConfigTests extends AbstractBWCSerializationTestC
         assertTooSmall(
             expectThrows(
                 ElasticsearchStatusException.class,
-                () -> builder.setModelMemoryLimit(new ByteSizeValue(-1, ByteSizeUnit.BYTES)).build()
+                () -> builder.setModelMemoryLimit(ByteSizeValue.of(-1, ByteSizeUnit.BYTES)).build()
             )
         );
         assertTooSmall(
             expectThrows(
                 ElasticsearchStatusException.class,
-                () -> builder.setModelMemoryLimit(new ByteSizeValue(0, ByteSizeUnit.BYTES)).build()
+                () -> builder.setModelMemoryLimit(ByteSizeValue.of(0, ByteSizeUnit.BYTES)).build()
             )
         );
         assertTooSmall(
             expectThrows(
                 ElasticsearchStatusException.class,
-                () -> builder.setModelMemoryLimit(new ByteSizeValue(0, ByteSizeUnit.KB)).build()
+                () -> builder.setModelMemoryLimit(ByteSizeValue.of(0, ByteSizeUnit.KB)).build()
             )
         );
         assertTooSmall(
             expectThrows(
                 ElasticsearchStatusException.class,
-                () -> builder.setModelMemoryLimit(new ByteSizeValue(0, ByteSizeUnit.MB)).build()
+                () -> builder.setModelMemoryLimit(ByteSizeValue.of(0, ByteSizeUnit.MB)).build()
             )
         );
         assertTooSmall(
             expectThrows(
                 ElasticsearchStatusException.class,
-                () -> builder.setModelMemoryLimit(new ByteSizeValue(1023, ByteSizeUnit.BYTES)).build()
+                () -> builder.setModelMemoryLimit(ByteSizeValue.of(1023, ByteSizeUnit.BYTES)).build()
             )
         );
     }
@@ -329,7 +329,7 @@ public class DataFrameAnalyticsConfigTests extends AbstractBWCSerializationTestC
 
         DataFrameAnalyticsConfig defaultLimitConfig = createRandomBuilder("foo").setModelMemoryLimit(null).build();
 
-        ByteSizeValue maxLimit = new ByteSizeValue(randomIntBetween(500, 1000), ByteSizeUnit.MB);
+        ByteSizeValue maxLimit = ByteSizeValue.of(randomIntBetween(500, 1000), ByteSizeUnit.MB);
         if (maxLimit.compareTo(defaultLimitConfig.getModelMemoryLimit()) < 0) {
             assertThat(maxLimit, equalTo(new DataFrameAnalyticsConfig.Builder(defaultLimitConfig, maxLimit).build().getModelMemoryLimit()));
         } else {
@@ -342,10 +342,10 @@ public class DataFrameAnalyticsConfigTests extends AbstractBWCSerializationTestC
 
     public void testExplicitModelMemoryLimitTooHigh() {
 
-        ByteSizeValue configuredLimit = new ByteSizeValue(randomIntBetween(5, 10), ByteSizeUnit.GB);
+        ByteSizeValue configuredLimit = ByteSizeValue.of(randomIntBetween(5, 10), ByteSizeUnit.GB);
         DataFrameAnalyticsConfig explicitLimitConfig = createRandomBuilder("foo").setModelMemoryLimit(configuredLimit).build();
 
-        ByteSizeValue maxLimit = new ByteSizeValue(randomIntBetween(500, 1000), ByteSizeUnit.MB);
+        ByteSizeValue maxLimit = ByteSizeValue.of(randomIntBetween(500, 1000), ByteSizeUnit.MB);
         ElasticsearchStatusException e = expectThrows(
             ElasticsearchStatusException.class,
             () -> new DataFrameAnalyticsConfig.Builder(explicitLimitConfig, maxLimit).build()

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/explain/MemoryEstimationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/explain/MemoryEstimationTests.java
@@ -54,19 +54,19 @@ public class MemoryEstimationTests extends AbstractXContentSerializingTestCase<M
 
     public void testConstructor_SmallValues() {
         MemoryEstimation memoryEstimation = new MemoryEstimation(
-            new ByteSizeValue(120, ByteSizeUnit.KB),
-            new ByteSizeValue(30, ByteSizeUnit.KB)
+            ByteSizeValue.of(120, ByteSizeUnit.KB),
+            ByteSizeValue.of(30, ByteSizeUnit.KB)
         );
-        assertThat(memoryEstimation.getExpectedMemoryWithoutDisk(), equalTo(new ByteSizeValue(120, ByteSizeUnit.KB)));
-        assertThat(memoryEstimation.getExpectedMemoryWithDisk(), equalTo(new ByteSizeValue(30, ByteSizeUnit.KB)));
+        assertThat(memoryEstimation.getExpectedMemoryWithoutDisk(), equalTo(ByteSizeValue.of(120, ByteSizeUnit.KB)));
+        assertThat(memoryEstimation.getExpectedMemoryWithDisk(), equalTo(ByteSizeValue.of(30, ByteSizeUnit.KB)));
     }
 
     public void testConstructor() {
         MemoryEstimation memoryEstimation = new MemoryEstimation(
-            new ByteSizeValue(20, ByteSizeUnit.MB),
-            new ByteSizeValue(10, ByteSizeUnit.MB)
+            ByteSizeValue.of(20, ByteSizeUnit.MB),
+            ByteSizeValue.of(10, ByteSizeUnit.MB)
         );
-        assertThat(memoryEstimation.getExpectedMemoryWithoutDisk(), equalTo(new ByteSizeValue(20, ByteSizeUnit.MB)));
-        assertThat(memoryEstimation.getExpectedMemoryWithDisk(), equalTo(new ByteSizeValue(10, ByteSizeUnit.MB)));
+        assertThat(memoryEstimation.getExpectedMemoryWithoutDisk(), equalTo(ByteSizeValue.of(20, ByteSizeUnit.MB)));
+        assertThat(memoryEstimation.getExpectedMemoryWithDisk(), equalTo(ByteSizeValue.of(10, ByteSizeUnit.MB)));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
@@ -176,7 +176,7 @@ public class JobTests extends AbstractXContentSerializingTestCase<Job> {
 
     public void testValidateAnalysisLimitsAndSetDefaults_whenMaxIsLessThanTheDefault() {
         Job.Builder builder = buildJobBuilder("foo");
-        builder.validateAnalysisLimitsAndSetDefaults(new ByteSizeValue(512L, ByteSizeUnit.MB));
+        builder.validateAnalysisLimitsAndSetDefaults(ByteSizeValue.of(512L, ByteSizeUnit.MB));
 
         Job job = builder.build();
         assertNotNull(job.getAnalysisLimits());
@@ -189,7 +189,7 @@ public class JobTests extends AbstractXContentSerializingTestCase<Job> {
         builder.setAnalysisLimits(new AnalysisLimits(4096L, null));
         ElasticsearchStatusException e = expectThrows(
             ElasticsearchStatusException.class,
-            () -> builder.validateAnalysisLimitsAndSetDefaults(new ByteSizeValue(1000L, ByteSizeUnit.MB))
+            () -> builder.validateAnalysisLimitsAndSetDefaults(ByteSizeValue.of(1000L, ByteSizeUnit.MB))
         );
         assertEquals(
             "model_memory_limit [4gb] must be less than the value of the "
@@ -198,7 +198,7 @@ public class JobTests extends AbstractXContentSerializingTestCase<Job> {
             e.getMessage()
         );
 
-        builder.validateAnalysisLimitsAndSetDefaults(new ByteSizeValue(8192L, ByteSizeUnit.MB));
+        builder.validateAnalysisLimitsAndSetDefaults(ByteSizeValue.of(8192L, ByteSizeUnit.MB));
     }
 
     public void testEquals_GivenDifferentClass() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
@@ -360,7 +360,7 @@ public class JobUpdateTests extends AbstractXContentSerializingTestCase<JobUpdat
 
         ElasticsearchStatusException e = expectThrows(
             ElasticsearchStatusException.class,
-            () -> update.mergeWithJob(jobBuilder.build(), new ByteSizeValue(512L, ByteSizeUnit.MB))
+            () -> update.mergeWithJob(jobBuilder.build(), ByteSizeValue.of(512L, ByteSizeUnit.MB))
         );
         assertEquals(
             "model_memory_limit [1gb] must be less than the value of the xpack.ml.max_model_memory_limit setting [512mb]",
@@ -386,14 +386,14 @@ public class JobUpdateTests extends AbstractXContentSerializingTestCase<JobUpdat
 
         Exception e = expectThrows(
             ElasticsearchStatusException.class,
-            () -> updateAboveMaxLimit.mergeWithJob(jobBuilder.build(), new ByteSizeValue(5000L, ByteSizeUnit.MB))
+            () -> updateAboveMaxLimit.mergeWithJob(jobBuilder.build(), ByteSizeValue.of(5000L, ByteSizeUnit.MB))
         );
         assertEquals(
             "model_memory_limit [7.8gb] must be less than the value of the xpack.ml.max_model_memory_limit setting [4.8gb]",
             e.getMessage()
         );
 
-        updateAboveMaxLimit.mergeWithJob(jobBuilder.build(), new ByteSizeValue(10000L, ByteSizeUnit.MB));
+        updateAboveMaxLimit.mergeWithJob(jobBuilder.build(), ByteSizeValue.of(10000L, ByteSizeUnit.MB));
     }
 
     public void testUpdate_givenEmptySnapshot() {

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
@@ -81,8 +81,8 @@ class DownsampleShardIndexer {
 
     private static final Logger logger = LogManager.getLogger(DownsampleShardIndexer.class);
     public static final int DOWNSAMPLE_BULK_ACTIONS = 10000;
-    public static final ByteSizeValue DOWNSAMPLE_BULK_SIZE = new ByteSizeValue(1, ByteSizeUnit.MB);
-    public static final ByteSizeValue DOWNSAMPLE_MAX_BYTES_IN_FLIGHT = new ByteSizeValue(50, ByteSizeUnit.MB);
+    public static final ByteSizeValue DOWNSAMPLE_BULK_SIZE = ByteSizeValue.of(1, ByteSizeUnit.MB);
+    public static final ByteSizeValue DOWNSAMPLE_MAX_BYTES_IN_FLIGHT = ByteSizeValue.of(50, ByteSizeUnit.MB);
     private final IndexShard indexShard;
     private final Client client;
     private final DownsampleMetrics downsampleMetrics;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/HttpSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/HttpSettings.java
@@ -20,9 +20,9 @@ public class HttpSettings {
     // These settings are default scope for testing
     static final Setting<ByteSizeValue> MAX_HTTP_RESPONSE_SIZE = Setting.byteSizeSetting(
         "xpack.inference.http.max_response_size",
-        new ByteSizeValue(50, ByteSizeUnit.MB),   // default
+        ByteSizeValue.of(50, ByteSizeUnit.MB),   // default
         ByteSizeValue.ONE, // min
-        new ByteSizeValue(100, ByteSizeUnit.MB),   // max
+        ByteSizeValue.of(100, ByteSizeUnit.MB),   // max
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/SizeLimitInputStreamTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/SizeLimitInputStreamTests.java
@@ -86,7 +86,7 @@ public class SizeLimitInputStreamTests extends ESTestCase {
 
     private static SizeLimitInputStream createRandomLimitedStream(int dataSize, int maxAllowedSize) {
         String data = randomAlphaOfLength(dataSize);
-        ByteSizeValue byteSizeValue = new ByteSizeValue(maxAllowedSize, ByteSizeUnit.BYTES);
+        ByteSizeValue byteSizeValue = ByteSizeValue.of(maxAllowedSize, ByteSizeUnit.BYTES);
         return new SizeLimitInputStream(byteSizeValue, new ByteArrayInputStream(data.getBytes(UTF_8)));
     }
 }

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtils.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtils.java
@@ -63,7 +63,7 @@ final class ModelLoaderUtils {
     public static String METADATA_FILE_EXTENSION = ".metadata.json";
     public static String MODEL_FILE_EXTENSION = ".pt";
 
-    private static final ByteSizeValue VOCABULARY_SIZE_LIMIT = new ByteSizeValue(20, ByteSizeUnit.MB);
+    private static final ByteSizeValue VOCABULARY_SIZE_LIMIT = ByteSizeValue.of(20, ByteSizeUnit.MB);
     private static final String VOCABULARY = "vocabulary";
     private static final String MERGES = "merges";
     private static final String SCORES = "scores";

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -390,8 +390,8 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
         when(mockThreads.getCount()).thenReturn(9);
 
         final JvmStats.Mem mockMem = mock(JvmStats.Mem.class);
-        when(mockMem.getHeapUsed()).thenReturn(new ByteSizeValue(512, ByteSizeUnit.MB));
-        when(mockMem.getHeapMax()).thenReturn(new ByteSizeValue(24, ByteSizeUnit.GB));
+        when(mockMem.getHeapUsed()).thenReturn(ByteSizeValue.of(512, ByteSizeUnit.MB));
+        when(mockMem.getHeapMax()).thenReturn(ByteSizeValue.of(24, ByteSizeUnit.GB));
 
         final JvmStats mockJvmStats = mock(JvmStats.class);
         when(mockNodeStats.getJvm()).thenReturn(mockJvmStats);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseFrozenSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseFrozenSearchableSnapshotsIntegTestCase.java
@@ -30,9 +30,9 @@ public abstract class BaseFrozenSearchableSnapshotsIntegTestCase extends BaseSea
                 SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(),
                 rarely()
                     ? randomBoolean()
-                        ? new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.KB).getStringRep()
-                        : new ByteSizeValue(randomIntBetween(1, 1000), ByteSizeUnit.BYTES).getStringRep()
-                    : randomBoolean() ? new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB).getStringRep()
+                        ? ByteSizeValue.of(randomIntBetween(1, 10), ByteSizeUnit.KB).getStringRep()
+                        : ByteSizeValue.of(randomIntBetween(1, 1000), ByteSizeUnit.BYTES).getStringRep()
+                    : randomBoolean() ? ByteSizeValue.of(randomIntBetween(1, 10), ByteSizeUnit.MB).getStringRep()
                     : new RatioValue(randomDoubleBetween(0.0d, 0.1d, false)).toString() // only use up to 0.1% disk to be friendly.
                 // don't test mmap on Windows since we don't have code to unmap the shared cache file which trips assertions after tests
             ).put(SharedBlobCacheService.SHARED_CACHE_MMAP.getKey(), WINDOWS == false && randomBoolean());

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
@@ -109,8 +109,8 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
             builder.put(
                 CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(),
                 rarely()
-                    ? new ByteSizeValue(randomIntBetween(4, 1024), ByteSizeUnit.KB)
-                    : new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB)
+                    ? ByteSizeValue.of(randomIntBetween(4, 1024), ByteSizeUnit.KB)
+                    : ByteSizeValue.of(randomIntBetween(1, 10), ByteSizeUnit.MB)
             );
         }
         if (DiscoveryNode.canContainData(otherSettings) && randomBoolean()) {
@@ -119,23 +119,23 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
         builder.put(
             SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(),
             rarely()
-                ? pageAligned(new ByteSizeValue(randomIntBetween(4, 1024), ByteSizeUnit.KB))
-                : pageAligned(new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB))
+                ? pageAligned(ByteSizeValue.of(randomIntBetween(4, 1024), ByteSizeUnit.KB))
+                : pageAligned(ByteSizeValue.of(randomIntBetween(1, 10), ByteSizeUnit.MB))
         );
         if (randomBoolean()) {
             builder.put(
                 SharedBlobCacheService.SHARED_CACHE_RANGE_SIZE_SETTING.getKey(),
                 rarely()
-                    ? pageAligned(new ByteSizeValue(randomIntBetween(4, 1024), ByteSizeUnit.KB))
-                    : pageAligned(new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB))
+                    ? pageAligned(ByteSizeValue.of(randomIntBetween(4, 1024), ByteSizeUnit.KB))
+                    : pageAligned(ByteSizeValue.of(randomIntBetween(1, 10), ByteSizeUnit.MB))
             );
         }
         if (randomBoolean()) {
             builder.put(
                 SharedBlobCacheService.SHARED_CACHE_RECOVERY_RANGE_SIZE_SETTING.getKey(),
                 rarely()
-                    ? pageAligned(new ByteSizeValue(randomIntBetween(4, 1024), ByteSizeUnit.KB))
-                    : pageAligned(new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB))
+                    ? pageAligned(ByteSizeValue.of(randomIntBetween(4, 1024), ByteSizeUnit.KB))
+                    : pageAligned(ByteSizeValue.of(randomIntBetween(1, 10), ByteSizeUnit.MB))
             );
         }
         return builder.build();

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotDiskThresholdIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotDiskThresholdIntegTests.java
@@ -74,7 +74,7 @@ import static org.hamcrest.Matchers.is;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SearchableSnapshotDiskThresholdIntegTests extends DiskUsageIntegTestCase {
 
-    private static final long WATERMARK_BYTES = new ByteSizeValue(10, ByteSizeUnit.KB).getBytes();
+    private static final long WATERMARK_BYTES = ByteSizeValue.of(10, ByteSizeUnit.KB).getBytes();
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -74,7 +74,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
 
     @BeforeClass
     public static void setUpCacheSettings() {
-        blobCacheMaxLength = pageAligned(new ByteSizeValue(randomLongBetween(64L, 128L), ByteSizeUnit.KB));
+        blobCacheMaxLength = pageAligned(ByteSizeValue.of(randomLongBetween(64L, 128L), ByteSizeUnit.KB));
 
         final Settings.Builder builder = Settings.builder();
         // Align ranges to match the blob cache max length

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -204,10 +204,10 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
     public static final String SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH = "index.store.snapshot.blob_cache.metadata_files.max_length";
     public static final Setting<ByteSizeValue> SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH_SETTING = new Setting<>(
         SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH,
-        new ByteSizeValue(64L, ByteSizeUnit.KB).getStringRep(),
+        ByteSizeValue.of(64L, ByteSizeUnit.KB).getStringRep(),
         s -> Setting.parseByteSize(
             s,
-            new ByteSizeValue(1L, ByteSizeUnit.KB),
+            ByteSizeValue.of(1L, ByteSizeUnit.KB),
             ByteSizeValue.ofBytes(Long.MAX_VALUE),
             SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH
         ),

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheService.java
@@ -71,7 +71,7 @@ public class CacheService extends AbstractLifecycleComponent {
 
     private static final String SETTINGS_PREFIX = "xpack.searchable.snapshot.cache.";
 
-    public static final ByteSizeValue MIN_SNAPSHOT_CACHE_RANGE_SIZE = new ByteSizeValue(4, ByteSizeUnit.KB);
+    public static final ByteSizeValue MIN_SNAPSHOT_CACHE_RANGE_SIZE = ByteSizeValue.of(4, ByteSizeUnit.KB);
     public static final ByteSizeValue MAX_SNAPSHOT_CACHE_RANGE_SIZE = ByteSizeValue.ofBytes(Integer.MAX_VALUE);
 
     /**
@@ -82,7 +82,7 @@ public class CacheService extends AbstractLifecycleComponent {
      */
     public static final Setting<ByteSizeValue> SNAPSHOT_CACHE_RANGE_SIZE_SETTING = Setting.byteSizeSetting(
         SETTINGS_PREFIX + "range_size",
-        new ByteSizeValue(32, ByteSizeUnit.MB),                 // default
+        ByteSizeValue.of(32, ByteSizeUnit.MB),                 // default
         MIN_SNAPSHOT_CACHE_RANGE_SIZE,                          // min
         MAX_SNAPSHOT_CACHE_RANGE_SIZE,                          // max
         Setting.Property.NodeScope
@@ -96,7 +96,7 @@ public class CacheService extends AbstractLifecycleComponent {
      */
     public static final Setting<ByteSizeValue> SNAPSHOT_CACHE_RECOVERY_RANGE_SIZE_SETTING = Setting.byteSizeSetting(
         SETTINGS_PREFIX + "recovery_range_size",
-        new ByteSizeValue(128, ByteSizeUnit.KB),                // default
+        ByteSizeValue.of(128, ByteSizeUnit.KB),                // default
         MIN_SNAPSHOT_CACHE_RANGE_SIZE,                          // min
         MAX_SNAPSHOT_CACHE_RANGE_SIZE,                          // max
         Setting.Property.NodeScope

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/IndexInputStats.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/IndexInputStats.java
@@ -23,7 +23,7 @@ import java.util.function.LongSupplier;
 public class IndexInputStats {
 
     /* A threshold beyond which an index input seeking is counted as "large" */
-    static final ByteSizeValue SEEKING_THRESHOLD = new ByteSizeValue(8, ByteSizeUnit.MB);
+    static final ByteSizeValue SEEKING_THRESHOLD = ByteSizeValue.of(8, ByteSizeUnit.MB);
 
     private final long numFiles;
     private final long totalSize;

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -224,7 +224,7 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
     }
 
     protected static ByteSizeValue randomFrozenCacheRangeSize() {
-        return pageAlignedBetween(new ByteSizeValue(4, ByteSizeUnit.KB), ByteSizeValue.ofBytes(Integer.MAX_VALUE));
+        return pageAlignedBetween(ByteSizeValue.of(4, ByteSizeUnit.KB), ByteSizeValue.ofBytes(Integer.MAX_VALUE));
     }
 
     private static ByteSizeValue pageAlignedBetween(ByteSizeValue min, ByteSizeValue max) {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
@@ -116,7 +116,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
     public void testCachedBytesReadsAndWrites() throws Exception {
         // a cache service with a low range size but enough space to not evict the cache file
         final ByteSizeValue rangeSize = ByteSizeValue.ofBytes(SharedBytes.PAGE_SIZE * randomLongBetween(3, 6));
-        final ByteSizeValue cacheSize = new ByteSizeValue(10, ByteSizeUnit.MB);
+        final ByteSizeValue cacheSize = ByteSizeValue.of(10, ByteSizeUnit.MB);
 
         executeTestCaseWithCache(cacheSize, rangeSize, (fileName, fileContent, directory) -> {
             try (IndexInput input = directory.openInput(fileName, randomIOContext())) {
@@ -254,7 +254,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
     }
 
     public void testDirectBytesReadsWithoutCache() throws Exception {
-        final ByteSizeValue uncachedChunkSize = new ByteSizeValue(randomIntBetween(512, MAX_FILE_LENGTH), ByteSizeUnit.BYTES);
+        final ByteSizeValue uncachedChunkSize = ByteSizeValue.of(randomIntBetween(512, MAX_FILE_LENGTH), ByteSizeUnit.BYTES);
         executeTestCaseWithoutCache(uncachedChunkSize, (fileName, fileContent, directory) -> {
             assertThat(directory.getStats(fileName), nullValue());
 
@@ -291,7 +291,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
 
     public void testOptimizedBytesReads() throws Exception {
         // use a large uncached chunk size that allows to read the file in a single operation
-        final ByteSizeValue uncachedChunkSize = new ByteSizeValue(1, ByteSizeUnit.GB);
+        final ByteSizeValue uncachedChunkSize = ByteSizeValue.of(1, ByteSizeUnit.GB);
         executeTestCaseWithoutCache(uncachedChunkSize, (fileName, fileContent, directory) -> {
             final IOContext context = randomIOContext();
             try (IndexInput input = directory.openInput(fileName, context)) {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInputTests.java
@@ -66,13 +66,13 @@ public class DirectBlobContainerIndexInputTests extends ESIndexInputTestCase {
             new StoreFileMetadata(fileName, input.length, checksum, Version.LATEST.toString()),
             partSize == input.length
                 ? randomFrom(
-                    new ByteSizeValue(partSize, ByteSizeUnit.BYTES),
-                    new ByteSizeValue(randomLongBetween(partSize, Long.MAX_VALUE), ByteSizeUnit.BYTES),
+                    ByteSizeValue.of(partSize, ByteSizeUnit.BYTES),
+                    ByteSizeValue.of(randomLongBetween(partSize, Long.MAX_VALUE), ByteSizeUnit.BYTES),
                     ByteSizeValue.ZERO,
-                    new ByteSizeValue(-1, ByteSizeUnit.BYTES),
+                    ByteSizeValue.of(-1, ByteSizeUnit.BYTES),
                     null
                 )
-                : new ByteSizeValue(partSize, ByteSizeUnit.BYTES)
+                : ByteSizeValue.of(partSize, ByteSizeUnit.BYTES)
         );
 
         final BlobContainer blobContainer = mock(BlobContainer.class);

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -256,9 +256,9 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
     );
     private static final Setting<ByteSizeValue> SETTING_BULK_SIZE = Setting.byteSizeSetting(
         "xpack.watcher.bulk.size",
-        new ByteSizeValue(1, ByteSizeUnit.MB),
-        new ByteSizeValue(1, ByteSizeUnit.MB),
-        new ByteSizeValue(10, ByteSizeUnit.MB),
+        ByteSizeValue.of(1, ByteSizeUnit.MB),
+        ByteSizeValue.of(1, ByteSizeUnit.MB),
+        ByteSizeValue.of(10, ByteSizeUnit.MB),
         NodeScope
     );
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpSettings.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpSettings.java
@@ -58,9 +58,9 @@ public class HttpSettings {
 
     static final Setting<ByteSizeValue> MAX_HTTP_RESPONSE_SIZE = Setting.byteSizeSetting(
         "xpack.http.max_response_size",
-        new ByteSizeValue(10, ByteSizeUnit.MB),   // default
+        ByteSizeValue.of(10, ByteSizeUnit.MB),   // default
         ByteSizeValue.ONE, // min
-        new ByteSizeValue(50, ByteSizeUnit.MB),   // max
+        ByteSizeValue.of(50, ByteSizeUnit.MB),   // max
         Property.NodeScope
     );
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
@@ -566,7 +566,7 @@ public class HttpClientTests extends ESTestCase {
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(data));
 
         Settings settings = Settings.builder()
-            .put(HttpSettings.MAX_HTTP_RESPONSE_SIZE.getKey(), new ByteSizeValue(randomBytesLength - 1, ByteSizeUnit.BYTES))
+            .put(HttpSettings.MAX_HTTP_RESPONSE_SIZE.getKey(), ByteSizeValue.of(randomBytesLength - 1, ByteSizeUnit.BYTES))
             .build();
 
         HttpRequest.Builder requestBuilder = HttpRequest.builder("localhost", webServer.getPort()).method(HttpMethod.GET).path("/");

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/SizeLimitInputStreamTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/SizeLimitInputStreamTests.java
@@ -30,7 +30,7 @@ public class SizeLimitInputStreamTests extends ESTestCase {
     }
 
     public void testMarking() {
-        ByteSizeValue byteSizeValue = new ByteSizeValue(1, ByteSizeUnit.BYTES);
+        ByteSizeValue byteSizeValue = ByteSizeValue.of(1, ByteSizeUnit.BYTES);
         SizeLimitInputStream is = new SizeLimitInputStream(byteSizeValue, new ByteArrayInputStream("empty".getBytes(UTF_8)));
         assertThat(is.markSupported(), is(false));
         expectThrows(UnsupportedOperationException.class, () -> is.mark(10));
@@ -40,7 +40,7 @@ public class SizeLimitInputStreamTests extends ESTestCase {
 
     private void test(int inputStreamLength, int maxAllowedSize) throws IOException {
         String data = randomAlphaOfLength(inputStreamLength);
-        ByteSizeValue byteSizeValue = new ByteSizeValue(maxAllowedSize, ByteSizeUnit.BYTES);
+        ByteSizeValue byteSizeValue = ByteSizeValue.of(maxAllowedSize, ByteSizeUnit.BYTES);
         SizeLimitInputStream is = new SizeLimitInputStream(byteSizeValue, new ByteArrayInputStream(data.getBytes(UTF_8)));
 
         if (randomBoolean()) {


### PR DESCRIPTION
The effects:

- Byte sizes are now allowed with up to 2 decimals of precision (eg. `1.23 kb`)
- `ByteSizeValue` survives a round-trip through the transport protocol with precisely the same value
- `ByteSizeValue` survives a round-trip of parsing and `toString` with up to one decimal point[^1]

The changes:
1. Make the internal representation of `ByteSizeUnit` to store the size in bytes, and interpret the `unit` field as a display preference rather than a denominator for the `size` field.
2. Match up the parsing and `toString` logic so the values survive the round trip to 1 decimal.[^1]
3. Change the transport protocol to match the internal representation.
4. Remove deprecation warnings.

See:
- https://github.com/elastic/elasticsearch-serverless/pull/3376
- https://github.com/elastic/dev/issues/2881
- ES-10377

[^1]: Retaining two decimals in `toString` made values appear differently in exception and log messages, causing lots of tests to fail. I opted to leave `toString` as it was.