### PR TITLE
[8.x] [Test] Fix testcontainers wait for Minio (#120175)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -373,8 +373,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
   method: testSettingsApplied
   issue: https://github.com/elastic/elasticsearch/issues/116694
-- class: org.elasticsearch.repositories.blobstore.testkit.analyze.MinioRepositoryAnalysisRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/118548
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=migrate/20_reindex_status/Test Reindex With Existing Data Stream}
   issue: https://github.com/elastic/elasticsearch/issues/118576
@@ -430,12 +428,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
   method: testFeatureImportanceValues
   issue: https://github.com/elastic/elasticsearch/issues/116564
-- class: org.elasticsearch.xpack.searchablesnapshots.minio.MinioSearchableSnapshotsIT
-  issue: https://github.com/elastic/elasticsearch/issues/120101
-- class: org.elasticsearch.repositories.s3.RepositoryS3MinioBasicCredentialsRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/120117
-- class: org.elasticsearch.repositories.s3.S3RepositoryThirdPartyTests
-  issue: https://github.com/elastic/elasticsearch/issues/120115
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {date_nanos.Bucket Date nanos by 10 minutes}
   issue: https://github.com/elastic/elasticsearch/issues/120162

--- a/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
+++ b/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.test.fixtures.minio;
 
 import org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTestContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 public final class MinioTestContainer extends DockerEnvironmentAwareTestContainer {
@@ -31,6 +32,10 @@ public final class MinioTestContainer extends DockerEnvironmentAwareTestContaine
         );
         if (enabled) {
             addExposedPort(servicePort);
+            // The following waits for a specific log message as the readiness signal. When the minio docker image
+            // gets upgraded in future, we must ensure the log message still exists or update it here accordingly.
+            // Otherwise the tests using the minio fixture will fail with timeout on waiting the container to be ready.
+            setWaitStrategy(Wait.forLogMessage("API: .*:9000.*", 1));
         }
         this.enabled = enabled;
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Test] Fix testcontainers wait for Minio (#120175)](https://github.com/elastic/elasticsearch/pull/120175)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)