### PR TITLE
Filter deprecated settings when making dest index

### DIFF
--- a/docs/changelog/120163.yaml
+++ b/docs/changelog/120163.yaml
@@ -1,0 +1,5 @@
+pr: 120163
+summary: Filter deprecated settings when making dest index
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
@@ -41,6 +41,41 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
         return List.of(MigratePlugin.class, ReindexPlugin.class, MockTransportService.TestPlugin.class, DataStreamsPlugin.class);
     }
 
+    public void testOldSettingsManuallyFiltered() throws Exception {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        var numShards = randomIntBetween(1, 10);
+        var staticSettings = Settings.builder()
+            // setting to filter
+            .put("index.soft_deletes.enabled", true)
+            // good setting to keep
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+            .build();
+
+        // start with a static setting
+        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        indicesAdmin().create(new CreateIndexRequest(sourceIndex, staticSettings)).get();
+
+        // create from source
+        var destIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        assertAcked(
+            client().execute(CreateIndexFromSourceAction.INSTANCE, new CreateIndexFromSourceAction.Request(sourceIndex, destIndex))
+        );
+
+        // assert both static and dynamic settings set on dest index
+        var settingsResponse = indicesAdmin().getSettings(new GetSettingsRequest().indices(sourceIndex, destIndex)).actionGet();
+        var destSettings = settingsResponse.getIndexToSettings().get(destIndex);
+        var sourceSettings = settingsResponse.getIndexToSettings().get(sourceIndex);
+
+        // sanity check that source settings were added
+        assertEquals(true, sourceSettings.getAsBoolean("index.soft_deletes.enabled", false));
+        assertEquals(numShards, Integer.parseInt(destSettings.get(IndexMetadata.SETTING_NUMBER_OF_SHARDS)));
+
+        // check that old setting was not added to index
+        assertNull(destSettings.get("index.soft_deletes.enabled"));
+        assertEquals(numShards, Integer.parseInt(destSettings.get(IndexMetadata.SETTING_NUMBER_OF_SHARDS)));
+    }
+
     public void testDestIndexCreated() throws Exception {
         assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
 


### PR DESCRIPTION
Filter deprecated settings to match the behavior of the [upgrade assistant reindex code](https://github.com/elastic/kibana/blob/8a8363f02cc990732eb9cbb60cd388643a336bed/x-pack/plugins/upgrade_assistant/server/lib/reindexing/index_settings.ts#L25). Specifically, there are 5 settings which are removed in the upgrade assistant but were not being filtered in create_from:

1. index.force_memory_term_dictionary
2. index.max_adjacency_matrix_filters
3. index.soft_deletes.enabled
4. index.translog.retention.size
5. index.translog.retention.age

The first two settings have the `IndexSettingDeprecatedInV7AndRemovedInV8` property, so this PR adds a filter on this property. This causes a few other settings with this property to be filtered, but I believe this is the correct behavior.

Since the other 3 settings do not have a deprecated property, add them to a specific deny list. In the original UA code the last two settings were only removed if `index.soft_deletes.enabled` was set to true. Since `index.soft_deletes.enabled` is always enabled in v8 and we are removing the setting, we can unconditionally remove all three settings.
