### PR TITLE
Disable transport changes for ByteSizeValue

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -156,7 +156,8 @@ public class TransportVersions {
     public static final TransportVersion ELASTIC_INFERENCE_SERVICE_UNIFIED_CHAT_COMPLETIONS_INTEGRATION = def(8_822_00_0);
     public static final TransportVersion KQL_QUERY_TECH_PREVIEW = def(8_823_00_0);
     public static final TransportVersion ESQL_PROFILE_ROWS_PROCESSED = def(8_824_00_0);
-    public static final TransportVersion BYTE_SIZE_VALUE_ALWAYS_USES_BYTES = def(8_825_00_0);
+    public static final TransportVersion BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1 = def(8_825_00_0);
+    public static final TransportVersion REVERT_BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1 = def(8_826_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.common.unit;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -25,6 +26,7 @@ import java.util.Locale;
 import java.util.Objects;
 
 import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1;
+import static org.elasticsearch.TransportVersions.REVERT_BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1;
 import static org.elasticsearch.common.unit.ByteSizeUnit.BYTES;
 import static org.elasticsearch.common.unit.ByteSizeUnit.GB;
 import static org.elasticsearch.common.unit.ByteSizeUnit.KB;
@@ -111,8 +113,8 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
     public static ByteSizeValue readFrom(StreamInput in) throws IOException {
         long size = in.readZLong();
         ByteSizeUnit unit = ByteSizeUnit.readFrom(in);
-        // BYTE_SIZE_VALUE_ALWAYS_USES_BYTES was later reverted, so we use equals
-        if (in.getTransportVersion().equals(BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1)) {
+        TransportVersion tv = in.getTransportVersion();
+        if (tv.onOrAfter(BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1) && tv.before(REVERT_BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1)) {
             return newByteSizeValue(size, unit);
         } else {
             return of(size, unit);
@@ -121,8 +123,8 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        // BYTE_SIZE_VALUE_ALWAYS_USES_BYTES was later reverted, so we use equals
-        if (out.getTransportVersion().equals(BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1)) {
+        TransportVersion tv = out.getTransportVersion();
+        if (tv.onOrAfter(BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1) && tv.before(REVERT_BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1)) {
             out.writeZLong(sizeInBytes);
         } else {
             out.writeZLong(Math.divideExact(sizeInBytes, desiredUnit.toBytes(1)));

--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -24,7 +24,7 @@ import java.math.RoundingMode;
 import java.util.Locale;
 import java.util.Objects;
 
-import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES;
+import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1;
 import static org.elasticsearch.common.unit.ByteSizeUnit.BYTES;
 import static org.elasticsearch.common.unit.ByteSizeUnit.GB;
 import static org.elasticsearch.common.unit.ByteSizeUnit.KB;
@@ -111,7 +111,8 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
     public static ByteSizeValue readFrom(StreamInput in) throws IOException {
         long size = in.readZLong();
         ByteSizeUnit unit = ByteSizeUnit.readFrom(in);
-        if (in.getTransportVersion().onOrAfter(BYTE_SIZE_VALUE_ALWAYS_USES_BYTES)) {
+        // BYTE_SIZE_VALUE_ALWAYS_USES_BYTES was later reverted, so we use equals
+        if (in.getTransportVersion().equals(BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1)) {
             return newByteSizeValue(size, unit);
         } else {
             return of(size, unit);
@@ -120,7 +121,8 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getTransportVersion().onOrAfter(BYTE_SIZE_VALUE_ALWAYS_USES_BYTES)) {
+        // BYTE_SIZE_VALUE_ALWAYS_USES_BYTES was later reverted, so we use equals
+        if (out.getTransportVersion().equals(BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1)) {
             out.writeZLong(sizeInBytes);
         } else {
             out.writeZLong(Math.divideExact(sizeInBytes, desiredUnit.toBytes(1)));

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.MatcherAssert;
-import org.junit.Ignore;
 
 import java.io.IOException;
 import java.util.List;
@@ -537,7 +536,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     /**
      * @see TransportVersions#REVERT_BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1
      */
-    @Ignore("Transport changes have been temporarily reverted")
+    @AwaitsFix(bugUrl = "https://elasticco.atlassian.net/browse/ES-10585")
     public void testTwoDigitTransportRoundTrips() throws IOException {
         TransportVersion tv = TransportVersion.current();
         for (var desiredUnit : ByteSizeUnit.values()) {

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.MatcherAssert;
+import org.junit.Ignore;
 
 import java.io.IOException;
 import java.util.List;
@@ -533,6 +534,10 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
         }
     }
 
+    /**
+     * @see TransportVersions#REVERT_BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1
+     */
+    @Ignore("Transport changes have been temporarily reverted")
     public void testTwoDigitTransportRoundTrips() throws IOException {
         TransportVersion tv = TransportVersion.current();
         for (var desiredUnit : ByteSizeUnit.values()) {


### PR DESCRIPTION
Since transport versions cannot yet diverge between v8 and v9, we introduce a new TV in which the changes from #120142 are effectively reverted. We can reinstate the TV change once the transports are allowed to diverge.

I've added the suffix `_1` to refer to the first time we tried to add this feature. Ultimately, we can use the original TV name `BYTE_SIZE_VALUE_ALWAYS_USES_BYTES` when we re-add it for real.

See also #120473 for the v8 backport, and ES-10377.