### PR TITLE
[8.x] Stop caching source map on SearchHit#getSourceMap (#119888)

### DIFF
--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
@@ -184,8 +184,9 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         assertNoFailuresAndResponse(prepareSearch("test").setQuery(idsQuery().addIds("c1")), response -> {
             assertThat(response.getHits().getTotalHits().value, equalTo(1L));
             assertThat(response.getHits().getAt(0).getId(), equalTo("c1"));
-            assertThat(extractValue("join_field.name", response.getHits().getAt(0).getSourceAsMap()), equalTo("child"));
-            assertThat(extractValue("join_field.parent", response.getHits().getAt(0).getSourceAsMap()), equalTo("p1"));
+            Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+            assertThat(extractValue("join_field.name", source), equalTo("child"));
+            assertThat(extractValue("join_field.parent", source), equalTo("p1"));
 
         });
 
@@ -197,11 +198,13 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
             response -> {
                 assertThat(response.getHits().getTotalHits().value, equalTo(2L));
                 assertThat(response.getHits().getAt(0).getId(), anyOf(equalTo("c1"), equalTo("c2")));
-                assertThat(extractValue("join_field.name", response.getHits().getAt(0).getSourceAsMap()), equalTo("child"));
-                assertThat(extractValue("join_field.parent", response.getHits().getAt(0).getSourceAsMap()), equalTo("p1"));
+                Map<String, Object> source0 = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(extractValue("join_field.name", source0), equalTo("child"));
+                assertThat(extractValue("join_field.parent", source0), equalTo("p1"));
                 assertThat(response.getHits().getAt(1).getId(), anyOf(equalTo("c1"), equalTo("c2")));
-                assertThat(extractValue("join_field.name", response.getHits().getAt(1).getSourceAsMap()), equalTo("child"));
-                assertThat(extractValue("join_field.parent", response.getHits().getAt(1).getSourceAsMap()), equalTo("p1"));
+                Map<String, Object> source1 = response.getHits().getAt(1).getSourceAsMap();
+                assertThat(extractValue("join_field.name", source1), equalTo("child"));
+                assertThat(extractValue("join_field.parent", source1), equalTo("p1"));
             }
         );
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
@@ -655,8 +655,9 @@ public class TopHitsIT extends ESIntegTestCase {
                     assertThat(hit.field("field2").getValue(), equalTo(2.71f));
                     assertThat(hit.field("script").getValue().toString(), equalTo("5"));
 
-                    assertThat(hit.getSourceAsMap().size(), equalTo(1));
-                    assertThat(hit.getSourceAsMap().get("text").toString(), equalTo("some text to entertain"));
+                    Map<String, Object> source = hit.getSourceAsMap();
+                    assertThat(source.size(), equalTo(1));
+                    assertThat(source.get("text").toString(), equalTo("some text to entertain"));
                     assertEquals("some text to entertain", hit.getFields().get("text").getValue());
                     assertEquals("some text to entertain", hit.getFields().get("text_stored_lookup").getValue());
                 }
@@ -927,8 +928,9 @@ public class TopHitsIT extends ESIntegTestCase {
                 field = searchHit.field("script");
                 assertThat(field.getValue().toString(), equalTo("5"));
 
-                assertThat(searchHit.getSourceAsMap().size(), equalTo(1));
-                assertThat(extractValue("message", searchHit.getSourceAsMap()), equalTo("some comment"));
+                Map<String, Object> source = searchHit.getSourceAsMap();
+                assertThat(source.size(), equalTo(1));
+                assertThat(extractValue("message", source), equalTo("some comment"));
             }
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
@@ -490,8 +490,9 @@ public class InnerHitsIT extends ESIntegTestCase {
             response -> {
                 SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comments");
                 innerHits = innerHits.getAt(0).getInnerHits().get("remark");
-                assertNotNull(innerHits.getAt(0).getSourceAsMap());
-                assertFalse(innerHits.getAt(0).getSourceAsMap().isEmpty());
+                Map<String, Object> source = innerHits.getAt(0).getSourceAsMap();
+                assertNotNull(source);
+                assertFalse(source.isEmpty());
             }
         );
         assertNoFailuresAndResponse(
@@ -507,8 +508,9 @@ public class InnerHitsIT extends ESIntegTestCase {
             response -> {
                 SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comments");
                 innerHits = innerHits.getAt(0).getInnerHits().get("remark");
-                assertNotNull(innerHits.getAt(0).getSourceAsMap());
-                assertFalse(innerHits.getAt(0).getSourceAsMap().isEmpty());
+                Map<String, Object> source = innerHits.getAt(0).getSourceAsMap();
+                assertNotNull(source);
+                assertFalse(source.isEmpty());
             }
         );
     }
@@ -845,16 +847,12 @@ public class InnerHitsIT extends ESIntegTestCase {
                 assertHitCount(response, 1);
 
                 assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits().value, equalTo(2L));
-                assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getSourceAsMap().size(), equalTo(1));
-                assertThat(
-                    response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getSourceAsMap().get("message"),
-                    equalTo("fox eat quick")
-                );
-                assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(1).getSourceAsMap().size(), equalTo(1));
-                assertThat(
-                    response.getHits().getAt(0).getInnerHits().get("comments").getAt(1).getSourceAsMap().get("message"),
-                    equalTo("fox ate rabbit x y z")
-                );
+                Map<String, Object> source0 = response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getSourceAsMap();
+                assertThat(source0.size(), equalTo(1));
+                assertThat(source0.get("message"), equalTo("fox eat quick"));
+                Map<String, Object> source1 = response.getHits().getAt(0).getInnerHits().get("comments").getAt(1).getSourceAsMap();
+                assertThat(source1.size(), equalTo(1));
+                assertThat(source1.get("message"), equalTo("fox ate rabbit x y z"));
             }
         );
 
@@ -866,16 +864,12 @@ public class InnerHitsIT extends ESIntegTestCase {
                 assertHitCount(response, 1);
 
                 assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits().value, equalTo(2L));
-                assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getSourceAsMap().size(), equalTo(2));
-                assertThat(
-                    response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getSourceAsMap().get("message"),
-                    equalTo("fox eat quick")
-                );
-                assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getSourceAsMap().size(), equalTo(2));
-                assertThat(
-                    response.getHits().getAt(0).getInnerHits().get("comments").getAt(1).getSourceAsMap().get("message"),
-                    equalTo("fox ate rabbit x y z")
-                );
+                Map<String, Object> source0 = response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getSourceAsMap();
+                assertThat(source0.size(), equalTo(2));
+                assertThat(source0.get("message"), equalTo("fox eat quick"));
+                Map<String, Object> source1 = response.getHits().getAt(0).getInnerHits().get("comments").getAt(1).getSourceAsMap();
+                assertThat(source1.size(), equalTo(2));
+                assertThat(source1.get("message"), equalTo("fox ate rabbit x y z"));
             }
         );
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -152,8 +153,9 @@ public class SearchAfterIT extends ESIntegTestCase {
             searchResponse -> {
                 assertThat(searchResponse.getHits().getTotalHits().value, Matchers.equalTo(2L));
                 assertThat(searchResponse.getHits().getHits().length, Matchers.equalTo(1));
-                assertThat(searchResponse.getHits().getHits()[0].getSourceAsMap().get("field1"), Matchers.equalTo(100));
-                assertThat(searchResponse.getHits().getHits()[0].getSourceAsMap().get("field2"), Matchers.equalTo("toto"));
+                Map<String, Object> source = searchResponse.getHits().getHits()[0].getSourceAsMap();
+                assertThat(source.get("field1"), Matchers.equalTo(100));
+                assertThat(source.get("field2"), Matchers.equalTo("toto"));
             }
         );
     }
