### PR TITLE
[8.17] Map scope.name as a dimension (#120590)

### DIFF
--- a/docs/changelog/120590.yaml
+++ b/docs/changelog/120590.yaml
@@ -1,0 +1,5 @@
+pr: 120590
+summary: Map `scope.name` as a dimension
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/otel@mappings.yaml
@@ -32,6 +32,7 @@ template:
           name:
             type: keyword
             ignore_above: 1024
+            time_series_dimension: true
           version:
             type: version
           schema_url:

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_tests.yml
@@ -279,3 +279,29 @@ Empty IP field:
           fields: ["*"]
   - length: { hits.hits: 1 }
   - match: { hits.hits.0._ignored: ["resource.attributes.host.ip"] }
+---
+Metrics with different scope names are not duplicates:
+  - do:
+      bulk:
+        index: metrics-generic.otel-default
+        refresh: true
+        body:
+          - create: {"dynamic_templates":{"metrics.foo.bar":"counter_long"}}
+          - "@timestamp": 2024-07-18T14:00:00Z
+            scope:
+              name: foo
+            resource:
+              attributes:
+                service.name: foo
+            metrics:
+              foo.bar: 42
+          - create: {"dynamic_templates":{"metrics.foo.bar":"counter_long"}}
+          - "@timestamp": 2024-07-18T14:00:00Z
+            scope:
+              name: bar
+            resource:
+              attributes:
+                service.name: foo
+            metrics:
+              foo.bar: 42
+  - is_false: errors


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Map scope.name as a dimension (#120590)