### PR TITLE
[8.x] Use new semantic text format by default (#120813)

### DIFF
--- a/docs/changelog/120813.yaml
+++ b/docs/changelog/120813.yaml
@@ -1,0 +1,17 @@
+pr: 120813
+summary: Change Semantic Text To Act Like A Normal Text Field
+area: Search
+type: breaking
+issues: []
+breaking:
+  title: Change Semantic Text To Act Like A Normal Text Field
+  area: Search
+  details:
+    The previous semantic_text format used a complex subfield structure in _source to store the embeddings.
+    This complicated interactions/integrations with semantic_text fields and _source in general.
+    This new semantic_text format treats it as a normal text field, where the field's value in _source is the value assigned by the user.
+  impact:
+    Users who parsed the subfield structure of the previous semantic_text format in _source will need to update their parsing logic.
+    The new format does not directly expose the chunks and embeddings generated from the input text.
+    The new format will be applied to all new indices, any existing indices will continue to use the previous format.
+  notable: true

--- a/docs/changelog/120813.yaml
+++ b/docs/changelog/120813.yaml
@@ -5,7 +5,7 @@ type: breaking
 issues: []
 breaking:
   title: Change Semantic Text To Act Like A Normal Text Field
-  area: Search
+  area: Analysis
   details:
     The previous semantic_text format used a complex subfield structure in _source to store the embeddings.
     This complicated interactions/integrations with semantic_text fields and _source in general.

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
@@ -575,14 +575,14 @@
       nodes.stats: { metric: _all, level: "indices", human: true }
 
   - gte: { nodes.$node_id.indices.mappings.total_count: 28 }
-  - lte: { nodes.$node_id.indices.mappings.total_count: 29 }
+  - lte: { nodes.$node_id.indices.mappings.total_count: 30 }
   - gte: { nodes.$node_id.indices.mappings.total_estimated_overhead_in_bytes: 28672 }
-  - lte: { nodes.$node_id.indices.mappings.total_estimated_overhead_in_bytes: 29696 }
+  - lte: { nodes.$node_id.indices.mappings.total_estimated_overhead_in_bytes: 30720 }
   - match: { nodes.$node_id.indices.mappings.total_segments: 1 }
   - gte: { nodes.$node_id.indices.mappings.total_segment_fields: 28 }
-  - lte: { nodes.$node_id.indices.mappings.total_segment_fields: 29 }
+  - lte: { nodes.$node_id.indices.mappings.total_segment_fields: 30 }
   - gte: { nodes.$node_id.indices.mappings.average_fields_per_segment: 28 }
-  - lte: { nodes.$node_id.indices.mappings.average_fields_per_segment: 29 }
+  - lte: { nodes.$node_id.indices.mappings.average_fields_per_segment: 30 }
 
   - do:
       index:
@@ -595,14 +595,14 @@
       nodes.stats: { metric: _all, level: "indices", human: true }
 
   - gte: { nodes.$node_id.indices.mappings.total_count: 28 }
-  - lte: { nodes.$node_id.indices.mappings.total_count: 29 }
+  - lte: { nodes.$node_id.indices.mappings.total_count: 30 }
   - gte: { nodes.$node_id.indices.mappings.total_estimated_overhead_in_bytes: 28672 }
-  - lte: { nodes.$node_id.indices.mappings.total_estimated_overhead_in_bytes: 29696 }
+  - lte: { nodes.$node_id.indices.mappings.total_estimated_overhead_in_bytes: 30720 }
   - match: { nodes.$node_id.indices.mappings.total_segments: 2 }
   - gte: { nodes.$node_id.indices.mappings.total_segment_fields: 56 }
-  - lte: { nodes.$node_id.indices.mappings.total_segment_fields: 58 }
+  - lte: { nodes.$node_id.indices.mappings.total_segment_fields: 60 }
   - gte: { nodes.$node_id.indices.mappings.average_fields_per_segment: 28 }
-  - lte: { nodes.$node_id.indices.mappings.average_fields_per_segment: 29 }
+  - lte: { nodes.$node_id.indices.mappings.average_fields_per_segment: 30 }
 ---
 
 "indices mappings does not exist in shards level":

--- a/server/src/main/java/org/elasticsearch/index/mapper/InferenceMetadataFieldsMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/InferenceMetadataFieldsMapper.java
@@ -35,8 +35,7 @@ public abstract class InferenceMetadataFieldsMapper extends MetadataFieldMapper 
      */
     public static final Setting<Boolean> USE_LEGACY_SEMANTIC_TEXT_FORMAT = Setting.boolSetting(
         "index.mapping.semantic_text.use_legacy_format",
-        // don't use the new format by default yet
-        true,
+        false,
         Setting.Property.Final,
         Setting.Property.IndexScope,
         Setting.Property.InternalIndex

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -51,7 +51,8 @@ public class InferenceFeatures implements FeatureSpecification {
             SEMANTIC_SPARSE_VECTOR_QUERY_REWRITE_INTERCEPTION_SUPPORTED,
             SemanticInferenceMetadataFieldsMapper.EXPLICIT_NULL_FIXES,
             SEMANTIC_KNN_VECTOR_QUERY_REWRITE_INTERCEPTION_SUPPORTED,
-            TextSimilarityRankRetrieverBuilder.TEXT_SIMILARITY_RERANKER_ALIAS_HANDLING_FIX
+            TextSimilarityRankRetrieverBuilder.TEXT_SIMILARITY_RERANKER_ALIAS_HANDLING_FIX,
+            SemanticInferenceMetadataFieldsMapper.INFERENCE_METADATA_FIELDS_ENABLED_BY_DEFAULT
         );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapper.java
@@ -40,6 +40,9 @@ public class SemanticInferenceMetadataFieldsMapper extends InferenceMetadataFiel
     private static final SemanticInferenceMetadataFieldsMapper INSTANCE = new SemanticInferenceMetadataFieldsMapper();
 
     public static final NodeFeature EXPLICIT_NULL_FIXES = new NodeFeature("semantic_text.inference_metadata_fields.explicit_null_fixes");
+    public static final NodeFeature INFERENCE_METADATA_FIELDS_ENABLED_BY_DEFAULT = new NodeFeature(
+        "semantic_text.inference_metadata_fields.enabled_by_default"
+    );
 
     public static final TypeParser PARSER = new FixedTypeParser(
         c -> InferenceMetadataFieldsMapper.isEnabled(c.getSettings()) ? INSTANCE : null

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/30_semantic_text_inference.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/30_semantic_text_inference.yml
@@ -957,3 +957,51 @@ setup:
   - length: { hits.hits.1.highlight.field: 2 }
   - match:  { hits.hits.1.highlight.field.0: "some more <em>tests</em>" }
   - match:  { hits.hits.1.highlight.field.1: "that include <em>chunks</em>" }
+
+---
+"Inference metadata fields format is used by default":
+  - requires:
+      cluster_features: "semantic_text.inference_metadata_fields.enabled_by_default"
+      reason: Inference metadata fields format is used by default as of 8.18
+
+  - do:
+      indices.create:
+        index: default-index
+        body:
+          mappings:
+            properties:
+              sparse_field:
+                type: semantic_text
+                inference_id: sparse-inference-id
+              dense_field:
+                type: semantic_text
+                inference_id: dense-inference-id
+              non_inference_field:
+                type: text
+
+  - do:
+      index:
+        index: default-index
+        id: doc_1
+        body:
+          sparse_field: "inference test"
+          dense_field: "another inference test"
+          non_inference_field: "non inference test"
+        refresh: true
+
+  - do:
+      search:
+        index: default-index
+        body:
+          query:
+            semantic:
+              field: sparse_field
+              query: "inference test"
+          fields: [ "_inference_fields" ]
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.total.relation: eq }
+  - match: { hits.hits.0._source.sparse_field: "inference test" }
+  - match: { hits.hits.0._source.dense_field: "another inference test" }
+  - match: { hits.hits.0._source.non_inference_field: "non inference test" }
+  - exists: hits.hits.0._source._inference_fields


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Use new semantic text format by default (#120813)](https://github.com/elastic/elasticsearch/pull/120813)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)