### PR TITLE
Esql date casting tests

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -1463,7 +1463,7 @@ emp_no:integer | first_name:keyword
 10025          | Prasadram 
 ;
 
-IN operator with null in list, finds match
+IN operator with null in list, finds match#[skip:-8.13.99, reason: default date formatter is changed in 8.14]
 
 FROM employees
 | EVAL x = NULL
@@ -1474,7 +1474,7 @@ birth_date:datetime      | first_name:keyword
 1958-02-19T00:00:00.000Z | Saniya     
 ;
 
-IN operator with null in list, doesn't find match
+IN operator with null in list, doesn't find match#[skip:-8.13.99, reason: default date formatter is changed in 8.14]
 
 FROM employees
 | EVAL x = NULL
@@ -1484,7 +1484,7 @@ FROM employees
 birth_date:datetime      | first_name:keyword
 ;
 
-IN operator with null in list, doesn't find match, EVAL to check value
+IN operator with null in list, doesn't find match, EVAL to check value#[skip:-8.13.99, reason: default date formatter is changed in 8.14]
 
 FROM employees
 | EVAL x = NULL

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -1452,6 +1452,7 @@ cnt:long
 ;
 
 implicit casting strings to dates for IN operator
+required_capability: string_literal_auto_casting
 FROM employees
 | WHERE birth_date IN ("1953-04-20", "1958-10-31")
 | KEEP emp_no, first_name;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_nanos.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_nanos.csv-spec
@@ -748,6 +748,7 @@ ct:long | mo:date_nanos
 Bucket Date nanos by 10 minutes
 required_capability: date_trunc_date_nanos
 required_capability: date_nanos_bucket
+required_capability: string_literal_auto_casting
 
 FROM date_nanos 
 | WHERE millis > "2020-01-01" 


### PR DESCRIPTION
This adds appropriate ignore annotations for the date tests I added in https://github.com/elastic/elasticsearch/pull/119772 to not run the tests against very old versions. Should be a no-op for main, but fix some tests in 8.x BWC.  Still, I'd rather keep the tests in sync, so I'm applying this to main first.  It's not set for auto-backport because I'll need to add the unmutes to the backport.

