### PR TITLE
Backport - relax http stream.next closure assertion #120480

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -75,13 +75,15 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
 
     @Override
     public void next() {
-        assert closing == false : "cannot request next chunk on closing stream";
         assert handler != null : "handler must be set before requesting next chunk";
         requestContext = threadContext.newStoredContext();
         channel.eventLoop().submit(() -> {
             activityTracker.startActivity();
             requested = true;
             try {
+                if (closing) {
+                    return;
+                }
                 if (buf == null) {
                     channel.read();
                 } else {

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -456,6 +456,3 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=logsdb/10_settings/missing hostname field}
   issue: https://github.com/elastic/elasticsearch/issues/120476
-- class: org.elasticsearch.http.netty4.Netty4IncrementalRequestHandlingIT
-  method: testHttpBodyLoggingChannelClose
-  issue: https://github.com/elastic/elasticsearch/issues/120481


### PR DESCRIPTION
Backport #120480

fixes https://github.com/elastic/elasticsearch/issues/120481

Relax assertion for stream.next() when stream is closing. It's a valid state when stream consumer moves to another thread but stream closure happens in netty's event-loop thread. Replacing assertion with noop.