### PR TITLE
ESQL: Make all LOOKUP JOIN capabilities depend on the V12 one

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -696,7 +696,7 @@ public class EsqlCapabilities {
         /**
          * LOOKUP JOIN with TEXT fields on the right (right side of the join) (#119473)
          */
-        LOOKUP_JOIN_TEXT(Build.current().isSnapshot()),
+        LOOKUP_JOIN_TEXT(JOIN_LOOKUP_V12.isEnabled()),
 
         /**
          * LOOKUP JOIN without MV matching (https://github.com/elastic/elasticsearch/issues/118780)


### PR DESCRIPTION
We require additional capabilities to disable tests for LOOKUP JOIN on release builds, and to correctly enable only those bwc tests whose setup can work based on which version comes with what capability.

The capabilities are generally disabled on snapshots. Enabling related tests on snapshots normally requires updating the capability.

However, capabilities can also be made to depend on one another; we already do that for `JOIN_LOOKUP_SKIP_MV` which depends on `JOIN_LOOKUP_V12`, but not for `LOOKUP_JOIN_TEXT`.

Let's make the latter two consistent by always depending on `JOIN_LOOKUP_V12` - this way, we only have to enable the latter on release builds to enable all tests for `LOOKUP JOIN`, and will be less likely to forget to enable some tests.