### PR TITLE
Increasng the default value of migrate.data_stream_reindex_max_request_per_second

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -57,7 +57,7 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
 
     public static final Setting<Float> REINDEX_MAX_REQUESTS_PER_SECOND_SETTING = new Setting<>(
         REINDEX_MAX_REQUESTS_PER_SECOND_KEY,
-        Float.toString(10f),
+        Float.toString(1000f),
         s -> {
             if (s.equals("-1")) {
                 return Float.POSITIVE_INFINITY;


### PR DESCRIPTION
We use `migrate.data_stream_reindex_max_request_per_second` to set the `requestsPerSecond` field on the ReindexRequest. Despite what some documentation and comments say, this appears to put in scheduled waits that effectively make it the number of documents per second that are reindexed. For example, when I reindex an index with 320 documents, the reindex code fetches those 320, and then schedules completion 32 seconds in the future. For the 15 fairly small indexes I was testing, the number of seconds spent in the reindex logic was almost exactly (# of docs) / 10. So reindexing this test data stream with 1232 documents in 15 indices took more than 2 minutes (1232 / 10). Changing `migrate.data_stream_reindex_max_request_per_second` to 100, it took 9 seconds. Changing it to 100,000, it took 5 seconds.
This PR changes the default to 1,000. This is still a fair amount of throttling. For example, reindexing an index with 100 million documents will still include about 28 hours of wait time. But that seems better than the 115 *days* of wait time we'd have for the same index with it set to 10.