### PR TITLE
[DOCS] Search multiple indices added info

### DIFF
--- a/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
+++ b/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
@@ -1,5 +1,11 @@
 [[search-multiple-indices]]
-=== Search multiple data streams and indices
+=== Search multiple data streams and indices using a query
+
+There are two primary ways to search across multiple data streams and indices:
+
+* At the query level: Specify the indices directly in the search request path or use index patterns to target a group of indices.
+
+*	At the index level: Use <<aliases, index aliases>>, which act as pointers to one or more backing indices, allowing you to group and manage indices logically. 
 
 To search multiple data streams and indices, add them as comma-separated values
 in the <<search-search,search API>>'s request path.
@@ -38,6 +44,33 @@ GET /my-index-*/_search
 }
 ----
 // TEST[setup:my_index]
+
+You can also remove a subset of indices from being searched. The request will retun data from all indices that start with `my-index-` while excluding results from `my-index-01`.
+
+[source,console]
+----
+GET /my-index-*/_search
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match": {
+            "user.id": "kimchy"
+          }
+        }
+      ],
+      "must_not": [
+        {
+          "terms": {
+            "_index": ["my-index-01"]
+          }
+        }
+      ]
+    }
+  }
+}
+----
 
 To search all data streams and indices in a cluster, omit the target from the
 request path. Alternatively, you can use `_all` or `*`.

--- a/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
+++ b/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
@@ -71,6 +71,7 @@ GET /my-index-*/_search
   }
 }
 ----
+// TEST[setup:my_index]
 
 To search all data streams and indices in a cluster, omit the target from the
 request path. Alternatively, you can use `_all` or `*`.

--- a/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
+++ b/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
@@ -45,7 +45,7 @@ GET /my-index-*/_search
 ----
 // TEST[setup:my_index]
 
-You can also remove a subset of indices from being searched. The request will retun data from all indices that start with `my-index-` while excluding results from `my-index-01`.
+You can exclude specific indices from a search. The request will retrieve data from all indices starting with `my-index-`, except for `my-index-01`.
 
 [source,console]
 ----

--- a/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
+++ b/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
@@ -3,7 +3,7 @@
 
 There are two main methods for searching across multiple data streams and indices in {es}:
 
-* At the query level: Specify the indices directly in the search request path or use index patterns to target a group of indices.
+* *Query Level*: Directly specify indices in the search request path or use index patterns to target multiple indices.
 
 *	At the index level: Use <<aliases, index aliases>>, which act as pointers to one or more backing indices, allowing you to group and manage indices logically. 
 

--- a/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
+++ b/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
@@ -5,7 +5,7 @@ There are two main methods for searching across multiple data streams and indice
 
 * *Query Level*: Directly specify indices in the search request path or use index patterns to target multiple indices.
 
-*	At the index level: Use <<aliases, index aliases>>, which act as pointers to one or more backing indices, allowing you to group and manage indices logically. 
+* *Index level*: Use <<aliases, index aliases>>, which act as pointers to one or more backing indices, enabling logical grouping and management of indices.
 
 To search multiple data streams and indices, add them as comma-separated values
 in the <<search-search,search API>>'s request path.

--- a/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
+++ b/docs/reference/search/search-your-data/search-multiple-indices.asciidoc
@@ -1,7 +1,7 @@
 [[search-multiple-indices]]
 === Search multiple data streams and indices using a query
 
-There are two primary ways to search across multiple data streams and indices:
+There are two main methods for searching across multiple data streams and indices in {es}:
 
 * At the query level: Specify the indices directly in the search request path or use index patterns to target a group of indices.
 


### PR DESCRIPTION
- Clarified that using an alias can also be used to query multiple indices.
- Added an example to remove indices when using wild card