### PR TITLE
[8.x] Consistent mapping for OTel log and event bodies (#120547)

### DIFF
--- a/docs/changelog/120547.yaml
+++ b/docs/changelog/120547.yaml
@@ -1,0 +1,5 @@
+pr: 120547
+summary: Consistent mapping for OTel log and event bodies
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/logs-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/logs-otel@mappings.yaml
@@ -47,20 +47,11 @@ template:
         properties:
           text:
             type: match_only_text
-          flattened:
-            # this is used for complex bodies of regular log records
+          structured:
+            # this is used for complex bodies of log records (including events)
             # using the flattened field type avoids mapping issues which can be caused by logs containing arbitrary JSON objects
             # the tradeoff is that the flattened field type is currently not supported well by Kibana and has other limitations
             type: flattened
-          structured:
-            # this is used for events
-            # events are also represented as log records
-            # the event.name attribute uniquely identifies event structure / type of the payload (body)
-            # see also https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md
-            # this makes them less prone to mapping issues, which is why we're enabling dynamic mappings
-            type: passthrough
-            dynamic: true
-            priority: 10
       message:
         type: alias
         path: body.text

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
@@ -119,7 +119,7 @@ Event body:
       indices.get_mapping:
         index: $datastream-backing-index
   - is_true: $datastream-backing-index
-  - match: { .$datastream-backing-index.mappings.properties.body.properties.structured.properties.foo\.bar.type: "keyword" }
+  - match: { .$datastream-backing-index.mappings.properties.body.properties.structured.type: "flattened" }
   - match: { .$datastream-backing-index.mappings.properties.event_name.type: "keyword" }
 ---
 Structured log body:
@@ -134,7 +134,7 @@ Structured log body:
               attributes:
                 service.name: my-service
             body:
-              flattened:
+              structured:
                 foo:
                   bar: baz
   - is_false: errors
@@ -146,7 +146,7 @@ Structured log body:
       indices.get_mapping:
         index: $datastream-backing-index
   - is_true: $datastream-backing-index
-  - match: { .$datastream-backing-index.mappings.properties.body.properties.flattened.type: "flattened" }
+  - match: { .$datastream-backing-index.mappings.properties.body.properties.structured.type: "flattened" }
 ---
 "event.dataset alias must point to data_stream.dataset":
   - do:


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Consistent mapping for OTel log and event bodies (#120547)