### PR TITLE
LTR sometines throw NullPointerException: Cannot read field "approximation" because "top" is null

### DIFF
--- a/docs/changelog/120809.yaml
+++ b/docs/changelog/120809.yaml
@@ -1,0 +1,6 @@
+pr: 120809
+summary: LTR sometines throw `NullPointerException:` Cannot read field "approximation"
+  because "top" is null
+area: Ranking
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/QueryFeatureExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/QueryFeatureExtractor.java
@@ -55,11 +55,16 @@ public class QueryFeatureExtractor implements FeatureExtractor {
             }
             scorers.add(scorer);
         }
-        rankerIterator = new DisjunctionDISIApproximation(disiPriorityQueue);
+
+        rankerIterator = disiPriorityQueue.size() > 0 ? new DisjunctionDISIApproximation(disiPriorityQueue) : null;
     }
 
     @Override
     public void addFeatures(Map<String, Object> featureMap, int docId) throws IOException {
+        if (rankerIterator == null) {
+            return;
+        }
+
         rankerIterator.advance(docId);
         for (int i = 0; i < featureNames.size(); i++) {
             Scorer scorer = scorers.get(i);


### PR DESCRIPTION
The error occurs when executing feature extraction using `QueryFeatureExtractor`

Example of a test that is flaky because of it: https://gradle-enterprise.elastic.co/s/n5u7qvehdrtdu/tests/task/:x-pack:plugin:ml:internalClusterTest/details/org.elasticsearch.xpack.ml.integration.LearningToRankExplainIT/testLtrExplainWithMultipleShards?top-execution=1

Full stacktrace of the error:

```
org.elasticsearch.action.search.ShardSearchFailure: null |  
-- | --
  | at org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:563) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.action.search.CountedCollector.onFailure(CountedCollector.java:58) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.action.search.DfsQueryPhase$1.onFailure(DfsQueryPhase.java:118) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:54) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:719) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.transport.TransportService$UnregisterChildTransportResponseHandler.handleException(TransportService.java:1786) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.transport.TransportService$ContextRestoreResponseHandler.handleException(TransportService.java:1510) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.transport.TransportService$DirectResponseChannel.processException(TransportService.java:1644) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.transport.TransportService$DirectResponseChannel.sendResponse(TransportService.java:1619) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.transport.TaskTransportChannel.sendResponse(TaskTransportChannel.java:44) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.action.support.ChannelActionListener.onFailure(ChannelActionListener.java:45) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.search.SearchService$2.onFailure(SearchService.java:1282) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.action.ActionRunnable.onFailure(ActionRunnable.java:152) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:29) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:34) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1023) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?] |  
  | at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?] |  
  | at java.lang.Thread.run(Thread.java:1575) ~[?:?] |  
  | Caused by: java.lang.NullPointerException: Cannot read field "approximation" because "top" is null |  
  | at org.apache.lucene.search.DisjunctionDISIApproximation.advance(DisjunctionDISIApproximation.java:67) ~[lucene-core-9.12.0.jar:9.12.0 e913796758de3d9b9440669384b29bec07e6a5cd - 2024-09-25 16:37:02] |  
  | at org.elasticsearch.xpack.ml.inference.ltr.QueryFeatureExtractor.addFeatures(QueryFeatureExtractor.java:63) ~[main/:?] |  
  | at org.elasticsearch.xpack.ml.inference.ltr.LearningToRankRescorer.rescore(LearningToRankRescorer.java:108) ~[main/:?] |  
  | at org.elasticsearch.search.rescore.RescorePhase.execute(RescorePhase.java:56) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.search.query.QueryPhase.executeQuery(QueryPhase.java:145) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.search.query.QueryPhase.execute(QueryPhase.java:70) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.search.SearchService.lambda$executeQueryPhase$7(SearchService.java:840) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.action.ActionRunnable$3.accept(ActionRunnable.java:79) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.action.ActionRunnable$3.accept(ActionRunnable.java:76) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.action.ActionRunnable$4.doRun(ActionRunnable.java:101) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27) ~[elasticsearch-8.16.4-SNAPSHOT.jar:8.16.4-SNAPSHOT] |  
  | ... 6 more

****
```