### PR TITLE
[8.16] [TEST] Use Docker Compose v2 for TestFixturePlugin (#120214)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
@@ -122,7 +122,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
         composeExtension.getRemoveContainers().set(true);
         composeExtension.getCaptureContainersOutput()
             .set(EnumSet.of(LogLevel.INFO, LogLevel.DEBUG).contains(project.getGradle().getStartParameter().getLogLevel()));
-        composeExtension.getUseDockerComposeV2().set(false);
+        composeExtension.getUseDockerComposeV2().set(true);
         composeExtension.getExecutable().set(this.providerFactory.provider(() -> {
             String composePath = dockerSupport.get().getDockerAvailability().dockerComposePath();
             LOGGER.debug("Docker Compose path: {}", composePath);


### PR DESCRIPTION
Backports the following commits to 8.16:
 - [TEST] Use Docker Compose v2 for TestFixturePlugin (#120214)