### PR TITLE
[8.x] Delete persisted cold cache index if created in the future (#120465)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/PersistentCache.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/PersistentCache.java
@@ -434,6 +434,16 @@ public class PersistentCache implements Closeable {
             } catch (IndexNotFoundException e) {
                 logger.debug("persistent cache index does not exist yet", e);
             }
+        } catch (Exception e) {
+            if (e instanceof IllegalArgumentException iae) {
+                final var message = iae.getMessage();
+                if (message != null && message.startsWith("indexCreatedVersionMajor is in the future:")) {
+                    logger.warn("Deleting persistent cache index created in the future [message: {}]", message);
+                    IOUtils.rm(directoryPath);
+                    return Map.of();
+                }
+            }
+            throw e;
         }
         return documents;
     }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Delete persisted cold cache index if created in the future (#120465)