### PR TITLE
Document that disabling stack templates is not recommended

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -58,7 +58,8 @@ applying the templates, do one or more of the following:
 
 - To disable all built-in index and component templates, set
 <<stack-templates-enabled,`stack.templates.enabled`>> to `false` using the
-<<cluster-update-settings,cluster update settings API>>.
+<<cluster-update-settings,cluster update settings API>>. Note, however, that this is not
+recommended, see the <<stack-templates-enabled,setting documentation>> for more information.
 
 - Use a non-overlapping index pattern.
 

--- a/docs/reference/modules/indices/index_management.asciidoc
+++ b/docs/reference/modules/indices/index_management.asciidoc
@@ -37,6 +37,12 @@ If `true`, enables built-in index and component templates.
 streams. If `false`, {es} disables these index and component templates. Defaults
 to `true`.
 
+NOTE: It is not recommended to disable the built-in stack templates, as some functionality of {es}
+or Kibana will not work correctly when disabled. Features like log and metric collection, as well as
+Kibana reporting, may malfunction without the built-in stack templates. Stack templates should only
+be disabled temporarily, if necessary, to resolve upgrade issues, then re-enabled after any issues
+have been resolved.
+
 This setting affects the following built-in index templates:
 
 include::{es-ref-dir}/indices/index-templates.asciidoc[tag=built-in-index-template-patterns]


### PR DESCRIPTION
There are many features of the Elasticsearch ecosystem that may malfunction, or fail to work entirely, if these templates are not installed. This commit adds documentation cautioning against disabling the installation of templates.
