### PR TITLE
(Doc+) System Index definition

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -254,6 +254,16 @@ as they contain data essential to the operation of the system.
 IMPORTANT: Direct access to system indices is deprecated and
 will no longer be allowed in a future major version.
 
+To view system indices within cluster:
+
+[source,console]
+--------------------------------------------------
+GET _cluster/state/metadata?filter_path=metadata.indices.*.system
+--------------------------------------------------
+
+WARNING: When overwriting current cluster state, system indices should be restored
+as part of their {ref}/snapshot-restore.html#feature-state[feature state].
+
 [discrete]
 [[api-conventions-parameters]]
 === Parameters


### PR DESCRIPTION
👋 howdy team! While waiting for https://github.com/elastic/elasticsearch/issues/50251#issuecomment-1107637953, may we at least include the per-current-version method of telling which indices are system indices? Also cross-warns from [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-restore.html#feature-state) that snapshot restoring system indices needs to happen per feature state or it won't work.