### PR TITLE
[8.x] Node deprecation warning for indexes and component templates with sou… (#120387)

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -89,7 +89,8 @@ public class DeprecationChecks {
                 NodeDeprecationChecks::checkEqlEnabledSetting,
                 NodeDeprecationChecks::checkNodeAttrData,
                 NodeDeprecationChecks::checkWatcherBulkConcurrentRequestsSetting,
-                NodeDeprecationChecks::checkTracingApmSettings
+                NodeDeprecationChecks::checkTracingApmSettings,
+                NodeDeprecationChecks::checkSourceModeInComponentTemplates
             );
 
     static List<BiFunction<IndexMetadata, ClusterState, DeprecationIssue>> INDEX_SETTINGS_CHECKS = List.of(
@@ -98,8 +99,7 @@ public class DeprecationChecks {
         IndexDeprecationChecks::checkIndexDataPath,
         IndexDeprecationChecks::storeTypeSettingCheck,
         IndexDeprecationChecks::frozenIndexSettingCheck,
-        IndexDeprecationChecks::deprecatedCamelCasePattern,
-        IndexDeprecationChecks::checkSourceModeInMapping
+        IndexDeprecationChecks::deprecatedCamelCasePattern
     );
 
     static List<BiFunction<DataStream, ClusterState, DeprecationIssue>> DATA_STREAM_CHECKS = List.of(

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -16,7 +16,6 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.engine.frozen.FrozenEngine;
-import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.xpack.core.deprecation.DeprecatedIndexPredicate;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
@@ -202,31 +201,6 @@ public class IndexDeprecationChecks {
         }
 
         return issues;
-    }
-
-    static DeprecationIssue checkSourceModeInMapping(IndexMetadata indexMetadata, ClusterState clusterState) {
-        if (indexMetadata.getCreationVersion().onOrAfter(IndexVersions.DEPRECATE_SOURCE_MODE_MAPPER)) {
-            boolean[] useSourceMode = { false };
-            fieldLevelMappingIssue(indexMetadata, ((mappingMetadata, sourceAsMap) -> {
-                Object source = sourceAsMap.get("_source");
-                if (source instanceof Map<?, ?> sourceMap) {
-                    if (sourceMap.containsKey("mode")) {
-                        useSourceMode[0] = true;
-                    }
-                }
-            }));
-            if (useSourceMode[0]) {
-                return new DeprecationIssue(
-                    DeprecationIssue.Level.CRITICAL,
-                    SourceFieldMapper.DEPRECATION_WARNING,
-                    "https://github.com/elastic/elasticsearch/pull/117172",
-                    SourceFieldMapper.DEPRECATION_WARNING,
-                    false,
-                    null
-                );
-            }
-        }
-        return null;
     }
 
     static DeprecationIssue deprecatedCamelCasePattern(IndexMetadata indexMetadata, ClusterState clusterState) {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.time.LegacyFormatNames;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.engine.frozen.FrozenEngine;
 import org.elasticsearch.xpack.core.deprecation.DeprecatedIndexPredicate;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -9,13 +9,16 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.settings.SecureSetting;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
@@ -1033,6 +1036,45 @@ public class NodeDeprecationChecks {
             "[tracing.apm.*] settings are no longer accepted as of 9.0.0"
                 + " and should be replaced by [telemetry.*] or [telemetry.tracing.*] settings.",
             DeprecationIssue.Level.CRITICAL
+        );
+    }
+
+    static DeprecationIssue checkSourceModeInComponentTemplates(
+        final Settings settings,
+        final PluginsAndModules pluginsAndModules,
+        final ClusterState clusterState,
+        final XPackLicenseState licenseState
+    ) {
+        List<String> templates = new ArrayList<>();
+        var templateNames = clusterState.metadata().componentTemplates().keySet();
+        for (String templateName : templateNames) {
+            ComponentTemplate template = clusterState.metadata().componentTemplates().get(templateName);
+            if (template.template().mappings() != null) {
+                var sourceAsMap = (Map<?, ?>) XContentHelper.convertToMap(template.template().mappings().uncompressed(), true)
+                    .v2()
+                    .get("_doc");
+                if (sourceAsMap != null) {
+                    Object source = sourceAsMap.get("_source");
+                    if (source instanceof Map<?, ?> sourceMap) {
+                        if (sourceMap.containsKey("mode")) {
+                            templates.add(templateName);
+                        }
+                    }
+                }
+            }
+
+        }
+        if (templates.isEmpty()) {
+            return null;
+        }
+        Collections.sort(templates);
+        return new DeprecationIssue(
+            DeprecationIssue.Level.CRITICAL,
+            SourceFieldMapper.DEPRECATION_WARNING,
+            "https://github.com/elastic/elasticsearch/pull/117172",
+            SourceFieldMapper.DEPRECATION_WARNING + " Affected component templates: [" + String.join(", ", templates) + "]",
+            false,
+            null
         );
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -11,24 +11,30 @@ import org.apache.logging.log4j.Level;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -855,6 +861,44 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             "One or more of your nodes is configured with node.attributes.data settings. This is typically used to create a "
                 + "hot/warm or tiered architecture, based on legacy guidelines. Data tiers are a recommended replacement for tiered "
                 + "architecture clusters.",
+            false,
+            null
+        );
+        assertThat(issues, hasItem(expected));
+    }
+
+    public void testCheckSourceModeInComponentTemplates() throws IOException {
+        Template template = Template.builder().mappings(CompressedXContent.fromJSON("""
+            { "_doc": { "_source": { "mode": "stored"} } }""")).build();
+        ComponentTemplate componentTemplate = new ComponentTemplate(template, 1L, new HashMap<>());
+
+        Template template2 = Template.builder().mappings(CompressedXContent.fromJSON("""
+            { "_doc": { "_source": { "enabled": false} } }""")).build();
+        ComponentTemplate componentTemplate2 = new ComponentTemplate(template2, 1L, new HashMap<>());
+
+        ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(
+                Metadata.builder()
+                    .componentTemplates(
+                        Map.of("my-template-1", componentTemplate, "my-template-2", componentTemplate, "my-template-3", componentTemplate2)
+                    )
+            )
+            .build();
+
+        final List<DeprecationIssue> issues = DeprecationChecks.filterChecks(
+            DeprecationChecks.NODE_SETTINGS_CHECKS,
+            c -> c.apply(
+                Settings.EMPTY,
+                new PluginsAndModules(Collections.emptyList(), Collections.emptyList()),
+                clusterState,
+                new XPackLicenseState(() -> 0)
+            )
+        );
+        final DeprecationIssue expected = new DeprecationIssue(
+            DeprecationIssue.Level.CRITICAL,
+            SourceFieldMapper.DEPRECATION_WARNING,
+            "https://github.com/elastic/elasticsearch/pull/117172",
+            SourceFieldMapper.DEPRECATION_WARNING + " Affected component templates: [my-template-1, my-template-2]",
             false,
             null
         );

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsIndexModeCustomSettingsIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsIndexModeCustomSettingsIT.java
@@ -126,7 +126,7 @@ public class LogsIndexModeCustomSettingsIT extends LogsIndexModeRestTestIT {
         assertThat(sourceMode, equalTo("stored"));
 
         request = new Request("GET", "/_migration/deprecations");
-        var nodeSettings = (Map<?, ?>) ((List<?>) entityAsMap(client.performRequest(request)).get("node_settings")).getFirst();
+        var nodeSettings = (Map<?, ?>) ((List<?>) entityAsMap(client.performRequest(request)).get("node_settings")).get(0);
         assertThat(nodeSettings.get("message"), equalTo(SourceFieldMapper.DEPRECATION_WARNING));
         assertThat(
             (String) nodeSettings.get("details"),
@@ -208,7 +208,7 @@ public class LogsIndexModeCustomSettingsIT extends LogsIndexModeRestTestIT {
         assertThat(sourceMode, equalTo("stored"));
 
         request = new Request("GET", "/_migration/deprecations");
-        var nodeSettings = (Map<?, ?>) ((List<?>) entityAsMap(client.performRequest(request)).get("node_settings")).getFirst();
+        var nodeSettings = (Map<?, ?>) ((List<?>) entityAsMap(client.performRequest(request)).get("node_settings")).get(0);
         assertThat(nodeSettings.get("message"), equalTo(SourceFieldMapper.DEPRECATION_WARNING));
         assertThat(
             (String) nodeSettings.get("details"),

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsIndexModeCustomSettingsIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsIndexModeCustomSettingsIT.java
@@ -124,6 +124,14 @@ public class LogsIndexModeCustomSettingsIT extends LogsIndexModeRestTestIT {
         var mapping = getMapping(client, getDataStreamBackingIndex(client, "logs-custom-dev", 0));
         String sourceMode = (String) subObject("_source").apply(mapping).get("mode");
         assertThat(sourceMode, equalTo("stored"));
+
+        request = new Request("GET", "/_migration/deprecations");
+        var nodeSettings = (Map<?, ?>) ((List<?>) entityAsMap(client.performRequest(request)).get("node_settings")).getFirst();
+        assertThat(nodeSettings.get("message"), equalTo(SourceFieldMapper.DEPRECATION_WARNING));
+        assertThat(
+            (String) nodeSettings.get("details"),
+            containsString(SourceFieldMapper.DEPRECATION_WARNING + " Affected component templates: [logs@custom]")
+        );
     }
 
     public void testConfigureDisabledSourceBeforeIndexCreation() {
@@ -198,6 +206,14 @@ public class LogsIndexModeCustomSettingsIT extends LogsIndexModeRestTestIT {
         var mapping = getMapping(client, getDataStreamBackingIndex(client, "logs-custom-dev", 0));
         String sourceMode = (String) subObject("_source").apply(mapping).get("mode");
         assertThat(sourceMode, equalTo("stored"));
+
+        request = new Request("GET", "/_migration/deprecations");
+        var nodeSettings = (Map<?, ?>) ((List<?>) entityAsMap(client.performRequest(request)).get("node_settings")).getFirst();
+        assertThat(nodeSettings.get("message"), equalTo(SourceFieldMapper.DEPRECATION_WARNING));
+        assertThat(
+            (String) nodeSettings.get("details"),
+            containsString(SourceFieldMapper.DEPRECATION_WARNING + " Affected component templates: [logs@custom]")
+        );
     }
 
     public void testConfigureDisabledSourceWhenIndexIsCreated() throws IOException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Node deprecation warning for indexes and component templates with sou… (#120387)](https://github.com/elastic/elasticsearch/pull/120387)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)