### PR TITLE
[Connector APIs] Update docs with new privilege

### DIFF
--- a/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
@@ -24,6 +24,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[cancel-connector-sync-job-api-prereqs]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_sync_job_id` parameter should reference an existing connector sync job.
 

--- a/docs/reference/connector/apis/check-in-connector-api.asciidoc
+++ b/docs/reference/connector/apis/check-in-connector-api.asciidoc
@@ -25,6 +25,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[check-in-connector-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 

--- a/docs/reference/connector/apis/check-in-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/check-in-connector-sync-job-api.asciidoc
@@ -24,6 +24,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[check-in-connector-sync-job-api-prereqs]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege..
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_sync_job_id` parameter should reference an existing connector sync job.
 

--- a/docs/reference/connector/apis/claim-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/claim-connector-sync-job-api.asciidoc
@@ -26,6 +26,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[claim-connector-sync-job-api-prereqs]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_sync_job_id` parameter should reference an existing connector sync job.
 

--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -23,6 +23,8 @@ Find a list of all supported service types in the <<es-connectors,connectors doc
 This API provides an alternative to relying solely on {kib} UI for connector and sync job management. The API comes with a set of
 validations and assertions to ensure that the state representation in the internal index remains valid.
 
+Managing connectors requires the `manage_connector` cluster privilege.
+
 [TIP]
 ====
 We also have a command-line interface for Elastic connectors. Learn more in the https://github.com/elastic/connectors/blob/main/docs/CLI.md[elastic/connectors] repository.

--- a/docs/reference/connector/apis/create-connector-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-api.asciidoc
@@ -50,6 +50,7 @@ DELETE _connector/my-connector
 [[create-connector-api-prereqs]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `service_type` parameter should reference a supported third-party service. See the available service types for <<es-native-connectors,Elastic managed>> and <<es-build-connector,self-managed>> connectors. This can also reference the service type of your custom connector.
 

--- a/docs/reference/connector/apis/create-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-sync-job-api.asciidoc
@@ -37,6 +37,7 @@ POST _connector/_sync_job
 [[create-connector-sync-job-api-prereqs]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `id` parameter should reference an existing connector.
 

--- a/docs/reference/connector/apis/delete-connector-api.asciidoc
+++ b/docs/reference/connector/apis/delete-connector-api.asciidoc
@@ -28,6 +28,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[delete-connector-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 

--- a/docs/reference/connector/apis/delete-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/delete-connector-sync-job-api.asciidoc
@@ -26,6 +26,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[delete-connector-sync-job-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 
 [[delete-connector-sync-job-api-path-params]]

--- a/docs/reference/connector/apis/get-connector-api.asciidoc
+++ b/docs/reference/connector/apis/get-connector-api.asciidoc
@@ -25,6 +25,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[get-connector-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `monitor_connector` or `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 
 [[get-connector-api-path-params]]

--- a/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
@@ -25,6 +25,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[get-connector-sync-job-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `monitor_connector` or `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 
 [[get-connector-sync-job-api-path-params]]

--- a/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
+++ b/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
@@ -26,6 +26,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[list-connector-sync-jobs-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `monitor_connector` or `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 
 [[list-connector-sync-jobs-api-path-params]]

--- a/docs/reference/connector/apis/list-connectors-api.asciidoc
+++ b/docs/reference/connector/apis/list-connectors-api.asciidoc
@@ -27,6 +27,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[list-connector-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `monitor_connector` or `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 
 [[list-connector-api-path-params]]

--- a/docs/reference/connector/apis/set-connector-sync-job-error-api.asciidoc
+++ b/docs/reference/connector/apis/set-connector-sync-job-error-api.asciidoc
@@ -24,6 +24,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[set-connector-sync-job-error-api-prereqs]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_sync_job_id` parameter should reference an existing connector sync job.
 

--- a/docs/reference/connector/apis/set-connector-sync-job-stats-api.asciidoc
+++ b/docs/reference/connector/apis/set-connector-sync-job-stats-api.asciidoc
@@ -24,6 +24,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[set-connector-sync-job-stats-api-prereqs]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_sync_job_id` parameter should reference an existing connector sync job.
 

--- a/docs/reference/connector/apis/update-connector-api-key-id-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-api-key-id-api.asciidoc
@@ -32,6 +32,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-api-key-id-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 * The `api_key_id` parameter should reference an existing API key.

--- a/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
@@ -25,6 +25,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-configuration-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 * To update configuration `values`, the connector `configuration` schema must be first registered by a running instance of Elastic connector service.

--- a/docs/reference/connector/apis/update-connector-error-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-error-api.asciidoc
@@ -25,6 +25,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-error-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 

--- a/docs/reference/connector/apis/update-connector-features-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-features-api.asciidoc
@@ -32,6 +32,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-features-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -27,6 +27,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-filtering-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 * Filtering draft is activated once validated by the running Elastic connector service, the `draft.validation.state` must be `valid`.

--- a/docs/reference/connector/apis/update-connector-index-name-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-index-name-api.asciidoc
@@ -25,6 +25,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-index-name-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 

--- a/docs/reference/connector/apis/update-connector-last-sync-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-last-sync-api.asciidoc
@@ -27,6 +27,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-last-sync-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 

--- a/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
@@ -25,6 +25,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-name-description-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 

--- a/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
@@ -27,6 +27,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-pipeline-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 

--- a/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
@@ -25,6 +25,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-scheduling-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 

--- a/docs/reference/connector/apis/update-connector-service-type-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-service-type-api.asciidoc
@@ -25,6 +25,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-service-type-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 * The `service_type` must be a valid type as defined by the Connector framework.

--- a/docs/reference/connector/apis/update-connector-status-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-status-api.asciidoc
@@ -25,6 +25,7 @@ To get started with Connector APIs, check out <<es-connectors-tutorial-api, our 
 [[update-connector-status-api-prereq]]
 ==== {api-prereq-title}
 
+* Requires the `manage_connector` privilege.
 * To sync data using self-managed connectors, you need to deploy the <<es-connectors-deploy-connector-service,Elastic connector service>>. on your own infrastructure. This service runs automatically on Elastic Cloud for Elastic managed connectors.
 * The `connector_id` parameter should reference an existing connector.
 * The change of `status` must be a valid status transition according to the https://github.com/elastic/connectors/blob/main/docs/CONNECTOR_PROTOCOL.md[Connector Protocol].

--- a/docs/reference/security/authorization/privileges.asciidoc
+++ b/docs/reference/security/authorization/privileges.asciidoc
@@ -229,6 +229,9 @@ security roles of the user who created or updated them.
 All cluster read-only operations, like cluster health and state, hot threads,
 node info, node and cluster stats, and pending cluster tasks.
 
+`monitor_connector`::
+All read-only operations on <<connector-apis, connectors>>.
+
 `monitor_data_stream_global_retention`::
 This privilege has no effect.deprecated[8.16]
 

--- a/docs/reference/security/authorization/privileges.asciidoc
+++ b/docs/reference/security/authorization/privileges.asciidoc
@@ -95,6 +95,9 @@ only on clusters that contain follower indices.
 +
 This privilege is not available in {serverless-full}.
 
+`manage_connector`::
+All CRUD operations on <<connector-apis, connectors>>.
+
 `manage_data_frame_transforms`::
 All operations related to managing {transforms}.
 deprecated[7.5] Use `manage_transform` instead.


### PR DESCRIPTION
Update docs after merging: https://github.com/elastic/elasticsearch/pull/119863

Now we have `monitor_connector` and `manage_connector` cluster privilege that controls access to API. 