@@ -438,8 +440,9 @@ public class SearchAfterIT extends ESIntegTestCase {
                 int foundHits = 0;
                 do {
                     for (SearchHit hit : resp.getHits().getHits()) {
-                        assertNotNull(hit.getSourceAsMap());
-                        final Object timestamp = hit.getSourceAsMap().get("timestamp");
+                        Map<String, Object> source = hit.getSourceAsMap();
+                        assertNotNull(source);
+                        final Object timestamp = source.get("timestamp");
                         assertNotNull(timestamp);
                         assertThat(((Number) timestamp).longValue(), equalTo(timestamps.get(foundHits)));
                         foundHits++;
@@ -469,8 +472,9 @@ public class SearchAfterIT extends ESIntegTestCase {
                 do {
                     Object[] after = null;
                     for (SearchHit hit : resp.getHits().getHits()) {
-                        assertNotNull(hit.getSourceAsMap());
-                        final Object timestamp = hit.getSourceAsMap().get("timestamp");
+                        Map<String, Object> source = hit.getSourceAsMap();
+                        assertNotNull(source);
+                        final Object timestamp = source.get("timestamp");
                         assertNotNull(timestamp);
                         assertThat(((Number) timestamp).longValue(), equalTo(timestamps.get(foundHits)));
                         after = hit.getSortValues();
@@ -505,8 +509,9 @@ public class SearchAfterIT extends ESIntegTestCase {
                 do {
                     Object[] after = null;
                     for (SearchHit hit : resp.getHits().getHits()) {
-                        assertNotNull(hit.getSourceAsMap());
-                        final Object timestamp = hit.getSourceAsMap().get("timestamp");
+                        Map<String, Object> source = hit.getSourceAsMap();
+                        assertNotNull(source);
+                        final Object timestamp = source.get("timestamp");
                         assertNotNull(timestamp);
                         foundSeqNos.add(((Number) timestamp).longValue());
                         after = hit.getSortValues();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -128,10 +128,11 @@ public class FieldSortIT extends ESIntegTestCase {
                 .setSize(10),
             response -> {
                 logClusterState();
+                Number previous = (Number) response.getHits().getHits()[0].getSourceAsMap().get("entry");
                 for (int j = 1; j < response.getHits().getHits().length; j++) {
                     Number current = (Number) response.getHits().getHits()[j].getSourceAsMap().get("entry");
-                    Number previous = (Number) response.getHits().getHits()[j - 1].getSourceAsMap().get("entry");
                     assertThat(response.toString(), current.intValue(), lessThan(previous.intValue()));
+                    previous = current;
                 }
             }
         );
@@ -142,10 +143,11 @@ public class FieldSortIT extends ESIntegTestCase {
                 .setSize(10),
             response -> {
                 logClusterState();
+                Number previous = (Number) response.getHits().getHits()[0].getSourceAsMap().get("entry");
                 for (int j = 1; j < response.getHits().getHits().length; j++) {
                     Number current = (Number) response.getHits().getHits()[j].getSourceAsMap().get("entry");
-                    Number previous = (Number) response.getHits().getHits()[j - 1].getSourceAsMap().get("entry");
                     assertThat(response.toString(), current.intValue(), greaterThan(previous.intValue()));
+                    previous = current;
                 }
             }
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/source/SourceFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/source/SourceFetchingIT.java
@@ -11,12 +11,16 @@ package org.elasticsearch.search.source;
 
 import org.elasticsearch.test.ESIntegTestCase;
 
+import java.util.Map;
+
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponses;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class SourceFetchingIT extends ESIntegTestCase {
+
     public void testSourceDefaultBehavior() {
         createIndex("test");
         ensureGreen();
@@ -24,18 +28,16 @@ public class SourceFetchingIT extends ESIntegTestCase {
         indexDoc("test", "1", "field", "value");
         refresh();
 
-        assertResponse(prepareSearch("test"), response -> assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue()));
+        assertResponses(
+            response -> assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue()),
+            prepareSearch("test"),
+            prepareSearch("test").addStoredField("_source")
+        );
 
         assertResponse(
             prepareSearch("test").addStoredField("bla"),
             response -> assertThat(response.getHits().getAt(0).getSourceAsString(), nullValue())
         );
-
-        assertResponse(
-            prepareSearch("test").addStoredField("_source"),
-            response -> assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue())
-        );
-
     }
 
     public void testSourceFiltering() {
@@ -55,20 +57,21 @@ public class SourceFetchingIT extends ESIntegTestCase {
             response -> assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue())
         );
 
-        assertResponse(prepareSearch("test").setFetchSource("field1", null), response -> {
+        assertResponses(response -> {
             assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue());
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-            assertThat((String) response.getHits().getAt(0).getSourceAsMap().get("field1"), equalTo("value"));
-        });
+            Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+            assertThat(source.size(), equalTo(1));
+            assertThat(source.get("field1"), equalTo("value"));
+        },
+            prepareSearch("test").setFetchSource("field1", null),
+            prepareSearch("test").setFetchSource(new String[] { "*" }, new String[] { "field2" })
+        );
+
         assertResponse(prepareSearch("test").setFetchSource("hello", null), response -> {
             assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue());
             assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(0));
         });
-        assertResponse(prepareSearch("test").setFetchSource(new String[] { "*" }, new String[] { "field2" }), response -> {
-            assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue());
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-            assertThat((String) response.getHits().getAt(0).getSourceAsMap().get("field1"), equalTo("value"));
-        });
+
     }
 
     /**
@@ -82,15 +85,14 @@ public class SourceFetchingIT extends ESIntegTestCase {
         prepareIndex("test").setId("1").setSource("field", "value").get();
         refresh();
 
-        assertResponse(prepareSearch("test").setFetchSource(new String[] { "*.notexisting", "field" }, null), response -> {
+        assertResponses(response -> {
             assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue());
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-            assertThat((String) response.getHits().getAt(0).getSourceAsMap().get("field"), equalTo("value"));
-        });
-        assertResponse(prepareSearch("test").setFetchSource(new String[] { "field.notexisting.*", "field" }, null), response -> {
-            assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue());
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-            assertThat((String) response.getHits().getAt(0).getSourceAsMap().get("field"), equalTo("value"));
-        });
+            Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+            assertThat(source.size(), equalTo(1));
+            assertThat((String) source.get("field"), equalTo("value"));
+        },
+            prepareSearch("test").setFetchSource(new String[] { "*.notexisting", "field" }, null),
+            prepareSearch("test").setFetchSource(new String[] { "field.notexisting.*", "field" }, null)
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
@@ -356,8 +356,9 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
                     assertThat(option.getText().toString(), equalTo("suggestion" + id));
                     assertThat(option.getHit(), hasId("" + id));
                     assertThat(option.getHit(), hasScore((id)));
-                    assertNotNull(option.getHit().getSourceAsMap());
-                    Set<String> sourceFields = option.getHit().getSourceAsMap().keySet();
+                    Map<String, Object> source = option.getHit().getSourceAsMap();
+                    assertNotNull(source);
+                    Set<String> sourceFields = source.keySet();
                     assertThat(sourceFields, contains("a"));
                     assertThat(sourceFields, not(contains("b")));
                     id--;

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -104,7 +104,8 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
     private transient String index;
     private transient String clusterAlias;
 
-    private Map<String, Object> sourceAsMap;
+    // For asserting that the method #getSourceAsMap is called just once on the lifetime of this object
+    private boolean sourceAsMapCalled = false;
 
     private Map<String, SearchHits> innerHits;
 
@@ -142,7 +143,6 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
             null,
             null,
             null,
-            null,
             new HashMap<>(),
             new HashMap<>(),
             refCounted
@@ -166,7 +166,6 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
         SearchShardTarget shard,
         String index,
         String clusterAlias,
-        Map<String, Object> sourceAsMap,
         Map<String, SearchHits> innerHits,
         Map<String, DocumentField> documentFields,
         Map<String, DocumentField> metaFields,
@@ -188,7 +187,6 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
         this.shard = shard;
         this.index = index;
         this.clusterAlias = clusterAlias;
-        this.sourceAsMap = sourceAsMap;
         this.innerHits = innerHits;
         this.documentFields = documentFields;
         this.metaFields = metaFields;
@@ -279,7 +277,6 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
             shardTarget,
             index,
             clusterAlias,
-            null,
             innerHits,
             documentFields,
             metaFields,
@@ -447,7 +444,6 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
      */
     public SearchHit sourceRef(BytesReference source) {
         this.source = source;
-        this.sourceAsMap = null;
         return this;
     }
 
@@ -476,19 +472,18 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
     }
 
     /**
-     * The source of the document as a map (can be {@code null}).
+     * The source of the document as a map (can be {@code null}). This method is expected
+     * to be called at most once during the lifetime of the object as the generated map
+     * is expensive to generate and it does not get cache.
      */
     public Map<String, Object> getSourceAsMap() {
         assert hasReferences();
+        assert sourceAsMapCalled == false : "getSourceAsMap() called twice";
+        sourceAsMapCalled = true;
         if (source == null) {
             return null;
         }
-        if (sourceAsMap != null) {
-            return sourceAsMap;
-        }
-
-        sourceAsMap = Source.fromBytes(source).source();
-        return sourceAsMap;
+        return Source.fromBytes(source).source();
     }
 
     /**
@@ -758,7 +753,6 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
             shard,
             index,
             clusterAlias,
-            sourceAsMap,
             innerHits == null
                 ? null
                 : innerHits.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().asUnpooled())),

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
@@ -235,6 +235,8 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
         } else if (tokens[0].equals(SCORE)) {
             return topHit.getScore();
         } else if (tokens[0].equals(SOURCE)) {
+            // Caching the map might help here but memory usage is a concern for this class
+            // This is dead code, pipeline aggregations do not support _source.field.
             Map<String, Object> sourceAsMap = topHit.getSourceAsMap();
             if (sourceAsMap != null) {
                 Object property = sourceAsMap.get(tokens[1]);

--- a/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -317,9 +317,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
 
         assertThat(searchHit.getSourceAsMap(), nullValue());
         assertThat(searchHit.getSourceRef(), nullValue());
-        assertThat(searchHit.getSourceAsMap(), nullValue());
         assertThat(searchHit.getSourceAsString(), nullValue());
-        assertThat(searchHit.getSourceAsMap(), nullValue());
         assertThat(searchHit.getSourceRef(), nullValue());
         assertThat(searchHit.getSourceAsString(), nullValue());
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/SearchResponseUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/SearchResponseUtils.java
@@ -883,7 +883,6 @@ public enum SearchResponseUtils {
             shardTarget,
             index,
             clusterAlias,
-            null,
             get(SearchHit.Fields.INNER_HITS, values, null),
             get(SearchHit.DOCUMENT_FIELDS, values, Collections.emptyMap()),
             get(SearchHit.METADATA_FIELDS, values, Collections.emptyMap()),

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
@@ -173,8 +173,11 @@ public final class EnrichCache {
         List<Map<?, ?>> result = new ArrayList<>(response.getHits().getHits().length);
         long size = 0;
         for (SearchHit hit : response.getHits()) {
-            result.add(deepCopy(hit.getSourceAsMap(), true));
+            // There is a cost of decompressing source here plus caching it.
+            // We do it first so we don't decompress it twice.
             size += hit.getSourceRef() != null ? hit.getSourceRef().ramBytesUsed() : 0;
+            // Do we need deep copy here, we are creating a modifiable map already?
+            result.add(deepCopy(hit.getSourceAsMap(), true));
         }
         return new CacheValue(Collections.unmodifiableList(result), size);
     }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchActionTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.enrich.LocalStateEnrich;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
@@ -65,11 +66,9 @@ public class EnrichShardMultiSearchActionTests extends ESSingleNodeTestCase {
                 for (int i = 0; i < numSearches; i++) {
                     assertThat(response.getResponses()[i].isFailure(), is(false));
                     assertThat(response.getResponses()[i].getResponse().getHits().getTotalHits().value, equalTo(1L));
-                    assertThat(response.getResponses()[i].getResponse().getHits().getHits()[0].getSourceAsMap().size(), equalTo(1));
-                    assertThat(
-                        response.getResponses()[i].getResponse().getHits().getHits()[0].getSourceAsMap().get("key1"),
-                        equalTo("value1")
-                    );
+                    Map<String, Object> sourceAsMap = response.getResponses()[i].getResponse().getHits().getHits()[0].getSourceAsMap();
+                    assertThat(sourceAsMap.size(), equalTo(1));
+                    assertThat(sourceAsMap.get("key1"), equalTo("value1"));
                 }
             }
         );

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
@@ -33,7 +33,6 @@ import org.elasticsearch.indices.ExecutorNames;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
-import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xcontent.ToXContent;
@@ -434,13 +433,12 @@ public class QueryRulesIndexService {
 
     private static QueryRulesetResult mapSearchResponseToQueryRulesetList(SearchResponse response) {
         final List<QueryRulesetListItem> rulesetResults = Arrays.stream(response.getHits().getHits())
-            .map(QueryRulesIndexService::hitToQueryRulesetListItem)
+            .map(searchHit -> QueryRulesIndexService.hitToQueryRulesetListItem(searchHit.getSourceAsMap()))
             .toList();
         return new QueryRulesetResult(rulesetResults, (int) response.getHits().getTotalHits().value);
     }
 
-    private static QueryRulesetListItem hitToQueryRulesetListItem(SearchHit searchHit) {
-        final Map<String, Object> sourceMap = searchHit.getSourceAsMap();
+    private static QueryRulesetListItem hitToQueryRulesetListItem(final Map<String, Object> sourceMap) {
         final String rulesetId = (String) sourceMap.get(QueryRuleset.ID_FIELD.getPreferredName());
         @SuppressWarnings("unchecked")
         final List<LinkedHashMap<?, ?>> rules = ((List<LinkedHashMap<?, ?>>) sourceMap.get(QueryRuleset.RULES_FIELD.getPreferredName()));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryTests.java
@@ -187,7 +187,6 @@ public class ModelRegistryTests extends ESTestCase {
         var listener = new PlainActionFuture<UnparsedModel>();
         registry.getModel("1", listener);
 
-        registry.getModel("1", listener);
         var modelConfig = listener.actionGet(TIMEOUT);
         assertEquals("1", modelConfig.inferenceEntityId());
         assertEquals("foo", modelConfig.service());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractor;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorUtils;
 import org.elasticsearch.xpack.ml.extractor.ExtractedField;
+import org.elasticsearch.xpack.ml.extractor.SourceSupplier;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -203,11 +204,12 @@ class ScrollDataExtractor implements DataExtractor {
         BytesStreamOutput outputStream = new BytesStreamOutput();
 
         SearchHit lastHit = hits.getAt(hits.getHits().length - 1);
-        lastTimestamp = context.extractedFields.timeFieldValue(lastHit);
+        lastTimestamp = context.extractedFields.timeFieldValue(lastHit, new SourceSupplier(lastHit));
         try (SearchHitToJsonProcessor hitProcessor = new SearchHitToJsonProcessor(context.extractedFields, outputStream)) {
             for (SearchHit hit : hits) {
+                SourceSupplier sourceSupplier = new SourceSupplier(hit);
                 if (isCancelled) {
-                    Long timestamp = context.extractedFields.timeFieldValue(hit);
+                    Long timestamp = context.extractedFields.timeFieldValue(hit, sourceSupplier);
                     if (timestamp != null) {
                         if (timestampOnCancel == null) {
                             timestampOnCancel = timestamp;
@@ -218,7 +220,7 @@ class ScrollDataExtractor implements DataExtractor {
                         }
                     }
                 }
-                hitProcessor.process(hit);
+                hitProcessor.process(hit, sourceSupplier);
             }
         }
         return outputStream.bytes().streamInput();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/SearchHitToJsonProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/SearchHitToJsonProcessor.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
+import org.elasticsearch.xpack.ml.extractor.SourceSupplier;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -27,10 +28,10 @@ class SearchHitToJsonProcessor implements Releasable {
         this.jsonBuilder = new XContentBuilder(JsonXContent.jsonXContent, outputStream);
     }
 
-    public void process(SearchHit hit) throws IOException {
+    public void process(SearchHit hit, SourceSupplier sourceSupplier) throws IOException {
         jsonBuilder.startObject();
         for (ExtractedField field : fields.getAllFields()) {
-            writeKeyValue(field.getName(), field.value(hit));
+            writeKeyValue(field.getName(), field.value(hit, sourceSupplier));
         }
         jsonBuilder.endObject();
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFields.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFields.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
+import org.elasticsearch.xpack.ml.extractor.SourceSupplier;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,8 +41,8 @@ public class TimeBasedExtractedFields extends ExtractedFields {
         return timeField.getName();
     }
 
-    public Long timeFieldValue(SearchHit hit) {
-        Object[] value = timeField.value(hit);
+    public Long timeFieldValue(SearchHit hit, SourceSupplier source) {
+        Object[] value = timeField.value(hit, source);
         if (value.length != 1) {
             throw new RuntimeException(
                 "Time field [" + timeField.getName() + "] expected a single value; actual was: " + Arrays.toString(value)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
@@ -39,6 +39,7 @@ import org.elasticsearch.xpack.ml.dataframe.stats.DataCountsTracker;
 import org.elasticsearch.xpack.ml.dataframe.stats.ProgressTracker;
 import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
+import org.elasticsearch.xpack.ml.extractor.SourceSupplier;
 import org.elasticsearch.xpack.ml.inference.loadingservice.LocalModel;
 import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.utils.MlIndicesUtils;
@@ -210,8 +211,11 @@ public class InferenceRunner {
 
                 for (SearchHit doc : batch) {
                     dataCountsTracker.incrementTestDocsCount();
-                    InferenceResults inferenceResults = model.inferNoStats(featuresFromDoc(doc));
-                    bulkIndexer.addAndExecuteIfNeeded(createIndexRequest(doc, inferenceResults, config.getDest().getResultsField()));
+                    SourceSupplier sourceSupplier = new SourceSupplier(doc);
+                    InferenceResults inferenceResults = model.inferNoStats(featuresFromDoc(doc, sourceSupplier));
+                    bulkIndexer.addAndExecuteIfNeeded(
+                        createIndexRequest(doc, sourceSupplier, inferenceResults, config.getDest().getResultsField())
+                    );
 
                     processedDocCount++;
                     int progressPercent = Math.min((int) (processedDocCount * 100.0 / totalDocCount), MAX_PROGRESS_BEFORE_COMPLETION);
@@ -225,10 +229,10 @@ public class InferenceRunner {
         }
     }
 
-    private Map<String, Object> featuresFromDoc(SearchHit doc) {
+    private Map<String, Object> featuresFromDoc(SearchHit doc, SourceSupplier sourceSupplier) {
         Map<String, Object> features = new HashMap<>();
         for (ExtractedField extractedField : extractedFields.getAllFields()) {
-            Object[] values = extractedField.value(doc);
+            Object[] values = extractedField.value(doc, sourceSupplier);
             if (values.length == 1) {
                 features.put(extractedField.getName(), values[0]);
             }
@@ -236,11 +240,10 @@ public class InferenceRunner {
         return features;
     }
 
-    private IndexRequest createIndexRequest(SearchHit hit, InferenceResults results, String resultField) {
+    private IndexRequest createIndexRequest(SearchHit hit, SourceSupplier sourceSupplier, InferenceResults results, String resultField) {
         Map<String, Object> resultsMap = new LinkedHashMap<>(results.asMap());
         resultsMap.put(DestinationIndex.IS_TRAINING, false);
-
-        Map<String, Object> source = new LinkedHashMap<>(hit.getSourceAsMap());
+        Map<String, Object> source = new LinkedHashMap<>(sourceSupplier.get());
         source.put(resultField, resultsMap);
         IndexRequest indexRequest = new IndexRequest(hit.getIndex());
         indexRequest.id(hit.getId());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
@@ -102,7 +102,7 @@ class DataFrameRowsJoiner implements AutoCloseable {
                 RowResults result = currentResults.pop();
                 DataFrameDataExtractor.Row row = dataFrameRowsIterator.next();
                 checkChecksumsMatch(row, result);
-                bulkIndexer.addAndExecuteIfNeeded(createIndexRequest(result, row.getHit()));
+                bulkIndexer.addAndExecuteIfNeeded(createIndexRequest(result, row));
             }
         }
 
@@ -130,11 +130,11 @@ class DataFrameRowsJoiner implements AutoCloseable {
         }
     }
 
-    private IndexRequest createIndexRequest(RowResults result, SearchHit hit) {
-        Map<String, Object> source = new LinkedHashMap<>(hit.getSourceAsMap());
+    private IndexRequest createIndexRequest(RowResults result, DataFrameDataExtractor.Row row) {
+        Map<String, Object> source = new LinkedHashMap<>(row.getSource());
         source.putAll(result.getResults());
-        IndexRequest indexRequest = new IndexRequest(hit.getIndex());
-        indexRequest.id(hit.getId());
+        IndexRequest indexRequest = new IndexRequest(row.getHit().getIndex());
+        indexRequest.id(row.getHit().getId());
         indexRequest.source(source);
         indexRequest.opType(DocWriteRequest.OpType.INDEX);
         indexRequest.setParentTask(parentTaskId);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/DocValueField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/DocValueField.java
@@ -23,7 +23,7 @@ public class DocValueField extends AbstractField {
     }
 
     @Override
-    public Object[] value(SearchHit hit) {
+    public Object[] value(SearchHit hit, SourceSupplier source) {
         return getFieldValue(hit);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ExtractedField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ExtractedField.java
@@ -48,10 +48,12 @@ public interface ExtractedField {
 
     /**
      * Extracts the value from a {@link SearchHit}
-     * @param hit the search hit
+     *
+     * @param hit    the search hit
+     * @param source the source supplier
      * @return the extracted value
      */
-    Object[] value(SearchHit hit);
+    Object[] value(SearchHit hit, SourceSupplier source);
 
     /**
      * @return Whether the field can be fetched from source instead

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ExtractedFields.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ExtractedFields.java
@@ -263,8 +263,8 @@ public class ExtractedFields {
         }
 
         @Override
-        public Object[] value(SearchHit hit) {
-            Object[] value = field.value(hit);
+        public Object[] value(SearchHit hit, SourceSupplier source) {
+            Object[] value = field.value(hit, source);
             if (value != null) {
                 return Arrays.stream(value).map(v -> {
                     boolean asBoolean;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/GeoPointField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/GeoPointField.java
@@ -23,8 +23,8 @@ public class GeoPointField extends DocValueField {
     }
 
     @Override
-    public Object[] value(SearchHit hit) {
-        Object[] value = super.value(hit);
+    public Object[] value(SearchHit hit, SourceSupplier source) {
+        Object[] value = super.value(hit, source);
         if (value.length == 0) {
             return value;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/GeoShapeField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/GeoShapeField.java
@@ -33,8 +33,8 @@ public class GeoShapeField extends SourceField {
     }
 
     @Override
-    public Object[] value(SearchHit hit) {
-        Object[] value = super.value(hit);
+    public Object[] value(SearchHit hit, SourceSupplier source) {
+        Object[] value = super.value(hit, source);
         if (value.length == 0) {
             return value;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/MultiField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/MultiField.java
@@ -50,8 +50,8 @@ public class MultiField implements ExtractedField {
     }
 
     @Override
-    public Object[] value(SearchHit hit) {
-        return field.value(hit);
+    public Object[] value(SearchHit hit, SourceSupplier source) {
+        return field.value(hit, source);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ProcessedField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ProcessedField.java
@@ -38,7 +38,7 @@ public class ProcessedField {
         return Collections.singleton(preProcessor.getOutputFieldType(outputField));
     }
 
-    public Object[] value(SearchHit hit, Function<String, ExtractedField> fieldExtractor) {
+    public Object[] value(SearchHit hit, SourceSupplier sourceSupplier, Function<String, ExtractedField> fieldExtractor) {
         List<String> inputFields = getInputFieldNames();
         Map<String, Object> inputs = Maps.newMapWithExpectedSize(inputFields.size());
         for (String field : inputFields) {
@@ -46,7 +46,7 @@ public class ProcessedField {
             if (extractedField == null) {
                 return new Object[0];
             }
-            Object[] values = extractedField.value(hit);
+            Object[] values = extractedField.value(hit, sourceSupplier);
             if (values == null || values.length == 0) {
                 continue;
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ScriptField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ScriptField.java
@@ -22,7 +22,7 @@ public class ScriptField extends AbstractField {
     }
 
     @Override
-    public Object[] value(SearchHit hit) {
+    public Object[] value(SearchHit hit, SourceSupplier source) {
         return getFieldValue(hit);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/SourceField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/SourceField.java
@@ -27,15 +27,16 @@ public class SourceField extends AbstractField {
     }
 
     @Override
-    public Object[] value(SearchHit hit) {
-        Map<String, Object> source = hit.getSourceAsMap();
+    public Object[] value(SearchHit hit, SourceSupplier source) {
+        // This is the only one that might be problematic
+        Map<String, Object> sourceMap = source.get();
         int level = 0;
-        while (source != null && level < path.length - 1) {
-            source = getNextLevel(source, path[level]);
+        while (sourceMap != null && level < path.length - 1) {
+            sourceMap = getNextLevel(sourceMap, path[level]);
             level++;
         }
-        if (source != null) {
-            Object values = source.get(path[level]);
+        if (sourceMap != null) {
+            Object values = sourceMap.get(path[level]);
             if (values != null) {
                 if (values instanceof List<?>) {
                     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/SourceSupplier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/SourceSupplier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.extractor;
+
+import org.elasticsearch.search.SearchHit;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * A supplier for the source of a search hit with caching capabilities.
+ */
+public final class SourceSupplier implements Supplier<Map<String, Object>> {
+
+    private final SearchHit searchHit;
+    private Map<String, Object> sourceMap;
+
+    public SourceSupplier(SearchHit searchHit) {
+        this.searchHit = searchHit;
+    }
+
+    @Override
+    public Map<String, Object> get() {
+        if (sourceMap == null) {
+            sourceMap = searchHit.getSourceAsMap();
+        }
+        return sourceMap;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/TimeField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/TimeField.java
@@ -38,7 +38,7 @@ public class TimeField extends AbstractField {
     }
 
     @Override
-    public Object[] value(SearchHit hit) {
+    public Object[] value(SearchHit hit, SourceSupplier source) {
         Object[] value = getFieldValue(hit);
         if (value.length != 1) {
             return value;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/SearchHitToJsonProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/SearchHitToJsonProcessorTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ml.extractor.DocValueField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
+import org.elasticsearch.xpack.ml.extractor.SourceSupplier;
 import org.elasticsearch.xpack.ml.extractor.TimeField;
 import org.elasticsearch.xpack.ml.test.SearchHitBuilder;
 
@@ -75,7 +76,7 @@ public class SearchHitToJsonProcessorTests extends ESTestCase {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (SearchHitToJsonProcessor hitProcessor = new SearchHitToJsonProcessor(fields, outputStream)) {
             for (int i = 0; i < searchHits.length; i++) {
-                hitProcessor.process(searchHits[i]);
+                hitProcessor.process(searchHits[i], new SourceSupplier(searchHits[i]));
             }
         }
         return outputStream.toString(StandardCharsets.UTF_8.name());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFieldsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFieldsTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
 import org.elasticsearch.xpack.ml.extractor.ScriptField;
 import org.elasticsearch.xpack.ml.extractor.SourceField;
+import org.elasticsearch.xpack.ml.extractor.SourceSupplier;
 import org.elasticsearch.xpack.ml.extractor.TimeField;
 import org.elasticsearch.xpack.ml.test.SearchHitBuilder;
 
@@ -79,7 +80,7 @@ public class TimeBasedExtractedFieldsTests extends ESTestCase {
         long millis = randomLong();
         SearchHit hit = new SearchHitBuilder(randomInt()).addField("time", Long.toString(millis)).build();
         TimeBasedExtractedFields extractedFields = new TimeBasedExtractedFields(timeField, Collections.singletonList(timeField));
-        assertThat(extractedFields.timeFieldValue(hit), equalTo(millis));
+        assertThat(extractedFields.timeFieldValue(hit, new SourceSupplier(hit)), equalTo(millis));
     }
 
     public void testPre6xTimeFieldValue() {
@@ -87,7 +88,7 @@ public class TimeBasedExtractedFieldsTests extends ESTestCase {
         long millis = randomLong();
         SearchHit hit = new SearchHitBuilder(randomInt()).addField("time", millis).build();
         TimeBasedExtractedFields extractedFields = new TimeBasedExtractedFields(timeField, Collections.singletonList(timeField));
-        assertThat(extractedFields.timeFieldValue(hit), equalTo(millis));
+        assertThat(extractedFields.timeFieldValue(hit, new SourceSupplier(hit)), equalTo(millis));
     }
 
     public void testTimeFieldValueGivenEmptyArray() {
@@ -95,7 +96,7 @@ public class TimeBasedExtractedFieldsTests extends ESTestCase {
 
         TimeBasedExtractedFields extractedFields = new TimeBasedExtractedFields(timeField, Arrays.asList(timeField));
 
-        expectThrows(RuntimeException.class, () -> extractedFields.timeFieldValue(hit));
+        expectThrows(RuntimeException.class, () -> extractedFields.timeFieldValue(hit, new SourceSupplier(hit)));
     }
 
     public void testTimeFieldValueGivenValueHasTwoElements() {
@@ -103,7 +104,7 @@ public class TimeBasedExtractedFieldsTests extends ESTestCase {
 
         TimeBasedExtractedFields extractedFields = new TimeBasedExtractedFields(timeField, Arrays.asList(timeField));
 
-        expectThrows(RuntimeException.class, () -> extractedFields.timeFieldValue(hit));
+        expectThrows(RuntimeException.class, () -> extractedFields.timeFieldValue(hit, new SourceSupplier(hit)));
     }
 
     public void testTimeFieldValueGivenValueIsString() {
@@ -111,7 +112,7 @@ public class TimeBasedExtractedFieldsTests extends ESTestCase {
 
         TimeBasedExtractedFields extractedFields = new TimeBasedExtractedFields(timeField, Arrays.asList(timeField));
 
-        expectThrows(RuntimeException.class, () -> extractedFields.timeFieldValue(hit));
+        expectThrows(RuntimeException.class, () -> extractedFields.timeFieldValue(hit, new SourceSupplier(hit)));
     }
 
     public void testBuildGivenMixtureOfTypes() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorTests.java
@@ -592,7 +592,7 @@ public class DataFrameDataExtractorTests extends ESTestCase {
 
     public void testExtractionWithProcessedFieldThrows() {
         ProcessedField processedField = mock(ProcessedField.class);
-        doThrow(new RuntimeException("process field error")).when(processedField).value(any(), any());
+        doThrow(new RuntimeException("process field error")).when(processedField).value(any(), any(), any());
 
         extractedFields = new ExtractedFields(
             Arrays.asList(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.core.ml.inference.preprocessing.OneHotEncoding;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.PreProcessor;
 import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
+import org.elasticsearch.xpack.ml.extractor.SourceSupplier;
 import org.elasticsearch.xpack.ml.test.SearchHitBuilder;
 
 import java.util.ArrayList;
@@ -814,13 +815,14 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         );
 
         SearchHit hit = new SearchHitBuilder(42).addField("some_boolean", true).build();
-        assertThat(booleanField.value(hit), arrayContaining(1));
+        SourceSupplier sourceSupplier = new SourceSupplier(hit);
+        assertThat(booleanField.value(hit, sourceSupplier), arrayContaining(1));
 
         hit = new SearchHitBuilder(42).addField("some_boolean", false).build();
-        assertThat(booleanField.value(hit), arrayContaining(0));
+        assertThat(booleanField.value(hit, sourceSupplier), arrayContaining(0));
 
         hit = new SearchHitBuilder(42).addField("some_boolean", Arrays.asList(false, true, false)).build();
-        assertThat(booleanField.value(hit), arrayContaining(0, 1, 0));
+        assertThat(booleanField.value(hit, sourceSupplier), arrayContaining(0, 1, 0));
     }
 
     public void testDetect_GivenBooleanField_OutlierDetection() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoinerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoinerTests.java
@@ -326,6 +326,7 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
     private static DataFrameDataExtractor.Row newRow(SearchHit hit, String[] values, boolean isTraining, int checksum) {
         DataFrameDataExtractor.Row row = mock(DataFrameDataExtractor.Row.class);
         when(row.getHit()).thenReturn(hit);
+        when(row.getSource()).thenReturn(hit.getSourceAsMap());
         when(row.getValues()).thenReturn(values);
         when(row.isTraining()).thenReturn(isTraining);
         when(row.getChecksum()).thenReturn(checksum);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/DocValueFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/DocValueFieldTests.java
@@ -25,7 +25,7 @@ public class DocValueFieldTests extends ESTestCase {
 
         ExtractedField field = new DocValueField("a_keyword", Collections.singleton("keyword"));
 
-        assertThat(field.value(hit), equalTo(new String[] { "bar" }));
+        assertThat(field.value(hit, new SourceSupplier(hit)), equalTo(new String[] { "bar" }));
         assertThat(field.getName(), equalTo("a_keyword"));
         assertThat(field.getSearchField(), equalTo("a_keyword"));
         assertThat(field.getTypes(), contains("keyword"));
@@ -41,7 +41,7 @@ public class DocValueFieldTests extends ESTestCase {
 
         ExtractedField field = new DocValueField("array", Collections.singleton("keyword"));
 
-        assertThat(field.value(hit), equalTo(new String[] { "a", "b" }));
+        assertThat(field.value(hit, new SourceSupplier(hit)), equalTo(new String[] { "a", "b" }));
         assertThat(field.getName(), equalTo("array"));
         assertThat(field.getSearchField(), equalTo("array"));
         assertThat(field.getTypes(), contains("keyword"));
@@ -52,7 +52,7 @@ public class DocValueFieldTests extends ESTestCase {
         expectThrows(UnsupportedOperationException.class, () -> field.getParentField());
 
         ExtractedField missing = new DocValueField("missing", Collections.singleton("keyword"));
-        assertThat(missing.value(hit), equalTo(new Object[0]));
+        assertThat(missing.value(hit, new SourceSupplier(hit)), equalTo(new Object[0]));
     }
 
     public void testMissing() {
@@ -60,7 +60,7 @@ public class DocValueFieldTests extends ESTestCase {
 
         ExtractedField missing = new DocValueField("missing", Collections.singleton("keyword"));
 
-        assertThat(missing.value(hit), equalTo(new Object[0]));
+        assertThat(missing.value(hit, new SourceSupplier(hit)), equalTo(new Object[0]));
     }
 
     public void testNewFromSource() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/ExtractedFieldsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/ExtractedFieldsTests.java
@@ -127,8 +127,8 @@ public class ExtractedFieldsTests extends ESTestCase {
         SearchHit hitTrue = new SearchHitBuilder(42).addField("a_bool", true).build();
         SearchHit hitFalse = new SearchHitBuilder(42).addField("a_bool", false).build();
 
-        assertThat(mapped.value(hitTrue), equalTo(new Integer[] { 1 }));
-        assertThat(mapped.value(hitFalse), equalTo(new Integer[] { 0 }));
+        assertThat(mapped.value(hitTrue, new SourceSupplier(hitTrue)), equalTo(new Integer[] { 1 }));
+        assertThat(mapped.value(hitFalse, new SourceSupplier(hitFalse)), equalTo(new Integer[] { 0 }));
 
         assertThat(mapped.getName(), equalTo(aBool.getName()));
         assertThat(mapped.getMethod(), equalTo(aBool.getMethod()));
@@ -145,10 +145,10 @@ public class ExtractedFieldsTests extends ESTestCase {
         SearchHit hitTrueArray = new SearchHitBuilder(42).setSource("{\"a_bool\": [\"true\", true]}").build();
         SearchHit hitFalseArray = new SearchHitBuilder(42).setSource("{\"a_bool\": [\"false\", false]}").build();
 
-        assertThat(mapped.value(hitTrue), equalTo(new Integer[] { 1 }));
-        assertThat(mapped.value(hitFalse), equalTo(new Integer[] { 0 }));
-        assertThat(mapped.value(hitTrueArray), equalTo(new Integer[] { 1, 1 }));
-        assertThat(mapped.value(hitFalseArray), equalTo(new Integer[] { 0, 0 }));
+        assertThat(mapped.value(hitTrue, new SourceSupplier(hitTrue)), equalTo(new Integer[] { 1 }));
+        assertThat(mapped.value(hitFalse, new SourceSupplier(hitFalse)), equalTo(new Integer[] { 0 }));
+        assertThat(mapped.value(hitTrueArray, new SourceSupplier(hitTrueArray)), equalTo(new Integer[] { 1, 1 }));
+        assertThat(mapped.value(hitFalseArray, new SourceSupplier(hitFalseArray)), equalTo(new Integer[] { 0, 0 }));
 
         assertThat(mapped.getName(), equalTo(aBool.getName()));
         assertThat(mapped.getMethod(), equalTo(aBool.getMethod()));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/GeoPointFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/GeoPointFieldTests.java
@@ -28,7 +28,7 @@ public class GeoPointFieldTests extends ESTestCase {
         // doc_value field
         ExtractedField geo = new GeoPointField("geo");
 
-        assertThat(geo.value(hit), equalTo(expected));
+        assertThat(geo.value(hit, new SourceSupplier(hit)), equalTo(expected));
         assertThat(geo.getName(), equalTo("geo"));
         assertThat(geo.getSearchField(), equalTo("geo"));
         assertThat(geo.getMethod(), equalTo(ExtractedField.Method.DOC_VALUE));
@@ -45,7 +45,7 @@ public class GeoPointFieldTests extends ESTestCase {
 
         ExtractedField geo = new GeoPointField("missing");
 
-        assertThat(geo.value(hit), equalTo(new Object[0]));
+        assertThat(geo.value(hit, new SourceSupplier(hit)), equalTo(new Object[0]));
     }
 
     public void testArray() {
@@ -53,7 +53,7 @@ public class GeoPointFieldTests extends ESTestCase {
 
         ExtractedField geo = new GeoPointField("geo");
 
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> geo.value(hit));
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> geo.value(hit, new SourceSupplier(hit)));
         assertThat(e.getMessage(), equalTo("Unexpected values for a geo_point field: [1, 2]"));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/GeoShapeFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/GeoShapeFieldTests.java
@@ -27,7 +27,7 @@ public class GeoShapeFieldTests extends ESTestCase {
 
         ExtractedField geo = new GeoShapeField("geo");
 
-        assertThat(geo.value(hit), equalTo(expected));
+        assertThat(geo.value(hit, new SourceSupplier(hit)), equalTo(expected));
         assertThat(geo.getName(), equalTo("geo"));
         assertThat(geo.getSearchField(), equalTo("geo"));
         assertThat(geo.getTypes(), contains("geo_shape"));
@@ -48,7 +48,7 @@ public class GeoShapeFieldTests extends ESTestCase {
 
         ExtractedField geo = new GeoShapeField("geo");
 
-        assertThat(geo.value(hit), equalTo(expected));
+        assertThat(geo.value(hit, new SourceSupplier(hit)), equalTo(expected));
         assertThat(geo.getName(), equalTo("geo"));
         assertThat(geo.getSearchField(), equalTo("geo"));
         assertThat(geo.getTypes(), contains("geo_shape"));
@@ -65,7 +65,7 @@ public class GeoShapeFieldTests extends ESTestCase {
 
         ExtractedField geo = new GeoShapeField("missing");
 
-        assertThat(geo.value(hit), equalTo(new Object[0]));
+        assertThat(geo.value(hit, new SourceSupplier(hit)), equalTo(new Object[0]));
     }
 
     public void testArray() {
@@ -73,7 +73,7 @@ public class GeoShapeFieldTests extends ESTestCase {
 
         ExtractedField geo = new GeoShapeField("geo");
 
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> geo.value(hit));
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> geo.value(hit, new SourceSupplier(hit)));
         assertThat(e.getMessage(), equalTo("Unexpected values for a geo_shape field: [1, 2]"));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/MultiFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/MultiFieldTests.java
@@ -23,7 +23,7 @@ public class MultiFieldTests extends ESTestCase {
         ExtractedField wrapped = new DocValueField("a.b", Collections.singleton("integer"));
         ExtractedField field = new MultiField("a", wrapped);
 
-        assertThat(field.value(hit), equalTo(new Integer[] { 2 }));
+        assertThat(field.value(hit, new SourceSupplier(hit)), equalTo(new Integer[] { 2 }));
         assertThat(field.getName(), equalTo("a.b"));
         assertThat(field.getSearchField(), equalTo("a.b"));
         assertThat(field.getMethod(), equalTo(ExtractedField.Method.DOC_VALUE));
@@ -39,7 +39,7 @@ public class MultiFieldTests extends ESTestCase {
         ExtractedField wrapped = new DocValueField("a", Collections.singleton("integer"));
         ExtractedField field = new MultiField("a.b", "a", "a", wrapped);
 
-        assertThat(field.value(hit), equalTo(new Integer[] { 1 }));
+        assertThat(field.value(hit, new SourceSupplier(hit)), equalTo(new Integer[] { 1 }));
         assertThat(field.getName(), equalTo("a.b"));
         assertThat(field.getSearchField(), equalTo("a"));
         assertThat(field.getMethod(), equalTo(ExtractedField.Method.DOC_VALUE));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/ProcessedFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/ProcessedFieldTests.java
@@ -44,13 +44,13 @@ public class ProcessedFieldTests extends ESTestCase {
 
     public void testMissingExtractor() {
         ProcessedField processedField = new ProcessedField(makeOneHotPreProcessor(randomAlphaOfLength(10), "bar", "baz"));
-        assertThat(processedField.value(makeHit(), (s) -> null), emptyArray());
+        assertThat(processedField.value(makeHit(), null, (s) -> null), emptyArray());
     }
 
     public void testMissingInputValues() {
         ExtractedField extractedField = makeExtractedField(new Object[0]);
         ProcessedField processedField = new ProcessedField(makeOneHotPreProcessor(randomAlphaOfLength(10), "bar", "baz"));
-        assertThat(processedField.value(makeHit(), (s) -> extractedField), arrayContaining(is(nullValue()), is(nullValue())));
+        assertThat(processedField.value(makeHit(), null, (s) -> extractedField), arrayContaining(is(nullValue()), is(nullValue())));
     }
 
     public void testProcessedFieldFrequencyEncoding() {
@@ -101,7 +101,7 @@ public class ProcessedFieldTests extends ESTestCase {
         assert inputs.length == expectedOutputs.length;
         for (int i = 0; i < inputs.length; i++) {
             Object input = inputs[i];
-            Object[] result = processedField.value(makeHit(input), (s) -> makeExtractedField(new Object[] { input }));
+            Object[] result = processedField.value(makeHit(input), null, (s) -> makeExtractedField(new Object[] { input }));
             assertThat(
                 "Input [" + input + "] Expected " + Arrays.toString(expectedOutputs[i]) + " but received " + Arrays.toString(result),
                 result,
@@ -120,7 +120,7 @@ public class ProcessedFieldTests extends ESTestCase {
 
     private static ExtractedField makeExtractedField(Object[] value) {
         ExtractedField extractedField = mock(ExtractedField.class);
-        when(extractedField.value(any())).thenReturn(value);
+        when(extractedField.value(any(), any())).thenReturn(value);
         return extractedField;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/ScriptFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/ScriptFieldTests.java
@@ -23,7 +23,7 @@ public class ScriptFieldTests extends ESTestCase {
 
         ExtractedField field = new ScriptField("a_keyword");
 
-        assertThat(field.value(hit), equalTo(new String[] { "bar" }));
+        assertThat(field.value(hit, new SourceSupplier(hit)), equalTo(new String[] { "bar" }));
         assertThat(field.getName(), equalTo("a_keyword"));
         assertThat(field.getSearchField(), equalTo("a_keyword"));
         assertThat(field.getTypes().isEmpty(), is(true));
@@ -40,7 +40,7 @@ public class ScriptFieldTests extends ESTestCase {
 
         ExtractedField field = new ScriptField("array");
 
-        assertThat(field.value(hit), equalTo(new String[] { "a", "b" }));
+        assertThat(field.value(hit, new SourceSupplier(hit)), equalTo(new String[] { "a", "b" }));
         assertThat(field.getName(), equalTo("array"));
         assertThat(field.getSearchField(), equalTo("array"));
         assertThat(field.getTypes().isEmpty(), is(true));
@@ -52,7 +52,7 @@ public class ScriptFieldTests extends ESTestCase {
         expectThrows(UnsupportedOperationException.class, () -> field.newFromSource());
 
         ExtractedField missing = new DocValueField("missing", Collections.singleton("keyword"));
-        assertThat(missing.value(hit), equalTo(new Object[0]));
+        assertThat(missing.value(hit, new SourceSupplier(hit)), equalTo(new Object[0]));
     }
 
     public void testMissing() {
@@ -60,6 +60,6 @@ public class ScriptFieldTests extends ESTestCase {
 
         ExtractedField missing = new ScriptField("missing");
 
-        assertThat(missing.value(hit), equalTo(new Object[0]));
+        assertThat(missing.value(hit, new SourceSupplier(hit)), equalTo(new Object[0]));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/SourceFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/SourceFieldTests.java
@@ -24,7 +24,7 @@ public class SourceFieldTests extends ESTestCase {
 
         ExtractedField field = new SourceField("single", Collections.singleton("text"));
 
-        assertThat(field.value(hit), equalTo(new String[] { "bar" }));
+        assertThat(field.value(hit, new SourceSupplier(hit)), equalTo(new String[] { "bar" }));
         assertThat(field.getName(), equalTo("single"));
         assertThat(field.getSearchField(), equalTo("single"));
         assertThat(field.getTypes(), contains("text"));
@@ -42,7 +42,7 @@ public class SourceFieldTests extends ESTestCase {
 
         ExtractedField field = new SourceField("array", Collections.singleton("text"));
 
-        assertThat(field.value(hit), equalTo(new String[] { "a", "b" }));
+        assertThat(field.value(hit, new SourceSupplier(hit)), equalTo(new String[] { "a", "b" }));
         assertThat(field.getName(), equalTo("array"));
         assertThat(field.getSearchField(), equalTo("array"));
         assertThat(field.getTypes(), contains("text"));
@@ -60,7 +60,7 @@ public class SourceFieldTests extends ESTestCase {
 
         ExtractedField missing = new SourceField("missing", Collections.singleton("text"));
 
-        assertThat(missing.value(hit), equalTo(new Object[0]));
+        assertThat(missing.value(hit, new SourceSupplier(hit)), equalTo(new Object[0]));
     }
 
     public void testValueGivenNested() {
@@ -69,7 +69,7 @@ public class SourceFieldTests extends ESTestCase {
 
         ExtractedField nested = new SourceField("level_1.level_2.foo", Collections.singleton("text"));
 
-        assertThat(nested.value(hit), equalTo(new String[] { "bar" }));
+        assertThat(nested.value(hit, new SourceSupplier(hit)), equalTo(new String[] { "bar" }));
     }
 
     public void testValueGivenNestedArray() {
@@ -78,6 +78,6 @@ public class SourceFieldTests extends ESTestCase {
 
         ExtractedField nested = new SourceField("level_1.level_2.foo", Collections.singleton("text"));
 
-        assertThat(nested.value(hit), equalTo(new String[] { "bar" }));
+        assertThat(nested.value(hit, new SourceSupplier(hit)), equalTo(new String[] { "bar" }));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/TimeFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/extractor/TimeFieldTests.java
@@ -29,7 +29,7 @@ public class TimeFieldTests extends ESTestCase {
 
         ExtractedField timeField = new TimeField("time", ExtractedField.Method.DOC_VALUE);
 
-        assertThat(timeField.value(hit), equalTo(new Object[] { millis }));
+        assertThat(timeField.value(hit, new SourceSupplier(hit)), equalTo(new Object[] { millis }));
         assertThat(timeField.getName(), equalTo("time"));
         assertThat(timeField.getSearchField(), equalTo("time"));
         assertThat(timeField.getTypes(), containsInAnyOrder("date", "date_nanos"));
@@ -51,7 +51,7 @@ public class TimeFieldTests extends ESTestCase {
 
         ExtractedField timeField = new TimeField("time", ExtractedField.Method.DOC_VALUE);
 
-        assertThat(timeField.value(hit), equalTo(new Object[] { millis }));
+        assertThat(timeField.value(hit, new SourceSupplier(hit)), equalTo(new Object[] { millis }));
         assertThat(timeField.getName(), equalTo("time"));
         assertThat(timeField.getSearchField(), equalTo("time"));
         assertThat(timeField.getTypes(), containsInAnyOrder("date", "date_nanos"));
@@ -69,7 +69,7 @@ public class TimeFieldTests extends ESTestCase {
 
         ExtractedField timeField = new TimeField("time", ExtractedField.Method.SCRIPT_FIELD);
 
-        assertThat(timeField.value(hit), equalTo(new Object[] { millis }));
+        assertThat(timeField.value(hit, new SourceSupplier(hit)), equalTo(new Object[] { millis }));
         assertThat(timeField.getName(), equalTo("time"));
         assertThat(timeField.getSearchField(), equalTo("time"));
         assertThat(timeField.getTypes(), containsInAnyOrder("date", "date_nanos"));
@@ -87,7 +87,7 @@ public class TimeFieldTests extends ESTestCase {
         final ExtractedField timeField = new TimeField("time", ExtractedField.Method.DOC_VALUE);
 
         assertThat(
-            expectThrows(IllegalStateException.class, () -> timeField.value(hit)).getMessage(),
+            expectThrows(IllegalStateException.class, () -> timeField.value(hit, new SourceSupplier(hit))).getMessage(),
             startsWith("Unexpected value for a time field")
         );
     }

--- a/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
+++ b/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
@@ -166,19 +166,18 @@ public class MonitoringIT extends ESSingleNodeTestCase {
                 final SearchHits hits = response.getHits();
 
                 assertThat(response.getHits().getTotalHits().value, equalTo(3L));
-                assertThat(
-                    "Monitoring documents must have the same timestamp",
-                    Arrays.stream(hits.getHits()).map(hit -> extractValue("timestamp", hit.getSourceAsMap())).distinct().count(),
-                    equalTo(1L)
-                );
-                assertThat(
-                    "Monitoring documents must have the same source_node timestamp",
-                    Arrays.stream(hits.getHits())
-                        .map(hit -> extractValue("source_node.timestamp", hit.getSourceAsMap()))
-                        .distinct()
-                        .count(),
-                    equalTo(1L)
-                );
+                Map<String, Object> sourceHit = hits.getHits()[0].getSourceAsMap();
+                Object ts = extractValue("timestamp", sourceHit);
+                Object sn_ts = extractValue("source_node.timestamp", sourceHit);
+                for (int i = 1; i < hits.getHits().length; i++) {
+                    sourceHit = hits.getHits()[i].getSourceAsMap();
+                    assertThat("Monitoring documents must have the same timestamp", extractValue("timestamp", sourceHit), equalTo(ts));
+                    assertThat(
+                        "Monitoring documents must have the same source_node timestamp",
+                        extractValue("source_node.timestamp", sourceHit),
+                        equalTo(sn_ts)
+                    );
+                }
 
                 for (final SearchHit hit : hits.getHits()) {
                     assertMonitoringDoc(toMap(hit), system, interval);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterResourceIntegTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterResourceIntegTests.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.test.ESIntegTestCase.Scope.TEST;
@@ -267,15 +268,16 @@ public class LocalExporterResourceIntegTests extends LocalExporterIntegTestCase 
         Set<String> watchIds = new HashSet<>(Arrays.asList(ClusterAlertsUtil.WATCH_IDS));
         assertResponse(prepareSearch(".watches").setSource(searchSource), response -> {
             for (SearchHit hit : response.getHits().getHits()) {
-                String watchId = ObjectPath.eval("metadata.xpack.watch", hit.getSourceAsMap());
+                Map<String, Object> source = hit.getSourceAsMap();
+                String watchId = ObjectPath.eval("metadata.xpack.watch", source);
                 assertNotNull("Missing watch ID", watchId);
                 assertTrue("found unexpected watch id", watchIds.contains(watchId));
 
-                String version = ObjectPath.eval("metadata.xpack.version_created", hit.getSourceAsMap());
+                String version = ObjectPath.eval("metadata.xpack.version_created", source);
                 assertNotNull("Missing version from returned watch [" + watchId + "]", version);
                 assertTrue(Version.fromId(Integer.parseInt(version)).onOrAfter(Version.fromId(ClusterAlertsUtil.LAST_UPDATED_VERSION)));
 
-                String uuid = ObjectPath.eval("metadata.xpack.cluster_uuid", hit.getSourceAsMap());
+                String uuid = ObjectPath.eval("metadata.xpack.cluster_uuid", source);
                 assertNotNull("Missing cluster uuid", uuid);
                 assertEquals(clusterUUID, uuid);
             }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
@@ -119,9 +119,10 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
             response -> {
                 assertHitCount(response, 1);
                 assertSearchHits(response, "1");
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("id").toString(), equalTo("1"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), equalTo(2));
+                assertThat(source.get("field1").toString(), equalTo("value1"));
+                assertThat(source.get("id").toString(), equalTo("1"));
             }
         );
 
@@ -131,9 +132,10 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
             response -> {
                 assertHitCount(response, 1);
                 assertSearchHits(response, "2");
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2").toString(), equalTo("value2"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("id").toString(), equalTo("2"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), equalTo(2));
+                assertThat(source.get("field2").toString(), equalTo("value2"));
+                assertThat(source.get("id").toString(), equalTo("2"));
             }
         );
 
@@ -197,8 +199,9 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
             response -> {
                 assertHitCount(response, 1);
                 assertSearchHits(response, "2");
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value2"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), equalTo(1));
+                assertThat(source.get("field1").toString(), equalTo("value2"));
             }
         );
 
@@ -228,9 +231,10 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
                 response -> {
                     assertHitCount(response, 1);
                     assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), equalTo("value1"));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("1"));
+                    Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                    assertThat(source.size(), equalTo(2));
+                    assertThat(source.get("field1"), equalTo("value1"));
+                    assertThat(source.get("id"), equalTo("1"));
                 }
             );
             assertResponse(
@@ -239,9 +243,10 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
                 response -> {
                     assertHitCount(response, 1);
                     assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2"), equalTo("value2"));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("2"));
+                    Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                    assertThat(source.size(), equalTo(2));
+                    assertThat(source.get("field2"), equalTo("value2"));
+                    assertThat(source.get("id"), equalTo("2"));
                 }
             );
 
@@ -254,8 +259,9 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
                 response -> {
                     assertHitCount(response, 1);
                     assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("2"));
+                    Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                    assertThat(source.size(), equalTo(1));
+                    assertThat(source.get("id"), equalTo("2"));
                 }
             );
 
@@ -267,13 +273,15 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
                 response -> {
                     assertHitCount(response, 2);
                     assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), equalTo("value1"));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("1"));
+                    Map<String, Object> source0 = response.getHits().getAt(0).getSourceAsMap();
+                    assertThat(source0.size(), equalTo(2));
+                    assertThat(source0.get("field1"), equalTo("value1"));
+                    assertThat(source0.get("id"), equalTo("1"));
                     assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
-                    assertThat(response.getHits().getAt(1).getSourceAsMap().size(), equalTo(2));
-                    assertThat(response.getHits().getAt(1).getSourceAsMap().get("field2"), equalTo("value2"));
-                    assertThat(response.getHits().getAt(1).getSourceAsMap().get("id"), equalTo("2"));
+                    Map<String, Object> source1 = response.getHits().getAt(1).getSourceAsMap();
+                    assertThat(source1.size(), equalTo(2));
+                    assertThat(source1.get("field2"), equalTo("value2"));
+                    assertThat(source1.get("id"), equalTo("2"));
                 }
             );
         }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
@@ -475,15 +475,17 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
                 response -> {
                     assertFalse(response.getResponses()[0].isFailure());
                     assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
+                    Map<String, Object> source0 = response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap();
+                    assertThat(source0.size(), is(2));
+                    assertThat(source0.get("field1"), is("value1"));
+                    assertThat(source0.get("id"), is(1));
 
                     assertFalse(response.getResponses()[1].isFailure());
                     assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
+                    Map<String, Object> source1 = response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap();
+                    assertThat(source1.size(), is(2));
+                    assertThat(source1.get("field1"), is("value1"));
+                    assertThat(source1.get("id"), is(1));
                 }
             );
         }
@@ -496,15 +498,17 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
                 response -> {
                     assertFalse(response.getResponses()[0].isFailure());
                     assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(2));
+                    Map<String, Object> source0 = response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap();
+                    assertThat(source0.size(), is(2));
+                    assertThat(source0.get("field2"), is("value2"));
+                    assertThat(source0.get("id"), is(2));
 
                     assertFalse(response.getResponses()[1].isFailure());
                     assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(2));
+                    Map<String, Object> source1 = response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap();
+                    assertThat(source1.size(), is(2));
+                    assertThat(source1.get("field2"), is("value2"));
+                    assertThat(source1.get("id"), is(2));
                 }
             );
         }
@@ -523,21 +527,25 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
                 response -> {
                     assertFalse(response.getResponses()[0].isFailure());
                     assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(2L));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(1).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(1).getSourceAsMap().get("field2"), is("value2"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(1).getSourceAsMap().get("id"), is(2));
+                    Map<String, Object> source0 = response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap();
+                    assertThat(source0.size(), is(2));
+                    assertThat(source0.get("field1"), is("value1"));
+                    assertThat(source0.get("id"), is(1));
+                    source0 = response.getResponses()[0].getResponse().getHits().getAt(1).getSourceAsMap();
+                    assertThat(source0.size(), is(2));
+                    assertThat(source0.get("field2"), is("value2"));
+                    assertThat(source0.get("id"), is(2));
 
                     assertFalse(response.getResponses()[1].isFailure());
                     assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(2L));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(1).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(1).getSourceAsMap().get("field2"), is("value2"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(1).getSourceAsMap().get("id"), is(2));
+                    Map<String, Object> source1 = response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap();
+                    assertThat(source1.size(), is(2));
+                    assertThat(source1.get("field1"), is("value1"));
+                    assertThat(source1.get("id"), is(1));
+                    source1 = response.getResponses()[1].getResponse().getHits().getAt(1).getSourceAsMap();
+                    assertThat(source1.size(), is(2));
+                    assertThat(source1.get("field2"), is("value2"));
+                    assertThat(source1.get("id"), is(2));
                 }
             );
         }
@@ -1266,8 +1274,9 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
             do {
                 assertNoFailures(response);
                 assertThat(response.getHits().getTotalHits().value, is((long) numVisible));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), is(1));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), is(1));
+                assertThat(source.get("field1"), is("value1"));
 
                 if (response.getScrollId() == null) {
                     break;
@@ -1326,8 +1335,9 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
                     .get();
                 assertNoFailures(response);
                 assertThat(response.getHits().getTotalHits().value, is((long) numVisible));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), is(1));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), is(1));
+                assertThat(source.get("field1"), is("value1"));
             }
         } finally {
             client().execute(TransportClosePointInTimeAction.TYPE, new ClosePointInTimeRequest(response.pointInTimeId())).actionGet();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -955,13 +955,15 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                     .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
                     .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery())),
                 response -> {
+                    Map<String, Object> source0 = response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap();
+                    Map<String, Object> source1 = response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap();
                     assertFalse(response.getResponses()[0].isFailure());
                     assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                    assertThat(source0.size(), is(1));
+                    assertThat(source0.get("field1"), is("value1"));
                     assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                    assertThat(source1.size(), is(1));
+                    assertThat(source1.get("field1"), is("value1"));
                 }
             );
         }
@@ -992,15 +994,17 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                     .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
                     .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery())),
                 response -> {
+                    Map<String, Object> source0 = response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap();
+                    Map<String, Object> source1 = response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap();
                     assertFalse(response.getResponses()[0].isFailure());
                     assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                    assertThat(source0.size(), is(2));
+                    assertThat(source0.get("field1"), is("value1"));
+                    assertThat(source0.get("field2"), is("value2"));
                     assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                    assertThat(source1.size(), is(2));
+                    assertThat(source1.get("field1"), is("value1"));
+                    assertThat(source1.get("field2"), is("value2"));
                 }
             );
         }
@@ -1016,7 +1020,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                     assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
                     assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(0));
                     assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(0));
+                    assertThat(response.getResponses()[01].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(0));
                 }
             );
         }
@@ -1028,17 +1032,19 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                     .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
                     .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery())),
                 response -> {
+                    Map<String, Object> source0 = response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap();
+                    Map<String, Object> source1 = response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap();
                     assertFalse(response.getResponses()[0].isFailure());
                     assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+                    assertThat(source0.size(), is(3));
+                    assertThat(source0.get("field1"), is("value1"));
+                    assertThat(source0.get("field2"), is("value2"));
+                    assertThat(source0.get("field3"), is("value3"));
                     assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+                    assertThat(source1.size(), is(3));
+                    assertThat(source1.get("field1"), is("value1"));
+                    assertThat(source1.get("field2"), is("value2"));
+                    assertThat(source1.get("field3"), is("value3"));
                 }
             );
         }
