### PR TITLE
[8.x] [ML] Unified schema API remove name field (#119799)

### DIFF
--- a/server/src/main/java/org/elasticsearch/inference/UnifiedCompletionRequest.java
+++ b/server/src/main/java/org/elasticsearch/inference/UnifiedCompletionRequest.java
@@ -111,18 +111,14 @@ public record UnifiedCompletionRequest(
         out.writeOptionalFloat(topP);
     }
 
-    public record Message(
-        Content content,
-        String role,
-        @Nullable String name,
-        @Nullable String toolCallId,
-        @Nullable List<ToolCall> toolCalls
-    ) implements Writeable {
+    public record Message(Content content, String role, @Nullable String toolCallId, @Nullable List<ToolCall> toolCalls)
+        implements
+            Writeable {
 
         @SuppressWarnings("unchecked")
         static final ConstructingObjectParser<Message, Void> PARSER = new ConstructingObjectParser<>(
             Message.class.getSimpleName(),
-            args -> new Message((Content) args[0], (String) args[1], (String) args[2], (String) args[3], (List<ToolCall>) args[4])
+            args -> new Message((Content) args[0], (String) args[1], (String) args[2], (List<ToolCall>) args[3])
         );
 
         static {
@@ -133,7 +129,6 @@ public record UnifiedCompletionRequest(
                 ObjectParser.ValueType.VALUE_ARRAY
             );
             PARSER.declareString(constructorArg(), new ParseField("role"));
-            PARSER.declareString(optionalConstructorArg(), new ParseField("name"));
             PARSER.declareString(optionalConstructorArg(), new ParseField("tool_call_id"));
             PARSER.declareObjectArray(optionalConstructorArg(), ToolCall.PARSER::apply, new ParseField("tool_calls"));
         }
@@ -155,7 +150,6 @@ public record UnifiedCompletionRequest(
                 in.readOptionalNamedWriteable(Content.class),
                 in.readString(),
                 in.readOptionalString(),
-                in.readOptionalString(),
                 in.readOptionalCollectionAsList(ToolCall::new)
             );
         }
@@ -164,7 +158,6 @@ public record UnifiedCompletionRequest(
         public void writeTo(StreamOutput out) throws IOException {
             out.writeOptionalNamedWriteable(content);
             out.writeString(role);
-            out.writeOptionalString(name);
             out.writeOptionalString(toolCallId);
             out.writeOptionalCollection(toolCalls);
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/UnifiedCompletionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/UnifiedCompletionRequestTests.java
@@ -35,7 +35,6 @@ public class UnifiedCompletionRequestTests extends AbstractBWCWireSerializationT
                           "type": "string"
                         }
                     ],
-                    "name": "a name",
                     "tool_call_id": "100",
                     "tool_calls": [
                         {
@@ -83,7 +82,6 @@ public class UnifiedCompletionRequestTests extends AbstractBWCWireSerializationT
                             List.of(new UnifiedCompletionRequest.ContentObject("some text", "string"))
                         ),
                         "user",
-                        "a name",
                         "100",
                         List.of(
                             new UnifiedCompletionRequest.ToolCall(
@@ -155,7 +153,6 @@ public class UnifiedCompletionRequestTests extends AbstractBWCWireSerializationT
                         new UnifiedCompletionRequest.ContentString("What is the weather like in Boston today?"),
                         "user",
                         null,
-                        null,
                         null
                     )
                 ),
@@ -199,7 +196,6 @@ public class UnifiedCompletionRequestTests extends AbstractBWCWireSerializationT
         return new UnifiedCompletionRequest.Message(
             randomContent(),
             randomAlphaOfLength(10),
-            randomAlphaOfLengthOrNull(10),
             randomAlphaOfLengthOrNull(10),
             randomToolCallListOrNull()
         );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/UnifiedChatInput.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/UnifiedChatInput.java
@@ -40,15 +40,7 @@ public class UnifiedChatInput extends InferenceInputs {
 
     private static List<UnifiedCompletionRequest.Message> convertToMessages(List<String> inputs, String roleValue) {
         return inputs.stream()
-            .map(
-                value -> new UnifiedCompletionRequest.Message(
-                    new UnifiedCompletionRequest.ContentString(value),
-                    roleValue,
-                    null,
-                    null,
-                    null
-                )
-            )
+            .map(value -> new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString(value), roleValue, null, null))
             .toList();
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/unified/UnifiedChatCompletionRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/unified/UnifiedChatCompletionRequestEntity.java
@@ -75,9 +75,6 @@ public class UnifiedChatCompletionRequestEntity implements ToXContentFragment {
                     }
 
                     builder.field(ROLE_FIELD, message.role());
-                    if (message.name() != null) {
-                        builder.field(NAME_FIELD, message.name());
-                    }
                     if (message.toolCallId() != null) {
                         builder.field(TOOL_CALL_ID_FIELD, message.toolCallId());
                     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/UnifiedChatInputTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/UnifiedChatInputTests.java
@@ -24,20 +24,8 @@ public class UnifiedChatInputTests extends ESTestCase {
             Matchers.is(
                 UnifiedCompletionRequest.of(
                     List.of(
-                        new UnifiedCompletionRequest.Message(
-                            new UnifiedCompletionRequest.ContentString("hello"),
-                            "a role",
-                            null,
-                            null,
-                            null
-                        ),
-                        new UnifiedCompletionRequest.Message(
-                            new UnifiedCompletionRequest.ContentString("awesome"),
-                            "a role",
-                            null,
-                            null,
-                            null
-                        )
+                        new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString("hello"), "a role", null, null),
+                        new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString("awesome"), "a role", null, null)
                     )
                 )
             )

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceUnifiedChatCompletionRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceUnifiedChatCompletionRequestEntityTests.java
@@ -32,7 +32,6 @@ public class ElasticInferenceServiceUnifiedChatCompletionRequestEntityTests exte
             new UnifiedCompletionRequest.ContentString("Hello, world!"),
             ROLE,
             null,
-            null,
             null
         );
         var messageList = new ArrayList<UnifiedCompletionRequest.Message>();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/openai/OpenAiUnifiedChatCompletionRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/openai/OpenAiUnifiedChatCompletionRequestEntityTests.java
@@ -32,7 +32,6 @@ public class OpenAiUnifiedChatCompletionRequestEntityTests extends ESTestCase {
             new UnifiedCompletionRequest.ContentString("Hello, world!"),
             ROLE,
             null,
-            null,
             null
         );
         var messageList = new ArrayList<UnifiedCompletionRequest.Message>();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/unified/UnifiedChatCompletionRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/unified/UnifiedChatCompletionRequestEntityTests.java
@@ -39,7 +39,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
             new UnifiedCompletionRequest.ContentString("Hello, world!"),
             ROLE,
             null,
-            null,
             null
         );
         var messageList = new ArrayList<UnifiedCompletionRequest.Message>();
@@ -78,7 +77,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
         UnifiedCompletionRequest.Message message = new UnifiedCompletionRequest.Message(
             new UnifiedCompletionRequest.ContentString("Hello, world!"),
             ROLE,
-            "name",
             "tool_call_id",
             Collections.singletonList(
                 new UnifiedCompletionRequest.ToolCall(
@@ -127,7 +125,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
                     {
                         "content": "Hello, world!",
                         "role": "user",
-                        "name": "name",
                         "tool_call_id": "tool_call_id",
                         "tool_calls": [
                             {
@@ -189,7 +186,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
             new UnifiedCompletionRequest.ContentString("Hello, world!"),
             ROLE,
             null,
-            null,
             null
         );
         var messageList = new ArrayList<UnifiedCompletionRequest.Message>();
@@ -240,7 +236,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
             new UnifiedCompletionRequest.ContentString("Hello, world!"),
             ROLE,
             null,
-            null,
             Collections.emptyList() // empty toolCalls list
         );
         var messageList = new ArrayList<UnifiedCompletionRequest.Message>();
@@ -290,7 +285,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
         Random random = Randomness.get();
 
         String randomContent = "Hello, world! " + random.nextInt(1000);
-        String randomName = "name" + random.nextInt(1000);
         String randomToolCallId = "tool_call_id" + random.nextInt(1000);
         String randomArguments = "arguments" + random.nextInt(1000);
         String randomFunctionName = "function_name" + random.nextInt(1000);
@@ -303,7 +297,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
         UnifiedCompletionRequest.Message message = new UnifiedCompletionRequest.Message(
             new UnifiedCompletionRequest.ContentString(randomContent),
             ROLE,
-            randomName,
             randomToolCallId,
             Collections.singletonList(
                 new UnifiedCompletionRequest.ToolCall(
@@ -357,7 +350,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
                         {
                             "content": "%s",
                             "role": "user",
-                            "name": "%s",
                             "tool_call_id": "%s",
                             "tool_calls": [
                                 {
@@ -416,7 +408,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
                 }
                 """,
             randomContent,
-            randomName,
             randomToolCallId,
             randomArguments,
             randomFunctionName,
@@ -449,11 +440,10 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
             new UnifiedCompletionRequest.ContentString(randomContentString),
             ROLE,
             null,
-            null,
             null
         );
 
-        UnifiedCompletionRequest.Message messageWithObjects = new UnifiedCompletionRequest.Message(contentObjects, ROLE, null, null, null);
+        UnifiedCompletionRequest.Message messageWithObjects = new UnifiedCompletionRequest.Message(contentObjects, ROLE, null, null);
         var messageList = new ArrayList<UnifiedCompletionRequest.Message>();
         messageList.add(messageWithString);
         messageList.add(messageWithObjects);
@@ -502,7 +492,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
         UnifiedCompletionRequest.Message message = new UnifiedCompletionRequest.Message(
             new UnifiedCompletionRequest.ContentString("Hello, world! \n \"Special\" characters: \t \\ /"),
             ROLE,
-            "name\nwith\nnewlines",
             "tool_call_id\twith\ttabs",
             Collections.singletonList(
                 new UnifiedCompletionRequest.ToolCall(
@@ -541,7 +530,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
                     {
                         "content": "Hello, world! \\n \\"Special\\" characters: \\t \\\\ /",
                         "role": "user",
-                        "name": "name\\nwith\\nnewlines",
                         "tool_call_id": "tool_call_id\\twith\\ttabs",
                         "tool_calls": [
                             {
@@ -570,7 +558,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
         UnifiedCompletionRequest.Message message = new UnifiedCompletionRequest.Message(
             new UnifiedCompletionRequest.ContentString("Hello, world!"),
             ROLE,
-            null,
             null,
             null
         );
@@ -641,7 +628,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
         UnifiedCompletionRequest.Message message = new UnifiedCompletionRequest.Message(
             null,
             "assistant",
-            "name\nwith\nnewlines",
             "tool_call_id\twith\ttabs",
             Collections.singletonList(
                 new UnifiedCompletionRequest.ToolCall(
@@ -669,7 +655,6 @@ public class UnifiedChatCompletionRequestEntityTests extends ESTestCase {
                 "messages": [
                     {
                         "role": "assistant",
-                        "name": "name\\nwith\\nnewlines",
                         "tool_call_id": "tool_call_id\\twith\\ttabs",
                         "tool_calls": [
                             {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModelTests.java
@@ -33,7 +33,7 @@ public class ElasticInferenceServiceCompletionModelTests extends ESTestCase {
         );
 
         var request = new UnifiedCompletionRequest(
-            List.of(new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString("message"), "user", null, null, null)),
+            List.of(new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString("message"), "user", null, null)),
             "new_model_id",
             null,
             null,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
@@ -967,9 +967,7 @@ public class OpenAiServiceTests extends ESTestCase {
             service.unifiedCompletionInfer(
                 model,
                 UnifiedCompletionRequest.of(
-                    List.of(
-                        new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString("hello"), "user", null, null, null)
-                    )
+                    List.of(new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString("hello"), "user", null, null))
                 ),
                 InferenceAction.Request.DEFAULT_TIMEOUT,
                 listener

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionModelTests.java
@@ -51,7 +51,7 @@ public class OpenAiChatCompletionModelTests extends ESTestCase {
     public void testOverrideWith_UnifiedCompletionRequest_OverridesModelId() {
         var model = createChatCompletionModel("url", "org", "api_key", "model_name", "user");
         var request = new UnifiedCompletionRequest(
-            List.of(new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString("hello"), "role", null, null, null)),
+            List.of(new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString("hello"), "role", null, null)),
             "different_model",
             null,
             null,
@@ -70,7 +70,7 @@ public class OpenAiChatCompletionModelTests extends ESTestCase {
     public void testOverrideWith_UnifiedCompletionRequest_UsesModelFields_WhenRequestDoesNotOverride() {
         var model = createChatCompletionModel("url", "org", "api_key", "model_name", "user");
         var request = new UnifiedCompletionRequest(
-            List.of(new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString("hello"), "role", null, null, null)),
+            List.of(new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString("hello"), "role", null, null)),
             null, // not overriding model
             null,
             null,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ML] Unified schema API remove name field (#119799)](https://github.com/elastic/elasticsearch/pull/119799)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)