### PR TITLE
Retry internally when CAS upload is throttled [GCS]

### DIFF
--- a/docs/changelog/120250.yaml
+++ b/docs/changelog/120250.yaml
@@ -1,0 +1,6 @@
+pr: 120250
+summary: "Retry internally when CAS upload is throttled [GCS]"
+area: Snapshot/Restore
+type: enhancement
+issues:
+ - 116546

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerStatsTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerStatsTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.blobstore.BlobStoreActionStats;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.http.ResponseInjectingHttpHandler;
 import org.elasticsearch.rest.RestStatus;
 import org.junit.Before;
 
@@ -34,14 +35,14 @@ import static org.elasticsearch.repositories.azure.AzureBlobStore.Operation.PUT_
 
 public class AzureBlobContainerStatsTests extends AbstractAzureServerTestCase {
 
-    private final Queue<ResponseInjectingAzureHttpHandler.RequestHandler> requestHandlers = new ConcurrentLinkedQueue<>();
+    private final Queue<ResponseInjectingHttpHandler.RequestHandler> requestHandlers = new ConcurrentLinkedQueue<>();
 
     @SuppressForbidden(reason = "use a http server")
     @Before
     public void configureAzureHandler() {
         httpServer.createContext(
             "/",
-            new ResponseInjectingAzureHttpHandler(
+            new ResponseInjectingHttpHandler(
                 requestHandlers,
                 new AzureHttpHandler(ACCOUNT, CONTAINER, null, MockAzureBlobStore.LeaseExpiryPredicate.NEVER_EXPIRE)
             )
@@ -61,7 +62,7 @@ public class AzureBlobContainerStatsTests extends AbstractAzureServerTestCase {
         for (int i = 0; i < randomIntBetween(10, 50); i++) {
             final boolean triggerRetry = randomBoolean();
             if (triggerRetry) {
-                requestHandlers.offer(new ResponseInjectingAzureHttpHandler.FixedRequestHandler(RestStatus.TOO_MANY_REQUESTS));
+                requestHandlers.offer(new ResponseInjectingHttpHandler.FixedRequestHandler(RestStatus.TOO_MANY_REQUESTS));
             }
             final AzureBlobStore.Operation operation = randomFrom(supportedOperations);
             switch (operation) {

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.ResponseInjectingHttpHandler;
 import org.elasticsearch.indices.recovery.RecoverySettings;
@@ -329,7 +330,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
                             storageService,
                             bigArrays,
                             randomIntBetween(1, 8) * 1024,
-                            BackoffPolicy.noBackoff()
+                            BackoffPolicy.linearBackoff(TimeValue.timeValueMillis(10), 10, TimeValue.timeValueSeconds(1))
                         ) {
                             @Override
                             long getLargeBlobThresholdInBytes() {

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -25,9 +25,12 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.blobstore.OptionalBytesReference;
+import org.elasticsearch.common.blobstore.support.BlobContainerUtils;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.Streams;
@@ -39,6 +42,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.http.ResponseInjectingHttpHandler;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.RepositoriesMetrics;
@@ -46,7 +50,10 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.repositories.blobstore.ESMockAPIBasedRepositoryIntegTestCase;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.junit.After;
+import org.junit.Before;
 import org.threeten.bp.Duration;
 
 import java.io.IOException;
@@ -55,6 +62,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,6 +78,22 @@ import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.CL
 
 @SuppressForbidden(reason = "this test uses a HttpServer to emulate a Google Cloud Storage endpoint")
 public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTestCase {
+
+    private static final int MAX_RETRIES = 5;
+    private static final AtomicBoolean INTRODUCE_ERRORS = new AtomicBoolean(true);
+    private final Queue<ResponseInjectingHttpHandler.RequestHandler> requestHandlers = new ConcurrentLinkedQueue<>();
+
+    @Before
+    public void resetIntroduceErrors() {
+        INTRODUCE_ERRORS.set(true);
+    }
+
+    @After
+    public void checkRequestHandlerQueue() {
+        if (requestHandlers.isEmpty() == false) {
+            fail("There were unused request handlers left in the queue, this is probably a broken test");
+        }
+    }
 
     @Override
     protected String repositoryType() {
@@ -95,7 +121,9 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
     protected Map<String, HttpHandler> createHttpHandlers() {
         return Map.of(
             "/",
-            new GoogleCloudStorageStatsCollectorHttpHandler(new GoogleCloudStorageBlobStoreHttpHandler("bucket")),
+            new GoogleCloudStorageStatsCollectorHttpHandler(
+                new ResponseInjectingHttpHandler(requestHandlers, new GoogleCloudStorageBlobStoreHttpHandler("bucket"))
+            ),
             "/token",
             new FakeOAuth2HttpHandler()
         );
@@ -204,6 +232,38 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
         }
     }
 
+    public void testCompareAndExchangeWhenThrottled() throws IOException {
+        INTRODUCE_ERRORS.set(false);
+        try (BlobStore store = newBlobStore()) {
+            final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
+            final byte[] data = randomBytes(randomIntBetween(1, BlobContainerUtils.MAX_REGISTER_CONTENT_LENGTH));
+            final String key = randomIdentifier();
+
+            final OptionalBytesReference createResult = safeAwait(
+                l -> container.compareAndExchangeRegister(randomPurpose(), key, BytesArray.EMPTY, new BytesArray(data), l)
+            );
+            assertEquals(createResult, OptionalBytesReference.EMPTY);
+
+            final byte[] updatedData = randomBytes(randomIntBetween(1, BlobContainerUtils.MAX_REGISTER_CONTENT_LENGTH));
+            final int numberOfThrottles = randomIntBetween(MAX_RETRIES, 3 * MAX_RETRIES);
+            for (int i = 0; i < numberOfThrottles; i++) {
+                requestHandlers.offer(
+                    new ResponseInjectingHttpHandler.FixedRequestHandler(
+                        RestStatus.TOO_MANY_REQUESTS,
+                        null,
+                        ex -> ex.getRequestURI().getPath().equals("/upload/storage/v1/b/bucket/o") && ex.getRequestMethod().equals("POST")
+                    )
+                );
+            }
+            final OptionalBytesReference updateResult = safeAwait(
+                l -> container.compareAndExchangeRegister(randomPurpose(), key, new BytesArray(data), new BytesArray(updatedData), l)
+            );
+            assertEquals(new BytesArray(data), updateResult.bytesReference());
+
+            container.delete(randomPurpose());
+        }
+    }
+
     public static class TestGoogleCloudStoragePlugin extends GoogleCloudStoragePlugin {
 
         public TestGoogleCloudStoragePlugin(Settings settings) {
@@ -229,7 +289,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
                                 .setInitialRetryDelay(Duration.ofMillis(10L))
                                 .setRetryDelayMultiplier(options.getRetrySettings().getRetryDelayMultiplier())
                                 .setMaxRetryDelay(Duration.ofSeconds(1L))
-                                .setMaxAttempts(0)
+                                .setMaxAttempts(MAX_RETRIES)
                                 .setJittered(false)
                                 .setInitialRpcTimeout(options.getRetrySettings().getInitialRpcTimeout())
                                 .setRpcTimeoutMultiplier(options.getRetrySettings().getRpcTimeoutMultiplier())
@@ -268,7 +328,8 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
                             metadata.name(),
                             storageService,
                             bigArrays,
-                            randomIntBetween(1, 8) * 1024
+                            randomIntBetween(1, 8) * 1024,
+                            BackoffPolicy.noBackoff()
                         ) {
                             @Override
                             long getLargeBlobThresholdInBytes() {
@@ -326,7 +387,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
         protected boolean canFailRequest(final HttpExchange exchange) {
             // Batch requests are not retried so we don't want to fail them
             // The batched request are supposed to be retried (not tested here)
-            return exchange.getRequestURI().toString().startsWith("/batch/") == false;
+            return INTRODUCE_ERRORS.get() && exchange.getRequestURI().toString().startsWith("/batch/") == false;
         }
     }
 

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
@@ -24,6 +24,7 @@ import com.google.cloud.storage.StorageException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
@@ -41,6 +42,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Streams;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.ByteArrayInputStream;
@@ -105,6 +107,7 @@ class GoogleCloudStorageBlobStore implements BlobStore {
     private final GoogleCloudStorageOperationsStats stats;
     private final int bufferSize;
     private final BigArrays bigArrays;
+    private final BackoffPolicy casBackoffPolicy;
 
     GoogleCloudStorageBlobStore(
         String bucketName,
@@ -112,7 +115,8 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         String repositoryName,
         GoogleCloudStorageService storageService,
         BigArrays bigArrays,
-        int bufferSize
+        int bufferSize,
+        BackoffPolicy casBackoffPolicy
     ) {
         this.bucketName = bucketName;
         this.clientName = clientName;
@@ -121,6 +125,7 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         this.bigArrays = bigArrays;
         this.stats = new GoogleCloudStorageOperationsStats(bucketName);
         this.bufferSize = bufferSize;
+        this.casBackoffPolicy = casBackoffPolicy;
     }
 
     private Storage client() throws IOException {
@@ -648,7 +653,7 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         String key,
         BytesReference expected,
         BytesReference updated
-    ) throws IOException {
+    ) throws Exception {
         BlobContainerUtils.ensureValidRegisterContent(updated);
 
         final var blobId = BlobId.of(bucketName, blobName);
@@ -691,28 +696,45 @@ class GoogleCloudStorageBlobStore implements BlobStore {
             .setMd5(Base64.getEncoder().encodeToString(MessageDigests.digest(updated, MessageDigests.md5())))
             .build();
         final var bytesRef = updated.toBytesRef();
-        try {
-            SocketAccess.doPrivilegedVoidIOException(
-                () -> client().create(
-                    blobInfo,
-                    bytesRef.bytes,
-                    bytesRef.offset,
-                    bytesRef.length,
-                    Storage.BlobTargetOption.generationMatch()
-                )
-            );
-        } catch (Exception e) {
-            final var serviceException = unwrapServiceException(e);
-            if (serviceException != null) {
-                final var statusCode = serviceException.getCode();
-                if (statusCode == RestStatus.PRECONDITION_FAILED.getStatus() || statusCode == RestStatus.TOO_MANY_REQUESTS.getStatus()) {
-                    return OptionalBytesReference.MISSING;
-                }
-            }
-            throw e;
-        }
 
-        return OptionalBytesReference.of(expected);
+        final Iterator<TimeValue> retries = casBackoffPolicy.iterator();
+        Exception finalException = null;
+        while (true) {
+            try {
+                SocketAccess.doPrivilegedVoidIOException(
+                    () -> client().create(
+                        blobInfo,
+                        bytesRef.bytes,
+                        bytesRef.offset,
+                        bytesRef.length,
+                        Storage.BlobTargetOption.generationMatch()
+                    )
+                );
+                return OptionalBytesReference.of(expected);
+            } catch (Exception e) {
+                finalException = ExceptionsHelper.useOrSuppress(finalException, e);
+                final var serviceException = unwrapServiceException(e);
+                if (serviceException != null) {
+                    final var statusCode = serviceException.getCode();
+                    if (statusCode == RestStatus.PRECONDITION_FAILED.getStatus()) {
+                        return OptionalBytesReference.MISSING;
+                    }
+                    if (statusCode == RestStatus.TOO_MANY_REQUESTS.getStatus()) {
+                        if (retries.hasNext()) {
+                            try {
+                                // noinspection BusyWait
+                                Thread.sleep(retries.next().millis());
+                                continue;
+                            } catch (InterruptedException iex) {
+                                Thread.currentThread().interrupt();
+                                finalException = ExceptionsHelper.useOrSuppress(finalException, iex);
+                            }
+                        }
+                    }
+                }
+                throw finalException;
+            }
+        }
     }
 
     private static BaseServiceException unwrapServiceException(Throwable t) {

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -64,12 +64,12 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
      */
     static final Setting<TimeValue> RETRY_THROTTLED_CAS_DELAY_INCREMENT = Setting.timeSetting(
         "throttled_cas_retry.delay_increment",
-        TimeValue.timeValueMillis(50),
+        TimeValue.timeValueMillis(100),
         TimeValue.ZERO
     );
     static final Setting<Integer> RETRY_THROTTLED_CAS_MAX_NUMBER_OF_RETRIES = Setting.intSetting(
         "throttled_cas_retry.maximum_number_of_retries",
-        10,
+        2,
         0
     );
     static final Setting<TimeValue> RETRY_THROTTLED_CAS_MAXIMUM_DELAY = Setting.timeSetting(

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -59,7 +59,7 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
     static final Setting<String> CLIENT_NAME = Setting.simpleString("client", "default");
 
     /**
-     * We will retry deletes that fail due to throttling. We use an {@link BackoffPolicy#linearBackoff(TimeValue, int, TimeValue)}
+     * We will retry CASes that fail due to throttling. We use an {@link BackoffPolicy#linearBackoff(TimeValue, int, TimeValue)}
      * with the following parameters
      */
     static final Setting<TimeValue> RETRY_THROTTLED_CAS_DELAY_INCREMENT = Setting.timeSetting(

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -13,12 +13,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.blobstore.MeteredBlobStoreRepository;
@@ -56,10 +58,33 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
     );
     static final Setting<String> CLIENT_NAME = Setting.simpleString("client", "default");
 
+    /**
+     * We will retry deletes that fail due to throttling. We use an {@link BackoffPolicy#linearBackoff(TimeValue, int, TimeValue)}
+     * with the following parameters
+     */
+    static final Setting<TimeValue> RETRY_THROTTLED_CAS_DELAY_INCREMENT = Setting.timeSetting(
+        "throttled_cas_retry.delay_increment",
+        TimeValue.timeValueMillis(50),
+        TimeValue.ZERO
+    );
+    static final Setting<Integer> RETRY_THROTTLED_CAS_MAX_NUMBER_OF_RETRIES = Setting.intSetting(
+        "throttled_cas_retry.maximum_number_of_retries",
+        10,
+        0
+    );
+    static final Setting<TimeValue> RETRY_THROTTLED_CAS_MAXIMUM_DELAY = Setting.timeSetting(
+        "throttled_cas_retry.maximum_delay",
+        TimeValue.timeValueSeconds(5),
+        TimeValue.ZERO
+    );
+
     private final GoogleCloudStorageService storageService;
     private final ByteSizeValue chunkSize;
     private final String bucket;
     private final String clientName;
+    private final TimeValue retryThrottledCasDelayIncrement;
+    private final int retryThrottledCasMaxNumberOfRetries;
+    private final TimeValue retryThrottledCasMaxDelay;
 
     GoogleCloudStorageRepository(
         final RepositoryMetadata metadata,
@@ -83,6 +108,9 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
         this.chunkSize = getSetting(CHUNK_SIZE, metadata);
         this.bucket = getSetting(BUCKET, metadata);
         this.clientName = CLIENT_NAME.get(metadata.settings());
+        this.retryThrottledCasDelayIncrement = RETRY_THROTTLED_CAS_DELAY_INCREMENT.get(metadata.settings());
+        this.retryThrottledCasMaxNumberOfRetries = RETRY_THROTTLED_CAS_MAX_NUMBER_OF_RETRIES.get(metadata.settings());
+        this.retryThrottledCasMaxDelay = RETRY_THROTTLED_CAS_MAXIMUM_DELAY.get(metadata.settings());
         logger.debug("using bucket [{}], base_path [{}], chunk_size [{}], compress [{}]", bucket, basePath(), chunkSize, isCompress());
     }
 
@@ -105,7 +133,15 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
 
     @Override
     protected GoogleCloudStorageBlobStore createBlobStore() {
-        return new GoogleCloudStorageBlobStore(bucket, clientName, metadata.name(), storageService, bigArrays, bufferSize);
+        return new GoogleCloudStorageBlobStore(
+            bucket,
+            clientName,
+            metadata.name(),
+            storageService,
+            bigArrays,
+            bufferSize,
+            BackoffPolicy.linearBackoff(retryThrottledCasDelayIncrement, retryThrottledCasMaxNumberOfRetries, retryThrottledCasMaxDelay)
+        );
     }
 
     @Override

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -476,7 +476,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         httpServer.createContext("/", new ResponseInjectingHttpHandler(requestHandlers, new GoogleCloudStorageHttpHandler("bucket")));
 
         final int maxRetries = 3;
-        final BlobContainer container = createBlobContainer(3, null, null, null);
+        final BlobContainer container = createBlobContainer(maxRetries, null, null, null);
         final byte[] data = randomBytes(randomIntBetween(1, BlobContainerUtils.MAX_REGISTER_CONTENT_LENGTH));
         final String key = randomIdentifier();
 
@@ -486,8 +486,8 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         assertEquals(createResult, OptionalBytesReference.EMPTY);
 
         final byte[] updatedData = randomBytes(randomIntBetween(1, BlobContainerUtils.MAX_REGISTER_CONTENT_LENGTH));
-        final int failuresToTriggerRetry = maxRetries + 1;
-        final int numberOfThrottles = randomIntBetween(failuresToTriggerRetry, 3 * failuresToTriggerRetry);
+        final int failuresToExhaustAttempts = maxRetries + 1;
+        final int numberOfThrottles = randomIntBetween(failuresToExhaustAttempts, (4 * failuresToExhaustAttempts) - 1);
         for (int i = 0; i < numberOfThrottles; i++) {
             requestHandlers.offer(
                 new ResponseInjectingHttpHandler.FixedRequestHandler(

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -475,7 +475,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         final Queue<ResponseInjectingHttpHandler.RequestHandler> requestHandlers = new ConcurrentLinkedQueue<>();
         httpServer.createContext("/", new ResponseInjectingHttpHandler(requestHandlers, new GoogleCloudStorageHttpHandler("bucket")));
 
-        final int maxRetries = 3;
+        final int maxRetries = randomIntBetween(1, 3);
         final BlobContainer container = createBlobContainer(maxRetries, null, null, null);
         final byte[] data = randomBytes(randomIntBetween(1, BlobContainerUtils.MAX_REGISTER_CONTENT_LENGTH));
         final String key = randomIdentifier();

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -18,6 +18,7 @@ import com.google.cloud.storage.StorageRetryStrategy;
 import com.sun.net.httpserver.HttpHandler;
 
 import org.apache.http.HttpStatus;
+import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.BlobContainer;
@@ -158,7 +159,8 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
             "repo",
             service,
             BigArrays.NON_RECYCLING_INSTANCE,
-            randomIntBetween(1, 8) * 1024
+            randomIntBetween(1, 8) * 1024,
+            BackoffPolicy.noBackoff()
         );
 
         return new GoogleCloudStorageBlobContainer(randomBoolean() ? BlobPath.EMPTY : BlobPath.EMPTY.add("foo"), blobStore);

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.repositories.gcs;
 
 import fixture.gcs.FakeOAuth2HttpHandler;
+import fixture.gcs.GoogleCloudStorageHttpHandler;
 
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.http.HttpTransportOptions;
@@ -23,6 +24,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.OptionalBytesReference;
+import org.elasticsearch.common.blobstore.support.BlobContainerUtils;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.Streams;
@@ -38,6 +41,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.http.ResponseInjectingHttpHandler;
 import org.elasticsearch.repositories.blobstore.AbstractBlobContainerRetriesTestCase;
 import org.elasticsearch.repositories.blobstore.ESMockAPIBasedRepositoryIntegTestCase;
 import org.elasticsearch.rest.RestStatus;
@@ -56,6 +60,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -160,7 +166,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
             service,
             BigArrays.NON_RECYCLING_INSTANCE,
             randomIntBetween(1, 8) * 1024,
-            BackoffPolicy.noBackoff()
+            BackoffPolicy.linearBackoff(TimeValue.timeValueMillis(1), 3, TimeValue.timeValueSeconds(1))
         );
 
         return new GoogleCloudStorageBlobContainer(randomBoolean() ? BlobPath.EMPTY : BlobPath.EMPTY.add("foo"), blobStore);
@@ -463,6 +469,41 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
 
             assertThat(pendingDeletes.get(), is(lessThanOrEqualTo(MAX_DELETES_PER_BATCH)));
         }
+    }
+
+    public void testCompareAndExchangeWhenThrottled() throws IOException {
+        final Queue<ResponseInjectingHttpHandler.RequestHandler> requestHandlers = new ConcurrentLinkedQueue<>();
+        httpServer.createContext("/", new ResponseInjectingHttpHandler(requestHandlers, new GoogleCloudStorageHttpHandler("bucket")));
+
+        final int maxRetries = 3;
+        final BlobContainer container = createBlobContainer(3, null, null, null);
+        final byte[] data = randomBytes(randomIntBetween(1, BlobContainerUtils.MAX_REGISTER_CONTENT_LENGTH));
+        final String key = randomIdentifier();
+
+        final OptionalBytesReference createResult = safeAwait(
+            l -> container.compareAndExchangeRegister(randomPurpose(), key, BytesArray.EMPTY, new BytesArray(data), l)
+        );
+        assertEquals(createResult, OptionalBytesReference.EMPTY);
+
+        final byte[] updatedData = randomBytes(randomIntBetween(1, BlobContainerUtils.MAX_REGISTER_CONTENT_LENGTH));
+        final int failuresToTriggerRetry = maxRetries + 1;
+        final int numberOfThrottles = randomIntBetween(failuresToTriggerRetry, 3 * failuresToTriggerRetry);
+        for (int i = 0; i < numberOfThrottles; i++) {
+            requestHandlers.offer(
+                new ResponseInjectingHttpHandler.FixedRequestHandler(
+                    RestStatus.TOO_MANY_REQUESTS,
+                    null,
+                    ex -> ex.getRequestURI().getPath().equals("/upload/storage/v1/b/bucket/o") && ex.getRequestMethod().equals("POST")
+                )
+            );
+        }
+        final OptionalBytesReference updateResult = safeAwait(
+            l -> container.compareAndExchangeRegister(randomPurpose(), key, new BytesArray(data), new BytesArray(updatedData), l)
+        );
+        assertEquals(new BytesArray(data), updateResult.bytesReference());
+
+        assertEquals(0, requestHandlers.size());
+        container.delete(randomPurpose());
     }
 
     private HttpHandler safeHandler(HttpHandler handler) {

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
@@ -17,6 +17,7 @@ import com.google.cloud.storage.StorageBatch;
 import com.google.cloud.storage.StorageBatchResult;
 import com.google.cloud.storage.StorageException;
 
+import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
@@ -87,7 +88,8 @@ public class GoogleCloudStorageBlobStoreContainerTests extends ESTestCase {
                 "repo",
                 storageService,
                 BigArrays.NON_RECYCLING_INSTANCE,
-                randomIntBetween(1, 8) * 1024
+                randomIntBetween(1, 8) * 1024,
+                BackoffPolicy.noBackoff()
             )
         ) {
             final BlobContainer container = store.blobContainer(BlobPath.EMPTY);

--- a/test/framework/src/main/java/org/elasticsearch/http/ResponseInjectingHttpHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/http/ResponseInjectingHttpHandler.java
@@ -7,9 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.repositories.azure;
+package org.elasticsearch.http;
 
-import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
@@ -19,21 +18,18 @@ import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Queue;
 import java.util.function.Predicate;
 
-@SuppressForbidden(reason = "we use a HttpServer to emulate Azure")
-class ResponseInjectingAzureHttpHandler implements ESMockAPIBasedRepositoryIntegTestCase.DelegatingHttpHandler {
+@SuppressForbidden(reason = "We use HttpServer for the fixtures")
+public class ResponseInjectingHttpHandler implements ESMockAPIBasedRepositoryIntegTestCase.DelegatingHttpHandler {
 
     private final HttpHandler delegate;
     private final Queue<RequestHandler> requestHandlerQueue;
 
-    ResponseInjectingAzureHttpHandler(Queue<RequestHandler> requestHandlerQueue, HttpHandler delegate) {
+    public ResponseInjectingHttpHandler(Queue<RequestHandler> requestHandlerQueue, HttpHandler delegate) {
         this.delegate = delegate;
         this.requestHandlerQueue = requestHandlerQueue;
-        AzureBlobContainerStatsTests test = new AzureBlobContainerStatsTests();
     }
 
     @Override
@@ -51,38 +47,9 @@ class ResponseInjectingAzureHttpHandler implements ESMockAPIBasedRepositoryInteg
         return delegate;
     }
 
-    /**
-     * Creates a {@link ResponseInjectingAzureHttpHandler.RequestHandler} that will persistently fail the first <code>numberToFail</code>
-     * distinct requests it sees. Any other requests are passed through to the delegate.
-     *
-     * @param numberToFail The number of requests to fail
-     * @return the handler
-     */
-    static ResponseInjectingAzureHttpHandler.RequestHandler createFailNRequestsHandler(int numberToFail) {
-        final List<String> requestsToFail = new ArrayList<>(numberToFail);
-        return (exchange, delegate) -> {
-            final Headers requestHeaders = exchange.getRequestHeaders();
-            final String requestId = requestHeaders.get("X-ms-client-request-id").get(0);
-            boolean failRequest = false;
-            synchronized (requestsToFail) {
-                if (requestsToFail.contains(requestId)) {
-                    failRequest = true;
-                } else if (requestsToFail.size() < numberToFail) {
-                    requestsToFail.add(requestId);
-                    failRequest = true;
-                }
-            }
-            if (failRequest) {
-                exchange.sendResponseHeaders(500, -1);
-            } else {
-                delegate.handle(exchange);
-            }
-        };
-    }
-
-    @SuppressForbidden(reason = "we use a HttpServer to emulate Azure")
+    @SuppressForbidden(reason = "We use HttpServer for the fixtures")
     @FunctionalInterface
-    interface RequestHandler {
+    public interface RequestHandler {
         void writeResponse(HttpExchange exchange, HttpHandler delegate) throws IOException;
 
         default boolean matchesRequest(HttpExchange exchange) {
@@ -90,14 +57,14 @@ class ResponseInjectingAzureHttpHandler implements ESMockAPIBasedRepositoryInteg
         }
     }
 
-    @SuppressForbidden(reason = "we use a HttpServer to emulate Azure")
-    static class FixedRequestHandler implements RequestHandler {
+    @SuppressForbidden(reason = "We use HttpServer for the fixtures")
+    public static class FixedRequestHandler implements RequestHandler {
 
         private final RestStatus status;
         private final String responseBody;
         private final Predicate<HttpExchange> requestMatcher;
 
-        FixedRequestHandler(RestStatus status) {
+        public FixedRequestHandler(RestStatus status) {
             this(status, null, req -> true);
         }
 
@@ -106,7 +73,7 @@ class ResponseInjectingAzureHttpHandler implements ESMockAPIBasedRepositoryInteg
          * that because the errors are stored in a queue this will prevent any subsequently queued errors from
          * being returned until after it returns.
          */
-        FixedRequestHandler(RestStatus status, String responseBody, Predicate<HttpExchange> requestMatcher) {
+        public FixedRequestHandler(RestStatus status, String responseBody, Predicate<HttpExchange> requestMatcher) {
             this.status = status;
             this.responseBody = responseBody;
             this.requestMatcher = requestMatcher;
@@ -121,7 +88,7 @@ class ResponseInjectingAzureHttpHandler implements ESMockAPIBasedRepositoryInteg
         public void writeResponse(HttpExchange exchange, HttpHandler delegateHandler) throws IOException {
             if (responseBody != null) {
                 byte[] responseBytes = responseBody.getBytes(StandardCharsets.UTF_8);
-                exchange.sendResponseHeaders(status.getStatus(), responseBytes.length);
+                exchange.sendResponseHeaders(status.getStatus(), responseBytes.length == 0 ? -1 : responseBytes.length);
                 exchange.getResponseBody().write(responseBytes);
             } else {
                 exchange.sendResponseHeaders(status.getStatus(), -1);


### PR DESCRIPTION
Fixes #116546

I've only changed the case where we are throttled trying to upload the new register contents, because currently that was the only place we returned `MISSING` when we were throttled. Do we think it'd make more sense to start the whole CAS again in the event that ANY of the requests are throttled?

It looks like by default, GCS is configured with

initial retry delay = 1s
retry delay multiplier = 2
max retry delay = 32s
max attempts = 6

So by adding another layer of retries, this CAS could end up taking some time. By default I allowed two retries, which will take the maximum time out to 96s.