### PR TITLE
Add ByteSizeValue transport version numbers

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -148,7 +148,6 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
                 .map(e -> e.getCurrentTransportVersion(TransportVersions.LATEST_DEFINED))
                 .orElse(TransportVersions.LATEST_DEFINED);
             assert version.onOrAfter(TransportVersions.LATEST_DEFINED);
-            assert version.equals(TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1) == false : "Not supported";
             return version;
         }
     }

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -148,6 +148,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
                 .map(e -> e.getCurrentTransportVersion(TransportVersions.LATEST_DEFINED))
                 .orElse(TransportVersions.LATEST_DEFINED);
             assert version.onOrAfter(TransportVersions.LATEST_DEFINED);
+            assert version.equals(TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1) == false : "Not supported";
             return version;
         }
     }

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -162,6 +162,8 @@ public class TransportVersions {
     public static final TransportVersion ELASTIC_INFERENCE_SERVICE_UNIFIED_CHAT_COMPLETIONS_INTEGRATION = def(8_822_00_0);
     public static final TransportVersion KQL_QUERY_TECH_PREVIEW = def(8_823_00_0);
     public static final TransportVersion ESQL_PROFILE_ROWS_PROCESSED = def(8_824_00_0);
+    public static final TransportVersion BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1 = def(8_825_00_0);
+    public static final TransportVersion REVERT_BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1 = def(8_826_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
For compatibility with v9.  See #120472 and ES-10377.
