### PR TITLE
[8.x] Move `TransportVersion` negotiation to handshake (#120261)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -28,7 +28,6 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.core.UpdateForV10;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -41,7 +40,6 @@ final class OutboundHandler {
 
     private final String nodeName;
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // only used in assertions, can be dropped in future
     private final TransportVersion version;
 
     private final StatsTracker statsTracker;

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -257,7 +257,7 @@ final class TransportHandshaker {
                         )
                     );
                 } else {
-                    listener.onResponse(responseVersion);
+                    listener.onResponse(TransportVersion.min(TransportHandshaker.this.version, response.getResponseVersion()));
                 }
             }
         }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Move `TransportVersion` negotiation to handshake (#120261)