### PR TITLE
[8.17] [Gradle] Make rolling upgrade tests configuration cache compatible (#119577)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -26,7 +26,7 @@ public interface TestClustersAware extends Task {
     Collection<ElasticsearchCluster> getClusters();
 
     @ServiceReference(REGISTRY_SERVICE_NAME)
-    Property<TestClustersRegistry> getRegistery();
+    Property<TestClustersRegistry> getRegistry();
 
     @ServiceReference(TEST_CLUSTER_TASKS_SERVICE)
     Property<TestClustersPlugin.TaskEventsService> getTasksService();
@@ -45,6 +45,14 @@ public interface TestClustersAware extends Task {
             dependsOn(cluster.getPluginAndModuleConfigurations());
         }
         getClusters().add(cluster);
+    }
+
+    default Provider<TestClusterInfo> getClusterInfo(String clusterName) {
+        return getProject().getProviders().of(TestClusterValueSource.class, source -> {
+            source.getParameters().getService().set(getRegistry());
+            source.getParameters().getClusterName().set(clusterName);
+            source.getParameters().getPath().set(getProject().getIsolated().getPath());
+        });
     }
 
     default void useCluster(Provider<ElasticsearchCluster> cluster) {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -249,7 +249,7 @@ public class TestClustersPlugin implements Plugin<Project> {
                     .forEach(awareTask -> {
                         awareTask.doFirst(task -> {
                             awareTask.beforeStart();
-                            awareTask.getClusters().forEach(awareTask.getRegistery().get()::maybeStartCluster);
+                            awareTask.getClusters().forEach(awareTask.getRegistry().get()::maybeStartCluster);
                         });
                     });
             });

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
@@ -109,6 +109,23 @@ public abstract class TestClustersRegistry implements BuildService<BuildServiceP
         cluster.restart();
     }
 
+    public void nextNodeToNextVersion(Provider<ElasticsearchCluster> cluster) {
+        nextNodeToNextVersion(cluster.get());
+    }
+
+    public void nextNodeToNextVersion(ElasticsearchCluster cluster) {
+        nextNodeToNextVersion(cluster.getPath(), cluster.getName());
+    }
+
+    public void nextNodeToNextVersion(String path, String clusterName) {
+        ElasticsearchCluster cluster = runningClusters.stream()
+            .filter(c -> c.getPath().equals(path))
+            .filter(c -> c.getName().equals(clusterName))
+            .findFirst()
+            .orElseThrow();
+        cluster.nextNodeToNextVersion();
+    }
+
     public void storeProcess(String id, Process esProcess) {
         nodeProcesses.put(id, esProcess);
     }

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -46,13 +46,11 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     useCluster localCluster
     useCluster remoteCluster
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(localCluster.name).map { it.allHttpSocketURI.join(",") })
+    nonInputProperties.systemProperty('tests.rest.remote_cluster', getClusterInfo(remoteCluster.name).map { it.allHttpSocketURI.join(",") })
 
-    doFirst {
-      nonInputProperties.systemProperty('tests.rest.cluster', localCluster.map(c -> c.allHttpSocketURI.join(",")))
-      nonInputProperties.systemProperty('tests.rest.remote_cluster', remoteCluster.map(c -> c.allHttpSocketURI.join(",")))
-    }
-
-    onlyIf("FIPS mode disabled") { buildParams.inFipsJvm == false }
+    def fipsDisabled = buildParams.inFipsJvm == false
+    onlyIf("FIPS mode disabled") { fipsDisabled }
   }
 
   tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
@@ -63,28 +61,28 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
       cluster.nodes.forEach { node ->
         node.getAllTransportPortURI()
       }
