### PR TITLE
[8.x] Skip flaky configuration in randomized testing for logsdb (#120859)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -444,21 +444,3 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncEnrichStopIT
   method: testEnrichAfterStop
   issue: https://github.com/elastic/elasticsearch/issues/120757
-- class: org.elasticsearch.xpack.logsdb.qa.StoredSourceLogsDbVersusReindexedLogsDbChallengeRestIT
-  method: testTermsQuery
-  issue: https://github.com/elastic/elasticsearch/issues/120853
-- class: org.elasticsearch.xpack.logsdb.qa.StoredSourceLogsDbVersusReindexedLogsDbChallengeRestIT
-  method: testMatchAllQuery
-  issue: https://github.com/elastic/elasticsearch/issues/120854
-- class: org.elasticsearch.xpack.logsdb.qa.StandardVersusLogsIndexModeRandomDataChallengeRestIT
-  method: testMatchAllQuery
-  issue: https://github.com/elastic/elasticsearch/issues/120855
-- class: org.elasticsearch.xpack.logsdb.qa.StandardVersusLogsIndexModeRandomDataChallengeRestIT
-  method: testTermsQuery
-  issue: https://github.com/elastic/elasticsearch/issues/120856
-- class: org.elasticsearch.xpack.logsdb.qa.StandardVersusStandardReindexedIntoLogsDbChallengeRestIT
-  method: testMatchAllQuery
-  issue: https://github.com/elastic/elasticsearch/issues/120857
-- class: org.elasticsearch.xpack.logsdb.qa.StandardVersusStandardReindexedIntoLogsDbChallengeRestIT
-  method: testTermsQuery
-  issue: https://github.com/elastic/elasticsearch/issues/120858

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldType.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldType.java
@@ -11,13 +11,9 @@ package org.elasticsearch.logsdb.datageneration;
 
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.ByteFieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.fields.leaf.DoubleFieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.fields.leaf.FloatFieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.fields.leaf.HalfFloatFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.IntegerFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.KeywordFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.LongFieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.fields.leaf.ScaledFloatFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.ShortFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.UnsignedLongFieldDataGenerator;
 
@@ -30,11 +26,7 @@ public enum FieldType {
     UNSIGNED_LONG("unsigned_long"),
     INTEGER("integer"),
     SHORT("short"),
-    BYTE("byte"),
-    DOUBLE("double"),
-    FLOAT("float"),
-    HALF_FLOAT("half_float"),
-    SCALED_FLOAT("scaled_float");
+    BYTE("byte");
 
     private final String name;
 
@@ -50,10 +42,6 @@ public enum FieldType {
             case INTEGER -> new IntegerFieldDataGenerator(fieldName, dataSource);
             case SHORT -> new ShortFieldDataGenerator(fieldName, dataSource);
             case BYTE -> new ByteFieldDataGenerator(fieldName, dataSource);
-            case DOUBLE -> new DoubleFieldDataGenerator(fieldName, dataSource);
-            case FLOAT -> new FloatFieldDataGenerator(fieldName, dataSource);
-            case HALF_FLOAT -> new HalfFloatFieldDataGenerator(fieldName, dataSource);
-            case SCALED_FLOAT -> new ScaledFloatFieldDataGenerator(fieldName, dataSource);
         };
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -32,8 +32,8 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
 
         return new DataSourceResponse.LeafMappingParametersGenerator(switch (request.fieldType()) {
             case KEYWORD -> keywordMapping(request, map);
-            case LONG, INTEGER, SHORT, BYTE, DOUBLE, FLOAT, HALF_FLOAT, UNSIGNED_LONG -> plain(map);
-            case SCALED_FLOAT -> scaledFloatMapping(map);
+            case LONG, INTEGER, SHORT, BYTE, UNSIGNED_LONG -> plain(map);
+
         });
     }
 
@@ -61,7 +61,8 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
                     .collect(Collectors.toSet());
 
                 if (options.isEmpty() == false) {
-                    injected.put("copy_to", ESTestCase.randomFrom(options));
+                    // TODO: re-enable once #120831 is resolved
+                    // injected.put("copy_to", ESTestCase.randomFrom(options));
                 }
             }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Skip flaky configuration in randomized testing for logsdb (#120859)](https://github.com/elastic/elasticsearch/pull/120859)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)