@@ -1050,17 +1056,19 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                     .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
                     .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery())),
                 response -> {
+                    Map<String, Object> source0 = response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap();
+                    Map<String, Object> source1 = response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap();
                     assertFalse(response.getResponses()[0].isFailure());
                     assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+                    assertThat(source0.size(), is(3));
+                    assertThat(source0.get("field1"), is("value1"));
+                    assertThat(source0.get("field2"), is("value2"));
+                    assertThat(source0.get("field3"), is("value3"));
                     assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+                    assertThat(source1.size(), is(3));
+                    assertThat(source1.get("field1"), is("value1"));
+                    assertThat(source1.get("field2"), is("value2"));
+                    assertThat(source1.get("field3"), is("value3"));
                 }
             );
         }
@@ -1072,17 +1080,19 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                     .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
                     .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery())),
                 response -> {
+                    Map<String, Object> source0 = response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap();
+                    Map<String, Object> source1 = response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap();
                     assertFalse(response.getResponses()[0].isFailure());
                     assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+                    assertThat(source0.size(), is(3));
+                    assertThat(source0.get("field1"), is("value1"));
+                    assertThat(source0.get("field2"), is("value2"));
+                    assertThat(source0.get("field3"), is("value3"));
                     assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+                    assertThat(source1.size(), is(3));
+                    assertThat(source1.get("field1"), is("value1"));
+                    assertThat(source1.get("field2"), is("value2"));
+                    assertThat(source1.get("field3"), is("value3"));
                 }
             );
         }
