### PR TITLE
[8.x] Simplify synonyms YAML tests after auto expand replicas changed (#120700)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
@@ -17,10 +17,8 @@ setup:
 
   - do:
       cluster.health:
-        index: .synonyms-2
-        timeout: 2s
+        index: .synonyms
         wait_for_status: green
-        ignore: 408
 
   - do:
       synonyms.get_synonym:
@@ -67,10 +65,8 @@ setup:
 
   - do:
       cluster.health:
-        index: .synonyms-2
-        timeout: 2s
+        index: .synonyms
         wait_for_status: green
-        ignore: 408
 
   - do:
       synonyms.get_synonym:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/110_synonyms_invalid.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/110_synonyms_invalid.yml
@@ -14,10 +14,8 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        index: .synonyms-2
-        timeout: 2s
+        index: .synonyms
         wait_for_status: green
-        ignore: 408
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/20_synonyms_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/20_synonyms_get.yml
@@ -17,10 +17,8 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        index: .synonyms-2
-        timeout: 2s
+        index: .synonyms
         wait_for_status: green
-        ignore: 408
 
 ---
 "Get synonyms set":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
@@ -15,10 +15,8 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        index: .synonyms-2
-        timeout: 2s
+        index: .synonyms
         wait_for_status: green
-        ignore: 408
 
 ---
 "Delete synonyms set":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
@@ -13,10 +13,8 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        index: .synonyms-2
-        timeout: 2s
+        index: .synonyms
         wait_for_status: green
-        ignore: 408
 
   - do:
       synonyms.put_synonym:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/50_synonym_rule_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/50_synonym_rule_put.yml
@@ -17,10 +17,8 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        index: .synonyms-2
-        timeout: 2s
+        index: .synonyms
         wait_for_status: green
-        ignore: 408
 
 ---
 "Update a synonyms rule":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
@@ -17,10 +17,8 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        index: .synonyms-2
-        timeout: 2s
+        index: .synonyms
         wait_for_status: green
-        ignore: 408
 
 ---
 "Get a synonym rule":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
@@ -17,10 +17,8 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        index: .synonyms-2
-        timeout: 2s
+        index: .synonyms
         wait_for_status: green
-        ignore: 408
 
 ---
 "Delete synonym rule":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/80_synonyms_from_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/80_synonyms_from_index.yml
@@ -17,10 +17,8 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        index: .synonyms-2
-        timeout: 2s
+        index: .synonyms
         wait_for_status: green
-        ignore: 408
 
   # Create an index with synonym_filter that uses that synonyms set
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -28,10 +28,8 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        index: .synonyms-2
-        timeout: 2s
+        index: .synonyms
         wait_for_status: green
-        ignore: 408
 
   # Create my_index1 with synonym_filter that uses synonyms_set1
   - do:


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Simplify synonyms YAML tests after auto expand replicas changed (#120700)