### PR TITLE
[8.x] Failure store - No selectors in snapshots (#120114)

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
@@ -36,7 +36,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamAlias;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.index.Index;
@@ -334,13 +333,13 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(rolloverResponse.getNewIndex(), equalTo(DataStream.getDefaultBackingIndexName("ds", 3)));
     }
 
-    public void testFailureStoreSnapshotAndRestore() throws Exception {
+    public void testFailureStoreSnapshotAndRestore() {
         String dataStreamName = "with-fs";
         CreateSnapshotResponse createSnapshotResponse = client.admin()
             .cluster()
             .prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, REPO, SNAPSHOT)
             .setWaitForCompletion(true)
-            .setIndices(IndexNameExpressionResolver.combineSelector(dataStreamName, IndexComponentSelector.ALL_APPLICABLE))
+            .setIndices(dataStreamName)
             .setIncludeGlobalState(false)
             .get();
 
@@ -388,6 +387,49 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
             assertEquals(1, dataStreamInfos.get(0).getDataStream().getIndices().size());
             assertEquals(fs2BackingIndexName, dataStreamInfos.get(0).getDataStream().getIndices().get(0).getName());
             assertEquals(fs2FailureIndexName, dataStreamInfos.get(0).getDataStream().getFailureIndices().get(0).getName());
+        }
+    }
+
+    public void testSelectorsNotAllowedInSnapshotAndRestore() {
+        String dataStreamName = "with-fs";
+        try {
+            client.admin()
+                .cluster()
+                .prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, REPO, SNAPSHOT)
+                .setWaitForCompletion(true)
+                .setIndices(dataStreamName + "::" + randomFrom(IndexComponentSelector.values()).getKey())
+                .setIncludeGlobalState(false)
+                .get();
+            fail("Should have failed because selectors are not allowed in snapshot creation");
+        } catch (IllegalArgumentException e) {
+            assertThat(
+                e.getMessage(),
+                containsString("Index component selectors are not supported in this context but found selector in expression")
+            );
+        }
+        CreateSnapshotResponse createSnapshotResponse = client.admin()
+            .cluster()
+            .prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, REPO, SNAPSHOT)
+            .setWaitForCompletion(true)
+            .setIndices("ds")
+            .setIncludeGlobalState(false)
+            .get();
+
+        RestStatus status = createSnapshotResponse.getSnapshotInfo().status();
+        assertEquals(RestStatus.OK, status);
+        try {
+            client.admin()
+                .cluster()
+                .prepareRestoreSnapshot(TEST_REQUEST_TIMEOUT, REPO, SNAPSHOT)
+                .setWaitForCompletion(true)
+                .setIndices(dataStreamName + "::" + randomFrom(IndexComponentSelector.values()).getKey())
+                .get();
+            fail("Should have failed because selectors are not allowed in snapshot restore");
+        } catch (IllegalArgumentException e) {
+            assertThat(
+                e.getMessage(),
+                containsString("Index component selectors are not supported in this context but found selector in expression")
+            );
         }
     }
 
@@ -1216,6 +1258,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
             SnapshotInfo retrievedSnapshot = getSnapshot(REPO, SNAPSHOT);
             assertThat(retrievedSnapshot.dataStreams(), contains(dataStreamName));
             assertThat(retrievedSnapshot.indices(), containsInAnyOrder(fsBackingIndexName));
