### PR TITLE
Revert "Revert "Remove deprecated tracing.apm.* settings for v9""

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
@@ -187,20 +187,12 @@ class APMJvmOptions {
     static void extractSecureSettings(SecureSettings secrets, Map<String, String> propertiesMap) {
         final Set<String> settingNames = secrets.getSettingNames();
         for (String key : List.of("api_key", "secret_token")) {
-            for (String prefix : List.of("telemetry.", "tracing.apm.")) {
-                if (settingNames.contains(prefix + key)) {
-                    if (propertiesMap.containsKey(key)) {
-                        throw new IllegalStateException(
-                            Strings.format("Duplicate telemetry setting: [telemetry.%s] and [tracing.apm.%s]", key, key)
-                        );
-                    }
-
-                    try (SecureString token = secrets.getString(prefix + key)) {
-                        propertiesMap.put(key, token.toString());
-                    }
+            String prefix = "telemetry.";
+            if (settingNames.contains(prefix + key)) {
+                try (SecureString token = secrets.getString(prefix + key)) {
+                    propertiesMap.put(key, token.toString());
                 }
             }
-
         }
     }
 
@@ -227,44 +219,12 @@ class APMJvmOptions {
     static Map<String, String> extractApmSettings(Settings settings) throws UserException {
         final Map<String, String> propertiesMap = new HashMap<>();
 
-        // tracing.apm.agent. is deprecated by telemetry.agent.
         final String telemetryAgentPrefix = "telemetry.agent.";
-        final String deprecatedTelemetryAgentPrefix = "tracing.apm.agent.";
 
         final Settings telemetryAgentSettings = settings.getByPrefix(telemetryAgentPrefix);
         telemetryAgentSettings.keySet().forEach(key -> propertiesMap.put(key, String.valueOf(telemetryAgentSettings.get(key))));
 
-        final Settings apmAgentSettings = settings.getByPrefix(deprecatedTelemetryAgentPrefix);
-        for (String key : apmAgentSettings.keySet()) {
-            if (propertiesMap.containsKey(key)) {
-                throw new IllegalStateException(
-                    Strings.format(
-                        "Duplicate telemetry setting: [%s%s] and [%s%s]",
-                        telemetryAgentPrefix,
-                        key,
-                        deprecatedTelemetryAgentPrefix,
-                        key
-                    )
-                );
-            }
-            propertiesMap.put(key, String.valueOf(apmAgentSettings.get(key)));
-        }
-
         StringJoiner globalLabels = extractGlobalLabels(telemetryAgentPrefix, propertiesMap, settings);
-        if (globalLabels.length() == 0) {
-            globalLabels = extractGlobalLabels(deprecatedTelemetryAgentPrefix, propertiesMap, settings);
-        } else {
-            StringJoiner tracingGlobalLabels = extractGlobalLabels(deprecatedTelemetryAgentPrefix, propertiesMap, settings);
-            if (tracingGlobalLabels.length() != 0) {
-                throw new IllegalArgumentException(
-                    "Cannot have global labels with tracing.agent prefix ["
-                        + globalLabels
-                        + "] and telemetry.apm.agent prefix ["
-                        + tracingGlobalLabels
-                        + "]"
-                );
-            }
-        }
         if (globalLabels.length() > 0) {
             propertiesMap.put("global_labels", globalLabels.toString());
         }
@@ -274,7 +234,7 @@ class APMJvmOptions {
             if (propertiesMap.containsKey(key)) {
                 throw new UserException(
                     ExitCodes.CONFIG,
-                    "Do not set a value for [tracing.apm.agent." + key + "], as this is configured automatically by Elasticsearch"
+                    "Do not set a value for [telemetry.agent." + key + "], as this is configured automatically by Elasticsearch"
                 );
             }
         }

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/APMJvmOptionsTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/APMJvmOptionsTests.java
@@ -25,18 +25,15 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.elasticsearch.test.MapMatcher.matchesMap;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -82,109 +79,63 @@ public class APMJvmOptionsTests extends ESTestCase {
     }
 
     public void testExtractSecureSettings() {
-        MockSecureSettings duplicateSecureSettings = new MockSecureSettings();
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString("telemetry.secret_token", "token");
+        secureSettings.setString("telemetry.api_key", "key");
 
-        for (String prefix : List.of("telemetry.", "tracing.apm.")) {
-            MockSecureSettings secureSettings = new MockSecureSettings();
-            secureSettings.setString(prefix + "secret_token", "token");
-            secureSettings.setString(prefix + "api_key", "key");
+        Map<String, String> propertiesMap = new HashMap<>();
+        APMJvmOptions.extractSecureSettings(secureSettings, propertiesMap);
 
-            duplicateSecureSettings.setString(prefix + "api_key", "secret");
-
-            Map<String, String> propertiesMap = new HashMap<>();
-            APMJvmOptions.extractSecureSettings(secureSettings, propertiesMap);
-
-            assertThat(propertiesMap, matchesMap(Map.of("secret_token", "token", "api_key", "key")));
-        }
-
-        Exception exception = expectThrows(
-            IllegalStateException.class,
-            () -> APMJvmOptions.extractSecureSettings(duplicateSecureSettings, new HashMap<>())
-        );
-        assertThat(exception.getMessage(), containsString("Duplicate telemetry setting"));
-        assertThat(exception.getMessage(), containsString("telemetry.api_key"));
-        assertThat(exception.getMessage(), containsString("tracing.apm.api_key"));
-
+        assertThat(propertiesMap, matchesMap(Map.of("secret_token", "token", "api_key", "key")));
     }
 
     public void testExtractSettings() throws UserException {
-        Function<String, Settings.Builder> buildSettings = (prefix) -> Settings.builder()
-            .put(prefix + "server_url", "https://myurl:443")
-            .put(prefix + "service_node_name", "instance-0000000001");
-
-        for (String prefix : List.of("tracing.apm.agent.", "telemetry.agent.")) {
-            var name = "APM Tracing";
-            var deploy = "123";
-            var org = "456";
-            var extracted = APMJvmOptions.extractApmSettings(
-                buildSettings.apply(prefix)
-                    .put(prefix + "global_labels.deployment_name", name)
-                    .put(prefix + "global_labels.deployment_id", deploy)
-                    .put(prefix + "global_labels.organization_id", org)
-                    .build()
-            );
-
-            assertThat(
-                extracted,
-                allOf(
-                    hasEntry("server_url", "https://myurl:443"),
-                    hasEntry("service_node_name", "instance-0000000001"),
-                    hasEntry(equalTo("global_labels"), not(endsWith(","))), // test that we have collapsed all global labels into one
-                    not(hasKey("global_labels.organization_id")) // tests that we strip out the top level label keys
-                )
-            );
-
-            List<String> labels = Arrays.stream(extracted.get("global_labels").split(",")).toList();
-            assertThat(labels, hasSize(3));
-            assertThat(labels, containsInAnyOrder("deployment_name=APM Tracing", "organization_id=" + org, "deployment_id=" + deploy));
-
-            // test replacing with underscores and skipping empty
-            name = "APM=Tracing";
-            deploy = "";
-            org = ",456";
-            extracted = APMJvmOptions.extractApmSettings(
-                buildSettings.apply(prefix)
-                    .put(prefix + "global_labels.deployment_name", name)
-                    .put(prefix + "global_labels.deployment_id", deploy)
-                    .put(prefix + "global_labels.organization_id", org)
-                    .build()
-            );
-            labels = Arrays.stream(extracted.get("global_labels").split(",")).toList();
-            assertThat(labels, hasSize(2));
-            assertThat(labels, containsInAnyOrder("deployment_name=APM_Tracing", "organization_id=_456"));
-        }
-
-        IllegalStateException err = expectThrows(
-            IllegalStateException.class,
-            () -> APMJvmOptions.extractApmSettings(
-                Settings.builder()
-                    .put("tracing.apm.agent.server_url", "https://myurl:443")
-                    .put("telemetry.agent.server_url", "https://myurl-2:443")
-                    .build()
-            )
-        );
-        assertThat(err.getMessage(), is("Duplicate telemetry setting: [telemetry.agent.server_url] and [tracing.apm.agent.server_url]"));
-    }
-
-    public void testNoMixedLabels() {
-        String telemetryAgent = "telemetry.agent.";
-        String tracingAgent = "tracing.apm.agent.";
-        Settings settings = Settings.builder()
-            .put("tracing.apm.enabled", true)
-            .put(telemetryAgent + "server_url", "https://myurl:443")
-            .put(telemetryAgent + "service_node_name", "instance-0000000001")
-            .put(tracingAgent + "global_labels.deployment_id", "123")
-            .put(telemetryAgent + "global_labels.organization_id", "456")
+        Settings defaults = Settings.builder()
+            .put("telemetry.agent.server_url", "https://myurl:443")
+            .put("telemetry.agent.service_node_name", "instance-0000000001")
             .build();
 
-        IllegalArgumentException err = assertThrows(IllegalArgumentException.class, () -> APMJvmOptions.extractApmSettings(settings));
+        var name = "APM Tracing";
+        var deploy = "123";
+        var org = "456";
+        var extracted = APMJvmOptions.extractApmSettings(
+            Settings.builder()
+                .put(defaults)
+                .put("telemetry.agent.global_labels.deployment_name", name)
+                .put("telemetry.agent.global_labels.deployment_id", deploy)
+                .put("telemetry.agent.global_labels.organization_id", org)
+                .build()
+        );
+
         assertThat(
-            err.getMessage(),
-            is(
-                "Cannot have global labels with tracing.agent prefix [organization_id=456] and"
-                    + " telemetry.apm.agent prefix [deployment_id=123]"
+            extracted,
+            allOf(
+                hasEntry("server_url", "https://myurl:443"),
+                hasEntry("service_node_name", "instance-0000000001"),
+                hasEntry(equalTo("global_labels"), not(endsWith(","))), // test that we have collapsed all global labels into one
+                not(hasKey("global_labels.organization_id")) // tests that we strip out the top level label keys
             )
         );
+
+        List<String> labels = Arrays.stream(extracted.get("global_labels").split(",")).toList();
+        assertThat(labels, hasSize(3));
+        assertThat(labels, containsInAnyOrder("deployment_name=APM Tracing", "organization_id=" + org, "deployment_id=" + deploy));
+
+        // test replacing with underscores and skipping empty
+        name = "APM=Tracing";
+        deploy = "";
+        org = ",456";
+        extracted = APMJvmOptions.extractApmSettings(
+            Settings.builder()
+                .put(defaults)
+                .put("telemetry.agent.global_labels.deployment_name", name)
+                .put("telemetry.agent.global_labels.deployment_id", deploy)
+                .put("telemetry.agent.global_labels.organization_id", org)
+                .build()
+        );
+        labels = Arrays.stream(extracted.get("global_labels").split(",")).toList();
+        assertThat(labels, hasSize(2));
+        assertThat(labels, containsInAnyOrder("deployment_name=APM_Tracing", "organization_id=_456"));
     }
 
     private Path makeFakeAgentJar() throws IOException {

--- a/docs/changelog/119926.yaml
+++ b/docs/changelog/119926.yaml
@@ -1,0 +1,11 @@
+pr: 119926
+summary: "Deprecated tracing.apm.* settings got removed."
+area: Infra/Metrics
+type: breaking
+issues: []
+breaking:
+  title: "Deprecated tracing.apm.* settings got removed."
+  area: Cluster and node setting
+  details: Deprecated `tracing.apm.*` settings got removed, use respective `telemetry.*` / `telemetry.tracing.*` settings instead.
+  impact: 9.x nodes will refuse to start if any such setting (including secret settings) is still present.
+  notable: false

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
@@ -92,14 +92,7 @@ public class APM extends Plugin implements NetworkPlugin, TelemetryPlugin {
             APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING,
             APMAgentSettings.TELEMETRY_TRACING_NAMES_INCLUDE_SETTING,
             APMAgentSettings.TELEMETRY_TRACING_NAMES_EXCLUDE_SETTING,
-            APMAgentSettings.TELEMETRY_TRACING_SANITIZE_FIELD_NAMES,
-            // The settings below are deprecated and are currently kept as fallback.
-            APMAgentSettings.TRACING_APM_SECRET_TOKEN_SETTING,
-            APMAgentSettings.TRACING_APM_API_KEY_SETTING,
-            APMAgentSettings.TRACING_APM_ENABLED_SETTING,
-            APMAgentSettings.TRACING_APM_NAMES_INCLUDE_SETTING,
-            APMAgentSettings.TRACING_APM_NAMES_EXCLUDE_SETTING,
-            APMAgentSettings.TRACING_APM_SANITIZE_FIELD_NAMES
+            APMAgentSettings.TELEMETRY_TRACING_SANITIZE_FIELD_NAMES
         );
     }
 }

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
@@ -25,9 +25,7 @@ import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 
-import static org.elasticsearch.common.settings.Setting.Property.Deprecated;
 import static org.elasticsearch.common.settings.Setting.Property.NodeScope;
 import static org.elasticsearch.common.settings.Setting.Property.OperatorDynamic;
 
@@ -109,9 +107,6 @@ public class APMAgentSettings {
     }
 
     private static final String TELEMETRY_SETTING_PREFIX = "telemetry.";
-
-    // The old legacy prefix
-    private static final String LEGACY_TRACING_APM_SETTING_PREFIX = "tracing.apm.";
 
     /**
      * Allow-list of APM agent config keys users are permitted to configure.
@@ -259,56 +254,24 @@ public class APMAgentSettings {
 
     public static final Setting.AffixSetting<String> APM_AGENT_SETTINGS = Setting.prefixKeySetting(
         TELEMETRY_SETTING_PREFIX + "agent.",
-        LEGACY_TRACING_APM_SETTING_PREFIX + "agent.",
-        (namespace, qualifiedKey) -> qualifiedKey.startsWith(LEGACY_TRACING_APM_SETTING_PREFIX)
-            ? concreteAgentSetting(namespace, qualifiedKey, NodeScope, OperatorDynamic, Deprecated)
-            : concreteAgentSetting(namespace, qualifiedKey, NodeScope, OperatorDynamic)
+        null, // no fallback
+        (namespace, qualifiedKey) -> concreteAgentSetting(namespace, qualifiedKey, NodeScope, OperatorDynamic)
     );
 
-    /**
-     * @deprecated in favor of TELEMETRY_TRACING_NAMES_INCLUDE_SETTING.
-     */
-    @Deprecated
-    public static final Setting<List<String>> TRACING_APM_NAMES_INCLUDE_SETTING = Setting.stringListSetting(
-        LEGACY_TRACING_APM_SETTING_PREFIX + "names.include",
-        OperatorDynamic,
-        NodeScope,
-        Deprecated
-    );
-
-    public static final Setting<List<String>> TELEMETRY_TRACING_NAMES_INCLUDE_SETTING = Setting.listSetting(
+    public static final Setting<List<String>> TELEMETRY_TRACING_NAMES_INCLUDE_SETTING = Setting.stringListSetting(
         TELEMETRY_SETTING_PREFIX + "tracing.names.include",
-        TRACING_APM_NAMES_INCLUDE_SETTING,
-        Function.identity(),
         OperatorDynamic,
         NodeScope
     );
 
-    /**
-     * @deprecated in favor of TELEMETRY_TRACING_NAMES_EXCLUDE_SETTING.
-     */
-    @Deprecated
-    public static final Setting<List<String>> TRACING_APM_NAMES_EXCLUDE_SETTING = Setting.stringListSetting(
-        LEGACY_TRACING_APM_SETTING_PREFIX + "names.exclude",
-        OperatorDynamic,
-        NodeScope,
-        Deprecated
-    );
-
-    public static final Setting<List<String>> TELEMETRY_TRACING_NAMES_EXCLUDE_SETTING = Setting.listSetting(
+    public static final Setting<List<String>> TELEMETRY_TRACING_NAMES_EXCLUDE_SETTING = Setting.stringListSetting(
         TELEMETRY_SETTING_PREFIX + "tracing.names.exclude",
-        TRACING_APM_NAMES_EXCLUDE_SETTING,
-        Function.identity(),
         OperatorDynamic,
         NodeScope
     );
 
-    /**
-     * @deprecated in favor of TELEMETRY_TRACING_SANITIZE_FIELD_NAMES.
-     */
-    @Deprecated
-    public static final Setting<List<String>> TRACING_APM_SANITIZE_FIELD_NAMES = Setting.stringListSetting(
-        LEGACY_TRACING_APM_SETTING_PREFIX + "sanitize_field_names",
+    public static final Setting<List<String>> TELEMETRY_TRACING_SANITIZE_FIELD_NAMES = Setting.stringListSetting(
+        TELEMETRY_SETTING_PREFIX + "tracing.sanitize_field_names",
         List.of(
             "password",
             "passwd",
@@ -324,33 +287,12 @@ public class APMAgentSettings {
             "set-cookie"
         ),
         OperatorDynamic,
-        NodeScope,
-        Deprecated
-    );
-
-    public static final Setting<List<String>> TELEMETRY_TRACING_SANITIZE_FIELD_NAMES = Setting.listSetting(
-        TELEMETRY_SETTING_PREFIX + "tracing.sanitize_field_names",
-        TRACING_APM_SANITIZE_FIELD_NAMES,
-        Function.identity(),
-        OperatorDynamic,
         NodeScope
-    );
-
-    /**
-     * @deprecated in favor of TELEMETRY_TRACING_ENABLED_SETTING.
-     */
-    @Deprecated
-    public static final Setting<Boolean> TRACING_APM_ENABLED_SETTING = Setting.boolSetting(
-        LEGACY_TRACING_APM_SETTING_PREFIX + "enabled",
-        false,
-        OperatorDynamic,
-        NodeScope,
-        Deprecated
     );
 
     public static final Setting<Boolean> TELEMETRY_TRACING_ENABLED_SETTING = Setting.boolSetting(
         TELEMETRY_SETTING_PREFIX + "tracing.enabled",
-        TRACING_APM_ENABLED_SETTING,
+        false,
         OperatorDynamic,
         NodeScope
     );
@@ -362,33 +304,13 @@ public class APMAgentSettings {
         NodeScope
     );
 
-    /**
-     * @deprecated in favor of TELEMETRY_SECRET_TOKEN_SETTING.
-     */
-    @Deprecated
-    public static final Setting<SecureString> TRACING_APM_SECRET_TOKEN_SETTING = SecureSetting.secureString(
-        LEGACY_TRACING_APM_SETTING_PREFIX + "secret_token",
-        null,
-        Deprecated
-    );
-
     public static final Setting<SecureString> TELEMETRY_SECRET_TOKEN_SETTING = SecureSetting.secureString(
         TELEMETRY_SETTING_PREFIX + "secret_token",
-        TRACING_APM_SECRET_TOKEN_SETTING
-    );
-
-    /**
-     * @deprecated in favor of TELEMETRY_API_KEY_SETTING.
-     */
-    @Deprecated
-    public static final Setting<SecureString> TRACING_APM_API_KEY_SETTING = SecureSetting.secureString(
-        LEGACY_TRACING_APM_SETTING_PREFIX + "api_key",
-        null,
-        Deprecated
+        null
     );
 
     public static final Setting<SecureString> TELEMETRY_API_KEY_SETTING = SecureSetting.secureString(
         TELEMETRY_SETTING_PREFIX + "api_key",
-        TRACING_APM_API_KEY_SETTING
+        null
     );
 }

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettingsTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettingsTests.java
@@ -11,8 +11,6 @@ package org.elasticsearch.telemetry.apm.internal;
 
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.MockSecureSettings;
-import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.mockito.Mockito;
@@ -21,21 +19,13 @@ import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.APM_AGENT_SETTINGS;
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TELEMETRY_API_KEY_SETTING;
 import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TELEMETRY_METRICS_ENABLED_SETTING;
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TELEMETRY_SECRET_TOKEN_SETTING;
 import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING;
 import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TELEMETRY_TRACING_NAMES_EXCLUDE_SETTING;
 import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TELEMETRY_TRACING_NAMES_INCLUDE_SETTING;
 import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TELEMETRY_TRACING_SANITIZE_FIELD_NAMES;
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TRACING_APM_API_KEY_SETTING;
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TRACING_APM_ENABLED_SETTING;
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TRACING_APM_NAMES_EXCLUDE_SETTING;
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TRACING_APM_NAMES_INCLUDE_SETTING;
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TRACING_APM_SANITIZE_FIELD_NAMES;
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TRACING_APM_SECRET_TOKEN_SETTING;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
@@ -68,14 +58,6 @@ public class APMAgentSettingsTests extends ESTestCase {
             verify(apmAgentSettings).setAgentSetting("recording", "true");
             verify(apmTelemetryProvider.getTracer()).setEnabled(true);
         }
-    }
-
-    public void testEnableTracingUsingLegacySetting() {
-        Settings settings = Settings.builder().put(TRACING_APM_ENABLED_SETTING.getKey(), true).build();
-        apmAgentSettings.initAgentSystemProperties(settings);
-
-        verify(apmAgentSettings).setAgentSetting("recording", "true");
-        assertWarnings("[tracing.apm.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.");
     }
 
     public void testEnableMetrics() {
@@ -119,14 +101,6 @@ public class APMAgentSettingsTests extends ESTestCase {
             verify(apmAgentSettings).setAgentSetting("recording", Boolean.toString(metricsEnabled));
             verify(apmTelemetryProvider.getTracer()).setEnabled(false);
         }
-    }
-
-    public void testDisableTracingUsingLegacySetting() {
-        Settings settings = Settings.builder().put(TRACING_APM_ENABLED_SETTING.getKey(), false).build();
-        apmAgentSettings.initAgentSystemProperties(settings);
-
-        verify(apmAgentSettings).setAgentSetting("recording", "false");
-        assertWarnings("[tracing.apm.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.");
     }
 
     public void testDisableMetrics() {
@@ -181,97 +155,23 @@ public class APMAgentSettingsTests extends ESTestCase {
         verify(apmAgentSettings).setAgentSetting("span_compression_enabled", "true");
     }
 
-    public void testSetAgentsSettingsWithLegacyPrefix() {
-        Settings settings = Settings.builder()
-            .put(TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true)
-            .put("tracing.apm.agent.span_compression_enabled", "true")
-            .build();
-        apmAgentSettings.initAgentSystemProperties(settings);
-
-        verify(apmAgentSettings).setAgentSetting("recording", "true");
-        verify(apmAgentSettings).setAgentSetting("span_compression_enabled", "true");
-        assertWarnings(
-            "[tracing.apm.agent.span_compression_enabled] setting was deprecated in Elasticsearch and will be removed in a future release."
-        );
-    }
-
     /**
      * Check that invalid or forbidden APM agent settings are rejected.
      */
     public void testRejectForbiddenOrUnknownAgentSettings() {
-        List<String> prefixes = List.of(APM_AGENT_SETTINGS.getKey(), "tracing.apm.agent.");
-        for (String prefix : prefixes) {
-            Settings settings = Settings.builder().put(prefix + "unknown", "true").build();
-            Exception exception = expectThrows(IllegalArgumentException.class, () -> APM_AGENT_SETTINGS.getAsMap(settings));
-            assertThat(exception.getMessage(), containsString("[" + prefix + "unknown]"));
-        }
+        String prefix = APM_AGENT_SETTINGS.getKey();
+        Settings settings = Settings.builder().put(prefix + "unknown", "true").build();
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> APM_AGENT_SETTINGS.getAsMap(settings));
+        assertThat(exception.getMessage(), containsString("[" + prefix + "unknown]"));
+
         // though, accept / ignore nested global_labels
-        for (String prefix : prefixes) {
-            Settings settings = Settings.builder().put(prefix + "global_labels.abc", "123").build();
-            APMAgentSettings.APM_AGENT_SETTINGS.getAsMap(settings);
-
-            if (prefix.startsWith("tracing.apm.agent.")) {
-                assertWarnings(
-                    "[tracing.apm.agent.global_labels.abc] setting was deprecated in Elasticsearch and will be removed in a future release."
-                );
-            }
-        }
-    }
-
-    public void testTelemetryTracingNamesIncludeFallback() {
-        Settings settings = Settings.builder().put(TRACING_APM_NAMES_INCLUDE_SETTING.getKey(), "abc,xyz").build();
-
-        List<String> included = TELEMETRY_TRACING_NAMES_INCLUDE_SETTING.get(settings);
-
-        assertThat(included, containsInAnyOrder("abc", "xyz"));
-        assertWarnings("[tracing.apm.names.include] setting was deprecated in Elasticsearch and will be removed in a future release.");
-    }
-
-    public void testTelemetryTracingNamesExcludeFallback() {
-        Settings settings = Settings.builder().put(TRACING_APM_NAMES_EXCLUDE_SETTING.getKey(), "abc,xyz").build();
-
-        List<String> included = TELEMETRY_TRACING_NAMES_EXCLUDE_SETTING.get(settings);
-
-        assertThat(included, containsInAnyOrder("abc", "xyz"));
-        assertWarnings("[tracing.apm.names.exclude] setting was deprecated in Elasticsearch and will be removed in a future release.");
-    }
-
-    public void testTelemetryTracingSanitizeFieldNamesFallback() {
-        Settings settings = Settings.builder().put(TRACING_APM_SANITIZE_FIELD_NAMES.getKey(), "abc,xyz").build();
-
-        List<String> included = TELEMETRY_TRACING_SANITIZE_FIELD_NAMES.get(settings);
-
-        assertThat(included, containsInAnyOrder("abc", "xyz"));
-        assertWarnings(
-            "[tracing.apm.sanitize_field_names] setting was deprecated in Elasticsearch and will be removed in a future release."
-        );
+        var map = APMAgentSettings.APM_AGENT_SETTINGS.getAsMap(Settings.builder().put(prefix + "global_labels.abc", "123").build());
+        assertThat(map, hasEntry("global_labels.abc", "123"));
     }
 
     public void testTelemetryTracingSanitizeFieldNamesFallbackDefault() {
         List<String> included = TELEMETRY_TRACING_SANITIZE_FIELD_NAMES.get(Settings.EMPTY);
         assertThat(included, hasItem("password")); // and more defaults
-    }
-
-    public void testTelemetrySecretTokenFallback() {
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(TRACING_APM_SECRET_TOKEN_SETTING.getKey(), "verysecret");
-        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
-
-        try (SecureString secureString = TELEMETRY_SECRET_TOKEN_SETTING.get(settings)) {
-            assertEquals("verysecret", secureString.toString());
-        }
-        assertWarnings("[tracing.apm.secret_token] setting was deprecated in Elasticsearch and will be removed in a future release.");
-    }
-
-    public void testTelemetryApiKeyFallback() {
-        MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(TRACING_APM_API_KEY_SETTING.getKey(), "abc");
-        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
-
-        try (SecureString secureString = TELEMETRY_API_KEY_SETTING.get(settings)) {
-            assertEquals("abc", secureString.toString());
-        }
-        assertWarnings("[tracing.apm.api_key] setting was deprecated in Elasticsearch and will be removed in a future release.");
     }
 
     /**


### PR DESCRIPTION
Reverts elastic/elasticsearch#120268

Reverting the revert as `non-issue`, the deprecation change log entry was already created.

Relates to ES-10293