### PR TITLE
[8.17] [CI] Do not pull latest mutes from main when not for PR (#120119)

### DIFF
--- a/.buildkite/scripts/get-latest-test-mutes.sh
+++ b/.buildkite/scripts/get-latest-test-mutes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ ! "${BUILDKITE_PULL_REQUEST:-}" || "${BUILDKITE_AGENT_META_DATA_PROVIDER:-}" == "k8s" ]]; then
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false"  || "${BUILDKITE_AGENT_META_DATA_PROVIDER:-}" == "k8s" ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [CI] Do not pull latest mutes from main when not for PR (#120119)