### PR TITLE
Rely on default shard count

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
@@ -25,7 +25,6 @@ setup:
           settings:
             index:
               mode: lookup
-            number_of_shards: 1
           mappings:
             properties:
               key:


### PR DESCRIPTION
Previously it is possible the the error happened due to the conflict with `LogsdbIndexModeSettingsProvider`.
It has changed a lot lately. I would like to update test to rely on default shard count again to see if the issue is still present.

Related to: https://github.com/elastic/elasticsearch/issues/119059#issuecomment-2598207961