### PR TITLE
[8.x] [TEST] Restore scaled_float and half_float data generation (#120756)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldType.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldType.java
@@ -13,9 +13,11 @@ import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.ByteFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.DoubleFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.FloatFieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.fields.leaf.HalfFloatFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.IntegerFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.KeywordFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.LongFieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.fields.leaf.ScaledFloatFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.ShortFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.UnsignedLongFieldDataGenerator;
 
@@ -30,7 +32,9 @@ public enum FieldType {
     SHORT("short"),
     BYTE("byte"),
     DOUBLE("double"),
-    FLOAT("float");
+    FLOAT("float"),
+    HALF_FLOAT("half_float"),
+    SCALED_FLOAT("scaled_float");
 
     private final String name;
 
@@ -48,6 +52,8 @@ public enum FieldType {
             case BYTE -> new ByteFieldDataGenerator(fieldName, dataSource);
             case DOUBLE -> new DoubleFieldDataGenerator(fieldName, dataSource);
             case FLOAT -> new FloatFieldDataGenerator(fieldName, dataSource);
+            case HALF_FLOAT -> new HalfFloatFieldDataGenerator(fieldName, dataSource);
+            case SCALED_FLOAT -> new ScaledFloatFieldDataGenerator(fieldName, dataSource);
         };
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -32,7 +32,8 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
 
         return new DataSourceResponse.LeafMappingParametersGenerator(switch (request.fieldType()) {
             case KEYWORD -> keywordMapping(request, map);
-            case LONG, INTEGER, SHORT, BYTE, DOUBLE, FLOAT, UNSIGNED_LONG -> plain(map);
+            case LONG, INTEGER, SHORT, BYTE, DOUBLE, FLOAT, HALF_FLOAT, UNSIGNED_LONG -> plain(map);
+            case SCALED_FLOAT -> scaledFloatMapping(map);
         });
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/ArrayEqualMatcher.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/ArrayEqualMatcher.java
@@ -1,11 +1,13 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.xpack.logsdb.qa.matchers;
+package org.elasticsearch.logsdb.datageneration.matchers;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -13,8 +15,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.elasticsearch.xpack.logsdb.qa.matchers.Messages.formatErrorMessage;
-import static org.elasticsearch.xpack.logsdb.qa.matchers.Messages.prettyPrintArrays;
+import static org.elasticsearch.logsdb.datageneration.matchers.Messages.formatErrorMessage;
+import static org.elasticsearch.logsdb.datageneration.matchers.Messages.prettyPrintArrays;
 
 class ArrayEqualMatcher extends GenericEqualsMatcher<Object[]> {
     ArrayEqualMatcher(

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/GenericEqualsMatcher.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/GenericEqualsMatcher.java
@@ -1,18 +1,20 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.xpack.logsdb.qa.matchers;
+package org.elasticsearch.logsdb.datageneration.matchers;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.util.List;
 
-import static org.elasticsearch.xpack.logsdb.qa.matchers.Messages.formatErrorMessage;
+import static org.elasticsearch.logsdb.datageneration.matchers.Messages.formatErrorMessage;
 
 public class GenericEqualsMatcher<T> extends Matcher {
     protected final XContentBuilder actualMappings;

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/ListEqualMatcher.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/ListEqualMatcher.java
@@ -1,19 +1,21 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.xpack.logsdb.qa.matchers;
+package org.elasticsearch.logsdb.datageneration.matchers;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.util.List;
 
-import static org.elasticsearch.xpack.logsdb.qa.matchers.Messages.formatErrorMessage;
-import static org.elasticsearch.xpack.logsdb.qa.matchers.Messages.prettyPrintCollections;
+import static org.elasticsearch.logsdb.datageneration.matchers.Messages.formatErrorMessage;
+import static org.elasticsearch.logsdb.datageneration.matchers.Messages.prettyPrintCollections;
 
 public class ListEqualMatcher extends GenericEqualsMatcher<List<?>> {
     public ListEqualMatcher(

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/MatchResult.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/MatchResult.java
@@ -1,11 +1,13 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.xpack.logsdb.qa.matchers;
+package org.elasticsearch.logsdb.datageneration.matchers;
 
 import java.util.Objects;
 

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/Matcher.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/Matcher.java
@@ -1,15 +1,17 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.xpack.logsdb.qa.matchers;
+package org.elasticsearch.logsdb.datageneration.matchers;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.logsdb.datageneration.matchers.source.SourceMatcher;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.logsdb.qa.matchers.source.SourceMatcher;
 
 import java.util.List;
 import java.util.Map;

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/Messages.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/Messages.java
@@ -1,11 +1,13 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.xpack.logsdb.qa.matchers;
+package org.elasticsearch.logsdb.datageneration.matchers;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/ObjectMatcher.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/ObjectMatcher.java
@@ -1,16 +1,18 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.xpack.logsdb.qa.matchers;
+package org.elasticsearch.logsdb.datageneration.matchers;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xcontent.XContentBuilder;
 
-import static org.elasticsearch.xpack.logsdb.qa.matchers.Messages.formatErrorMessage;
+import static org.elasticsearch.logsdb.datageneration.matchers.Messages.formatErrorMessage;
 
 public class ObjectMatcher extends GenericEqualsMatcher<Object> {
     ObjectMatcher(

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/DynamicFieldMatcher.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/DynamicFieldMatcher.java
@@ -1,15 +1,17 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.xpack.logsdb.qa.matchers.source;
+package org.elasticsearch.logsdb.datageneration.matchers.source;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.logsdb.datageneration.matchers.MatchResult;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.logsdb.qa.matchers.MatchResult;
 
 import java.util.List;
 import java.util.Objects;
@@ -18,8 +20,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.logsdb.qa.matchers.Messages.formatErrorMessage;
-import static org.elasticsearch.xpack.logsdb.qa.matchers.Messages.prettyPrintCollections;
+import static org.elasticsearch.logsdb.datageneration.matchers.Messages.formatErrorMessage;
+import static org.elasticsearch.logsdb.datageneration.matchers.Messages.prettyPrintCollections;
 
 class DynamicFieldMatcher {
     private final XContentBuilder actualMappings;

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/MappingTransforms.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/MappingTransforms.java
@@ -1,11 +1,13 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.xpack.logsdb.qa.matchers.source;
+package org.elasticsearch.logsdb.datageneration.matchers.source;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/SourceMatcher.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/SourceMatcher.java
@@ -1,27 +1,29 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.xpack.logsdb.qa.matchers.source;
+package org.elasticsearch.logsdb.datageneration.matchers.source;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.logsdb.datageneration.matchers.GenericEqualsMatcher;
+import org.elasticsearch.logsdb.datageneration.matchers.ListEqualMatcher;
+import org.elasticsearch.logsdb.datageneration.matchers.MatchResult;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.logsdb.qa.matchers.GenericEqualsMatcher;
-import org.elasticsearch.xpack.logsdb.qa.matchers.ListEqualMatcher;
-import org.elasticsearch.xpack.logsdb.qa.matchers.MatchResult;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.elasticsearch.xpack.logsdb.qa.matchers.Messages.formatErrorMessage;
-import static org.elasticsearch.xpack.logsdb.qa.matchers.Messages.prettyPrintCollections;
+import static org.elasticsearch.logsdb.datageneration.matchers.Messages.formatErrorMessage;
+import static org.elasticsearch.logsdb.datageneration.matchers.Messages.prettyPrintCollections;
 
 public class SourceMatcher extends GenericEqualsMatcher<List<Map<String, Object>>> {
     private final Map<String, MappingTransforms.FieldMapping> actualNormalizedMapping;

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/SourceTransforms.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/SourceTransforms.java
@@ -1,11 +1,13 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.xpack.logsdb.qa.matchers.source;
+package org.elasticsearch.logsdb.datageneration.matchers.source;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/SourceMatcherTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/SourceMatcherTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.logsdb.datageneration;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.logsdb.datageneration.matchers.source.SourceMatcher;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class SourceMatcherTests extends ESTestCase {
+    public void testDynamicMatch() throws IOException {
+        List<Map<String, Object>> values = List.of(
+            Map.of("aaa", 124, "bbb", false, "ccc", 12.34),
+            Map.of("aaa", 124, "bbb", false, "ccc", 12.34)
+        );
+
+        var sut = new SourceMatcher(
+            XContentBuilder.builder(XContentType.JSON.xContent()).startObject().endObject(),
+            Settings.builder(),
+            XContentBuilder.builder(XContentType.JSON.xContent()).startObject().endObject(),
+            Settings.builder(),
+            values,
+            values,
+            false
+        );
+        assertTrue(sut.match().isMatch());
+    }
+
+    public void testDynamicMismatch() throws IOException {
+        List<Map<String, Object>> actual = List.of(
+            Map.of("aaa", 124, "bbb", false, "ccc", 12.34),
+            Map.of("aaa", 124, "bbb", false, "ccc", 12.34)
+        );
+        List<Map<String, Object>> expected = List.of(
+            Map.of("aaa", 124, "bbb", false, "ccc", 12.34),
+            Map.of("aaa", 125, "bbb", false, "ccc", 12.34)
+        );
+
+        var sut = new SourceMatcher(
+            XContentBuilder.builder(XContentType.JSON.xContent()).startObject().endObject(),
+            Settings.builder(),
+            XContentBuilder.builder(XContentType.JSON.xContent()).startObject().endObject(),
+            Settings.builder(),
+            actual,
+            expected,
+            false
+        );
+        assertFalse(sut.match().isMatch());
+    }
+
+    public void testMappedMatch() throws IOException {
+        List<Map<String, Object>> values = List.of(
+            Map.of("aaa", 124, "bbb", false, "ccc", 12.34),
+            Map.of("aaa", 124, "bbb", false, "ccc", 12.34)
+        );
+
+        var mapping = XContentBuilder.builder(XContentType.JSON.xContent());
+        mapping.startObject();
+        mapping.startObject("_doc");
+        {
+            mapping.startObject("aaa").field("type", "long").endObject();
+            mapping.startObject("bbb").field("type", "boolean").endObject();
+            mapping.startObject("ccc").field("type", "half_float").endObject();
+        }
+        mapping.endObject();
+        mapping.endObject();
+
+        var sut = new SourceMatcher(mapping, Settings.builder(), mapping, Settings.builder(), values, values, false);
+        assertTrue(sut.match().isMatch());
+    }
+
+    public void testMappedMismatch() throws IOException {
+        List<Map<String, Object>> actual = List.of(
+            Map.of("aaa", 124, "bbb", false, "ccc", 12.34),
+            Map.of("aaa", 124, "bbb", false, "ccc", 12.34)
+        );
+        List<Map<String, Object>> expected = List.of(
+            Map.of("aaa", 124, "bbb", false, "ccc", 12.34),
+            Map.of("aaa", 124, "bbb", false, "ccc", 12.35)
+        );
+
+        var mapping = XContentBuilder.builder(XContentType.JSON.xContent());
+        mapping.startObject();
+        mapping.startObject("_doc");
+        {
+            mapping.startObject("aaa").field("type", "long").endObject();
+            mapping.startObject("bbb").field("type", "boolean").endObject();
+            mapping.startObject("ccc").field("type", "half_float").endObject();
+        }
+        mapping.endObject();
+        mapping.endObject();
+
+        var sut = new SourceMatcher(mapping, Settings.builder(), mapping, Settings.builder(), actual, expected, false);
+        assertFalse(sut.match().isMatch());
+    }
+}

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
@@ -17,6 +17,8 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.logsdb.datageneration.matchers.MatchResult;
+import org.elasticsearch.logsdb.datageneration.matchers.Matcher;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
@@ -27,8 +29,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.logsdb.qa.matchers.MatchResult;
-import org.elasticsearch.xpack.logsdb.qa.matchers.Matcher;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [TEST] Restore scaled_float and half_float data generation (#120756)