### PR TITLE
[8.x] Shorten method name in PostOptimizationVerificationAware (#120307)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/PostOptimizationVerificationAware.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/PostOptimizationVerificationAware.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.capabilities;
 
 import org.elasticsearch.xpack.esql.common.Failures;
-import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
 
 /**
  * Interface implemented by expressions that require validation post logical optimization,
@@ -21,13 +20,13 @@ public interface PostOptimizationVerificationAware {
      * {@link Failures} class.
      *
      * <p>
-     *     Example: the {@link Bucket} function, which produces buckets over a numerical or date field, based on a number of literal
+     *     Example: the {@code Bucket} function, which produces buckets over a numerical or date field, based on a number of literal
      *     arguments needs to check if its arguments are all indeed literals. This is how this verification is performed:
      *     <pre>
      *     {@code
      *
      *      @Override
-     *      public void postLogicalOptimizationVerification(Failures failures) {
+     *      public void postOptimizationVerification(Failures failures) {
      *          String operation = sourceText();
      *
      *          failures.add(isFoldable(buckets, operation, SECOND))
@@ -38,5 +37,5 @@ public interface PostOptimizationVerificationAware {
      *     </pre>
      *
      */
-    void postLogicalOptimizationVerification(Failures failures);
+    void postOptimizationVerification(Failures failures);
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
@@ -195,7 +195,7 @@ public class Match extends FullTextFunction implements PostOptimizationVerificat
     }
 
     @Override
-    public void postLogicalOptimizationVerification(Failures failures) {
+    public void postOptimizationVerification(Failures failures) {
         Expression fieldExpression = field();
         // Field may be converted to other data type (field_name :: data_type), so we need to check the original field
         if (fieldExpression instanceof AbstractConvertFunction convertFunction) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Term.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Term.java
@@ -100,7 +100,7 @@ public class Term extends FullTextFunction implements PostOptimizationVerificati
     }
 
     @Override
-    public void postLogicalOptimizationVerification(Failures failures) {
+    public void postOptimizationVerification(Failures failures) {
         if (field instanceof FieldAttribute == false) {
             failures.add(
                 Failure.fail(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
@@ -409,7 +409,7 @@ public class Bucket extends GroupingFunction implements PostOptimizationVerifica
     }
 
     @Override
-    public void postLogicalOptimizationVerification(Failures failures) {
+    public void postOptimizationVerification(Failures failures) {
         String operation = sourceText();
 
         failures.add(isFoldable(buckets, operation, SECOND))

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FoldablesConvertFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FoldablesConvertFunction.java
@@ -71,7 +71,7 @@ public abstract class FoldablesConvertFunction extends AbstractConvertFunction i
     }
 
     @Override
-    public final void postLogicalOptimizationVerification(Failures failures) {
+    public final void postOptimizationVerification(Failures failures) {
         failures.add(isFoldable(field(), sourceText(), null));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSort.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSort.java
@@ -231,7 +231,7 @@ public class MvSort extends EsqlScalarFunction implements OptionalArgument, Post
     }
 
     @Override
-    public void postLogicalOptimizationVerification(Failures failures) {
+    public void postOptimizationVerification(Failures failures) {
         if (order == null) {
             return;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalVerifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalVerifier.java
@@ -29,7 +29,7 @@ public final class LogicalVerifier {
             if (failures.hasFailures() == false) {
                 p.forEachExpression(ex -> {
                     if (ex instanceof PostOptimizationVerificationAware va) {
-                        va.postLogicalOptimizationVerification(failures);
+                        va.postOptimizationVerification(failures);
                     }
                 });
             }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Shorten method name in PostOptimizationVerificationAware (#120307)