### PR TITLE
Add missing capability

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/191_lookup_join_text.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/191_lookup_join_text.yml
@@ -6,7 +6,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [lookup_join_text]
+          capabilities: [lookup_join_text, join_lookup_v11]
       reason: "uses LOOKUP JOIN"
   - do:
       indices.create:
@@ -31,7 +31,6 @@ setup:
           settings:
             index:
               mode: lookup
-            number_of_shards: 1
           mappings:
             properties:
               color:


### PR DESCRIPTION
`191_lookup_join_text.yml` does not declare `join_lookup_v11`.
This causes `yamlRestCompatTest` test to fail for prs where a basic lookup join behavior is changed (for example in https://github.com/elastic/elasticsearch/pull/120494) and above capability is incremented. 