### PR TITLE
[8.x] Add a replicate_for option to the ILM searchable_snapshot action (#119003)

### DIFF
--- a/docs/changelog/119003.yaml
+++ b/docs/changelog/119003.yaml
@@ -1,0 +1,5 @@
+pr: 119003
+summary: Add a `replicate_for` option to the ILM `searchable_snapshot` action
+area: ILM+SLM
+type: enhancement
+issues: []

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -55,6 +55,13 @@ snapshot retention runs off the index lifecycle management (ILM) policies and is
 (Required, string)
 <<snapshots-register-repository,Repository>> used to store the snapshot.
 
+`replicate_for`::
+(Optional, TimeValue)
+By default, searchable snapshot indices are mounted without replicas. Using this will
+result in a searchable snapshot index being mounted with a single replica for the time period
+specified, after which the replica will be removed. This option is only permitted on the
+first searchable snapshot action of a policy.
+
 `force_merge_index`::
 (Optional, Boolean)
 Force merges the managed index to one segment.
@@ -109,3 +116,44 @@ PUT _ilm/policy/my_policy
   }
 }
 --------------------------------------------------
+
+[[ilm-searchable-snapshot-replicate-for-ex]]
+===== Mount a searchable snapshot with replicas for fourteen days
+
+This policy mounts a searchable snapshot in the hot phase with a
+single replica and maintains that replica for fourteen days. After
+that time has elapsed, the searchable snapshot index will remain (with
+no replicas) for another fourteen days, at which point it will proceed
+into the delete phase and will be deleted.
+
+[source,console]
+--------------------------------------------------
+PUT _ilm/policy/my_policy
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "actions": {
+          "rollover" : {
+            "max_primary_shard_size": "50gb"
+          },
+          "searchable_snapshot" : {
+            "snapshot_repository" : "backing_repo",
+            "replicate_for": "14d"
+          }
+        }
+      },
+      "delete": {
+        "min_age": "28d",
+        "actions": {
+          "delete" : { }
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+
+[NOTE]
+If the `replicate_for` option is specified, its value must be
+less than the minimum age of the next phase in the policy.

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -171,6 +171,7 @@ public class TransportVersions {
     public static final TransportVersion ADD_INCLUDE_FAILURE_INDICES_OPTION = def(8_831_00_0);
     public static final TransportVersion ESQL_RESPONSE_PARTIAL = def(8_832_00_0);
     public static final TransportVersion RANK_DOC_OPTIONAL_METADATA_FOR_EXPLAIN = def(8_833_00_0);
+    public static final TransportVersion ILM_ADD_SEARCHABLE_SNAPSHOT_ADD_REPLICATE_FOR = def(8_834_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
@@ -517,8 +517,8 @@ public class TimeseriesLifecycleType implements LifecycleType {
             }
         }
 
-        final var firstSearchableSnapshotPhase = searchableSnapshotActions.getFirst().v1();
-        final var firstSearchableSnapshotAction = searchableSnapshotActions.getFirst().v2();
+        final var firstSearchableSnapshotPhase = searchableSnapshotActions.get(0).v1();
+        final var firstSearchableSnapshotAction = searchableSnapshotActions.get(0).v2();
         // second validation rule: if the first searchable_snapshot action has a 'replicate_for', then the replication time
         // must be less than the next explicit min_age (if there is a min_age)
         final TimeValue firstReplicateFor = firstSearchableSnapshotAction.getReplicateFor();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilReplicateForTimePassesStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilReplicateForTimePassesStep.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ilm;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.xpack.core.ilm.step.info.EmptyInfo;
+import org.elasticsearch.xpack.core.ilm.step.info.SingleMessageFieldInfo;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * This {@link Step} waits until the `replicate_for` time of a searchable_snapshot action to pass.
+ * <p>
+ * It's an {@link AsyncWaitStep} rather than a {@link ClusterStateWaitStep} because we aren't guaranteed to
+ * receive a new cluster state in timely fashion when the waiting finishes -- by extending {@link AsyncWaitStep}
+ * we are guaranteed to check the condition on each ILM execution.
+ */
+public class WaitUntilReplicateForTimePassesStep extends AsyncWaitStep {
+
+    public static final String NAME = "check-replicate-for-time-passed";
+
+    private final TimeValue replicateFor;
+    private final Supplier<Instant> nowSupplier;
+
+    WaitUntilReplicateForTimePassesStep(StepKey key, StepKey nextStepKey, TimeValue replicateFor, Supplier<Instant> nowSupplier) {
+        super(key, nextStepKey, null);
+        this.replicateFor = replicateFor;
+        this.nowSupplier = nowSupplier;
+    }
+
+    WaitUntilReplicateForTimePassesStep(StepKey key, StepKey nextStepKey, TimeValue replicateFor) {
+        this(key, nextStepKey, replicateFor, Instant::now);
+    }
+
+    public TimeValue getReplicateFor() {
+        return this.replicateFor;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), this.replicateFor);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        WaitUntilReplicateForTimePassesStep other = (WaitUntilReplicateForTimePassesStep) obj;
+        return super.equals(obj) && Objects.equals(this.replicateFor, other.replicateFor);
+    }
+
+    @Override
+    public void evaluateCondition(Metadata metadata, Index index, Listener listener, TimeValue masterTimeout) {
+        IndexMetadata indexMetadata = metadata.index(index);
+        assert indexMetadata != null
+            : "the index metadata for index [" + index.getName() + "] must exist in the cluster state for step [" + NAME + "]";
+
+        final LifecycleExecutionState executionState = metadata.index(index.getName()).getLifecycleExecutionState();
+        assert executionState != null
+            : "the lifecycle execution state for index [" + index.getName() + "] must exist in the cluster state for step [" + NAME + "]";
+
+        if (replicateFor == null) {
+            // assert at dev-time, but treat this as a no-op at runtime if somehow this should happen (which it shouldn't)
+            assert false : "the replicate_for time value for index [" + index.getName() + "] must not be null for step [" + NAME + "]";
+            listener.onResponse(true, EmptyInfo.INSTANCE);
+            return;
+        }
+
+        final Instant endTime = Instant.ofEpochMilli(executionState.phaseTime() + this.replicateFor.millis());
+        final Instant nowTime = nowSupplier.get();
+        if (nowTime.isBefore(endTime)) {
+            final TimeValue remaining = TimeValue.timeValueMillis(endTime.toEpochMilli() - nowTime.toEpochMilli());
+            listener.onResponse(
+                false,
+                new SingleMessageFieldInfo(
+                    Strings.format(
+                        "Waiting [%s] until the replicate_for time [%s] has elapsed for index [%s] before removing replicas.",
+                        // note: we're sacrificing specificity for stability of string representation. if this string stays the same then
+                        // there isn't a cluster state change to update the string (since it is lazy) -- and we'd rather avoid unnecessary
+                        // cluster state changes. this approach gives us one cluster state change per day, which seems like a reasonable
+                        // balance between precision and efficiency.
+                        approximateTimeRemaining(remaining),
+                        this.replicateFor,
+                        index.getName()
+                    )
+                )
+            );
+            return;
+        }
+
+        listener.onResponse(true, EmptyInfo.INSTANCE);
+    }
+
+    private static final TimeValue TWENTY_FOUR_HOURS = TimeValue.timeValueHours(24);
+
+    /**
+     * Turns a {@link TimeValue} into a very approximate time value String.
+     *
+     * @param remaining the time remaining
+     * @return a String representing the approximate time remaining in days (e.g. "approximately 2d" OR "less than 1d")
+     */
+    // visible for testing
+    static String approximateTimeRemaining(TimeValue remaining) {
+        if (remaining.compareTo(TWENTY_FOUR_HOURS) >= 0) {
+            return "approximately " + Math.round(remaining.daysFrac()) + "d";
+        } else {
+            return "less than 1d";
+        }
+    }
+
+    @Override
+    public boolean isRetryable() {
+        return true;
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
@@ -220,7 +220,8 @@ public class LifecyclePolicyTests extends AbstractXContentSerializingTestCase<Li
                         new SearchableSnapshotAction(
                             randomAlphaOfLength(10),
                             randomBoolean(),
-                            (randomBoolean() ? null : randomIntBetween(1, 100))
+                            (randomBoolean() ? null : randomIntBetween(1, 100)),
+                            null
                         )
                     )
                 )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
@@ -32,7 +33,8 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
 
         List<Step> steps = action.toSteps(null, phase, nextStepKey, null);
 
-        List<StepKey> expectedSteps = expectedStepKeys(phase, action.isForceMergeIndex());
+        List<StepKey> expectedSteps = expectedStepKeys(phase, action.isForceMergeIndex(), action.getReplicateFor() != null);
+
         assertThat(steps.size(), is(expectedSteps.size()));
         for (int i = 0; i < expectedSteps.size(); i++) {
             assertThat("steps match expectation at index " + i, steps.get(i).getKey(), is(expectedSteps.get(i)));
@@ -88,12 +90,12 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
 
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> new SearchableSnapshotAction("test", true, invalidTotalShardsPerNode)
+            () -> new SearchableSnapshotAction("test", true, invalidTotalShardsPerNode, null)
         );
         assertEquals("[" + TOTAL_SHARDS_PER_NODE.getPreferredName() + "] must be >= 1", exception.getMessage());
     }
 
