### PR TITLE
[8.x] Removing the reindex data stream feature flag (#120677)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -19,8 +19,7 @@ public enum FeatureFlag {
     TIME_SERIES_MODE("es.index_mode_feature_flag_registered=true", Version.fromString("8.0.0"), null),
     FAILURE_STORE_ENABLED("es.failure_store_feature_flag_enabled=true", Version.fromString("8.12.0"), null),
     SUB_OBJECTS_AUTO_ENABLED("es.sub_objects_auto_feature_flag_enabled=true", Version.fromString("8.16.0"), null),
-    INFERENCE_UNIFIED_API_ENABLED("es.inference_unified_feature_flag_enabled=true", Version.fromString("8.18.0"), null),
-    MIGRATION_REINDEX_ENABLED("es.reindex_data_stream_feature_flag_enabled=true", Version.fromString("8.18.0"), null);
+    INFERENCE_UNIFIED_API_ENABLED("es.inference_unified_feature_flag_enabled=true", Version.fromString("8.18.0"), null);
 
     public final String systemProperty;
     public final Version from;

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
@@ -32,7 +32,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
 
 public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
 
@@ -42,8 +41,6 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
     }
 
     public void testOldSettingsManuallyFiltered() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var numShards = randomIntBetween(1, 10);
         var staticSettings = Settings.builder()
             // setting to filter
@@ -77,8 +74,6 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
     }
 
     public void testDestIndexCreated() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         indicesAdmin().create(new CreateIndexRequest(sourceIndex)).get();
 
@@ -96,8 +91,6 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
     }
 
     public void testSettingsCopiedFromSource() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         // start with a static setting
         var numShards = randomIntBetween(1, 10);
         var staticSettings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards).build();
