### PR TITLE
[8.17] LTR sometines throw NullPointerException: Cannot read field "approximation" because "top" is null (#120809)

### DIFF
--- a/docs/changelog/120809.yaml
+++ b/docs/changelog/120809.yaml
@@ -1,0 +1,6 @@
+pr: 120809
+summary: LTR sometines throw `NullPointerException:` Cannot read field "approximation"
+  because "top" is null
+area: Ranking
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/QueryFeatureExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/QueryFeatureExtractor.java
@@ -55,11 +55,16 @@ public class QueryFeatureExtractor implements FeatureExtractor {
             }
             scorers.add(scorer);
         }
-        rankerIterator = new DisjunctionDISIApproximation(disiPriorityQueue);
+
+        rankerIterator = disiPriorityQueue.size() > 0 ? new DisjunctionDISIApproximation(disiPriorityQueue) : null;
     }
 
     @Override
     public void addFeatures(Map<String, Object> featureMap, int docId) throws IOException {
+        if (rankerIterator == null) {
+            return;
+        }
+
         rankerIterator.advance(docId);
         for (int i = 0; i < featureNames.size(); i++) {
             Scorer scorer = scorers.get(i);


### PR DESCRIPTION
Backports the following commits to 8.17:
 - LTR sometines throw NullPointerException: Cannot read field "approximation" because "top" is null (#120809)