### PR TITLE
Incorrect `false` value for default `ignore_malformed`

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -382,7 +382,7 @@ public final class DateFieldMapper extends FieldMapper {
             if (ft.name().equals(DataStreamTimestampFieldMapper.DEFAULT_PATH)
                 && context.isDataStream()
                 && ignoreMalformed.isConfigured() == false) {
-                ignoreMalformed.setValue(false);
+                ignoreMalformed.setValue(ignoreMalformed.getDefaultValue());
             }
             hasScript = script.get() != null;
             onScriptError = onScriptErrorParam.get();


### PR DESCRIPTION
Here we fix an issue with the default value of `ignore_malformed`. The value is set to `false`
assuming that `false` is the default value. PR #113072 changes the default value of `ignore_malformed`
depending on the index mode so to make sure that it is `true` when LogsDB is used.
As a result, we need to pick the right value for the default instead of setting it explicitly to `false`.
