### PR TITLE
[DOCS][TEST] Test consolidating deployment types in connector refs

### DIFF
--- a/docs/reference/connector/docs/_connectors-docker-instructions.asciidoc
+++ b/docs/reference/connector/docs/_connectors-docker-instructions.asciidoc
@@ -3,7 +3,7 @@ Follow these instructions.
 
 .*Step 1: Download sample configuration file*
 [%collapsible]
-====
+==============
 Download the sample configuration file.
 You can either download it manually or run the following command:
 
@@ -14,11 +14,11 @@ curl https://raw.githubusercontent.com/elastic/connectors/main/config.yml.exampl
 // NOTCONSOLE
 
 Remember to update the `--output` argument value if your directory name is different, or you want to use a different config file name.
-====
+==============
 
 .*Step 2: Update the configuration file for your self-managed connector*
 [%collapsible]
-====
+==============
 Update the configuration file with the following settings to match your environment:
 
 * `elasticsearch.host`
@@ -45,11 +45,11 @@ Using the `elasticsearch.api_key` is the recommended authentication method. Howe
 
 Note: You can change other default configurations by simply uncommenting specific settings in the configuration file and modifying their values.
 
-====
+==============
 
 .*Step 3: Run the Docker image*
 [%collapsible]
-====
+==============
 Run the Docker image with the Connector Service using the following command:
 
 [source,sh,subs="attributes"]
@@ -63,7 +63,7 @@ docker.elastic.co/integrations/elastic-connectors:{version}.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ----
-====
+==============
 
 Refer to {connectors-python}/docs/DOCKER.md[`DOCKER.md`^] in the `elastic/connectors` repo for more details.
 

--- a/docs/reference/connector/docs/connectors-azure-blob.asciidoc
+++ b/docs/reference/connector/docs/connectors-azure-blob.asciidoc
@@ -9,86 +9,115 @@
 
 The _Elastic Azure Blob Storage connector_ is a <<es-connectors,connector>> for https://azure.microsoft.com/en-us/services/storage/blobs/[Azure Blob Storage^].
 
-This connector is written in Python using the {connectors-python}[Elastic connector framework^]. 
+This connector is written in Python using the {connectors-python}[Elastic connector framework^].
 
 View the {connectors-python}/connectors/sources/{service-name-stub}.py[*source code* for this connector^] (branch _{connectors-branch}_, compatible with Elastic _{minor-version}_).
 
