### PR TITLE
Force propagating the X-Opaque-Id to the settings update task if set

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -78,9 +78,6 @@ tests:
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/116175
-- class: org.elasticsearch.xpack.deprecation.DeprecationHttpIT
-  method: testDeprecatedSettingsReturnWarnings
-  issue: https://github.com/elastic/elasticsearch/issues/108628
 - class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
   method: testAllocationPreventedForRemoval
   issue: https://github.com/elastic/elasticsearch/issues/116363


### PR DESCRIPTION
Force propagating the X-Opaque-Id to the settings update task if set, so deprecation warnings are correctly tracked.

Interestingly, it looks like the behavior here changed. This test used to fail randomly, on current main this is failing consistently. Issue is that headers are not propagated into the update task.

(closes #108628)