### PR TITLE
Exclude (unused) snakeyaml dependency

### DIFF
--- a/x-pack/snapshot-tool/build.gradle
+++ b/x-pack/snapshot-tool/build.gradle
@@ -71,7 +71,7 @@ dependencies {
 }
 
 configurations.configureEach {
-  exclude group: 'org.yaml', module: "snakeyaml"
+  exclude group: 'org.yaml', module: 'snakeyaml' // Avoid CVE: https://nvd.nist.gov/vuln/detail/cve-2022-1471
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/x-pack/snapshot-tool/build.gradle
+++ b/x-pack/snapshot-tool/build.gradle
@@ -70,6 +70,10 @@ dependencies {
   api 'javax.xml.bind:jaxb-api:2.2.2'
 }
 
+configurations.configureEach {
+  exclude group: 'org.yaml', module: "snakeyaml"
+}
+
 tasks.named("dependencyLicenses").configure {
   mapping from: /aws-java-sdk-.*/, to: 'aws-java-sdk'
   mapping from: /jmespath-java.*/, to: 'aws-java-sdk'


### PR DESCRIPTION
Eliminate an unused library with a CVE. Succeeds in eliminating snakeyaml from the output of `./gradlew :x-pack:snapshot-tool:dependencies --configuration runtimeClasspath`.

I ran `:x-pack:snapshot-tool:qa:s3:check` manually in IntelliJ and it passed.

See ES-10199