### PR TITLE
unmute AsyncSearchActionIT.testRestartAfterCompletion

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -200,7 +200,6 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/81941")
     public void testRestartAfterCompletion() throws Exception {
         final String initialId;
         try (SearchResponseIterator it = assertBlockingIterator(indexName, numShards, new SearchSourceBuilder(), 0, 2)) {


### PR DESCRIPTION
Closes #81941 

Wasn't able to reproduce the failure in either of the muted branches (8.15 up to main), going to unmute the failing test to see if it's still failing, and if so to have a fresher failure to analyse.