### PR TITLE
[8.x] Remove unused `Transport#version` field (#120202)

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
@@ -79,7 +79,7 @@ public class SimpleNetty4TransportTests extends AbstractSimpleTransportTestCase 
                 if (doHandshake) {
                     super.executeHandshake(node, channel, profile, listener);
                 } else {
-                    assert getVersion().equals(TransportVersion.current());
+                    assert version.equals(TransportVersion.current());
                     listener.onResponse(TransportVersions.MINIMUM_COMPATIBLE);
                 }
             }

--- a/server/src/main/java/org/elasticsearch/client/internal/RemoteClusterClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/RemoteClusterClient.java
@@ -47,7 +47,8 @@ public interface RemoteClusterClient {
 
     /**
      * Obtain a connection to the remote cluster for use with the {@link #execute} override that allows to specify the connection. Useful
-     * for cases where you need to inspect {@link Transport.Connection#getVersion} before deciding the exact remote action to invoke.
+     * for cases where you need to inspect {@link Transport.Connection#getTransportVersion} before deciding the exact remote action to
+     * invoke.
      */
     <Request extends ActionRequest> void getConnection(@Nullable Request request, ActionListener<Transport.Connection> listener);
 }

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -114,7 +114,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     protected final NetworkService networkService;
     protected final Set<ProfileSettings> profileSettingsSet;
     protected final boolean rstOnClose;
-    private final TransportVersion version;
     private final CircuitBreakerService circuitBreakerService;
 
     private final ConcurrentMap<String, BoundTransportAddress> profileBoundAddresses = newConcurrentMap();
@@ -148,7 +147,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     ) {
         this.settings = settings;
         this.profileSettingsSet = getProfileSettings(settings);
-        this.version = version;
         this.threadPool = threadPool;
         this.circuitBreakerService = circuitBreakerService;
         this.networkService = networkService;
@@ -197,11 +195,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             networkService.getHandlingTimeTracker(),
             ignoreDeserializationErrors
         );
-    }
-
-    @Override
-    public TransportVersion getVersion() {
-        return version;
     }
 
     public StatsTracker getStatsTracker() {

--- a/server/src/main/java/org/elasticsearch/transport/Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transport.java
@@ -50,10 +50,6 @@ public interface Transport extends LifecycleComponent {
         return false;
     }
 
-    default TransportVersion getVersion() {
-        return TransportVersion.current();
-    }
-
     /**
      * The address the transport is bound on.
      */

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -139,11 +139,6 @@ public class StubbableTransport implements Transport {
     }
 
     @Override
-    public TransportVersion getVersion() {
-        return delegate.getVersion();
-    }
-
-    @Override
     public void setMessageListener(TransportMessageListener listener) {
         delegate.setMessageListener(listener);
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
@@ -1016,6 +1016,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
 
     static class TestSecurityNetty4ServerTransport extends SecurityNetty4ServerTransport {
         private final boolean doHandshake;
+        private final TransportVersion version;
 
         TestSecurityNetty4ServerTransport(
             Settings settings,
@@ -1043,6 +1044,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
                 sharedGroupFactory,
                 mock(CrossClusterAccessAuthenticationService.class)
             );
+            this.version = version;
             this.doHandshake = doHandshake;
         }
 
@@ -1056,7 +1058,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
             if (doHandshake) {
                 super.executeHandshake(node, channel, profile, listener);
             } else {
-                assert getVersion().equals(TransportVersion.current());
+                assert version.equals(TransportVersion.current());
                 listener.onResponse(TransportVersions.MINIMUM_COMPATIBLE);
             }
         }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Remove unused `Transport#version` field (#120202)