### PR TITLE
[TEST] Skip flaky configuration in randomized testing for logsdb

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -243,17 +243,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
   issue: https://github.com/elastic/elasticsearch/issues/120810
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/120816
-- class: org.elasticsearch.xpack.logsdb.qa.StandardVersusStandardReindexedIntoLogsDbChallengeRestIT
-  method: testEsqlSource
-  issue: https://github.com/elastic/elasticsearch/issues/120830
-- class: org.elasticsearch.xpack.logsdb.qa.StandardVersusLogsIndexModeRandomDataChallengeRestIT
-  method: testEsqlSource
-  issue: https://github.com/elastic/elasticsearch/issues/120831
-- class: org.elasticsearch.xpack.logsdb.qa.StoredSourceLogsDbVersusReindexedLogsDbChallengeRestIT
-  method: testEsqlSource
-  issue: https://github.com/elastic/elasticsearch/issues/120832
 
 # Examples:
 #

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldType.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldType.java
@@ -11,13 +11,9 @@ package org.elasticsearch.logsdb.datageneration;
 
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.ByteFieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.fields.leaf.DoubleFieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.fields.leaf.FloatFieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.fields.leaf.HalfFloatFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.IntegerFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.KeywordFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.LongFieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.fields.leaf.ScaledFloatFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.ShortFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.UnsignedLongFieldDataGenerator;
 
@@ -30,11 +26,7 @@ public enum FieldType {
     UNSIGNED_LONG("unsigned_long"),
     INTEGER("integer"),
     SHORT("short"),
-    BYTE("byte"),
-    DOUBLE("double"),
-    FLOAT("float"),
-    HALF_FLOAT("half_float"),
-    SCALED_FLOAT("scaled_float");
+    BYTE("byte");
 
     private final String name;
 
@@ -50,10 +42,6 @@ public enum FieldType {
             case INTEGER -> new IntegerFieldDataGenerator(fieldName, dataSource);
             case SHORT -> new ShortFieldDataGenerator(fieldName, dataSource);
             case BYTE -> new ByteFieldDataGenerator(fieldName, dataSource);
-            case DOUBLE -> new DoubleFieldDataGenerator(fieldName, dataSource);
-            case FLOAT -> new FloatFieldDataGenerator(fieldName, dataSource);
-            case HALF_FLOAT -> new HalfFloatFieldDataGenerator(fieldName, dataSource);
-            case SCALED_FLOAT -> new ScaledFloatFieldDataGenerator(fieldName, dataSource);
         };
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -32,8 +32,8 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
 
         return new DataSourceResponse.LeafMappingParametersGenerator(switch (request.fieldType()) {
             case KEYWORD -> keywordMapping(request, map);
-            case LONG, INTEGER, SHORT, BYTE, DOUBLE, FLOAT, HALF_FLOAT, UNSIGNED_LONG -> plain(map);
-            case SCALED_FLOAT -> scaledFloatMapping(map);
+            case LONG, INTEGER, SHORT, BYTE, UNSIGNED_LONG -> plain(map);
+
         });
     }
 
@@ -61,7 +61,8 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
                     .collect(Collectors.toSet());
 
                 if (options.isEmpty() == false) {
-                    injected.put("copy_to", ESTestCase.randomFrom(options));
+                    // TODO: re-enable once #120831 is resolved
+                    // injected.put("copy_to", ESTestCase.randomFrom(options));
                 }
             }
 


### PR DESCRIPTION
`copy_to` has a known issue, #120831

Double, float etc values cause noise in matching logic, likely due to dynamic values being all mapped to float:
https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java#L201

We will be addressing these issues promptly and reverting this.