### PR TITLE
[main] Removes outdated admonition (#120556)

### DIFF
--- a/docs/reference/esql/esql-security-solution.asciidoc
+++ b/docs/reference/esql/esql-security-solution.asciidoc
@@ -34,8 +34,3 @@ more, refer to {security-guide}/rules-ui-create.html#create-esql-rule[Create an
 Use the Elastic AI Assistant to build {esql} queries, or answer questions about
 the {esql} query language. To learn more, refer to
 {security-guide}/security-assistant.html[AI Assistant].
-
-NOTE: For AI Assistant to answer questions about {esql} and write {esql}
-queries, you need to
-{security-guide}/security-assistant.html#set-up-ai-assistant[enable knowledge
-base].


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.17` to `main`:
 - [Removes outdated admonition (#120556)](https://github.com/elastic/elasticsearch/pull/120556)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)