### PR TITLE
Add back keep_alive to async_search.submit rest-api-spec

### DIFF
--- a/docs/changelog/120781.yaml
+++ b/docs/changelog/120781.yaml
@@ -1,0 +1,5 @@
+pr: 120781
+summary: Add back `keep_alive` to `async_search.submit` rest-api-spec
+area: Search
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -43,6 +43,11 @@
         "description":"Control whether the response should be stored in the cluster if it completed within the provided [wait_for_completion] time (default: false)",
         "default":false
       },
+      "keep_alive": {
+        "type": "time",
+        "description": "Update the time interval in which the results (partial or final) for this search will be available",
+        "default": "5d"
+      },
       "batched_reduce_size":{
         "type":"number",
         "description":"The number of shard results that should be reduced at once on the coordinating node. This value should be used as the granularity at which progress results will be made available.",


### PR DESCRIPTION
Partially reverts https://github.com/elastic/elasticsearch/pull/117626. (This change won't affect clients, but I'll make the corresponding change in https://github.com/elastic/elasticsearch-specification/.)

The Kibana team, specifically @lukasolson, noticed this. Thank you! 