### PR TITLE
Test/standard token filter archive indices - Backport to version 8.x

### DIFF
--- a/x-pack/qa/repository-old-versions/README.md
+++ b/x-pack/qa/repository-old-versions/README.md
@@ -1,0 +1,11 @@
+
+### Project repository-old-versions
+
+Test project, for Lucene indices backward compatibility with versions before N-2
+(Archive-indices).
+
+The project aims to do the following
+1. Deploy a cluster in version 5 / 6
+2. Create an index, add a document, verify index integrity, create a snapshot
+3. Deploy a cluster in the Current version
+4. Restore an index and verify index integrity

--- a/x-pack/qa/repository-old-versions/src/test/resources/org/elasticsearch/oldrepos/standard_token_filter.json
+++ b/x-pack/qa/repository-old-versions/src/test/resources/org/elasticsearch/oldrepos/standard_token_filter.json
@@ -1,0 +1,8 @@
+"_default_": {
+  "properties": {
+    "content": {
+      "type": "text",
+      "analyzer": "custom_analyzer"
+    }
+  }
+}


### PR DESCRIPTION
This is a manual backport of #120107