### PR TITLE
[8.x] Remove redundant load from SumAggregator (#120383)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
@@ -83,9 +83,9 @@ public class SumAggregator extends NumericMetricsAggregator.SingleDoubleValue {
                         value = v + value;
                     }
 
-                    var compensations = SumAggregator.this.compensations;
-                    double delta = compensations.get(bucket);
                     if (Double.isFinite(value)) {
+                        var compensations = SumAggregator.this.compensations;
+                        double delta = compensations.get(bucket);
                         double correctedSum = v + delta;
                         double updatedValue = value + correctedSum;
                         delta = correctedSum - (updatedValue - value);


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Remove redundant load from SumAggregator (#120383)