### PR TITLE
ESQL: Ask for correct field names if only LOOKUP/ENRICH fields are kept

### DIFF
--- a/docs/changelog/120372.yaml
+++ b/docs/changelog/120372.yaml
@@ -1,0 +1,6 @@
+pr: 120372
+summary: Ask for correct field names if only LOOKUP/ENRICH fields are kept
+area: ES|QL
+type: bug
+issues:
+ - 120272

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -645,6 +645,7 @@ IDR       |  Indore       |  POINT(75.8472 22.7167)  |  India      |  POINT(75.8
 ;
 
 enrichDroppingOriginalIndexFields
+required_capability: enrich_load
 required_capability: fix_field_names_enrich_lookup_no_valid_fields
 
 from employees

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -645,7 +645,7 @@ IDR       |  Indore       |  POINT(75.8472 22.7167)  |  India      |  POINT(75.8
 ;
 
 enrichDroppingOriginalIndexFields
-required_capability: enrich_load
+required_capability: fix_field_names_enrich_lookup_no_valid_fields
 
 from employees
 | limit 3

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -643,3 +643,18 @@ FROM airports
 abbrev:k  |  city_name:k  |  city_location:geo_point |  country:k  |  location:geo_point                       |  name:text                    |  region:text  |  boundary_wkt_length:i
 IDR       |  Indore       |  POINT(75.8472 22.7167)  |  India      |  POINT(75.8092915005895 22.727749187571)  |  Devi Ahilyabai Holkar Int'l  |  Indore City  |  231
 ;
+
+enrichDroppingOriginalIndexFields
+required_capability: enrich_load
+
+from employees
+| limit 3
+| eval x = 2 
+| enrich languages_policy on x
+| keep language_name;
+
+language_name:keyword
+French
+French
+French
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -244,6 +244,7 @@ emp_no:integer
 
 dropAllOriginalIndexFields
 required_capability: join_lookup_v11
+required_capability: fix_field_names_enrich_lookup_no_valid_fields
 
 FROM employees
 | LIMIT 2

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -251,6 +251,28 @@ emp_no:integer
 10002
 ;
 
+dropAllOriginalIndexFields
+required_capability: join_lookup_v11
+
+FROM employees
+| LIMIT 2
+| EVAL language_code = 1
+| LOOKUP JOIN languages_lookup_non_unique_key ON language_code
+| SORT language_name, country
+| KEEP language_name, country
+;
+
+language_name:keyword | country:text
+English               | Canada
+English               | Canada
+English               | United States of America
+English               | United States of America
+English               | null
+English               | null
+null                  | United Kingdom
+null                  | United Kingdom
+;
+
 ###############################################
 # Filtering tests with languages_lookup index
 ###############################################

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -736,6 +736,13 @@ public class EsqlCapabilities {
         SEMANTIC_TEXT_FIELD_CAPS,
 
         /**
+         * Fix for https://github.com/elastic/elasticsearch/issues/120272.
+         * When there's an ENRICH/LOOKUP, and all fields from the original indices are discarded,
+         * field-caps wasn't asking for any existing field.
+         */
+        FIX_FIELD_NAMES_ENRICH_LOOKUP_NO_VALID_FIELDS,
+
+        /**
          * Support named argument for function in map format.
          */
         OPTIONAL_NAMED_ARGUMENT_MAP_FOR_FUNCTION(Build.current().isSnapshot());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -644,7 +644,7 @@ public class EsqlSession {
         fieldNames.addAll(subfields(fieldNames));
         fieldNames.addAll(enrichPolicyMatchFields);
         fieldNames.addAll(subfields(enrichPolicyMatchFields));
-        // We add the "_field" because it's light, and there must always be some field matching the indices.
+        // We add the "_index" field because it's light, and there must always be some field matching the indices.
         // Originally, this was used only when no fields were found, but ENRICH/LOOKUP fields can't currently
         // be distinguished from fields of the original index, so we always add it as a safety measure.
         fieldNames.addAll(IndexResolver.INDEX_METADATA_FIELD);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -543,6 +543,10 @@ public class EsqlSession {
         }
     }
 
+    /**
+     * Get the field names from the parsed plan combined with the ENRICH match fields from the ENRICH policy
+     * and the JOIN ON keys.
+     */
     static PreAnalysisResult fieldNames(LogicalPlan parsed, Set<String> enrichPolicyMatchFields, PreAnalysisResult result) {
         if (false == parsed.anyMatch(plan -> plan instanceof Aggregate || plan instanceof Project)) {
             // no explicit columns selection, for example "from employees"
@@ -635,18 +639,14 @@ public class EsqlSession {
         // remove valid metadata attributes because they will be filtered out by the IndexResolver anyway
         // otherwise, in some edge cases, we will fail to ask for "*" (all fields) instead
         references.removeIf(a -> a instanceof MetadataAttribute || MetadataAttribute.isSupported(a.name()));
-        Set<String> fieldNames = references.names();
 
-        if (fieldNames.isEmpty() && enrichPolicyMatchFields.isEmpty()) {
-            // there cannot be an empty list of fields, we'll ask the simplest and lightest one instead: _index
-            return result.withFieldNames(IndexResolver.INDEX_METADATA_FIELD);
-        } else {
+        Set<String> fieldNames = references.names();
             fieldNames.addAll(subfields(fieldNames));
             fieldNames.addAll(enrichPolicyMatchFields);
             fieldNames.addAll(subfields(enrichPolicyMatchFields));
+        fieldNames.addAll(IndexResolver.INDEX_METADATA_FIELD);
             return result.withFieldNames(fieldNames);
         }
-    }
 
     private static boolean matchByName(Attribute attr, String other, boolean skipIfPattern) {
         boolean isPattern = Regex.isSimpleMatchPattern(attr.name());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -644,6 +644,9 @@ public class EsqlSession {
         fieldNames.addAll(subfields(fieldNames));
         fieldNames.addAll(enrichPolicyMatchFields);
         fieldNames.addAll(subfields(enrichPolicyMatchFields));
+        // We add the "_field" because it's light, and there must always be some field matching the indices.
+        // Originally, this was used only when no fields were found, but ENRICH/LOOKUP fields can't currently
+        // be distinguished from fields of the original index, so we always add it as a safety measure.
         fieldNames.addAll(IndexResolver.INDEX_METADATA_FIELD);
         return result.withFieldNames(fieldNames);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -641,12 +641,12 @@ public class EsqlSession {
         references.removeIf(a -> a instanceof MetadataAttribute || MetadataAttribute.isSupported(a.name()));
 
         Set<String> fieldNames = references.names();
-            fieldNames.addAll(subfields(fieldNames));
-            fieldNames.addAll(enrichPolicyMatchFields);
-            fieldNames.addAll(subfields(enrichPolicyMatchFields));
+        fieldNames.addAll(subfields(fieldNames));
+        fieldNames.addAll(enrichPolicyMatchFields);
+        fieldNames.addAll(subfields(enrichPolicyMatchFields));
         fieldNames.addAll(IndexResolver.INDEX_METADATA_FIELD);
-            return result.withFieldNames(fieldNames);
-        }
+        return result.withFieldNames(fieldNames);
+    }
 
     private static boolean matchByName(Attribute attr, String other, boolean skipIfPattern) {
         boolean isPattern = Regex.isSimpleMatchPattern(attr.name());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverFieldNamesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverFieldNamesTests.java
@@ -1574,14 +1574,11 @@ public class IndexResolverFieldNamesTests extends ESTestCase {
 
     public void testLookupJoinWithEvalKey() {
         assumeTrue("LOOKUP JOIN available as snapshot only", EsqlCapabilities.Cap.JOIN_LOOKUP_V11.isEnabled());
-        assertFieldNames(
-            """
-                FROM some_index
-                | EVAL key = 5
-                | LOOKUP JOIN some_lookup ON key
-                | KEEP test""",
-            Set.of("test", "test.*", "key", "key.*")
-        );
+        assertFieldNames("""
+            FROM some_index
+            | EVAL key = 5
+            | LOOKUP JOIN some_lookup ON key
+            | KEEP test""", Set.of("test", "test.*", "key", "key.*"));
     }
 
     private Set<String> fieldNames(String query, Set<String> enrichPolicyMatchFields) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverFieldNamesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverFieldNamesTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.session;
 
 import org.elasticsearch.Build;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.parser.EsqlParser;
@@ -1321,15 +1322,14 @@ public class IndexResolverFieldNamesTests extends ESTestCase {
             from employees
             | enrich languages_policy
             | keep emp_no""", Set.of("language_name"));
-        assertThat(fieldNames, equalTo(Set.of("emp_no", "emp_no.*", "language_name", "language_name.*")));
+        assertThat(fieldNames, equalTo(expectedFieldNames(Set.of("emp_no", "emp_no.*", "language_name", "language_name.*"))));
     }
 
     public void testDissectOverwriteName() {
-        Set<String> fieldNames = fieldNames("""
+        assertFieldNames("""
             from employees
             | dissect first_name "%{first_name} %{more}"
-            | keep emp_no, first_name, more""", Set.of());
-        assertThat(fieldNames, equalTo(Set.of("emp_no", "emp_no.*", "first_name", "first_name.*")));
+            | keep emp_no, first_name, more""", Set.of("emp_no", "emp_no.*", "first_name", "first_name.*"));
     }
 
     public void testEnrichOnDefaultField() {
@@ -1346,20 +1346,17 @@ public class IndexResolverFieldNamesTests extends ESTestCase {
             assertThat(e.getMessage(), containsString("line 1:1: mismatched input 'METRICS' expecting {"));
             return;
         }
-        Set<String> fieldNames = fieldNames(query, Set.of());
-        assertThat(
-            fieldNames,
-            equalTo(
-                Set.of(
-                    "@timestamp",
-                    "@timestamp.*",
-                    "network.total_bytes_in",
-                    "network.total_bytes_in.*",
-                    "network.total_cost",
-                    "network.total_cost.*",
-                    "cluster",
-                    "cluster.*"
-                )
+        assertFieldNames(
+            query,
+            Set.of(
+                "@timestamp",
+                "@timestamp.*",
+                "network.total_bytes_in",
+                "network.total_bytes_in.*",
+                "network.total_cost",
+                "network.total_cost.*",
+                "cluster",
+                "cluster.*"
             )
         );
     }
@@ -1575,6 +1572,18 @@ public class IndexResolverFieldNamesTests extends ESTestCase {
         );
     }
 
+    public void testLookupJoinWithEvalKey() {
+        assumeTrue("LOOKUP JOIN available as snapshot only", EsqlCapabilities.Cap.JOIN_LOOKUP_V11.isEnabled());
+        assertFieldNames(
+            """
+                FROM some_index
+                | EVAL key = 5
+                | LOOKUP JOIN some_lookup ON key
+                | KEEP test""",
+            Set.of("test", "test.*", "key", "key.*")
+        );
+    }
+
     private Set<String> fieldNames(String query, Set<String> enrichPolicyMatchFields) {
         var preAnalysisResult = new EsqlSession.PreAnalysisResult(null);
         return EsqlSession.fieldNames(parser.createStatement(query), enrichPolicyMatchFields, preAnalysisResult).fieldNames();
@@ -1582,12 +1591,20 @@ public class IndexResolverFieldNamesTests extends ESTestCase {
 
     private void assertFieldNames(String query, Set<String> expected) {
         Set<String> fieldNames = fieldNames(query, Collections.emptySet());
-        assertThat(fieldNames, equalTo(expected));
+        assertThat(fieldNames, equalTo(expectedFieldNames(expected)));
     }
 
     private void assertFieldNames(String query, Set<String> expected, Set<String> wildCardIndices) {
         var preAnalysisResult = EsqlSession.fieldNames(parser.createStatement(query), Set.of(), new EsqlSession.PreAnalysisResult(null));
-        assertThat("Query-wide field names", preAnalysisResult.fieldNames(), equalTo(expected));
+        assertThat("Query-wide field names", preAnalysisResult.fieldNames(), equalTo(expectedFieldNames(expected)));
         assertThat("Lookup Indices that expect wildcard lookups", preAnalysisResult.wildcardJoinIndices(), equalTo(wildCardIndices));
+    }
+
+    private Set<String> expectedFieldNames(Set<String> expected) {
+        if (expected.size() == 1 && expected.contains("*")) {
+            return expected;
+        }
+
+        return Sets.union(expected, IndexResolver.INDEX_METADATA_FIELD);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/120272

# Some context on the bug

The issue occurs as follows, top-down (Read linked issue for context on the bug):
- A query like `FROM index | EVAL x = 1 | LOOKUP l ON x | KEEP lookup_field` returns no rows. Exactly the same with ENRICH
- It returns no rows because the FROM relationship is replaced by an EMPTY LocalRelationship
- The EMPTY rel comes from the EsIndex having no concrete indices
- It has no concrete indices because field-caps returns no results for that index+fields
- The fields come from fieldNames(), which must return an existing field, or _index if there's no field to query
- There's a logic in fieldNames() that says "If no fields, then use _index". It's not working, because the fields requested from LOOKUP appear in the list of fields

# Potential solution

Givens:
- We don't know which fields every lookup returns, so we can't substract them from the list
- We would have to first make the field-caps for lookup
- But the field-caps requets for lookup depends on the results of fieldNames()

Which means we will probably have to reorganize the `EsqlSession.analyzedPlan()` code to correctly trace every field.

# Current solution

This PR's solution is a simple, lazy one. It works well apparently, and I suppose it wasn't done before to try to keep the fieldNames "exact". But since enrich&lookup, it wasn't exact anymore, and we were asking for enrich/lookup index fields indistinctly.

Consider this a temporary solution until analyzedPlan() and fieldNames() get a refactor