### PR TITLE
[Inference API] Pass model ID in sparse model inference request body

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequest.java
@@ -55,7 +55,11 @@ public class ElasticInferenceServiceSparseEmbeddingsRequest implements ElasticIn
         var httpPost = new HttpPost(uri);
         var usageContext = inputTypeToUsageContext(inputType);
         var requestEntity = Strings.toString(
-            new ElasticInferenceServiceSparseEmbeddingsRequestEntity(truncationResult.input(), model.getServiceSettings().modelId(), usageContext)
+            new ElasticInferenceServiceSparseEmbeddingsRequestEntity(
+                truncationResult.input(),
+                model.getServiceSettings().modelId(),
+                usageContext
+            )
         );
 
         ByteArrayEntity byteEntity = new ByteArrayEntity(requestEntity.getBytes(StandardCharsets.UTF_8));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequest.java
@@ -55,7 +55,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequest implements ElasticIn
         var httpPost = new HttpPost(uri);
         var usageContext = inputTypeToUsageContext(inputType);
         var requestEntity = Strings.toString(
-            new ElasticInferenceServiceSparseEmbeddingsRequestEntity(truncationResult.input(), usageContext)
+            new ElasticInferenceServiceSparseEmbeddingsRequestEntity(truncationResult.input(), model.getServiceSettings().modelId(), usageContext)
         );
 
         ByteArrayEntity byteEntity = new ByteArrayEntity(requestEntity.getBytes(StandardCharsets.UTF_8));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntity.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 
 public record ElasticInferenceServiceSparseEmbeddingsRequestEntity(
     List<String> inputs,
+    String modelId,
     @Nullable ElasticInferenceServiceUsageContext usageContext
 ) implements ToXContentObject {
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntity.java
@@ -22,10 +22,12 @@ public record ElasticInferenceServiceSparseEmbeddingsRequestEntity(
 ) implements ToXContentObject {
 
     private static final String INPUT_FIELD = "input";
+    private static final String MODEL_ID_FIELD = "model_id";
     private static final String USAGE_CONTEXT = "usage_context";
 
     public ElasticInferenceServiceSparseEmbeddingsRequestEntity {
         Objects.requireNonNull(inputs);
+        Objects.requireNonNull(modelId);
     }
 
     @Override
@@ -33,13 +35,13 @@ public record ElasticInferenceServiceSparseEmbeddingsRequestEntity(
         builder.startObject();
         builder.startArray(INPUT_FIELD);
 
-        {
-            for (String input : inputs) {
-                builder.value(input);
-            }
+        for (String input : inputs) {
+            builder.value(input);
         }
 
         builder.endArray();
+
+        builder.field(MODEL_ID_FIELD, modelId);
 
         // optional field
         if ((usageContext == ElasticInferenceServiceUsageContext.UNSPECIFIED) == false) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModel.java
@@ -20,14 +20,10 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.elastic.ElasticInferenceServiceActionVisitor;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
-import org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Locale;
 import java.util.Map;
-
-import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.ELASTIC_INFERENCE_SERVICE_IDENTIFIER;
 
 public class ElasticInferenceServiceSparseEmbeddingsModel extends ElasticInferenceServiceExecutableActionModel {
 
@@ -95,27 +91,10 @@ public class ElasticInferenceServiceSparseEmbeddingsModel extends ElasticInferen
     }
 
     private URI createUri() throws ElasticsearchStatusException {
-        String modelId = getServiceSettings().modelId();
-        String modelIdUriPath;
-
-        switch (modelId) {
-            case ElserModels.ELSER_V2_MODEL -> modelIdUriPath = "ELSERv2";
-            default -> throw new ElasticsearchStatusException(
-                String.format(
-                    Locale.ROOT,
-                    "Unsupported model [%s] for service [%s] and task type [%s]",
-                    modelId,
-                    ELASTIC_INFERENCE_SERVICE_IDENTIFIER,
-                    TaskType.SPARSE_EMBEDDING
-                ),
-                RestStatus.BAD_REQUEST
-            );
-        }
-
         try {
             // TODO, consider transforming the base URL into a URI for better error handling.
             return new URI(
-                elasticInferenceServiceComponents().elasticInferenceServiceUrl() + "/api/v1/embed/text/sparse/" + modelIdUriPath
+                elasticInferenceServiceComponents().elasticInferenceServiceUrl() + "/api/v1/embed/text/sparse"
             );
         } catch (URISyntaxException e) {
             throw new ElasticsearchStatusException(
@@ -123,8 +102,6 @@ public class ElasticInferenceServiceSparseEmbeddingsModel extends ElasticInferen
                     + this.getConfigurations().getService()
                     + "] with taskType ["
                     + this.getTaskType()
-                    + "] with model ["
-                    + this.getServiceSettings().modelId()
                     + "]: "
                     + e.getMessage(),
                 RestStatus.BAD_REQUEST,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModel.java
@@ -93,9 +93,7 @@ public class ElasticInferenceServiceSparseEmbeddingsModel extends ElasticInferen
     private URI createUri() throws ElasticsearchStatusException {
         try {
             // TODO, consider transforming the base URL into a URI for better error handling.
-            return new URI(
-                elasticInferenceServiceComponents().elasticInferenceServiceUrl() + "/api/v1/embed/text/sparse"
-            );
+            return new URI(elasticInferenceServiceComponents().elasticInferenceServiceUrl() + "/api/v1/embed/text/sparse");
         } catch (URISyntaxException e) {
             throw new ElasticsearchStatusException(
                 "Failed to create URI for service ["

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsServiceSettings.java
@@ -17,7 +17,6 @@ import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
-import org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels;
 import org.elasticsearch.xpack.inference.services.settings.FilteredXContentObject;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
@@ -60,10 +59,6 @@ public class ElasticInferenceServiceSparseEmbeddingsServiceSettings extends Filt
             ElasticInferenceService.NAME,
             context
         );
-
-        if (modelId != null && ElserModels.isValidEisModel(modelId) == false) {
-            validationException.addValidationError("unknown ELSER model id [" + modelId + "]");
-        }
 
         if (validationException.validationErrors().isEmpty() == false) {
             throw validationException;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/elastic/ElasticInferenceServiceActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/elastic/ElasticInferenceServiceActionCreatorTests.java
@@ -90,7 +90,7 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
 
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
-            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer));
+            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer), "my-model-id");
             var actionCreator = new ElasticInferenceServiceActionCreator(
                 sender,
                 createWithEmptySettings(threadPool),
@@ -120,10 +120,11 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
             assertThat(webServer.requests().get(0).getHeader(HttpHeaders.CONTENT_TYPE), equalTo(XContentType.JSON.mediaType()));
 
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
-            assertThat(requestMap.size(), is(1));
+            assertThat(requestMap.size(), is(2));
             assertThat(requestMap.get("input"), instanceOf(List.class));
             var inputList = (List<String>) requestMap.get("input");
             assertThat(inputList, contains("hello world"));
+            assertThat(requestMap.get("model_id"), is("my-model-id"));
         }
     }
 
@@ -151,7 +152,7 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
 
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
-            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer));
+            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer), "my-model-id");
             var actionCreator = new ElasticInferenceServiceActionCreator(
                 sender,
                 createWithEmptySettings(threadPool),
@@ -174,10 +175,11 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
             assertThat(webServer.requests().get(0).getHeader(HttpHeaders.CONTENT_TYPE), equalTo(XContentType.JSON.mediaType()));
 
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
-            assertThat(requestMap.size(), is(1));
+            assertThat(requestMap.size(), is(2));
             assertThat(requestMap.get("input"), instanceOf(List.class));
             var inputList = (List<String>) requestMap.get("input");
             assertThat(inputList, contains("hello world"));
+            assertThat(requestMap.get("model_id"), is("my-model-id"));
         }
     }
 
