### PR TITLE
Increase time in IntervalThrottlerTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/IntervalThrottlerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IntervalThrottlerTests.java
@@ -14,12 +14,12 @@ import org.elasticsearch.test.ESTestCase;
 public class IntervalThrottlerTests extends ESTestCase {
 
     public void testThrottling() throws Exception {
-        var throttler = new IntervalThrottler.Acceptor(10);
+        var throttler = new IntervalThrottler.Acceptor(100);
         assertTrue(throttler.accept());
         assertFalse(throttler.accept());
         assertFalse(throttler.accept());
 
-        Thread.sleep(20);
+        Thread.sleep(110);
         assertTrue(throttler.accept());
         assertFalse(throttler.accept());
         assertFalse(throttler.accept());


### PR DESCRIPTION
We suspect that something in the test environment is causing more than 10ms to pass between some of the calls so increasing to 100 for now to verify

Closes #120023
