### PR TITLE
[8.x] Rename ES|QL LOOKUP JOIN test (#120637)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
@@ -102,7 +102,7 @@ non-lookup index:
   - contains: { error.reason: "Found 1 problem\nline 1:45: invalid [test] resolution in lookup mode to an index in [standard] mode" }
 
 ---
-alias:
+"Alias as lookup index":
   - do:
       esql.query:
         body:


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Rename ES|QL LOOKUP JOIN test (#120637)