### PR TITLE
Relax http stream.next closure assertion

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -78,12 +78,12 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
         assert handler != null : "handler must be set before requesting next chunk";
         requestContext = threadContext.newStoredContext();
         channel.eventLoop().submit(() -> {
-            if (closing) {
-                return;
-            }
             activityTracker.startActivity();
             requested = true;
             try {
+                if (closing) {
+                    return;
+                }
                 if (buf == null) {
                     channel.read();
                 } else {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -75,10 +75,12 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
 
     @Override
     public void next() {
-        assert closing == false : "cannot request next chunk on closing stream";
         assert handler != null : "handler must be set before requesting next chunk";
         requestContext = threadContext.newStoredContext();
         channel.eventLoop().submit(() -> {
+            if (closing) {
+                return;
+            }
             activityTracker.startActivity();
             requested = true;
             try {

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -244,9 +244,6 @@ tests:
 - class: org.elasticsearch.search.ccs.CrossClusterIT
   method: testCancel
   issue: https://github.com/elastic/elasticsearch/issues/108061
-- class: org.elasticsearch.http.netty4.Netty4IncrementalRequestHandlingIT
-  method: testOversizedChunkedEncoding
-  issue: https://github.com/elastic/elasticsearch/issues/120444
 - class: org.elasticsearch.xpack.logsdb.seqno.RetentionLeaseRestIT
   issue: https://github.com/elastic/elasticsearch/issues/120434
 


### PR DESCRIPTION
fixes https://github.com/elastic/elasticsearch/issues/120444

Relax assertion for stream.next() when stream is closing. It's a valid state when stream consumer moves to another thread but stream closure happens in netty's event-loop thread. Replacing assertion with noop.