### PR TITLE
[8.x] ESQL: Test LOOKUP JOIN with alias for index pattern (#120292)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
@@ -20,7 +20,21 @@ setup:
                 type: keyword
   - do:
       indices.create:
-        index: test-lookup
+        index: test-lookup-1
+        body:
+          settings:
+            index:
+              mode: lookup
+            number_of_shards: 1
+          mappings:
+            properties:
+              key:
+                type: long
+              color:
+                type: keyword
+  - do:
+      indices.create:
+        index: test-lookup-2
         body:
           settings:
             index:
@@ -36,8 +50,14 @@ setup:
         body:
           actions:
             - add:
-                index: test-lookup
+                index: test-lookup-1
                 alias: test-lookup-alias
+            - add:
+                index: test-lookup-*
+                alias: test-lookup-alias-pattern-multiple
+            - add:
+                index: test-lookup-1*
+                alias: test-lookup-alias-pattern-single
   - do:
       bulk:
         index: "test"
@@ -49,7 +69,7 @@ setup:
           - { "key": 2, "color": "blue" }
   - do:
       bulk:
-        index: "test-lookup"
+        index: "test-lookup-1"
         refresh: true
         body:
           - { "index": { } }
@@ -62,7 +82,7 @@ basic:
   - do:
       esql.query:
         body:
-          query: 'FROM test | SORT key | LOOKUP JOIN `test-lookup` ON key | LIMIT 3'
+          query: 'FROM test | SORT key | LOOKUP JOIN `test-lookup-1` ON key | LIMIT 3'
 
   - match: {columns.0.name: "key"}
   - match: {columns.0.type: "long"}
@@ -76,11 +96,11 @@ non-lookup index:
   - do:
       esql.query:
         body:
-          query: 'FROM test-lookup | SORT key | LOOKUP JOIN `test` ON key | LIMIT 3'
+          query: 'FROM test-lookup-1 | SORT key | LOOKUP JOIN `test` ON key | LIMIT 3'
       catch: "bad_request"
 
   - match: { error.type: "verification_exception" }
-  - contains: { error.reason: "Found 1 problem\nline 1:43: invalid [test] resolution in lookup mode to an index in [standard] mode" }
+  - contains: { error.reason: "Found 1 problem\nline 1:45: invalid [test] resolution in lookup mode to an index in [standard] mode" }
 
 ---
 alias:
@@ -115,7 +135,32 @@ alias-repeated-index:
   - do:
       esql.query:
         body:
-          query: 'FROM test-lookup | SORT key | LOOKUP JOIN `test-lookup-alias` ON key | LIMIT 3'
+          query: 'FROM test-lookup-1 | SORT key | LOOKUP JOIN `test-lookup-alias` ON key | LIMIT 3'
+
+  - match: {columns.0.name: "key"}
+  - match: {columns.0.type: "long"}
+  - match: {columns.1.name: "color"}
+  - match: {columns.1.type: "keyword"}
+  - match: {values.0: [1, "cyan"]}
+  - match: {values.1: [2, "yellow"]}
+
+---
+alias-pattern-multiple:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test-lookup-1 | LOOKUP JOIN `test-lookup-alias-pattern-multiple` ON key'
+      catch: "bad_request"
+
+  - match: { error.type: "verification_exception" }
+  - contains: { error.reason: "Found 1 problem\nline 1:34: invalid [test-lookup-alias-pattern-multiple] resolution in lookup mode to [2] indices" }
+
+---
+alias-pattern-single:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test | SORT key | LOOKUP JOIN `test-lookup-alias-pattern-single` ON key | LIMIT 3'
 
   - match: {columns.0.name: "key"}
   - match: {columns.0.type: "long"}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Test LOOKUP JOIN with alias for index pattern (#120292)