### PR TITLE
[8.x] [Entitlements] Deny setting global defaults for Locale / TimeZone (#120804)

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -42,7 +42,9 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.security.cert.CertStoreParameters;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
+import java.util.TimeZone;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -187,6 +189,12 @@ public interface EntitlementChecker {
     void check$java_util_spi_TimeZoneNameProvider$(Class<?> callerClass);
 
     void check$java_util_logging_LogManager$(Class<?> callerClass);
+
+    void check$java_util_Locale$$setDefault(Class<?> callerClass, Locale locale);
+
+    void check$java_util_Locale$$setDefault(Class<?> callerClass, Locale.Category category, Locale locale);
+
+    void check$java_util_TimeZone$$setDefault(Class<?> callerClass, TimeZone zone);
 
     void check$java_net_DatagramSocket$$setDatagramSocketImplFactory(Class<?> callerClass, DatagramSocketImplFactory fac);
 

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
@@ -123,6 +123,10 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
         entry("timeZoneNameProvider", alwaysDenied(RestEntitlementsCheckAction::timeZoneNameProvider$)),
         entry("logManager", alwaysDenied(RestEntitlementsCheckAction::logManager$)),
 
+        entry("locale_setDefault", alwaysDenied(WritePropertiesCheckActions::setDefaultLocale)),
+        entry("locale_setDefaultForCategory", alwaysDenied(WritePropertiesCheckActions::setDefaultLocaleForCategory)),
+        entry("timeZone_setDefault", alwaysDenied(WritePropertiesCheckActions::setDefaultTimeZone)),
+
         entry("system_setProperty", forPlugins(WritePropertiesCheckActions::setSystemProperty)),
         entry("system_clearProperty", forPlugins(WritePropertiesCheckActions::clearSystemProperty)),
         entry("system_setSystemProperties", alwaysDenied(WritePropertiesCheckActions::setSystemProperties)),

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/WritePropertiesCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/WritePropertiesCheckActions.java
@@ -11,6 +11,9 @@ package org.elasticsearch.entitlement.qa.test;
 
 import org.elasticsearch.core.SuppressForbidden;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 @SuppressForbidden(reason = "testing entitlements")
 class WritePropertiesCheckActions {
     private WritePropertiesCheckActions() {}
@@ -31,5 +34,17 @@ class WritePropertiesCheckActions {
 
     static void setSystemProperties() {
         System.setProperties(System.getProperties()); // no side effect in case if allowed (but shouldn't)
+    }
+
+    static void setDefaultLocale() {
+        Locale.setDefault(Locale.getDefault());
+    }
+
+    static void setDefaultLocaleForCategory() {
+        Locale.setDefault(Locale.Category.DISPLAY, Locale.getDefault(Locale.Category.DISPLAY));
+    }
+
+    static void setDefaultTimeZone() {
+        TimeZone.setDefault(TimeZone.getDefault());
     }
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -46,7 +46,9 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.security.cert.CertStoreParameters;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
+import java.util.TimeZone;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -289,6 +291,21 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     @Override
     public void check$java_util_logging_LogManager$(Class<?> callerClass) {
+        policyManager.checkChangeJVMGlobalState(callerClass);
+    }
+
+    @Override
+    public void check$java_util_Locale$$setDefault(Class<?> callerClass, Locale.Category category, Locale locale) {
+        policyManager.checkChangeJVMGlobalState(callerClass);
+    }
+
+    @Override
+    public void check$java_util_Locale$$setDefault(Class<?> callerClass, Locale locale) {
+        policyManager.checkChangeJVMGlobalState(callerClass);
+    }
+
+    @Override
+    public void check$java_util_TimeZone$$setDefault(Class<?> callerClass, TimeZone zone) {
         policyManager.checkChangeJVMGlobalState(callerClass);
     }
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [Entitlements] Deny setting global defaults for Locale / TimeZone (#120804)