### PR TITLE
[Entitlements] Removing unneeded check on SSLSession#getSessionContext

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -32,7 +32,6 @@ import java.util.List;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 
 @SuppressWarnings("unused") // Called from instrumentation code inserted by the Entitlements agent
@@ -192,9 +191,6 @@ public interface EntitlementChecker {
     void check$java_net_URL$(Class<?> callerClass, String protocol, String host, int port, String file, URLStreamHandler handler);
 
     void check$java_net_URL$(Class<?> callerClass, URL context, String spec, URLStreamHandler handler);
-
-    // The only implementation of SSLSession#getSessionContext(); unfortunately it's an interface, so we need to check the implementation
-    void check$sun_security_ssl_SSLSessionImpl$getSessionContext(Class<?> callerClass, SSLSession sslSession);
 
     void check$java_net_DatagramSocket$bind(Class<?> callerClass, DatagramSocket that, SocketAddress addr);
 

--- a/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/RestEntitlementsCheckAction.java
@@ -60,9 +60,6 @@ import java.util.stream.Collectors;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
 
 import static java.util.Map.entry;
 import static org.elasticsearch.entitlement.qa.common.RestEntitlementsCheckAction.CheckAction.alwaysDenied;
@@ -147,7 +144,6 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
         entry("createURLStreamHandlerProvider", alwaysDenied(RestEntitlementsCheckAction::createURLStreamHandlerProvider)),
         entry("createURLWithURLStreamHandler", alwaysDenied(RestEntitlementsCheckAction::createURLWithURLStreamHandler)),
         entry("createURLWithURLStreamHandler2", alwaysDenied(RestEntitlementsCheckAction::createURLWithURLStreamHandler2)),
-        entry("sslSessionImpl_getSessionContext", alwaysDenied(RestEntitlementsCheckAction::sslSessionImplGetSessionContext)),
         entry("datagram_socket_bind", forPlugins(RestEntitlementsCheckAction::bindDatagramSocket)),
         entry("datagram_socket_connect", forPlugins(RestEntitlementsCheckAction::connectDatagramSocket)),
         entry("datagram_socket_send", forPlugins(RestEntitlementsCheckAction::sendDatagramSocket)),
@@ -163,15 +159,6 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
                 return null;
             }
         };
-    }
-
-    private static void sslSessionImplGetSessionContext() throws IOException {
-        SSLSocketFactory factory = HttpsURLConnection.getDefaultSSLSocketFactory();
-        try (SSLSocket socket = (SSLSocket) factory.createSocket()) {
-            SSLSession session = socket.getSession();
-
-            session.getSessionContext();
-        }
     }
 
     @SuppressWarnings("deprecation")

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -36,7 +36,6 @@ import java.util.List;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
@@ -350,11 +349,6 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     @Override
     public void check$java_net_URL$(Class<?> callerClass, URL context, String spec, URLStreamHandler handler) {
         policyManager.checkChangeNetworkHandling(callerClass);
-    }
-
-    @Override
-    public void check$sun_security_ssl_SSLSessionImpl$getSessionContext(Class<?> callerClass, SSLSession sslSession) {
-        policyManager.checkReadSensitiveNetworkInformation(callerClass);
     }
 
     @Override

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -235,12 +235,6 @@ tests:
 - class: org.elasticsearch.index.mapper.IntervalThrottlerTests
   method: testThrottling
   issue: https://github.com/elastic/elasticsearch/issues/120023
-- class: org.elasticsearch.entitlement.qa.EntitlementsDeniedIT
-  method: testCheckThrows {pathPrefix=denied actionName=sslSessionImpl_getSessionContext}
-  issue: https://github.com/elastic/elasticsearch/issues/120053
-- class: org.elasticsearch.entitlement.qa.EntitlementsDeniedIT
-  method: testCheckThrows {pathPrefix=denied_nonmodular actionName=sslSessionImpl_getSessionContext}
-  issue: https://github.com/elastic/elasticsearch/issues/120054
 - class: org.elasticsearch.xpack.ilm.actions.SearchableSnapshotActionIT
   method: testUpdatePolicyToAddPhasesYieldsInvalidActionsToBeSkipped
   issue: https://github.com/elastic/elasticsearch/issues/118406


### PR DESCRIPTION
This PR removes the check to `SSLSession#getSessionContext`. As we discussed at the sync, we don't care about clients reading this information.

Fixes https://github.com/elastic/elasticsearch/issues/120053
Fixes https://github.com/elastic/elasticsearch/issues/120054