@@ -208,7 +210,7 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
             webServer.enqueue(new MockResponse().setResponseCode(413).setBody(responseJsonContentTooLarge));
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
-            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer));
+            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer), "my-model-id");
             var actionCreator = new ElasticInferenceServiceActionCreator(
                 sender,
                 createWithEmptySettings(threadPool),
@@ -273,7 +275,7 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
             // truncated to 1 token = 3 characters
-            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer), 1);
+            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer), "my-model-id", 1);
             var actionCreator = new ElasticInferenceServiceActionCreator(
                 sender,
                 createWithEmptySettings(threadPool),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntityTests.java
@@ -24,7 +24,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestEntityTests extends E
     public void testToXContent_SingleInput_UnspecifiedUsageContext() throws IOException {
         var entity = new ElasticInferenceServiceSparseEmbeddingsRequestEntity(
             List.of("abc"),
-			"my-model-id",
+            "my-model-id",
             ElasticInferenceServiceUsageContext.UNSPECIFIED
         );
         String xContentString = xContentEntityToString(entity);
@@ -38,7 +38,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestEntityTests extends E
     public void testToXContent_MultipleInputs_UnspecifiedUsageContext() throws IOException {
         var entity = new ElasticInferenceServiceSparseEmbeddingsRequestEntity(
             List.of("abc", "def"),
-			"my-model-id",
+            "my-model-id",
             ElasticInferenceServiceUsageContext.UNSPECIFIED
         );
         String xContentString = xContentEntityToString(entity);
@@ -54,22 +54,32 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestEntityTests extends E
     }
 
     public void testToXContent_MultipleInputs_SearchUsageContext() throws IOException {
-        var entity = new ElasticInferenceServiceSparseEmbeddingsRequestEntity(List.of("abc"), ElasticInferenceServiceUsageContext.SEARCH);
+        var entity = new ElasticInferenceServiceSparseEmbeddingsRequestEntity(
+            List.of("abc"),
+            "my-model-id",
+            ElasticInferenceServiceUsageContext.SEARCH
+        );
         String xContentString = xContentEntityToString(entity);
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
             {
                 "input": ["abc"],
+                "model_id": "my-model-id",
                 "usage_context": "search"
             }
             """));
     }
 
     public void testToXContent_MultipleInputs_IngestUsageContext() throws IOException {
-        var entity = new ElasticInferenceServiceSparseEmbeddingsRequestEntity(List.of("abc"), ElasticInferenceServiceUsageContext.INGEST);
+        var entity = new ElasticInferenceServiceSparseEmbeddingsRequestEntity(
+            List.of("abc"),
+            "my-model-id",
+            ElasticInferenceServiceUsageContext.INGEST
+        );
         String xContentString = xContentEntityToString(entity);
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
             {
                 "input": ["abc"],
+                "model_id": "my-model-id",
                 "usage_context": "ingest"
             }
             """));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntityTests.java
@@ -24,18 +24,21 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestEntityTests extends E
     public void testToXContent_SingleInput_UnspecifiedUsageContext() throws IOException {
         var entity = new ElasticInferenceServiceSparseEmbeddingsRequestEntity(
             List.of("abc"),
+			"my-model-id",
             ElasticInferenceServiceUsageContext.UNSPECIFIED
         );
         String xContentString = xContentEntityToString(entity);
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
             {
-                "input": ["abc"]
+                "input": ["abc"],
+                "model_id": "my-model-id"
             }"""));
     }
 
     public void testToXContent_MultipleInputs_UnspecifiedUsageContext() throws IOException {
         var entity = new ElasticInferenceServiceSparseEmbeddingsRequestEntity(
             List.of("abc", "def"),
+			"my-model-id",
             ElasticInferenceServiceUsageContext.UNSPECIFIED
         );
         String xContentString = xContentEntityToString(entity);
@@ -44,7 +47,8 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestEntityTests extends E
                 "input": [
                     "abc",
                     "def"
-                ]
+                ],
+                "model_id": "my-model-id"
             }
             """));
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
@@ -44,7 +44,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
 
         assertThat(httpPost.getLastHeader(HttpHeaders.CONTENT_TYPE).getValue(), is(XContentType.JSON.mediaType()));
         var requestMap = entityAsMap(httpPost.getEntity().getContent());
