### PR TITLE
Add test for system index migration using reindexing script

### DIFF
--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -45,6 +45,9 @@ dependencies {
   clusterModules project(':modules:lang-painless')
   clusterModules project(':modules:parent-join')
   clusterModules project(":modules:rest-root")
+
+  internalClusterTestImplementation project(':modules:lang-painless')
+  internalClusterTestImplementation project(':modules:lang-painless:spi')
 }
 
 restResources {

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -371,8 +371,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             Arrays.asList(".int-mans-old", ".internal-managed-with-script-alias")
         );
 
-        SearchRequestBuilder searchRequestBuilder = prepareSearch(newIndexName)
-            .setQuery(QueryBuilders.termsQuery(FIELD_NAME, "migrated"))
+        SearchRequestBuilder searchRequestBuilder = prepareSearch(newIndexName).setQuery(QueryBuilders.termsQuery(FIELD_NAME, "migrated"))
             .setSize(0);
         assertHitCountAndNoFailures(searchRequestBuilder, INDEX_DOC_COUNT);
     }

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -110,7 +110,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
     }
 
     public void testStartMigrationAndImmediatelyCheckStatus() throws Exception {
-        createSystemIndexForDescriptor(INTERNAL_MANAGED_WITH_SCRIPT);
+        createSystemIndexForDescriptor(INTERNAL_MANAGED);
         createSystemIndexForDescriptor(INTERNAL_UNMANAGED);
         createSystemIndexForDescriptor(EXTERNAL_MANAGED);
         createSystemIndexForDescriptor(EXTERNAL_UNMANAGED);
@@ -130,7 +130,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             .stream()
             .map(PostFeatureUpgradeResponse.Feature::getFeatureName)
             .collect(Collectors.toSet());
-        assertThat(migratingFeatures, hasItem(SCRIPTED_INDEX_FEATURE_NAME));
+        assertThat(migratingFeatures, hasItem(FEATURE_NAME));
 
         // We should see that the migration is in progress even though we just started the migration.
         assertThat(statusResponse.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.IN_PROGRESS));
@@ -275,7 +275,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
     }
 
     public void testMigrationWillRunAfterError() throws Exception {
-        createSystemIndexForDescriptor(INTERNAL_MANAGED_WITH_SCRIPT);
+        createSystemIndexForDescriptor(INTERNAL_MANAGED);
 
         ensureGreen();
 
@@ -287,7 +287,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     FeatureMigrationResults newResults = new FeatureMigrationResults(
                         Collections.singletonMap(
-                            SCRIPTED_INDEX_FEATURE_NAME,
+                            FEATURE_NAME,
                             SingleFeatureMigrationResult.failure(INTERNAL_MANAGED_INDEX_NAME, new RuntimeException("it failed :("))
                         )
                     );
@@ -319,8 +319,8 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         PostFeatureUpgradeResponse migrationResponse = client().execute(PostFeatureUpgradeAction.INSTANCE, migrationRequest).get();
         // Make sure we actually started the migration
         assertTrue(
-            "could not find [" + SCRIPTED_INDEX_FEATURE_NAME + "] in response: " + Strings.toString(migrationResponse),
-            migrationResponse.getFeatures().stream().anyMatch(feature -> feature.getFeatureName().equals(SCRIPTED_INDEX_FEATURE_NAME))
+            "could not find [" + FEATURE_NAME + "] in response: " + Strings.toString(migrationResponse),
+            migrationResponse.getFeatures().stream().anyMatch(feature -> feature.getFeatureName().equals(FEATURE_NAME))
         );
 
         // Now wait for the migration to finish (otherwise the test infra explodes)

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.template.put.PutComponentTemplateAction;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
@@ -33,8 +34,11 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.painless.PainlessPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.upgrades.FeatureMigrationResults;
 import org.elasticsearch.upgrades.SingleFeatureMigrationResult;
@@ -51,6 +55,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -62,6 +67,27 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
+    private static final String INTERNAL_MANAGED_WITH_SCRIPT_INDEX_NAME = ".int-mans-old";
+    private static final String SCRIPTED_INDEX_FEATURE_NAME = "B-test-feature";
+    private static final SystemIndexDescriptor INTERNAL_MANAGED_WITH_SCRIPT = SystemIndexDescriptor.builder()
+        .setIndexPattern(".int-mans-*")
+        .setAliasName(".internal-managed-with-script-alias")
+        .setPrimaryIndex(INTERNAL_MANAGED_WITH_SCRIPT_INDEX_NAME)
+        .setType(SystemIndexDescriptor.Type.INTERNAL_MANAGED)
+        .setSettings(createSettings(NEEDS_UPGRADE_INDEX_VERSION, INTERNAL_MANAGED_FLAG_VALUE))
+        .setMappings(createMapping(true, true))
+        .setOrigin(ORIGIN)
+        .setVersionMetaKey(VERSION_META_KEY)
+        .setAllowedElasticProductOrigins(Collections.emptyList())
+        .setMinimumNodeVersion(NEEDS_UPGRADE_VERSION)
+        .setPriorSystemIndexDescriptors(Collections.emptyList())
+        .setMigrationScript("""
+            if (ctx._source.some_field != null) {
+              ctx._source.some_field = 'migrated';
+            }
+            """)
+        .build();
+
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         return Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings)).build();
@@ -77,12 +103,14 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
         plugins.add(TestPlugin.class);
