### PR TITLE
Unmute LearningToRankExplainIT since it is fixed by #120809

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -237,9 +237,6 @@ tests:
 - class: org.elasticsearch.action.search.SearchProgressActionListenerIT
   method: testSearchProgressWithHits
   issue: https://github.com/elastic/elasticsearch/issues/120671
-- class: org.elasticsearch.xpack.ml.integration.LearningToRankExplainIT
-  method: testLtrExplainWithMultipleShardsAndReplicas
-  issue: https://github.com/elastic/elasticsearch/issues/120805
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
   issue: https://github.com/elastic/elasticsearch/issues/120810


### PR DESCRIPTION
Fix for #120805

Just unmute the test on main since the test failure has been fixed as part of #120809