### PR TITLE
[8.x] Fix cat_component_templates documentation (#120487)

### DIFF
--- a/docs/changelog/120487.yaml
+++ b/docs/changelog/120487.yaml
@@ -1,0 +1,5 @@
+pr: 120487
+summary: Fix cat_component_templates documentation
+area: CAT APIs
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatComponentTemplateAction.java
@@ -54,7 +54,7 @@ public class RestCatComponentTemplateAction extends AbstractCatAction {
 
     @Override
     protected void documentation(StringBuilder sb) {
-        sb.append("/_cat/component_templates");
+        sb.append("/_cat/component_templates\n");
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix cat_component_templates documentation (#120487)