### PR TITLE
[8.x] Add rest-api-spec for unified inference API (#120447)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.unified_inference.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.unified_inference.json
@@ -1,0 +1,45 @@
+{
+  "inference.unified_inference": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/unified-inference-api.html",
+      "description": "Perform inference using the Unified Schema"
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["text/event-stream"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_inference/{inference_id}/_unified",
+          "methods": ["POST"],
+          "parts": {
+            "inference_id": {
+              "type": "string",
+              "description": "The inference Id"
+            }
+          }
+        },
+        {
+          "path": "/_inference/{task_type}/{inference_id}/_unified",
+          "methods": ["POST"],
+          "parts": {
+            "task_type": {
+              "type": "string",
+              "description": "The task type"
+            },
+            "inference_id": {
+              "type": "string",
+              "description": "The inference Id"
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "The inference payload"
+    }
+  }
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add rest-api-spec for unified inference API (#120447)