### PR TITLE
Simplify and speedup handling of AliasFilter logic in search

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -769,7 +769,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
      *                   tiebreak results with identical sort values
      */
     protected final ShardSearchRequest buildShardSearchRequest(SearchShardIterator shardIt, int shardIndex) {
-        AliasFilter filter = aliasFilter.get(shardIt.shardId().getIndex().getUUID());
+        AliasFilter filter = aliasFilter.getOrDefault(shardIt.shardId().getIndex().getUUID(), AliasFilter.EMPTY);
         assert filter != null;
         float indexBoost = concreteIndexBoosts.getOrDefault(shardIt.shardId().getIndex().getUUID(), DEFAULT_INDEX_BOOST);
         ShardSearchRequest shardRequest = new ShardSearchRequest(

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -376,16 +376,13 @@ final class CanMatchPreFilterSearchPhase {
     private static final float DEFAULT_INDEX_BOOST = 1.0f;
 
     public CanMatchNodeRequest.Shard buildShardLevelRequest(SearchShardIterator shardIt) {
-        AliasFilter filter = aliasFilter.get(shardIt.shardId().getIndex().getUUID());
-        assert filter != null;
-        float indexBoost = concreteIndexBoosts.getOrDefault(shardIt.shardId().getIndex().getUUID(), DEFAULT_INDEX_BOOST);
         int shardRequestIndex = shardItIndexMap.get(shardIt);
         return new CanMatchNodeRequest.Shard(
             shardIt.getOriginalIndices().indices(),
             shardIt.shardId(),
             shardRequestIndex,
-            filter,
-            indexBoost,
+            aliasFilter.getOrDefault(shardIt.shardId().getIndex().getUUID(), AliasFilter.EMPTY),
+            concreteIndexBoosts.getOrDefault(shardIt.shardId().getIndex().getUUID(), DEFAULT_INDEX_BOOST),
             shardIt.getSearchContextId(),
             shardIt.getSearchContextKeepAlive(),
             ShardSearchRequest.computeWaitForCheckpoint(request.getWaitForCheckpoints(), shardIt.shardId(), shardRequestIndex)

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -266,7 +266,9 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             clusterState.blocks().indexBlockedRaiseException(ClusterBlockLevel.READ, index.getName());
             AliasFilter aliasFilter = searchService.buildAliasFilter(clusterState, index.getName(), indicesAndAliases);
             assert aliasFilter != null;
-            aliasFilterMap.put(index.getUUID(), aliasFilter);
+            if (aliasFilter != AliasFilter.EMPTY) {
+                aliasFilterMap.put(index.getUUID(), aliasFilter);
+            }
         }
         return aliasFilterMap;
     }
@@ -1087,7 +1089,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 // add the cluster name to the remote index names for indices disambiguation
                 // this ends up in the hits returned with the search response
                 ShardId shardId = searchShardsGroup.shardId();
-                AliasFilter aliasFilter = aliasFilterMap.get(shardId.getIndex().getUUID());
+                AliasFilter aliasFilter = aliasFilterMap.getOrDefault(shardId.getIndex().getUUID(), AliasFilter.EMPTY);
                 String[] aliases = aliasFilter.getAliases();
                 String clusterAlias = entry.getKey();
                 String[] finalIndices = aliases.length == 0 ? new String[] { shardId.getIndexName() } : aliases;

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -259,14 +259,15 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     Map<String, AliasFilter> buildIndexAliasFilters(
         ClusterState clusterState,
         Set<ResolvedExpression> indicesAndAliases,
-        Index[] concreteIndices
+        Index[] concreteIndices,
+        boolean filterEmpty
     ) {
         final Map<String, AliasFilter> aliasFilterMap = new HashMap<>();
         for (Index index : concreteIndices) {
             clusterState.blocks().indexBlockedRaiseException(ClusterBlockLevel.READ, index.getName());
             AliasFilter aliasFilter = searchService.buildAliasFilter(clusterState, index.getName(), indicesAndAliases);
             assert aliasFilter != null;
-            if (aliasFilter != AliasFilter.EMPTY) {
+            if (filterEmpty == false || aliasFilter != AliasFilter.EMPTY) {
                 aliasFilterMap.put(index.getUUID(), aliasFilter);
             }
         }
@@ -1249,7 +1250,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 clusterState,
                 searchRequest.indices()
             );
-            aliasFilter = buildIndexAliasFilters(clusterState, indicesAndAliases, indices);
+            aliasFilter = buildIndexAliasFilters(clusterState, indicesAndAliases, indices, true);
             aliasFilter.putAll(remoteAliasMap);
             localShardIterators = getLocalShardsIterator(
                 clusterState,

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
@@ -135,7 +135,8 @@ public class TransportSearchShardsAction extends HandledTransportAction<SearchSh
                 final Map<String, AliasFilter> aliasFilters = transportSearchAction.buildIndexAliasFilters(
                     clusterState,
                     indicesAndAliases,
-                    concreteIndices
+                    concreteIndices,
+                    false
                 );
                 String[] concreteIndexNames = Arrays.stream(concreteIndices).map(Index::getName).toArray(String[]::new);
                 GroupShardsIterator<SearchShardIterator> shardIts = GroupShardsIterator.sortAndCreate(

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -621,7 +622,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
      * Returns {@code null} if no filtering is required.</p>
      */
     public static QueryBuilder parseAliasFilter(
-        CheckedFunction<BytesReference, QueryBuilder, IOException> filterParser,
+        CheckedFunction<CompressedXContent, QueryBuilder, IOException> filterParser,
         IndexMetadata metadata,
         String... aliasNames
     ) {
@@ -635,7 +636,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
                 return null;
             }
             try {
-                return filterParser.apply(alias.filter().uncompressed());
+                return filterParser.apply(alias.filter());
             } catch (IOException ex) {
                 throw new AliasFilterParsingException(index, alias.getAlias(), "Invalid alias filter", ex);
             }

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -210,7 +210,7 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
     public QueryBuilder aliasFilter(IndexMetadata indexMetadata, String... aliasNames) {
         return ShardSearchRequest.parseAliasFilter(bytes -> {
             try (
-                InputStream inputStream = bytes.streamInput();
+                InputStream inputStream = bytes.uncompressed().streamInput();
                 XContentParser parser = XContentFactory.xContentType(inputStream)
                     .xContent()
                     .createParser(xContentRegistry(), DeprecationHandler.THROW_UNSUPPORTED_OPERATION, inputStream)


### PR DESCRIPTION
Building the map is needlessly expensive, we can just use the empty filter as a default throughout the logic and save a lot of indirection.

This is a reasonable simplification + memory saving now and a critical performance improvement once #118490 lands.
Also, made the `buildAliasFilter` method faster on the hot path without aliases.