### PR TITLE
Update search-across-clusters.asciidoc to reflect the `true` default value of `skip_unavailable` setting

### DIFF
--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -109,7 +109,7 @@ PUT _cluster/settings
 // end::ccs-remote-cluster-setup[]
 
 <1> Since `skip_unavailable` was not set on `cluster_three`, it uses
-the default of `false`. See the <<skip-unavailable-clusters>>
+the default of `true`. See the <<skip-unavailable-clusters>>
 section for details.
 
 


### PR DESCRIPTION
With https://github.com/elastic/elasticsearch/pull/105792 the default value changed from `false` to `true`.