### PR TITLE
[8.x] unmute testRestartAfterCompletion (#120361)

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -200,7 +200,6 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/81941")
     public void testRestartAfterCompletion() throws Exception {
         final String initialId;
         try (SearchResponseIterator it = assertBlockingIterator(indexName, numShards, new SearchSourceBuilder(), 0, 2)) {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - unmute testRestartAfterCompletion (#120361)