+        plugins.add(SecondTestPlugin.class);
         plugins.add(ReindexPlugin.class);
+        plugins.add(PainlessPlugin.class);
         return plugins;
     }
 
     public void testStartMigrationAndImmediatelyCheckStatus() throws Exception {
-        createSystemIndexForDescriptor(INTERNAL_MANAGED);
+        createSystemIndexForDescriptor(INTERNAL_MANAGED_WITH_SCRIPT);
         createSystemIndexForDescriptor(INTERNAL_UNMANAGED);
         createSystemIndexForDescriptor(EXTERNAL_MANAGED);
         createSystemIndexForDescriptor(EXTERNAL_UNMANAGED);
@@ -102,7 +130,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             .stream()
             .map(PostFeatureUpgradeResponse.Feature::getFeatureName)
             .collect(Collectors.toSet());
-        assertThat(migratingFeatures, hasItem(FEATURE_NAME));
+        assertThat(migratingFeatures, hasItem(SCRIPTED_INDEX_FEATURE_NAME));
 
         // We should see that the migration is in progress even though we just started the migration.
         assertThat(statusResponse.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.IN_PROGRESS));
@@ -115,7 +143,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         });
     }
 
-    public void testMigrateInternalManagedSystemIndex() throws Exception {
+    public void testMigrateSystemIndex() throws Exception {
         createSystemIndexForDescriptor(INTERNAL_MANAGED);
         createSystemIndexForDescriptor(INTERNAL_UNMANAGED);
         createSystemIndexForDescriptor(EXTERNAL_MANAGED);
@@ -171,25 +199,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             postUpgradeHookCalled.set(true);
         });
 
-        PostFeatureUpgradeRequest migrationRequest = new PostFeatureUpgradeRequest(TEST_REQUEST_TIMEOUT);
-        PostFeatureUpgradeResponse migrationResponse = client().execute(PostFeatureUpgradeAction.INSTANCE, migrationRequest).get();
-        assertThat(migrationResponse.getReason(), nullValue());
-        assertThat(migrationResponse.getElasticsearchException(), nullValue());
-        final Set<String> migratingFeatures = migrationResponse.getFeatures()
-            .stream()
-            .map(PostFeatureUpgradeResponse.Feature::getFeatureName)
-            .collect(Collectors.toSet());
-        assertThat(migratingFeatures, hasItem(FEATURE_NAME));
-
-        GetFeatureUpgradeStatusRequest getStatusRequest = new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT);
-        // The feature upgrade may take longer than ten seconds when tests are running
-        // in parallel, so we give assertBusy a sixty-second timeout.
-        assertBusy(() -> {
-            GetFeatureUpgradeStatusResponse statusResponse = client().execute(GetFeatureUpgradeStatusAction.INSTANCE, getStatusRequest)
-                .get();
-            logger.info(Strings.toString(statusResponse));
-            assertThat(statusResponse.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
-        }, 60, TimeUnit.SECONDS);
+        executeMigration(FEATURE_NAME);
 
         // Waiting for shards to stabilize if indices were moved around
         ensureGreen();
@@ -197,14 +207,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         assertTrue("the pre-migration hook wasn't actually called", preUpgradeHookCalled.get());
         assertTrue("the post-migration hook wasn't actually called", postUpgradeHookCalled.get());
 
-        Metadata finalMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata();
-        // Check that the results metadata is what we expect.
-        FeatureMigrationResults currentResults = finalMetadata.custom(FeatureMigrationResults.TYPE);
-        assertThat(currentResults, notNullValue());
-        assertThat(currentResults.getFeatureStatuses(), allOf(aMapWithSize(1), hasKey(FEATURE_NAME)));
-        assertThat(currentResults.getFeatureStatuses().get(FEATURE_NAME).succeeded(), is(true));
-        assertThat(currentResults.getFeatureStatuses().get(FEATURE_NAME).getFailedIndexName(), nullValue());
-        assertThat(currentResults.getFeatureStatuses().get(FEATURE_NAME).getException(), nullValue());
+        Metadata finalMetadata = assertMetadataAfterMigration(FEATURE_NAME);
 
         assertIndexHasCorrectProperties(
             finalMetadata,
@@ -240,6 +243,18 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         );
     }
 
