### PR TITLE
[8.17] Update index-templates.asciidoc (#113461)

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -44,6 +44,7 @@ following index patterns:
 - `metrics-*-*`
 - `synthetics-*-*`
 - `profiling-*`
+- `security_solution-*-*`
 // end::built-in-index-template-patterns[]
 
 {fleet-guide}/fleet-overview.html[{agent}] uses these templates to create


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Update index-templates.asciidoc (#113461)](https://github.com/elastic/elasticsearch/pull/113461)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)