### PR TITLE
Mute org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT test {p0=data_stream/80_resolve_index_data_streams/Resolve index with hidden and closed indices} #120965

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -280,6 +280,9 @@ tests:
 - class: org.elasticsearch.action.search.SearchProgressActionListenerIT
   method: testSearchProgressWithQuery
   issue: https://github.com/elastic/elasticsearch/issues/120994
+- class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
+  method: test {p0=data_stream/80_resolve_index_data_streams/Resolve index with hidden and closed indices}
+  issue: https://github.com/elastic/elasticsearch/issues/120965
 
 # Examples:
 #


### PR DESCRIPTION
Mutes test in main. Related: #120965