### PR TITLE
Remove index blocks by default in create_from

### DIFF
--- a/docs/changelog/120643.yaml
+++ b/docs/changelog/120643.yaml
@@ -1,0 +1,5 @@
+pr: 120643
+summary: Remove index blocks by default in `create_from`
+area: Indices APIs
+type: enhancement
+issues: []

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
@@ -222,7 +222,7 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
         assertNull(destSettings.get(IndexMetadata.SETTING_BLOCKS_WRITE));
     }
 
-    public void testRemoveIndexBlocks() throws Exception {
+    public void testRemoveIndexBlocksByDefault() throws Exception {
         assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
 
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
@@ -241,12 +241,10 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
 
         // create from source
         var destIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
-        assertAcked(
-            client().execute(
-                CreateIndexFromSourceAction.INSTANCE,
-                new CreateIndexFromSourceAction.Request(sourceIndex, destIndex, settingsOverride, Map.of(), true)
-            )
-        );
+
+        CreateIndexFromSourceAction.Request request = new CreateIndexFromSourceAction.Request(sourceIndex, destIndex);
+        request.settingsOverride(settingsOverride);
+        assertAcked(client().execute(CreateIndexFromSourceAction.INSTANCE, request));
 
         // assert settings overridden
         var settingsResponse = indicesAdmin().getSettings(new GetSettingsRequest().indices(destIndex)).actionGet();

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceAction.java
@@ -65,7 +65,7 @@ public class CreateIndexFromSourceAction extends ActionType<AcknowledgedResponse
         }
 
         public Request(String sourceIndex, String destIndex) {
-            this(sourceIndex, destIndex, Settings.EMPTY, Map.of(), false);
+            this(sourceIndex, destIndex, Settings.EMPTY, Map.of(), true);
         }
 
         public Request(

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/30_create_from.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/30_create_from.yml
@@ -120,7 +120,7 @@ teardown:
   - match: {dest-index-1.mappings.properties.baz.type: integer}
 
 ---
-"Test create_from with remove_index_blocks":
+"Test create_from with remove_index_blocks set to false":
   - requires:
       reason: "migration reindex is behind a feature flag"
       test_runner_features: [capabilities]
@@ -136,8 +136,6 @@ teardown:
             index:
               blocks.write: true
               blocks.read: true
-              number_of_shards: 1
-              number_of_replicas: 0
   - do:
       migrate.create_from:
         source: "source-index-1"
@@ -147,11 +145,42 @@ teardown:
             index:
               blocks.write: false
               blocks.read: true
-          remove_index_blocks: true
+          remove_index_blocks: false
   - do:
       indices.get_settings:
         index: dest-index-1
-  - match: { dest-index-1.settings.index.number_of_shards: "1" }
+  - match: { dest-index-1.settings.index.blocks.write: "false" }
+  - match: { dest-index-1.settings.index.blocks.read: "true" }
+
+---
+"Test create_from with remove_index_blocks default of true":
+  - requires:
+      reason: "migration reindex is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_migration/reindex
+          capabilities: [migration_reindex]
+  - do:
+      indices.create:
+        index: source-index-1
+        body:
+          settings:
+            index:
+              blocks.write: true
+              blocks.read: true
+  - do:
+      migrate.create_from:
+        source: "source-index-1"
+        dest: "dest-index-1"
+        body:
+          settings_override:
+            index:
+              blocks.write: false
+              blocks.read: true
+  - do:
+      indices.get_settings:
+        index: dest-index-1
   - match: { dest-index-1.settings.index.blocks.write: null }
   - match: { dest-index-1.settings.index.blocks.read: null }
 


### PR DESCRIPTION
`_create_from` takes a argument `remove_index_blocks` which determines whether the destination index will have any index blocks from the source index filtered out before creation. Change the default to true, meaning index blocks are removed.