-      cluster.nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(cluster)
     }
   }
 
   tasks.register("${baseName}#oneThirdUpgraded", StandaloneRestIntegTestTask) {
     dependsOn "${baseName}#oldClusterTest"
     doFirst {
-      remoteCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(remoteCluster)
     }
   }
 
   tasks.register("${baseName}#twoThirdUpgraded", StandaloneRestIntegTestTask) {
     dependsOn "${baseName}#oneThirdUpgraded"
     doFirst {
-      remoteCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(remoteCluster)
     }
   }
 
   tasks.register("${baseName}#fullUpgraded", StandaloneRestIntegTestTask) {
     dependsOn "${baseName}#twoThirdUpgraded"
     doFirst {
-      remoteCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(remoteCluster)
     }
   }
 

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -75,7 +75,7 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     def baseCluster = testClusters.register(baseName) {
       versions = [bwcVersion.toString(), project.version]
       numberOfNodes = 4
-      setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      setting 'path.repo', "${layout.buildDirectory.asFile.get()}/cluster/shared/repo/${baseName}"
       setting 'xpack.security.enabled', 'false'
       setting "xpack.license.self_generated.type", "trial"
       /* There is a chance we have more master changes than "normal", so to avoid this test from failing,
@@ -89,50 +89,32 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
       useCluster baseCluster
       mustRunAfter("precommit")
-      Provider<TestClustersRegistry> serviceProvider = GradleUtils.getBuildService(
-        project.gradle.sharedServices,
-        TestClustersPlugin.REGISTRY_SERVICE_NAME
-      )
-
-      def baseInfo = project.getProviders().of(TestClusterValueSource.class) {
-        it.parameters.path.set(clusterPath)
-        it.parameters.clusterName.set(baseName)
-        it.parameters.service = serviceProvider
-      }.map { it.getAllHttpSocketURI() }
-
-      def baseInfoAfterOneNodeUpdate = project.getProviders().of(TestClusterValueSource.class) {
-        it.parameters.path.set(clusterPath)
-        it.parameters.clusterName.set(baseName)
-        it.parameters.service = serviceProvider
-      }.map { it.getAllHttpSocketURI() }
-
-      def baseInfoAfterTwoNodesUpdate = project.getProviders().of(TestClusterValueSource.class) {
-        it.parameters.path.set(clusterPath)
-        it.parameters.clusterName.set(baseName)
-        it.parameters.service = serviceProvider
-      }.map { it.getAllHttpSocketURI() }
-      def nonInputProps = nonInputProperties
-      def sharedRepoFolder = new File(buildDir, "cluster/shared/repo/${baseName}")
+      def baseInfo = getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") }
+      def baseInfoAfterOneNodeUpdate = getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") }
+      def baseInfoAfterTwoNodesUpdate = getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") }
+      def sharedRepoFolder = layout.buildDirectory.file("cluster/shared/repo/${baseName}").get().asFile
       doFirst {
         delete(sharedRepoFolder)
         // Getting the endpoints causes a wait for the cluster
         println "Test cluster endpoints are: ${-> baseInfo.get().join(",")}"
         println "Upgrading one node to create a mixed cluster"
-        baseCluster.get().nextNodeToNextVersion()
+        getRegistry().get().nextNodeToNextVersion(baseCluster)
+
         // Getting the endpoints causes a wait for the cluster
-        println "Upgrade complete, endpoints are: ${-> baseInfoAfterOneNodeUpdate.get().join(",")}"
+        println "Upgrade complete, endpoints are: ${-> baseInfoAfterOneNodeUpdate.get()}"
         println "Upgrading another node to create a mixed cluster"
-        baseCluster.get().nextNodeToNextVersion()
-        nonInputProps.systemProperty('tests.rest.cluster', baseInfoAfterTwoNodesUpdate.map(c -> c.join(",")))
-        nonInputProps.systemProperty('tests.clustername', baseName)
-        if (excludeList.isEmpty() == false) {
-          systemProperty 'tests.rest.blacklist', excludeList.join(',')
-        }
+        getRegistry().get().nextNodeToNextVersion(baseCluster)
       }
-      systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      if (excludeList.isEmpty() == false) {
+        systemProperty 'tests.rest.blacklist', excludeList.join(',')
+      }
+      nonInputProperties.systemProperty('tests.rest.cluster', baseInfoAfterTwoNodesUpdate)
+      nonInputProperties.systemProperty('tests.clustername', baseName)
+      systemProperty 'tests.path.repo', "${layout.buildDirectory.file("cluster/shared/repo/${baseName}").get().asFile}"
       systemProperty 'tests.bwc_nodes_version', bwcVersion.toString().replace('-SNAPSHOT', '')
       systemProperty 'tests.new_nodes_version', project.version.toString().replace('-SNAPSHOT', '')
-//      onlyIf("BWC tests disabled") { project.bwc_tests_enabled }
+      def bwcEnabled = project.bwc_tests_enabled
+      onlyIf("BWC tests disabled") { bwcEnabled }
     }
 
     tasks.register(bwcTaskName(bwcVersion)) {

--- a/qa/rolling-upgrade-legacy/build.gradle
+++ b/qa/rolling-upgrade-legacy/build.gradle
@@ -40,7 +40,7 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     numberOfNodes = 3
 
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
-    setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+    setting 'path.repo', "${layout.buildDirectory.get().asFile}/cluster/shared/repo/${baseName}"
     setting 'xpack.security.enabled', 'false'
     requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
   }
@@ -52,12 +52,12 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     useCluster baseCluster
     mustRunAfter("precommit")
     doFirst {
-      delete("${buildDir}/cluster/shared/repo/${baseName}")
+      delete("${layout.buildDirectory.get().asFile}/cluster/shared/repo/${baseName}")
     }
     def excludeList = []
     systemProperty 'tests.rest.suite', 'old_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     if (excludeList.isEmpty() == false) {
       systemProperty 'tests.rest.blacklist', excludeList.join(',')
@@ -68,12 +68,12 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     dependsOn "${baseName}#oldClusterTest"
     useCluster baseCluster
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
     systemProperty 'tests.first_round', 'true'
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     def excludeList = []
     if (excludeList.isEmpty() == false) {
@@ -85,12 +85,12 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     dependsOn "${baseName}#oneThirdUpgradedTest"
     useCluster baseCluster
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
     systemProperty 'tests.first_round', 'false'
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     def excludeList = []
     if (excludeList.isEmpty() == false) {
@@ -101,12 +101,12 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   tasks.register("${baseName}#upgradedClusterTest", StandaloneRestIntegTestTask) {
     dependsOn "${baseName}#twoThirdsUpgradedTest"
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
     useCluster testClusters.named(baseName)
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     def excludeList = []
     if (excludeList.isEmpty() == false) {

--- a/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
@@ -71,24 +71,7 @@ tasks.register("follow-cluster", RestIntegTestTask) {
   useCluster leaderCluster
   systemProperty 'tests.target_cluster', 'follow'
   nonInputProperties.systemProperty 'java.security.policy', "file://${policyFile}"
-  Provider<TestClustersRegistry> serviceProvider = GradleUtils.getBuildService(
-    project.gradle.sharedServices,
-    TestClustersPlugin.REGISTRY_SERVICE_NAME
-  )
-  def leaderInfo = project.getProviders().of(TestClusterValueSource.class) {
-    it.parameters.path.set(clusterPath)
-    it.parameters.clusterName.set("leader-cluster")
-    it.parameters.service = serviceProvider
-  }
-  def followInfo = project.getProviders().of(TestClusterValueSource.class) {
-    it.parameters.path.set(clusterPath)
-    it.parameters.clusterName.set("follow-cluster")
-    it.parameters.service = serviceProvider
-  }
-  def leaderUri = leaderInfo.map { it.getAllHttpSocketURI().get(0) }
-  def followerUri = followInfo.map { it.getAllHttpSocketURI().get(0) }
-
-  nonInputProperties.systemProperty 'tests.leader_host', leaderUri
+  nonInputProperties.systemProperty 'tests.leader_host', getClusterInfo('leader-cluster').map { it.getAllHttpSocketURI().get(0) }
   nonInputProperties.systemProperty 'log', followCluster.map(c -> c.getFirstNode().getServerLog())
 }
 

--- a/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
@@ -22,7 +22,7 @@ def leaderCluster = testClusters.register('leader-cluster') {
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'xpack.security.enabled', 'true'
   user username: 'admin', password: 'admin-password', role: 'superuser'
-  setting 'path.repo', "${buildDir}/cluster/shared/repo/leader-cluster"
+  setting 'path.repo', "${layout.buildDirectory.asFile.get()}/cluster/shared/repo/leader-cluster"
 }
 
 def middleCluster = testClusters.register('middle-cluster') {
@@ -48,25 +48,16 @@ def middleCluster = testClusters.register('middle-cluster') {
 tasks.register("leader-cluster", RestIntegTestTask) {
   mustRunAfter("precommit")
   systemProperty 'tests.target_cluster', 'leader'
-  systemProperty 'tests.leader_cluster_repository_path', "${buildDir}/cluster/shared/repo/leader-cluster"
+  systemProperty 'tests.leader_cluster_repository_path', "${layout.buildDirectory.asFile.get()}/cluster/shared/repo/leader-cluster"
 }
 
 tasks.register("middle-cluster", RestIntegTestTask) {
   dependsOn "leader-cluster"
   useCluster testClusters.named("leader-cluster")
   systemProperty 'tests.target_cluster', 'middle'
-  systemProperty 'tests.leader_cluster_repository_path', "${buildDir}/cluster/shared/repo/leader-cluster"
+  systemProperty 'tests.leader_cluster_repository_path', "${layout.buildDirectory.asFile.get()}/cluster/shared/repo/leader-cluster"
 
-  Provider<TestClustersRegistry> serviceProvider = GradleUtils.getBuildService(
-    project.gradle.sharedServices,
-    TestClustersPlugin.REGISTRY_SERVICE_NAME
-  )
-
-  def leaderUri = project.getProviders().of(TestClusterValueSource.class) {
-    it.parameters.path.set(clusterPath)
-    it.parameters.clusterName.set("leader-cluster")
-    it.parameters.service = serviceProvider
-  }.map { it.allHttpSocketURI.get(0) }
+  def leaderUri = getClusterInfo('leader-cluster').map { it.allHttpSocketURI.get(0) }
   nonInputProperties.systemProperty 'tests.leader_host', leaderUri
 }
 
@@ -75,24 +66,10 @@ tasks.register('follow-cluster', RestIntegTestTask) {
   useCluster leaderCluster
   useCluster middleCluster
   systemProperty 'tests.target_cluster', 'follow'
-  systemProperty 'tests.leader_cluster_repository_path', "${buildDir}/cluster/shared/repo/leader-cluster"
+  systemProperty 'tests.leader_cluster_repository_path', "${layout.buildDirectory.asFile.get()}/cluster/shared/repo/leader-cluster"
 
-  Provider<TestClustersRegistry> serviceProvider = GradleUtils.getBuildService(
-    project.gradle.sharedServices,
-    TestClustersPlugin.REGISTRY_SERVICE_NAME
-  )
-
-  def leaderUri = project.getProviders().of(TestClusterValueSource.class) {
-    it.parameters.path.set(clusterPath)
-    it.parameters.clusterName.set("leader-cluster")
-    it.parameters.service = serviceProvider
-  }.map { it.allHttpSocketURI.get(0) }
-
-  def middleUri = project.getProviders().of(TestClusterValueSource.class) {
-    it.parameters.path.set(clusterPath)
-    it.parameters.clusterName.set("middle-cluster")
-    it.parameters.service = serviceProvider
-  }.map { it.allHttpSocketURI.get(0) }
+  def leaderUri = getClusterInfo('leader-cluster').map { it.allHttpSocketURI.get(0) }
+  def middleUri = getClusterInfo('middle-cluster').map { it.allHttpSocketURI.get(0) }
   nonInputProperties.systemProperty 'tests.leader_host', leaderUri
   nonInputProperties.systemProperty 'tests.middle_host', middleUri
 }

--- a/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
@@ -53,17 +53,7 @@ tasks.register('follow-cluster', RestIntegTestTask) {
   useCluster leaderCluster
   systemProperty 'tests.target_cluster', 'follow'
 
-  Provider<TestClustersRegistry> serviceProvider = GradleUtils.getBuildService(
-    project.gradle.sharedServices,
-    TestClustersPlugin.REGISTRY_SERVICE_NAME
-  )
-  def followInfo = project.getProviders().of(TestClusterValueSource.class) {
-    it.parameters.path.set(clusterPath)
-    it.parameters.clusterName.set("follow-cluster")
-    it.parameters.service = serviceProvider
-  }
-  def followUri = followInfo.map { it.allHttpSocketURI.get(0) }
-
+  def followUri = getClusterInfo('follow-cluster').map { it.allHttpSocketURI.get(0) }
   nonInputProperties.systemProperty 'tests.leader_host', followUri
 }
 

--- a/x-pack/plugin/ccr/qa/restart/build.gradle
+++ b/x-pack/plugin/ccr/qa/restart/build.gradle
@@ -55,18 +55,8 @@ tasks.register('follow-cluster', RestIntegTestTask) {
   useCluster leaderCluster
   systemProperty 'tests.target_cluster', 'follow'
 
-  Provider<TestClustersRegistry> serviceProvider = GradleUtils.getBuildService(
-    project.gradle.sharedServices,
-    TestClustersPlugin.REGISTRY_SERVICE_NAME
-  )
-  def leaderUri = project.getProviders().of(TestClusterValueSource.class) {
-    it.parameters.path.set(clusterPath)
-    it.parameters.clusterName.set("leader-cluster")
-    it.parameters.service = serviceProvider
-  }.map { it.allHttpSocketURI.get(0) }
-
-  nonInputProperties.systemProperty 'tests.leader_host',
-          "${-> leaderUri.get() }"
+  def leaderUri = getClusterInfo("leader-cluster").map { it.allHttpSocketURI.get(0) }
+  nonInputProperties.systemProperty 'tests.leader_host', leaderUri
 }
 
 tasks.register("followClusterRestartTest", StandaloneRestIntegTestTask) {
@@ -76,27 +66,13 @@ tasks.register("followClusterRestartTest", StandaloneRestIntegTestTask) {
 
   systemProperty 'tests.rest.load_packaged', 'false'
   systemProperty 'tests.target_cluster', 'follow-restart'
-  Provider<TestClustersRegistry> serviceProvider = GradleUtils.getBuildService(
-    project.gradle.sharedServices,
-    TestClustersPlugin.REGISTRY_SERVICE_NAME
-  )
-  def leaderUri = project.getProviders().of(TestClusterValueSource.class) {
-    it.parameters.path.set(clusterPath)
-    it.parameters.clusterName.set("leader-cluster")
-    it.parameters.service = serviceProvider
-  }.map { it.allHttpSocketURI.get(0) }
-
-  def followUris = project.getProviders().of(TestClusterValueSource.class) {
-    it.parameters.path.set(clusterPath)
-    it.parameters.clusterName.set("follow-cluster")
-    it.parameters.service = serviceProvider
-  }.map { it.allHttpSocketURI.join(",") }
-
+  def leaderUri = getClusterInfo('leader-cluster').map { it.allHttpSocketURI.get(0) }
+  def followUris = getClusterInfo('follow-cluster').map { it.allHttpSocketURI.join(",") }
   nonInputProperties.systemProperty 'tests.leader_host', leaderUri
   nonInputProperties.systemProperty 'tests.rest.cluster', followUris
 
   doFirst {
-    serviceProvider.get().restart(clusterPath, "follow-cluster")
+    getRegistry().get().restart(clusterPath, "follow-cluster")
   }
 }
 

--- a/x-pack/plugin/ccr/qa/security/build.gradle
+++ b/x-pack/plugin/ccr/qa/security/build.gradle
@@ -58,16 +58,7 @@ def followerClusterTestTask = tasks.register('follow-cluster', RestIntegTestTask
   dependsOn 'leader-cluster'
   useCluster leadCluster
   systemProperty 'tests.target_cluster', 'follow'
-  Provider<TestClustersRegistry> serviceProvider = GradleUtils.getBuildService(
-    project.gradle.sharedServices,
-    TestClustersPlugin.REGISTRY_SERVICE_NAME
-  )
-  def leaderUri = project.getProviders().of(TestClusterValueSource.class) {
-    it.parameters.path.set(clusterPath)
-    it.parameters.clusterName.set("leader-cluster")
-    it.parameters.service = serviceProvider
-  }.map { it.allHttpSocketURI.get(0) }
-
+  def leaderUri = getClusterInfo('leader-cluster').map { it.allHttpSocketURI.get(0) }
   nonInputProperties.systemProperty 'tests.leader_host', leaderUri
 }
 

--- a/x-pack/plugin/eql/qa/ccs-rolling-upgrade/build.gradle
+++ b/x-pack/plugin/eql/qa/ccs-rolling-upgrade/build.gradle
@@ -44,39 +44,36 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     useCluster localCluster
     useCluster remoteCluster
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
-
-    doFirst {
-      nonInputProperties.systemProperty('tests.rest.cluster', localCluster.map(c -> c.allHttpSocketURI.join(",")))
-      nonInputProperties.systemProperty('tests.rest.remote_cluster', remoteCluster.map(c -> c.allHttpSocketURI.join(",")))
-    }
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo("${baseName}-local").map { it.allHttpSocketURI.join(",") })
+    nonInputProperties.systemProperty('tests.rest.remote_cluster', getClusterInfo("${baseName}-remote").map { it.allHttpSocketURI.join(",") })
   }
 
   tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
     dependsOn "processTestResources"
     mustRunAfter("precommit")
     doFirst {
-      localCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(localCluster)
     }
   }
 
   tasks.register("${baseName}#oneThirdUpgraded", StandaloneRestIntegTestTask) {
     dependsOn "${baseName}#oldClusterTest"
     doFirst {
-      remoteCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(remoteCluster)
     }
   }
 
   tasks.register("${baseName}#twoThirdUpgraded", StandaloneRestIntegTestTask) {
     dependsOn "${baseName}#oneThirdUpgraded"
     doFirst {
-      remoteCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(remoteCluster)
     }
   }
 
   tasks.register("${baseName}#fullUpgraded", StandaloneRestIntegTestTask) {
     dependsOn "${baseName}#twoThirdUpgraded"
     doFirst {
-      remoteCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(remoteCluster)
     }
   }
 

--- a/x-pack/plugin/eql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/eql/qa/mixed-node/build.gradle
@@ -33,19 +33,22 @@ buildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.10.0") &&
         mustRunAfter("precommit")
         classpath = sourceSets.javaRestTest.runtimeClasspath
         testClassesDirs = sourceSets.javaRestTest.output.classesDirs
+        def socketsProvider1 = getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") }
+        def socketsProvider2 = getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") }
         doFirst {
             // Getting the endpoints causes a wait for the cluster
-            println "Endpoints are: ${-> testClusters."${baseName}".allHttpSocketURI.join(",")}"
+            println "Endpoints are: ${-> socketsProvider1.get()}"
             println "Upgrading one node to create a mixed cluster"
-            cluster.get().nextNodeToNextVersion()
-
-            println "Upgrade complete, endpoints are: ${-> testClusters.named(baseName).get().allHttpSocketURI.join(",")}"
-            nonInputProperties.systemProperty('tests.rest.cluster', cluster.map(c -> c.allHttpSocketURI.join(",")))
-            nonInputProperties.systemProperty('tests.clustername', baseName)
+            getRegistry().get().nextNodeToNextVersion(cluster)
+            println "Upgrade complete, endpoints are: ${-> socketsProvider2.get()} }"
         }
+        nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
+        nonInputProperties.systemProperty('tests.clustername', baseName)
         systemProperty 'tests.bwc_nodes_version', bwcVersion.toString().replace('-SNAPSHOT', '')
         systemProperty 'tests.new_nodes_version', project.version.toString().replace('-SNAPSHOT', '')
-        onlyIf("BWC tests disabled") { project.bwc_tests_enabled }
+
+        def bwcEnabled = project.bwc_tests_enabled
+        onlyIf("BWC tests disabled") { bwcEnabled }
     }
 
     tasks.register(bwcTaskName(bwcVersion)) {

--- a/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
+++ b/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
@@ -28,7 +28,8 @@ tasks.named("forbiddenPatterns").configure {
   exclude '**/system_key'
 }
 
