### PR TITLE
Ensure entitlements have exactly one external constructor

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
@@ -71,7 +71,8 @@ public class PolicyParser {
     }
 
     // package private for tests
-    PolicyParser(InputStream inputStream, String policyName, boolean isExternalPlugin, Map<String, Class<?>> externalEntitlements) throws IOException {
+    PolicyParser(InputStream inputStream, String policyName, boolean isExternalPlugin, Map<String, Class<?>> externalEntitlements)
+        throws IOException {
         this.policyParser = YamlXContent.yamlXContent.createParser(XContentParserConfiguration.EMPTY, Objects.requireNonNull(inputStream));
         this.policyName = policyName;
         this.isExternalPlugin = isExternalPlugin;
@@ -143,8 +144,11 @@ public class PolicyParser {
             var metadata = ctor.getAnnotation(ExternalEntitlement.class);
             if (metadata != null) {
                 if (entitlementMetadata != null) {
-                    throw new IllegalStateException("entitlement class [" + entitlementClass.getName() +
-                        "] has more than one constructor annotated with ExternalEntitlement");
+                    throw new IllegalStateException(
+                        "entitlement class ["
+                            + entitlementClass.getName()
+                            + "] has more than one constructor annotated with ExternalEntitlement"
+                    );
                 }
                 entitlementConstructor = ctor;
                 entitlementMetadata = metadata;

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
@@ -48,6 +48,7 @@ public class PolicyParser {
     protected final XContentParser policyParser;
     protected final String policyName;
     private final boolean isExternalPlugin;
+    private final Map<String, Class<?>> externalEntitlements;
 
     static String getEntitlementTypeName(Class<? extends Entitlement> entitlementClass) {
         var entitlementClassName = entitlementClass.getSimpleName();
@@ -66,9 +67,15 @@ public class PolicyParser {
     }
 
     public PolicyParser(InputStream inputStream, String policyName, boolean isExternalPlugin) throws IOException {
+        this(inputStream, policyName, isExternalPlugin, EXTERNAL_ENTITLEMENTS);
+    }
+
+    // package private for tests
+    PolicyParser(InputStream inputStream, String policyName, boolean isExternalPlugin, Map<String, Class<?>> externalEntitlements) throws IOException {
         this.policyParser = YamlXContent.yamlXContent.createParser(XContentParserConfiguration.EMPTY, Objects.requireNonNull(inputStream));
         this.policyName = policyName;
         this.isExternalPlugin = isExternalPlugin;
+        this.externalEntitlements = externalEntitlements;
     }
 
     public Policy parsePolicy() {
@@ -124,14 +131,26 @@ public class PolicyParser {
 
     protected Entitlement parseEntitlement(String scopeName, String entitlementType) throws IOException {
         XContentLocation startLocation = policyParser.getTokenLocation();
-        Class<?> entitlementClass = EXTERNAL_ENTITLEMENTS.get(entitlementType);
+        Class<?> entitlementClass = externalEntitlements.get(entitlementType);
 
         if (entitlementClass == null) {
             throw newPolicyParserException(scopeName, "unknown entitlement type [" + entitlementType + "]");
         }
 
-        Constructor<?> entitlementConstructor = entitlementClass.getConstructors()[0];
-        ExternalEntitlement entitlementMetadata = entitlementConstructor.getAnnotation(ExternalEntitlement.class);
+        Constructor<?> entitlementConstructor = null;
+        ExternalEntitlement entitlementMetadata = null;
+        for (var ctor : entitlementClass.getConstructors()) {
+            var metadata = ctor.getAnnotation(ExternalEntitlement.class);
+            if (metadata != null) {
+                if (entitlementMetadata != null) {
+                    throw new IllegalStateException("entitlement class [" + entitlementClass.getName() +
+                        "] has more than one constructor annotated with ExternalEntitlement");
+                }
+                entitlementConstructor = ctor;
+                entitlementMetadata = metadata;
+            }
+
+        }
         if (entitlementMetadata == null) {
             throw newPolicyParserException(scopeName, "unknown entitlement type [" + entitlementType + "]");
         }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -22,6 +23,13 @@ import static org.hamcrest.Matchers.equalTo;
 public class PolicyParserTests extends ESTestCase {
 
     private static class TestWrongEntitlementName implements Entitlement {}
+
+    public static class ManyConstructorsEntitlement implements Entitlement {
+        @ExternalEntitlement
+        public ManyConstructorsEntitlement(String s) {}
+        @ExternalEntitlement
+        public ManyConstructorsEntitlement(int i) {}
+    }
 
     public void testGetEntitlementTypeName() {
         assertEquals("create_class_loader", PolicyParser.getEntitlementTypeName(CreateClassLoaderEntitlement.class));
@@ -134,5 +142,18 @@ public class PolicyParserTests extends ESTestCase {
             List.of(new Scope("entitlement-module-name", List.of(new LoadNativeLibrariesEntitlement())))
         );
         assertEquals(expected, parsedPolicy);
+    }
+
+    public void testMultipleConstructorsAnnotated() throws IOException {
+        var parser = new PolicyParser(new ByteArrayInputStream("""
+            entitlement-module-name:
+              - many_constructors
+            """.getBytes(StandardCharsets.UTF_8)), "test-policy.yaml", true,
+            Map.of("many_constructors", ManyConstructorsEntitlement.class));
+
+        var e = expectThrows(IllegalStateException.class, parser::parsePolicy);
+        assertThat(e.getMessage(), equalTo("entitlement class " +
+            "[org.elasticsearch.entitlement.runtime.policy.PolicyParserTests$ManyConstructorsEntitlement]" +
+            " has more than one constructor annotated with ExternalEntitlement"));
     }
 }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
@@ -27,6 +27,7 @@ public class PolicyParserTests extends ESTestCase {
     public static class ManyConstructorsEntitlement implements Entitlement {
         @ExternalEntitlement
         public ManyConstructorsEntitlement(String s) {}
+
         @ExternalEntitlement
         public ManyConstructorsEntitlement(int i) {}
     }
@@ -145,15 +146,24 @@ public class PolicyParserTests extends ESTestCase {
     }
 
     public void testMultipleConstructorsAnnotated() throws IOException {
-        var parser = new PolicyParser(new ByteArrayInputStream("""
-            entitlement-module-name:
-              - many_constructors
-            """.getBytes(StandardCharsets.UTF_8)), "test-policy.yaml", true,
-            Map.of("many_constructors", ManyConstructorsEntitlement.class));
+        var parser = new PolicyParser(
+            new ByteArrayInputStream("""
+                entitlement-module-name:
+                  - many_constructors
+                """.getBytes(StandardCharsets.UTF_8)),
+            "test-policy.yaml",
+            true,
+            Map.of("many_constructors", ManyConstructorsEntitlement.class)
+        );
 
         var e = expectThrows(IllegalStateException.class, parser::parsePolicy);
-        assertThat(e.getMessage(), equalTo("entitlement class " +
-            "[org.elasticsearch.entitlement.runtime.policy.PolicyParserTests$ManyConstructorsEntitlement]" +
-            " has more than one constructor annotated with ExternalEntitlement"));
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "entitlement class "
+                    + "[org.elasticsearch.entitlement.runtime.policy.PolicyParserTests$ManyConstructorsEntitlement]"
+                    + " has more than one constructor annotated with ExternalEntitlement"
+            )
+        );
     }
 }


### PR DESCRIPTION
When an entitlement is available to policy files, it should have one constructor that the parser uses. This commit adjusts the policy parser to scan the constructor to find that one annotated constructor, and errors if more than one is found.