### PR TITLE
[Profiling] Add os.type mapping to profiling-hosts

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hosts.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hosts.json
@@ -55,6 +55,13 @@
             }
           }
         },
+        "os": {
+          "properties": {
+            "type": {
+              "type": "keyword"
+            }
+          }
+        },
         "profiling": {
           "properties": {
             "project.id": {


### PR DESCRIPTION
Add OTEL semconv `os.type` mapping to `profiling.hosts` (host metadata).