### PR TITLE
Move migrate APIs to rest-api-spec indices namespace

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.cancel_migrate_reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.cancel_migrate_reindex.json
@@ -1,5 +1,5 @@
 {
-  "migrate.cancel_reindex":{
+  "indices.cancel_migrate_reindex":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-reindex.html",
       "description":"This API returns the status of a migration reindex attempt for a data stream or index"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create_from.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create_from.json
@@ -1,5 +1,5 @@
 {
-  "migrate.create_from":{
+  "indices.create_from":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-reindex.html",
       "description":"This API creates a destination from a source index. It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_migrate_reindex_status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_migrate_reindex_status.json
@@ -1,5 +1,5 @@
 {
-  "migrate.get_reindex_status":{
+  "indices.get_migrate_reindex_status":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-reindex.html",
       "description":"This API returns the status of a migration reindex attempt for a data stream or index"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.migrate_reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.migrate_reindex.json
@@ -1,5 +1,5 @@
 {
-  "migrate.reindex":{
+  "indices.migrate_reindex":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-reindex.html",
       "description":"This API reindexes all legacy backing indices for a data stream. It does this in a persistent task. The persistent task id is returned immediately, and the reindexing work is completed in that task"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/10_reindex.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/10_reindex.yml
@@ -15,7 +15,7 @@ setup:
           capabilities: [migration_reindex]
   - do:
       catch: /illegal_argument_exception/
-      migrate.reindex:
+      indices.migrate_reindex:
         body: |
           {
             "mode": "unsupported_mode",
@@ -35,7 +35,7 @@ setup:
           capabilities: [migration_reindex]
   - do:
       catch: /resource_not_found_exception/
-      migrate.reindex:
+      indices.migrate_reindex:
         body: |
           {
             "mode": "upgrade",
@@ -46,7 +46,7 @@ setup:
 
   - do:
       catch: /resource_not_found_exception/
-      migrate.reindex:
+      indices.migrate_reindex:
         body: |
           {
             "mode": "upgrade",
@@ -67,7 +67,7 @@ setup:
           capabilities: [migration_reindex]
   - do:
       catch: /illegal_argument_exception/
-      migrate.reindex:
+      indices.migrate_reindex:
         body: |
           {
             "mode": "upgrade",
@@ -105,7 +105,7 @@ setup:
   - is_true: acknowledged
 
   - do:
-      migrate.reindex:
+      indices.migrate_reindex:
         body: |
           {
             "mode": "upgrade",
@@ -116,11 +116,11 @@ setup:
   - match: { acknowledged: true }
 
   - do:
-      migrate.cancel_reindex:
+      indices.cancel_migrate_reindex:
         index: "my-data-stream"
   - match: { acknowledged: true }
 
   - do:
       catch: /resource_not_found_exception/
-      migrate.cancel_reindex:
+      indices.cancel_migrate_reindex:
         index: "my-data-stream"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/20_reindex_status.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/20_reindex_status.yml
@@ -47,7 +47,7 @@ setup:
   - is_true: acknowledged
 
   - do:
-      migrate.reindex:
+      indices.migrate_reindex:
         body: |
           {
             "mode": "upgrade",
@@ -69,13 +69,13 @@ setup:
   - match: { errors: [] }
 
   - do:
-      migrate.cancel_reindex:
+      indices.cancel_migrate_reindex:
         index: "my-data-stream"
   - match: { acknowledged: true }
 
   - do:
       catch: /resource_not_found_exception/
-      migrate.cancel_reindex:
+      indices.cancel_migrate_reindex:
         index: "my-data-stream"
 
   - do:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/20_reindex_status.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/20_reindex_status.yml
@@ -15,7 +15,7 @@ setup:
           capabilities: [migration_reindex]
   - do:
       catch: /resource_not_found_exception/
-      migrate.get_reindex_status:
+      indices.get_migrate_reindex_status:
         index: "does_not_exist"
 
 ---
@@ -58,7 +58,7 @@ setup:
   - match: { acknowledged: true }
 
   - do:
-      migrate.get_reindex_status:
+      indices.get_migrate_reindex_status:
         index: "my-data-stream"
   - match: { complete: true }
   - match: { total_indices_in_data_stream: 1 }
@@ -80,5 +80,5 @@ setup:
 
   - do:
       catch: /resource_not_found_exception/
-      migrate.get_reindex_status:
+      indices.get_migrate_reindex_status:
         index: "my-data-stream"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/30_create_from.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/30_create_from.yml
@@ -26,7 +26,7 @@ teardown:
           capabilities: [migration_reindex]
   - do:
       catch: /index_not_found_exception/
-      migrate.create_from:
+      indices.create_from:
         source: "does_not_exist"
         dest: "dest1"
 
@@ -53,7 +53,7 @@ teardown:
               bar:
                 type: text
   - do:
-      migrate.create_from:
+      indices.create_from:
         source: "source-index-1"
         dest: "dest-index-1"
   - do:
@@ -91,7 +91,7 @@ teardown:
               foo:
                 type: boolean
   - do:
-      migrate.create_from:
+      indices.create_from:
         source: "source-index-1"
         dest: "dest-index-1"
         body:
@@ -139,7 +139,7 @@ teardown:
               number_of_shards: 1
               number_of_replicas: 0
   - do:
-      migrate.create_from:
+      indices.create_from:
         source: "source-index-1"
         dest: "dest-index-1"
         body:


### PR DESCRIPTION
To improve the developer experience in language clients, we agree on the following changes offline:

| Original PR | Existing name  | New name |
| ------------- | ------------- | - |
| #118109 |  migrate.reindex | indices.migrate_reindex  |
| #118291 | migrate.cancel_reindex  | indices.cancel_migrate_reindex  |
| #118267 | migrate.get_reindex_status | indices.get_migrate_reindex_status |
| #119250 | migrate.create_from | indices.create_from |

But I'm happy to continue tweaking this as long as we don't use the `migrate` namespace, which was already confused with the `migration` namespace in https://github.com/elastic/elasticsearch-specification/pull/3564. Note that this does not change the REST API URLs themselves. Tagging as `>non-issue` since those APIs have not been released yet.