### PR TITLE
[Entitlements] Introducing runtime version-specific checks in IT tests

### DIFF
--- a/libs/entitlement/qa/common/build.gradle
+++ b/libs/entitlement/qa/common/build.gradle
@@ -7,10 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import org.elasticsearch.gradle.internal.precommit.CheckForbiddenApisTask
+
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.mrjar'
 
 dependencies {
   implementation project(':server')
   implementation project(':libs:logging')
+}
+
+tasks.withType(CheckForbiddenApisTask).configureEach {
+  replaceSignatureFiles 'jdk-signatures'
 }

--- a/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/RestEntitlementsCheckAction.java
@@ -49,14 +49,13 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
-import java.net.spi.InetAddressResolver;
-import java.net.spi.InetAddressResolverProvider;
 import java.net.spi.URLStreamHandlerProvider;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -73,25 +72,25 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
     public static final Thread NO_OP_SHUTDOWN_HOOK = new Thread(() -> {}, "Shutdown hook for testing");
     private final String prefix;
 
-    record CheckAction(CheckedRunnable<Exception> action, boolean isAlwaysDeniedToPlugins) {
+    record CheckAction(CheckedRunnable<Exception> action, boolean isAlwaysDeniedToPlugins, Integer fromJavaVersion) {
         /**
          * These cannot be granted to plugins, so our test plugins cannot test the "allowed" case.
-         * Used both for always-denied entitlements as well as those granted only to the server itself.
+         * Used both for always-denied entitlements and those granted only to the server itself.
          */
         static CheckAction deniedToPlugins(CheckedRunnable<Exception> action) {
-            return new CheckAction(action, true);
+            return new CheckAction(action, true, null);
         }
 
         static CheckAction forPlugins(CheckedRunnable<Exception> action) {
-            return new CheckAction(action, false);
+            return new CheckAction(action, false, null);
         }
 
         static CheckAction alwaysDenied(CheckedRunnable<Exception> action) {
-            return new CheckAction(action, true);
+            return new CheckAction(action, true, null);
         }
     }
 
-    private static final Map<String, CheckAction> checkActions = Map.ofEntries(
+    private static final Map<String, CheckAction> checkActions = Stream.of(
         entry("runtime_exit", deniedToPlugins(RestEntitlementsCheckAction::runtimeExit)),
         entry("runtime_halt", deniedToPlugins(RestEntitlementsCheckAction::runtimeHalt)),
         entry("system_exit", deniedToPlugins(RestEntitlementsCheckAction::systemExit)),
@@ -140,7 +139,10 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
 
         entry("proxySelector_setDefault", alwaysDenied(RestEntitlementsCheckAction::setDefaultProxySelector)),
         entry("responseCache_setDefault", alwaysDenied(RestEntitlementsCheckAction::setDefaultResponseCache)),
-        entry("createInetAddressResolverProvider", alwaysDenied(RestEntitlementsCheckAction::createInetAddressResolverProvider)),
+        entry(
+            "createInetAddressResolverProvider",
+            new CheckAction(VersionSpecificNetworkChecks::createInetAddressResolverProvider, true, 18)
+        ),
         entry("createURLStreamHandlerProvider", alwaysDenied(RestEntitlementsCheckAction::createURLStreamHandlerProvider)),
         entry("createURLWithURLStreamHandler", alwaysDenied(RestEntitlementsCheckAction::createURLWithURLStreamHandler)),
         entry("createURLWithURLStreamHandler2", alwaysDenied(RestEntitlementsCheckAction::createURLWithURLStreamHandler2)),
@@ -156,7 +158,9 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
         entry("socket_connect", forPlugins(NetworkAccessCheckActions::socketConnect)),
         entry("server_socket_bind", forPlugins(NetworkAccessCheckActions::serverSocketBind)),
         entry("server_socket_accept", forPlugins(NetworkAccessCheckActions::serverSocketAccept))
-    );
+    )
+        .filter(entry -> entry.getValue().fromJavaVersion() == null || Runtime.version().feature() >= entry.getValue().fromJavaVersion())
+        .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
 
     private static void createURLStreamHandlerProvider() {
         var x = new URLStreamHandlerProvider() {
@@ -185,20 +189,6 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
                 return null;
             }
         });
-    }
-
-    private static void createInetAddressResolverProvider() {
-        var x = new InetAddressResolverProvider() {
-            @Override
-            public InetAddressResolver get(Configuration configuration) {
-                return null;
-            }
-
-            @Override
-            public String name() {
-                return "TEST";
-            }
-        };
     }
 
     private static void setDefaultResponseCache() {

--- a/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/VersionSpecificNetworkChecks.java
+++ b/libs/entitlement/qa/common/src/main/java/org/elasticsearch/entitlement/qa/common/VersionSpecificNetworkChecks.java
@@ -7,10 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-apply plugin: 'elasticsearch.build'
-apply plugin: 'elasticsearch.mrjar'
+package org.elasticsearch.entitlement.qa.common;
 
-dependencies {
-  implementation project(':server')
-  implementation project(':libs:logging')
+class VersionSpecificNetworkChecks {
+    static void createInetAddressResolverProvider() {}
 }

--- a/libs/entitlement/qa/common/src/main18/java/org/elasticsearch/entitlement/qa/common/VersionSpecificNetworkChecks.java
+++ b/libs/entitlement/qa/common/src/main18/java/org/elasticsearch/entitlement/qa/common/VersionSpecificNetworkChecks.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.qa.common;
+
+import java.net.spi.InetAddressResolver;
+import java.net.spi.InetAddressResolverProvider;
+
+class VersionSpecificNetworkChecks {
+    static void createInetAddressResolverProvider() {
+        var x = new InetAddressResolverProvider() {
+            @Override
+            public InetAddressResolver get(Configuration configuration) {
+                return null;
+            }
+
+            @Override
+            public String name() {
+                return "TEST";
+            }
+        };
+    }
+}


### PR DESCRIPTION
Forward port (to main) of the changes introduced in https://github.com/elastic/elasticsearch/pull/120027
Cherry-pick of [883f7b2](https://github.com/elastic/elasticsearch/commit/883f7b24161f7edf1844d5b5a796db3bc9c0ad04)

While not strictly needed ATM for main/9.x, keeping it in sync with 8.x makes auto-backport work.