### PR TITLE
[8.x] [Transform] Use seqno when migrating max_page_search_size (#120639)

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -322,7 +322,9 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
         transformServices.set(new TransformServices(configManager, checkpointService, auditor, scheduler, transformNode));
 
         var transformMeterRegistry = TransformMeterRegistry.create(services.telemetryProvider().getMeterRegistry());
-        transformConfigAutoMigration.set(new TransformConfigAutoMigration(configManager, auditor, transformMeterRegistry));
+        transformConfigAutoMigration.set(
+            new TransformConfigAutoMigration(configManager, auditor, transformMeterRegistry, services.threadPool())
+        );
 
         return List.of(
             transformServices.get(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformConfigAutoMigration.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformConfigAutoMigration.java
@@ -10,12 +10,16 @@ package org.elasticsearch.xpack.transform;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.telemetry.TransformMeterRegistry;
 
@@ -34,15 +38,18 @@ public class TransformConfigAutoMigration {
     private final TransformConfigManager transformConfigManager;
     private final TransformAuditor auditor;
     private final TransformMeterRegistry transformMeterRegistry;
+    private final ThreadPool threadPool;
 
     TransformConfigAutoMigration(
         TransformConfigManager transformConfigManager,
         TransformAuditor auditor,
-        TransformMeterRegistry transformMeterRegistry
+        TransformMeterRegistry transformMeterRegistry,
+        ThreadPool threadPool
     ) {
         this.transformConfigManager = transformConfigManager;
         this.auditor = auditor;
         this.transformMeterRegistry = transformMeterRegistry;
+        this.threadPool = threadPool;
     }
 
     public TransformConfig migrate(TransformConfig currentConfig) {
@@ -75,18 +82,26 @@ public class TransformConfigAutoMigration {
     }
 
     public void migrateAndSave(TransformConfig currentConfig, ActionListener<TransformConfig> listener) {
-        var updatedConfig = migrate(currentConfig);
-        if (currentConfig == updatedConfig) {
+        // most transforms shouldn't need to migrate, so let's exit early
+        if (currentConfig.shouldAutoMigrateMaxPageSearchSize() == false) {
             listener.onResponse(currentConfig);
-        } else {
-            ActionListener<Boolean> putConfigListener = ActionListener.wrap(r -> listener.onResponse(updatedConfig), e -> {
-                var errorMessage = "Failed to persist auto-migrated Config. Please see Elasticsearch logs. Continuing with old config.";
-                logger.atWarn().withThrowable(e).log(errorMessage);
-                auditor.warning(currentConfig.getId(), errorMessage);
-                listener.onResponse(currentConfig);
-            });
-
-            transformConfigManager.putTransformConfiguration(updatedConfig, putConfigListener);
+            return;
         }
+
+        SubscribableListener.<Tuple<TransformConfig, SeqNoPrimaryTermAndIndex>>newForked(l -> {
+            transformConfigManager.getTransformConfigurationForUpdate(currentConfig.getId(), l);
+        }).<TransformConfig>andThen(threadPool.generic(), threadPool.getThreadContext(), (l, configAndVersion) -> {
+            var updatedConfig = migrate(configAndVersion.v1());
+            if (configAndVersion.v1() == updatedConfig) {
+                l.onResponse(currentConfig);
+            } else {
+                transformConfigManager.updateTransformConfiguration(updatedConfig, configAndVersion.v2(), l.map(ignored -> updatedConfig));
+            }
+        }).addListener(listener.delegateResponse((l, e) -> {
+            var errorMessage = "Failed to auto-migrate Config. Please see Elasticsearch logs. Continuing with old config.";
+            logger.atWarn().withThrowable(e).log(errorMessage);
+            auditor.warning(currentConfig.getId(), errorMessage);
+            l.onResponse(currentConfig);
+        }), threadPool.generic(), threadPool.getThreadContext());
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [Transform] Use seqno when migrating max_page_search_size (#120639)