### PR TITLE
Add deprecated 7->8 label to some settings

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -433,7 +433,8 @@ public final class IndexSettings {
         "index.soft_deletes.enabled",
         true,
         Property.IndexScope,
-        Property.Final
+        Property.Final,
+        Property.IndexSettingDeprecatedInV7AndRemovedInV8
     );
 
     /**
@@ -460,7 +461,8 @@ public final class IndexSettings {
         TimeValue.MINUS_ONE,
         TimeValue.MINUS_ONE,
         Property.Dynamic,
-        Property.IndexScope
+        Property.IndexScope,
+        Property.IndexSettingDeprecatedInV7AndRemovedInV8
     );
 
     /**
@@ -473,7 +475,8 @@ public final class IndexSettings {
         "index.translog.retention.size",
         settings -> "-1",
         Property.Dynamic,
-        Property.IndexScope
+        Property.IndexScope,
+        Property.IndexSettingDeprecatedInV7AndRemovedInV8
     );
 
     /**


### PR DESCRIPTION
Add the `IndexSettingDeprecatedInV7AndRemovedInV8` label to the settings:
* index.soft_deletes.enabled
* index.translog.retention.size
* index.translog.retention.age

The latter two have a `TODO: Remove this setting in 9.0.` comment so this seems like the right thing to do. I am less confident about `index.soft_deletes.enabled`, but since soft deletes are always in enabled in v8 it seems we should remove the setting.

Some context:
While working on reindexing datastreams from v7 to v8, tried to [copy](https://github.com/elastic/elasticsearch/pull/120163) what the [upgrade assistant does](https://github.com/elastic/kibana/blob/8a8363f02cc990732eb9cbb60cd388643a336bed/x-pack/plugins/upgrade_assistant/server/lib/reindexing/index_settings.ts#L25) to filter out old settings when its upgrading an index. These three settings are specifically filtered out when upgrading. `index.translog.retention.size` and `index.translog.retention.age` are only removed if `index.soft_deletes.enabled` is enabled. But since `index.soft_deletes.enabled` is always enabled in v8, all three should be removed.