### PR TITLE
[8.x] Fix `CrossClusterEsqlEnrichUnavailableRemotesIT`: also track `node_not_connected_exception` as a valid node not available error (#120413)

### DIFF
--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1EnrichUnavailableRemotesIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1EnrichUnavailableRemotesIT.java
@@ -187,7 +187,10 @@ public class CrossClusterEsqlRCS1EnrichUnavailableRemotesIT extends AbstractRemo
             Map<String, ?> failuresMap = (Map<String, ?>) remoteClusterFailures.get(0);
 
             Map<String, ?> reason = (Map<String, ?>) failuresMap.get("reason");
-            assertThat(reason.get("type").toString(), oneOf("node_disconnected_exception", "connect_transport_exception"));
+            assertThat(
+                reason.get("type").toString(),
+                oneOf("node_disconnected_exception", "connect_transport_exception", "node_not_connected_exception")
+            );
         } finally {
             fulfillingCluster.start();
             closeFulfillingClusterClient();
@@ -206,7 +209,11 @@ public class CrossClusterEsqlRCS1EnrichUnavailableRemotesIT extends AbstractRemo
 
             assertThat(
                 ex.getMessage(),
-                anyOf(containsString("connect_transport_exception"), containsString("node_disconnected_exception"))
+                anyOf(
+                    containsString("connect_transport_exception"),
+                    containsString("node_disconnected_exception"),
+                    containsString("node_not_connected_exception")
+                )
             );
         } finally {
             fulfillingCluster.start();

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS2EnrichUnavailableRemotesIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS2EnrichUnavailableRemotesIT.java
@@ -207,7 +207,10 @@ public class CrossClusterEsqlRCS2EnrichUnavailableRemotesIT extends AbstractRemo
             Map<String, ?> failuresMap = (Map<String, ?>) remoteClusterFailures.get(0);
 
             Map<String, ?> reason = (Map<String, ?>) failuresMap.get("reason");
-            assertThat(reason.get("type").toString(), oneOf("node_disconnected_exception", "connect_transport_exception"));
+            assertThat(
+                reason.get("type").toString(),
+                oneOf("node_disconnected_exception", "connect_transport_exception", "node_not_connected_exception")
+            );
         } finally {
             fulfillingCluster.start();
             closeFulfillingClusterClient();
@@ -225,7 +228,11 @@ public class CrossClusterEsqlRCS2EnrichUnavailableRemotesIT extends AbstractRemo
             ResponseException ex = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUser(esqlRequest(query)));
             assertThat(
                 ex.getMessage(),
-                anyOf(containsString("connect_transport_exception"), containsString("node_disconnected_exception"))
+                anyOf(
+                    containsString("connect_transport_exception"),
+                    containsString("node_disconnected_exception"),
+                    containsString("node_not_connected_exception")
+                )
             );
         } finally {
             fulfillingCluster.start();


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix `CrossClusterEsqlEnrichUnavailableRemotesIT`: also track `node_not_connected_exception` as a valid node not available error (#120413)