### PR TITLE
Rename these test utility methods

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1237,7 +1237,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         return randomBoolean() ? null : randomLong();
     }
 
-    public static Long randomPositiveLongOrNull() {
+    public static Long randomNonNegativeLongOrNull() {
         return randomBoolean() ? null : randomNonNegativeLong();
     }
 
@@ -1245,7 +1245,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         return randomBoolean() ? null : randomInt();
     }
 
-    public static Integer randomPositiveIntOrNull() {
+    public static Integer randomNonNegativeIntOrNull() {
         return randomBoolean() ? null : randomNonNegativeInt();
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/UnifiedCompletionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/UnifiedCompletionRequestTests.java
@@ -183,7 +183,7 @@ public class UnifiedCompletionRequestTests extends AbstractBWCWireSerializationT
         return new UnifiedCompletionRequest(
             randomList(5, UnifiedCompletionRequestTests::randomMessage),
             randomAlphaOfLengthOrNull(10),
-            randomPositiveLongOrNull(),
+            randomNonNegativeLongOrNull(),
             randomStopOrNull(),
             randomFloatOrNull(),
             randomToolChoiceOrNull(),


### PR DESCRIPTION
I'm here because these methods didn't do what I want (they can return zero), and so I'm renaming them to reflect what they actually do. Since I was working on ILM while I ran into this, I labeled this PR as being ILM related.