### PR TITLE
Fix RequestIndexFilteringIT::testIndicesDontExist

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -245,9 +245,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/120810
 - class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
   issue: https://github.com/elastic/elasticsearch/issues/116126
-- class: org.elasticsearch.xpack.esql.ccq.RequestIndexFilteringIT
-  method: testIndicesDontExist
-  issue: https://github.com/elastic/elasticsearch/issues/120889
 - class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
   method: test {p0=data_stream/140_data_stream_aliases/Create data stream aliases using wildcard expression}
   issue: https://github.com/elastic/elasticsearch/issues/120890

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RequestIndexFilteringTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RequestIndexFilteringTestCase.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.esql.AssertWarnings;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
@@ -212,13 +213,18 @@ public abstract class RequestIndexFilteringTestCase extends ESRestTestCase {
         assertThat(e.getMessage(), anyOf(containsString("no such index [foo]"), containsString("no such index [remote_cluster:foo]")));
 
         if (EsqlCapabilities.Cap.JOIN_LOOKUP_V12.isEnabled()) {
+            var pattern = from("test1");
             e = expectThrows(
                 ResponseException.class,
-                () -> runEsql(timestampFilter("gte", "2020-01-01").query(from("test1") + " | LOOKUP JOIN foo ON id1"))
+                () -> runEsql(timestampFilter("gte", "2020-01-01").query(pattern + " | LOOKUP JOIN foo ON id1"))
             );
             assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
-            assertThat(e.getMessage(), containsString("verification_exception"));
-            assertThat(e.getMessage(), containsString("Unknown index [foo]"));
+            assertThat(
+                e.getMessage(),
+                RemoteClusterAware.isRemoteIndexName(pattern)
+                    ? allOf(containsString("parsing_exception"), containsString("remote clusters are not supported in LOOKUP JOIN"))
+                    : allOf(containsString("verification_exception"), containsString("Unknown index [foo]"))
+            );
         }
     }
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RequestIndexFilteringTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RequestIndexFilteringTestCase.java
@@ -221,6 +221,8 @@ public abstract class RequestIndexFilteringTestCase extends ESRestTestCase {
             assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
             assertThat(
                 e.getMessage(),
+                // currently we don't support remote clusters in LOOKUP JOIN
+                // this check happens before resolving actual indices and results in a different error message
                 RemoteClusterAware.isRemoteIndexName(pattern)
                     ? allOf(containsString("parsing_exception"), containsString("remote clusters are not supported in LOOKUP JOIN"))
                     : allOf(containsString("verification_exception"), containsString("Unknown index [foo]"))


### PR DESCRIPTION
Remote cluster was randomly picked by the test. The failure was happening as now we emit a different error when attempting a join with a remote cluster.

Closes: #120889