### PR TITLE
Counted keyword synthetic source inherit keep

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -269,7 +269,9 @@ public final class DocumentParser {
         for (RuntimeField runtimeField : context.getDynamicRuntimeFields()) {
             rootBuilder.addRuntimeField(runtimeField);
         }
-        RootObjectMapper root = rootBuilder.build(MapperBuilderContext.root(context.mappingLookup().isSourceSynthetic(), false));
+        RootObjectMapper root = rootBuilder.build(
+            MapperBuilderContext.root(context.mappingLookup().isSourceSynthetic(), context.sourceKeepModeFromIndexSettings(), false)
+        );
         return context.mappingLookup().getMapping().mappingUpdate(root);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -452,7 +452,7 @@ public final class DocumentParser {
                 parseObjectOrNested(context.createFlattenContext(currentFieldName));
                 context.path().add(currentFieldName);
             } else {
-                var sourceKeepMode = getSourceKeepMode(context, fieldMapper.sourceKeepMode());
+                var sourceKeepMode = fieldMapper.sourceKeepMode();
                 if (context.canAddIgnoredField()
                     && (fieldMapper.syntheticSourceMode() == FieldMapper.SyntheticSourceMode.FALLBACK
                         || sourceKeepMode == Mapper.SourceKeepMode.ALL
@@ -700,7 +700,7 @@ public final class DocumentParser {
             boolean fieldWithFallbackSyntheticSource = false;
             boolean fieldWithStoredArraySource = false;
             if (mapper instanceof FieldMapper fieldMapper) {
-                mode = getSourceKeepMode(context, fieldMapper.sourceKeepMode());
+                mode = fieldMapper.sourceKeepMode();
                 fieldWithFallbackSyntheticSource = fieldMapper.syntheticSourceMode() == FieldMapper.SyntheticSourceMode.FALLBACK;
                 fieldWithStoredArraySource = mode != Mapper.SourceKeepMode.NONE;
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -785,6 +785,7 @@ public abstract class DocumentParserContext {
         var contextParams = new MapperBuilderContext.MapperBuilderContextParams(
             p,
             mappingLookup.isSourceSynthetic(),
+            sourceKeepModeFromIndexSettings(),
             mappingLookup.isDataStreamTimestampFieldEnabled(),
             containsDimensions,
             dynamic,

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -781,15 +781,16 @@ public abstract class DocumentParserContext {
         if (objectMapper instanceof PassThroughObjectMapper passThroughObjectMapper) {
             containsDimensions = passThroughObjectMapper.containsDimensions();
         }
-        return new MapperBuilderContext(
+
+        var contextParams = new MapperBuilderContext.MapperBuilderContextParams(
             p,
             mappingLookup.isSourceSynthetic(),
             mappingLookup.isDataStreamTimestampFieldEnabled(),
             containsDimensions,
             dynamic,
-            MergeReason.MAPPING_UPDATE,
-            false
+            MergeReason.MAPPING_UPDATE
         );
+        return new MapperBuilderContext(contextParams, false);
     }
 
     public abstract XContentParser parser();

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperBuilderContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperBuilderContext.java
@@ -14,6 +14,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Holds context for building Mapper objects from their Builders
@@ -24,13 +25,27 @@ public class MapperBuilderContext {
      * The root context, to be used when building a tree of mappers
      */
     public static MapperBuilderContext root(boolean isSourceSynthetic, boolean isDataStream) {
-        return root(isSourceSynthetic, isDataStream, MergeReason.MAPPING_UPDATE);
+        return root(isSourceSynthetic, Mapper.SourceKeepMode.NONE, isDataStream, MergeReason.MAPPING_UPDATE);
+    }
+
+    public static MapperBuilderContext root(boolean isSourceSynthetic, Mapper.SourceKeepMode sourceKeepMode, boolean isDataStream) {
+        return root(isSourceSynthetic, sourceKeepMode, isDataStream, MergeReason.MAPPING_UPDATE);
     }
 
     public static MapperBuilderContext root(boolean isSourceSynthetic, boolean isDataStream, MergeReason mergeReason) {
+        return root(isSourceSynthetic, Mapper.SourceKeepMode.NONE, isDataStream, mergeReason);
+    }
+
+    public static MapperBuilderContext root(
+        boolean isSourceSynthetic,
+        Mapper.SourceKeepMode sourceKeepMode,
+        boolean isDataStream,
+        MergeReason mergeReason
+    ) {
         var params = new MapperBuilderContextParams(
             null,
             isSourceSynthetic,
+            sourceKeepMode,
             isDataStream,
             false,
             ObjectMapper.Defaults.DYNAMIC,
@@ -41,6 +56,7 @@ public class MapperBuilderContext {
 
     private final String path;
     private final boolean isSourceSynthetic;
+    private final Mapper.SourceKeepMode sourceKeepMode;
     private final boolean isDataStream;
     private final boolean parentObjectContainsDimensions;
     private final ObjectMapper.Dynamic dynamic;
@@ -58,6 +74,7 @@ public class MapperBuilderContext {
     public record MapperBuilderContextParams(
         String path,
         boolean isSourceSynthetic,
+        Mapper.SourceKeepMode sourceKeepMode,
         boolean isDataStream,
         boolean parentObjectContainsDimensions,
         ObjectMapper.Dynamic dynamic,
@@ -72,6 +89,7 @@ public class MapperBuilderContext {
         Objects.requireNonNull(params, "params must not be null");
         this.path = params.path;
         this.isSourceSynthetic = params.isSourceSynthetic;
+        this.sourceKeepMode = params.sourceKeepMode;
         this.isDataStream = params.isDataStream;
         this.parentObjectContainsDimensions = params.parentObjectContainsDimensions;
         this.dynamic = params.dynamic;
@@ -87,7 +105,51 @@ public class MapperBuilderContext {
      * @return a new MapperBuilderContext with this context as its parent
      */
     public MapperBuilderContext createChildContext(String name, @Nullable ObjectMapper.Dynamic dynamic) {
-        return createChildContext(name, this.parentObjectContainsDimensions, dynamic);
+        return createChildContext(name, this.parentObjectContainsDimensions, dynamic, Optional.empty());
+    }
+
+    /**
+     * Creates a new MapperBuilderContext that is a child of this context
+     *
+     * @param name    the name of the child context
+     * @param dynamic strategy for handling dynamic mappings in this context
+     * @param sourceKeepMode the synthetic_source_keep mapping setting configured on the child
+     * @return a new MapperBuilderContext with this context as its parent
+     */
+    public MapperBuilderContext createChildContext(
+        String name,
+        @Nullable ObjectMapper.Dynamic dynamic,
+        Optional<Mapper.SourceKeepMode> sourceKeepMode
+    ) {
+        return createChildContext(name, this.parentObjectContainsDimensions, dynamic, sourceKeepMode);
+    }
+
+    /**
+     * Creates a new MapperBuilderContext that is a child of this context
+     *
+     * @param name    the name of the child context
+     * @param dynamic strategy for handling dynamic mappings in this context
+     * @param parentObjectContainsDimensions whether the parent object contains dimensions
+     * @param sourceKeepMode the synthetic_source_keep mapping setting configured on the child
+     * @return a new MapperBuilderContext with this context as its parent
+     */
+    public MapperBuilderContext createChildContext(
+        String name,
+        boolean parentObjectContainsDimensions,
+        @Nullable ObjectMapper.Dynamic dynamic,
+        Optional<Mapper.SourceKeepMode> sourceKeepMode
+    ) {
+        var params = new MapperBuilderContextParams(
+            buildFullName(name),
+            this.isSourceSynthetic,
+            sourceKeepMode.orElseGet(this::sourceKeepMode),
+            this.isDataStream,
+            parentObjectContainsDimensions,
+            getDynamic(dynamic),
+            this.mergeReason
+        );
+
+        return new MapperBuilderContext(params, isInNestedContext());
     }
 
     /**
@@ -103,16 +165,7 @@ public class MapperBuilderContext {
         boolean parentObjectContainsDimensions,
         @Nullable ObjectMapper.Dynamic dynamic
     ) {
-        var params = new MapperBuilderContextParams(
-            buildFullName(name),
-            this.isSourceSynthetic,
-            this.isDataStream,
-            parentObjectContainsDimensions,
-            getDynamic(dynamic),
-            this.mergeReason
-        );
-
-        return new MapperBuilderContext(params, isInNestedContext());
+        return createChildContext(name, parentObjectContainsDimensions, dynamic, Optional.empty());
     }
 
     protected ObjectMapper.Dynamic getDynamic(@Nullable ObjectMapper.Dynamic dynamic) {
@@ -134,6 +187,13 @@ public class MapperBuilderContext {
      */
     public boolean isSourceSynthetic() {
         return isSourceSynthetic;
+    }
+
+    /**
+     * Should the {@code _source} field be stored to avoid synthetic source modifications?
+     */
+    public Mapper.SourceKeepMode sourceKeepMode() {
+        return sourceKeepMode;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -143,7 +143,13 @@ public final class Mapping implements ToXContentFragment {
      * @return the resulting merged mapping.
      */
     Mapping merge(Mapping mergeWith, MergeReason reason, long newFieldsBudget) {
-        MapperMergeContext mergeContext = MapperMergeContext.root(isSourceSynthetic(), false, reason, newFieldsBudget);
+        MapperMergeContext mergeContext = MapperMergeContext.root(
+            isSourceSynthetic(),
+            getRoot().sourceKeepMode().orElse(Mapper.SourceKeepMode.NONE),
+            false,
+            reason,
+            newFieldsBudget
+        );
         RootObjectMapper mergedRoot = root.merge(mergeWith.root, mergeContext);
 
         // When merging metadata fields as part of applying an index template, new field definitions
@@ -182,7 +188,13 @@ public final class Mapping implements ToXContentFragment {
      * @param fieldsBudget the maximum number of fields this mapping may have
      */
     public Mapping withFieldsBudget(long fieldsBudget) {
-        MapperMergeContext mergeContext = MapperMergeContext.root(isSourceSynthetic(), false, MergeReason.MAPPING_RECOVERY, fieldsBudget);
+        MapperMergeContext mergeContext = MapperMergeContext.root(
+            isSourceSynthetic(),
+            getRoot().sourceKeepMode().orElse(Mapper.SourceKeepMode.NONE),
+            false,
+            MergeReason.MAPPING_RECOVERY,
+            fieldsBudget
+        );
         // get a copy of the root mapper, without any fields
         RootObjectMapper shallowRoot = root.withoutMappers();
         // calling merge on the shallow root to ensure we're only adding as many fields as allowed by the fields budget

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -192,7 +192,9 @@ public final class MappingParser {
         }
 
         return new Mapping(
-            rootObjectMapper.build(MapperBuilderContext.root(isSourceSynthetic, isDataStream, reason)),
+            rootObjectMapper.build(
+                MapperBuilderContext.root(isSourceSynthetic, mappingParserContext.getIndexSettings().sourceKeepMode(), isDataStream, reason)
+            ),
             metadataMappers.values().toArray(new MetadataFieldMapper[0]),
             meta
         );

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -113,14 +113,16 @@ public class NestedObjectMapper extends ObjectMapper {
             }
             final Query nestedTypeFilter = NestedPathFieldMapper.filter(indexCreatedVersion, nestedTypePath);
             NestedMapperBuilderContext nestedContext = new NestedMapperBuilderContext(
-                context.buildFullName(leafName()),
-                context.isSourceSynthetic(),
-                context.isDataStream(),
-                context.parentObjectContainsDimensions(),
+                new MapperBuilderContext.MapperBuilderContextParams(
+                    context.buildFullName(leafName()),
+                    context.isSourceSynthetic(),
+                    context.isDataStream(),
+                    context.parentObjectContainsDimensions(),
+                    context.getDynamic(dynamic),
+                    context.getMergeReason()
+                ),
                 nestedTypeFilter,
-                parentIncludedInRoot,
-                context.getDynamic(dynamic),
-                context.getMergeReason()
+                parentIncludedInRoot
             );
             return new NestedObjectMapper(
                 leafName(),
@@ -179,32 +181,26 @@ public class NestedObjectMapper extends ObjectMapper {
         final Query nestedTypeFilter;
 
         NestedMapperBuilderContext(
-            String path,
-            boolean isSourceSynthetic,
-            boolean isDataStream,
-            boolean parentObjectContainsDimensions,
+            MapperBuilderContextParams mapperBuilderContextParams,
             Query nestedTypeFilter,
-            boolean parentIncludedInRoot,
-            Dynamic dynamic,
-            MapperService.MergeReason mergeReason
+            boolean parentIncludedInRoot
         ) {
-            super(path, isSourceSynthetic, isDataStream, parentObjectContainsDimensions, dynamic, mergeReason, true);
+            super(mapperBuilderContextParams, true);
             this.parentIncludedInRoot = parentIncludedInRoot;
             this.nestedTypeFilter = nestedTypeFilter;
         }
 
         @Override
         public MapperBuilderContext createChildContext(String name, Dynamic dynamic) {
-            return new NestedMapperBuilderContext(
+            var params = new MapperBuilderContextParams(
                 buildFullName(name),
                 isSourceSynthetic(),
                 isDataStream(),
                 parentObjectContainsDimensions(),
-                nestedTypeFilter,
-                parentIncludedInRoot,
                 getDynamic(dynamic),
                 getMergeReason()
             );
+            return new NestedMapperBuilderContext(params, nestedTypeFilter, parentIncludedInRoot);
         }
     }
 
@@ -396,14 +392,16 @@ public class NestedObjectMapper extends ObjectMapper {
         }
         return mapperMergeContext.createChildContext(
             new NestedMapperBuilderContext(
-                mapperBuilderContext.buildFullName(name),
-                mapperBuilderContext.isSourceSynthetic(),
-                mapperBuilderContext.isDataStream(),
-                mapperBuilderContext.parentObjectContainsDimensions(),
+                new MapperBuilderContext.MapperBuilderContextParams(
+                    mapperBuilderContext.buildFullName(name),
+                    mapperBuilderContext.isSourceSynthetic(),
+                    mapperBuilderContext.isDataStream(),
+                    mapperBuilderContext.parentObjectContainsDimensions(),
+                    mapperBuilderContext.getDynamic(dynamic),
+                    mapperBuilderContext.getMergeReason()
+                ),
                 nestedTypeFilter,
-                parentIncludedInRoot,
-                mapperBuilderContext.getDynamic(dynamic),
-                mapperBuilderContext.getMergeReason()
+                parentIncludedInRoot
             )
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -116,6 +116,7 @@ public class NestedObjectMapper extends ObjectMapper {
                 new MapperBuilderContext.MapperBuilderContextParams(
                     context.buildFullName(leafName()),
                     context.isSourceSynthetic(),
+                    sourceKeepMode.orElseGet(context::sourceKeepMode),
                     context.isDataStream(),
                     context.parentObjectContainsDimensions(),
                     context.getDynamic(dynamic),
@@ -191,10 +192,11 @@ public class NestedObjectMapper extends ObjectMapper {
         }
 
         @Override
-        public MapperBuilderContext createChildContext(String name, Dynamic dynamic) {
+        public MapperBuilderContext createChildContext(String name, Dynamic dynamic, Optional<Mapper.SourceKeepMode> sourceKeepMode) {
             var params = new MapperBuilderContextParams(
                 buildFullName(name),
                 isSourceSynthetic(),
+                sourceKeepMode.orElseGet(this::sourceKeepMode),
                 isDataStream(),
                 parentObjectContainsDimensions(),
                 getDynamic(dynamic),
@@ -395,6 +397,7 @@ public class NestedObjectMapper extends ObjectMapper {
                 new MapperBuilderContext.MapperBuilderContextParams(
                     mapperBuilderContext.buildFullName(name),
                     mapperBuilderContext.isSourceSynthetic(),
+                    sourceKeepMode.orElseGet(mapperMergeContext.getMapperBuilderContext()::sourceKeepMode),
                     mapperBuilderContext.isDataStream(),
                     mapperBuilderContext.parentObjectContainsDimensions(),
                     mapperBuilderContext.getDynamic(dynamic),

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -254,7 +254,7 @@ public class ObjectMapper extends Mapper {
                 subobjects,
                 sourceKeepMode,
                 dynamic,
-                buildMappers(context.createChildContext(leafName(), dynamic))
+                buildMappers(context.createChildContext(leafName(), dynamic, sourceKeepMode))
             );
         }
     }
@@ -546,7 +546,7 @@ public class ObjectMapper extends Mapper {
     }
 
     protected MapperMergeContext createChildContext(MapperMergeContext mapperMergeContext, String name) {
-        return mapperMergeContext.createChildContext(name, dynamic);
+        return mapperMergeContext.createChildContext(name, dynamic, sourceKeepMode);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/PassThroughObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/PassThroughObjectMapper.java
@@ -78,7 +78,7 @@ public class PassThroughObjectMapper extends ObjectMapper {
                 enabled,
                 sourceKeepMode,
                 dynamic,
-                buildMappers(context.createChildContext(leafName(), timeSeriesDimensionSubFields.value(), dynamic)),
+                buildMappers(context.createChildContext(leafName(), timeSeriesDimensionSubFields.value(), dynamic, sourceKeepMode)),
                 timeSeriesDimensionSubFields,
                 priority
             );

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -115,7 +115,7 @@ public class RootObjectMapper extends ObjectMapper {
                 subobjects,
                 sourceKeepMode,
                 dynamic,
-                buildMappers(context.createChildContext(null, dynamic)),
+                buildMappers(context.createChildContext(null, dynamic, sourceKeepMode)),
                 new HashMap<>(runtimeFields),
                 dynamicDateTimeFormatters,
                 dynamicTemplates,
@@ -221,7 +221,7 @@ public class RootObjectMapper extends ObjectMapper {
     @Override
     protected MapperMergeContext createChildContext(MapperMergeContext mapperMergeContext, String name) {
         assert Objects.equals(mapperMergeContext.getMapperBuilderContext().buildFullName("foo"), "foo");
-        return mapperMergeContext.createChildContext(null, dynamic);
+        return mapperMergeContext.createChildContext(null, dynamic, sourceKeepMode);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1456,8 +1456,8 @@ public final class TextFieldMapper extends FieldMapper {
         b.store.toXContent(builder, includeDefaults);
         multiFields().toXContent(builder, params);
         copyTo().toXContent(builder);
-        if (sourceKeepMode().isPresent()) {
-            sourceKeepMode().get().toXContent(builder);
+        if (localSourceKeepMode().isPresent()) {
+            localSourceKeepMode().get().toXContent(builder);
         }
         b.meta.toXContent(builder, includeDefaults);
         b.indexOptions.toXContent(builder, includeDefaults);

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
@@ -162,12 +162,14 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
     private static FieldMapper createFieldMapper(String parent, String name) {
         return new BooleanFieldMapper.Builder(name, ScriptCompiler.NONE, false, IndexVersion.current()).build(
             new MapperBuilderContext(
-                parent,
-                false,
-                false,
-                false,
-                ObjectMapper.Defaults.DYNAMIC,
-                MapperService.MergeReason.MAPPING_UPDATE,
+                new MapperBuilderContext.MapperBuilderContextParams(
+                    parent,
+                    false,
+                    false,
+                    false,
+                    ObjectMapper.Defaults.DYNAMIC,
+                    MapperService.MergeReason.MAPPING_UPDATE
+                ),
                 false
             )
         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
@@ -165,6 +165,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
                 new MapperBuilderContext.MapperBuilderContextParams(
                     parent,
                     false,
+                    Mapper.SourceKeepMode.NONE,
                     false,
                     false,
                     ObjectMapper.Defaults.DYNAMIC,

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -728,13 +728,9 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
     }
 
     @Override
-    public void testSyntheticSourceKeepArrays() {
+    public boolean supportsNestedArrayValues() {
         // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
-    }
-
-    @Override
-    public void testSyntheticSourceInheritsKeepArrays() {
-        // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
+        return false;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -733,6 +733,11 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
     }
 
     @Override
+    public void testSyntheticSourceInheritsKeepArrays() {
+        // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
+    }
+
+    @Override
     protected IngestScriptSupport ingestScriptSupport() {
         throw new AssumptionViolatedException("not supported");
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -1919,15 +1919,18 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testIsInNestedContext() {
-        NestedObjectMapper.NestedMapperBuilderContext context = new NestedObjectMapper.NestedMapperBuilderContext(
+        var mapperBuilderParams = new MapperBuilderContext.MapperBuilderContextParams(
             "nested_path",
             false,
             false,
             false,
-            null,
-            false,
             Dynamic.FALSE,
             MergeReason.INDEX_TEMPLATE
+        );
+        NestedObjectMapper.NestedMapperBuilderContext context = new NestedObjectMapper.NestedMapperBuilderContext(
+            mapperBuilderParams,
+            null,
+            false
         );
         assertTrue(context.isInNestedContext());
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -1922,6 +1922,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
         var mapperBuilderParams = new MapperBuilderContext.MapperBuilderContextParams(
             "nested_path",
             false,
+            Mapper.SourceKeepMode.NONE,
             false,
             false,
             Dynamic.FALSE,

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -365,12 +365,14 @@ public final class ObjectMapperMergeTests extends ESTestCase {
         KeywordFieldMapper.Builder fieldBuilder = new KeywordFieldMapper.Builder("host.name", IndexVersion.current());
         KeywordFieldMapper fieldMapper = fieldBuilder.build(
             new MapperBuilderContext(
-                "foo.metrics",
-                false,
-                false,
-                false,
-                ObjectMapper.Defaults.DYNAMIC,
-                MapperService.MergeReason.MAPPING_UPDATE,
+                new MapperBuilderContext.MapperBuilderContextParams(
+                    "foo.metrics",
+                    false,
+                    false,
+                    false,
+                    ObjectMapper.Defaults.DYNAMIC,
+                    MapperService.MergeReason.MAPPING_UPDATE
+                ),
                 false
             )
         );
@@ -385,12 +387,14 @@ public final class ObjectMapperMergeTests extends ESTestCase {
         TextFieldMapper.Builder fieldBuilder = createTextKeywordMultiField("host.name");
         TextFieldMapper textKeywordMultiField = fieldBuilder.build(
             new MapperBuilderContext(
-                "foo.metrics",
-                false,
-                false,
-                false,
-                ObjectMapper.Defaults.DYNAMIC,
-                MapperService.MergeReason.MAPPING_UPDATE,
+                new MapperBuilderContext.MapperBuilderContextParams(
+                    "foo.metrics",
+                    false,
+                    false,
+                    false,
+                    ObjectMapper.Defaults.DYNAMIC,
+                    MapperService.MergeReason.MAPPING_UPDATE
+                ),
                 false
             )
         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -368,6 +368,7 @@ public final class ObjectMapperMergeTests extends ESTestCase {
                 new MapperBuilderContext.MapperBuilderContextParams(
                     "foo.metrics",
                     false,
+                    Mapper.SourceKeepMode.NONE,
                     false,
                     false,
                     ObjectMapper.Defaults.DYNAMIC,
@@ -390,6 +391,7 @@ public final class ObjectMapperMergeTests extends ESTestCase {
                 new MapperBuilderContext.MapperBuilderContextParams(
                     "foo.metrics",
                     false,
+                    Mapper.SourceKeepMode.NONE,
                     false,
                     false,
                     ObjectMapper.Defaults.DYNAMIC,

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -2150,12 +2150,8 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
     }
 
     @Override
-    public void testSyntheticSourceKeepArrays() {
+    public boolean supportsNestedArrayValues() {
         // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
-    }
-
-    @Override
-    public void testSyntheticSourceInheritsKeepArrays() {
-        // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
+        return false;
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -2153,4 +2153,9 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
     public void testSyntheticSourceKeepArrays() {
         // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
     }
+
+    @Override
+    public void testSyntheticSourceInheritsKeepArrays() {
+        // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1705,6 +1705,34 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         assertThat(syntheticSource(mapperAll, example::buildInput), equalTo(expected));
     }
 
+    public void testSyntheticSourceInheritsKeepAll() throws IOException {
+        SyntheticSourceExample example = syntheticSourceSupportForKeepTests(shouldUseIgnoreMalformed()).example(1);
+        DocumentMapper mapperAll = createSytheticSourceMapperService(mapping(b -> {
+            b.startObject("wrapper");
+            b.field("type", "object");
+            b.field("synthetic_source_keep", "all");
+            b.startObject("properties");
+            b.startObject("field");
+            example.mapping().accept(b);
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        })).documentMapper();
+
+        CheckedConsumer<XContentBuilder, IOException> buildInput = (XContentBuilder builder) -> {
+            builder.startObject("wrapper");
+            example.buildInput(builder);
+            builder.endObject();
+        };
+
+        var builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        buildInput.accept(builder);
+        builder.endObject();
+        String expected = Strings.toString(builder);
+        assertThat(syntheticSource(mapperAll, buildInput), equalTo(expected));
+    }
+
     public void testSyntheticSourceKeepArrays() throws IOException {
         SyntheticSourceExample example = syntheticSourceSupportForKeepTests(shouldUseIgnoreMalformed()).example(1);
         DocumentMapper mapperAll = createSytheticSourceMapperService(mapping(b -> {
@@ -1717,6 +1745,36 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         int elementCount = randomIntBetween(2, 5);
         CheckedConsumer<XContentBuilder, IOException> buildInput = (XContentBuilder builder) -> {
             example.buildInputArray(builder, elementCount);
+        };
+
+        var builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        buildInput.accept(builder);
+        builder.endObject();
+        String expected = Strings.toString(builder);
+        String actual = syntheticSource(mapperAll, buildInput);
+        assertThat(actual, equalTo(expected));
+    }
+
+    public void testSyntheticSourceInheritsKeepArrays() throws IOException {
+        SyntheticSourceExample example = syntheticSourceSupportForKeepTests(shouldUseIgnoreMalformed()).example(1);
+        DocumentMapper mapperAll = createSytheticSourceMapperService(mapping(b -> {
+            b.startObject("wrapper");
+            b.field("type", "object");
+            b.field("synthetic_source_keep", "arrays");  // Both options keep array source.
+            b.startObject("properties");
+            b.startObject("field");
+            example.mapping().accept(b);
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        })).documentMapper();
+
+        int elementCount = randomIntBetween(2, 5);
+        CheckedConsumer<XContentBuilder, IOException> buildInput = (XContentBuilder builder) -> {
+            builder.startObject("wrapper");
+            example.buildInputArray(builder, elementCount);
+            builder.endObject();
         };
 
         var builder = XContentFactory.jsonBuilder();

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
@@ -451,12 +451,8 @@ public class HistogramFieldMapperTests extends MapperTestCase {
     }
 
     @Override
-    public void testSyntheticSourceKeepArrays() {
+    public boolean supportsNestedArrayValues() {
         // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
-    }
-
-    @Override
-    public void testSyntheticSourceInheritsKeepArrays() {
-        // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
+        return false;
     }
 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
@@ -454,4 +454,9 @@ public class HistogramFieldMapperTests extends MapperTestCase {
     public void testSyntheticSourceKeepArrays() {
         // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
     }
+
+    @Override
+    public void testSyntheticSourceInheritsKeepArrays() {
+        // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
+    }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/OffsetSourceFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/OffsetSourceFieldMapperTests.java
@@ -117,13 +117,9 @@ public class OffsetSourceFieldMapperTests extends MapperTestCase {
     }
 
     @Override
-    public void testSyntheticSourceKeepArrays() {
+    public boolean supportsNestedArrayValues() {
         // This mapper doesn't support multiple values (array of objects).
-    }
-
-    @Override
-    public void testSyntheticSourceInheritsKeepArrays() {
-        // This mapper doesn't support multiple values (array of objects).
+        return false;
     }
 
     public void testDefaults() throws Exception {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/OffsetSourceFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/OffsetSourceFieldMapperTests.java
@@ -121,6 +121,11 @@ public class OffsetSourceFieldMapperTests extends MapperTestCase {
         // This mapper doesn't support multiple values (array of objects).
     }
 
+    @Override
+    public void testSyntheticSourceInheritsKeepArrays() {
+        // This mapper doesn't support multiple values (array of objects).
+    }
+
     public void testDefaults() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         assertEquals(Strings.toString(fieldMapping(this::minimalMapping)), mapper.mappingSource().toString());

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapperTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapperTests.java
@@ -610,13 +610,9 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
     }
 
     @Override
-    public void testSyntheticSourceKeepArrays() {
+    public boolean supportsNestedArrayValues() {
         // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
-    }
-
-    @Override
-    public void testSyntheticSourceInheritsKeepArrays() {
-        // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapperTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapperTests.java
@@ -615,6 +615,11 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
     }
 
     @Override
+    public void testSyntheticSourceInheritsKeepArrays() {
+        // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
+    }
+
+    @Override
     protected boolean supportsCopyTo() {
         return false;
     }

--- a/x-pack/plugin/mapper-counted-keyword/src/main/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-counted-keyword/src/main/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapper.java
@@ -76,8 +76,7 @@ import static org.elasticsearch.common.lucene.Lucene.KEYWORD_ANALYZER;
  * 2 for each key (one per document), a <code>counted_terms</code> aggregation on a <code>counted_keyword</code> field will consider
  * the actual count and report a count of 3 for each key.</p>
  *
- * <p>Synthetic source is supported, but uses the fallback "ignore source" infrastructure unless the <code>source_keep_mode</code> is
- *  explicitly set to <code>none</code> in the field mapping parameters.</p>
+ * <p>Only regular source is supported; synthetic source won't work.</p>
  */
 public class CountedKeywordFieldMapper extends FieldMapper {
     public static final String CONTENT_TYPE = "counted_keyword";
@@ -493,7 +492,7 @@ public class CountedKeywordFieldMapper extends FieldMapper {
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport() {
         var keepMode = sourceKeepMode();
-        if (keepMode.isPresent() == false || keepMode.get() != SourceKeepMode.NONE) {
+        if (keepMode.isPresent() && keepMode.get() != SourceKeepMode.NONE) {
             return super.syntheticSourceSupport();
         }
 

--- a/x-pack/plugin/mapper-counted-keyword/src/main/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-counted-keyword/src/main/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapper.java
@@ -491,8 +491,7 @@ public class CountedKeywordFieldMapper extends FieldMapper {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport() {
-        var keepMode = sourceKeepMode();
-        if (keepMode.isPresent() && keepMode.get() != SourceKeepMode.NONE) {
+        if (sourceKeepMode() != SourceKeepMode.NONE) {
             return super.syntheticSourceSupport();
         }
 

--- a/x-pack/plugin/mapper-counted-keyword/src/test/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-counted-keyword/src/test/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapperTests.java
@@ -25,7 +25,9 @@ import org.junit.AssumptionViolatedException;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -134,8 +136,15 @@ public class CountedKeywordFieldMapperTests extends MapperTestCase {
                 return new SyntheticSourceExample(in, out, this::mapping);
             }
 
+            private final Set<String> previousValues = new HashSet<>();
             private Tuple<String, String> generateValue() {
-                String v = ESTestCase.randomAlphaOfLength(5);
+                String v;
+                if(previousValues.size() > 0 && randomBoolean()) {
+                    v = randomFrom(previousValues);
+                } else {
+                    v = ESTestCase.randomAlphaOfLength(5);
+                    previousValues.add(v);
+                }
                 return Tuple.tuple(v, v);
             }
 

--- a/x-pack/plugin/mapper-counted-keyword/src/test/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-counted-keyword/src/test/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapperTests.java
@@ -137,9 +137,10 @@ public class CountedKeywordFieldMapperTests extends MapperTestCase {
             }
 
             private final Set<String> previousValues = new HashSet<>();
+
             private Tuple<String, String> generateValue() {
                 String v;
-                if(previousValues.size() > 0 && randomBoolean()) {
+                if (previousValues.size() > 0 && randomBoolean()) {
                     v = randomFrom(previousValues);
                 } else {
                     v = ESTestCase.randomAlphaOfLength(5);

--- a/x-pack/plugin/mapper-counted-keyword/src/test/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-counted-keyword/src/test/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapperTests.java
@@ -75,7 +75,6 @@ public class CountedKeywordFieldMapperTests extends MapperTestCase {
         DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("field");
             minimalMapping(b);
-            b.field("synthetic_source_keep", "none");
             b.endObject();
         })).documentMapper();
 
@@ -94,7 +93,6 @@ public class CountedKeywordFieldMapperTests extends MapperTestCase {
         DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("field");
             minimalMapping(b);
-            b.field("synthetic_source_keep", "none");
             b.endObject();
         })).documentMapper();
 
@@ -112,21 +110,6 @@ public class CountedKeywordFieldMapperTests extends MapperTestCase {
         assertThat(syntheticSource(mapper, buildInput), equalTo(expected));
         assertThat(syntheticSource(mapper, new SourceFilter(new String[] { "field" }, null), buildInput), equalTo(expected));
         assertThat(syntheticSource(mapper, new SourceFilter(null, new String[] { "field" }), buildInput), equalTo("{}"));
-    }
-
-    @Override
-    public void testSyntheticSourceKeepAll() throws IOException {
-        // For now, native synthetic source is only supported when "synthetic_source_keep" mapping attribute is "none"
-    }
-
-    @Override
-    public void testSyntheticSourceKeepArrays() throws IOException {
-        // For now, native synthetic source is only supported when "synthetic_source_keep" mapping attribute is "none"
-    }
-
-    @Override
-    public void testSyntheticSourceKeepNone() throws IOException {
-        // For now, native synthetic source is only supported when "synthetic_source_keep" mapping attribute is "none"
     }
 
     @Override
@@ -158,9 +141,6 @@ public class CountedKeywordFieldMapperTests extends MapperTestCase {
 
             private void mapping(XContentBuilder b) throws IOException {
                 minimalMapping(b);
-                // For now, synthetic source is only supported when "synthetic_source_keep" is "none".
-                // Once we implement true synthetic source support, we should remove this.
-                b.field("synthetic_source_keep", "none");
             }
 
             @Override

--- a/x-pack/plugin/rank-vectors/src/test/java/org/elasticsearch/xpack/rank/vectors/mapper/RankVectorsFieldMapperTests.java
+++ b/x-pack/plugin/rank-vectors/src/test/java/org/elasticsearch/xpack/rank/vectors/mapper/RankVectorsFieldMapperTests.java
@@ -496,12 +496,8 @@ public class RankVectorsFieldMapperTests extends MapperTestCase {
     }
 
     @Override
-    public void testSyntheticSourceKeepArrays() {
+    public boolean supportsNestedArrayValues() {
         // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
-    }
-
-    @Override
-    public void testSyntheticSourceInheritsKeepArrays() {
-        // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
+        return false;
     }
 }

--- a/x-pack/plugin/rank-vectors/src/test/java/org/elasticsearch/xpack/rank/vectors/mapper/RankVectorsFieldMapperTests.java
+++ b/x-pack/plugin/rank-vectors/src/test/java/org/elasticsearch/xpack/rank/vectors/mapper/RankVectorsFieldMapperTests.java
@@ -499,4 +499,9 @@ public class RankVectorsFieldMapperTests extends MapperTestCase {
     public void testSyntheticSourceKeepArrays() {
         // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
     }
+
+    @Override
+    public void testSyntheticSourceInheritsKeepArrays() {
+        // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
+    }
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/counted_keyword/30_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/counted_keyword/30_synthetic_source.yml
@@ -1,4 +1,4 @@
-setup:
+"Source values are mutated as expected":
   - requires:
       cluster_features: ["mapper.counted_keyword.synthetic_source_native_support"]
       reason: "Feature implemented"
@@ -55,68 +55,458 @@ setup:
   - do:
       indices.refresh: { }
 
----
-"Source values are mutated as expected":
- - do:
-    search:
-      index: test-events
-      body:
-        query:
-          ids:
-            values: [1]
- - match:
-     hits.hits.0._source:
-       events: ["a", "a", "b", "c"]
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [1]
+  - match:
+      hits.hits.0._source:
+        events: ["a", "a", "b", "c"]
 
- - do:
-     search:
-       index: test-events
-       body:
+  - do:
+      search:
+        index: test-events
+        body:
          query:
            ids:
              values: [2]
- - match:
+  - match:
      hits.hits.0._source:
        events: ["a", "b", "b", "b", "c"]
 
- - do:
-     search:
-       index: test-events
-       body:
+  - do:
+      search:
+        index: test-events
+        body:
          query:
            ids:
              values: [3]
- - match:
+  - match:
      hits.hits.0._source:
        events: ["a", "b", "c", "c"]
 
- - do:
-     search:
-       index: test-events
-       body:
+  - do:
+      search:
+        index: test-events
+        body:
          query:
            ids:
              values: [4]
- - match:
+  - match:
      hits.hits.0._source:
        events: "a"
 
- - do:
-     search:
-       index: test-events
-       body:
+  - do:
+      search:
+        index: test-events
+        body:
          query:
            ids:
              values: [5]
- - match:
+  - match:
      hits.hits.0._source: {}
 
- - do:
-     search:
-       index: test-events
-       body:
+  - do:
+      search:
+        index: test-events
+        body:
          query:
            ids:
              values: [6]
- - match:
+  - match:
      hits.hits.0._source: {}
+
+---
+
+"synthetic_source_keep value is respected":
+  - requires:
+      cluster_features: ["mapper.counted_keyword.synthetic_source_native_support"]
+      reason: "Feature implemented"
+
+  - do:
+      indices.create:
+        index: test-events
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              events:
+                type: counted_keyword
+                synthetic_source_keep: all
+
+  - do:
+      index:
+        index: test-events
+        id: "1"
+        body: { "events": [ "a", "b", "a", "c" ] }
+
+  - do:
+      index:
+        index: test-events
+        id: "2"
+        body: { "events": [ "b", "b", "c", "a", "b" ] }
+
+  - do:
+      index:
+        index: test-events
+        id: "3"
+        body: { "events": [ "c", "a", null, "b", null, "c" ] }
+
+  - do:
+      index:
+        index: test-events
+        id: "4"
+        body: { "events": [ "a" ] }
+
+  - do:
+      index:
+        index: test-events
+        id: "5"
+        body: { "events": [ ] }
+
+  - do:
+      index:
+        index: test-events
+        id: "6"
+        body: { "events": [ null, null ] }
+
+  - do:
+      indices.refresh: { }
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 1 ]
+  - match:
+      hits.hits.0._source:
+        events: [ "a", "b", "a", "c" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 2 ]
+  - match:
+      hits.hits.0._source:
+        events: [ "b", "b", "c", "a", "b" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 3 ]
+  - match:
+      hits.hits.0._source:
+        events: [ "c", "a", null, "b", null, "c" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 4 ]
+  - match:
+      hits.hits.0._source:
+        events: [ "a" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 5 ]
+  - match:
+      hits.hits.0._source:
+        events: [ ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 6 ]
+  - match:
+      hits.hits.0._source:
+        events: [ null, null ]
+
+---
+
+"Nested synthetic_source_keep value is respected":
+  - requires:
+      cluster_features: ["mapper.counted_keyword.synthetic_source_native_support"]
+      reason: "Feature implemented"
+
+  - do:
+      indices.create:
+        index: test-events
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              event-object:
+                type: object
+                synthetic_source_keep: arrays
+                properties:
+                  event-object-2:
+                    type: object
+                    properties:
+                      events:
+                        type: counted_keyword
+  - do:
+      index:
+        index: test-events
+        id: "1"
+        body: { "event-object": { "event-object-2": { "events": [ "a", "b", "a", "c" ] } } }
+
+  - do:
+      index:
+        index: test-events
+        id: "2"
+        body: { "event-object": { "event-object-2": { "events": [ "b", "b", "c", "a", "b" ] } } }
+
+  - do:
+      index:
+        index: test-events
+        id: "3"
+        body: { "event-object": { "event-object-2": { "events": [ "c", "a", null, "b", null, "c" ] } } }
+
+  - do:
+      index:
+        index: test-events
+        id: "4"
+        body: { "event-object": { "event-object-2": { "events": [ "a" ] } } }
+
+  - do:
+      index:
+        index: test-events
+        id: "5"
+        body: { "event-object": { "event-object-2": { "events": [ ] } } }
+
+  - do:
+      index:
+        index: test-events
+        id: "6"
+        body: { "event-object": { "event-object-2": { "events": [ null, null ] } } }
+
+  - do:
+      indices.refresh: { }
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 1 ]
+  - match:
+      hits.hits.0._source:
+        event-object:
+          event-object-2:
+            events: [ "a", "b", "a", "c" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 2 ]
+  - match:
+      hits.hits.0._source:
+        event-object:
+          event-object-2:
+            events: [ "b", "b", "c", "a", "b" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 3 ]
+  - match:
+      hits.hits.0._source:
+        event-object:
+          event-object-2:
+            events: [ "c", "a", null, "b", null, "c" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 4 ]
+  - match:
+      hits.hits.0._source:
+        event-object:
+          event-object-2:
+            events: [ "a" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 5 ]
+  - match:
+      hits.hits.0._source:
+        event-object:
+          event-object-2:
+            events: [ ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 6 ]
+  - match:
+      hits.hits.0._source:
+        event-object:
+          event-object-2:
+            events: [ null, null ]
+
+---
+
+"Index-level synthetic_source_keep value is respected":
+  - requires:
+      cluster_features: ["mapper.counted_keyword.synthetic_source_native_support"]
+      reason: "Feature implemented"
+
+  - do:
+      indices.create:
+        index: test-events
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+              mapping.synthetic_source_keep: arrays
+          mappings:
+            properties:
+              events:
+                type: counted_keyword
+
+  - do:
+      index:
+        index: test-events
+        id: "1"
+        body: { "events": [ "a", "b", "a", "c" ] }
+
+  - do:
+      index:
+        index: test-events
+        id: "2"
+        body: { "events": [ "b", "b", "c", "a", "b" ] }
+
+  - do:
+      index:
+        index: test-events
+        id: "3"
+        body: { "events": [ "c", "a", null, "b", null, "c" ] }
+
+  - do:
+      index:
+        index: test-events
+        id: "4"
+        body: { "events": [ "a" ] }
+
+  - do:
+      index:
+        index: test-events
+        id: "5"
+        body: { "events": [ ] }
+
+  - do:
+      index:
+        index: test-events
+        id: "6"
+        body: { "events": [ null, null ] }
+
+  - do:
+      indices.refresh: { }
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 1 ]
+  - match:
+      hits.hits.0._source:
+        events: [ "a", "b", "a", "c" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 2 ]
+  - match:
+      hits.hits.0._source:
+        events: [ "b", "b", "c", "a", "b" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 3 ]
+  - match:
+      hits.hits.0._source:
+        events: [ "c", "a", null, "b", null, "c" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 4 ]
+  - match:
+      hits.hits.0._source:
+        events: [ "a" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 5 ]
+  - match:
+      hits.hits.0._source:
+        events: [ ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 6 ]
+  - match:
+      hits.hits.0._source:
+        events: [ null, null ]

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/counted_keyword/30_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/counted_keyword/30_synthetic_source.yml
@@ -14,7 +14,6 @@ setup:
             properties:
               events:
                 type: counted_keyword
-                synthetic_source_keep: none
 
 
   - do:


### PR DESCRIPTION
This PR adds a mechanism to track the value of the `synthetic_source_keep` setting if it is set in the mapping settings, inherited from an object field at a higher level, or specified in the index settings. This value is then used to properly implement synthetic source support in the `counted_keyword` field type.

This PR also adds tests to MapperTestCase to verify that if `synthetic_source_keep` is set on an outer object field, or in the index settings, it is respected by mappers.

Follow-up to #120078
Relates to #109796