-    private List<StepKey> expectedStepKeys(String phase, boolean forceMergeIndex) {
+    private List<StepKey> expectedStepKeys(String phase, boolean forceMergeIndex, boolean hasReplicateFor) {
         return Stream.of(
             new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_SKIP_ACTION_STEP),
             new StepKey(phase, NAME, CheckNotDataStreamWriteIndexStep.NAME),
@@ -110,6 +112,8 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
             new StepKey(phase, NAME, WaitForIndexColorStep.NAME),
             new StepKey(phase, NAME, CopyExecutionStateStep.NAME),
             new StepKey(phase, NAME, CopySettingsStep.NAME),
+            hasReplicateFor ? new StepKey(phase, NAME, WaitUntilReplicateForTimePassesStep.NAME) : null,
+            hasReplicateFor ? new StepKey(phase, NAME, UpdateSettingsStep.NAME) : null,
             new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_DATASTREAM_CHECK_KEY),
             new StepKey(phase, NAME, ReplaceDataStreamBackingIndexStep.NAME),
             new StepKey(phase, NAME, DeleteStep.NAME),
@@ -134,21 +138,32 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
 
     @Override
     protected SearchableSnapshotAction mutateInstance(SearchableSnapshotAction instance) {
-        return switch (randomIntBetween(0, 2)) {
+        return switch (randomIntBetween(0, 3)) {
             case 0 -> new SearchableSnapshotAction(
                 randomAlphaOfLengthBetween(5, 10),
                 instance.isForceMergeIndex(),
-                instance.getTotalShardsPerNode()
+                instance.getTotalShardsPerNode(),
+                instance.getReplicateFor()
             );
             case 1 -> new SearchableSnapshotAction(
                 instance.getSnapshotRepository(),
                 instance.isForceMergeIndex() == false,
-                instance.getTotalShardsPerNode()
+                instance.getTotalShardsPerNode(),
+                instance.getReplicateFor()
             );
             case 2 -> new SearchableSnapshotAction(
                 instance.getSnapshotRepository(),
                 instance.isForceMergeIndex(),
-                instance.getTotalShardsPerNode() == null ? 1 : instance.getTotalShardsPerNode() + randomIntBetween(1, 100)
+                instance.getTotalShardsPerNode() == null ? 1 : instance.getTotalShardsPerNode() + randomIntBetween(1, 100),
+                instance.getReplicateFor()
+            );
+            case 3 -> new SearchableSnapshotAction(
+                instance.getSnapshotRepository(),
+                instance.isForceMergeIndex(),
+                instance.getTotalShardsPerNode(),
+                instance.getReplicateFor() == null
+                    ? TimeValue.timeValueDays(1)
+                    : TimeValue.timeValueDays(instance.getReplicateFor().getDays() + randomIntBetween(1, 10))
             );
             default -> throw new IllegalArgumentException("Invalid mutation branch");
         };
@@ -158,7 +173,8 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
         return new SearchableSnapshotAction(
             randomAlphaOfLengthBetween(5, 10),
             randomBoolean(),
-            (randomBoolean() ? null : randomIntBetween(1, 100))
+            (randomBoolean() ? null : randomIntBetween(1, 100)),
+            (randomBoolean() ? null : TimeValue.timeValueDays(randomIntBetween(1, 10)))
         );
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitUntilReplicateForTimePassesStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitUntilReplicateForTimePassesStepTests.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ilm;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xpack.core.ilm.step.info.EmptyInfo;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.cluster.metadata.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
+import static org.elasticsearch.xpack.core.ilm.WaitUntilReplicateForTimePassesStep.approximateTimeRemaining;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class WaitUntilReplicateForTimePassesStepTests extends AbstractStepTestCase<WaitUntilReplicateForTimePassesStep> {
+
+    @Override
+    protected WaitUntilReplicateForTimePassesStep createRandomInstance() {
+        Step.StepKey stepKey = randomStepKey();
+        Step.StepKey nextStepKey = randomStepKey();
+        TimeValue replicateFor = randomPositiveTimeValue();
+        return new WaitUntilReplicateForTimePassesStep(stepKey, nextStepKey, replicateFor, Instant::now);
+    }
+
+    @Override
+    protected WaitUntilReplicateForTimePassesStep mutateInstance(WaitUntilReplicateForTimePassesStep instance) {
+        Step.StepKey key = instance.getKey();
+        Step.StepKey nextKey = instance.getNextStepKey();
+        TimeValue replicateFor = instance.getReplicateFor();
+
+        switch (between(0, 2)) {
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
+            case 2 -> replicateFor = randomValueOtherThan(replicateFor, ESTestCase::randomPositiveTimeValue);
+        }
+        return new WaitUntilReplicateForTimePassesStep(key, nextKey, replicateFor, Instant::now);
+    }
+
+    @Override
+    protected WaitUntilReplicateForTimePassesStep copyInstance(WaitUntilReplicateForTimePassesStep instance) {
+        return new WaitUntilReplicateForTimePassesStep(
+            instance.getKey(),
+            instance.getNextStepKey(),
+            instance.getReplicateFor(),
+            Instant::now
+        );
+    }
+
+    public void testEvaluateCondition() {
+        // a mutable box that we can put Instants into
+        final AtomicReference<Instant> returnVal = new AtomicReference<>();
+
+        final WaitUntilReplicateForTimePassesStep step = new WaitUntilReplicateForTimePassesStep(
+            randomStepKey(),
+            randomStepKey(),
+            TimeValue.timeValueHours(1),
+            () -> returnVal.get()
+        );
+
+        final Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        final Instant t1 = now.minus(2, ChronoUnit.HOURS);
+        final Instant t2 = now.plus(2, ChronoUnit.HOURS);
+
+        final IndexMetadata indexMeta = getIndexMetadata(randomAlphaOfLengthBetween(10, 30), randomAlphaOfLengthBetween(10, 30), step);
+        final Metadata metadata = Metadata.builder().put(indexMeta, true).build();
+        final Index index = indexMeta.getIndex();
+
+        // if we evaluate the condition now, it hasn't been met, because it hasn't been an hour
+        returnVal.set(now);
+        step.evaluateCondition(metadata, index, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean complete, ToXContentObject informationContext) {
+                assertThat(complete, is(false));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError("Unexpected method call", e);
+            }
+        }, MASTER_TIMEOUT);
+
+        returnVal.set(t1); // similarly, if we were in the past, enough time also wouldn't have passed
+        step.evaluateCondition(metadata, index, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean complete, ToXContentObject informationContext) {
+                assertThat(complete, is(false));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError("Unexpected method call", e);
+            }
+        }, MASTER_TIMEOUT);
+
+        returnVal.set(t2); // but two hours from now in the future, an hour will have passed
+        step.evaluateCondition(metadata, index, new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean complete, ToXContentObject informationContext) {
+                assertThat(complete, is(true));
+                assertThat(informationContext, is(EmptyInfo.INSTANCE));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError("Unexpected method call", e);
+            }
+        }, MASTER_TIMEOUT);
+    }
+
+    public void testApproximateTimeRemaining() {
+        assertThat(approximateTimeRemaining(TimeValue.ZERO), equalTo("less than 1d"));
+
+        for (int i : new int[] { -2000, 0, 2000 }) {
+            assertThat(
+                approximateTimeRemaining(TimeValue.timeValueMillis(TimeValue.timeValueDays(2).millis() + i)),
+                equalTo("approximately 2d")
+            );
+        }
+
+        assertThat(approximateTimeRemaining(TimeValue.timeValueHours(24)), equalTo("approximately 1d"));
+        assertThat(approximateTimeRemaining(TimeValue.timeValueMillis(TimeValue.timeValueHours(24).millis() - 1)), equalTo("less than 1d"));
+    }
+
+    private IndexMetadata getIndexMetadata(String index, String lifecycleName, WaitUntilReplicateForTimePassesStep step) {
+        IndexMetadata idxMetadata = IndexMetadata.builder(index)
+            .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_NAME, lifecycleName))
+            .numberOfShards(randomIntBetween(1, 5))
+            .numberOfReplicas(randomIntBetween(0, 5))
+            .build();
+
+        LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
+        lifecycleState.setPhase(step.getKey().phase());
+        lifecycleState.setAction(step.getKey().action());
+        lifecycleState.setStep(step.getKey().name());
+        long stateTimes = System.currentTimeMillis();
+        lifecycleState.setPhaseTime(stateTimes);
+        lifecycleState.setActionTime(stateTimes);
+        lifecycleState.setStepTime(stateTimes);
+        lifecycleState.setIndexCreationDate(randomNonNegativeLong());
+        return IndexMetadata.builder(idxMetadata).putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.build().asMap()).build();
+    }
+}

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
 import org.elasticsearch.xpack.core.ilm.SetPriorityAction;
 import org.elasticsearch.xpack.core.ilm.ShrinkAction;
 import org.elasticsearch.xpack.core.ilm.Step;
