### PR TITLE
Speedup sum aggregator

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
@@ -67,18 +67,33 @@ public class SumAggregator extends NumericMetricsAggregator.SingleDoubleValue {
 
     @Override
     protected LeafBucketCollector getLeafCollector(NumericDoubleValues values, final LeafBucketCollector sub) {
-        final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (values.advanceExact(doc)) {
                     maybeGrow(bucket);
+                    var sums = SumAggregator.this.sums;
                     // Compute the sum of double values with Kahan summation algorithm which is more
                     // accurate than naive summation.
-                    kahanSummation.reset(sums.get(bucket), compensations.get(bucket));
-                    kahanSummation.add(values.doubleValue());
-                    compensations.set(bucket, kahanSummation.delta());
-                    sums.set(bucket, kahanSummation.value());
+                    double value = sums.get(bucket);
+                    // If the value is Inf or NaN, just add it to the running tally to "convert" to
+                    // Inf/NaN. This keeps the behavior bwc from before kahan summing
+                    double v = values.doubleValue();
+                    if (Double.isFinite(v) == false) {
+                        value = v + value;
+                    }
+
+                    var compensations = SumAggregator.this.compensations;
+                    double delta = compensations.get(bucket);
+                    if (Double.isFinite(value)) {
+                        double correctedSum = v + delta;
+                        double updatedValue = value + correctedSum;
+                        delta = correctedSum - (updatedValue - value);
+                        value = updatedValue;
+                        compensations.set(bucket, delta);
+                    }
+
+                    sums.set(bucket, value);
                 }
             }
         };


### PR DESCRIPTION
Random profiling find :)

Using an object to track the two double fields is extremely inefficient here since the object can't be removed by escape analysis.
We have a couple more like this that could be fixed in a similar way. There is no state to retain in that summation object but since it's injected from the outside the compiler has no way to optimize away the two double stores at the end of the method call (and might not even be able to do away with the intermediary steps). 
It's mildly unfortunate admittedly that there isn't really a neat Java way of drying this calculation up as far as I can tell because we need two double returns.