### PR TITLE
Fix and unmute `CrossClusterEsqlRCS1UnavailableRemotesIT` tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -170,9 +170,6 @@ tests:
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
   method: testBottomFieldSort
   issue: https://github.com/elastic/elasticsearch/issues/118214
-- class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS1UnavailableRemotesIT
-  method: testEsqlRcs1UnavailableRemoteScenarios
-  issue: https://github.com/elastic/elasticsearch/issues/118350
 - class: org.elasticsearch.xpack.searchablesnapshots.RetrySearchIntegTests
   method: testSearcherId
   issue: https://github.com/elastic/elasticsearch/issues/118374

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1UnavailableRemotesIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1UnavailableRemotesIT.java
@@ -180,7 +180,11 @@ public class CrossClusterEsqlRCS1UnavailableRemotesIT extends AbstractRemoteClus
             ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(query)));
             assertThat(
                 ex.getMessage(),
-                anyOf(containsString("connect_transport_exception"), containsString("node_disconnected_exception"))
+                anyOf(
+                    containsString("connect_transport_exception"),
+                    containsString("node_disconnected_exception"),
+                    containsString("node_not_connected_exception")
+                )
             );
         } finally {
             fulfillingCluster.start();

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1UnavailableRemotesIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1UnavailableRemotesIT.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class CrossClusterEsqlRCS1UnavailableRemotesIT extends AbstractRemoteClusterSecurityTestCase {
@@ -177,7 +178,10 @@ public class CrossClusterEsqlRCS1UnavailableRemotesIT extends AbstractRemoteClus
             // A simple query that targets our remote cluster.
             String query = "FROM *,my_remote_cluster:* | LIMIT 10";
             ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(query)));
-            assertThat(ex.getMessage(), containsString("connect_transport_exception"));
+            assertThat(
+                ex.getMessage(),
+                anyOf(containsString("connect_transport_exception"), containsString("node_disconnected_exception"))
+            );
         } finally {
             fulfillingCluster.start();
             closeFulfillingClusterClient();


### PR DESCRIPTION
Fixes #118350.

Solution inline with https://github.com/elastic/elasticsearch/pull/119977.