### PR TITLE
Fix connector YAML test

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/15_connector_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/15_connector_post.yml
@@ -48,7 +48,7 @@ setup:
   - do:
       connector.post:
         body:
-          index_name: search-test
+          index_name: search-test-2
 
   - set:  { id: id }
   - match: { id: $id }
@@ -58,7 +58,7 @@ setup:
         connector_id: $id
 
   - match: { id: $id }
-  - match: { index_name: search-test }
+  - match: { index_name: search-test-2 }
   - match: { is_native: false }
   - match: { sync_now: false }
   - match: { status: created }


### PR DESCRIPTION
Two tests reuse the same index. The second test fails with `status_exception: Index name [search-test] is used by another connector` when using the custom test runner maintained by @elastic/devtools-team. Should we instead stop/delete connectors between tests?