### PR TITLE
[CI] Unmute FullClusterRestartLuceneIndexCompatibilityIT and RollingUpgradeLuceneIndexCompatibilityTestCase

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -240,10 +240,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
   method: testEnrichExplosionManyMatches
   issue: https://github.com/elastic/elasticsearch/issues/120587
-- class: org.elasticsearch.lucene.FullClusterRestartLuceneIndexCompatibilityIT
-  issue: https://github.com/elastic/elasticsearch/issues/120597
-- class: org.elasticsearch.lucene.RollingUpgradeLuceneIndexCompatibilityTestCase
-  issue: https://github.com/elastic/elasticsearch/issues/120598
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {lookup-join.NonUniqueRightKeyOnTheCoordinator ASYNC}
   issue: https://github.com/elastic/elasticsearch/issues/120600


### PR DESCRIPTION
The tests have been muted because I merged #120537 before updating the changes in `main` (or disabling the BWC tests in main first).

Closes #120597
Closes #120598