### PR TITLE
ESQL: Fix DateExtract with nanos tests

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_nanos.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_nanos.csv-spec
@@ -506,7 +506,8 @@ required_capability: date_nanos_date_extract
 FROM date_nanos
 | EVAL nn = MV_MAX(nanos)
 | EVAL year = DATE_EXTRACT("year", nn), ns = DATE_EXTRACT("nano_of_second", nn)
-| KEEP nn, year, ns;
+| KEEP nn, year, ns
+| SORT nn DESC;
 
 nn:date_nanos                  | year:long | ns:long
 2023-10-23T13:55:01.543123456Z | 2023      | 543123456

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtract.java
@@ -114,8 +114,8 @@ public class DateExtract extends EsqlConfigurationFunction {
     @Override
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         boolean isNanos = switch (field().dataType()) {
-            case DataType.DATETIME -> false;
-            case DataType.DATE_NANOS -> true;
+            case DATETIME -> false;
+            case DATE_NANOS -> true;
             default -> throw new UnsupportedOperationException(
                 "Unsupported field type ["
                     + field().dataType().name()


### PR DESCRIPTION
Fix switch failing in 8.x: https://buildkite.com/elastic/elasticsearch-pull-request/builds/52921#0194a834-0080-4d4e-906e-2bafbfd8aba8

Fix tests failing in main because of order: https://gradle-enterprise.elastic.co/s/pfbdstwc4qa4o/tests/overview?outcome=FAILED