@@ -1134,8 +1144,9 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             do {
                 assertThat(response.getHits().getTotalHits().value, is((long) numDocs));
                 assertThat(response.getHits().getHits().length, is(1));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), is(1));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), is(1));
+                assertThat(source.get("field1"), is("value1"));
 
                 if (response.getScrollId() == null) {
                     break;
@@ -1191,10 +1202,11 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                         .setQuery(constantScoreQuery(termQuery("field1", "value1")))
                         .setFetchSource(true),
                     response -> {
+                        Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
                         assertThat(response.getHits().getTotalHits().value, is((long) numDocs));
                         assertThat(response.getHits().getHits().length, is(1));
-                        assertThat(response.getHits().getAt(0).getSourceAsMap().size(), is(1));
-                        assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                        assertThat(source.size(), is(1));
+                        assertThat(source.get("field1"), is("value1"));
                     }
                 );
             }
@@ -1221,9 +1233,10 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                     .prepareSearch("test")
                     .setQuery(constantScoreQuery(termQuery("field1", "value1"))),
                 response -> {
+                    Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
                     assertHitCount(response, 1);
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().size(), is(1));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                    assertThat(source.size(), is(1));
+                    assertThat(source.get("field1"), is("value1"));
                 }
             );
             assertHitCountAndNoFailures(
@@ -1238,11 +1251,12 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                     Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue(multipleFieldsUser, USERS_PASSWD))
                 ).prepareSearch("test").setQuery(constantScoreQuery(termQuery("field1", "value1"))),
                 response -> {
+                    Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
                     assertHitCount(response, 1);
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().size(), is(3));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+                    assertThat(source.size(), is(3));
+                    assertThat(source.get("field1"), is("value1"));
+                    assertThat(source.get("field2"), is("value2"));
+                    assertThat(source.get("field3"), is("value3"));
                 }
             );
         }
