### PR TITLE
Allow unmapped fields in MultiClustersIT tests

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/MultiClustersIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/MultiClustersIT.java
@@ -184,7 +184,11 @@ public class MultiClustersIT extends ESRestTestCase {
         final boolean sorted = randomBoolean();
         if (sorted) {
             searchSource.startArray("sort");
-            searchSource.value("message_id");
+            searchSource.startObject();
+            searchSource.startObject("message_id");
+            searchSource.field("unmapped_type", "long"); // message_id can be unmapped if no doc is indexed.
+            searchSource.endObject();
+            searchSource.endObject();
             searchSource.endArray();
         }
         final Predicate<String> filterHost;


### PR DESCRIPTION
The message_id field may be unmapped if documents were indexed into some indices but not all. This change specifies the unmapped type for message_id, allowing it to be sorted in such cases.

Closes #120796