### PR TITLE
[8.x] Merge field mappers when updating mappings with [subobjects:false] (#120370)

### DIFF
--- a/docs/changelog/120370.yaml
+++ b/docs/changelog/120370.yaml
@@ -1,0 +1,6 @@
+pr: 120370
+summary: "Merge field mappers when updating mappings with [subobjects:false]"
+area: Mapping
+type: bug
+issues:
+ - 120216

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_mapping/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_mapping/10_basic.yml
@@ -211,3 +211,92 @@
         body:
           _source:
             mode: synthetic
+
+---
+"modify field type with subobjects:false":
+  - requires:
+      cluster_features: [ "mapper.subobjects_false_mapping_update_fix" ]
+      reason: requires fix for mapping updates when [subobjects:false] is set
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            subobjects: false
+            properties:
+              user.id:
+                type: long
+              user.name:
+                type: text
+
+  - do:
+      catch: bad_request
+      indices.put_mapping:
+        index: test_index
+        body:
+          properties:
+            user.id:
+              type: keyword
+
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "mapper [user.id] cannot be changed from type [long] to [keyword]" }
+
+  - do:
+      indices.put_mapping:
+        index: test_index
+        body:
+          properties:
+            user.name:
+              type: text
+              fields:
+                raw:
+                  type: keyword
+
+  - is_true: acknowledged
+
+
+---
+"modify nested field type with subobjects:false":
+  - requires:
+      cluster_features: [ "mapper.subobjects_false_mapping_update_fix" ]
+      reason: requires fix for mapping updates when [subobjects:false] is set
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            properties:
+              path:
+                properties:
+                  to:
+                    subobjects: false
+                    properties:
+                      user.id:
+                        type: long
+                      user.name:
+                        type: text
+
+  - do:
+      catch: bad_request
+      indices.put_mapping:
+        index: test_index
+        body:
+          properties:
+            path.to.user.id:
+              type: keyword
+
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "mapper [path.to.user.id] cannot be changed from type [long] to [keyword]" }
+
+  - do:
+      indices.put_mapping:
+        index: test_index
+        body:
+          properties:
+            path.to.user.name:
+              type: text
+              fields:
+                raw:
+                  type: keyword
+
+  - is_true: acknowledged

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -71,7 +71,8 @@ public class MapperFeatures implements FeatureSpecification {
             CONSTANT_KEYWORD_SYNTHETIC_SOURCE_WRITE_FIX,
             META_FETCH_FIELDS_ERROR_CODE_CHANGED,
             SPARSE_VECTOR_STORE_SUPPORT,
-            SourceFieldMapper.SYNTHETIC_RECOVERY_SOURCE
+            SourceFieldMapper.SYNTHETIC_RECOVERY_SOURCE,
+            ObjectMapper.SUBOBJECTS_FALSE_MAPPING_UPDATE_FIX
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -49,6 +49,7 @@ public class ObjectMapper extends Mapper {
     private static final Logger logger = LogManager.getLogger(ObjectMapper.class);
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ObjectMapper.class);
     public static final FeatureFlag SUB_OBJECTS_AUTO_FEATURE_FLAG = new FeatureFlag("sub_objects_auto");
+    static final NodeFeature SUBOBJECTS_FALSE_MAPPING_UPDATE_FIX = new NodeFeature("mapper.subobjects_false_mapping_update_fix");
 
     public static final String CONTENT_TYPE = "object";
     static final String STORE_ARRAY_SOURCE_PARAM = "store_array_source";
@@ -663,11 +664,21 @@ public class ObjectMapper extends Mapper {
                     if (subobjects.isPresent()
                         && subobjects.get() == Subobjects.DISABLED
                         && mergeWithMapper instanceof ObjectMapper objectMapper) {
-                        // An existing mapping that has set `subobjects: false` is merged with a mapping with sub-objects
-                        objectMapper.asFlattenedFieldMappers(objectMergeContext.getMapperBuilderContext())
-                            .stream()
-                            .filter(m -> objectMergeContext.decrementFieldBudgetIfPossible(m.getTotalFieldsCount()))
-                            .forEach(m -> putMergedMapper(mergedMappers, m));
+                        // An existing mapping that has set `subobjects: false` is merged with a mapping with sub-objects.
+                        List<FieldMapper> flattenedMappers = objectMapper.asFlattenedFieldMappers(
+                            objectMergeContext.getMapperBuilderContext()
+                        );
+                        for (FieldMapper flattenedMapper : flattenedMappers) {
+                            if (objectMergeContext.decrementFieldBudgetIfPossible(flattenedMapper.getTotalFieldsCount())) {
+                                var conflict = mergedMappers.get(flattenedMapper.leafName());
+                                if (objectMergeContext.getMapperBuilderContext().getMergeReason() == MergeReason.INDEX_TEMPLATE
+                                    || conflict == null) {
+                                    putMergedMapper(mergedMappers, flattenedMapper);
+                                } else {
+                                    putMergedMapper(mergedMappers, conflict.merge(flattenedMapper, objectMergeContext));
+                                }
+                            }
+                        }
                     } else if (objectMergeContext.decrementFieldBudgetIfPossible(mergeWithMapper.getTotalFieldsCount())) {
                         putMergedMapper(mergedMappers, mergeWithMapper);
                     } else if (mergeWithMapper instanceof ObjectMapper om) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Merge field mappers when updating mappings with [subobjects:false] (#120370)](https://github.com/elastic/elasticsearch/pull/120370)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)