### PR TITLE
[ML] Unmute XPackRestIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -251,8 +251,6 @@ tests:
 - class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
   method: test {p0=data_stream/140_data_stream_aliases/Create data stream aliases using wildcard expression}
   issue: https://github.com/elastic/elasticsearch/issues/120890
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/120816
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -251,6 +251,9 @@ tests:
 - class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
   method: test {p0=data_stream/140_data_stream_aliases/Create data stream aliases using wildcard expression}
   issue: https://github.com/elastic/elasticsearch/issues/120890
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=ml/inference_crud/*}
+  issue: https://github.com/elastic/elasticsearch/issues/120816
 
 # Examples:
 #

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/inference_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/inference_crud.yml
@@ -2,7 +2,6 @@ setup:
   - skip:
       features:
         - headers
-      awaits_fix: "https://github.com/elastic/elasticsearch/issues/120816"
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/inference_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/inference_crud.yml
@@ -2,6 +2,7 @@ setup:
   - skip:
       features:
         - headers
+      awaits_fix: "https://github.com/elastic/elasticsearch/issues/120816"
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser


### PR DESCRIPTION
Mute failing inference_crud yml tests and unmute the rest of XPackRestIT

For https://github.com/elastic/elasticsearch/issues/120816