### PR TITLE
[8.x] Rely on default shard count (#120521)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
@@ -25,7 +25,6 @@ setup:
           settings:
             index:
               mode: lookup
-            number_of_shards: 1
           mappings:
             properties:
               key:


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Rely on default shard count (#120521)