-.Choose your connector reference
-*******************************
-Are you using a managed connector on Elastic Cloud or a self-managed connector? Expand the documentation based on your deployment method.
-*******************************
-
-// //////// //// //// //// //// //// //// ////////
-// ////////   NATIVE CONNECTOR REFERENCE   ///////
-// //////// //// //// //// //// //// //// ////////
-
-[discrete#es-connectors-azure-blob-native-connector-reference]
-==== *Elastic managed connector reference*
-
-.View *Elastic managed connector* reference
-
-[%collapsible]
-===============
-
 [discrete#es-connectors-azure-blob-availability-prerequisites]
-===== Availability and prerequisites
+==== Availability and prerequisites
 
-This connector is available as a *managed connector* on Elastic Cloud, as of *8.9.1*.
+[discrete]
+===== Managed connector availability
+* Available as a managed connector on Elastic Cloud as of *8.9.1*
+* See <<es-native-connectors-prerequisites,managed connector requirements>>
 
-To use this connector natively in Elastic Cloud, satisfy all <<es-native-connectors-prerequisites,managed connector requirements>>.
+[discrete]
+===== Self-managed connector availability
+* Available as a self-managed connector for Elastic versions *8.6.0+*
+* See <<es-build-connector,self-managed connector requirements>>
 
-[discrete#es-connectors-azure-blob-compatability]
-===== Compatibility
+[discrete#es-connectors-azure-blob-compatibility]
+==== Compatibility
 
-This connector has not been tested with Azure Government.
-Therefore we cannot guarantee that it will work with Azure Government endpoints.
-For more information on Azure Government compared to Global Azure, refer to the
- https://learn.microsoft.com/en-us/azure/azure-government/compare-azure-government-global-azure[official Microsoft documentation^].
-
-[discrete#es-connectors-{service-name-stub}-create-native-connector]
-===== Create {service-name} connector
-
-include::_connectors-create-native.asciidoc[]
-
-[discrete#es-connectors-azure-blob-usage]
-===== Usage
-
-To use this connector as a *managed connector*, see <<es-native-connectors>>.
-
-For additional operations, see <<es-connectors-usage>>.
+This connector has not been tested with Azure Government. Therefore we cannot guarantee that it will work with Azure Government endpoints. For more information on Azure Government compared to Global Azure, refer to the https://learn.microsoft.com/en-us/azure/azure-government/compare-azure-government-global-azure[official Microsoft documentation^].
 
 [discrete#es-connectors-azure-blob-configuration]
-===== Configuration
+==== Configuration
 
-The following configuration fields are required to set up the connector:
+[discrete]
+===== Required configuration fields
 
-Account name::
-Name of Azure Blob Storage account.
+[cols="2,5"]
+|===
+|Field |Description
 
-Account key::
-https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal[Account key^] for the Azure Blob Storage account.
+|`Azure Blob Storage account name`
+|Name of Azure Blob Storage account.
 
-Blob endpoint::
-Endpoint for the Blob Service.
+|`Azure Blob Storage account key`
+|https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal[Account key^] for the Azure Blob Storage account.
 
-Containers::
-List of containers to index.
-`*` will index all containers.
+|`Azure Blob Storage blob endpoint`
+|Endpoint for the Blob Service.
+
+|`Azure Blob Storage containers`
+|List of containers to index. `*` will index all containers.
+|===
+
+[discrete]
+===== Additional self-managed configuration fields
+
+[NOTE]
+====
+The following fields are only available for self-managed connectors.
+====
+
+[cols="2,5,2"]
+|===
+|Field |Description |Default
+
+|`Retries per request`
+|Number of retry attempts after a failed call.
+|`3`
+
+|`Maximum concurrent downloads`
+|Number of concurrent downloads for fetching content.
+|`100`
+
+|`Use text extraction service`
+|Requires separate deployment of Elastic Text Extraction Service.
+|`false`
+|===
+
+[discrete#es-connectors-azure-blob-create]
+==== Creating a connector
+
+[discrete]
+.Create managed connector
+[%collapsible]
+=============
+include::_connectors-create-native.asciidoc[]
+=============
+
+[discrete]
+.Create self-managed connector
+[%collapsible]
+=============
+include::_connectors-create-client.asciidoc[]
+=============
+
+[discrete]
+.Docker deployment (self-managed only)
+[%collapsible]
+=============
+include::_connectors-docker-instructions.asciidoc[]
+=============
 
 [discrete#es-connectors-azure-blob-documents-syncs]
-===== Documents and syncs
+==== Documents and syncs
 
 The connector will fetch all data available in the container.
 
 [NOTE]
 ====
-* Content from files bigger than 10 MB won't be extracted. (Self-managed connectors can use the <<es-connectors-content-extraction-local, self-managed local extraction service>> to handle larger binary files.)
-* Permissions are not synced.
-**All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
+* Content from files bigger than 10 MB:
+** Managed connector: Content extraction not supported
+** Self-managed connector: Can use the <<es-connectors-content-extraction-local, self-managed local extraction service>>
+* Permissions are not synced. *All documents* indexed to an Elastic deployment will be visible to *all users with access* to that Elastic Deployment.
 ====
 
 [discrete#es-connectors-azure-blob-sync-types]
-====== Sync types
+===== Sync types
 
 <<es-connectors-sync-types-full,Full syncs>> are supported by default for all connectors.
 
@@ -103,189 +132,38 @@ Advanced sync rules are not available for this connector in the present version.
 Currently filtering is controlled via ingest pipelines.
 
 [discrete#es-connectors-azure-blob-content-extraction]
-===== Content extraction
+==== Content extraction
 
 See <<es-connectors-content-extraction>>.
 
-[discrete#es-connectors-azure-blob-known-issues]
-===== Known issues
+[discrete#es-connectors-azure-blob-testing]
+==== Testing (self-managed only)
 
-This connector has the following known issues:
-
-* *`lease data` and `tier` fields are not updated in Elasticsearch indices*
-+
-This is because the blob timestamp is not updated.
-Refer to https://github.com/elastic/connectors-python/issues/289[Github issue^].
-
-[discrete#es-connectors-azure-blob-troubleshooting]
-===== Troubleshooting
-
-See <<es-connectors-troubleshooting>>.
-
-[discrete#es-connectors-azure-blob-security]
-===== Security
-
-See <<es-connectors-security>>.
-
-View the {connectors-python}/connectors/sources/azure_blob_storage.py[source code for this connector^] (branch _{connectors-branch}_, compatible with Elastic _{minor-version}_)
-
-// Closing the collapsible section 
-===============
-
-
-// //////// //// //// //// //// //// //// ////////
-// //////// CONNECTOR CLIENT REFERENCE     ///////
-// //////// //// //// //// //// //// //// ////////
-
-[discrete#es-connectors-azure-blob-connector-client-reference]
-==== *Self-managed connector*
-
-.View *self-managed connector* reference
-
-[%collapsible]
-===============
-
-[discrete#es-connectors-azure-blob-client-availability-prerequisites]
-===== Availability and prerequisites
-
-This connector is available as a self-managed *self-managed connector*.
-This self-managed connector is compatible with Elastic versions *8.6.0+*.
-To use this connector, satisfy all <<es-build-connector,self-managed connector requirements>>.
-
-[discrete#es-connectors-azure-blob-client-compatability]
-===== Compatibility
-
-This connector has not been tested with Azure Government.
-Therefore we cannot guarantee that it will work with Azure Government endpoints.
-For more information on Azure Government compared to Global Azure, refer to the
- https://learn.microsoft.com/en-us/azure/azure-government/compare-azure-government-global-azure[official Microsoft documentation^].
-
-[discrete#es-connectors-{service-name-stub}-create-connector-client]
-===== Create {service-name} connector
-
-include::_connectors-create-client.asciidoc[]
-
-[discrete#es-connectors-azure-blob-client-usage]
-===== Usage
-
-To use this connector as a *self-managed connector*, see <<es-build-connector>>
-For additional usage operations, see <<es-connectors-usage>>.
-
-[discrete#es-connectors-azure-blob-client-configuration]
-===== Configuration
-
-[TIP]
-====
-When using the <<es-build-connector, self-managed connector>> workflow, initially these fields will use the default configuration set in the {connectors-python}/connectors/sources/azure_blob_storage.py[connector source code^].
-These are set in the `get_default_configuration` function definition.
-
-These configurable fields will be rendered with their respective *labels* in the Kibana UI.
-Once connected, you'll be able to update these values in Kibana.
-====
-
-The following configuration fields are required to set up the connector:
-
-`account_name`::
-Name of Azure Blob Storage account.
-
-`account_key`::
-https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal[Account key^] for the Azure Blob Storage account.
-
-`blob_endpoint`::
-Endpoint for the Blob Service.
-
-`containers`::
-List of containers to index.
-`*` will index all containers.
-
-`retry_count`::
-Number of retry attempts after a failed call.
-Default value is `3`.
-
-`concurrent_downloads`::
-Number of concurrent downloads for fetching content.
-Default value is `100`.
-
-`use_text_extraction_service`::
-Requires a separate deployment of the <<es-connectors-content-extraction-local,Elastic Text Extraction Service>>. Requires that ingest pipeline settings disable text extraction.
-Default value is `False`.
-
-[discrete#es-connectors-azure-blob-client-docker]
-===== Deployment using Docker
-
-include::_connectors-docker-instructions.asciidoc[]
-
-[discrete#es-connectors-azure-blob-client-documents-syncs]
-===== Documents and syncs
-
-The connector will fetch all data available in the container.
-
-[NOTE]
-====
-* Content from files bigger than 10 MB won't be extracted by default. You can use the <<es-connectors-content-extraction-local, self-managed local extraction service>> to handle larger binary files.
-* Permissions are not synced.
-**All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
-====
-
-[discrete#es-connectors-azure-blob-client-sync-types]
-====== Sync types
-
-<<es-connectors-sync-types-full,Full syncs>> are supported by default for all connectors.
-
-This connector also supports <<es-connectors-sync-types-incremental,incremental syncs>>.
-
-[discrete#es-connectors-azure-blob-client-sync-rules]
-===== Sync rules
-
-<<es-sync-rules-basic,Basic sync rules>> are identical for all connectors and are available by default.
-
-Advanced sync rules are not available for this connector in the present version.
-Currently filtering is controlled via ingest pipelines.
-
-[discrete#es-connectors-azure-blob-client-content-extraction]
-===== Content extraction
-
-See <<es-connectors-content-extraction>>.
-
-[discrete#es-connectors-azure-blob-client-testing]
-===== End-to-end testing
-
-The connector framework enables operators to run functional tests against a real data source.
-Refer to <<es-build-connector-testing>> for more details.
-
-To perform E2E testing for the Azure Blob Storage connector, run the following command:
+To perform E2E testing for the Azure Blob Storage connector, run:
 
 [source,shell]
 ----
-$ make ftest NAME=azure_blob_storage
+make ftest NAME=azure_blob_storage
 ----
 
-For faster tests, add the `DATA_SIZE=small` flag:
-
+For faster tests:
 [source,shell]
 ----
 make ftest NAME=azure_blob_storage DATA_SIZE=small
 ----
 
-[discrete#es-connectors-azure-blob-client-known-issues]
-===== Known issues
+[discrete#es-connectors-azure-blob-known-issues]
+==== Known issues
 
-This connector has the following known issues:
-
-* *`lease data` and `tier` fields are not updated in Elasticsearch indices*
-+
-This is because the blob timestamp is not updated.
+* `lease data` and `tier` fields are not updated in Elasticsearch indices because the blob timestamp is not updated.
 Refer to https://github.com/elastic/connectors/issues/289[Github issue^].
 
-[discrete#es-connectors-azure-blob-client-troubleshooting]
-===== Troubleshooting
+[discrete#es-connectors-azure-blob-troubleshooting]
+==== Troubleshooting
 
 See <<es-connectors-troubleshooting>>.
 
-[discrete#es-connectors-azure-blob-client-security]
-===== Security
+[discrete#es-connectors-azure-blob-security]
+==== Security
 
 See <<es-connectors-security>>.
-
-// Closing the collapsible section 
-===============


### PR DESCRIPTION
- Remove collapsible with duplicated sections (this was a hack we used for clarity between self-managed/managed connectors way back when)
- Simplifies and prepares pages for new syntax in docs v3