### PR TITLE
Remove support for types field in watcher search

### DIFF
--- a/docs/changelog/120748.yaml
+++ b/docs/changelog/120748.yaml
@@ -1,12 +1,15 @@
 pr: 120748
-summary: Remove support for types field in watcher search
+summary: Removing support for types field in watcher search
 area: Watcher
 type: breaking
 issues: []
 breaking:
-  title: Remove support for types field in watcher search
-  area: Watcher
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  title: Removing support for types field in watcher search
+  area: REST API
+  details: >-
+    Previously, setting the `input.search.request.types` field in the payload when creating a watcher to an empty array
+    was  allowed, although it resulted in a deprecation warning and had no effect (and any value other than an empty
+    array would result in an error). Now, support for this field is entirely removed, and the empty array will also
+    result in an error.
+  impact: Users should stop setting this field (which did not have any effect anyway).
   notable: false

--- a/docs/changelog/120748.yaml
+++ b/docs/changelog/120748.yaml
@@ -1,0 +1,12 @@
+pr: 120748
+summary: Remove support for types field in watcher search
+area: Watcher
+type: breaking
+issues: []
+breaking:
+  title: Remove support for types field in watcher search
+  area: Watcher
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users
+  notable: false

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.script.Script;
@@ -173,7 +172,6 @@ public class WatcherSearchTemplateRequest implements ToXContentObject {
         IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
         BytesReference searchSource = null;
         Script template = null;
-        // TODO this is to retain BWC compatibility in 7.0 and can be removed for 8.0
         boolean totalHitsAsInt = true;
 
         XContentParser.Token token;
@@ -196,17 +194,6 @@ public class WatcherSearchTemplateRequest implements ToXContentObject {
                             );
                         }
                     }
-                } else if (TYPES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    // Tolerate an empty types array, because some watches created internally in 6.x have
-                    // an empty types array in their search, and it's clearly equivalent to typeless.
-                    if (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                        throw new ElasticsearchParseException(
-                            "could not read search request. unsupported non-empty array field [" + currentFieldName + "]"
-                        );
-                    }
-                    // Empty types arrays still generate the same deprecation warning they did in 7.x.
-                    // Ideally they should be removed from the definition.
-                    deprecationLogger.critical(DeprecationCategory.PARSING, "watcher_search_input", TYPES_DEPRECATION_MESSAGE);
                 } else {
                     throw new ElasticsearchParseException(
                         "could not read search request. unexpected array field [" + currentFieldName + "]"
@@ -289,7 +276,6 @@ public class WatcherSearchTemplateRequest implements ToXContentObject {
     }
 
     private static final ParseField INDICES_FIELD = new ParseField("indices");
-    private static final ParseField TYPES_FIELD = new ParseField("types");
     private static final ParseField BODY_FIELD = new ParseField("body");
     private static final ParseField SEARCH_TYPE_FIELD = new ParseField("search_type");
     private static final ParseField INDICES_OPTIONS_FIELD = new ParseField("indices_options");

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequestTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequestTests.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonMap;
-import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -52,8 +51,11 @@ public class WatcherSearchTemplateRequestTests extends ESTestCase {
             """;
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
             parser.nextToken();
-            WatcherSearchTemplateRequest result = WatcherSearchTemplateRequest.fromXContent(parser, randomFrom(SearchType.values()));
-            assertThat(result.getIndices(), arrayContaining(".ml-anomalies-*"));
+            ElasticsearchParseException e = expectThrows(
+                ElasticsearchParseException.class,
+                () -> WatcherSearchTemplateRequest.fromXContent(parser, randomFrom(SearchType.values()))
+            );
+            assertThat(e.getMessage(), is("could not read search request. unexpected array field [types]"));
         }
     }
 
@@ -74,7 +76,7 @@ public class WatcherSearchTemplateRequestTests extends ESTestCase {
                 ElasticsearchParseException.class,
                 () -> WatcherSearchTemplateRequest.fromXContent(parser, randomFrom(SearchType.values()))
             );
-            assertThat(e.getMessage(), is("could not read search request. unsupported non-empty array field [types]"));
+            assertThat(e.getMessage(), is("could not read search request. unexpected array field [types]"));
         }
     }
 


### PR DESCRIPTION
In 8.x, setting `input.search.request.types` to an empty array was allowed, although it resulted in a deprecation warning and had no effect (and any value other than an empty array would result in an error).

In 9.x, support for this field is entirely removed, and the empty array will also result in an error.

We have already introduced a script to be run as part of the upgrade which removes the field from existing watches in
https://github.com/elastic/elasticsearch/pull/120371.