### PR TITLE
Do not capture ClusterChangedEvent in IndicesStore call to #onClusterStateShardsClosed

### DIFF
--- a/docs/changelog/120193.yaml
+++ b/docs/changelog/120193.yaml
@@ -1,0 +1,5 @@
+pr: 120193
+summary: "Do not capture `ClusterChangedEvent` in `IndicesStore` call to #onClusterStateShardsClosed"
+area: Store
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingNode;
@@ -174,8 +175,12 @@ public final class IndicesStore implements ClusterStateListener, Closeable {
                     );
                     switch (shardDeletionCheckResult) {
                         case FOLDER_FOUND_CAN_DELETE:
+                            var clusterState = event.state();
+                            var clusterName = clusterState.getClusterName();
+                            var nodes = clusterState.nodes();
+                            var clusterStateVersion = clusterState.getVersion();
                             indicesClusterStateService.onClusterStateShardsClosed(
-                                () -> deleteShardIfExistElseWhere(event.state(), indexShardRoutingTable)
+                                () -> deleteShardIfExistElseWhere(clusterName, nodes, clusterStateVersion, indexShardRoutingTable)
                             );
                             break;
                         case NO_FOLDER_FOUND:
@@ -218,14 +223,18 @@ public final class IndicesStore implements ClusterStateListener, Closeable {
         return true;
     }
 
-    private void deleteShardIfExistElseWhere(ClusterState state, IndexShardRoutingTable indexShardRoutingTable) {
+    private void deleteShardIfExistElseWhere(
+        ClusterName clusterName,
+        DiscoveryNodes nodes,
+        long clusterStateVersion,
+        IndexShardRoutingTable indexShardRoutingTable
+    ) {
         List<Tuple<DiscoveryNode, ShardActiveRequest>> requests = new ArrayList<>(indexShardRoutingTable.size());
         String indexUUID = indexShardRoutingTable.shardId().getIndex().getUUID();
-        ClusterName clusterName = state.getClusterName();
         for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
             ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
             assert shardRouting.started() : "expected started shard but was " + shardRouting;
-            DiscoveryNode currentNode = state.nodes().get(shardRouting.currentNodeId());
+            DiscoveryNode currentNode = nodes.get(shardRouting.currentNodeId());
             requests.add(
                 new Tuple<>(currentNode, new ShardActiveRequest(clusterName, indexUUID, shardRouting.shardId(), deleteShardTimeout))
             );
@@ -233,7 +242,7 @@ public final class IndicesStore implements ClusterStateListener, Closeable {
 
         ShardActiveResponseHandler responseHandler = new ShardActiveResponseHandler(
             indexShardRoutingTable.shardId(),
-            state.getVersion(),
+            clusterStateVersion,
             requests.size()
         );
         for (Tuple<DiscoveryNode, ShardActiveRequest> request : requests) {


### PR DESCRIPTION
#108145 introduced async close of `IndexShard`. Before that change `IndicesStore` called `deleteShardIfExistElseWhere` directly when needed, but now it rely on `IndicesClusterStateService#onClusterStateShardsClosed` to be notified when the shard is closed and go through the process of deleting the local contents. The listener was using a lambda that captured the entire `ClusterChangedEvent` and in some cases if the shard was too slow to be closed we could keep capturing new cluster state instances and finally OOM the node. This commit just avoids capturing the entire `ClusterChangedEvent`.
