### PR TITLE
[8.x] Use getOrDefault in IngestDocument rather than containsKey+get (#120571)

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -55,6 +55,9 @@ public final class IngestDocument {
     // This is the maximum number of nested pipelines that can be within a pipeline. If there are more, we bail out with an error
     public static final int MAX_PIPELINES = Integer.parseInt(System.getProperty("es.ingest.max_pipelines", "100"));
 
+    // a 'not found' sentinel value for use in getOrDefault calls in order to avoid containsKey-and-then-get
+    private static final Object NOT_FOUND = new Object();
+
     private final IngestCtxMap ctxMap;
     private final Map<String, Object> ingestMetadata;
 
@@ -375,11 +378,15 @@ public final class IngestDocument {
         if (context == null) {
             return ResolveResult.error("cannot resolve [" + pathElement + "] from null as part of path [" + fullPath + "]");
         }
-        if (context instanceof Map<?, ?> map) {
-            if (map.containsKey(pathElement)) {
-                return ResolveResult.success(map.get(pathElement));
+        if (context instanceof Map<?, ?>) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = (Map<String, Object>) context;
+            Object object = map.getOrDefault(pathElement, NOT_FOUND); // getOrDefault is faster than containsKey + get
+            if (object == NOT_FOUND) {
+                return ResolveResult.error("field [" + pathElement + "] not present as part of path [" + fullPath + "]");
+            } else {
+                return ResolveResult.success(object);
             }
-            return ResolveResult.error("field [" + pathElement + "] not present as part of path [" + fullPath + "]");
         }
         if (context instanceof List<?> list) {
             int index;
@@ -546,12 +553,13 @@ public final class IngestDocument {
             if (context instanceof Map) {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> map = (Map<String, Object>) context;
-                if (map.containsKey(pathElement)) {
-                    context = map.get(pathElement);
-                } else {
-                    HashMap<Object, Object> newMap = new HashMap<>();
+                Object object = map.getOrDefault(pathElement, NOT_FOUND); // getOrDefault is faster than containsKey + get
+                if (object == NOT_FOUND) {
+                    Map<Object, Object> newMap = new HashMap<>();
                     map.put(pathElement, newMap);
                     context = newMap;
+                } else {
+                    context = object;
                 }
             } else if (context instanceof List<?> list) {
                 int index;
@@ -590,16 +598,16 @@ public final class IngestDocument {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) context;
             if (append) {
-                if (map.containsKey(leafKey)) {
-                    Object object = map.get(leafKey);
+                Object object = map.getOrDefault(leafKey, NOT_FOUND); // getOrDefault is faster than containsKey + get
+                if (object == NOT_FOUND) {
+                    List<Object> list = new ArrayList<>();
+                    appendValues(list, value);
+                    map.put(leafKey, list);
+                } else {
                     Object list = appendValues(object, value, allowDuplicates);
                     if (list != object) {
                         map.put(leafKey, list);
                     }
-                } else {
-                    List<Object> list = new ArrayList<>();
-                    appendValues(list, value);
-                    map.put(leafKey, list);
                 }
                 return;
             }

--- a/server/src/main/java/org/elasticsearch/script/CtxMap.java
+++ b/server/src/main/java/org/elasticsearch/script/CtxMap.java
@@ -196,6 +196,18 @@ public class CtxMap<T extends Metadata> extends AbstractMap<String, Object> {
         return directSourceAccess() ? source.get(key) : (SOURCE.equals(key) ? source : null);
     }
 
+    @Override
+    public Object getOrDefault(Object key, Object defaultValue) {
+        // uses map directly to avoid Map's implementation that is just get and then containsKey and so could require two isAvailable calls
+        if (key instanceof String str) {
+            if (metadata.isAvailable(str)) {
+                return metadata.getOrDefault(str, defaultValue);
+            }
+            return directSourceAccess() ? source.getOrDefault(key, defaultValue) : (SOURCE.equals(key) ? source : defaultValue);
+        }
+        return defaultValue;
+    }
+
     /**
      * Set of entries of the wrapped map that calls the appropriate validator before changing an entries value or removing an entry.
      *

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -241,6 +241,13 @@ public class Metadata {
     }
 
     /**
+     * Get the value associated with {@param key}, otherwise return {@param defaultValue}
+     */
+    public Object getOrDefault(String key, Object defaultValue) {
+        return map.getOrDefault(key, defaultValue);
+    }
+
+    /**
      * Remove the mapping associated with {@param key}
      * @throws IllegalArgumentException if {@link #isAvailable(String)} is false or the key cannot be removed.
      */

--- a/server/src/test/java/org/elasticsearch/ingest/IngestCtxMapTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestCtxMapTests.java
@@ -329,6 +329,18 @@ public class IngestCtxMapTests extends ESTestCase {
         assertNull(md.getVersionType());
     }
 
+    public void testGetOrDefault() {
+        map = new IngestCtxMap(Map.of("foo", "bar"), new IngestDocMetadata(Map.of("_version", 5L), null));
+
+        // it does the expected thing for fields that are present
+        assertThat(map.getOrDefault("_version", -1L), equalTo(5L));
+        assertThat(map.getOrDefault("foo", "wat"), equalTo("bar"));
+
+        // it does the expected thing for fields that are not present
+        assertThat(map.getOrDefault("_version_type", "something"), equalTo("something"));
+        assertThat(map.getOrDefault("baz", "quux"), equalTo("quux"));
+    }
+
     private static class TestEntry implements Map.Entry<String, Object> {
         String key;
         Object value;

--- a/server/src/test/java/org/elasticsearch/script/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/script/MetadataTests.java
@@ -16,6 +16,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class MetadataTests extends ESTestCase {
     Metadata md;
     private static final Metadata.FieldProperty<String> STRING_PROP = new Metadata.FieldProperty<>(String.class, true, true, null);
@@ -278,5 +280,12 @@ public class MetadataTests extends ESTestCase {
         // Map.of and Map.copyOf are permissible (the former for code that should be fast, and the latter for e.g. tests)
         new Metadata(Map.of(), Map.of());
         new Metadata(Map.of(), Map.copyOf(new HashMap<>()));
+    }
+
+    public void testGetOrDefault() {
+        md = new Metadata(new HashMap<>(Map.of("foo", "bar")), Map.of("foo", STRING_PROP, "baz", STRING_PROP));
+        assertThat(md.getOrDefault("foo", "wat"), equalTo("bar"));
+        assertThat(md.getOrDefault("bar", "wat"), equalTo("wat"));
+        assertThat(md.getOrDefault("yo", "wat"), equalTo("wat"));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Use getOrDefault in IngestDocument rather than containsKey+get (#120571)