@@ -1311,8 +1325,9 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                             .get();
                         assertThat(user1SearchResponse.getHits().getTotalHits().value, is((long) numDocs));
                         assertThat(user1SearchResponse.getHits().getHits().length, is(1));
-                        assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().size(), is(1));
-                        assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                        Map<String, Object> source = user1SearchResponse.getHits().getAt(0).getSourceAsMap();
+                        assertThat(source.size(), is(1));
+                        assertThat(source.get("field1"), is("value1"));
                         scrolledDocsUser1++;
                     } else {
                         user1SearchResponse.decRef();
@@ -1322,8 +1337,9 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                         assertThat(user1SearchResponse.getHits().getTotalHits().value, is((long) numDocs));
                         if (scrolledDocsUser1 < numDocs) {
                             assertThat(user1SearchResponse.getHits().getHits().length, is(1));
-                            assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().size(), is(1));
-                            assertThat(user1SearchResponse.getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                            Map<String, Object> source = user1SearchResponse.getHits().getAt(0).getSourceAsMap();
+                            assertThat(source.size(), is(1));
+                            assertThat(source.get("field1"), is("value1"));
                             scrolledDocsUser1++;
                         } else {
                             assertThat(user1SearchResponse.getHits().getHits().length, is(0));
@@ -1575,9 +1591,10 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
                 .prepareSearch("test"),
             response -> {
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2").toString(), equalTo("value2"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), equalTo(2));
+                assertThat(source.get("field1").toString(), equalTo("value1"));
+                assertThat(source.get("field2").toString(), equalTo("value2"));
             }
         );
 
@@ -1593,10 +1610,11 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
                 .prepareSearch("test"),
             response -> {
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(3));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2").toString(), equalTo("value2"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field3").toString(), equalTo("value3"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), equalTo(3));
+                assertThat(source.get("field1").toString(), equalTo("value1"));
+                assertThat(source.get("field2").toString(), equalTo("value2"));
+                assertThat(source.get("field3").toString(), equalTo("value3"));
             }
         );
 
