### PR TITLE
Fix realtime get of nested fields with synthetic source (#119575)

### DIFF
--- a/docs/changelog/119575.yaml
+++ b/docs/changelog/119575.yaml
@@ -1,0 +1,6 @@
+pr: 119575
+summary: Fix realtime get of nested fields with synthetic source
+area: Mapping
+type: bug
+issues:
+ - 119553

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -410,9 +410,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testWatcherWithApiKey {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/119396
-- class: org.elasticsearch.index.engine.LuceneSyntheticSourceChangesSnapshotTests
-  method: testSkipNonRootOfNestedDocuments
-  issue: https://github.com/elastic/elasticsearch/issues/119553
 - class: org.elasticsearch.upgrades.SearchStatesIT
   method: testCanMatch
   issue: https://github.com/elastic/elasticsearch/issues/118718

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -819,7 +819,7 @@ public class InternalEngine extends Engine {
     ) throws IOException {
         assert get.isReadFromTranslog();
         translogGetCount.incrementAndGet();
-        final TranslogDirectoryReader inMemoryReader = new TranslogDirectoryReader(
+        final DirectoryReader inMemoryReader = TranslogDirectoryReader.create(
             shardId,
             index,
             mappingLookup,

--- a/server/src/main/java/org/elasticsearch/index/engine/TranslogDirectoryReader.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/TranslogDirectoryReader.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.engine;
 
+import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.BaseTermsEnum;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.ByteVectorValues;
@@ -45,6 +46,9 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
+import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.fieldvisitor.FieldNamesProvidingStoredFieldsVisitor;
@@ -75,9 +79,9 @@ import java.util.concurrent.atomic.AtomicReference;
  * into an in-memory Lucene segment that is created on-demand.
  */
 final class TranslogDirectoryReader extends DirectoryReader {
-    private final TranslogLeafReader leafReader;
+    private final LeafReader leafReader;
 
-    TranslogDirectoryReader(
+    static DirectoryReader create(
         ShardId shardId,
         Translog.Index operation,
         MappingLookup mappingLookup,
@@ -85,11 +89,39 @@ final class TranslogDirectoryReader extends DirectoryReader {
         EngineConfig engineConfig,
         Runnable onSegmentCreated
     ) throws IOException {
-        this(new TranslogLeafReader(shardId, operation, mappingLookup, documentParser, engineConfig, onSegmentCreated));
+        final Directory directory = new ByteBuffersDirectory();
+        boolean success = false;
+        try {
+            final LeafReader leafReader;
+            // When using synthetic source, the translog operation must always be reindexed into an in-memory Lucene to ensure consistent
+            // output for realtime-get operations. However, this can degrade the performance of realtime-get and update operations.
+            // If slight inconsistencies in realtime-get operations are acceptable, the translog operation can be reindexed lazily.
+            if (mappingLookup.isSourceSynthetic()) {
+                onSegmentCreated.run();
+                leafReader = createInMemoryReader(shardId, engineConfig, directory, documentParser, mappingLookup, false, operation);
+            } else {
+                leafReader = new TranslogLeafReader(
+                    shardId,
+                    operation,
+                    mappingLookup,
+                    documentParser,
+                    engineConfig,
+                    directory,
+                    onSegmentCreated
+                );
+            }
+            var directoryReader = ElasticsearchDirectoryReader.wrap(new TranslogDirectoryReader(directory, leafReader), shardId);
+            success = true;
+            return directoryReader;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(directory);
+            }
+        }
     }
 
-    private TranslogDirectoryReader(TranslogLeafReader leafReader) throws IOException {
-        super(leafReader.directory, new LeafReader[] { leafReader }, null);
+    private TranslogDirectoryReader(Directory directory, LeafReader leafReader) throws IOException {
+        super(directory, new LeafReader[] { leafReader }, null);
         this.leafReader = leafReader;
     }
 
@@ -138,12 +170,13 @@ final class TranslogDirectoryReader extends DirectoryReader {
         return leafReader.getReaderCacheHelper();
     }
 
-    static DirectoryReader createInMemoryReader(
+    private static LeafReader createInMemoryReader(
         ShardId shardId,
         EngineConfig engineConfig,
         Directory directory,
         DocumentParser documentParser,
         MappingLookup mappingLookup,
+        boolean rootDocOnly,
         Translog.Index operation
     ) {
         final ParsedDocument parsedDocs = documentParser.parseDocument(
@@ -158,13 +191,55 @@ final class TranslogDirectoryReader extends DirectoryReader {
             IndexWriterConfig.OpenMode.CREATE
         ).setCodec(engineConfig.getCodec());
         try (IndexWriter writer = new IndexWriter(directory, writeConfig)) {
-            writer.addDocuments(parsedDocs.docs());
-            final DirectoryReader reader = open(writer);
-            if (reader.leaves().size() != 1) {
-                reader.close();
-                throw new IllegalStateException("Expected a single segment; " + "but  got[" + reader.leaves().size() + "] segments");
+            final int numDocs;
+            if (rootDocOnly) {
+                numDocs = 1;
+                writer.addDocument(parsedDocs.rootDoc());
+            } else {
+                numDocs = parsedDocs.docs().size();
+                writer.addDocuments(parsedDocs.docs());
             }
-            return reader;
+            final DirectoryReader reader = open(writer);
+            if (reader.leaves().size() != 1 || reader.leaves().get(0).reader().numDocs() != numDocs) {
+                reader.close();
+                throw new IllegalStateException(
+                    "Expected a single segment with "
+                        + numDocs
+                        + " documents, "
+                        + "but ["
+                        + reader.leaves().size()
+                        + " segments with "
+                        + reader.leaves().get(0).reader().numDocs()
+                        + " documents"
+                );
+            }
+            LeafReader leafReader = reader.leaves().get(0).reader();
+            return new SequentialStoredFieldsLeafReader(leafReader) {
+                @Override
+                protected void doClose() throws IOException {
+                    IOUtils.close(super::doClose, directory);
+                }
+
+                @Override
+                public CacheHelper getCoreCacheHelper() {
+                    return leafReader.getCoreCacheHelper();
+                }
+
+                @Override
+                public CacheHelper getReaderCacheHelper() {
+                    return leafReader.getReaderCacheHelper();
+                }
+
+                @Override
+                public StoredFieldsReader getSequentialStoredFieldsReader() {
+                    return Lucene.segmentReader(leafReader).getFieldsReader().getMergeInstance();
+                }
+
+                @Override
+                protected StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader) {
+                    return reader;
+                }
+            };
         } catch (IOException e) {
             throw new EngineException(shardId, "failed to create an in-memory segment for get [" + operation.id() + "]", e);
         }
@@ -248,6 +323,7 @@ final class TranslogDirectoryReader extends DirectoryReader {
             MappingLookup mappingLookup,
             DocumentParser documentParser,
             EngineConfig engineConfig,
+            Directory directory,
             Runnable onSegmentCreated
         ) {
             this.shardId = shardId;
@@ -256,7 +332,7 @@ final class TranslogDirectoryReader extends DirectoryReader {
             this.documentParser = documentParser;
             this.engineConfig = engineConfig;
             this.onSegmentCreated = onSegmentCreated;
-            this.directory = new ByteBuffersDirectory();
+            this.directory = directory;
             this.uid = Uid.encodeId(operation.id());
         }
 
@@ -268,7 +344,15 @@ final class TranslogDirectoryReader extends DirectoryReader {
                     ensureOpen();
                     reader = delegate.get();
                     if (reader == null) {
-                        var indexReader = createInMemoryReader(shardId, engineConfig, directory, documentParser, mappingLookup, operation);
+                        var indexReader = createInMemoryReader(
+                            shardId,
+                            engineConfig,
+                            directory,
+                            documentParser,
+                            mappingLookup,
+                            true,
+                            operation
+                        );
                         reader = indexReader.leaves().get(0).reader();
                         final LeafReader existing = delegate.getAndSet(reader);
                         assert existing == null;
@@ -458,7 +542,12 @@ final class TranslogDirectoryReader extends DirectoryReader {
 
         @Override
         protected synchronized void doClose() throws IOException {
-            IOUtils.close(delegate.get(), directory);
+            final LeafReader leaf = delegate.get();
+            if (leaf != null) {
+                leaf.close();
+            } else {
+                directory.close();
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/TranslogOperationAsserter.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/TranslogOperationAsserter.java
@@ -10,8 +10,6 @@
 package org.elasticsearch.index.engine;
 
 import org.apache.lucene.search.similarities.BM25Similarity;
-import org.apache.lucene.store.ByteBuffersDirectory;
-import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.index.cache.query.TrivialQueryCachingPolicy;
 import org.elasticsearch.index.mapper.DocumentParser;
 import org.elasticsearch.index.mapper.MappingLookup;
@@ -53,13 +51,7 @@ public abstract class TranslogOperationAsserter {
         final ShardId shardId = engineConfig.getShardId();
         final MappingLookup mappingLookup = engineConfig.getMapperService().mappingLookup();
         final DocumentParser documentParser = engineConfig.getMapperService().documentParser();
-        try (
-            var directory = new ByteBuffersDirectory();
-            var reader = ElasticsearchDirectoryReader.wrap(
-                TranslogDirectoryReader.createInMemoryReader(shardId, engineConfig, directory, documentParser, mappingLookup, op),
-                new ShardId("index", "_na_", 0)
-            )
-        ) {
+        try (var reader = TranslogDirectoryReader.create(shardId, op, mappingLookup, documentParser, engineConfig, () -> {})) {
             final Engine.Searcher searcher = new Engine.Searcher(
                 "assert_translog",
                 reader,


### PR DESCRIPTION
Today, for get-from-translog operations, we only need to reindex the root document into an in-memory Lucene, as the _source is stored in the root document and is sufficient. However, synthesizing the source for nested fields requires both the root document and its child documents. This causes realtime-get operations (as well as update and update-by-query operations) to miss nested fields.

Another issue is that the translog operation is reindexed lazily during get-from-translog operations. As a result, two realtime-get operations can return slightly different outputs: one reading from the translog and the other from Lucene.

This change resolves both issues. However, addressing the second issue can degrade the performance of realtime-get and update operations. If slight inconsistencies are acceptable, the translog operation should be reindexed lazily instead.

Closes #119553