+    private static Metadata assertMetadataAfterMigration(String featureName) {
+        Metadata finalMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata();
+        // Check that the results metadata is what we expect.
+        FeatureMigrationResults currentResults = finalMetadata.custom(FeatureMigrationResults.TYPE);
+        assertThat(currentResults, notNullValue());
+        assertThat(currentResults.getFeatureStatuses(), allOf(aMapWithSize(1), hasKey(featureName)));
+        assertThat(currentResults.getFeatureStatuses().get(featureName).succeeded(), is(true));
+        assertThat(currentResults.getFeatureStatuses().get(featureName).getFailedIndexName(), nullValue());
+        assertThat(currentResults.getFeatureStatuses().get(featureName).getException(), nullValue());
+        return finalMetadata;
+    }
+
     public void testMigrateIndexWithWriteBlock() throws Exception {
         createSystemIndexForDescriptor(INTERNAL_UNMANAGED);
 
@@ -260,7 +275,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
     }
 
     public void testMigrationWillRunAfterError() throws Exception {
-        createSystemIndexForDescriptor(INTERNAL_MANAGED);
+        createSystemIndexForDescriptor(INTERNAL_MANAGED_WITH_SCRIPT);
 
         ensureGreen();
 
@@ -272,7 +287,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     FeatureMigrationResults newResults = new FeatureMigrationResults(
                         Collections.singletonMap(
-                            FEATURE_NAME,
+                            SCRIPTED_INDEX_FEATURE_NAME,
                             SingleFeatureMigrationResult.failure(INTERNAL_MANAGED_INDEX_NAME, new RuntimeException("it failed :("))
                         )
                     );
@@ -304,8 +319,8 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         PostFeatureUpgradeResponse migrationResponse = client().execute(PostFeatureUpgradeAction.INSTANCE, migrationRequest).get();
         // Make sure we actually started the migration
         assertTrue(
-            "could not find [" + FEATURE_NAME + "] in response: " + Strings.toString(migrationResponse),
-            migrationResponse.getFeatures().stream().anyMatch(feature -> feature.getFeatureName().equals(FEATURE_NAME))
+            "could not find [" + SCRIPTED_INDEX_FEATURE_NAME + "] in response: " + Strings.toString(migrationResponse),
+            migrationResponse.getFeatures().stream().anyMatch(feature -> feature.getFeatureName().equals(SCRIPTED_INDEX_FEATURE_NAME))
         );
 
         // Now wait for the migration to finish (otherwise the test infra explodes)
@@ -315,6 +330,51 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             logger.info(Strings.toString(statusResp));
             assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
         });
