### PR TITLE
Re-enable geoip FullClusterRestartIT

### DIFF
--- a/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
+++ b/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
@@ -20,9 +20,6 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(":qa:full-cluster-restart"), "javaRestTest"))
 }
 
-
-// once we are ready to test migrations from 8.x to 9.x, we can set the compatible version to 8.0.0
-// see https://github.com/elastic/elasticsearch/pull/93666
 buildParams.bwcVersions.withWireCompatible(v -> v.before("9.0.0")) { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)

--- a/modules/ingest-geoip/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
+++ b/modules/ingest-geoip/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
@@ -13,9 +13,7 @@ import fixture.geoip.GeoIpHttpFixture;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.client.Request;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
@@ -34,8 +32,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.contains;
 
-@UpdateForV9(owner = UpdateForV9.Owner.DATA_MANAGEMENT)
-@LuceneTestCase.AwaitsFix(bugUrl = "we need to figure out the index migrations here for 9.0")
 public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCase {
 
     private static final boolean useFixture = Boolean.getBoolean("geoip_use_service") == false;

--- a/modules/ingest-geoip/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
+++ b/modules/ingest-geoip/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
@@ -42,7 +42,6 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
         .distribution(DistributionType.DEFAULT)
         .version(getOldClusterTestVersion())
         .nodes(2)
-        .setting("indices.memory.shard_inactive_time", "60m")
         .setting("xpack.security.enabled", "false")
         .setting("ingest.geoip.downloader.endpoint", () -> fixture.getAddress(), s -> useFixture)
         .feature(FeatureFlag.TIME_SERIES_MODE)

--- a/modules/ingest-geoip/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
+++ b/modules/ingest-geoip/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
@@ -42,8 +42,8 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
         .distribution(DistributionType.DEFAULT)
         .version(getOldClusterTestVersion())
         .nodes(2)
-        .setting("xpack.security.enabled", "false")
         .setting("ingest.geoip.downloader.endpoint", () -> fixture.getAddress(), s -> useFixture)
+        .setting("xpack.security.enabled", "false")
         .feature(FeatureFlag.TIME_SERIES_MODE)
         .build();
 

--- a/modules/ingest-geoip/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
+++ b/modules/ingest-geoip/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
@@ -93,7 +93,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
             Request migrateSystemFeatures = new Request("POST", "/_migration/system_features");
             assertOK(client().performRequest(migrateSystemFeatures));
 
-            assertBusy(() -> testCatIndices(".geoip_databases-reindexed-for-8", "my-index-00001"));
+            assertBusy(() -> testCatIndices(".geoip_databases-reindexed-for-10", "my-index-00001"));
             assertBusy(() -> testIndexGeoDoc());
 
             Request disableDownloader = new Request("PUT", "/_cluster/settings");


### PR DESCRIPTION
This PR removes some comments, updates some fiddly bits, and re-enables the geoip `FullClusterRestartIT` on the `main` branch. There's a version of this PR that'll work on 8.x as well, but some of the specific version stuff will be slightly different.

In the end, though, the behavior matches my expectations: if you have a `.geoip_databases` index from version 8.x and you ask 9.0.0+ of Elasticsearch to reindex it, you'd get a `.geoip_databases-reindexed-for-10` (since we would need that index to be writable by Elasticsearch 10.0.0+).

In a subsequent PR, I'd like to have a version of this test that runs with X-Pack Security enabled, but this PR doesn't do that.