### PR TITLE
[8.17] [DOCS] Clarifies param description of model_size_bytes. (#120190)

### DIFF
--- a/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
@@ -384,6 +384,7 @@ A collection of model size stats fields.
 `model_size_bytes`:::
 (integer)
 The size of the model in bytes.
+This parameter applies only to PyTorch models.
 
 `required_native_memory_bytes`:::
 (integer)

--- a/docs/reference/ml/trained-models/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models.asciidoc
@@ -130,6 +130,7 @@ The free-text description of the trained model.
 `model_size_bytes`:::
 (integer)
 The estimated model size in bytes to keep the trained model in memory.
+This parameter applies only to {dfanalytics} trained models.
 
 `estimated_operations`:::
 (integer)


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [DOCS] Clarifies param description of model_size_bytes. (#120190)