-        assertThat(requestMap.size(), equalTo(2));
+        assertThat(requestMap.size(), equalTo(3));
         assertThat(requestMap.get("input"), is(List.of(input)));
         assertThat(requestMap.get("model_id"), is(modelId));
         assertThat(requestMap.get("usage_context"), equalTo("search"));
@@ -115,8 +115,8 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
         assertThat(inputTypeToUsageContext(InputType.CLUSTERING), equalTo(ElasticInferenceServiceUsageContext.UNSPECIFIED));
     }
 
-    public ElasticInferenceServiceSparseEmbeddingsRequest createRequest(String url, String input, InputType inputType) {
-        var embeddingsModel = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(url);
+    public ElasticInferenceServiceSparseEmbeddingsRequest createRequest(String url, String modelId, String input, InputType inputType) {
+        var embeddingsModel = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(url, modelId);
 
         return new ElasticInferenceServiceSparseEmbeddingsRequest(
             TruncatorTests.createTruncator(),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
@@ -34,8 +34,9 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
     public void testCreateHttpRequest_UsageContextSearch() throws IOException {
         var url = "http://eis-gateway.com";
         var input = "input";
+        var modelId = "my-model-id";
 
-        var request = createRequest(url, input, InputType.SEARCH);
+        var request = createRequest(url, modelId, input, InputType.SEARCH);
         var httpRequest = request.createHttpRequest();
 
         assertThat(httpRequest.httpRequestBase(), instanceOf(HttpPost.class));
@@ -45,15 +46,16 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
         var requestMap = entityAsMap(httpPost.getEntity().getContent());
         assertThat(requestMap.size(), equalTo(2));
         assertThat(requestMap.get("input"), is(List.of(input)));
-        assertThat(requestMap.get("model_id"), is("my-model-id"));
+        assertThat(requestMap.get("model_id"), is(modelId));
         assertThat(requestMap.get("usage_context"), equalTo("search"));
     }
 
     public void testTraceContextPropagatedThroughHTTPHeaders() {
         var url = "http://eis-gateway.com";
         var input = "input";
+        var modelId = "my-model-id";
 
-        var request = createRequest(url, input, InputType.UNSPECIFIED);
+        var request = createRequest(url, modelId, input, InputType.UNSPECIFIED);
         var httpRequest = request.createHttpRequest();
 
         assertThat(httpRequest.httpRequestBase(), instanceOf(HttpPost.class));
@@ -69,8 +71,9 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
     public void testTruncate_ReducesInputTextSizeByHalf() throws IOException {
         var url = "http://eis-gateway.com";
         var input = "abcd";
+        var modelId = "my-model-id";
 
-        var request = createRequest(url, input, InputType.UNSPECIFIED);
+        var request = createRequest(url, modelId, input, InputType.UNSPECIFIED);
         var truncatedRequest = request.truncate();
 
         var httpRequest = truncatedRequest.createHttpRequest();
@@ -80,14 +83,15 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
         var requestMap = entityAsMap(httpPost.getEntity().getContent());
         assertThat(requestMap, aMapWithSize(2));
         assertThat(requestMap.get("input"), is(List.of("ab")));
-        assertThat(requestMap.get("model_id"), is("my-model-id"));
+        assertThat(requestMap.get("model_id"), is(modelId));
     }
 
     public void testIsTruncated_ReturnsTrue() {
         var url = "http://eis-gateway.com";
         var input = "abcd";
+        var modelId = "my-model-id";
 
-        var request = createRequest(url, input, InputType.UNSPECIFIED);
+        var request = createRequest(url, modelId, input, InputType.UNSPECIFIED);
         assertFalse(request.getTruncationInfo()[0]);
 
         var truncatedRequest = request.truncate();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
@@ -45,6 +45,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
         var requestMap = entityAsMap(httpPost.getEntity().getContent());
         assertThat(requestMap.size(), equalTo(2));
         assertThat(requestMap.get("input"), is(List.of(input)));
+        assertThat(requestMap.get("model_id"), is("my-model-id"));
         assertThat(requestMap.get("usage_context"), equalTo("search"));
     }
 
@@ -77,8 +78,9 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
 
         var httpPost = (HttpPost) httpRequest.httpRequestBase();
         var requestMap = entityAsMap(httpPost.getEntity().getContent());
-        assertThat(requestMap, aMapWithSize(1));
+        assertThat(requestMap, aMapWithSize(2));
         assertThat(requestMap.get("input"), is(List.of("ab")));
+        assertThat(requestMap.get("model_id"), is("my-model-id"));
     }
 
     public void testIsTruncated_ReturnsTrue() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModelTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.inference.EmptySecretSettings;
 import org.elasticsearch.inference.EmptyTaskSettings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels;
 
 public class ElasticInferenceServiceSparseEmbeddingsModelTests extends ESTestCase {
 
@@ -24,7 +23,7 @@ public class ElasticInferenceServiceSparseEmbeddingsModelTests extends ESTestCas
             "id",
             TaskType.SPARSE_EMBEDDING,
             "service",
-            new ElasticInferenceServiceSparseEmbeddingsServiceSettings(ElserModels.ELSER_V2_MODEL, maxInputTokens, null),
+            new ElasticInferenceServiceSparseEmbeddingsServiceSettings("my-model-id", maxInputTokens, null),
             EmptyTaskSettings.INSTANCE,
             EmptySecretSettings.INSTANCE,
             new ElasticInferenceServiceComponents(url)

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModelTests.java
@@ -14,16 +14,16 @@ import org.elasticsearch.test.ESTestCase;
 
 public class ElasticInferenceServiceSparseEmbeddingsModelTests extends ESTestCase {
 
-    public static ElasticInferenceServiceSparseEmbeddingsModel createModel(String url) {
-        return createModel(url, null);
+    public static ElasticInferenceServiceSparseEmbeddingsModel createModel(String url, String modelId) {
+        return createModel(url, modelId, null);
     }
 
-    public static ElasticInferenceServiceSparseEmbeddingsModel createModel(String url, Integer maxInputTokens) {
+    public static ElasticInferenceServiceSparseEmbeddingsModel createModel(String url, String modelId, Integer maxInputTokens) {
         return new ElasticInferenceServiceSparseEmbeddingsModel(
             "id",
             TaskType.SPARSE_EMBEDDING,
             "service",
-            new ElasticInferenceServiceSparseEmbeddingsServiceSettings("my-model-id", maxInputTokens, null),
+            new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, maxInputTokens, null),
             EmptyTaskSettings.INSTANCE,
             EmptySecretSettings.INSTANCE,
             new ElasticInferenceServiceComponents(url)

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.elastic;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -23,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModelsTests.randomElserModel;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 public class ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests extends AbstractWireSerializingTestCase<
@@ -47,7 +45,7 @@ public class ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests extends
     }
 
     public void testFromMap() {
-        var modelId = ElserModels.ELSER_V2_MODEL;
+        var modelId = "my-model-id";
 
         var serviceSettings = ElasticInferenceServiceSparseEmbeddingsServiceSettings.fromMap(
             new HashMap<>(Map.of(ServiceFields.MODEL_ID, modelId)),
@@ -55,20 +53,6 @@ public class ElasticInferenceServiceSparseEmbeddingsServiceSettingsTests extends
         );
 
         assertThat(serviceSettings, is(new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, null, null)));
-    }
-
-    public void testFromMap_InvalidElserModelId() {
-        var invalidModelId = "invalid";
-
-        ValidationException validationException = expectThrows(
-            ValidationException.class,
-            () -> ElasticInferenceServiceSparseEmbeddingsServiceSettings.fromMap(
-                new HashMap<>(Map.of(ServiceFields.MODEL_ID, invalidModelId)),
-                ConfigurationParseContext.REQUEST
-            )
-        );
-
-        assertThat(validationException.getMessage(), containsString(Strings.format("unknown ELSER model id [%s]", invalidModelId)));
     }
 
     public void testToXContent_WritesAllFields() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -486,7 +486,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
             assertThat(request.getHeader(HttpHeaders.CONTENT_TYPE), Matchers.equalTo(XContentType.JSON.mediaType()));
 
             var requestMap = entityAsMap(request.getBody());
-            assertThat(requestMap, is(Map.of("input", List.of("input text"), "usage_context", "search")));
+            assertThat(requestMap, is(Map.of("input", List.of("input text"), "model_id", "my-model-id", "usage_context", "search")));
         }
     }
 
@@ -544,7 +544,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
             );
 
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
-            assertThat(requestMap, is(Map.of("input", List.of("input text"), "usage_context", "ingest")));
+            assertThat(requestMap, is(Map.of("input", List.of("input text"), "model_id", "my-model-id", "usage_context", "ingest")));
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -308,12 +308,12 @@ public class ElasticInferenceServiceTests extends ESTestCase {
     public void testCheckModelConfig_ReturnsNewModelReference() throws IOException {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
         try (var service = createService(senderFactory, getUrl(webServer))) {
-            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer));
+            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer), "my-model-id");
             PlainActionFuture<Model> listener = new PlainActionFuture<>();
             service.checkModelConfig(model, listener);
 
             var returnedModel = listener.actionGet(TIMEOUT);
-            assertThat(returnedModel, is(ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer))));
+            assertThat(returnedModel, is(ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer), "my-model-id")));
         }
     }
 
