### PR TITLE
[8.x] [CI] Bump memory on PR part-4 agents

### DIFF
--- a/.buildkite/pipelines/pull-request/part-4-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-4-fips.yml
@@ -7,5 +7,5 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
-      machineType: custom-32-98304
+      machineType: n1-standard-32
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -7,5 +7,5 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
-      machineType: custom-32-98304
+      machineType: n1-standard-32
       buildDirectory: /dev/shm/bk


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [CI] Bump memory on PR part-4 agents (10d09a1d)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)