### PR TITLE
Move migrate actions into core so they can be called by other plugins

### DIFF
--- a/x-pack/plugin/core/src/main/java/module-info.java
+++ b/x-pack/plugin/core/src/main/java/module-info.java
@@ -78,6 +78,8 @@ module org.elasticsearch.xcore {
     exports org.elasticsearch.xpack.core.inference.results;
     exports org.elasticsearch.xpack.core.inference;
     exports org.elasticsearch.xpack.core.logstash;
+    exports org.elasticsearch.xpack.core.migrate.action;
+    exports org.elasticsearch.xpack.core.migrate.task;
     exports org.elasticsearch.xpack.core.ml.action;
     exports org.elasticsearch.xpack.core.ml.annotations;
     exports org.elasticsearch.xpack.core.ml.autoscaling;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/action/CancelReindexDataStreamAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/action/CancelReindexDataStreamAction.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/action/CreateIndexFromSourceAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/action/CreateIndexFromSourceAction.java
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/action/GetMigrationReindexStatusAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/action/GetMigrationReindexStatusAction.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -18,7 +18,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.migrate.task.ReindexDataStreamEnrichedStatus;
+import org.elasticsearch.xpack.core.migrate.task.ReindexDataStreamEnrichedStatus;
 
 import java.io.IOException;
 import java.util.Objects;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/action/ReindexDataStreamAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/action/ReindexDataStreamAction.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/action/ReindexDataStreamIndexAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/action/ReindexDataStreamIndexAction.java
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/task/ReindexDataStreamEnrichedStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/task/ReindexDataStreamEnrichedStatus.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.task;
+package org.elasticsearch.xpack.core.migrate.task;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/CancelReindexDataStreamRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/CancelReindexDataStreamRequestTests.java
@@ -5,15 +5,16 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.xpack.migrate.action.GetMigrationReindexStatusAction.Request;
+import org.elasticsearch.xpack.core.migrate.action.CancelReindexDataStreamAction.Request;
 
 import java.io.IOException;
 
-public class GetMigrationReindexStatusActionRequestTests extends AbstractWireSerializingTestCase<Request> {
+public class CancelReindexDataStreamRequestTests extends AbstractWireSerializingTestCase<Request> {
+
     @Override
     protected Writeable.Reader<Request> instanceReader() {
         return Request::new;
@@ -21,11 +22,11 @@ public class GetMigrationReindexStatusActionRequestTests extends AbstractWireSer
 
     @Override
     protected Request createTestInstance() {
-        return new Request(randomAlphaOfLength(100));
+        return new Request(randomAlphaOfLength(30));
     }
 
     @Override
     protected Request mutateInstance(Request instance) throws IOException {
-        return createTestInstance(); // There's only one field
+        return new Request(instance.getIndex() + randomAlphaOfLength(5));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/CreateFromSourceIndexRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/CreateFromSourceIndexRequestTests.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -14,7 +14,7 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.migrate.action.CreateIndexFromSourceAction.Request;
+import org.elasticsearch.xpack.core.migrate.action.CreateIndexFromSourceAction.Request;
 
 import java.io.IOException;
 import java.util.Map;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/GetMigrationReindexStatusActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/GetMigrationReindexStatusActionRequestTests.java
@@ -5,16 +5,15 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.xpack.migrate.action.CancelReindexDataStreamAction.Request;
+import org.elasticsearch.xpack.core.migrate.action.GetMigrationReindexStatusAction.Request;
 
 import java.io.IOException;
 
-public class CancelReindexDataStreamRequestTests extends AbstractWireSerializingTestCase<Request> {
-
+public class GetMigrationReindexStatusActionRequestTests extends AbstractWireSerializingTestCase<Request> {
     @Override
     protected Writeable.Reader<Request> instanceReader() {
         return Request::new;
@@ -22,11 +21,11 @@ public class CancelReindexDataStreamRequestTests extends AbstractWireSerializing
 
     @Override
     protected Request createTestInstance() {
-        return new Request(randomAlphaOfLength(30));
+        return new Request(randomAlphaOfLength(100));
     }
 
     @Override
     protected Request mutateInstance(Request instance) throws IOException {
-        return new Request(instance.getIndex() + randomAlphaOfLength(5));
+        return createTestInstance(); // There's only one field
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/GetMigrationReindexStatusActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/GetMigrationReindexStatusActionResponseTests.java
@@ -5,15 +5,15 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.xpack.migrate.action.GetMigrationReindexStatusAction.Response;
-import org.elasticsearch.xpack.migrate.task.ReindexDataStreamEnrichedStatus;
+import org.elasticsearch.xpack.core.migrate.action.GetMigrationReindexStatusAction.Response;
+import org.elasticsearch.xpack.core.migrate.task.ReindexDataStreamEnrichedStatus;
 
 import java.io.IOException;
 import java.util.List;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/ReindexDataStreamRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/ReindexDataStreamRequestTests.java
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.ReindexDataStreamRequest;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction.ReindexDataStreamRequest;
 
 import java.io.IOException;
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/ReindexDatastreamIndexRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/ReindexDatastreamIndexRequestTests.java
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexAction.Request;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamIndexAction.Request;
 
 public class ReindexDatastreamIndexRequestTests extends AbstractWireSerializingTestCase<Request> {
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/ReindexDatastreamIndexResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/action/ReindexDatastreamIndexResponseTests.java
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.action;
+package org.elasticsearch.xpack.core.migrate.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexAction.Response;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamIndexAction.Response;
 
 public class ReindexDatastreamIndexResponseTests extends AbstractWireSerializingTestCase<Response> {
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/task/ReindexDataStreamEnrichedStatusTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/migrate/task/ReindexDataStreamEnrichedStatusTests.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.migrate.task;
+package org.elasticsearch.xpack.core.migrate.task;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesReference;

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.migrate.action.CreateIndexFromSourceAction;
 import org.elasticsearch.xpack.migrate.MigratePlugin;
 
 import java.util.Collection;
@@ -32,7 +33,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
+import static org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
 
 public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
 

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamTransportActionIT.java
@@ -26,9 +26,12 @@ import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.migrate.action.CancelReindexDataStreamAction;
+import org.elasticsearch.xpack.core.migrate.action.GetMigrationReindexStatusAction;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction.ReindexDataStreamRequest;
+import org.elasticsearch.xpack.core.migrate.task.ReindexDataStreamEnrichedStatus;
 import org.elasticsearch.xpack.migrate.MigratePlugin;
-import org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.ReindexDataStreamRequest;
-import org.elasticsearch.xpack.migrate.task.ReindexDataStreamEnrichedStatus;
 import org.elasticsearch.xpack.migrate.task.ReindexDataStreamTask;
 
 import java.util.Collection;
@@ -40,7 +43,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
+import static org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
@@ -40,6 +40,7 @@ import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamIndexAction;
 import org.elasticsearch.xpack.migrate.MigratePlugin;
 
 import java.io.IOException;
@@ -53,7 +54,7 @@ import static org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.DE
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
+import static org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigratePlugin.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigratePlugin.java
@@ -33,14 +33,14 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
-import org.elasticsearch.xpack.migrate.action.CancelReindexDataStreamAction;
+import org.elasticsearch.xpack.core.migrate.action.CancelReindexDataStreamAction;
+import org.elasticsearch.xpack.core.migrate.action.CreateIndexFromSourceAction;
+import org.elasticsearch.xpack.core.migrate.action.GetMigrationReindexStatusAction;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamIndexAction;
 import org.elasticsearch.xpack.migrate.action.CancelReindexDataStreamTransportAction;
-import org.elasticsearch.xpack.migrate.action.CreateIndexFromSourceAction;
 import org.elasticsearch.xpack.migrate.action.CreateIndexFromSourceTransportAction;
-import org.elasticsearch.xpack.migrate.action.GetMigrationReindexStatusAction;
 import org.elasticsearch.xpack.migrate.action.GetMigrationReindexStatusTransportAction;
-import org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction;
-import org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexAction;
 import org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexTransportAction;
 import org.elasticsearch.xpack.migrate.action.ReindexDataStreamTransportAction;
 import org.elasticsearch.xpack.migrate.rest.RestCancelReindexDataStreamAction;
@@ -58,7 +58,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
+import static org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
 import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexTransportAction.REINDEX_MAX_REQUESTS_PER_SECOND_SETTING;
 import static org.elasticsearch.xpack.migrate.task.ReindexDataStreamPersistentTaskExecutor.MAX_CONCURRENT_INDICES_REINDEXED_PER_DATA_STREAM_SETTING;
 

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CancelReindexDataStreamTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CancelReindexDataStreamTransportAction.java
@@ -18,7 +18,9 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.migrate.action.CancelReindexDataStreamAction.Request;
+import org.elasticsearch.xpack.core.migrate.action.CancelReindexDataStreamAction;
+import org.elasticsearch.xpack.core.migrate.action.CancelReindexDataStreamAction.Request;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction;
 
 public class CancelReindexDataStreamTransportAction extends HandledTransportAction<Request, AcknowledgedResponse> {
     private final PersistentTasksService persistentTasksService;

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.migrate.action.CreateIndexFromSourceAction;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/GetMigrationReindexStatusTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/GetMigrationReindexStatusTransportAction.java
@@ -33,9 +33,11 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.migrate.action.GetMigrationReindexStatusAction.Request;
-import org.elasticsearch.xpack.migrate.action.GetMigrationReindexStatusAction.Response;
-import org.elasticsearch.xpack.migrate.task.ReindexDataStreamEnrichedStatus;
+import org.elasticsearch.xpack.core.migrate.action.GetMigrationReindexStatusAction;
+import org.elasticsearch.xpack.core.migrate.action.GetMigrationReindexStatusAction.Request;
+import org.elasticsearch.xpack.core.migrate.action.GetMigrationReindexStatusAction.Response;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction;
+import org.elasticsearch.xpack.core.migrate.task.ReindexDataStreamEnrichedStatus;
 import org.elasticsearch.xpack.migrate.task.ReindexDataStreamStatus;
 
 import java.util.HashMap;

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -43,6 +43,8 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.deprecation.DeprecatedIndexPredicate;
+import org.elasticsearch.xpack.core.migrate.action.CreateIndexFromSourceAction;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamIndexAction;
 
 import java.util.Locale;
 import java.util.Map;

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamTransportAction.java
@@ -22,12 +22,13 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
-import org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.ReindexDataStreamRequest;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction.ReindexDataStreamRequest;
 import org.elasticsearch.xpack.migrate.task.ReindexDataStreamTask;
 import org.elasticsearch.xpack.migrate.task.ReindexDataStreamTaskParams;
 
 import static org.elasticsearch.xpack.core.deprecation.DeprecatedIndexPredicate.getReindexRequiredPredicate;
-import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.TASK_ID_PREFIX;
+import static org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction.TASK_ID_PREFIX;
 
 /*
  * This transport action creates a new persistent task for reindexing the source data stream given in the request. On successful creation

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestCancelReindexDataStreamAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestCancelReindexDataStreamAction.java
@@ -11,7 +11,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
-import org.elasticsearch.xpack.migrate.action.CancelReindexDataStreamAction;
+import org.elasticsearch.xpack.core.migrate.action.CancelReindexDataStreamAction;
 
 import java.io.IOException;
 import java.util.List;

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestCreateIndexFromSourceAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestCreateIndexFromSourceAction.java
@@ -11,7 +11,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
-import org.elasticsearch.xpack.migrate.action.CreateIndexFromSourceAction;
+import org.elasticsearch.xpack.core.migrate.action.CreateIndexFromSourceAction;
 
 import java.io.IOException;
 import java.util.List;

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestGetMigrationReindexStatusAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestGetMigrationReindexStatusAction.java
@@ -11,7 +11,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
-import org.elasticsearch.xpack.migrate.action.GetMigrationReindexStatusAction;
+import org.elasticsearch.xpack.core.migrate.action.GetMigrationReindexStatusAction;
 
 import java.io.IOException;
 import java.util.List;

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestMigrationReindexAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestMigrationReindexAction.java
@@ -17,7 +17,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestBuilderListener;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
+import static org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
 
 public class RestMigrationReindexAction extends BaseRestHandler {
     public static final String MIGRATION_REINDEX_CAPABILITY = "migration_reindex";

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
@@ -34,7 +34,7 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexAction;
+import org.elasticsearch.xpack.core.migrate.action.ReindexDataStreamIndexAction;
 
 import java.util.ArrayList;
 import java.util.Collections;


### PR DESCRIPTION
The migrate plugin has a [CreateIndexFromSourceAction](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceAction.java#L28) that ML would like to use as to automatically create new indices from legacy indices during the version 9 upgrade. For ML and other plugins to call they action it must be move to xpack core so it is visible outside of the migrate plugin.

This PR moves the various actions defined in `migrate/action/` and their tests to `core`.

ie. contents of 
`x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/`
to 
`x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/migrate/action`

`ReindexDataStreamEnrichedStatus` is also moved because is is used in one of the response classes.