+            assertThat(retrievedSnapshot.indices(), not(containsInAnyOrder(fsFailureIndexName)));
 
             assertAcked(
                 safeGet(client.execute(DeleteDataStreamAction.INSTANCE, new DeleteDataStreamAction.Request(TEST_REQUEST_TIMEOUT, "*")))

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/DataStreamsStatsTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/DataStreamsStatsTransportAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.datastreams.DataStreamsActionUtil;
 import org.elasticsearch.action.datastreams.DataStreamsStatsAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
-import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.action.support.broadcast.node.TransportBroadcastByNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -99,17 +98,6 @@ public class DataStreamsStatsTransportAction extends TransportBroadcastByNodeAct
         String[] concreteIndices
     ) {
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, concreteIndices);
-    }
-
-    @Override
-    protected String[] resolveConcreteIndexNames(ClusterState clusterState, DataStreamsStatsAction.Request request) {
-        return DataStreamsActionUtil.resolveConcreteIndexNamesWithSelector(
-            indexNameExpressionResolver,
-            clusterState,
-            request.indices(),
-            IndexComponentSelector.ALL_APPLICABLE,
-            request.indicesOptions()
-        ).toArray(String[]::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -167,6 +167,8 @@ public class TransportVersions {
     public static final TransportVersion ESQL_SKIP_ES_INDEX_SERIALIZATION = def(8_827_00_0);
     public static final TransportVersion ADD_INDEX_BLOCK_TWO_PHASE = def(8_828_00_0);
     public static final TransportVersion RESOLVE_CLUSTER_NO_INDEX_EXPRESSION = def(8_829_00_0);
+    public static final TransportVersion ML_ROLLOVER_LEGACY_INDICES = def(8_830_00_0);
+    public static final TransportVersion ADD_INCLUDE_FAILURE_INDICES_OPTION = def(8_831_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -69,9 +68,7 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
 
     private String[] indices = EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = DataStream.isFailureStoreFeatureFlagEnabled()
-        ? IndicesOptions.strictExpandHiddenIncludeFailureStore()
-        : IndicesOptions.strictExpandHidden();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandHiddenFailureNoSelectors();
 
     private String[] featureStates = EMPTY_ARRAY;
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -14,6 +14,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -43,7 +44,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
     private String snapshot;
     private String repository;
     private String[] indices = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpenFailureNoSelectors();
     private String[] featureStates = Strings.EMPTY_ARRAY;
     private String renamePattern;
     private String renameReplacement;
@@ -137,6 +138,16 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         }
         if (indicesOptions == null) {
             validationException = addValidationError("indicesOptions is missing", validationException);
+        }
+        // This action does not use the IndexNameExpressionResolver to resolve concrete indices, this is why we check here for selectors
+        if (indicesOptions.allowSelectors() == false) {
+            for (String index : indices) {
+                try {
+                    IndexNameExpressionResolver.SelectorResolver.parseExpression(index, indicesOptions);
+                } catch (IllegalArgumentException e) {
+                    validationException = addValidationError(e.getMessage(), validationException);
+                }
+            }
         }
         if (featureStates == null) {
             validationException = addValidationError("featureStates is missing", validationException);

--- a/server/src/main/java/org/elasticsearch/action/datastreams/DataStreamsActionUtil.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/DataStreamsActionUtil.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.action.datastreams;
 
-import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -55,64 +54,24 @@ public class DataStreamsActionUtil {
         String[] names,
         IndicesOptions indicesOptions
     ) {
-        List<ResolvedExpression> abstractionNames = indexNameExpressionResolver.dataStreams(
+        List<ResolvedExpression> resolvedDataStreamExpressions = indexNameExpressionResolver.dataStreams(
             clusterState,
             updateIndicesOptions(indicesOptions),
             names
         );
         SortedMap<String, IndexAbstraction> indicesLookup = clusterState.getMetadata().getIndicesLookup();
 
-        List<String> results = new ArrayList<>(abstractionNames.size());
-        for (ResolvedExpression abstractionName : abstractionNames) {
-            IndexAbstraction indexAbstraction = indicesLookup.get(abstractionName.resource());
+        List<String> results = new ArrayList<>(resolvedDataStreamExpressions.size());
+        for (ResolvedExpression resolvedExpression : resolvedDataStreamExpressions) {
+            IndexAbstraction indexAbstraction = indicesLookup.get(resolvedExpression.resource());
             assert indexAbstraction != null;
             if (indexAbstraction.getType() == IndexAbstraction.Type.DATA_STREAM) {
-                selectDataStreamIndicesNames(
-                    (DataStream) indexAbstraction,
-                    IndexComponentSelector.FAILURES.equals(abstractionName.selector()),
-                    results
-                );
-            }
-        }
-        return results;
-    }
-
-    /**
-     * Resolves a list of expressions into data stream names and then collects the concrete indices
-     * that are applicable for those data streams based on the selector provided in the arguments.
-     * @param indexNameExpressionResolver resolver object
-     * @param clusterState state to query
-     * @param names data stream expressions
-     * @param selector which component indices of the data stream should be returned
-     * @param indicesOptions options for expression resolution
-     * @return A stream of concrete index names that belong to the components specified
-     *         on the data streams returned from the expressions given
-     */
-    public static List<String> resolveConcreteIndexNamesWithSelector(
-        IndexNameExpressionResolver indexNameExpressionResolver,
-        ClusterState clusterState,
-        String[] names,
-        IndexComponentSelector selector,
-        IndicesOptions indicesOptions
-    ) {
-        assert indicesOptions.allowSelectors() == false : "If selectors are enabled, use resolveConcreteIndexNames instead";
-        List<String> abstractionNames = indexNameExpressionResolver.dataStreamNames(
-            clusterState,
-            updateIndicesOptions(indicesOptions),
-            names
-        );
-        SortedMap<String, IndexAbstraction> indicesLookup = clusterState.getMetadata().getIndicesLookup();
-
-        List<String> results = new ArrayList<>(abstractionNames.size());
-        for (String abstractionName : abstractionNames) {
-            IndexAbstraction indexAbstraction = indicesLookup.get(abstractionName);
-            assert indexAbstraction != null;
-            if (indexAbstraction.getType() == IndexAbstraction.Type.DATA_STREAM) {
-                if (selector.shouldIncludeData()) {
-                    selectDataStreamIndicesNames((DataStream) indexAbstraction, false, results);
+                DataStream dataStream = (DataStream) indexAbstraction;
+                if (IndexNameExpressionResolver.shouldIncludeRegularIndices(indicesOptions, resolvedExpression.selector())) {
+                    selectDataStreamIndicesNames(dataStream, false, results);
                 }
-                if (selector.shouldIncludeFailures()) {
-                    selectDataStreamIndicesNames((DataStream) indexAbstraction, true, results);
+                if (IndexNameExpressionResolver.shouldIncludeFailureIndices(indicesOptions, resolvedExpression.selector())) {
+                    selectDataStreamIndicesNames(dataStream, true, results);
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/action/datastreams/DataStreamsStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/DataStreamsStatsAction.java
@@ -57,6 +57,7 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
                             .allowClosedIndices(true)
                             .ignoreThrottled(false)
                             .allowSelectors(false)
+                            .includeFailureIndices(true)
                             .build()
                     )
                     .build()

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -4136,9 +4136,6 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
                 request.partial(),
                 indexIds,
                 CollectionUtils.concatLists(
-                    // It's ok to just get the data stream names here because we have already resolved every concrete index that will be
-                    // in the snapshot, and thus already resolved any selectors that might be present. We now only care about which data
-                    // streams we're packing up in the resulting snapshot, not what their contents are.
                     indexNameExpressionResolver.dataStreamNames(currentState, request.indicesOptions(), request.indices()),
                     systemDataStreamNames
                 ),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
@@ -89,6 +89,7 @@ public class CreateSnapshotRequestTests extends ESTestCase {
                             randomBoolean()
                         )
                     )
+                    .gatekeeperOptions(IndicesOptions.GatekeeperOptions.builder().allowSelectors(false).includeFailureIndices(true).build())
                     .build()
             );
         }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
@@ -89,6 +89,7 @@ public class RestoreSnapshotRequestTests extends AbstractWireSerializingTestCase
                             randomBoolean()
                         )
                     )
+                    .gatekeeperOptions(IndicesOptions.GatekeeperOptions.builder().allowSelectors(false).includeFailureIndices(true).build())
                     .build()
             );
         }

--- a/server/src/test/java/org/elasticsearch/action/datastreams/DataStreamsActionUtilTests.java
+++ b/server/src/test/java/org/elasticsearch/action/datastreams/DataStreamsActionUtilTests.java
@@ -104,6 +104,19 @@ public class DataStreamsActionUtilTests extends ESTestCase {
 
         assertThat(resolved, containsInAnyOrder(".ds-foo1", ".ds-foo2", ".ds-baz1"));
 
+        // Including the failure indices
+        resolved = DataStreamsActionUtil.resolveConcreteIndexNames(
+            indexNameExpressionResolver,
+            clusterState,
+            query,
+            IndicesOptions.builder()
+                .wildcardOptions(IndicesOptions.WildcardOptions.builder().includeHidden(true))
+                .gatekeeperOptions(IndicesOptions.GatekeeperOptions.builder().allowSelectors(false).includeFailureIndices(true))
+                .build()
+        );
+
+        assertThat(resolved, containsInAnyOrder(".ds-foo1", ".ds-foo2", ".ds-baz1", ".fs-foo1"));
+
         when(indexNameExpressionResolver.dataStreams(any(), any(), eq(query))).thenReturn(
             List.of(
                 new ResolvedExpression("fooDs", IndexComponentSelector.DATA),

--- a/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -55,6 +55,7 @@ public class IndicesOptionsTests extends ESTestCase {
                         .ignoreThrottled(randomBoolean())
                         .allowAliasToMultipleIndices(randomBoolean())
                         .allowClosedIndices(randomBoolean())
+                        .allowSelectors(randomBoolean())
                 )
                 .build();
 
@@ -340,7 +341,13 @@ public class IndicesOptionsTests extends ESTestCase {
             randomBoolean(),
             randomBoolean()
         );
-        GatekeeperOptions gatekeeperOptions = new GatekeeperOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        GatekeeperOptions gatekeeperOptions = new GatekeeperOptions(
+            randomBoolean(),
+            randomBoolean(),
+            randomBoolean(),
+            randomBoolean(),
+            randomBoolean()
+        );
 
         IndicesOptions indicesOptions = new IndicesOptions(concreteTargetOptions, wildcardOptions, gatekeeperOptions);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
@@ -349,7 +349,7 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
                         + "indices_options [IndicesOptions[ignore_unavailable=false, allow_no_indices=true, expand_wildcards_open=true, "
                         + "expand_wildcards_closed=false, expand_wildcards_hidden=false, allow_aliases_to_multiple_indices=true, "
                         + "forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true, "
-                        + "allow_selectors=true]] with exception [no such index [not_foo]]"
+                        + "allow_selectors=true, include_failure_indices=false]] with exception [no such index [not_foo]]"
                 )
             )
         );
@@ -383,7 +383,8 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
                         + "indices given [not_foo] and indices_options [IndicesOptions[ignore_unavailable=false, allow_no_indices=true, "
                         + "expand_wildcards_open=true, expand_wildcards_closed=false, expand_wildcards_hidden=false, "
                         + "allow_aliases_to_multiple_indices=true, forbid_closed_indices=true, ignore_aliases=false, "
-                        + "ignore_throttled=true, allow_selectors=true]] with exception [no such index [not_foo]]]"
+                        + "ignore_throttled=true, allow_selectors=true, include_failure_indices=false]] with exception "
+                        + "[no such index [not_foo]]]"
                 )
             )
         );
@@ -560,7 +561,7 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
                         + "indices_options [IndicesOptions[ignore_unavailable=false, allow_no_indices=true, expand_wildcards_open=true, "
                         + "expand_wildcards_closed=false, expand_wildcards_hidden=false, allow_aliases_to_multiple_indices=true, "
                         + "forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true, "
-                        + "allow_selectors=true]] with exception [no such index [not_foo]]]"
+                        + "allow_selectors=true, include_failure_indices=false]] with exception [no such index [not_foo]]]"
                 )
             )
         );