@@ -122,8 +115,6 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
     }
 
     public void testMappingsCopiedFromSource() {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         String mapping = """
             {
@@ -156,8 +147,6 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
     }
 
     public void testSettingsOverridden() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var numShardsSource = randomIntBetween(1, 10);
         var numReplicasSource = randomIntBetween(0, 10);
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
@@ -190,8 +179,6 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
     }
 
     public void testSettingsNullOverride() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         var sourceSettings = Settings.builder()
             .put(IndexMetadata.SETTING_BLOCKS_WRITE, true)
@@ -222,8 +209,6 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
     }
 
     public void testRemoveIndexBlocksByDefault() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
 
         var sourceSettings = Settings.builder()
@@ -256,8 +241,6 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
     }
 
     public void testMappingsOverridden() {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         String sourceMapping = """
             {

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamTransportActionIT.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -52,7 +51,6 @@ public class ReindexDataStreamTransportActionIT extends ESIntegTestCase {
     }
 
     public void testNonExistentDataStream() {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
         String nonExistentDataStreamName = randomAlphaOfLength(50);
         ReindexDataStreamRequest reindexDataStreamRequest = new ReindexDataStreamRequest(
             ReindexDataStreamAction.Mode.UPGRADE,
@@ -65,7 +63,6 @@ public class ReindexDataStreamTransportActionIT extends ESIntegTestCase {
     }
 
     public void testAlreadyUpToDateDataStream() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
         String dataStreamName = randomAlphaOfLength(50).toLowerCase(Locale.ROOT);
         ReindexDataStreamRequest reindexDataStreamRequest = new ReindexDataStreamRequest(
             ReindexDataStreamAction.Mode.UPGRADE,

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
@@ -53,7 +53,6 @@ import static org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.DE
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
@@ -77,8 +76,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testDestIndexDeletedIfExists() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         // empty source index
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         indicesAdmin().create(new CreateIndexRequest(sourceIndex)).get();
@@ -99,8 +96,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testDestIndexNameSet_noDotPrefix() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         indicesAdmin().create(new CreateIndexRequest(sourceIndex)).get();
 
@@ -113,7 +108,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testDestIndexNameSet_withDotPrefix() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
 
         var sourceIndex = "." + randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         indicesAdmin().create(new CreateIndexRequest(sourceIndex)).get();
@@ -127,8 +121,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testDestIndexContainsDocs() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         // source index with docs
         var numDocs = randomIntBetween(1, 100);
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
@@ -145,8 +137,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testSetSourceToBlockWrites() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var settings = randomBoolean() ? Settings.builder().put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build() : Settings.EMPTY;
 
         // empty source index
@@ -163,8 +153,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testSettingsAddedBeforeReindex() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         // start with a static setting
         var numShards = randomIntBetween(1, 10);
         var staticSettings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards).build();
@@ -193,8 +181,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testMappingsAddedToDestIndex() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         indicesAdmin().create(new CreateIndexRequest(sourceIndex).mapping(MAPPING)).actionGet();
 
@@ -214,8 +200,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testFailIfMetadataBlockSet() {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         var settings = Settings.builder().put(IndexMetadata.SETTING_BLOCKS_METADATA, true).build();
         indicesAdmin().create(new CreateIndexRequest(sourceIndex, settings)).actionGet();
@@ -230,8 +214,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testFailIfReadBlockSet() {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         var settings = Settings.builder().put(IndexMetadata.SETTING_BLOCKS_READ, true).build();
         indicesAdmin().create(new CreateIndexRequest(sourceIndex, settings)).actionGet();
@@ -246,8 +228,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testReadOnlyBlocksNotAddedBack() {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         var settings = Settings.builder()
             .put(IndexMetadata.SETTING_READ_ONLY, randomBoolean())
@@ -271,8 +251,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testUpdateSettingsDefaultsRestored() {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         // ESIntegTestCase creates a template random_index_template which contains a value for number_of_replicas.
         // Since this test checks the behavior of default settings, there cannot be a value for number_of_replicas,
         // so we delete the template within this method. This has no effect on other tests which will still
@@ -303,8 +281,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     }
 
     public void testSettingsAndMappingsFromTemplate() throws IOException {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var numShards = randomIntBetween(1, 10);
         var numReplicas = randomIntBetween(0, 10);
 
@@ -391,8 +367,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
         """;
 
     public void testTsdbStartEndSet() throws Exception {
-        assumeTrue("requires the migration reindex feature flag", REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled());
-
         var templateSettings = Settings.builder().put("index.mode", "time_series");
         if (randomBoolean()) {
             templateSettings.put("index.routing_path", "metricset");

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigratePlugin.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigratePlugin.java
@@ -60,7 +60,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.core.ClientHelper.REINDEX_DATA_STREAM_ORIGIN;
-import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
 import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamIndexTransportAction.REINDEX_MAX_REQUESTS_PER_SECOND_SETTING;
 import static org.elasticsearch.xpack.migrate.task.ReindexDataStreamPersistentTaskExecutor.MAX_CONCURRENT_INDICES_REINDEXED_PER_DATA_STREAM_SETTING;
 
@@ -79,67 +78,55 @@ public class MigratePlugin extends Plugin implements ActionPlugin, PersistentTas
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
         List<RestHandler> handlers = new ArrayList<>();
-        if (REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled()) {
-            handlers.add(new RestMigrationReindexAction());
-            handlers.add(new RestGetMigrationReindexStatusAction());
-            handlers.add(new RestCancelReindexDataStreamAction());
-            handlers.add(new RestCreateIndexFromSourceAction());
-        }
+        handlers.add(new RestMigrationReindexAction());
+        handlers.add(new RestGetMigrationReindexStatusAction());
+        handlers.add(new RestCancelReindexDataStreamAction());
+        handlers.add(new RestCreateIndexFromSourceAction());
         return handlers;
     }
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>();
-        if (REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled()) {
-            actions.add(new ActionHandler<>(ReindexDataStreamAction.INSTANCE, ReindexDataStreamTransportAction.class));
-            actions.add(new ActionHandler<>(GetMigrationReindexStatusAction.INSTANCE, GetMigrationReindexStatusTransportAction.class));
-            actions.add(new ActionHandler<>(CancelReindexDataStreamAction.INSTANCE, CancelReindexDataStreamTransportAction.class));
-            actions.add(new ActionHandler<>(ReindexDataStreamIndexAction.INSTANCE, ReindexDataStreamIndexTransportAction.class));
-            actions.add(new ActionHandler<>(CreateIndexFromSourceAction.INSTANCE, CreateIndexFromSourceTransportAction.class));
-        }
+        actions.add(new ActionHandler<>(ReindexDataStreamAction.INSTANCE, ReindexDataStreamTransportAction.class));
+        actions.add(new ActionHandler<>(GetMigrationReindexStatusAction.INSTANCE, GetMigrationReindexStatusTransportAction.class));
+        actions.add(new ActionHandler<>(CancelReindexDataStreamAction.INSTANCE, CancelReindexDataStreamTransportAction.class));
+        actions.add(new ActionHandler<>(ReindexDataStreamIndexAction.INSTANCE, ReindexDataStreamIndexTransportAction.class));
+        actions.add(new ActionHandler<>(CreateIndexFromSourceAction.INSTANCE, CreateIndexFromSourceTransportAction.class));
         return actions;
     }
 
     @Override
     public List<NamedXContentRegistry.Entry> getNamedXContent() {
-        if (REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled()) {
-            return List.of(
-                new NamedXContentRegistry.Entry(
-                    PersistentTaskState.class,
-                    new ParseField(ReindexDataStreamPersistentTaskState.NAME),
-                    ReindexDataStreamPersistentTaskState::fromXContent
-                ),
-                new NamedXContentRegistry.Entry(
-                    PersistentTaskParams.class,
-                    new ParseField(ReindexDataStreamTaskParams.NAME),
-                    ReindexDataStreamTaskParams::fromXContent
-                )
-            );
-        } else {
-            return List.of();
-        }
+        return List.of(
+            new NamedXContentRegistry.Entry(
+                PersistentTaskState.class,
+                new ParseField(ReindexDataStreamPersistentTaskState.NAME),
+                ReindexDataStreamPersistentTaskState::fromXContent
+            ),
+            new NamedXContentRegistry.Entry(
+                PersistentTaskParams.class,
+                new ParseField(ReindexDataStreamTaskParams.NAME),
+                ReindexDataStreamTaskParams::fromXContent
+            )
+        );
     }
 
     @Override
     public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
-        if (REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled()) {
-            return List.of(
-                new NamedWriteableRegistry.Entry(
-                    PersistentTaskState.class,
-                    ReindexDataStreamPersistentTaskState.NAME,
-                    ReindexDataStreamPersistentTaskState::new
-                ),
-                new NamedWriteableRegistry.Entry(
-                    PersistentTaskParams.class,
-                    ReindexDataStreamTaskParams.NAME,
-                    ReindexDataStreamTaskParams::new
-                ),
-                new NamedWriteableRegistry.Entry(Task.Status.class, ReindexDataStreamStatus.NAME, ReindexDataStreamStatus::new)
-            );
-        } else {
-            return List.of();
-        }
+        return List.of(
+            new NamedWriteableRegistry.Entry(
+                PersistentTaskState.class,
+                ReindexDataStreamPersistentTaskState.NAME,
+                ReindexDataStreamPersistentTaskState::new
+            ),
+            new NamedWriteableRegistry.Entry(
+                PersistentTaskParams.class,
+                ReindexDataStreamTaskParams.NAME,
+                ReindexDataStreamTaskParams::new
+            ),
+            new NamedWriteableRegistry.Entry(Task.Status.class, ReindexDataStreamStatus.NAME, ReindexDataStreamStatus::new)
+        );
     }
 
     @Override
@@ -150,18 +137,14 @@ public class MigratePlugin extends Plugin implements ActionPlugin, PersistentTas
         SettingsModule settingsModule,
         IndexNameExpressionResolver expressionResolver
     ) {
-        if (REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled()) {
-            return List.of(
-                new ReindexDataStreamPersistentTaskExecutor(
-                    new OriginSettingClient(client, REINDEX_DATA_STREAM_ORIGIN),
-                    clusterService,
-                    ReindexDataStreamTask.TASK_NAME,
-                    threadPool
-                )
-            );
-        } else {
-            return List.of();
-        }
+        return List.of(
+            new ReindexDataStreamPersistentTaskExecutor(
+                new OriginSettingClient(client, REINDEX_DATA_STREAM_ORIGIN),
+                clusterService,
+                ReindexDataStreamTask.TASK_NAME,
+                threadPool
+            )
+        );
     }
 
     @Override

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -29,7 +28,6 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 public class ReindexDataStreamAction extends ActionType<AcknowledgedResponse> {
-    public static final FeatureFlag REINDEX_DATA_STREAM_FEATURE_FLAG = new FeatureFlag("reindex_data_stream");
     public static final String TASK_ID_PREFIX = "reindex-data-stream-";
 
     public static final ReindexDataStreamAction INSTANCE = new ReindexDataStreamAction();

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestMigrationReindexAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestMigrationReindexAction.java
@@ -20,13 +20,10 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.xpack.migrate.action.ReindexDataStreamAction.REINDEX_DATA_STREAM_FEATURE_FLAG;
 
 public class RestMigrationReindexAction extends BaseRestHandler {
     public static final String MIGRATION_REINDEX_CAPABILITY = "migration_reindex";
@@ -56,11 +53,7 @@ public class RestMigrationReindexAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedCapabilities() {
-        Set<String> capabilities = new HashSet<>();
-        if (REINDEX_DATA_STREAM_FEATURE_FLAG.isEnabled()) {
-            capabilities.add(MIGRATION_REINDEX_CAPABILITY);
-        }
-        return Collections.unmodifiableSet(capabilities);
+        return Set.of(MIGRATION_REINDEX_CAPABILITY);
     }
 
     static class ReindexDataStreamRestToXContentListener extends RestBuilderListener<AcknowledgedResponse> {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/10_reindex.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/10_reindex.yml
@@ -7,7 +7,7 @@ setup:
 ---
 "Test Reindex With Unsupported Mode":
   - requires:
-      reason: "migration reindex is behind a feature flag"
+      reason: "requires a cluster with the migration reindex feature"
       test_runner_features: [capabilities]
       capabilities:
         - method: POST
@@ -27,7 +27,7 @@ setup:
 ---
 "Test Reindex With Nonexistent Data Stream":
   - requires:
-      reason: "migration reindex is behind a feature flag"
+      reason: "requires a cluster with the migration reindex feature"
       test_runner_features: [capabilities]
       capabilities:
         - method: POST
@@ -59,7 +59,7 @@ setup:
 ---
 "Test Reindex With Bad Data Stream Name":
   - requires:
-      reason: "migration reindex is behind a feature flag"
+      reason: "requires a cluster with the migration reindex feature"
       test_runner_features: [capabilities]
       capabilities:
         - method: POST
@@ -79,7 +79,7 @@ setup:
 ---
 "Test Reindex With Existing Data Stream":
   - requires:
-      reason: "migration reindex is behind a feature flag"
+      reason: "requires a cluster with the migration reindex feature"
       test_runner_features: [capabilities]
       capabilities:
         - method: POST

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/20_reindex_status.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/20_reindex_status.yml
@@ -7,7 +7,7 @@ setup:
 ---
 "Test get reindex status with nonexistent task id":
   - requires:
-      reason: "migration reindex is behind a feature flag"
+      reason: "requires a cluster with the migration reindex feature"
       test_runner_features: [capabilities]
       capabilities:
         - method: POST
@@ -21,7 +21,7 @@ setup:
 ---
 "Test Reindex With Existing Data Stream":
   - requires:
-      reason: "migration reindex is behind a feature flag"
+      reason: "requires a cluster with the migration reindex feature"
       test_runner_features: [capabilities]
       capabilities:
         - method: POST

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/30_create_from.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/30_create_from.yml
@@ -18,7 +18,7 @@ teardown:
 ---
 "Test create from with nonexistent source index":
   - requires:
-      reason: "migration reindex is behind a feature flag"
+      reason: "requires a cluster with the migration reindex feature"
       test_runner_features: [capabilities]
       capabilities:
         - method: POST
@@ -33,7 +33,7 @@ teardown:
 ---
 "Test create_from with existing source index":
   - requires:
-      reason: "migration reindex is behind a feature flag"
+      reason: "requires a cluster with the migration reindex feature"
       test_runner_features: [capabilities]
       capabilities:
         - method: POST
@@ -69,7 +69,7 @@ teardown:
 ---
 "Test create_from with existing source index and overrides":
   - requires:
-      reason: "migration reindex is behind a feature flag"
+      reason: "requires a cluster with the migration reindex feature"
       test_runner_features: [capabilities]
       capabilities:
         - method: POST
@@ -122,7 +122,7 @@ teardown:
 ---
 "Test create_from with remove_index_blocks set to false":
   - requires:
-      reason: "migration reindex is behind a feature flag"
+      reason: "requires a cluster with the migration reindex feature"
       test_runner_features: [capabilities]
       capabilities:
         - method: POST
@@ -155,7 +155,7 @@ teardown:
 ---
 "Test create_from with remove_index_blocks default of true":
   - requires:
-      reason: "migration reindex is behind a feature flag"
+      reason: "requires a cluster with the migration reindex feature"
       test_runner_features: [capabilities]
       capabilities:
         - method: POST


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Removing the reindex data stream feature flag (#120677)