### PR TITLE
Remove unnecessary entitlement

### DIFF
--- a/docs/changelog/120959.yaml
+++ b/docs/changelog/120959.yaml
@@ -1,0 +1,5 @@
+pr: 120959
+summary: Remove unnecessary entitlement
+area: Infra/Plugins
+type: bug
+issues: []

--- a/modules/reindex/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/reindex/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,4 +1,2 @@
 ALL-UNNAMED:
   - outbound_network
-org.elasticsearch.painless:
-  - create_class_loader


### PR DESCRIPTION
This removes an unnecessary entitlement from reindex that is causing test failures.