### PR TITLE
[8.x] Rename test utility methods (#120213)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1232,7 +1232,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         return randomBoolean() ? null : randomLong();
     }
 
-    public static Long randomPositiveLongOrNull() {
+    public static Long randomNonNegativeLongOrNull() {
         return randomBoolean() ? null : randomNonNegativeLong();
     }
 
@@ -1240,7 +1240,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         return randomBoolean() ? null : randomInt();
     }
 
-    public static Integer randomPositiveIntOrNull() {
+    public static Integer randomNonNegativeIntOrNull() {
         return randomBoolean() ? null : randomNonNegativeInt();
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/UnifiedCompletionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/UnifiedCompletionRequestTests.java
@@ -183,7 +183,7 @@ public class UnifiedCompletionRequestTests extends AbstractBWCWireSerializationT
         return new UnifiedCompletionRequest(
             randomList(5, UnifiedCompletionRequestTests::randomMessage),
             randomAlphaOfLengthOrNull(10),
-            randomPositiveLongOrNull(),
+            randomNonNegativeLongOrNull(),
             randomStopOrNull(),
             randomFloatOrNull(),
             randomToolChoiceOrNull(),


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Rename test utility methods (#120213)