### PR DESCRIPTION
Backport of #120114

In this PR we include the failure store indices while
disallowing the user to use selectors in the `indices` field of the
create and restore snapshot requests.

**Security concerns**

The create and restore snapshot require cluster privileges only, so we
do not have to worry about how to handle index level security (see [Create Snapshot API](https://www.elastic.co/guide/en/elasticsearch/reference/current/create-snapshot-api.html#create-snapshot-api-prereqs) & [Restore Snapshot API](https://www.elastic.co/guide/en/elasticsearch/reference/current/restore-snapshot-api.html#restore-snapshot-api-prereqs)).

**Challenges**

While there are other APIs that do not support selectors but they do
include the failure indices in their response such as `GET
_data_stream/<target>`, `GET _data_stream/<target>/stats`, etc; the
snapshot APIs are a little bit different. The reason for that is that
the data stream APIs first collect only the relevant data streams and
then they select the backing indices and/or the failure indices. On the
other hand, the snapshot API that works with both indices and data
streams cannot take such a shortcut and needs to use the
`concreteIndices` method.

We propose, to add a flag that when the selectors are not "allowed" can
determine if we need to include the failure store or not. In the past we
had something similar called the default selector, but it was more
flexible and it was used a fallback always. 

Our goal now is to only specify the behaviour we want when the selectors
are not supported. This new flag allowed also to simplify the concrete
index resolution in `GET _data_stream/<target>/stats`

Relates to #119545