+import org.elasticsearch.xpack.core.ilm.WaitUntilReplicateForTimePassesStep;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -47,6 +48,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createComposableTemplate;
@@ -938,7 +940,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
             new Phase(
                 "frozen",
                 TimeValue.ZERO,
-                Map.of(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean(), totalShardsPerNode))
+                Map.of(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean(), totalShardsPerNode, null))
             ),
             null
         );
@@ -974,6 +976,104 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
             snapshotTotalShardsPerNode,
             totalShardsPerNode
         );
+    }
+
+    public void testSearchableSnapshotReplicateFor() throws Exception {
+        createSnapshotRepo(client(), snapshotRepo, randomBoolean());
+
+        final boolean forceMergeIndex = randomBoolean();
+        createPolicy(
+            client(),
+            policy,
+            null,
+            null,
+            null,
+            new Phase(
+                "cold",
+                TimeValue.ZERO,
+                Map.of(
+                    SearchableSnapshotAction.NAME,
+                    new SearchableSnapshotAction(snapshotRepo, forceMergeIndex, null, TimeValue.timeValueHours(2))
+                )
+            ),
+            new Phase("delete", TimeValue.timeValueDays(1), Map.of(DeleteAction.NAME, WITH_SNAPSHOT_DELETE))
+        );
+
+        createComposableTemplate(
+            client(),
+            randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT),
+            dataStream,
+            new Template(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy).build(), null, null)
+        );
+
+        indexDocument(client(), dataStream, true);
+
+        // rolling over the data stream so we can apply the searchable snapshot policy to a backing index that's not the write index
+        rolloverMaxOneDocCondition(client(), dataStream);
+
+        String backingIndexName = DataStream.getDefaultBackingIndexName(dataStream, 1L);
+        String restoredIndexName = SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX + backingIndexName;
+        assertTrue(waitUntil(() -> {
+            try {
+                return indexExists(restoredIndexName);
+            } catch (IOException e) {
+                return false;
+            }
+        }, 30, TimeUnit.SECONDS));
+
+        // check that the index is in the expected step and has the expected step_info.message
+        assertBusy(() -> {
+            triggerStateChange();
+            Map<String, Object> explainResponse = explainIndex(client(), restoredIndexName);
+            assertThat(explainResponse.get("step"), is(WaitUntilReplicateForTimePassesStep.NAME));
+            @SuppressWarnings("unchecked")
+            final var stepInfo = (Map<String, String>) explainResponse.get("step_info");
+            String message = stepInfo == null ? "" : stepInfo.get("message");
+            assertThat(message, containsString("Waiting [less than 1d] until the replicate_for time [2h] has elapsed"));
+            assertThat(message, containsString("for index [" + restoredIndexName + "] before removing replicas."));
+        }, 30, TimeUnit.SECONDS);
+
+        // check that it has the right number of replicas
+        {
+            Map<String, Object> indexSettings = getIndexSettingsAsMap(restoredIndexName);
+            assertNotNull("expected number_of_replicas to exist", indexSettings.get(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey()));
+            Integer numberOfReplicas = Integer.valueOf((String) indexSettings.get(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey()));
+            assertThat(numberOfReplicas, is(1));
+        }
+
+        // tweak the policy to replicate_for hardly any time at all
+        createPolicy(
+            client(),
+            policy,
+            null,
+            null,
+            null,
+            new Phase(
+                "cold",
+                TimeValue.ZERO,
+                Map.of(
+                    SearchableSnapshotAction.NAME,
+                    new SearchableSnapshotAction(snapshotRepo, forceMergeIndex, null, TimeValue.timeValueSeconds(10))
+                )
+            ),
+            new Phase("delete", TimeValue.timeValueDays(1), Map.of(DeleteAction.NAME, WITH_SNAPSHOT_DELETE))
+        );
+
+        // check that the index has progressed because enough time has passed now that the policy is different
+        assertBusy(() -> {
+            triggerStateChange();
+            Map<String, Object> explainResponse = explainIndex(client(), restoredIndexName);
+            assertThat(explainResponse.get("phase"), is("cold"));
+            assertThat(explainResponse.get("step"), is(PhaseCompleteStep.NAME));
+        }, 30, TimeUnit.SECONDS);
+
+        // check that it has the right number of replicas
+        {
+            Map<String, Object> indexSettings = getIndexSettingsAsMap(restoredIndexName);
+            assertNotNull("expected number_of_replicas to exist", indexSettings.get(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey()));
+            Integer numberOfReplicas = Integer.valueOf((String) indexSettings.get(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey()));
+            assertThat(numberOfReplicas, is(0));
+        }
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add a replicate_for option to the ILM searchable_snapshot action (#119003)