### PR TITLE
[8.17] Use approximation to advance matched queries (#120133)

### DIFF
--- a/docs/changelog/120133.yaml
+++ b/docs/changelog/120133.yaml
@@ -1,0 +1,6 @@
+pr: 120133
+summary: Use approximation to advance matched queries
+area: Search
+type: bug
+issues:
+ - 120130

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/MatchedQueriesPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/MatchedQueriesPhase.java
@@ -9,10 +9,12 @@
 package org.elasticsearch.search.fetch.subphase;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.search.fetch.FetchContext;
@@ -52,8 +54,9 @@ public final class MatchedQueriesPhase implements FetchSubPhase {
             );
         }
         return new FetchSubPhaseProcessor() {
+            record ScorerAndIterator(Scorer scorer, DocIdSetIterator approximation, TwoPhaseIterator twoPhase) {}
 
-            final Map<String, Scorer> matchingIterators = new HashMap<>();
+            final Map<String, ScorerAndIterator> matchingIterators = new HashMap<>();
 
             @Override
             public void setNextReader(LeafReaderContext readerContext) throws IOException {
@@ -63,7 +66,14 @@ public final class MatchedQueriesPhase implements FetchSubPhase {
                     if (ss != null) {
                         Scorer scorer = ss.get(0L);
                         if (scorer != null) {
-                            matchingIterators.put(entry.getKey(), scorer);
+                            final TwoPhaseIterator twoPhase = scorer.twoPhaseIterator();
+                            final DocIdSetIterator iterator;
+                            if (twoPhase == null) {
+                                iterator = scorer.iterator();
+                            } else {
+                                iterator = twoPhase.approximation();
+                            }
+                            matchingIterators.put(entry.getKey(), new ScorerAndIterator(scorer, iterator, twoPhase));
                         }
                     }
                 }
@@ -73,13 +83,13 @@ public final class MatchedQueriesPhase implements FetchSubPhase {
             public void process(HitContext hitContext) throws IOException {
                 Map<String, Float> matches = new LinkedHashMap<>();
                 int doc = hitContext.docId();
-                for (Map.Entry<String, Scorer> entry : matchingIterators.entrySet()) {
-                    Scorer scorer = entry.getValue();
-                    if (scorer.iterator().docID() < doc) {
-                        scorer.iterator().advance(doc);
+                for (Map.Entry<String, ScorerAndIterator> entry : matchingIterators.entrySet()) {
+                    ScorerAndIterator query = entry.getValue();
+                    if (query.approximation.docID() < doc) {
+                        query.approximation.advance(doc);
                     }
-                    if (scorer.iterator().docID() == doc) {
-                        matches.put(entry.getKey(), scorer.score());
+                    if (query.approximation.docID() == doc && (query.twoPhase == null || query.twoPhase.matches())) {
+                        matches.put(entry.getKey(), query.scorer.score());
                     }
                 }
                 hitContext.hit().matchedQueries(matches);


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Use approximation to advance matched queries (#120133)