@@ -1605,10 +1623,11 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))
                 .prepareSearch("test"),
             response -> {
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(3));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2").toString(), equalTo("value2"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field3").toString(), equalTo("value3"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), equalTo(3));
+                assertThat(source.get("field1").toString(), equalTo("value1"));
+                assertThat(source.get("field2").toString(), equalTo("value2"));
+                assertThat(source.get("field3").toString(), equalTo("value3"));
             }
         );
 
@@ -1617,10 +1636,11 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user7", USERS_PASSWD)))
                 .prepareSearch("test"),
             response -> {
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(3));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2").toString(), equalTo("value2"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field3").toString(), equalTo("value3"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), equalTo(3));
+                assertThat(source.get("field1").toString(), equalTo("value1"));
+                assertThat(source.get("field2").toString(), equalTo("value2"));
+                assertThat(source.get("field3").toString(), equalTo("value3"));
             }
         );
 
@@ -1629,9 +1649,10 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user8", USERS_PASSWD)))
                 .prepareSearch("test"),
             response -> {
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2").toString(), equalTo("value2"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), equalTo(2));
+                assertThat(source.get("field1").toString(), equalTo("value1"));
+                assertThat(source.get("field2").toString(), equalTo("value2"));
             }
         );
     }
@@ -2127,9 +2148,10 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                 .setQuery(matchQuery("field1", "value1")),
             response -> {
                 assertHitCount(response, 1);
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2").toString(), equalTo("value2"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), equalTo(2));
+                assertThat(source.get("field1").toString(), equalTo("value1"));
+                assertThat(source.get("field2").toString(), equalTo("value2"));
             }
         );
 
