### PR TITLE
[8.x] Do not serialize EsIndex in plan (#119580)

### DIFF
--- a/docs/changelog/119580.yaml
+++ b/docs/changelog/119580.yaml
@@ -1,0 +1,5 @@
+pr: 119580
+summary: Do not serialize `EsIndex` in plan
+area: ES|QL
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -164,6 +164,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_PROFILE_ROWS_PROCESSED = def(8_824_00_0);
     public static final TransportVersion BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1 = def(8_825_00_0);
     public static final TransportVersion REVERT_BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1 = def(8_826_00_0);
+    public static final TransportVersion ESQL_SKIP_ES_INDEX_SERIALIZATION = def(8_827_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -215,7 +215,7 @@ public final class EsqlTestUtils {
     }
 
     public static EsRelation relation() {
-        return new EsRelation(EMPTY, new EsIndex(randomAlphaOfLength(8), emptyMap()), IndexMode.STANDARD, randomBoolean());
+        return new EsRelation(EMPTY, new EsIndex(randomAlphaOfLength(8), emptyMap()), IndexMode.STANDARD);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -269,7 +269,13 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             }
             var attributes = mappingAsAttributes(plan.source(), esIndex.mapping());
             attributes.addAll(plan.metadataFields());
-            return new EsRelation(plan.source(), esIndex, attributes.isEmpty() ? NO_FIELDS : attributes, plan.indexMode());
+            return new EsRelation(
+                plan.source(),
+                esIndex.name(),
+                plan.indexMode(),
+                esIndex.indexNameWithModes(),
+                attributes.isEmpty() ? NO_FIELDS : attributes
+            );
         }
     }
 
@@ -1371,9 +1377,13 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 }
 
                 if (missing.isEmpty() == false) {
-                    List<Attribute> newOutput = new ArrayList<>(esr.output());
-                    newOutput.addAll(missing);
-                    return new EsRelation(esr.source(), esr.index(), newOutput, esr.indexMode(), esr.frozen());
+                    return new EsRelation(
+                        esr.source(),
+                        esr.indexPattern(),
+                        esr.indexMode(),
+                        esr.indexNameWithModes(),
+                        CollectionUtils.combine(esr.output(), missing)
+                    );
                 }
                 return esr;
             });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -102,13 +102,13 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
                             p = new Eval(eval.source(), eval.child(), remaining);
                         }
                     }
-                } else if (p instanceof EsRelation esRelation && esRelation.indexMode() == IndexMode.LOOKUP) {
+                } else if (p instanceof EsRelation esr && esr.indexMode() == IndexMode.LOOKUP) {
                     // Normally, pruning EsRelation has no effect because InsertFieldExtraction only extracts the required fields, anyway.
                     // However, InsertFieldExtraction can't be currently used in LOOKUP JOIN right index,
                     // it works differently as we extract all fields (other than the join key) that the EsRelation has.
-                    var remaining = removeUnused(esRelation.output(), used);
+                    var remaining = removeUnused(esr.output(), used);
                     if (remaining != null) {
-                        p = new EsRelation(esRelation.source(), esRelation.index(), remaining, esRelation.indexMode(), esRelation.frozen());
+                        p = new EsRelation(esr.source(), esr.indexPattern(), esr.indexMode(), esr.indexNameWithModes(), remaining);
                     }
                 }
             } while (recheck);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SkipQueryOnEmptyMappings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SkipQueryOnEmptyMappings.java
