### PR TITLE
[Bug] Data stream stats fails when there is a concrete index in the cluster

### DIFF
--- a/docs/changelog/120901.yaml
+++ b/docs/changelog/120901.yaml
@@ -1,5 +1,0 @@
-pr: 120901
-summary: "Fix bug that caused data stream stats requests to fail when there was a concrete index in the cluster"
-area: Data streams
-type: bug
-issues: []

--- a/docs/changelog/120901.yaml
+++ b/docs/changelog/120901.yaml
@@ -1,0 +1,5 @@
+pr: 120901
+summary: "[Bug] Data stream stats fails when there is a concrete index in the cluster"
+area: Data streams
+type: bug
+issues: []

--- a/docs/changelog/120901.yaml
+++ b/docs/changelog/120901.yaml
@@ -1,5 +1,5 @@
 pr: 120901
-summary: "[Bug] Data stream stats fails when there is a concrete index in the cluster"
+summary: "Fix bug that caused data stream stats requests to fail when there was a concrete index in the cluster"
 area: Data streams
 type: bug
 issues: []

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/DataStreamsStatsTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/DataStreamsStatsTransportAction.java
@@ -133,6 +133,16 @@ public class DataStreamsStatsTransportAction extends TransportBroadcastByNodeAct
     }
 
     @Override
+    protected String[] resolveConcreteIndexNames(ClusterState clusterState, DataStreamsStatsAction.Request request) {
+        return DataStreamsActionUtil.resolveConcreteIndexNames(
+            indexNameExpressionResolver,
+            clusterState,
+            request.indices(),
+            request.indicesOptions()
+        ).toArray(String[]::new);
+    }
+
+    @Override
     protected DataStreamsStatsAction.DataStreamShardStats readShardResult(StreamInput in) throws IOException {
         return new DataStreamsStatsAction.DataStreamShardStats(in);
     }


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/120114 introduced a bug in the way `GET _data_stream/stats` resolved the shards of backing and failure indices.

**Bug behaviour**
When there is an index int he cluster state, the `GET _data_stream/stats` returns a 500 with an NPE.

In this PR, we add a test that reproduces that bug and we fix it. 
