### PR TITLE
[8.x] [ML] Adds a new field supported_task_types in the configuration response (#120150)

### DIFF
--- a/server/src/main/java/org/elasticsearch/inference/InferenceServiceConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceServiceConfiguration.java
@@ -191,7 +191,7 @@ public class InferenceServiceConfiguration implements Writeable, ToXContentObjec
         }
 
         public Builder setTaskTypes(EnumSet<TaskType> taskTypes) {
-            this.taskTypes = taskTypes;
+            this.taskTypes = TaskType.copyOf(taskTypes);
             return this;
         }
 

--- a/server/src/main/java/org/elasticsearch/inference/TaskType.java
+++ b/server/src/main/java/org/elasticsearch/inference/TaskType.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
+import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -77,5 +78,15 @@ public enum TaskType implements Writeable {
 
     public static String unsupportedTaskTypeErrorMsg(TaskType taskType, String serviceName) {
         return "The [" + serviceName + "] service does not support task type [" + taskType + "]";
+    }
+
+    /**
+     * Copies a {@link EnumSet<TaskType>} if non-empty, otherwise returns an empty {@link EnumSet<TaskType>}. This is essentially the same
+     * as {@link EnumSet#copyOf(EnumSet)}, except it does not throw for an empty set.
+     * @param taskTypes task types to copy
+     * @return a copy of the passed in {@link EnumSet<TaskType>}
+     */
+    public static EnumSet<TaskType> copyOf(EnumSet<TaskType> taskTypes) {
+        return taskTypes.isEmpty() ? EnumSet.noneOf(TaskType.class) : EnumSet.copyOf(taskTypes);
     }
 }

--- a/server/src/test/java/org/elasticsearch/inference/SettingsConfigurationTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/inference/SettingsConfigurationTestUtils.java
@@ -11,6 +11,8 @@ package org.elasticsearch.inference;
 
 import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 
+import java.util.EnumSet;
+
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomInt;
@@ -18,7 +20,9 @@ import static org.elasticsearch.test.ESTestCase.randomInt;
 public class SettingsConfigurationTestUtils {
 
     public static SettingsConfiguration getRandomSettingsConfigurationField() {
-        return new SettingsConfiguration.Builder().setDefaultValue(randomAlphaOfLength(10))
+        return new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.SPARSE_EMBEDDING)).setDefaultValue(
+            randomAlphaOfLength(10)
+        )
             .setDescription(randomAlphaOfLength(10))
             .setLabel(randomAlphaOfLength(10))
             .setRequired(randomBoolean())

--- a/server/src/test/java/org/elasticsearch/inference/SettingsConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/inference/SettingsConfigurationTests.java
@@ -34,7 +34,8 @@ public class SettingsConfigurationTests extends ESTestCase {
                "required": true,
                "sensitive": false,
                "updatable": true,
-               "type": "str"
+               "type": "str",
+               "supported_task_types": ["text_embedding", "completion", "sparse_embedding", "rerank"]
             }
             """);
 
@@ -56,7 +57,8 @@ public class SettingsConfigurationTests extends ESTestCase {
                "required": true,
                "sensitive": false,
                "updatable": true,
-               "type": "str"
+               "type": "str",
+               "supported_task_types": ["text_embedding"]
             }
             """);
 