@@ -2138,10 +2160,11 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                 .prepareSearch("test")
                 .setQuery(matchQuery("field2", "value2")),
             response -> {
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
                 assertHitCount(response, 1);
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2").toString(), equalTo("value2"));
+                assertThat(source.size(), equalTo(2));
+                assertThat(source.get("field1").toString(), equalTo("value1"));
+                assertThat(source.get("field2").toString(), equalTo("value2"));
             }
         );
     }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -976,13 +976,15 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                     .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
                     .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery())),
                 response -> {
+                    Map<String, Object> source0 = response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap();
+                    Map<String, Object> source1 = response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap();
                     assertFalse(response.getResponses()[0].isFailure());
                     assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                    assertThat(source0.size(), is(1));
+                    assertThat(source0.get("field2"), is("value2"));
                     assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                    assertThat(source1.size(), is(1));
+                    assertThat(source1.get("field2"), is("value2"));
                 }
             );
         }
@@ -1104,15 +1106,17 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
                     .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
                     .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery())),
                 response -> {
+                    Map<String, Object> source0 = response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap();
+                    Map<String, Object> source1 = response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap();
                     assertFalse(response.getResponses()[0].isFailure());
                     assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                    assertThat(source0.size(), is(2));
+                    assertThat(source0.get("field1"), is("value1"));
+                    assertThat(source0.get("field2"), is("value2"));
                     assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-                    assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                    assertThat(source1.size(), is(2));
+                    assertThat(source1.get("field1"), is("value1"));
+                    assertThat(source1.get("field2"), is("value2"));
                 }
             );
         }
