### PR TITLE
unmute RetrySearchIntegTests.testRetryPointInTime

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -378,6 +378,7 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/118576
 - class: org.elasticsearch.discovery.ec2.DiscoveryEc2AvailabilityZoneAttributeNoImdsIT
   method: testAvailabilityZoneAttribute
+  issue: https://github.com/elastic/elasticsearch/issues/118564
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/20_metrics_ingest/Test metrics-apm.app-* setting event.ingested via ingest pipeline}
   issue: https://github.com/elastic/elasticsearch/issues/118875

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -378,10 +378,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/118576
 - class: org.elasticsearch.discovery.ec2.DiscoveryEc2AvailabilityZoneAttributeNoImdsIT
   method: testAvailabilityZoneAttribute
-  issue: https://github.com/elastic/elasticsearch/issues/118564
-- class: org.elasticsearch.xpack.searchablesnapshots.RetrySearchIntegTests
-  method: testRetryPointInTime
-  issue: https://github.com/elastic/elasticsearch/issues/118514
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/20_metrics_ingest/Test metrics-apm.app-* setting event.ingested via ingest pipeline}
   issue: https://github.com/elastic/elasticsearch/issues/118875


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/118514

I couldn't reproduce the failure in either of the muted branches (8.17/8.18). The main branch is unmuted. I will unmute the failing test to see if it's still failing and, if so, to have a fresher failure to analyze.