### PR TITLE
[DOCS] Clarifies param description of `model_size_bytes`

### DIFF
--- a/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
@@ -384,6 +384,7 @@ A collection of model size stats fields.
 `model_size_bytes`:::
 (integer)
 The size of the model in bytes.
+This parameter applies only to PyTorch models.
 
 `required_native_memory_bytes`:::
 (integer)

--- a/docs/reference/ml/trained-models/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models.asciidoc
@@ -131,6 +131,7 @@ The free-text description of the trained model.
 `model_size_bytes`:::
 (integer)
 The estimated model size in bytes to keep the trained model in memory.
+This parameter applies only to {dfanalytics} trained models.
 
 `estimated_operations`:::
 (integer)


### PR DESCRIPTION
## Overview

Both the GET trained models and the GET trained model stats API report a parameter called `model_size_bytes` (however, the stats API has this nested under `model_size_stats`). These are not the same parameters. The first applies only to data frame analytics trained models while the second applies to PyTorch models. This PR clarifies this difference.

### Preview

* [GET trained models API](https://elasticsearch_bk_120190.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-trained-models.html)
* [GET trained model stats API](https://elasticsearch_bk_120190.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-trained-models-stats.html)