### PR TITLE
Fix broken yaml test `30_create_from`

### DIFF
--- a/docs/changelog/120662.yaml
+++ b/docs/changelog/120662.yaml
@@ -1,0 +1,5 @@
+pr: 120662
+summary: Fix broken yaml test `30_create_from`
+area: Indices APIs
+type: bug
+issues: []

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -255,9 +255,6 @@ tests:
 - class: org.elasticsearch.index.reindex.BulkByScrollUsesAllScrollDocumentsAfterConflictsIntegTests
   method: testReindex
   issue: https://github.com/elastic/elasticsearch/issues/120605
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=migrate/30_create_from/Test create_from with remove_index_blocks set to false}
-  issue: https://github.com/elastic/elasticsearch/issues/120657
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {lookup-join.MvJoinKeyOnFrom SYNC}
   issue: https://github.com/elastic/elasticsearch/issues/120658

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/30_create_from.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/30_create_from.yml
@@ -137,7 +137,7 @@ teardown:
               blocks.write: true
               blocks.read: true
   - do:
-      migrate.create_from:
+      indices.create_from:
         source: "source-index-1"
         dest: "dest-index-1"
         body:


### PR DESCRIPTION
The rest-api-spec namespace for reindex data stream APIs was changed from `migrate` to `indices` in https://github.com/elastic/elasticsearch/pull/120580 . The yaml test `Test create_from with remove_index_blocks set to false` incorrectly uses the old namespace.

The bug was introduced in https://github.com/elastic/elasticsearch/pull/120643
This fixes the test failure: https://github.com/elastic/elasticsearch/issues/120657

The ticket that introduced this bug was backported to 8.x in https://github.com/elastic/elasticsearch/pull/120652 . But this bug was caught in CI and the backport failed. So this issue will be fixed backport branch rather than having this fix backported.