### PR TITLE
Increase field limit for OTel metrics to 10 000

### DIFF
--- a/docs/changelog/120591.yaml
+++ b/docs/changelog/120591.yaml
@@ -1,0 +1,5 @@
+pr: 120591
+summary: Increase field limit for OTel metrics to 10 000
+area: TSDB
+type: enhancement
+issues: []

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
@@ -5,6 +5,7 @@ _meta:
 template:
   settings:
     index.mapping.ignore_malformed: true
+    index.mapping.total_fields.limit: 10000
   mappings:
     properties:
       start_timestamp:

--- a/x-pack/plugin/otel-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin otel-data. This must be increased whenever an existing template is
 # changed, in order for it to be updated on Elasticsearch upgrade.
-version: 7
+version: 8
 
 component-templates:
   - otel@mappings


### PR DESCRIPTION
The default field limit of 1000 seems undersized, especially for the default data stream. Each distinct attribute/dimension name and metric name count towards that limit.

For comparison, this makes us use the same field limit for OTel that we currently have for the prometheus integration.