### PR TITLE
[8.16] Clarify docs around disk capacity expectation. (#115745)

### DIFF
--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -37,9 +37,8 @@ TIP: The performance of an {es} node is often limited by the performance of the 
 For example hardware profiles, refer to Elastic Cloud's {cloud}/ec-reference-hardware.html[instance configurations]. 
 Review our recommendations for optimizing your storage for <<indexing-use-faster-hardware,indexing>> and <<search-use-faster-hardware,search>>.
 
-IMPORTANT: {es} generally expects nodes within a data tier to share the same 
-hardware profile. Variations not following this recommendation should be 
-carefully architected to avoid <<hotspotting,hot spotting>>.
+IMPORTANT: {es} assumes nodes within a data tier share the same hardware profile (such as CPU, RAM, disk capacity).
+Data tiers with unequally resourced nodes have a higher risk of <<hotspotting,hot spotting>>.
 
 The way data tiers are used often depends on the data's category:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Clarify docs around disk capacity expectation. (#115745)](https://github.com/elastic/elasticsearch/pull/115745)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)