### PR TITLE
Remove redundant load from SumAggregator

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
@@ -83,9 +83,9 @@ public class SumAggregator extends NumericMetricsAggregator.SingleDoubleValue {
                         value = v + value;
                     }
 
-                    var compensations = SumAggregator.this.compensations;
-                    double delta = compensations.get(bucket);
                     if (Double.isFinite(value)) {
+                        var compensations = SumAggregator.this.compensations;
+                        double delta = compensations.get(bucket);
                         double correctedSum = v + delta;
                         double updatedValue = value + correctedSum;
                         delta = correctedSum - (updatedValue - value);


### PR DESCRIPTION
Trivial follow up to #120241, no need for a redundant load though the not-load path is probably very cold anyway, but still better to give the compiler all the inputs it can get.
