### PR TITLE
[8.17] backporting support for deprecated window_size param for rank rrf

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
@@ -42,6 +42,8 @@ public final class SearchCapabilities {
     private static final String MOVING_FN_RIGHT_MATH = "moving_fn_right_math";
 
     private static final String RANDOM_SAMPLER_WITH_SCORED_SUBAGGS = "random_sampler_with_scored_subaggs";
+    /** Support deprecated window_size field in rank. */
+    private static final String RRF_WINDOW_SIZE_SUPPORT_DEPRECATED = "rrf_window_size_support_deprecated";
 
     public static final Set<String> CAPABILITIES;
     static {
@@ -60,6 +62,7 @@ public final class SearchCapabilities {
         if (Build.current().isSnapshot()) {
             capabilities.add(KQL_QUERY_SUPPORTED);
         }
+        capabilities.add(RRF_WINDOW_SIZE_SUPPORT_DEPRECATED);
         CAPABILITIES = Set.copyOf(capabilities);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/rank/RankBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/RankBuilder.java
@@ -35,7 +35,7 @@ import java.util.Objects;
  */
 public abstract class RankBuilder implements VersionedNamedWriteable, ToXContentObject {
 
-    public static final ParseField RANK_WINDOW_SIZE_FIELD = new ParseField("rank_window_size");
+    public static final ParseField RANK_WINDOW_SIZE_FIELD = new ParseField("rank_window_size", "window_size");
 
     public static final int DEFAULT_RANK_WINDOW_SIZE = SearchService.DEFAULT_SIZE;
 

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/100_rank_rrf.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/100_rank_rrf.yml
@@ -101,6 +101,42 @@ setup:
   - match: { hits.hits.2.fields.keyword.0: "other" }
 
 ---
+"Simple rank with old window_size param":
+
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ rrf_window_size_support_deprecated ]
+      test_runner_features: capabilities
+      reason: "add deprecated field [window_size] back to support upgrade"
+  - do:
+      warnings:
+        - "Deprecated field [rank] used, replaced by [retriever]"
+        - "Deprecated field [window_size] used, expected [rank_window_size] instead"
+      search:
+        index: test
+        body:
+          track_total_hits: false
+          fields: [ "keyword" ]
+          knn:
+            field: vector
+            query_vector: [ 0.0 ]
+            k: 3
+            num_candidates: 3
+          query:
+            term:
+              text: term
+          rank:
+            rrf:
+              window_size: 100
+              rank_constant: 1
+          size: 1
+
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.0.fields.keyword.0: "other" }
+
+---
 "Simple rank with multiple bm25 sub searches":
 
   - requires:


### PR DESCRIPTION
Backporting https://github.com/elastic/elasticsearch/pull/120690 to 8.17