-String outputDir = "${buildDir}/generated-resources/${project.name}"
+def buildDirectory = layout.buildDirectory
+String outputDir = "${buildDirectory.file("generated-resources/${project.name}").get().asFile}"
 
 tasks.register("copyTestNodeKeyMaterial", Copy) {
   from project(':x-pack:plugin:core').files('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem',
@@ -40,15 +41,15 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   String oldVersion = bwcVersion.toString()
 
   // SearchableSnapshotsRollingUpgradeIT uses a specific repository to not interfere with other tests
-  String searchableSnapshotRepository = "${buildDir}/cluster/shared/searchable-snapshots-repo/${baseName}"
-
+  String searchableSnapshotRepository = "${buildDirectory.file("cluster/shared/searchable-snapshots-repo/${baseName}").get().asFile}"
+  File repoFolder = buildDirectory.file("cluster/shared/repo/${baseName}").get().asFile
   def baseCluster = testClusters.register(baseName) {
     testDistribution = "DEFAULT"
     versions = [oldVersion, project.version]
     numberOfNodes = 3
 
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
-    setting 'path.repo', "['${buildDir}/cluster/shared/repo/${baseName}', '${searchableSnapshotRepository}']"
+    setting 'path.repo', "['${repoFolder}', '${searchableSnapshotRepository}']"
     setting 'xpack.license.self_generated.type', 'trial'
     setting 'xpack.security.enabled', 'true'
     setting 'xpack.security.transport.ssl.enabled', 'true'
@@ -107,15 +108,15 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     useCluster baseCluster
     mustRunAfter("precommit")
     dependsOn "copyTestNodeKeyMaterial"
+    def repoDir = buildDirectory.file("cluster/shared/repo/${baseName}").get().asFile
     doFirst {
-      delete("${buildDir}/cluster/shared/repo/${baseName}")
+      delete(repoDir)
       delete("${searchableSnapshotRepository}")
     }
-
     systemProperty 'tests.rest.suite', 'old_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
     systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c->c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
   }
 
@@ -123,9 +124,9 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     dependsOn "${baseName}#oldClusterTest"
     useCluster baseCluster
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c->c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'true'
@@ -137,9 +138,9 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     dependsOn "${baseName}#oneThirdUpgradedTest"
     useCluster baseCluster
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
-    nonInputProperties.systemProperty('tests.rest.cluster', "${-> baseCluster.get().allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'false'
@@ -151,9 +152,9 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     dependsOn "${baseName}#twoThirdsUpgradedTest"
     useCluster baseCluster
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
-    nonInputProperties.systemProperty('tests.rest.cluster', "${-> baseCluster.get().allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion

--- a/x-pack/plugin/sql/qa/jdbc/security/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/security/build.gradle
@@ -53,19 +53,8 @@ subprojects {
     dependsOn copyTestClasses
     classpath += configurations.testArtifacts
     testClassesDirs = project.files(testArtifactsDir)
-
-    Provider<TestClustersRegistry> serviceProvider = GradleUtils.getBuildService(
-      project.gradle.sharedServices,
-      TestClustersPlugin.REGISTRY_SERVICE_NAME
-    )
-    project.getProviders().of(TestClusterValueSource.class) {
-      it.parameters.path.set(clusterPath)
-      it.parameters.clusterName.set("javaRestTest")
-      it.parameters.service = serviceProvider
-    }
-
-    nonInputProperties.systemProperty 'tests.audit.logfile',
-      "${-> testClusters.javaRestTest.singleNode().getAuditLog()}"
+    def clusterInfo = getClusterInfo(taskName);
+    nonInputProperties.systemProperty 'tests.audit.logfile', clusterInfo.map { it.auditLogs.get(0) }
     nonInputProperties.systemProperty 'tests.audit.yesterday.logfile',
       "${-> testClusters.javaRestTest.singleNode().getAuditLog().getParentFile()}/javaRestTest_audit-${new Date().format('yyyy-MM-dd')}.json"
   }

--- a/x-pack/plugin/sql/qa/jdbc/security/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/security/build.gradle
@@ -50,6 +50,7 @@ subprojects {
 
 
   tasks.withType(RestIntegTestTask).configureEach {
+    def taskName = name
     dependsOn copyTestClasses
     classpath += configurations.testArtifacts
     testClassesDirs = project.files(testArtifactsDir)

--- a/x-pack/plugin/sql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/sql/qa/mixed-node/build.gradle
@@ -39,22 +39,23 @@ buildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.10.3") &&
       mustRunAfter("precommit")
       testClassesDirs = sourceSets.javaRestTest.output.classesDirs
       classpath = sourceSets.javaRestTest.runtimeClasspath
+      def beforeUpdateInfo = getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") }
+      def afterUpdateInfo = getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") }
       doFirst {
           def cluster = baseCluster.get()
           // Getting the endpoints causes a wait for the cluster
-          println "Endpoints are: ${-> cluster.allHttpSocketURI.join(",")}"
+          println "Endpoints are: ${-> beforeUpdateInfo.get()}"
           println "Upgrading one node to create a mixed cluster"
-          cluster.nextNodeToNextVersion()
-
-          println "Upgrade complete, endpoints are: ${-> cluster.allHttpSocketURI.join(",")}"
-          nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c->c.allHttpSocketURI.join(",")))
-          nonInputProperties.systemProperty('tests.clustername', baseName)
-
+          getRegistry().get().nextNodeToNextVersion(cluster)
+          println "Upgrade complete, endpoints are: ${-> afterUpdateInfo.get() }"
       }
+      nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
+      nonInputProperties.systemProperty('tests.clustername', baseName)
       systemProperty 'tests.bwc_nodes_version', bwcVersion.toString().replace('-SNAPSHOT', '')
       systemProperty 'tests.new_nodes_version', project.version.toString().replace('-SNAPSHOT', '')
 
-      onlyIf("BWC tests disabled") { project.bwc_tests_enabled }
+      def bwcEnabled = project.bwc_tests_enabled
+      onlyIf("BWC tests disabled") { bwcEnabled }
   }
 
   tasks.register(bwcTaskName(bwcVersion)) {

--- a/x-pack/qa/mixed-tier-cluster/build.gradle
+++ b/x-pack/qa/mixed-tier-cluster/build.gradle
@@ -34,14 +34,14 @@ buildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.9.0") &&
   tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
     useCluster baseCluster
     mustRunAfter("precommit")
+    def beforeEndpoints = getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") }
     doFirst {
       // Getting the endpoints causes a wait for the cluster
-      println "Endpoints are: ${-> baseCluster.get().allHttpSocketURI.join(",")}"
-      baseCluster.get().nextNodeToNextVersion()
-
-      nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c->c.allHttpSocketURI.join(",")))
-      nonInputProperties.systemProperty('tests.clustername', baseName)
+      println "Endpoints are: ${-> beforeEndpoints.get()}"
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
+    nonInputProperties.systemProperty('tests.clustername', baseName)
     onlyIf("BWC tests disabled") { project.bwc_tests_enabled }
   }
 

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -27,7 +27,7 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     mustRunAfter("precommit")
     systemProperty 'tests.rest.suite', 'old_cluster'
     systemProperty 'tests.upgrade_from_version', version.toString().replace('-SNAPSHOT', '')
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c->c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
   }
 
@@ -36,9 +36,9 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     dependsOn "${baseName}#oldClusterTest"
     useCluster baseCluster
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c->c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'true'
@@ -49,9 +49,9 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     dependsOn "${baseName}#oneThirdUpgradedTest"
     useCluster baseCluster
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c->c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'false'
@@ -62,9 +62,9 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     dependsOn "${baseName}#twoThirdsUpgradedTest"
     useCluster baseCluster
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c->c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -32,48 +32,44 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     useCluster baseLeaderCluster
     useCluster baseFollowerCluster
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
-
+    def baseClusterName = getName().substring(0, getName().lastIndexOf("#")).replace('#', '-')
+    def baseCluster = testClusters.named(baseClusterName)
     doFirst {
-      def baseCluster = testClusters.named("${baseName}-${kindExt}").get()
       if (name.endsWith("#clusterTest") == false) {
         println "Upgrade node $it"
-        baseCluster.nextNodeToNextVersion()
+        getRegistry().get().nextNodeToNextVersion(baseCluster)
       }
-      nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.allHttpSocketURI.join(","))
-      nonInputProperties.systemProperty('tests.clustername', baseName)
-      nonInputProperties.systemProperty('tests.leader_host', baseLeaderCluster.map(c->c.allHttpSocketURI.last()))
-      nonInputProperties.systemProperty('tests.leader_remote_cluster_seed', baseLeaderCluster.map(c -> c.allTransportPortURI.last()))
-      nonInputProperties.systemProperty('tests.follower_host', baseFollowerCluster.map(c -> c.allHttpSocketURI.last()))
-      nonInputProperties.systemProperty('tests.follower_remote_cluster_seed', baseFollowerCluster.map(c -> c.allTransportPortURI.last()))
     }
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseCluster.name).map { it.allHttpSocketURI.join(",") })
+    nonInputProperties.systemProperty('tests.clustername', baseName)
+    nonInputProperties.systemProperty('tests.leader_host', getClusterInfo(baseLeaderCluster.name).map { c->c.allHttpSocketURI.last() })
+    nonInputProperties.systemProperty('tests.leader_remote_cluster_seed', getClusterInfo(baseLeaderCluster.name).map { c -> c.allTransportPortURI.last() })
+    nonInputProperties.systemProperty('tests.follower_host', getClusterInfo(baseFollowerCluster.name).map { c->c.allHttpSocketURI.last() })
+    nonInputProperties.systemProperty('tests.follower_remote_cluster_seed', getClusterInfo(baseFollowerCluster.name).map { c -> c.allTransportPortURI.last() })
   }
 
   ["follower", "leader"].each { kind ->
     tasks.register("${baseName}#${kind}#clusterTest", StandaloneRestIntegTestTask) {
       systemProperty 'tests.rest.upgrade_state', 'none'
       systemProperty 'tests.rest.cluster_name', kind
-      ext.kindExt = kind
     }
 
     tasks.register("${baseName}#${kind}#oneThirdUpgradedTest", StandaloneRestIntegTestTask) {
       systemProperty 'tests.rest.upgrade_state', 'one_third'
       systemProperty 'tests.rest.cluster_name', kind
       dependsOn "${baseName}#leader#clusterTest", "${baseName}#follower#clusterTest"
-      ext.kindExt = kind
     }
 
     tasks.register("${baseName}#${kind}#twoThirdsUpgradedTest", StandaloneRestIntegTestTask) {
       systemProperty 'tests.rest.upgrade_state', 'two_third'
       systemProperty 'tests.rest.cluster_name', kind
       dependsOn "${baseName}#${kind}#oneThirdUpgradedTest"
-      ext.kindExt = kind
     }
 
     tasks.register("${baseName}#${kind}#upgradedClusterTest", StandaloneRestIntegTestTask) {
       systemProperty 'tests.rest.upgrade_state', 'all'
       systemProperty 'tests.rest.cluster_name', kind
       dependsOn "${baseName}#${kind}#twoThirdsUpgradedTest"
-      ext.kindExt = kind
     }
   }
 

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -23,7 +23,7 @@ tasks.named("forbiddenPatterns").configure {
   exclude '**/system_key'
 }
 