@@ -74,7 +76,8 @@ public class SettingsConfigurationTests extends ESTestCase {
         String content = XContentHelper.stripWhitespace("""
             {
                "label": "nextSyncConfig",
-               "value": null
+               "value": null,
+               "supported_task_types": ["text_embedding", "completion", "sparse_embedding", "rerank"]
             }
             """);
 

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
@@ -257,7 +257,7 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
 
                     configurationMap.put(
                         "model",
-                        new SettingsConfiguration.Builder().setDescription("")
+                        new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING)).setDescription("")
                             .setLabel("Model")
                             .setRequired(true)
                             .setSensitive(true)

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestRerankingServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestRerankingServiceExtension.java
@@ -171,7 +171,7 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
 
                     configurationMap.put(
                         "model",
-                        new SettingsConfiguration.Builder().setDescription("")
+                        new SettingsConfiguration.Builder(EnumSet.of(TaskType.RERANK)).setDescription("")
                             .setLabel("Model")
                             .setRequired(true)
                             .setSensitive(true)

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestSparseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestSparseInferenceServiceExtension.java
@@ -205,7 +205,7 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
 
                     configurationMap.put(
                         "model",
-                        new SettingsConfiguration.Builder().setDescription("")
+                        new SettingsConfiguration.Builder(EnumSet.of(TaskType.SPARSE_EMBEDDING)).setDescription("")
                             .setLabel("Model")
                             .setRequired(true)
                             .setSensitive(false)
@@ -215,7 +215,7 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
 
                     configurationMap.put(
                         "hidden_field",
-                        new SettingsConfiguration.Builder().setDescription("")
+                        new SettingsConfiguration.Builder(EnumSet.of(TaskType.SPARSE_EMBEDDING)).setDescription("")
                             .setLabel("Hidden Field")
                             .setRequired(true)
                             .setSensitive(false)

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestStreamingCompletionServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestStreamingCompletionServiceExtension.java
@@ -257,7 +257,7 @@ public class TestStreamingCompletionServiceExtension implements InferenceService
 
                     configurationMap.put(
                         "model_id",
-                        new SettingsConfiguration.Builder().setDescription("")
+                        new SettingsConfiguration.Builder(EnumSet.of(TaskType.COMPLETION)).setDescription("")
                             .setLabel("Model ID")
                             .setRequired(true)
                             .setSensitive(true)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchService.java
@@ -379,7 +379,9 @@ public class AlibabaCloudSearchService extends SenderService {
 
                 configurationMap.put(
                     SERVICE_ID,
-                    new SettingsConfiguration.Builder().setDescription("The name of the model service to use for the {infer} task.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
+                        "The name of the model service to use for the {infer} task."
+                    )
                         .setLabel("Project ID")
                         .setRequired(true)
                         .setSensitive(false)
@@ -390,7 +392,7 @@ public class AlibabaCloudSearchService extends SenderService {
 
                 configurationMap.put(
                     HOST,
-                    new SettingsConfiguration.Builder().setDescription(
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
                         "The name of the host address used for the {infer} task. You can find the host address at "
                             + "https://opensearch.console.aliyun.com/cn-shanghai/rag/api-key[ the API keys section] "
                             + "of the documentation."
@@ -405,7 +407,7 @@ public class AlibabaCloudSearchService extends SenderService {
 
                 configurationMap.put(
                     HTTP_SCHEMA_NAME,
-                    new SettingsConfiguration.Builder().setDescription("")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("")
                         .setLabel("HTTP Schema")
                         .setRequired(true)
                         .setSensitive(false)
@@ -416,7 +418,9 @@ public class AlibabaCloudSearchService extends SenderService {
 
                 configurationMap.put(
                     WORKSPACE_NAME,
-                    new SettingsConfiguration.Builder().setDescription("The name of the workspace used for the {infer} task.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
+                        "The name of the workspace used for the {infer} task."
+                    )
                         .setLabel("Workspace")
                         .setRequired(true)
                         .setSensitive(false)
@@ -426,9 +430,12 @@ public class AlibabaCloudSearchService extends SenderService {
                 );
 
                 configurationMap.putAll(
-                    DefaultSecretSettings.toSettingsConfigurationWithDescription("A valid API key for the AlibabaCloud AI Search API.")
+                    DefaultSecretSettings.toSettingsConfigurationWithDescription(
+                        "A valid API key for the AlibabaCloud AI Search API.",
+                        supportedTaskTypes
+                    )
                 );
-                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(supportedTaskTypes));
 
                 return new InferenceServiceConfiguration.Builder().setService(NAME)
                     .setName(SERVICE_NAME)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockSecretSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockSecretSettings.java
@@ -18,11 +18,13 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SecretSettings;
 import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -128,7 +130,9 @@ public class AmazonBedrockSecretSettings implements SecretSettings {
                 var configurationMap = new HashMap<String, SettingsConfiguration>();
                 configurationMap.put(
                     ACCESS_KEY_FIELD,
-                    new SettingsConfiguration.Builder().setDescription("A valid AWS access key that has permissions to use Amazon Bedrock.")
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.COMPLETION)).setDescription(
+                        "A valid AWS access key that has permissions to use Amazon Bedrock."
+                    )
                         .setLabel("Access Key")
                         .setRequired(true)
                         .setSensitive(true)
@@ -138,7 +142,9 @@ public class AmazonBedrockSecretSettings implements SecretSettings {
                 );
                 configurationMap.put(
                     SECRET_KEY_FIELD,
-                    new SettingsConfiguration.Builder().setDescription("A valid AWS secret key that is paired with the access_key.")
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.COMPLETION)).setDescription(
+                        "A valid AWS secret key that is paired with the access_key."
+                    )
                         .setLabel("Secret Key")
                         .setRequired(true)
                         .setSensitive(true)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockService.java
@@ -378,7 +378,7 @@ public class AmazonBedrockService extends SenderService {
 
                 configurationMap.put(
                     PROVIDER_FIELD,
-                    new SettingsConfiguration.Builder().setDescription("The model provider for your deployment.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("The model provider for your deployment.")
                         .setLabel("Provider")
                         .setRequired(true)
                         .setSensitive(false)
@@ -389,7 +389,7 @@ public class AmazonBedrockService extends SenderService {
 
                 configurationMap.put(
                     MODEL_FIELD,
-                    new SettingsConfiguration.Builder().setDescription(
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
                         "The base model ID or an ARN to a custom model based on a foundational model."
                     )
                         .setLabel("Model")
@@ -402,7 +402,9 @@ public class AmazonBedrockService extends SenderService {
 
                 configurationMap.put(
                     REGION_FIELD,
-                    new SettingsConfiguration.Builder().setDescription("The region that your model or ARN is deployed in.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
+                        "The region that your model or ARN is deployed in."
+                    )
                         .setLabel("Region")
                         .setRequired(true)
                         .setSensitive(false)
@@ -414,7 +416,8 @@ public class AmazonBedrockService extends SenderService {
                 configurationMap.putAll(AmazonBedrockSecretSettings.Configuration.get());
                 configurationMap.putAll(
                     RateLimitSettings.toSettingsConfigurationWithDescription(
-                        "By default, the amazonbedrock service sets the number of requests allowed per minute to 240."
+                        "By default, the amazonbedrock service sets the number of requests allowed per minute to 240.",
+                        supportedTaskTypes
                     )
                 );
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicService.java
@@ -256,7 +256,9 @@ public class AnthropicService extends SenderService {
 
                 configurationMap.put(
                     MODEL_ID,
-                    new SettingsConfiguration.Builder().setDescription("The name of the model to use for the inference task.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
+                        "The name of the model to use for the inference task."
+                    )
                         .setLabel("Model ID")
                         .setRequired(true)
                         .setSensitive(false)
@@ -265,10 +267,11 @@ public class AnthropicService extends SenderService {
                         .build()
                 );
 
-                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration(supportedTaskTypes));
                 configurationMap.putAll(
                     RateLimitSettings.toSettingsConfigurationWithDescription(
-                        "By default, the anthropic service sets the number of requests allowed per minute to 50."
+                        "By default, the anthropic service sets the number of requests allowed per minute to 50.",
+                        supportedTaskTypes
                     )
                 );
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioService.java
@@ -406,7 +406,9 @@ public class AzureAiStudioService extends SenderService {
 
                 configurationMap.put(
                     TARGET_FIELD,
-                    new SettingsConfiguration.Builder().setDescription("The target URL of your Azure AI Studio model deployment.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
+                        "The target URL of your Azure AI Studio model deployment."
+                    )
                         .setLabel("Target")
                         .setRequired(true)
                         .setSensitive(false)
@@ -417,7 +419,7 @@ public class AzureAiStudioService extends SenderService {
 
                 configurationMap.put(
                     ENDPOINT_TYPE_FIELD,
-                    new SettingsConfiguration.Builder().setDescription(
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
                         "Specifies the type of endpoint that is used in your model deployment."
                     )
                         .setLabel("Endpoint Type")
@@ -430,7 +432,7 @@ public class AzureAiStudioService extends SenderService {
 
                 configurationMap.put(
                     PROVIDER_FIELD,
-                    new SettingsConfiguration.Builder().setDescription("The model provider for your deployment.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("The model provider for your deployment.")
                         .setLabel("Provider")
                         .setRequired(true)
                         .setSensitive(false)
@@ -439,8 +441,8 @@ public class AzureAiStudioService extends SenderService {
                         .build()
                 );
 
-                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
-                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration(supportedTaskTypes));
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(supportedTaskTypes));
 
                 return new InferenceServiceConfiguration.Builder().setService(NAME)
                     .setName(SERVICE_NAME)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiSecretSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiSecretSettings.java
@@ -18,11 +18,13 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SecretSettings;
 import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -146,7 +148,9 @@ public class AzureOpenAiSecretSettings implements SecretSettings {
                 var configurationMap = new HashMap<String, SettingsConfiguration>();
                 configurationMap.put(
                     API_KEY,
-                    new SettingsConfiguration.Builder().setDescription("You must provide either an API key or an Entra ID.")
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.COMPLETION)).setDescription(
+                        "You must provide either an API key or an Entra ID."
+                    )
                         .setLabel("API Key")
                         .setRequired(false)
                         .setSensitive(true)
@@ -156,7 +160,9 @@ public class AzureOpenAiSecretSettings implements SecretSettings {
                 );
                 configurationMap.put(
                     ENTRA_ID,
-                    new SettingsConfiguration.Builder().setDescription("You must provide either an API key or an Entra ID.")
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.COMPLETION)).setDescription(
+                        "You must provide either an API key or an Entra ID."
+                    )
                         .setLabel("Entra ID")
                         .setRequired(false)
                         .setSensitive(true)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiService.java
@@ -351,7 +351,7 @@ public class AzureOpenAiService extends SenderService {
 
                 configurationMap.put(
                     RESOURCE_NAME,
-                    new SettingsConfiguration.Builder().setDescription("The name of your Azure OpenAI resource.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("The name of your Azure OpenAI resource.")
                         .setLabel("Resource Name")
                         .setRequired(true)
                         .setSensitive(false)
@@ -362,7 +362,7 @@ public class AzureOpenAiService extends SenderService {
 
                 configurationMap.put(
                     API_VERSION,
-                    new SettingsConfiguration.Builder().setDescription("The Azure API version ID to use.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("The Azure API version ID to use.")
                         .setLabel("API Version")
                         .setRequired(true)
                         .setSensitive(false)
@@ -373,7 +373,7 @@ public class AzureOpenAiService extends SenderService {
 
                 configurationMap.put(
                     DEPLOYMENT_ID,
-                    new SettingsConfiguration.Builder().setDescription("The deployment name of your deployed models.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("The deployment name of your deployed models.")
                         .setLabel("Deployment ID")
                         .setRequired(true)
                         .setSensitive(false)
@@ -385,7 +385,8 @@ public class AzureOpenAiService extends SenderService {
                 configurationMap.putAll(AzureOpenAiSecretSettings.Configuration.get());
                 configurationMap.putAll(
                     RateLimitSettings.toSettingsConfigurationWithDescription(
-                        "The azureopenai service sets a default number of requests allowed per minute depending on the task type."
+                        "The azureopenai service sets a default number of requests allowed per minute depending on the task type.",
+                        supportedTaskTypes
                     )
                 );
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
@@ -363,8 +363,8 @@ public class CohereService extends SenderService {
             () -> {
                 var configurationMap = new HashMap<String, SettingsConfiguration>();
 
-                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
-                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration(supportedTaskTypes));
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(supportedTaskTypes));
 
                 return new InferenceServiceConfiguration.Builder().setService(NAME)
                     .setName(SERVICE_NAME)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -371,7 +371,9 @@ public class ElasticInferenceService extends SenderService {
 
                 configurationMap.put(
                     MODEL_ID,
-                    new SettingsConfiguration.Builder().setDescription("The name of the model to use for the inference task.")
+                    new SettingsConfiguration.Builder(SUPPORTED_TASK_TYPES_FOR_SERVICES_API).setDescription(
+                        "The name of the model to use for the inference task."
+                    )
                         .setLabel("Model ID")
                         .setRequired(true)
                         .setSensitive(false)
@@ -382,7 +384,9 @@ public class ElasticInferenceService extends SenderService {
 
                 configurationMap.put(
                     MAX_INPUT_TOKENS,
-                    new SettingsConfiguration.Builder().setDescription("Allows you to specify the maximum number of tokens per input.")
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.SPARSE_EMBEDDING)).setDescription(
+                        "Allows you to specify the maximum number of tokens per input."
+                    )
                         .setLabel("Maximum Input Tokens")
                         .setRequired(false)
                         .setSensitive(false)
@@ -391,7 +395,7 @@ public class ElasticInferenceService extends SenderService {
                         .build()
                 );
 
-                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(SUPPORTED_TASK_TYPES_FOR_SERVICES_API));
 
                 return new InferenceServiceConfiguration.Builder().setService(NAME)
                     .setName(SERVICE_NAME)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -1146,7 +1146,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
 
                 configurationMap.put(
                     MODEL_ID,
-                    new SettingsConfiguration.Builder().setDefaultValue(MULTILINGUAL_E5_SMALL_MODEL_ID)
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDefaultValue(MULTILINGUAL_E5_SMALL_MODEL_ID)
                         .setDescription("The name of the model to use for the inference task.")
                         .setLabel("Model ID")
                         .setRequired(true)
@@ -1158,7 +1158,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
 
                 configurationMap.put(
                     NUM_ALLOCATIONS,
-                    new SettingsConfiguration.Builder().setDefaultValue(1)
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDefaultValue(1)
                         .setDescription("The total number of allocations this model is assigned across machine learning nodes.")
                         .setLabel("Number Allocations")
                         .setRequired(true)
@@ -1170,7 +1170,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
 
                 configurationMap.put(
                     NUM_THREADS,
-                    new SettingsConfiguration.Builder().setDefaultValue(2)
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDefaultValue(2)
                         .setDescription("Sets the number of threads used by each model allocation during inference.")
                         .setLabel("Number Threads")
                         .setRequired(true)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioService.java
@@ -351,7 +351,7 @@ public class GoogleAiStudioService extends SenderService {
 
                 configurationMap.put(
                     MODEL_ID,
-                    new SettingsConfiguration.Builder().setDescription("ID of the LLM you're using.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("ID of the LLM you're using.")
                         .setLabel("Model ID")
                         .setRequired(true)
                         .setSensitive(false)
@@ -360,8 +360,8 @@ public class GoogleAiStudioService extends SenderService {
                         .build()
                 );
 
-                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
-                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration(supportedTaskTypes));
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(supportedTaskTypes));
 
                 return new InferenceServiceConfiguration.Builder().setService(NAME)
                     .setName(SERVICE_NAME)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiSecretSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiSecretSettings.java
@@ -18,11 +18,13 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SecretSettings;
 import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -122,7 +124,9 @@ public class GoogleVertexAiSecretSettings implements SecretSettings {
                 var configurationMap = new HashMap<String, SettingsConfiguration>();
                 configurationMap.put(
                     SERVICE_ACCOUNT_JSON,
-                    new SettingsConfiguration.Builder().setDescription("API Key for the provider you're connecting to.")
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.RERANK)).setDescription(
+                        "API Key for the provider you're connecting to."
+                    )
                         .setLabel("Credentials JSON")
                         .setRequired(true)
                         .setSensitive(true)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiService.java
@@ -329,7 +329,7 @@ public class GoogleVertexAiService extends SenderService {
 
                 configurationMap.put(
                     MODEL_ID,
-                    new SettingsConfiguration.Builder().setDescription("ID of the LLM you're using.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("ID of the LLM you're using.")
                         .setLabel("Model ID")
                         .setRequired(true)
                         .setSensitive(false)
@@ -340,7 +340,7 @@ public class GoogleVertexAiService extends SenderService {
 
                 configurationMap.put(
                     LOCATION,
-                    new SettingsConfiguration.Builder().setDescription(
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
                         "Please provide the GCP region where the Vertex AI API(s) is enabled. "
                             + "For more information, refer to the {geminiVertexAIDocs}."
                     )
@@ -354,7 +354,7 @@ public class GoogleVertexAiService extends SenderService {
 
                 configurationMap.put(
                     PROJECT_ID,
-                    new SettingsConfiguration.Builder().setDescription(
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
                         "The GCP Project ID which has Vertex AI API(s) enabled. For more information "
                             + "on the URL, refer to the {geminiVertexAIDocs}."
                     )
@@ -367,7 +367,7 @@ public class GoogleVertexAiService extends SenderService {
                 );
 
                 configurationMap.putAll(GoogleVertexAiSecretSettings.Configuration.get());
-                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(supportedTaskTypes));
 
                 return new InferenceServiceConfiguration.Builder().setService(NAME)
                     .setName(SERVICE_NAME)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceService.java
@@ -181,7 +181,7 @@ public class HuggingFaceService extends HuggingFaceBaseService {
 
                 configurationMap.put(
                     URL,
-                    new SettingsConfiguration.Builder().setDefaultValue("https://api.openai.com/v1/embeddings")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDefaultValue("https://api.openai.com/v1/embeddings")
                         .setDescription("The URL endpoint to use for the requests.")
                         .setLabel("URL")
                         .setRequired(true)
@@ -191,8 +191,8 @@ public class HuggingFaceService extends HuggingFaceBaseService {
                         .build()
                 );
 
-                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
-                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration(supportedTaskTypes));
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(supportedTaskTypes));
 
                 return new InferenceServiceConfiguration.Builder().setService(NAME)
                     .setName(SERVICE_NAME)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserService.java
@@ -176,7 +176,7 @@ public class HuggingFaceElserService extends HuggingFaceBaseService {
 
                 configurationMap.put(
                     URL,
-                    new SettingsConfiguration.Builder().setDescription("The URL endpoint to use for the requests.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("The URL endpoint to use for the requests.")
                         .setLabel("URL")
                         .setRequired(true)
                         .setSensitive(false)
@@ -185,8 +185,8 @@ public class HuggingFaceElserService extends HuggingFaceBaseService {
                         .build()
                 );
 
-                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
-                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration(supportedTaskTypes));
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(supportedTaskTypes));
 
                 return new InferenceServiceConfiguration.Builder().setService(NAME)
                     .setName(SERVICE_NAME)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxService.java
@@ -324,7 +324,7 @@ public class IbmWatsonxService extends SenderService {
 
                 configurationMap.put(
                     API_VERSION,
-                    new SettingsConfiguration.Builder().setDescription("The IBM Watsonx API version ID to use.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("The IBM Watsonx API version ID to use.")
                         .setLabel("API Version")
                         .setRequired(true)
                         .setSensitive(false)
@@ -335,7 +335,7 @@ public class IbmWatsonxService extends SenderService {
 
                 configurationMap.put(
                     PROJECT_ID,
-                    new SettingsConfiguration.Builder().setDescription("")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("")
                         .setLabel("Project ID")
                         .setRequired(true)
                         .setSensitive(false)
@@ -346,7 +346,9 @@ public class IbmWatsonxService extends SenderService {
 
                 configurationMap.put(
                     MODEL_ID,
-                    new SettingsConfiguration.Builder().setDescription("The name of the model to use for the inference task.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
+                        "The name of the model to use for the inference task."
+                    )
                         .setLabel("Model ID")
                         .setRequired(true)
                         .setSensitive(false)
@@ -357,7 +359,7 @@ public class IbmWatsonxService extends SenderService {
 
                 configurationMap.put(
                     URL,
-                    new SettingsConfiguration.Builder().setDescription("")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("")
                         .setLabel("URL")
                         .setRequired(true)
                         .setSensitive(false)
@@ -368,7 +370,9 @@ public class IbmWatsonxService extends SenderService {
 
                 configurationMap.put(
                     MAX_INPUT_TOKENS,
-                    new SettingsConfiguration.Builder().setDescription("Allows you to specify the maximum number of tokens per input.")
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING)).setDescription(
+                        "Allows you to specify the maximum number of tokens per input."
+                    )
                         .setLabel("Maximum Input Tokens")
                         .setRequired(false)
                         .setSensitive(false)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIService.java
@@ -339,8 +339,8 @@ public class JinaAIService extends SenderService {
             () -> {
                 var configurationMap = new HashMap<String, SettingsConfiguration>();
 
-                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
-                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration(supportedTaskTypes));
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(supportedTaskTypes));
 
                 return new InferenceServiceConfiguration.Builder().setService(NAME)
                     .setName(SERVICE_NAME)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/MistralService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/MistralService.java
@@ -318,7 +318,7 @@ public class MistralService extends SenderService {
 
                 configurationMap.put(
                     MODEL_FIELD,
-                    new SettingsConfiguration.Builder().setDescription(
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
                         "Refer to the Mistral models documentation for the list of available text embedding models."
                     )
                         .setLabel("Model")
@@ -331,7 +331,9 @@ public class MistralService extends SenderService {
 
                 configurationMap.put(
                     MAX_INPUT_TOKENS,
-                    new SettingsConfiguration.Builder().setDescription("Allows you to specify the maximum number of tokens per input.")
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
+                        "Allows you to specify the maximum number of tokens per input."
+                    )
                         .setLabel("Maximum Input Tokens")
                         .setRequired(false)
                         .setSensitive(false)
@@ -340,8 +342,8 @@ public class MistralService extends SenderService {
                         .build()
                 );
 
-                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
-                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration(supportedTaskTypes));
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(supportedTaskTypes));
 
                 return new InferenceServiceConfiguration.Builder().setService(NAME)
                     .setName(SERVICE_NAME)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
@@ -415,7 +415,9 @@ public class OpenAiService extends SenderService {
 
                 configurationMap.put(
                     MODEL_ID,
-                    new SettingsConfiguration.Builder().setDescription("The name of the model to use for the inference task.")
+                    new SettingsConfiguration.Builder(SUPPORTED_TASK_TYPES_FOR_SERVICES_API).setDescription(
+                        "The name of the model to use for the inference task."
+                    )
                         .setLabel("Model ID")
                         .setRequired(true)
                         .setSensitive(false)
@@ -426,7 +428,9 @@ public class OpenAiService extends SenderService {
 
                 configurationMap.put(
                     ORGANIZATION,
-                    new SettingsConfiguration.Builder().setDescription("The unique identifier of your organization.")
+                    new SettingsConfiguration.Builder(SUPPORTED_TASK_TYPES_FOR_SERVICES_API).setDescription(
+                        "The unique identifier of your organization."
+                    )
                         .setLabel("Organization ID")
                         .setRequired(false)
                         .setSensitive(false)
@@ -437,7 +441,9 @@ public class OpenAiService extends SenderService {
 
                 configurationMap.put(
                     URL,
-                    new SettingsConfiguration.Builder().setDefaultValue("https://api.openai.com/v1/chat/completions")
+                    new SettingsConfiguration.Builder(SUPPORTED_TASK_TYPES_FOR_SERVICES_API).setDefaultValue(
+                        "https://api.openai.com/v1/chat/completions"
+                    )
                         .setDescription(
                             "The OpenAI API endpoint URL. For more information on the URL, refer to the "
                                 + "https://platform.openai.com/docs/api-reference."
@@ -453,12 +459,14 @@ public class OpenAiService extends SenderService {
                 configurationMap.putAll(
                     DefaultSecretSettings.toSettingsConfigurationWithDescription(
                         "The OpenAI API authentication key. For more details about generating OpenAI API keys, "
-                            + "refer to the https://platform.openai.com/account/api-keys."
+                            + "refer to the https://platform.openai.com/account/api-keys.",
+                        SUPPORTED_TASK_TYPES_FOR_SERVICES_API
                     )
                 );
                 configurationMap.putAll(
                     RateLimitSettings.toSettingsConfigurationWithDescription(
-                        "Default number of requests allowed per minute. For text_embedding is 3000. For completion is 500."
+                        "Default number of requests allowed per minute. For text_embedding is 3000. For completion is 500.",
+                        SUPPORTED_TASK_TYPES_FOR_SERVICES_API
                     )
                 );
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/settings/DefaultSecretSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/settings/DefaultSecretSettings.java
@@ -17,10 +17,12 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SecretSettings;
 import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -51,11 +53,14 @@ public record DefaultSecretSettings(SecureString apiKey) implements SecretSettin
         return new DefaultSecretSettings(secureApiToken);
     }
 
-    public static Map<String, SettingsConfiguration> toSettingsConfigurationWithDescription(String description) {
+    public static Map<String, SettingsConfiguration> toSettingsConfigurationWithDescription(
+        String description,
+        EnumSet<TaskType> supportedTaskTypes
+    ) {
         var configurationMap = new HashMap<String, SettingsConfiguration>();
         configurationMap.put(
             API_KEY,
-            new SettingsConfiguration.Builder().setDescription(description)
+            new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(description)
                 .setLabel("API Key")
                 .setRequired(true)
                 .setSensitive(true)
@@ -66,8 +71,11 @@ public record DefaultSecretSettings(SecureString apiKey) implements SecretSettin
         return configurationMap;
     }
 
-    public static Map<String, SettingsConfiguration> toSettingsConfiguration() {
-        return DefaultSecretSettings.toSettingsConfigurationWithDescription("API Key for the provider you're connecting to.");
+    public static Map<String, SettingsConfiguration> toSettingsConfiguration(EnumSet<TaskType> supportedTaskTypes) {
+        return DefaultSecretSettings.toSettingsConfigurationWithDescription(
+            "API Key for the provider you're connecting to.",
+            supportedTaskTypes
+        );
     }
 
     public DefaultSecretSettings {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/settings/RateLimitSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/settings/RateLimitSettings.java
@@ -12,12 +12,14 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 
 import java.io.IOException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -51,11 +53,14 @@ public class RateLimitSettings implements Writeable, ToXContentFragment {
         return requestsPerMinute == null ? defaultValue : new RateLimitSettings(requestsPerMinute);
     }
 
-    public static Map<String, SettingsConfiguration> toSettingsConfigurationWithDescription(String description) {
+    public static Map<String, SettingsConfiguration> toSettingsConfigurationWithDescription(
+        String description,
+        EnumSet<TaskType> supportedTaskTypes
+    ) {
         var configurationMap = new HashMap<String, SettingsConfiguration>();
         configurationMap.put(
             FIELD_NAME + "." + REQUESTS_PER_MINUTE_FIELD,
-            new SettingsConfiguration.Builder().setDescription(description)
+            new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(description)
                 .setLabel("Rate Limit")
                 .setRequired(false)
                 .setSensitive(false)
@@ -66,8 +71,8 @@ public class RateLimitSettings implements Writeable, ToXContentFragment {
         return configurationMap;
     }
 
-    public static Map<String, SettingsConfiguration> toSettingsConfiguration() {
-        return RateLimitSettings.toSettingsConfigurationWithDescription("Minimize the number of rate limit errors.");
+    public static Map<String, SettingsConfiguration> toSettingsConfiguration(EnumSet<TaskType> supportedTaskTypes) {
+        return RateLimitSettings.toSettingsConfigurationWithDescription("Minimize the number of rate limit errors.", supportedTaskTypes);
     }
 
     /**

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchServiceTests.java
@@ -448,7 +448,8 @@ public class AlibabaCloudSearchServiceTests extends ESTestCase {
                            "required": true,
                            "sensitive": false,
                            "updatable": false,
-                           "type": "str"
+                           "type": "str",
+                           "supported_task_types": ["text_embedding", "sparse_embedding", "rerank", "completion"]
                          },
                          "api_key": {
                            "description": "A valid API key for the AlibabaCloud AI Search API.",
@@ -456,7 +457,8 @@ public class AlibabaCloudSearchServiceTests extends ESTestCase {
                            "required": true,
                            "sensitive": true,
                            "updatable": true,
-                           "type": "str"
+                           "type": "str",
+                           "supported_task_types": ["text_embedding", "sparse_embedding", "rerank", "completion"]
                          },
                          "service_id": {
                            "description": "The name of the model service to use for the {infer} task.",
@@ -464,7 +466,8 @@ public class AlibabaCloudSearchServiceTests extends ESTestCase {
                            "required": true,
                            "sensitive": false,
                            "updatable": false,
-                           "type": "str"
+                           "type": "str",
+                           "supported_task_types": ["text_embedding", "sparse_embedding", "rerank", "completion"]
                          },
                          "host": {
                            "description": "The name of the host address used for the {infer} task. You can find the host address at https://opensearch.console.aliyun.com/cn-shanghai/rag/api-key[ the API keys section] of the documentation.",
@@ -472,7 +475,8 @@ public class AlibabaCloudSearchServiceTests extends ESTestCase {
                            "required": true,
                            "sensitive": false,
                            "updatable": false,
-                           "type": "str"
+                           "type": "str",
+                           "supported_task_types": ["text_embedding", "sparse_embedding", "rerank", "completion"]
                          },
                          "rate_limit.requests_per_minute": {
                            "description": "Minimize the number of rate limit errors.",
@@ -480,7 +484,8 @@ public class AlibabaCloudSearchServiceTests extends ESTestCase {
                            "required": false,
                            "sensitive": false,
                            "updatable": false,
-                           "type": "int"
+                           "type": "int",
+                           "supported_task_types": ["text_embedding", "sparse_embedding", "rerank", "completion"]
                          },
                          "http_schema": {
                            "description": "",
@@ -488,7 +493,8 @@ public class AlibabaCloudSearchServiceTests extends ESTestCase {
                            "required": true,
                            "sensitive": false,
                            "updatable": false,
-                           "type": "str"
+                           "type": "str",
+                           "supported_task_types": ["text_embedding", "sparse_embedding", "rerank", "completion"]
                          }
                        }
                     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
@@ -166,7 +166,8 @@ public class AmazonBedrockServiceTests extends ESTestCase {
                              "required": true,
                              "sensitive": true,
                              "updatable": true,
-                             "type": "str"
+                             "type": "str",
+                             "supported_task_types": ["text_embedding", "completion"]
                          },
                          "provider": {
                              "description": "The model provider for your deployment.",
@@ -174,7 +175,8 @@ public class AmazonBedrockServiceTests extends ESTestCase {
                              "required": true,
                              "sensitive": false,
                              "updatable": false,
-                             "type": "str"
+                             "type": "str",
+                             "supported_task_types": ["text_embedding", "completion"]
                          },
                          "access_key": {
                              "description": "A valid AWS access key that has permissions to use Amazon Bedrock.",
@@ -182,7 +184,8 @@ public class AmazonBedrockServiceTests extends ESTestCase {
                              "required": true,
                              "sensitive": true,
                              "updatable": true,
-                             "type": "str"
+                             "type": "str",
+                             "supported_task_types": ["text_embedding", "completion"]
                          },
                          "model": {
                              "description": "The base model ID or an ARN to a custom model based on a foundational model.",
@@ -190,7 +193,8 @@ public class AmazonBedrockServiceTests extends ESTestCase {
                              "required": true,
                              "sensitive": false,
                              "updatable": false,
-                             "type": "str"
+                             "type": "str",
+                             "supported_task_types": ["text_embedding", "completion"]
                          },
                          "rate_limit.requests_per_minute": {
                              "description": "By default, the amazonbedrock service sets the number of requests allowed per minute to 240.",
@@ -198,7 +202,8 @@ public class AmazonBedrockServiceTests extends ESTestCase {
                              "required": false,
                              "sensitive": false,
                              "updatable": false,
-                             "type": "int"
+                             "type": "int",
+                             "supported_task_types": ["text_embedding", "completion"]
                          },
                          "region": {
                              "description": "The region that your model or ARN is deployed in.",
@@ -206,7 +211,8 @@ public class AmazonBedrockServiceTests extends ESTestCase {
                              "required": true,
                              "sensitive": false,
                              "updatable": false,
-                             "type": "str"
+                             "type": "str",
+                             "supported_task_types": ["text_embedding", "completion"]
                          }
                      }
                  }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
@@ -614,7 +614,8 @@ public class AnthropicServiceTests extends ESTestCase {
                               "required": true,
                               "sensitive": true,
                               "updatable": true,
-                              "type": "str"
+                              "type": "str",
+                              "supported_task_types": ["completion"]
                           },
                           "rate_limit.requests_per_minute": {
                               "description": "By default, the anthropic service sets the number of requests allowed per minute to 50.",
@@ -622,7 +623,8 @@ public class AnthropicServiceTests extends ESTestCase {
                               "required": false,
                               "sensitive": false,
                               "updatable": false,
-                              "type": "int"
+                              "type": "int",
+                              "supported_task_types": ["completion"]
                           },
                           "model_id": {
                               "description": "The name of the model to use for the inference task.",
@@ -630,7 +632,8 @@ public class AnthropicServiceTests extends ESTestCase {
                               "required": true,
                               "sensitive": false,
                               "updatable": false,
-                              "type": "str"
+                              "type": "str",
+                              "supported_task_types": ["completion"]
                           }
                       }
                   }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioServiceTests.java
@@ -1400,7 +1400,8 @@ public class AzureAiStudioServiceTests extends ESTestCase {
                             "required": true,
                             "sensitive": false,
                             "updatable": false,
-                            "type": "str"
+                            "type": "str",
+                            "supported_task_types": ["text_embedding", "completion"]
                         },
                         "provider": {
                             "description": "The model provider for your deployment.",
@@ -1408,7 +1409,8 @@ public class AzureAiStudioServiceTests extends ESTestCase {
                             "required": true,
                             "sensitive": false,
                             "updatable": false,
-                            "type": "str"
+                            "type": "str",
+                            "supported_task_types": ["text_embedding", "completion"]
                         },
                         "api_key": {
                             "description": "API Key for the provider you're connecting to.",
@@ -1416,7 +1418,8 @@ public class AzureAiStudioServiceTests extends ESTestCase {
                             "required": true,
                             "sensitive": true,
                             "updatable": true,
-                            "type": "str"
+                            "type": "str",
+                            "supported_task_types": ["text_embedding", "completion"]
                         },
                         "rate_limit.requests_per_minute": {
                             "description": "Minimize the number of rate limit errors.",
@@ -1424,7 +1427,8 @@ public class AzureAiStudioServiceTests extends ESTestCase {
                             "required": false,
                             "sensitive": false,
                             "updatable": false,
-                            "type": "int"
+                            "type": "int",
+                            "supported_task_types": ["text_embedding", "completion"]
                         },
                         "target": {
                             "description": "The target URL of your Azure AI Studio model deployment.",
@@ -1432,7 +1436,8 @@ public class AzureAiStudioServiceTests extends ESTestCase {
                             "required": true,
                             "sensitive": false,
                             "updatable": false,
-                            "type": "str"
+                            "type": "str",
+                            "supported_task_types": ["text_embedding", "completion"]
                         }
                     }
                 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
@@ -1469,7 +1469,8 @@ public class AzureOpenAiServiceTests extends ESTestCase {
                                     "required": false,
                                     "sensitive": true,
                                     "updatable": true,
-                                    "type": "str"
+                                    "type": "str",
+                                    "supported_task_types": ["text_embedding", "completion"]
                                 },
                                 "entra_id": {
                                     "description": "You must provide either an API key or an Entra ID.",
@@ -1477,7 +1478,8 @@ public class AzureOpenAiServiceTests extends ESTestCase {
                                     "required": false,
                                     "sensitive": true,
                                     "updatable": true,
-                                    "type": "str"
+                                    "type": "str",
+                                    "supported_task_types": ["text_embedding", "completion"]
                                 },
                                 "rate_limit.requests_per_minute": {
                                     "description": "The azureopenai service sets a default number of requests allowed per minute depending on the task type.",
@@ -1485,7 +1487,8 @@ public class AzureOpenAiServiceTests extends ESTestCase {
                                     "required": false,
                                     "sensitive": false,
                                     "updatable": false,
-                                    "type": "int"
+                                    "type": "int",
+                                    "supported_task_types": ["text_embedding", "completion"]
                                 },
                                 "deployment_id": {
                                     "description": "The deployment name of your deployed models.",
@@ -1493,7 +1496,8 @@ public class AzureOpenAiServiceTests extends ESTestCase {
                                     "required": true,
                                     "sensitive": false,
                                     "updatable": false,
-                                    "type": "str"
+                                    "type": "str",
+                                    "supported_task_types": ["text_embedding", "completion"]
                                 },
                                 "resource_name": {
                                     "description": "The name of your Azure OpenAI resource.",
@@ -1501,7 +1505,8 @@ public class AzureOpenAiServiceTests extends ESTestCase {
                                     "required": true,
                                     "sensitive": false,
                                     "updatable": false,
-                                    "type": "str"
+                                    "type": "str",
+                                    "supported_task_types": ["text_embedding", "completion"]
                                 },
                                 "api_version": {
                                     "description": "The Azure API version ID to use.",
@@ -1509,7 +1514,8 @@ public class AzureOpenAiServiceTests extends ESTestCase {
                                     "required": true,
                                     "sensitive": false,
                                     "updatable": false,
-                                    "type": "str"
+                                    "type": "str",
+                                    "supported_task_types": ["text_embedding", "completion"]
                                 }
                             }
                         }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
@@ -1643,7 +1643,8 @@ public class CohereServiceTests extends ESTestCase {
                                 "required": true,
                                 "sensitive": true,
                                 "updatable": true,
-                                "type": "str"
+                                "type": "str",
+                                "supported_task_types": ["text_embedding", "rerank", "completion"]
                             },
                             "rate_limit.requests_per_minute": {
                                 "description": "Minimize the number of rate limit errors.",
@@ -1651,7 +1652,8 @@ public class CohereServiceTests extends ESTestCase {
                                 "required": false,
                                 "sensitive": false,
                                 "updatable": false,
-                                "type": "int"
+                                "type": "int",
+                                "supported_task_types": ["text_embedding", "rerank", "completion"]
                             }
                         }
                     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -581,7 +581,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
                                "required": false,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "int"
+                               "type": "int",
+                               "supported_task_types": ["sparse_embedding" , "chat_completion"]
                            },
                            "model_id": {
                                "description": "The name of the model to use for the inference task.",
@@ -589,7 +590,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["sparse_embedding" , "chat_completion"]
                            },
                            "max_input_tokens": {
                                "description": "Allows you to specify the maximum number of tokens per input.",
@@ -597,7 +599,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
                                "required": false,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "int"
+                               "type": "int",
+                               "supported_task_types": ["sparse_embedding"]
                            }
                        }
                    }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -1564,7 +1564,8 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": true,
-                               "type": "int"
+                               "type": "int",
+                               "supported_task_types": ["text_embedding", "sparse_embedding", "rerank"]
                            },
                            "num_threads": {
                                "default_value": 2,
@@ -1573,7 +1574,8 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "int"
+                               "type": "int",
+                               "supported_task_types": ["text_embedding", "sparse_embedding", "rerank"]
                            },
                            "model_id": {
                                "default_value": ".multilingual-e5-small",
@@ -1582,7 +1584,8 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["text_embedding", "sparse_embedding", "rerank"]
                            }
                        }
                    }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
@@ -1133,7 +1133,8 @@ public class GoogleAiStudioServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": true,
                                "updatable": true,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["text_embedding", "completion"]
                            },
                            "rate_limit.requests_per_minute": {
                                "description": "Minimize the number of rate limit errors.",
@@ -1141,7 +1142,8 @@ public class GoogleAiStudioServiceTests extends ESTestCase {
                                "required": false,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "int"
+                               "type": "int",
+                               "supported_task_types": ["text_embedding", "completion"]
                            },
                            "model_id": {
                                "description": "ID of the LLM you're using.",
@@ -1149,7 +1151,8 @@ public class GoogleAiStudioServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["text_embedding", "completion"]
                            }
                        }
                    }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiServiceTests.java
@@ -879,7 +879,8 @@ public class GoogleVertexAiServiceTests extends ESTestCase {
                                    "required": true,
                                    "sensitive": true,
                                    "updatable": true,
-                                   "type": "str"
+                                   "type": "str",
+                                   "supported_task_types": ["text_embedding", "rerank"]
                                },
                                "project_id": {
                                    "description": "The GCP Project ID which has Vertex AI API(s) enabled. For more information on the URL, refer to the {geminiVertexAIDocs}.",
@@ -887,7 +888,8 @@ public class GoogleVertexAiServiceTests extends ESTestCase {
                                    "required": true,
                                    "sensitive": false,
                                    "updatable": false,
-                                   "type": "str"
+                                   "type": "str",
+                                   "supported_task_types": ["text_embedding", "rerank"]
                                },
                                "location": {
                                    "description": "Please provide the GCP region where the Vertex AI API(s) is enabled. For more information, refer to the {geminiVertexAIDocs}.",
@@ -895,7 +897,8 @@ public class GoogleVertexAiServiceTests extends ESTestCase {
                                    "required": true,
                                    "sensitive": false,
                                    "updatable": false,
-                                   "type": "str"
+                                   "type": "str",
+                                   "supported_task_types": ["text_embedding", "rerank"]
                                },
                                "rate_limit.requests_per_minute": {
                                    "description": "Minimize the number of rate limit errors.",
@@ -903,7 +906,8 @@ public class GoogleVertexAiServiceTests extends ESTestCase {
                                    "required": false,
                                    "sensitive": false,
                                    "updatable": false,
-                                   "type": "int"
+                                   "type": "int",
+                                   "supported_task_types": ["text_embedding", "rerank"]
                                },
                                "model_id": {
                                    "description": "ID of the LLM you're using.",
@@ -911,7 +915,8 @@ public class GoogleVertexAiServiceTests extends ESTestCase {
                                    "required": true,
                                    "sensitive": false,
                                    "updatable": false,
-                                   "type": "str"
+                                   "type": "str",
+                                   "supported_task_types": ["text_embedding", "rerank"]
                                }
                            }
                        }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceElserServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceElserServiceTests.java
@@ -149,7 +149,8 @@ public class HuggingFaceElserServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": true,
                                "updatable": true,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["sparse_embedding"]
                            },
                            "rate_limit.requests_per_minute": {
                                "description": "Minimize the number of rate limit errors.",
@@ -157,7 +158,8 @@ public class HuggingFaceElserServiceTests extends ESTestCase {
                                "required": false,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "int"
+                               "type": "int",
+                               "supported_task_types": ["sparse_embedding"]
                            },
                            "url": {
                                "description": "The URL endpoint to use for the requests.",
@@ -165,7 +167,8 @@ public class HuggingFaceElserServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["sparse_embedding"]
                            }
                        }
                    }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
@@ -866,7 +866,8 @@ public class HuggingFaceServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": true,
                                "updatable": true,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["text_embedding", "sparse_embedding"]
                            },
                            "rate_limit.requests_per_minute": {
                                "description": "Minimize the number of rate limit errors.",
@@ -874,7 +875,8 @@ public class HuggingFaceServiceTests extends ESTestCase {
                                "required": false,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "int"
+                               "type": "int",
+                               "supported_task_types": ["text_embedding", "sparse_embedding"]
                            },
                            "url": {
                                "default_value": "https://api.openai.com/v1/embeddings",
@@ -883,7 +885,8 @@ public class HuggingFaceServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["text_embedding", "sparse_embedding"]
                            }
                        }
                    }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
@@ -985,7 +985,8 @@ public class IbmWatsonxServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["text_embedding"]
                            },
                            "model_id": {
                                "description": "The name of the model to use for the inference task.",
@@ -993,7 +994,8 @@ public class IbmWatsonxServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["text_embedding"]
                            },
                            "api_version": {
                                "description": "The IBM Watsonx API version ID to use.",
@@ -1001,7 +1003,8 @@ public class IbmWatsonxServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["text_embedding"]
                            },
                            "max_input_tokens": {
                                "description": "Allows you to specify the maximum number of tokens per input.",
@@ -1009,7 +1012,8 @@ public class IbmWatsonxServiceTests extends ESTestCase {
                                "required": false,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "int"
+                               "type": "int",
+                               "supported_task_types": ["text_embedding"]
                            },
                            "url": {
                                "description": "",
@@ -1017,7 +1021,8 @@ public class IbmWatsonxServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["text_embedding"]
                            }
                        }
                    }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
@@ -1843,7 +1843,8 @@ public class JinaAIServiceTests extends ESTestCase {
                                 "required": true,
                                 "sensitive": true,
                                 "updatable": true,
-                                "type": "str"
+                                "type": "str",
+                                "supported_task_types": ["text_embedding", "rerank"]
                             },
                             "rate_limit.requests_per_minute": {
                                 "description": "Minimize the number of rate limit errors.",
@@ -1851,7 +1852,8 @@ public class JinaAIServiceTests extends ESTestCase {
                                 "required": false,
                                 "sensitive": false,
                                 "updatable": false,
-                                "type": "int"
+                                "type": "int",
+                                "supported_task_types": ["text_embedding", "rerank"]
                             }
                         }
                     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
@@ -757,7 +757,8 @@ public class MistralServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": true,
                                "updatable": true,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["text_embedding"]
                            },
                            "model": {
                                "description": "Refer to the Mistral models documentation for the list of available text embedding models.",
@@ -765,7 +766,8 @@ public class MistralServiceTests extends ESTestCase {
                                "required": true,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "str"
+                               "type": "str",
+                               "supported_task_types": ["text_embedding"]
                            },
                            "rate_limit.requests_per_minute": {
                                "description": "Minimize the number of rate limit errors.",
@@ -773,7 +775,8 @@ public class MistralServiceTests extends ESTestCase {
                                "required": false,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "int"
+                               "type": "int",
+                               "supported_task_types": ["text_embedding"]
                            },
                            "max_input_tokens": {
                                "description": "Allows you to specify the maximum number of tokens per input.",
@@ -781,7 +784,8 @@ public class MistralServiceTests extends ESTestCase {
                                "required": false,
                                "sensitive": false,
                                "updatable": false,
-                               "type": "int"
+                               "type": "int",
+                               "supported_task_types": ["text_embedding"]
                            }
                        }
                    }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
@@ -1748,7 +1748,8 @@ public class OpenAiServiceTests extends ESTestCase {
                                     "required": true,
                                     "sensitive": true,
                                     "updatable": true,
-                                    "type": "str"
+                                    "type": "str",
+                                    "supported_task_types": ["text_embedding", "completion", "chat_completion"]
                                 },
                                 "organization_id": {
                                     "description": "The unique identifier of your organization.",
@@ -1756,7 +1757,8 @@ public class OpenAiServiceTests extends ESTestCase {
                                     "required": false,
                                     "sensitive": false,
                                     "updatable": false,
-                                    "type": "str"
+                                    "type": "str",
+                                    "supported_task_types": ["text_embedding", "completion", "chat_completion"]
                                 },
                                 "rate_limit.requests_per_minute": {
                                     "description": "Default number of requests allowed per minute. For text_embedding is 3000. For completion is 500.",
@@ -1764,7 +1766,8 @@ public class OpenAiServiceTests extends ESTestCase {
                                     "required": false,
                                     "sensitive": false,
                                     "updatable": false,
-                                    "type": "int"
+                                    "type": "int",
+                                    "supported_task_types": ["text_embedding", "completion", "chat_completion"]
                                 },
                                 "model_id": {
                                     "description": "The name of the model to use for the inference task.",
@@ -1772,7 +1775,8 @@ public class OpenAiServiceTests extends ESTestCase {
                                     "required": true,
                                     "sensitive": false,
                                     "updatable": false,
-                                    "type": "str"
+                                    "type": "str",
+                                    "supported_task_types": ["text_embedding", "completion", "chat_completion"]
                                 },
                                 "url": {
                                     "default_value": "https://api.openai.com/v1/chat/completions",
@@ -1781,7 +1785,8 @@ public class OpenAiServiceTests extends ESTestCase {
                                     "required": true,
                                     "sensitive": false,
                                     "updatable": false,
-                                    "type": "str"
+                                    "type": "str",
+                                    "supported_task_types": ["text_embedding", "completion", "chat_completion"]
                                 }
                             }
                         }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Adds a new field supported_task_types in the configuration response (#120150)