### PR TITLE
Unmute MixedClusterClientYamlTestSuiteIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -406,8 +406,6 @@ tests:
 - class: org.elasticsearch.upgrades.SearchStatesIT
   method: testCanMatch
   issue: https://github.com/elastic/elasticsearch/issues/118718
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/119806
 - class: org.elasticsearch.search.profile.dfs.DfsProfilerIT
   method: testProfileDfs
   issue: https://github.com/elastic/elasticsearch/issues/119711


### PR DESCRIPTION
The whole suite was muted in #119806 automatically, we should be more specific on
what test really need muting. Unmuting for now to get a better sense of whats failing still.
My suspicion is that part of the problem might have been fixed with https://github.com/elastic/elasticsearch/commit/b10643e80c315ff2379c8e3cb534f40a81110357 on 8.x