-String outputDir = "${buildDir}/generated-resources/${project.name}"
+String outputDir = "${layout.buildDirectory.get().asFile}/generated-resources/${project.name}"
 
 tasks.register("copyTestNodeKeyMaterial", Copy) {
   from project(':x-pack:plugin:core').files('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem',
@@ -35,7 +35,7 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   String oldVersion = bwcVersion.toString()
 
   // SearchableSnapshotsRollingUpgradeIT uses a specific repository to not interfere with other tests
-  String searchableSnapshotRepository = "${buildDir}/cluster/shared/searchable-snapshots-repo/${baseName}"
+  String searchableSnapshotRepository = "${layout.buildDirectory.get().asFile}/cluster/shared/searchable-snapshots-repo/${baseName}"
 
   def baseCluster = testClusters.register(baseName) {
     testDistribution = "DEFAULT"
@@ -50,7 +50,7 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     }
 
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
-    setting 'path.repo', "['${buildDir}/cluster/shared/repo/${baseName}', '${searchableSnapshotRepository}']"
+    setting 'path.repo', "['${layout.buildDirectory.get().asFile}/cluster/shared/repo/${baseName}', '${searchableSnapshotRepository}']"
     setting 'xpack.license.self_generated.type', 'trial'
     setting 'xpack.security.enabled', 'true'
     setting 'xpack.security.transport.ssl.enabled', 'true'
@@ -119,14 +119,14 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     mustRunAfter("precommit")
     dependsOn "copyTestNodeKeyMaterial"
     doFirst {
-      delete("${buildDir}/cluster/shared/repo/${baseName}")
+      delete("${layout.buildDirectory.get().asFile}/cluster/shared/repo/${baseName}")
       delete("${searchableSnapshotRepository}")
     }
 
     systemProperty 'tests.rest.suite', 'old_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
     systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c->c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
 
     // Disable ML tests for incompatible systems
@@ -140,9 +140,9 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     dependsOn "${baseName}#oldClusterTest"
     useCluster baseCluster
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
-    nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c->c.allHttpSocketURI.join(",")))
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'true'
@@ -177,9 +177,9 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     dependsOn "${baseName}#oneThirdUpgradedTest"
     useCluster baseCluster
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
-    nonInputProperties.systemProperty('tests.rest.cluster', "${-> baseCluster.get().allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'false'
@@ -197,9 +197,9 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     dependsOn "${baseName}#twoThirdsUpgradedTest"
     useCluster baseCluster
     doFirst {
-      baseCluster.get().nextNodeToNextVersion()
+      getRegistry().get().nextNodeToNextVersion(baseCluster)
     }
-    nonInputProperties.systemProperty('tests.rest.cluster', "${-> baseCluster.get().allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
     nonInputProperties.systemProperty('tests.clustername', baseName)
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Gradle] Make rolling upgrade tests configuration cache compatible (#119577)](https://github.com/elastic/elasticsearch/pull/119577)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)