### PR TITLE
[8.x] Increasng the default value of migrate.data_stream_reindex_max_request_per_second (#120758)

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -57,7 +57,7 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
 
     public static final Setting<Float> REINDEX_MAX_REQUESTS_PER_SECOND_SETTING = new Setting<>(
         REINDEX_MAX_REQUESTS_PER_SECOND_KEY,
-        Float.toString(10f),
+        Float.toString(1000f),
         s -> {
             if (s.equals("-1")) {
                 return Float.POSITIVE_INFINITY;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Increasng the default value of migrate.data_stream_reindex_max_request_per_second (#120758)