### PR TITLE
Rename ES|QL LOOKUP JOIN test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
@@ -102,7 +102,7 @@ non-lookup index:
   - contains: { error.reason: "Found 1 problem\nline 1:45: invalid [test] resolution in lookup mode to an index in [standard] mode" }
 
 ---
-alias:
+"Alias as lookup index":
   - do:
       esql.query:
         body:


### PR DESCRIPTION
Muting a yaml bwc test called "alias" apparently is not possible:

```
task.skipTest("esql/190_lookup_join/alias", "LOOKUP JOIN does not support index aliases for now") 
```

```
* What went wrong:
Execution failed for task ':x-pack:plugin:yamlRestCompatTestTransform'.
> class com.fasterxml.jackson.databind.node.TextNode cannot be cast to class com.fasterxml.jackson.databind.node.ArrayNode (com.fasterxml.jackson.databind.node.TextNode and com.fasterxml.jackson.databind.node.ArrayNode are in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader$InstrumentingVisitableURLClassLoader @725f7fdd)
```

I need to mute this test in https://github.com/elastic/elasticsearch/pull/120617