### PR TITLE
Script for migrating .watches and .triggered_watches indices

### DIFF
--- a/docs/changelog/120371.yaml
+++ b/docs/changelog/120371.yaml
@@ -1,5 +1,5 @@
 pr: 120371
 summary: Script for migrating `.watches` and `.triggered_watches` indices
-area: "Watcher, Infra/Core"
+area: "Watcher"
 type: upgrade
 issues: []

--- a/docs/changelog/120371.yaml
+++ b/docs/changelog/120371.yaml
@@ -1,0 +1,5 @@
+pr: 120371
+summary: Script for migrating `.watches` and `.triggered_watches` indices
+area: "Watcher, Infra/Core"
+type: upgrade
+issues: []

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -287,10 +287,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
     private static final String LEGACY_VERSION_FIELD_VALUE = "8.12.0";
 
     private static final String REINDEX_SCRIPT_FROM_V7 = """
-        if (ctx._source.containsKey('input') &&
-            ctx._source.input.containsKey('search') &&
-            ctx._source.input.search.containsKey('request') &&
-            ctx._source.input.search.request.containsKey('types')) {
+        if (ctx._source.input?.search?.request?.types != null) {
           ctx._source.input.search.request.remove('types');
         }
         """;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -285,6 +285,16 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
      * to these old nodes that the mappings are newer than they are.
      */
     private static final String LEGACY_VERSION_FIELD_VALUE = "8.12.0";
+
+    private static final String REINDEX_SCRIPT_FROM_V7 = """
+        if (ctx._source.containsKey('input') &&
+            ctx._source.input.containsKey('search') &&
+            ctx._source.input.search.containsKey('request') &&
+            ctx._source.input.search.request.containsKey('types')) {
+          ctx._source.input.search.request.remove('types');
+        }
+        """;
+
     private WatcherIndexingListener listener;
     private HttpClient httpClient;
     private BulkProcessor2 bulkProcessor;
@@ -808,6 +818,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
                 .setVersionMetaKey("version")
                 .setOrigin(WATCHER_ORIGIN)
                 .setIndexFormat(6)
+                .setMigrationScript(REINDEX_SCRIPT_FROM_V7)
                 .build(),
             SystemIndexDescriptor.builder()
                 .setIndexPattern(TriggeredWatchStoreField.INDEX_NAME + "*")
@@ -818,6 +829,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
                 .setVersionMetaKey("version")
                 .setOrigin(WATCHER_ORIGIN)
                 .setIndexFormat(6)
+                .setMigrationScript(REINDEX_SCRIPT_FROM_V7)
                 .build()
         );
     }


### PR DESCRIPTION
Introduces a script for reindexing .watches and .triggered_watches indices from V7, removing unused `types` field from documents if it exists.


Verified manually 7.0.1 (-> 7.17.0) -> 8.18:
POST http://localhost:9200/_migration/system_features:
```
{
    "accepted": true,
    "features": [
        {
            "feature_name": "geoip"
        },
        {
            "feature_name": "watcher"
        }
    ]
}
```
`types` field was removed from the document created in v7

Closes: ES-10022
