### PR TITLE
Allow overriding of module metadata files in integration tests

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -78,6 +78,8 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
     private static final String TESTS_CLUSTER_FIPS_JAR_PATH_SYSPROP = "tests.cluster.fips.jars.path";
     private static final String TESTS_CLUSTER_DEBUG_ENABLED_SYSPROP = "tests.cluster.debug.enabled";
     private static final String ENABLE_DEBUG_JVM_ARGS = "-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=";
+    private static final String ENTITLEMENT_POLICY_YAML = "entitlement-policy.yaml";
+    private static final String PLUGIN_DESCRIPTOR_PROPERTIES = "plugin-descriptor.properties";
 
     private final DistributionResolver distributionResolver;
 
@@ -662,7 +664,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                             .findFirst()
                             .map(path -> {
                                 DefaultPluginInstallSpec installSpec = plugin.getValue();
-                                // Path the plugin archive with configured overrides if necessary
+                                // Patch the plugin archive with configured overrides if necessary
                                 if (installSpec.entitlementsOverride != null || installSpec.propertiesOverride != null) {
                                     Path target;
                                     try {
@@ -673,13 +675,13 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                                     ArchivePatcher patcher = new ArchivePatcher(path, target);
                                     if (installSpec.entitlementsOverride != null) {
                                         patcher.override(
-                                            "entitlement-policy.yaml",
+                                            ENTITLEMENT_POLICY_YAML,
                                             original -> installSpec.entitlementsOverride.apply(original).asStream()
                                         );
                                     }
                                     if (installSpec.propertiesOverride != null) {
                                         patcher.override(
-                                            "plugin-descriptor.properties",
+                                            PLUGIN_DESCRIPTOR_PROPERTIES,
                                             original -> installSpec.propertiesOverride.apply(original).asStream()
                                         );
                                     }
@@ -729,11 +731,11 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                     .map(Path::of)
                     .toList();
 
-                spec.getModules().forEach(module -> installModule(module, modulePaths));
+                spec.getModules().forEach((module, spec) -> installModule(module, spec, modulePaths));
             }
         }
 
-        private void installModule(String moduleName, List<Path> modulePaths) {
+        private void installModule(String moduleName, DefaultPluginInstallSpec installSpec, List<Path> modulePaths) {
             Path destination = distributionDir.resolve("modules").resolve(moduleName);
             if (Files.notExists(destination)) {
                 Path modulePath = modulePaths.stream().filter(path -> path.endsWith(moduleName)).findFirst().orElseThrow(() -> {
@@ -743,7 +745,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                         ? "project(xpackModule('" + moduleName.substring(7) + "'))"
                         : "project(':modules:" + moduleName + "')";
 
-                    throw new RuntimeException(
+                    return new RuntimeException(
                         "Unable to locate module '"
                             + moduleName
                             + "'. Ensure you've added the following to the build script for project '"
@@ -758,20 +760,34 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                 });
 
                 IOUtils.syncWithCopy(modulePath, destination);
+                try {
+                    if (installSpec.entitlementsOverride != null) {
+                        Path entitlementsFile = modulePath.resolve(ENTITLEMENT_POLICY_YAML);
+                        String original = Files.exists(entitlementsFile) ? Files.readString(entitlementsFile) : "";
+                        Path target = destination.resolve(ENTITLEMENT_POLICY_YAML);
+                        installSpec.entitlementsOverride.apply(original).writeTo(target);
+                    }
+                    if (installSpec.propertiesOverride != null) {
+                        Path propertiesFiles = modulePath.resolve(PLUGIN_DESCRIPTOR_PROPERTIES);
+                        String original = Files.exists(propertiesFiles) ? Files.readString(propertiesFiles) : "";
+                        Path target = destination.resolve(PLUGIN_DESCRIPTOR_PROPERTIES);
+                        installSpec.propertiesOverride.apply(original).writeTo(target);
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Error patching module '" + moduleName + "'", e);
+                }
 
-                // Install any extended plugins
+                // Install any extended modules
                 Properties pluginProperties = new Properties();
                 try (
-                    InputStream in = new BufferedInputStream(
-                        new FileInputStream(modulePath.resolve("plugin-descriptor.properties").toFile())
-                    )
+                    InputStream in = new BufferedInputStream(new FileInputStream(modulePath.resolve(PLUGIN_DESCRIPTOR_PROPERTIES).toFile()))
                 ) {
                     pluginProperties.load(in);
                     String extendedProperty = pluginProperties.getProperty("extended.plugins");
                     if (extendedProperty != null) {
-                        String[] extendedPlugins = extendedProperty.split(",");
-                        for (String plugin : extendedPlugins) {
-                            installModule(plugin, modulePaths);
+                        String[] extendedModules = extendedProperty.split(",");
+                        for (String module : extendedModules) {
+                            installModule(module, new DefaultPluginInstallSpec(), modulePaths);
                         }
                     }
                 } catch (IOException e) {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
@@ -34,7 +34,7 @@ public abstract class AbstractLocalSpecBuilder<T extends LocalSpecBuilder<?>> im
     private final Map<String, String> settings = new HashMap<>();
     private final List<EnvironmentProvider> environmentProviders = new ArrayList<>();
     private final Map<String, String> environment = new HashMap<>();
-    private final Set<String> modules = new HashSet<>();
+    private final Map<String, DefaultPluginInstallSpec> modules = new HashMap<>();
     private final Map<String, DefaultPluginInstallSpec> plugins = new HashMap<>();
     private final Set<FeatureFlag> features = EnumSet.noneOf(FeatureFlag.class);
     private final List<SettingsProvider> keystoreProviders = new ArrayList<>();
@@ -123,11 +123,19 @@ public abstract class AbstractLocalSpecBuilder<T extends LocalSpecBuilder<?>> im
 
     @Override
     public T module(String moduleName) {
-        this.modules.add(moduleName);
+        this.modules.put(moduleName, new DefaultPluginInstallSpec());
         return cast(this);
     }
 
-    Set<String> getModules() {
+    @Override
+    public T module(String moduleName, Consumer<? super PluginInstallSpec> config) {
+        DefaultPluginInstallSpec spec = new DefaultPluginInstallSpec();
+        config.accept(spec);
+        this.modules.put(moduleName, spec);
+        return cast(this);
+    }
+
+    Map<String, DefaultPluginInstallSpec> getModules() {
         return inherit(() -> parent.getModules(), modules);
     }
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -91,7 +91,7 @@ public class LocalClusterSpec implements ClusterSpec {
         private final Map<String, String> settings;
         private final List<EnvironmentProvider> environmentProviders;
         private final Map<String, String> environment;
-        private final Set<String> modules;
+        private final Map<String, DefaultPluginInstallSpec> modules;
         private final Map<String, DefaultPluginInstallSpec> plugins;
         private final DistributionType distributionType;
         private final Set<FeatureFlag> features;
@@ -113,7 +113,7 @@ public class LocalClusterSpec implements ClusterSpec {
             Map<String, String> settings,
             List<EnvironmentProvider> environmentProviders,
             Map<String, String> environment,
-            Set<String> modules,
+            Map<String, DefaultPluginInstallSpec> modules,
             Map<String, DefaultPluginInstallSpec> plugins,
             DistributionType distributionType,
             Set<FeatureFlag> features,
@@ -175,7 +175,7 @@ public class LocalClusterSpec implements ClusterSpec {
             return distributionType;
         }
 
-        public Set<String> getModules() {
+        public Map<String, DefaultPluginInstallSpec> getModules() {
             return modules;
         }
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
@@ -70,6 +70,12 @@ interface LocalSpecBuilder<T extends LocalSpecBuilder<?>> {
     T module(String moduleName);
 
     /**
+     * Ensure module is installed into the distribution when using the {@link DistributionType#INTEG_TEST} distribution. This is ignored
+     * when the {@link DistributionType#DEFAULT} is being used.
+     */
+    T module(String moduleName, Consumer<? super PluginInstallSpec> config);
+
+    /**
      * Ensure plugin is installed into the distribution.
      */
     T plugin(String pluginName);

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ArchivePatcher.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ArchivePatcher.java
@@ -50,15 +50,25 @@ public class ArchivePatcher {
                 ZipEntry entry = entries.nextElement();
                 output.putNextEntry(entry);
                 if (overrides.containsKey(entry.getName())) {
+                    Function<? super String, ? extends InputStream> override = overrides.remove(entry.getName());
                     try (BufferedReader reader = new BufferedReader(new InputStreamReader(input.getInputStream(entry)))) {
                         String content = reader.lines().collect(Collectors.joining(System.lineSeparator()));
-                        overrides.get(entry.getName()).apply(content).transferTo(output);
+                        override.apply(content).transferTo(output);
                     }
                 } else {
                     input.getInputStream(entry).transferTo(output);
                 }
                 output.closeEntry();
             }
+
+            for (Map.Entry<String, Function<? super String, ? extends InputStream>> override : overrides.entrySet()) {
+                ZipEntry entry = new ZipEntry(override.getKey());
+                output.putNextEntry(entry);
+                override.getValue().apply("").transferTo(output);
+                output.closeEntry();
+            }
+            ;
+
             output.flush();
             output.finish();
         } catch (IOException e) {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ArchivePatcher.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ArchivePatcher.java
@@ -67,7 +67,6 @@ public class ArchivePatcher {
                 override.getValue().apply("").transferTo(output);
                 output.closeEntry();
             }
-            ;
 
             output.flush();
             output.finish();


### PR DESCRIPTION
This is a follow up to #120245 which adds similar functionality for modules, in addition to plugins. Also allows for providing overrides even when the original metadata file is missing.