@@ -16,6 +16,6 @@ public final class SkipQueryOnEmptyMappings extends OptimizerRules.OptimizerRule
 
     @Override
     protected LogicalPlan rule(EsRelation plan) {
-        return plan.index().concreteIndices().isEmpty() ? new LocalRelation(plan.source(), plan.output(), LocalSupplier.EMPTY) : plan;
+        return plan.concreteIndices().isEmpty() ? new LocalRelation(plan.source(), plan.output(), LocalSupplier.EMPTY) : plan;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateMetricsAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateMetricsAggregate.java
@@ -220,7 +220,7 @@ public final class TranslateMetricsAggregate extends OptimizerRules.OptimizerRul
             if (attributes.stream().noneMatch(a -> a.name().equals(MetadataAttribute.TIMESTAMP_FIELD))) {
                 attributes.removeIf(a -> a.name().equals(MetadataAttribute.TIMESTAMP_FIELD));
             }
-            return new EsRelation(r.source(), r.index(), new ArrayList<>(attributes), IndexMode.STANDARD);
+            return new EsRelation(r.source(), r.indexPattern(), IndexMode.STANDARD, r.indexNameWithModes(), new ArrayList<>(attributes));
         });
         return new Aggregate(metrics.source(), child, Aggregate.AggregateType.STANDARD, metrics.groupings(), metrics.aggregates());
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
@@ -104,8 +104,9 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
             var query = Queries.combine(Queries.Clause.FILTER, asList(queryExec.query(), planQuery));
             queryExec = new EsQueryExec(
                 queryExec.source(),
-                queryExec.index(),
+                queryExec.indexPattern(),
                 queryExec.indexMode(),
+                queryExec.indexNameWithModes(),
                 queryExec.output(),
                 query,
                 queryExec.limit(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToSource.java
@@ -59,7 +59,7 @@ public class PushStatsToSource extends PhysicalOptimizerRules.ParameterizedOptim
             if (tuple.v2().size() == aggregateExec.aggregates().size()) {
                 plan = new EsStatsQueryExec(
                     aggregateExec.source(),
-                    queryExec.index(),
+                    queryExec.indexPattern(),
                     queryExec.query(),
                     queryExec.limit(),
                     tuple.v1(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
@@ -53,6 +53,6 @@ public class ReplaceSourceAttributes extends PhysicalOptimizerRules.OptimizerRul
                 attributes.add(ma);
             }
         });
-        return new EsQueryExec(plan.source(), plan.index(), plan.indexMode(), attributes, plan.query());
+        return new EsQueryExec(plan.source(), plan.indexPattern(), plan.indexMode(), plan.indexNameWithModes(), attributes, plan.query());
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -27,6 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
+
+import static org.elasticsearch.TransportVersions.ESQL_SKIP_ES_INDEX_SERIALIZATION;
 
 public class EsRelation extends LeafPlan {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
@@ -35,30 +38,41 @@ public class EsRelation extends LeafPlan {
         EsRelation::readFrom
     );
 
-    private final EsIndex index;
-    private final List<Attribute> attrs;
-    private final boolean frozen;
+    private final String indexPattern;
     private final IndexMode indexMode;
+    private final Map<String, IndexMode> indexNameWithModes;
+    private final List<Attribute> attrs;
 
-    public EsRelation(Source source, EsIndex index, IndexMode indexMode, boolean frozen) {
-        this(source, index, flatten(source, index.mapping()), indexMode, frozen);
+    public EsRelation(Source source, EsIndex index, IndexMode indexMode) {
+        this(source, index.name(), indexMode, index.indexNameWithModes(), flatten(source, index.mapping()));
     }
 
-    public EsRelation(Source source, EsIndex index, List<Attribute> attributes, IndexMode indexMode) {
-        this(source, index, attributes, indexMode, false);
-    }
-
-    public EsRelation(Source source, EsIndex index, List<Attribute> attributes, IndexMode indexMode, boolean frozen) {
+    public EsRelation(
+        Source source,
+        String indexPattern,
+        IndexMode indexMode,
+        Map<String, IndexMode> indexNameWithModes,
+        List<Attribute> attributes
+    ) {
         super(source);
-        this.index = index;
-        this.attrs = attributes;
+        this.indexPattern = indexPattern;
         this.indexMode = indexMode;
-        this.frozen = frozen;
+        this.indexNameWithModes = indexNameWithModes;
+        this.attrs = attributes;
     }
 
     private static EsRelation readFrom(StreamInput in) throws IOException {
         Source source = Source.readFrom((PlanStreamInput) in);
-        EsIndex esIndex = EsIndex.readFrom(in);
+        String indexPattern;
+        Map<String, IndexMode> indexNameWithModes;
+        if (in.getTransportVersion().onOrAfter(ESQL_SKIP_ES_INDEX_SERIALIZATION)) {
+            indexPattern = in.readString();
+            indexNameWithModes = in.readMap(IndexMode::readFrom);
+        } else {
+            var index = EsIndex.readFrom(in);
+            indexPattern = index.name();
+            indexNameWithModes = index.indexNameWithModes();
+        }
         List<Attribute> attributes = in.readNamedWriteableCollectionAsList(Attribute.class);
         if (supportingEsSourceOptions(in.getTransportVersion())) {
             // We don't do anything with these strings
@@ -67,23 +81,32 @@ public class EsRelation extends LeafPlan {
             in.readOptionalString();
         }
         IndexMode indexMode = readIndexMode(in);
-        boolean frozen = in.readBoolean();
-        return new EsRelation(source, esIndex, attributes, indexMode, frozen);
+        if (in.getTransportVersion().before(ESQL_SKIP_ES_INDEX_SERIALIZATION)) {
+            in.readBoolean();
+        }
+        return new EsRelation(source, indexPattern, indexMode, indexNameWithModes, attributes);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         Source.EMPTY.writeTo(out);
-        index().writeTo(out);
-        out.writeNamedWriteableCollection(output());
+        if (out.getTransportVersion().onOrAfter(ESQL_SKIP_ES_INDEX_SERIALIZATION)) {
+            out.writeString(indexPattern);
+            out.writeMap(indexNameWithModes, (o, v) -> IndexMode.writeTo(v, out));
+        } else {
+            new EsIndex(indexPattern, Map.of(), indexNameWithModes).writeTo(out);
+        }
+        out.writeNamedWriteableCollection(attrs);
         if (supportingEsSourceOptions(out.getTransportVersion())) {
             // write (null) string fillers expected by remote
             out.writeOptionalString(null);
             out.writeOptionalString(null);
             out.writeOptionalString(null);
         }
-        writeIndexMode(out, indexMode());
-        out.writeBoolean(frozen());
+        writeIndexMode(out, indexMode);
+        if (out.getTransportVersion().before(ESQL_SKIP_ES_INDEX_SERIALIZATION)) {
+            out.writeBoolean(false);
+        }
     }
 
     private static boolean supportingEsSourceOptions(TransportVersion version) {
@@ -97,7 +120,7 @@ public class EsRelation extends LeafPlan {
 
     @Override
     protected NodeInfo<EsRelation> info() {
-        return NodeInfo.create(this, EsRelation::new, index, attrs, indexMode, frozen);
+        return NodeInfo.create(this, EsRelation::new, indexPattern, indexMode, indexNameWithModes, attrs);
     }
 
     private static List<Attribute> flatten(Source source, Map<String, EsField> mapping) {
@@ -128,21 +151,25 @@ public class EsRelation extends LeafPlan {
         return list;
     }
 
-    public EsIndex index() {
-        return index;
-    }
-
-    public boolean frozen() {
-        return frozen;
+    public String indexPattern() {
+        return indexPattern;
     }
 
     public IndexMode indexMode() {
         return indexMode;
     }
 
+    public Map<String, IndexMode> indexNameWithModes() {
+        return indexNameWithModes;
+    }
+
     @Override
     public List<Attribute> output() {
         return attrs;
+    }
+
+    public Set<String> concreteIndices() {
+        return indexNameWithModes.keySet();
     }
 
     @Override
@@ -159,7 +186,7 @@ public class EsRelation extends LeafPlan {
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, indexMode, frozen, attrs);
+        return Objects.hash(indexPattern, indexMode, indexNameWithModes, attrs);
     }
 
     @Override
@@ -173,9 +200,9 @@ public class EsRelation extends LeafPlan {
         }
 
         EsRelation other = (EsRelation) obj;
-        return Objects.equals(index, other.index)
-            && indexMode == other.indexMode()
-            && frozen == other.frozen
+        return Objects.equals(indexPattern, other.indexPattern)
+            && Objects.equals(indexMode, other.indexMode)
+            && Objects.equals(indexNameWithModes, other.indexNameWithModes)
             && Objects.equals(attrs, other.attrs);
     }
 
@@ -183,7 +210,7 @@ public class EsRelation extends LeafPlan {
     public String nodeString() {
         return nodeName()
             + "["
-            + index
+            + indexPattern
             + "]"
             + (indexMode != IndexMode.STANDARD ? "[" + indexMode.name() + "]" : "")
             + NodeUtils.limitedToString(attrs);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
@@ -36,22 +36,25 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.TransportVersions.ESQL_SKIP_ES_INDEX_SERIALIZATION;
+
 public class EsQueryExec extends LeafExec implements EstimatesRowSize {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         PhysicalPlan.class,
         "EsQueryExec",
-        EsQueryExec::deserialize
+        EsQueryExec::readFrom
     );
 
     public static final EsField DOC_ID_FIELD = new EsField("_doc", DataType.DOC_DATA_TYPE, Map.of(), false);
     public static final List<Sort> NO_SORTS = List.of();  // only exists to mimic older serialization, but we no longer serialize sorts
 
-    private final EsIndex index;
+    private final String indexPattern;
     private final IndexMode indexMode;
+    private final Map<String, IndexMode> indexNameWithModes;
+    private final List<Attribute> attrs;
     private final QueryBuilder query;
     private final Expression limit;
     private final List<Sort> sorts;
-    private final List<Attribute> attrs;
 
     /**
      * Estimate of the number of bytes that'll be loaded per position before
@@ -108,14 +111,22 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
         }
     }
 
-    public EsQueryExec(Source source, EsIndex index, IndexMode indexMode, List<Attribute> attributes, QueryBuilder query) {
-        this(source, index, indexMode, attributes, query, null, null, null);
+    public EsQueryExec(
+        Source source,
+        String indexPattern,
+        IndexMode indexMode,
+        Map<String, IndexMode> indexNameWithModes,
+        List<Attribute> attributes,
+        QueryBuilder query
+    ) {
+        this(source, indexPattern, indexMode, indexNameWithModes, attributes, query, null, null, null);
     }
 
     public EsQueryExec(
         Source source,
-        EsIndex index,
+        String indexPattern,
         IndexMode indexMode,
+        Map<String, IndexMode> indexNameWithModes,
         List<Attribute> attrs,
         QueryBuilder query,
         Expression limit,
@@ -123,10 +134,11 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
         Integer estimatedRowSize
     ) {
         super(source);
-        this.index = index;
+        this.indexPattern = indexPattern;
         this.indexMode = indexMode;
-        this.query = query;
+        this.indexNameWithModes = indexNameWithModes;
         this.attrs = attrs;
+        this.query = query;
         this.limit = limit;
         this.sorts = sorts;
         this.estimatedRowSize = estimatedRowSize;
@@ -136,9 +148,18 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
      * The matching constructor is used during physical plan optimization and needs valid sorts. But we no longer serialize sorts.
      * If this cluster node is talking to an older instance it might receive a plan with sorts, but it will ignore them.
      */
-    public static EsQueryExec deserialize(StreamInput in) throws IOException {
+    private static EsQueryExec readFrom(StreamInput in) throws IOException {
         var source = Source.readFrom((PlanStreamInput) in);
-        var index = EsIndex.readFrom(in);
+        String indexPattern;
+        Map<String, IndexMode> indexNameWithModes;
+        if (in.getTransportVersion().onOrAfter(ESQL_SKIP_ES_INDEX_SERIALIZATION)) {
+            indexPattern = in.readString();
+            indexNameWithModes = in.readMap(IndexMode::readFrom);
+        } else {
+            var index = EsIndex.readFrom(in);
+            indexPattern = index.name();
+            indexNameWithModes = index.indexNameWithModes();
+        }
         var indexMode = EsRelation.readIndexMode(in);
         var attrs = in.readNamedWriteableCollectionAsList(Attribute.class);
         var query = in.readOptionalNamedWriteable(QueryBuilder.class);
@@ -146,7 +167,7 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
         in.readOptionalCollectionAsList(EsQueryExec::readSort);
         var rowSize = in.readOptionalVInt();
         // Ignore sorts from the old serialization format
-        return new EsQueryExec(source, index, indexMode, attrs, query, limit, NO_SORTS, rowSize);
+        return new EsQueryExec(source, indexPattern, indexMode, indexNameWithModes, attrs, query, limit, NO_SORTS, rowSize);
     }
 
     private static Sort readSort(StreamInput in) throws IOException {
@@ -160,7 +181,12 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         Source.EMPTY.writeTo(out);
-        index().writeTo(out);
+        if (out.getTransportVersion().onOrAfter(ESQL_SKIP_ES_INDEX_SERIALIZATION)) {
+            out.writeString(indexPattern);
+            out.writeMap(indexNameWithModes, (o, v) -> IndexMode.writeTo(v, out));
+        } else {
+            new EsIndex(indexPattern, Map.of(), indexNameWithModes).writeTo(out);
+        }
         EsRelation.writeIndexMode(out, indexMode());
         out.writeNamedWriteableCollection(output());
         out.writeOptionalNamedWriteable(query());
@@ -180,15 +206,30 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
 
     @Override
     protected NodeInfo<EsQueryExec> info() {
-        return NodeInfo.create(this, EsQueryExec::new, index, indexMode, attrs, query, limit, sorts, estimatedRowSize);
+        return NodeInfo.create(
+            this,
+            EsQueryExec::new,
+            indexPattern,
+            indexMode,
+            indexNameWithModes,
+            attrs,
+            query,
+            limit,
+            sorts,
+            estimatedRowSize
+        );
     }
 
-    public EsIndex index() {
-        return index;
+    public String indexPattern() {
+        return indexPattern;
     }
 
     public IndexMode indexMode() {
         return indexMode;
+    }
+
+    public Map<String, IndexMode> indexNameWithModes() {
+        return indexNameWithModes;
     }
 
     public QueryBuilder query() {
@@ -234,13 +275,13 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
         }
         return Objects.equals(this.estimatedRowSize, size)
             ? this
-            : new EsQueryExec(source(), index, indexMode, attrs, query, limit, sorts, size);
+            : new EsQueryExec(source(), indexPattern, indexMode, indexNameWithModes, attrs, query, limit, sorts, size);
     }
 
     public EsQueryExec withLimit(Expression limit) {
         return Objects.equals(this.limit, limit)
             ? this
-            : new EsQueryExec(source(), index, indexMode, attrs, query, limit, sorts, estimatedRowSize);
+            : new EsQueryExec(source(), indexPattern, indexMode, indexNameWithModes, attrs, query, limit, sorts, estimatedRowSize);
     }
 
     public boolean canPushSorts() {
@@ -254,12 +295,12 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
         }
         return Objects.equals(this.sorts, sorts)
             ? this
-            : new EsQueryExec(source(), index, indexMode, attrs, query, limit, sorts, estimatedRowSize);
+            : new EsQueryExec(source(), indexPattern, indexMode, indexNameWithModes, attrs, query, limit, sorts, estimatedRowSize);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, indexMode, attrs, query, limit, sorts);
+        return Objects.hash(indexPattern, indexMode, indexNameWithModes, attrs, query, limit, sorts);
     }
 
     @Override
@@ -273,8 +314,9 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
         }
 
         EsQueryExec other = (EsQueryExec) obj;
-        return Objects.equals(index, other.index)
+        return Objects.equals(indexPattern, other.indexPattern)
             && Objects.equals(indexMode, other.indexMode)
+            && Objects.equals(indexNameWithModes, other.indexNameWithModes)
             && Objects.equals(attrs, other.attrs)
             && Objects.equals(query, other.query)
             && Objects.equals(limit, other.limit)
@@ -286,7 +328,7 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
     public String nodeString() {
         return nodeName()
             + "["
-            + index
+            + indexPattern
             + "], "
             + "indexMode["
             + indexMode

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExec.java
@@ -22,46 +22,71 @@ import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+
+import static org.elasticsearch.TransportVersions.ESQL_SKIP_ES_INDEX_SERIALIZATION;
 
 public class EsSourceExec extends LeafExec {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         PhysicalPlan.class,
         "EsSourceExec",
-        EsSourceExec::new
+        EsSourceExec::readFrom
     );
 
-    private final EsIndex index;
+    private final String indexPattern;
+    private final IndexMode indexMode;
+    private final Map<String, IndexMode> indexNameWithModes;
     private final List<Attribute> attributes;
     private final QueryBuilder query;
-    private final IndexMode indexMode;
 
     public EsSourceExec(EsRelation relation) {
-        this(relation.source(), relation.index(), relation.output(), null, relation.indexMode());
+        this(relation.source(), relation.indexPattern(), relation.indexMode(), relation.indexNameWithModes(), relation.output(), null);
     }
 
-    public EsSourceExec(Source source, EsIndex index, List<Attribute> attributes, QueryBuilder query, IndexMode indexMode) {
+    public EsSourceExec(
+        Source source,
+        String indexPattern,
+        IndexMode indexMode,
+        Map<String, IndexMode> indexNameWithModes,
+        List<Attribute> attributes,
+        QueryBuilder query
+    ) {
         super(source);
-        this.index = index;
+        this.indexPattern = indexPattern;
+        this.indexMode = indexMode;
+        this.indexNameWithModes = indexNameWithModes;
         this.attributes = attributes;
         this.query = query;
-        this.indexMode = indexMode;
     }
 
-    private EsSourceExec(StreamInput in) throws IOException {
-        this(
-            Source.readFrom((PlanStreamInput) in),
-            EsIndex.readFrom(in),
-            in.readNamedWriteableCollectionAsList(Attribute.class),
-            in.readOptionalNamedWriteable(QueryBuilder.class),
-            EsRelation.readIndexMode(in)
-        );
+    private static EsSourceExec readFrom(StreamInput in) throws IOException {
+        var source = Source.readFrom((PlanStreamInput) in);
+        String indexPattern;
+        Map<String, IndexMode> indexNameWithModes;
+        if (in.getTransportVersion().onOrAfter(ESQL_SKIP_ES_INDEX_SERIALIZATION)) {
+            indexPattern = in.readString();
+            indexNameWithModes = in.readMap(IndexMode::readFrom);
+        } else {
+            var index = EsIndex.readFrom(in);
+            indexPattern = index.name();
+            indexNameWithModes = index.indexNameWithModes();
+        }
+        var attributes = in.readNamedWriteableCollectionAsList(Attribute.class);
+        var query = in.readOptionalNamedWriteable(QueryBuilder.class);
+        var indexMode = EsRelation.readIndexMode(in);
+        return new EsSourceExec(source, indexPattern, indexMode, indexNameWithModes, attributes, query);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         Source.EMPTY.writeTo(out);
-        index().writeTo(out);
+        if (out.getTransportVersion().onOrAfter(ESQL_SKIP_ES_INDEX_SERIALIZATION)) {
+            out.writeString(indexPattern);
+            out.writeMap(indexNameWithModes, (o, v) -> IndexMode.writeTo(v, out));
+        } else {
+            new EsIndex(indexPattern, Map.of(), indexNameWithModes).writeTo(out);
+        }
         out.writeNamedWriteableCollection(output());
         out.writeOptionalNamedWriteable(query());
         EsRelation.writeIndexMode(out, indexMode());
@@ -72,16 +97,20 @@ public class EsSourceExec extends LeafExec {
         return ENTRY.name;
     }
 
-    public EsIndex index() {
-        return index;
-    }
-
-    public QueryBuilder query() {
-        return query;
+    public String indexPattern() {
+        return indexPattern;
     }
 
     public IndexMode indexMode() {
         return indexMode;
+    }
+
+    public Map<String, IndexMode> indexNameWithModes() {
+        return indexNameWithModes;
+    }
+
+    public QueryBuilder query() {
+        return query;
     }
 
     @Override
@@ -91,12 +120,12 @@ public class EsSourceExec extends LeafExec {
 
     @Override
     protected NodeInfo<? extends PhysicalPlan> info() {
-        return NodeInfo.create(this, EsSourceExec::new, index, attributes, query, indexMode);
+        return NodeInfo.create(this, EsSourceExec::new, indexPattern, indexMode, indexNameWithModes, attributes, query);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, attributes, query, indexMode);
+        return Objects.hash(indexPattern, indexMode, indexNameWithModes, attributes, query);
     }
 
     @Override
@@ -110,14 +139,15 @@ public class EsSourceExec extends LeafExec {
         }
 
         EsSourceExec other = (EsSourceExec) obj;
-        return Objects.equals(index, other.index)
+        return Objects.equals(indexPattern, other.indexPattern)
+            && Objects.equals(indexMode, other.indexMode)
+            && Objects.equals(indexNameWithModes, other.indexNameWithModes)
             && Objects.equals(attributes, other.attributes)
-            && Objects.equals(query, other.query)
-            && Objects.equals(indexMode, other.indexMode);
+            && Objects.equals(query, other.query);
     }
 
     @Override
     public String nodeString() {
-        return nodeName() + "[" + index + "]" + NodeUtils.limitedToString(attributes);
+        return nodeName() + "[" + indexPattern + "]" + NodeUtils.limitedToString(attributes);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsStatsQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsStatsQueryExec.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.Queries;
-import org.elasticsearch.xpack.esql.index.EsIndex;
 
 import java.io.IOException;
 import java.util.List;
@@ -44,7 +43,7 @@ public class EsStatsQueryExec extends LeafExec implements EstimatesRowSize {
         }
     }
 
-    private final EsIndex index;
+    private final String indexPattern;
     private final QueryBuilder query;
     private final Expression limit;
     private final List<Attribute> attrs;
@@ -52,14 +51,14 @@ public class EsStatsQueryExec extends LeafExec implements EstimatesRowSize {
 
     public EsStatsQueryExec(
         Source source,
-        EsIndex index,
+        String indexPattern,
         QueryBuilder query,
         Expression limit,
         List<Attribute> attributes,
         List<Stat> stats
     ) {
         super(source);
-        this.index = index;
+        this.indexPattern = indexPattern;
         this.query = query;
         this.limit = limit;
         this.attrs = attributes;
@@ -78,11 +77,7 @@ public class EsStatsQueryExec extends LeafExec implements EstimatesRowSize {
 
     @Override
     protected NodeInfo<EsStatsQueryExec> info() {
-        return NodeInfo.create(this, EsStatsQueryExec::new, index, query, limit, attrs, stats);
-    }
-
-    public EsIndex index() {
-        return index;
+        return NodeInfo.create(this, EsStatsQueryExec::new, indexPattern, query, limit, attrs, stats);
     }
 
     public QueryBuilder query() {
@@ -113,7 +108,7 @@ public class EsStatsQueryExec extends LeafExec implements EstimatesRowSize {
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, query, limit, attrs, stats);
+        return Objects.hash(indexPattern, query, limit, attrs, stats);
     }
 
     @Override
@@ -127,7 +122,7 @@ public class EsStatsQueryExec extends LeafExec implements EstimatesRowSize {
         }
 
         EsStatsQueryExec other = (EsStatsQueryExec) obj;
-        return Objects.equals(index, other.index)
+        return Objects.equals(indexPattern, other.indexPattern)
             && Objects.equals(attrs, other.attrs)
             && Objects.equals(query, other.query)
             && Objects.equals(limit, other.limit)
@@ -138,7 +133,7 @@ public class EsStatsQueryExec extends LeafExec implements EstimatesRowSize {
     public String nodeString() {
         return nodeName()
             + "["
-            + index
+            + indexPattern
             + "], stats"
             + stats
             + "], query["

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -562,7 +562,7 @@ public class LocalExecutionPlanner {
         if (localSourceExec.indexMode() != IndexMode.LOOKUP) {
             throw new IllegalArgumentException("can't plan [" + join + "]");
         }
-        Map<String, IndexMode> indicesWithModes = localSourceExec.index().indexNameWithModes();
+        Map<String, IndexMode> indicesWithModes = localSourceExec.indexNameWithModes();
         if (indicesWithModes.size() != 1) {
             throw new IllegalArgumentException("can't plan [" + join + "], found more than 1 index");
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -109,7 +109,7 @@ public class PlannerUtils {
             return Set.of();
         }
         var indices = new LinkedHashSet<String>();
-        forEachFromRelation(plan, relation -> indices.addAll(relation.index().concreteIndices()));
+        forEachFromRelation(plan, relation -> indices.addAll(relation.concreteIndices()));
         return indices;
     }
 
@@ -121,7 +121,7 @@ public class PlannerUtils {
             return Strings.EMPTY_ARRAY;
         }
         var indices = new LinkedHashSet<String>();
-        forEachFromRelation(plan, relation -> indices.addAll(asList(Strings.commaDelimitedListToStringArray(relation.index().name()))));
+        forEachFromRelation(plan, relation -> indices.addAll(asList(Strings.commaDelimitedListToStringArray(relation.indexPattern()))));
         return indices.toArray(String[]::new);
     }
 
@@ -191,7 +191,14 @@ public class PlannerUtils {
             if (filter != null) {
                 physicalFragment = physicalFragment.transformUp(
                     EsSourceExec.class,
-                    query -> new EsSourceExec(Source.EMPTY, query.index(), query.output(), filter, query.indexMode())
+                    query -> new EsSourceExec(
+                        Source.EMPTY,
+                        query.indexPattern(),
+                        query.indexMode(),
+                        query.indexNameWithModes(),
+                        query.output(),
+                        filter
+                    )
                 );
             }
             var localOptimized = physicalOptimizer.localOptimize(physicalFragment);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/QueryBuilderResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/QueryBuilderResolver.java
@@ -99,9 +99,7 @@ public class QueryBuilderResolver {
 
     public Set<String> indexNames(LogicalPlan plan) {
         Holder<Set<String>> indexNames = new Holder<>();
-
-        plan.forEachDown(EsRelation.class, esRelation -> { indexNames.set(esRelation.index().concreteIndices()); });
-
+        plan.forEachDown(EsRelation.class, esRelation -> indexNames.set(esRelation.concreteIndices()));
         return indexNames.get();
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -122,7 +122,7 @@ public class AnalyzerTests extends ESTestCase {
         var plan = analyzer.analyze(UNRESOLVED_RELATION);
         var limit = as(plan, Limit.class);
 
-        assertEquals(new EsRelation(EMPTY, idx, NO_FIELDS, IndexMode.STANDARD), limit.child());
+        assertEquals(new EsRelation(EMPTY, idx.name(), IndexMode.STANDARD, idx.indexNameWithModes(), NO_FIELDS), limit.child());
     }
 
     public void testFailOnUnresolvedIndex() {
@@ -140,7 +140,7 @@ public class AnalyzerTests extends ESTestCase {
         var plan = analyzer.analyze(UNRESOLVED_RELATION);
         var limit = as(plan, Limit.class);
 
-        assertEquals(new EsRelation(EMPTY, idx, NO_FIELDS, IndexMode.STANDARD), limit.child());
+        assertEquals(new EsRelation(EMPTY, idx.name(), IndexMode.STANDARD, idx.indexNameWithModes(), NO_FIELDS), limit.child());
     }
 
     public void testAttributeResolution() {
@@ -2078,7 +2078,7 @@ public class AnalyzerTests extends ESTestCase {
         assertThat(project.projections().stream().map(Object::toString).toList(), hasItem(matchesRegex("languages\\{f}#\\d+ AS int#\\d+")));
 
         var esRelation = as(project.child(), EsRelation.class);
-        assertThat(esRelation.index().name(), equalTo("test"));
+        assertThat(esRelation.indexPattern(), equalTo("test"));
 
         // Lookup's output looks sensible too
         assertMap(
@@ -2590,7 +2590,7 @@ public class AnalyzerTests extends ESTestCase {
         assertEquals(enrich.policy().getMatchField(), "language_code");
         var eval = as(enrich.child(), Eval.class);
         var esRelation = as(eval.child(), EsRelation.class);
-        assertEquals(esRelation.index().name(), "test");
+        assertEquals(esRelation.indexPattern(), "test");
     }
 
     public void testMapExpressionAsFunctionArgument() {
@@ -2618,7 +2618,7 @@ public class AnalyzerTests extends ESTestCase {
         assertEquals(new Literal(EMPTY, 2.0, DataType.DOUBLE), ee.value());
         assertEquals(DataType.DOUBLE, ee.dataType());
         EsRelation esRelation = as(eval.child(), EsRelation.class);
-        assertEquals(esRelation.index().name(), "test");
+        assertEquals(esRelation.indexPattern(), "test");
     }
 
     private void verifyMapExpression(MapExpression me) {
@@ -2706,7 +2706,6 @@ public class AnalyzerTests extends ESTestCase {
         assertThat(plan, instanceOf(EsRelation.class));
         EsRelation esRelation = (EsRelation) plan;
         assertThat(esRelation.output(), equalTo(NO_FIELDS));
-        assertTrue(esRelation.index().mapping().isEmpty());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/index/EsIndexSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/index/EsIndexSerializationTests.java
@@ -27,13 +27,14 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import static org.elasticsearch.core.Tuple.tuple;
 import static org.elasticsearch.test.ByteSizeEqualsMatcher.byteSizeEquals;
 
 public class EsIndexSerializationTests extends AbstractWireSerializingTestCase<EsIndex> {
     public static EsIndex randomEsIndex() {
         String name = randomAlphaOfLength(5);
         Map<String, EsField> mapping = randomMapping();
-        return new EsIndex(name, mapping, randomConcreteIndices());
+        return new EsIndex(name, mapping, randomIndexNameWithModes());
     }
 
     private static Map<String, EsField> randomMapping() {
@@ -45,13 +46,8 @@ public class EsIndexSerializationTests extends AbstractWireSerializingTestCase<E
         return result;
     }
 
-    private static Map<String, IndexMode> randomConcreteIndices() {
-        int size = between(0, 10);
-        Map<String, IndexMode> result = new HashMap<>(size);
-        while (result.size() < size) {
-            result.put(randomAlphaOfLength(5), randomFrom(IndexMode.values()));
-        }
-        return result;
+    public static Map<String, IndexMode> randomIndexNameWithModes() {
+        return randomMap(0, 10, () -> tuple(randomIdentifier(), randomFrom(IndexMode.values())));
     }
 
     @Override
@@ -77,7 +73,10 @@ public class EsIndexSerializationTests extends AbstractWireSerializingTestCase<E
         switch (between(0, 2)) {
             case 0 -> name = randomValueOtherThan(name, () -> randomAlphaOfLength(5));
             case 1 -> mapping = randomValueOtherThan(mapping, EsIndexSerializationTests::randomMapping);
-            case 2 -> indexedNameWithModes = randomValueOtherThan(indexedNameWithModes, EsIndexSerializationTests::randomConcreteIndices);
+            case 2 -> indexedNameWithModes = randomValueOtherThan(
+                indexedNameWithModes,
+                EsIndexSerializationTests::randomIndexNameWithModes
+            );
             default -> throw new IllegalArgumentException();
         }
         return new EsIndex(name, mapping, indexedNameWithModes);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -580,6 +580,6 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
     }
 
     public static EsRelation relation() {
-        return new EsRelation(EMPTY, new EsIndex(randomAlphaOfLength(8), emptyMap()), randomFrom(IndexMode.values()), randomBoolean());
+        return new EsRelation(EMPTY, new EsIndex(randomAlphaOfLength(8), emptyMap()), randomFrom(IndexMode.values()));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -6916,6 +6916,6 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
         assertEquals(DataType.DOUBLE, ee.dataType());
         Limit limit = as(eval.child(), Limit.class);
         EsRelation esRelation = as(limit.child(), EsRelation.class);
-        assertEquals(esRelation.index().name(), "test");
+        assertEquals(esRelation.indexPattern(), "test");
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -2578,10 +2578,16 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             | where round(emp_no) > 10
             """));
         // Transform the verified plan so that it is invalid (i.e. no source attributes)
-        List<Attribute> emptyAttrList = List.of();
         var badPlan = verifiedPlan.transformDown(
             EsQueryExec.class,
-            node -> new EsSourceExec(node.source(), node.index(), emptyAttrList, node.query(), IndexMode.STANDARD)
+            node -> new EsSourceExec(
+                node.source(),
+                node.indexPattern(),
+                IndexMode.STANDARD,
+                node.indexNameWithModes(),
+                List.of(),
+                node.query()
+            )
         );
 
         var e = expectThrows(VerificationException.class, () -> physicalPlanOptimizer.verify(badPlan));
@@ -2703,8 +2709,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
                     new EsField("some_field2", DataType.KEYWORD, Map.of(), true)
                 )
             ),
-            IndexMode.STANDARD,
-            false
+            IndexMode.STANDARD
         );
         Attribute some_field1 = relation.output().get(0);
         Attribute some_field2 = relation.output().get(1);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFiltersTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFiltersTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
-import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
@@ -33,9 +32,9 @@ import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.FOUR;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.ONE;
@@ -251,12 +250,6 @@ public class PushDownAndCombineFiltersTests extends ESTestCase {
     }
 
     private static EsRelation relation(List<Attribute> fieldAttributes) {
-        return new EsRelation(
-            EMPTY,
-            new EsIndex(randomAlphaOfLength(8), emptyMap()),
-            fieldAttributes,
-            randomFrom(IndexMode.values()),
-            randomBoolean()
-        );
+        return new EsRelation(EMPTY, randomIdentifier(), randomFrom(IndexMode.values()), Map.of(), fieldAttributes);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StDistance;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
-import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
@@ -582,9 +581,8 @@ public class PushTopNToSourceTests extends ESTestCase {
         }
 
         public TopNExec build() {
-            EsIndex esIndex = new EsIndex(this.index, Map.of());
             List<Attribute> attributes = new ArrayList<>(fields.values());
-            PhysicalPlan child = new EsQueryExec(Source.EMPTY, esIndex, indexMode, attributes, null, null, List.of(), 0);
+            PhysicalPlan child = new EsQueryExec(Source.EMPTY, this.index, indexMode, Map.of(), attributes, null, null, List.of(), 0);
             if (aliases.isEmpty() == false) {
                 child = new EvalExec(Source.EMPTY, child, aliases);
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/EsRelationSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/EsRelationSerializationTests.java
@@ -8,22 +8,25 @@
 package org.elasticsearch.xpack.esql.plan.logical;
 
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.index.EsIndexSerializationTests;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.index.EsIndexSerializationTests.randomIndexNameWithModes;
 
 public class EsRelationSerializationTests extends AbstractLogicalPlanSerializationTests<EsRelation> {
     public static EsRelation randomEsRelation() {
-        Source source = randomSource();
-        EsIndex index = EsIndexSerializationTests.randomEsIndex();
-        List<Attribute> attributes = randomFieldAttributes(0, 10, false);
-        IndexMode indexMode = randomFrom(IndexMode.values());
-        boolean frozen = randomBoolean();
-        return new EsRelation(source, index, attributes, indexMode, frozen);
+        return new EsRelation(
+            randomSource(),
+            randomIdentifier(),
+            randomFrom(IndexMode.values()),
+            randomIndexNameWithModes(),
+            randomFieldAttributes(0, 10, false)
+        );
     }
 
     @Override
@@ -33,18 +36,18 @@ public class EsRelationSerializationTests extends AbstractLogicalPlanSerializati
 
     @Override
     protected EsRelation mutateInstance(EsRelation instance) throws IOException {
-        EsIndex index = instance.index();
-        List<Attribute> attributes = instance.output();
+        String indexPattern = instance.indexPattern();
         IndexMode indexMode = instance.indexMode();
-        boolean frozen = instance.frozen();
+        Map<String, IndexMode> indexNameWithModes = instance.indexNameWithModes();
+        List<Attribute> attributes = instance.output();
         switch (between(0, 3)) {
-            case 0 -> index = randomValueOtherThan(index, EsIndexSerializationTests::randomEsIndex);
-            case 1 -> attributes = randomValueOtherThan(attributes, () -> randomFieldAttributes(0, 10, false));
-            case 2 -> indexMode = randomValueOtherThan(indexMode, () -> randomFrom(IndexMode.values()));
-            case 3 -> frozen = false == frozen;
+            case 0 -> indexPattern = randomValueOtherThan(indexPattern, ESTestCase::randomIdentifier);
+            case 1 -> indexMode = randomValueOtherThan(indexMode, () -> randomFrom(IndexMode.values()));
+            case 2 -> indexNameWithModes = randomValueOtherThan(indexNameWithModes, EsIndexSerializationTests::randomIndexNameWithModes);
+            case 3 -> attributes = randomValueOtherThan(attributes, () -> randomFieldAttributes(0, 10, false));
             default -> throw new IllegalArgumentException();
         }
-        return new EsRelation(instance.source(), index, attributes, indexMode, frozen);
+        return new EsRelation(instance.source(), indexPattern, indexMode, indexNameWithModes, attributes);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExecSerializationTests.java
@@ -10,24 +10,26 @@ package org.elasticsearch.xpack.esql.plan.physical;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.index.EsIndexSerializationTests;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
-import static org.elasticsearch.xpack.esql.plan.logical.AbstractLogicalPlanSerializationTests.randomFieldAttributes;
+import static org.elasticsearch.xpack.esql.index.EsIndexSerializationTests.randomIndexNameWithModes;
 
 public class EsSourceExecSerializationTests extends AbstractPhysicalPlanSerializationTests<EsSourceExec> {
     public static EsSourceExec randomEsSourceExec() {
-        Source source = randomSource();
-        EsIndex index = EsIndexSerializationTests.randomEsIndex();
-        List<Attribute> attributes = randomFieldAttributes(1, 10, false);
-        QueryBuilder query = new TermQueryBuilder(randomAlphaOfLength(5), randomAlphaOfLength(5));
-        IndexMode indexMode = randomFrom(IndexMode.values());
-        return new EsSourceExec(source, index, attributes, query, indexMode);
+        return new EsSourceExec(
+            randomSource(),
+            randomIdentifier(),
+            randomFrom(IndexMode.values()),
+            randomIndexNameWithModes(),
+            randomFieldAttributes(1, 10, false),
+            new TermQueryBuilder(randomAlphaOfLength(5), randomAlphaOfLength(5))
+        );
     }
 
     @Override
@@ -37,18 +39,20 @@ public class EsSourceExecSerializationTests extends AbstractPhysicalPlanSerializ
 
     @Override
     protected EsSourceExec mutateInstance(EsSourceExec instance) throws IOException {
-        EsIndex index = instance.index();
+        String indexPattern = instance.indexPattern();
+        IndexMode indexMode = instance.indexMode();
+        Map<String, IndexMode> indexNameWithModes = instance.indexNameWithModes();
         List<Attribute> attributes = instance.output();
         QueryBuilder query = instance.query();
-        IndexMode indexMode = instance.indexMode();
-        switch (between(0, 3)) {
-            case 0 -> index = randomValueOtherThan(index, EsIndexSerializationTests::randomEsIndex);
-            case 1 -> attributes = randomValueOtherThan(attributes, () -> randomFieldAttributes(1, 10, false));
-            case 2 -> query = randomValueOtherThan(query, () -> new TermQueryBuilder(randomAlphaOfLength(5), randomAlphaOfLength(5)));
-            case 3 -> indexMode = randomValueOtherThan(indexMode, () -> randomFrom(IndexMode.values()));
+        switch (between(0, 4)) {
+            case 0 -> indexPattern = randomValueOtherThan(indexPattern, ESTestCase::randomIdentifier);
+            case 1 -> indexMode = randomValueOtherThan(indexMode, () -> randomFrom(IndexMode.values()));
+            case 2 -> indexNameWithModes = randomValueOtherThan(indexNameWithModes, EsIndexSerializationTests::randomIndexNameWithModes);
+            case 3 -> attributes = randomValueOtherThan(attributes, () -> randomFieldAttributes(1, 10, false));
+            case 4 -> query = randomValueOtherThan(query, () -> new TermQueryBuilder(randomAlphaOfLength(5), randomAlphaOfLength(5)));
             default -> throw new IllegalStateException();
         }
-        return new EsSourceExec(instance.source(), index, attributes, query, indexMode);
+        return new EsSourceExec(instance.source(), indexPattern, indexMode, indexNameWithModes, attributes, query);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExecSerializationTests.java
@@ -25,7 +25,11 @@ import org.elasticsearch.xpack.esql.plan.logical.Project;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.IntStream;
 
+import static java.util.stream.Collectors.toMap;
 import static org.elasticsearch.test.ByteSizeEqualsMatcher.byteSizeEquals;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -66,14 +70,15 @@ public class ExchangeSinkExecSerializationTests extends AbstractPhysicalPlanSeri
      * See {@link #testManyTypeConflicts(boolean, ByteSizeValue)} for more.
      */
     public void testManyTypeConflicts() throws IOException {
-        testManyTypeConflicts(false, ByteSizeValue.ofBytes(1424046L));
         /*
          * History:
          *  2.3mb - shorten error messages for UnsupportedAttributes #111973
          *  1.8mb - cache EsFields #112008
          *  1.4mb - string serialization #112929
          *  1424046b - remove node-level plan #117422
+         *  1040607b - remove EsIndex mapping serialization #119580
          */
+        testManyTypeConflicts(false, ByteSizeValue.ofBytes(1040607));
     }
 
     /**
@@ -81,7 +86,6 @@ public class ExchangeSinkExecSerializationTests extends AbstractPhysicalPlanSeri
      * See {@link #testManyTypeConflicts(boolean, ByteSizeValue)} for more.
      */
     public void testManyTypeConflictsWithParent() throws IOException {
-        testManyTypeConflicts(true, ByteSizeValue.ofBytes(2774190));
         /*
          * History:
          *  2 gb+ - start
@@ -91,7 +95,9 @@ public class ExchangeSinkExecSerializationTests extends AbstractPhysicalPlanSeri
          *  2774214b - string serialization #112929
          *  2774192b - remove field attribute #112881
          *  2774190b - remove node-level plan #117422
+         *  2007288b - remove EsIndex mapping serialization #119580
          */
+        testManyTypeConflicts(true, ByteSizeValue.ofBytes(2007288));
     }
 
     private void testManyTypeConflicts(boolean withParent, ByteSizeValue expected) throws IOException {
@@ -105,19 +111,19 @@ public class ExchangeSinkExecSerializationTests extends AbstractPhysicalPlanSeri
      * with a single root field that has many children, grandchildren etc.
      */
     public void testDeeplyNestedFields() throws IOException {
-        ByteSizeValue expected = ByteSizeValue.ofBytes(47252409);
         /*
          * History:
          *  48223371b - string serialization #112929
          *  47252411b - remove field attribute #112881
-         *  47252409b - remove node-level plan
+         *  47252409b - remove node-level plan #117422
+         *  43927169b - remove EsIndex mapping serialization #119580
          */
 
         int depth = 6;
         int childrenPerLevel = 8;
 
         EsIndex index = EsIndexSerializationTests.deeplyNestedIndex(depth, childrenPerLevel);
-        testSerializePlanWithIndex(index, expected);
+        testSerializePlanWithIndex(index, ByteSizeValue.ofBytes(43927169));
     }
 
     /**
@@ -126,19 +132,39 @@ public class ExchangeSinkExecSerializationTests extends AbstractPhysicalPlanSeri
      * with a single root field that has many children, grandchildren etc.
      */
     public void testDeeplyNestedFieldsKeepOnlyOne() throws IOException {
-        ByteSizeValue expected = ByteSizeValue.ofBytes(9425804);
         /*
          * History:
          *  9426058b - string serialization #112929
          *  9425806b - remove field attribute #112881
          *  9425804b - remove node-level plan #117422
+         *  352b - remove EsIndex mapping serialization #119580
          */
 
         int depth = 6;
         int childrenPerLevel = 9;
 
         EsIndex index = EsIndexSerializationTests.deeplyNestedIndex(depth, childrenPerLevel);
-        testSerializePlanWithIndex(index, expected, false);
+        testSerializePlanWithIndex(index, ByteSizeValue.ofBytes(352), false);
+    }
+
+    /**
+     * Test the size of serializing a plan like
+     * FROM index* | LIMIT 10 | KEEP one_single_field
+     * with an index pattern pointing to a hundred actual indices with rather long names
+     */
+    public void testIndexPatternTargetingMultipleIndices() throws IOException {
+        /*
+         * History: 4996b - initial
+         */
+
+        var index = new EsIndex(
+            "index*",
+            Map.of(),
+            IntStream.range(0, 100)
+                .mapToObj(i -> "partial-.ds-index-service-logs-2025.01.01-000" + i)
+                .collect(toMap(Function.identity(), i -> IndexMode.STANDARD))
+        );
+        testSerializePlanWithIndex(index, ByteSizeValue.ofBytes(4996));
     }
 
     /**
@@ -165,8 +191,8 @@ public class ExchangeSinkExecSerializationTests extends AbstractPhysicalPlanSeri
 
     private void testSerializePlanWithIndex(EsIndex index, ByteSizeValue expected, boolean keepAllFields) throws IOException {
         List<Attribute> allAttributes = Analyzer.mappingAsAttributes(randomSource(), index.mapping());
-        List<Attribute> keepAttributes = keepAllFields ? allAttributes : List.of(allAttributes.get(0));
-        EsRelation relation = new EsRelation(randomSource(), index, keepAttributes, IndexMode.STANDARD);
+        List<Attribute> keepAttributes = keepAllFields || allAttributes.isEmpty() ? allAttributes : List.of(allAttributes.getFirst());
+        EsRelation relation = new EsRelation(randomSource(), index.name(), IndexMode.STANDARD, index.indexNameWithModes(), keepAttributes);
         Limit limit = new Limit(randomSource(), new Literal(randomSource(), 10, DataType.INTEGER), relation);
         Project project = new Project(randomSource(), limit, limit.output());
         FragmentExec fragmentExec = new FragmentExec(project);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExecSerializationTests.java
@@ -191,7 +191,7 @@ public class ExchangeSinkExecSerializationTests extends AbstractPhysicalPlanSeri
 
     private void testSerializePlanWithIndex(EsIndex index, ByteSizeValue expected, boolean keepAllFields) throws IOException {
         List<Attribute> allAttributes = Analyzer.mappingAsAttributes(randomSource(), index.mapping());
-        List<Attribute> keepAttributes = keepAllFields || allAttributes.isEmpty() ? allAttributes : List.of(allAttributes.getFirst());
+        List<Attribute> keepAttributes = keepAllFields || allAttributes.isEmpty() ? allAttributes : List.of(allAttributes.get(0));
         EsRelation relation = new EsRelation(randomSource(), index.name(), IndexMode.STANDARD, index.indexNameWithModes(), keepAttributes);
         Limit limit = new Limit(randomSource(), new Literal(randomSource(), 10, DataType.INTEGER), relation);
         Project project = new Project(randomSource(), limit, limit.output());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -85,7 +85,17 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
         int estimatedRowSize = randomEstimatedRowSize(estimatedRowSizeIsHuge);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(
             FoldContext.small(),
-            new EsQueryExec(Source.EMPTY, index(), IndexMode.STANDARD, List.of(), null, null, null, estimatedRowSize)
+            new EsQueryExec(
+                Source.EMPTY,
+                index().name(),
+                IndexMode.STANDARD,
+                index().indexNameWithModes(),
+                List.of(),
+                null,
+                null,
+                null,
+                estimatedRowSize
+            )
         );
         assertThat(plan.driverFactories.size(), lessThanOrEqualTo(pragmas.taskConcurrency()));
         LocalExecutionPlanner.DriverSupplier supplier = plan.driverFactories.get(0).driverSupplier();
@@ -101,7 +111,17 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
         Literal limit = new Literal(Source.EMPTY, 10, DataType.INTEGER);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(
             FoldContext.small(),
-            new EsQueryExec(Source.EMPTY, index(), IndexMode.STANDARD, List.of(), null, limit, List.of(sort), estimatedRowSize)
+            new EsQueryExec(
+                Source.EMPTY,
+                index().name(),
+                IndexMode.STANDARD,
+                index().indexNameWithModes(),
+                List.of(),
+                null,
+                limit,
+                List.of(sort),
+                estimatedRowSize
+            )
         );
         assertThat(plan.driverFactories.size(), lessThanOrEqualTo(pragmas.taskConcurrency()));
         LocalExecutionPlanner.DriverSupplier supplier = plan.driverFactories.get(0).driverSupplier();
@@ -117,7 +137,17 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
         Literal limit = new Literal(Source.EMPTY, 10, DataType.INTEGER);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(
             FoldContext.small(),
-            new EsQueryExec(Source.EMPTY, index(), IndexMode.STANDARD, List.of(), null, limit, List.of(sort), estimatedRowSize)
+            new EsQueryExec(
+                Source.EMPTY,
+                index().name(),
+                IndexMode.STANDARD,
+                index().indexNameWithModes(),
+                List.of(),
+                null,
+                limit,
+                List.of(sort),
+                estimatedRowSize
+            )
         );
         assertThat(plan.driverFactories.size(), lessThanOrEqualTo(pragmas.taskConcurrency()));
         LocalExecutionPlanner.DriverSupplier supplier = plan.driverFactories.get(0).driverSupplier();


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Do not serialize EsIndex in plan (#119580)