+    }
+
+    private void executeMigration(String featureName) throws Exception {
+        PostFeatureUpgradeRequest migrationRequest = new PostFeatureUpgradeRequest(TEST_REQUEST_TIMEOUT);
+        PostFeatureUpgradeResponse migrationResponse = client().execute(PostFeatureUpgradeAction.INSTANCE, migrationRequest).get();
+        assertThat(migrationResponse.getReason(), nullValue());
+        assertThat(migrationResponse.getElasticsearchException(), nullValue());
+        final Set<String> migratingFeatures = migrationResponse.getFeatures()
+            .stream()
+            .map(PostFeatureUpgradeResponse.Feature::getFeatureName)
+            .collect(Collectors.toSet());
+        assertThat(migratingFeatures, hasItem(featureName));
+
+        GetFeatureUpgradeStatusRequest getStatusRequest = new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT);
+        // The feature upgrade may take longer than ten seconds when tests are running
+        // in parallel, so we give assertBusy a sixty-second timeout.
+        assertBusy(() -> {
+            GetFeatureUpgradeStatusResponse statusResponse = client().execute(GetFeatureUpgradeStatusAction.INSTANCE, getStatusRequest)
+                .get();
+            logger.info(Strings.toString(statusResponse));
+            assertThat(statusResponse.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
+        }, 60, TimeUnit.SECONDS);
+    }
+
+    public void testMigrateUsingScript() throws Exception {
+        createSystemIndexForDescriptor(INTERNAL_MANAGED_WITH_SCRIPT);
+
+        executeMigration(SCRIPTED_INDEX_FEATURE_NAME);
+        ensureGreen();
+
+        Metadata metadata = assertMetadataAfterMigration(SCRIPTED_INDEX_FEATURE_NAME);
+        String newIndexName = ".int-mans-old-reindexed-for-9";
+        assertIndexHasCorrectProperties(
+            metadata,
+            newIndexName,
+            INTERNAL_MANAGED_FLAG_VALUE,
+            true,
+            true,
+            Arrays.asList(".int-mans-old", ".internal-managed-with-script-alias")
+        );
+
+        SearchRequestBuilder searchRequestBuilder = prepareSearch(newIndexName)
+            .setQuery(QueryBuilders.termsQuery(FIELD_NAME, "migrated"))
+            .setSize(0);
+        assertHitCountAndNoFailures(searchRequestBuilder, INDEX_DOC_COUNT);
     }
 
     private String featureUpgradeErrorResponse(GetFeatureUpgradeStatusResponse statusResp) {
@@ -462,5 +522,22 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             logger.info(Strings.toString(statusResp));
             assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
         });
+    }
+
+    public static class SecondTestPlugin extends Plugin implements SystemIndexPlugin {
+        @Override
+        public String getFeatureName() {
+            return SCRIPTED_INDEX_FEATURE_NAME;
+        }
+
+        @Override
+        public String getFeatureDescription() {
+            return "a plugin for testing system index migration";
+        }
+
+        @Override
+        public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+            return Collections.singletonList(INTERNAL_MANAGED_WITH_SCRIPT);
+        }
     }
 }

--- a/modules/reindex/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/reindex/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,2 +1,4 @@
 ALL-UNNAMED:
   - outbound_network
+org.elasticsearch.painless:
+  - create_class_loader

--- a/modules/reindex/src/main/plugin-metadata/plugin-security.policy
+++ b/modules/reindex/src/main/plugin-metadata/plugin-security.policy
@@ -10,6 +10,9 @@
 grant {
    // reindex opens socket connections using the rest client
    permission java.net.SocketPermission "*", "connect";
+
+  // needed for Painless to generate runtime classes
+  permission java.lang.RuntimePermission "createClassLoader";
 };
 
 grant codeBase "${codebase.elasticsearch-rest-client}" {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
-import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -56,7 +55,6 @@ public class TransportGetFeatureUpgradeStatusAction extends TransportMasterNodeA
     public static final IndexVersion NO_UPGRADE_REQUIRED_INDEX_VERSION = IndexVersions.V_8_0_0;
 
     private final SystemIndices systemIndices;
-    PersistentTasksService persistentTasksService;
 
     @Inject
     public TransportGetFeatureUpgradeStatusAction(
@@ -65,7 +63,6 @@ public class TransportGetFeatureUpgradeStatusAction extends TransportMasterNodeA
         ActionFilters actionFilters,
         ClusterService clusterService,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        PersistentTasksService persistentTasksService,
         SystemIndices systemIndices
     ) {
         super(
@@ -81,7 +78,6 @@ public class TransportGetFeatureUpgradeStatusAction extends TransportMasterNodeA
         );
 
         this.systemIndices = systemIndices;
-        this.persistentTasksService = persistentTasksService;
     }
 
     @Override


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/120333 added support for setting a reindexing script for system index migration during `/_migration/system_features` task. This change adds an integration test for it. This is backport of https://github.com/elastic/elasticsearch/pull/120667