### PR TITLE
Updating required cluster feature for knn queries using k parameter

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/130_knn_query_nested_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/130_knn_query_nested_search.yml
@@ -1,7 +1,7 @@
 setup:
   - requires:
-      cluster_features: "gte_v8.12.0"
-      reason: 'knn as query added in 8.12'
+      cluster_features: "search.vectors.k_param_supported"
+      reason: 'k param for knn as query is required'
   - do:
       indices.create:
         index: test

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/140_knn_query_with_other_queries.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/140_knn_query_with_other_queries.yml
@@ -1,8 +1,8 @@
 # test how knn query interact with other queries
 setup:
   - requires:
-      cluster_features: "gte_v8.12.0"
-      reason: 'knn as query added in 8.12'
+      cluster_features: "search.vectors.k_param_supported"
+      reason: 'k param for knn as query is required'
       test_runner_features: close_to
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/160_knn_query_missing_params.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/160_knn_query_missing_params.yml
@@ -1,7 +1,7 @@
 setup:
   - requires:
-      cluster_features: "gte_v8.13.0"
-      reason: '[k] and [num_candidates] were made optional for kNN query in 8.13.0'
+      cluster_features: "search.vectors.k_param_supported"
+      reason: 'k param for knn as query is required'
   - do:
       indices.create:
         index: knn_query_test_index

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/180_update_dense_vector_type.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/180_update_dense_vector_type.yml
@@ -1,7 +1,7 @@
 setup:
   - requires:
-      cluster_features: "gte_v8.15.0"
-      reason: 'updatable dense vector field types was added in 8.15'
+      cluster_features: "search.vectors.k_param_supported"
+      reason: 'k param for knn as query is required'
   - requires:
       test_runner_features: [ contains ]
 ---


### PR DESCRIPTION
Relates to:
* https://github.com/elastic/elasticsearch/pull/119700
* https://github.com/elastic/elasticsearch/pull/119942
* https://github.com/elastic/elasticsearch/pull/120462

In this PR we enforce the `search.vectors.k_param_supported` cluster feature to all tests making use of the `k` param for knn queries. 

Closes https://github.com/elastic/elasticsearch/issues/120425

