### PR TITLE
[8.x] Filter deprecated settings in CreateIndexFromSourceAction (#120163)

### DIFF
--- a/docs/changelog/120163.yaml
+++ b/docs/changelog/120163.yaml
@@ -1,0 +1,5 @@
+pr: 120163
+summary: Filter deprecated settings when making dest index
+area: Data streams
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1658,11 +1658,23 @@ public class MetadataCreateIndexService {
             throw new IllegalStateException("unknown resize type is " + type);
         }
 
-        final Settings.Builder builder;
+        final Settings.Builder builder = Settings.builder();
         if (copySettings) {
-            builder = copySettingsFromSource(true, sourceMetadata.getSettings(), indexScopedSettings, indexSettingsBuilder);
+            // copy all settings and non-copyable settings and settings that have already been set (e.g., from the request)
+            for (final String key : sourceMetadata.getSettings().keySet()) {
+                final Setting<?> setting = indexScopedSettings.get(key);
+                if (setting == null) {
+                    assert indexScopedSettings.isPrivateSetting(key) : key;
+                } else if (setting.getProperties().contains(Setting.Property.NotCopyableOnResize)) {
+                    continue;
+                }
+                // do not override settings that have already been set (for example, from the request)
+                if (indexSettingsBuilder.keys().contains(key)) {
+                    continue;
+                }
+                builder.copy(key, sourceMetadata.getSettings());
+            }
         } else {
-            builder = Settings.builder();
             final Predicate<String> sourceSettingsPredicate = (s) -> (s.startsWith("index.similarity.")
                 || s.startsWith("index.analysis.")
                 || s.startsWith("index.sort.")
@@ -1678,36 +1690,6 @@ public class MetadataCreateIndexService {
         if (sourceMetadata.getSettings().hasValue(IndexMetadata.SETTING_VERSION_COMPATIBILITY)) {
             indexSettingsBuilder.put(IndexMetadata.SETTING_VERSION_COMPATIBILITY, sourceMetadata.getCompatibilityVersion());
         }
-    }
-
-    public static Settings.Builder copySettingsFromSource(
-        boolean copyPrivateSettings,
-        Settings sourceSettings,
-        IndexScopedSettings indexScopedSettings,
-        Settings.Builder indexSettingsBuilder
-    ) {
-        final Settings.Builder builder = Settings.builder();
-        for (final String key : sourceSettings.keySet()) {
-            final Setting<?> setting = indexScopedSettings.get(key);
-            if (setting == null) {
-                assert indexScopedSettings.isPrivateSetting(key) : key;
-                if (copyPrivateSettings == false) {
-                    continue;
-                }
-            } else if (setting.getProperties().contains(Setting.Property.NotCopyableOnResize)) {
-                continue;
-            } else if (setting.isPrivateIndex()) {
-                if (copyPrivateSettings == false) {
-                    continue;
-                }
-            }
-            // do not override settings that have already been set (for example, from the request)
-            if (indexSettingsBuilder.keys().contains(key)) {
-                continue;
-            }
-            builder.copy(key, sourceSettings);
-        }
-        return builder;
     }
 
     /**

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
@@ -41,6 +41,41 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
         return List.of(MigratePlugin.class, ReindexPlugin.class, MockTransportService.TestPlugin.class, DataStreamsPlugin.class);
     }
 
+    public void testOldSettingsManuallyFiltered() throws Exception {
+        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
+
+        var numShards = randomIntBetween(1, 10);
+        var staticSettings = Settings.builder()
+            // setting to filter
+            .put("index.soft_deletes.enabled", true)
+            // good setting to keep
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+            .build();
+
+        // start with a static setting
+        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        indicesAdmin().create(new CreateIndexRequest(sourceIndex, staticSettings)).get();
+
+        // create from source
+        var destIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        assertAcked(
+            client().execute(CreateIndexFromSourceAction.INSTANCE, new CreateIndexFromSourceAction.Request(sourceIndex, destIndex))
+        );
+
+        // assert both static and dynamic settings set on dest index
+        var settingsResponse = indicesAdmin().getSettings(new GetSettingsRequest().indices(sourceIndex, destIndex)).actionGet();
+        var destSettings = settingsResponse.getIndexToSettings().get(destIndex);
+        var sourceSettings = settingsResponse.getIndexToSettings().get(sourceIndex);
+
+        // sanity check that source settings were added
+        assertEquals(true, sourceSettings.getAsBoolean("index.soft_deletes.enabled", false));
+        assertEquals(numShards, Integer.parseInt(destSettings.get(IndexMetadata.SETTING_NUMBER_OF_SHARDS)));
+
+        // check that old setting was not added to index
+        assertNull(destSettings.get("index.soft_deletes.enabled"));
+        assertEquals(numShards, Integer.parseInt(destSettings.get(IndexMetadata.SETTING_NUMBER_OF_SHARDS)));
+    }
+
     public void testDestIndexCreated() throws Exception {
         assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Filter deprecated settings in CreateIndexFromSourceAction (#120163)