@@ -1571,8 +1575,9 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
                 .prepareSearch("test"),
             response -> {
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), equalTo(1));
+                assertThat(source.get("field1").toString(), equalTo("value1"));
             }
         );
 
@@ -1581,8 +1586,9 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
                 .prepareSearch("test"),
             response -> {
-                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2").toString(), equalTo("value2"));
+                Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+                assertThat(source.size(), equalTo(1));
+                assertThat(source.get("field2").toString(), equalTo("value2"));
             }
         );
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -1769,7 +1769,7 @@ public class TokenService {
                                 client,
                                 request,
                                 new ContextPreservingActionListener<>(supplier, listener),
-                                (SearchHit hit) -> filterAndParseHit(hit, filter)
+                                (SearchHit hit) -> filterAndParseHit(hit.getSourceAsMap(), filter)
                             );
                         }, listener::onFailure));
                 }
@@ -1913,9 +1913,8 @@ public class TokenService {
         };
     }
 
-    private static Tuple<UserToken, String> filterAndParseHit(SearchHit hit, @Nullable Predicate<Map<String, Object>> filter)
+    private static Tuple<UserToken, String> filterAndParseHit(Map<String, Object> source, @Nullable Predicate<Map<String, Object>> filter)
         throws IllegalStateException, DateTimeException {
-        final Map<String, Object> source = hit.getSourceAsMap();
         if (source == null) {
             throw new IllegalStateException("token document did not have source but source should have been fetched");
         }
@@ -2737,7 +2736,6 @@ public class TokenService {
     }
 
     record Doc(String id, Map<String, Object> sourceAsMap, long seqNo, long primaryTerm) {
-
         Doc(SearchHit searchHit) {
             this(searchHit.getId(), searchHit.getSourceAsMap(), searchHit.getSeqNo(), searchHit.getPrimaryTerm());
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
@@ -10,8 +10,6 @@ package org.elasticsearch.xpack.transform.transforms.latest;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -93,11 +91,7 @@ public class Latest extends AbstractCompositeAggFunction {
             );
         }
 
-        // We don't use #getSourceAsMap here because we don't want to cache the object as we
-        // only need it here. More over we are modifying the map of maps so we will be holding
-        // the wrong map.
-        BytesReference bytes = topHits.getHits().getHits()[0].getSourceRef();
-        Map<String, Object> document = XContentHelper.convertToMap(bytes, true).v2();
+        Map<String, Object> document = topHits.getHits().getHits()[0].getSourceAsMap();
 
         // generator to create unique but deterministic document ids, so we
         // - do not create duplicates if we re-run after failure

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/RejectedExecutionTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/RejectedExecutionTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.watcher.test.AbstractWatcherIntegrationTestCase;
 import org.elasticsearch.xpack.watcher.trigger.schedule.IntervalSchedule;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
@@ -56,14 +57,15 @@ public class RejectedExecutionTests extends AbstractWatcherIntegrationTestCase {
             flushAndRefresh(".watcher-history-*");
             assertResponse(prepareSearch(".watcher-history-*"), searchResponse -> {
                 assertThat("Watcher history not found", searchResponse.getHits().getTotalHits().value, greaterThanOrEqualTo(2L));
+
                 assertThat(
                     "Did not find watcher history for rejected watch",
-                    Arrays.stream(searchResponse.getHits().getHits())
-                        .anyMatch(
-                            hit -> hit.getSourceAsMap() != null
-                                && hit.getSourceAsMap().get("messages") != null
-                                && hit.getSourceAsMap().get("messages").toString().contains("due to thread pool capacity")
-                        ),
+                    Arrays.stream(searchResponse.getHits().getHits()).anyMatch(hit -> {
+                        Map<String, Object> source = hit.getSourceAsMap();
+                        return source != null
+                            && source.get("messages") != null
+                            && source.get("messages").toString().contains("due to thread pool capacity");
+                    }),
                     equalTo(true)
                 );
             });

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/transform/TransformIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/transform/TransformIntegrationTests.java
@@ -140,14 +140,16 @@ public class TransformIntegrationTests extends AbstractWatcherIntegrationTestCas
 
         assertNoFailuresAndResponse(prepareSearch("output1"), response -> {
             assertThat(response.getHits().getTotalHits().value, greaterThanOrEqualTo(1L));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().get("key3").toString(), equalTo("20"));
+            Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+            assertThat(source.size(), equalTo(1));
+            assertThat(source.get("key3").toString(), equalTo("20"));
         });
 
         assertNoFailuresAndResponse(prepareSearch("output2"), response -> {
             assertThat(response.getHits().getTotalHits().value, greaterThanOrEqualTo(1L));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().get("key3").toString(), equalTo("20"));
+            Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+            assertThat(source.size(), equalTo(1));
+            assertThat(source.get("key3").toString(), equalTo("20"));
         });
     }
 
@@ -224,14 +226,16 @@ public class TransformIntegrationTests extends AbstractWatcherIntegrationTestCas
 
         assertNoFailuresAndResponse(prepareSearch("output1"), response -> {
             assertThat(response.getHits().getTotalHits().value, greaterThanOrEqualTo(1L));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().get("key4").toString(), equalTo("30"));
+            Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+            assertThat(source.size(), equalTo(1));
+            assertThat(source.get("key4").toString(), equalTo("30"));
         });
 
         assertNoFailuresAndResponse(prepareSearch("output2"), response -> {
             assertThat(response.getHits().getTotalHits().value, greaterThanOrEqualTo(1L));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().get("key4").toString(), equalTo("30"));
+            Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+            assertThat(source.size(), equalTo(1));
+            assertThat(source.get("key4").toString(), equalTo("30"));
         });
     }
 


### PR DESCRIPTION
This call has the side effect that if you are iterating a number of hits calling this method, you will be increasing the memory usage by a non trivial number which in most of cases is unwanted. Therefore this commit removes this caching all together and add an assertion so the method is call once during the lifetime of the object.

backport #119888