### PR TITLE
[8.16] [DOCS] More targeted link for ESQL in CCS overview (#120125)

### DIFF
--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -22,7 +22,7 @@ The following APIs support {ccs}:
 * experimental:[] <<eql-search-api,EQL search>>
 * experimental:[] <<sql-search-api,SQL search>>
 * experimental:[] <<search-vector-tile-api,Vector tile search>>
-* experimental:[] <<esql,ES|QL>>
+* experimental:[] <<esql-cross-clusters,ES|QL>>
 
 [discrete]
 === Prerequisites


### PR DESCRIPTION
Backports the following commits to 8.16:
 - [DOCS] More targeted link for ESQL in CCS overview (#120125)