### PR TITLE
Fix {lookup-join.MvJoinKeyFromRow ASYNC}

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -251,9 +251,6 @@ tests:
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldSourceOnlyRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/120080
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {lookup-join.MvJoinKeyFromRow ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/120242
 
 # Examples:
 #

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -450,13 +450,14 @@ required_capability: join_lookup_v11
 ROW language_code = [4, 5, 6, 7]
 | LOOKUP JOIN languages_lookup_non_unique_key ON language_code
 | KEEP language_code, language_name, country
+| SORT language_code, language_name, country
 ;
 
 language_code:integer | language_name:keyword | country:text
-[4, 5, 6, 7]          | Quenya                | null
-[4, 5, 6, 7]          | null                  | Atlantis
 [4, 5, 6, 7]          | Mv-Lang               | Mv-Land
 [4, 5, 6, 7]          | Mv-Lang2              | Mv-Land2
+[4, 5, 6, 7]          | Quenya                | null
+[4, 5, 6, 7]          | null                  | Atlantis
 ;
 
 mvJoinKeyFromRowExpanded


### PR DESCRIPTION
The test was failing due to the different order of rows in the result. 
This change fixes the test by explicitly sorting the rows.

Closes: #120242