@@ -457,7 +457,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
 
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
-            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(eisGatewayUrl);
+            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(eisGatewayUrl, "my-model-id");
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
             service.infer(
                 model,
@@ -508,7 +508,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
 
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
-            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(eisGatewayUrl);
+            var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(eisGatewayUrl, "my-model-id");
             PlainActionFuture<List<ChunkedInference>> listener = new PlainActionFuture<>();
             service.chunkedInfer(
                 model,


### PR DESCRIPTION
**Do not merge until related changes have been rolled out in the Inference Service.**

This PR enables any valid model ID to be specified in an Elastic Inference Service sparse embedding endpoint. 

From a client perspective this only changes the validation of the endpoint creation request body. Previously it only supported `"service_settings.model_id": ".elser_model_2"`. Now `model_id` is not validated in the Inference API, but in the Inference Service. Valid example:
```json
PUT _inference/sparse_embedding/{id}
{
  "service": "elastic",
  "service_settings": {
    "model_id": "elser-v2"
  }
}
```

This succeeds because `elser-v2` is a valid sparse embedding model name in the Elastic Inference Service.

The other part of the change is the model ID is now passed to the Inference Service in the request body, not in the path. This allows for the Inference Service supporting multiple models under the same endpoint.

Before (downstream request):
```json
POST /api/v1/embed/text/sparse/ELSERv2
{
  "input": ...
}
```

After:
```json
POST /api/v1/embed/text/sparse
{
  "input": ...
  "model_id": "elser-v2"
}
```