### PR TITLE
[DOCS] Adds anomaly detection info to migration guide

### DIFF
--- a/docs/reference/migration/migrate_9_0.asciidoc
+++ b/docs/reference/migration/migrate_9_0.asciidoc
@@ -73,9 +73,255 @@ Lucene 10 ships with an updated Korean dictionary (mecab-ko-dic-2.1.1).  For det
 The change is small and should generally provide better analysis results. Existing indices for full-text use cases should be reindexed though.
 ====
 
+
+[discrete]
+[[breaking_90_cluster_and_node_setting_changes]]
+==== Cluster and node setting changes
+
+[[minimum_shard_balancer_threshold_1_0]]
+.Minimum shard balancer threshold is now 1.0
+[%collapsible]
+====
+*Details* +
+Earlier versions of {es} accepted any non-negative value for `cluster.routing.allocation.balance.threshold`, but values smaller than `1.0` do not make sense and have been ignored since version 8.6.1. From 9.0.0 these nonsensical values are now forbidden.
+
+*Impact* +
+Do not set `cluster.routing.allocation.balance.threshold` to a value less than `1.0`.
+====
+
+[[remove_cluster_routing_allocation_disk_watermark_enable_for_single_data_node_setting]]
+.Remove `cluster.routing.allocation.disk.watermark.enable_for_single_data_node` setting
+[%collapsible]
+====
+*Details* +
+Prior to 7.8, whenever a cluster had only a single data node, the watermarks would not be respected. In order to change this in 7.8+ in a backwards compatible way, we introduced the  `cluster.routing.allocation.disk.watermark.enable_for_single_data_node` node setting. The setting was deprecated in 7.14 and was made to accept only true in 8.0
+
+*Impact* +
+No known end user impact
+====
+
+[[remove_deprecated_xpack_searchable_snapshot_allocate_on_rolling_restart_setting]]
+.Remove deprecated `xpack.searchable.snapshot.allocate_on_rolling_restart` setting
+[%collapsible]
+====
+*Details* +
+The `xpack.searchable.snapshot.allocate_on_rolling_restart` setting was created as an escape-hatch just in case relying on the `cluster.routing.allocation.enable=primaries` setting for allocating searchable snapshots during rolling restarts had some unintended side-effects. It has been deprecated since 8.2.0.
+
+*Impact* +
+Remove `xpack.searchable.snapshot.allocate_on_rolling_restart` from your settings if present.
+====
+
+[[remove_unsupported_legacy_value_for_discovery_type]]
+.Remove unsupported legacy value for `discovery.type`
+[%collapsible]
+====
+*Details* +
+Earlier versions of {es} had a `discovery.type` setting which permitted values that referred to legacy discovery types. From v9.0.0 onwards, the only supported values for this setting are `multi-node` (the default) and `single-node`.
+
+*Impact* +
+Remove any value for `discovery.type` from your `elasticsearch.yml` configuration file.
+====
+
+[discrete]
+[[breaking_90_ingest_changes]]
+==== Ingest changes
+
+[[remove_ecs_option_on_user_agent_processor]]
+.Remove `ecs` option on `user_agent` processor
+[%collapsible]
+====
+*Details* +
+The `user_agent` ingest processor no longer accepts the `ecs` option. (It was previously deprecated and ignored.)
+
+*Impact* +
+Users should stop using the `ecs` option when creating instances of the `user_agent` ingest processor. The option will be removed from existing processors stored in the cluster state on upgrade.
+====
+
+[[remove_ignored_fallback_option_on_geoip_processor]]
+.Remove ignored fallback option on GeoIP processor
+[%collapsible]
+====
+*Details* +
+The option fallback_to_default_databases on the geoip ingest processor has been removed. (It was deprecated and ignored since 8.0.0.)
+
+*Impact* +
+Customers should stop remove the noop fallback_to_default_databases option on any geoip ingest processors.
+====
+
+[discrete]
+[[breaking_90_mapping_changes]]
+==== Mapping changes
+
+[[remove_support_for_type_fields_copy_to_boost_in_metadata_field_definition]]
+.Remove support for type, fields, copy_to and boost in metadata field definition
+[%collapsible]
+====
+*Details* +
+The type, fields, copy_to and boost parameters are no longer supported in metadata field definition
+
+*Impact* +
+Users providing type, fields, copy_to or boost as part of metadata field definition should remove them from their mappings.
+====
+
+[discrete]
+[[breaking_90_rest_api_changes]]
+==== REST API changes
+
+[[apply_more_strict_parsing_of_actions_in_bulk_api]]
+.Apply more strict parsing of actions in bulk API
+[%collapsible]
+====
+*Details* +
+Previously, the following classes of malformed input were deprecated but not rejected in the action lines of the a bulk request: missing closing brace; additional keys after the action (which were ignored); additional data after the closing brace (which was ignored). They will now be considered errors and rejected.
+
+*Impact* +
+Users must provide well-formed input when using the bulk API. (They can request REST API compatibility with v8 to get the previous behaviour back as an interim measure.)
+====
+
+[[error_json_structure_has_changed_when_detailed_errors_are_disabled]]
+.Error JSON structure has changed when detailed errors are disabled
+[%collapsible]
+====
+*Details* +
+This change modifies the JSON format of error messages returned to REST clients
+when detailed messages are turned off.
+Previously, JSON returned when an exception occurred, and `http.detailed_errors.enabled: false` was set,
+just consisted of a single `"error"` text field with some basic information.
+Setting `http.detailed_errors.enabled: true` (the default) changed this field
+to an object with more detailed information.
+With this change, non-detailed errors now have the same structure as detailed errors. `"error"` will now always
+be an object with, at a minimum, a `"type"` and `"reason"` field. Additional fields are included when detailed
+errors are enabled.
+To use the previous structure for non-detailed errors, use the v8 REST API.
+
+*Impact* +
+If you have set `http.detailed_errors.enabled: false` (the default is `true`)
+the structure of JSON when any exceptions occur now matches the structure when
+detailed errors are enabled.
+To use the previous structure for non-detailed errors, use the v8 REST API.
+====
+
+[[remove_cluster_state_from_cluster_reroute_response]]
+.Remove cluster state from `/_cluster/reroute` response
+[%collapsible]
+====
+*Details* +
+The `POST /_cluster/reroute` API no longer returns the cluster state in its response. The `?metric` query parameter to this API now has no effect and its use will be forbidden in a future version.
+
+*Impact* +
+Cease usage of the `?metric` query parameter when calling the `POST /_cluster/reroute` API.
+====
+
+[[remove_deprecated_local_attribute_from_alias_apis]]
+.Remove deprecated local attribute from alias APIs
+[%collapsible]
+====
+*Details* +
+The following APIs no longer accept the `?local` query parameter: `GET /_alias`, `GET /_aliases`, `GET /_alias/{name}`, `HEAD /_alias/{name}`, `GET /{index}/_alias`, `HEAD /{index}/_alias`, `GET /{index}/_alias/{name}`, `HEAD /{index}/_alias/{name}`, `GET /_cat/aliases`, and `GET /_cat/aliases/{alias}`. This parameter has been deprecated and ignored since version 8.12.
+
+*Impact* +
+Cease usage of the `?local` query parameter when calling the listed APIs.
+====
+
+[[remove_legacy_params_from_range_query]]
+.Remove legacy params from range query
+[%collapsible]
+====
+*Details* +
+The deprecated range query parameters `to`, `from`, `include_lower`, and `include_upper` are no longer supported.
+
+*Impact* +
+Users should use `lt`, `lte`, `gt`, and `gte` query parameters instead.
+====
+
+[[remove_support_for_deprecated_force_source_highlighting_parameter]]
+.Remove support for deprecated `force_source` highlighting parameter
+[%collapsible]
+====
+*Details* +
+The deprecated highlighting `force_source` parameter is no longer supported.
+
+*Impact* +
+Users should remove usages of the `force_source` parameter from their search requests.
+====
+
+[discrete]
+[[breaking_90_transforms_changes]]
+==== {transforms-cap} changes
+
+[[updating_deprecated_transform_roles]]
+.Updating deprecated {transform} roles (`data_frame_transforms_admin` and `data_frame_transforms_user`)
+[%collapsible]
+====
+*Details* +
+The `data_frame_transforms_admin` and `data_frame_transforms_user` {transform} roles have been deprecated.
+
+*Impact* +
+Users must update any existing {transforms} that use deprecated {transform} roles (`data_frame_transforms_admin` or `data_frame_transforms_user`) to use the new equivalent {transform} roles (`transform_admin` or `transform_user`).
+To update the {transform} roles:
+
+1. Switch to a user with the `transform_admin` role (to replace `data_frame_transforms_admin`) or the `transform_user` role (to replace `data_frame_transforms_user`).
+2. Call the <<update-transform, update {transforms} API>> with that user.
+====
+
+
+[discrete]
+[[deprecated-9.0]]
+=== Deprecations
+
+The following functionality has been deprecated in {es} 9.0
+and will be removed in a future version.
+While this won't have an immediate impact on your applications,
+we strongly encourage you to take the described steps to update your code
+after upgrading to 9.0.
+
+To find out if you are using any deprecated functionality,
+enable <<deprecation-logging, deprecation logging>>.
+
+[discrete]
+[[deprecations_90_mapping]]
+==== Mapping deprecations
+
+[[deprecate_source_mode_in_mappings]]
+.Deprecate `_source.mode` in mappings
+[%collapsible]
+====
+*Details* +
+Configuring `_source.mode` in mappings is deprecated and will be removed in future versions. Use `index.mapping.source.mode` index setting instead.
+
+*Impact* +
+Use `index.mapping.source.mode` index setting instead
+====
+
+[discrete]
+[[deprecations_90_rest_api]]
+==== REST API deprecations
+
+[[document_type_deprecated_on_simulate_pipeline_api]]
+.Document `_type` deprecated on simulate pipeline API
+[%collapsible]
+====
+*Details* +
+Passing a document with a `_type` property is deprecated in the `/_ingest/pipeline/{id}/_simulate` and `/_ingest/pipeline/_simulate` APIs.
+
+*Impact* +
+Users should already have stopped using mapping types, which were deprecated in {es} 7. This deprecation warning will fire if they specify mapping types on documents pass to the simulate pipeline API.
+====
+
+[[inference_api_deprecate_elser_service]]
+.[Inference API] Deprecate elser service
+[%collapsible]
+====
+*Details* +
+The `elser` service of the inference API will be removed in an upcoming release. Please use the elasticsearch service instead.
+
+*Impact* +
+In the current version there is no impact. In a future version, users of the `elser` service will no longer be able to use it, and will be required to use the `elasticsearch` service to access elser through the inference API.
+====
+
 [discrete]
 [[breaking_90_anomaly_detection_results]]
-==== Anomaly detection results
+=== Anomaly detection results migration
 
 [[prepare_anomaly_detection_result_indices_for_upgrade]]
 .Preparing anomaly detection result indices for upgrade
@@ -95,17 +341,17 @@ The response contains the list of critical deprecation warnings in the `index_se
 
 [source,console-result]
 ------------------------------------------------------------
-"index_settings" : {
-    ".ml-anomalies-shared" : [
+"index_settings": {
+    ".ml-anomalies-shared": [
       {
-        "level" : "critical",
-        "message" : "Index created before 8.0",
-        "url" : "https://ela.st/es-deprecation-8-reindex",
-        "details" : "This index was created with version 7.8.23 and is not compatible with 9.0. Reindex or remove the index before upgrading.",
-        "resolve_during_rolling_upgrade" : false
+        "level": "critical",
+        "message": "Index created before 8.0",
+        "url": "https://ela.st/es-deprecation-8-reindex",
+        "details": "This index was created with version 7.8.23 and is not compatible with 9.0. Reindex or remove the index before upgrading.",
+        "resolve_during_rolling_upgrade": false
       }
     ]
-  },
+  }
 (...)
 ------------------------------------------------------------
 // NOTCONSOLE
@@ -388,250 +634,3 @@ PUT .ml-anomalies-custom-example/_block/write
 
 Indices created in {es} 7.x that have a `write` block will not raise a critical deprecation warning.
 ====
-
-
-[discrete]
-[[breaking_90_cluster_and_node_setting_changes]]
-==== Cluster and node setting changes
-
-[[minimum_shard_balancer_threshold_1_0]]
-.Minimum shard balancer threshold is now 1.0
-[%collapsible]
-====
-*Details* +
-Earlier versions of {es} accepted any non-negative value for `cluster.routing.allocation.balance.threshold`, but values smaller than `1.0` do not make sense and have been ignored since version 8.6.1. From 9.0.0 these nonsensical values are now forbidden.
-
-*Impact* +
-Do not set `cluster.routing.allocation.balance.threshold` to a value less than `1.0`.
-====
-
-[[remove_cluster_routing_allocation_disk_watermark_enable_for_single_data_node_setting]]
-.Remove `cluster.routing.allocation.disk.watermark.enable_for_single_data_node` setting
-[%collapsible]
-====
-*Details* +
-Prior to 7.8, whenever a cluster had only a single data node, the watermarks would not be respected. In order to change this in 7.8+ in a backwards compatible way, we introduced the  `cluster.routing.allocation.disk.watermark.enable_for_single_data_node` node setting. The setting was deprecated in 7.14 and was made to accept only true in 8.0
-
-*Impact* +
-No known end user impact
-====
-
-[[remove_deprecated_xpack_searchable_snapshot_allocate_on_rolling_restart_setting]]
-.Remove deprecated `xpack.searchable.snapshot.allocate_on_rolling_restart` setting
-[%collapsible]
-====
-*Details* +
-The `xpack.searchable.snapshot.allocate_on_rolling_restart` setting was created as an escape-hatch just in case relying on the `cluster.routing.allocation.enable=primaries` setting for allocating searchable snapshots during rolling restarts had some unintended side-effects. It has been deprecated since 8.2.0.
-
-*Impact* +
-Remove `xpack.searchable.snapshot.allocate_on_rolling_restart` from your settings if present.
-====
-
-[[remove_unsupported_legacy_value_for_discovery_type]]
-.Remove unsupported legacy value for `discovery.type`
-[%collapsible]
-====
-*Details* +
-Earlier versions of {es} had a `discovery.type` setting which permitted values that referred to legacy discovery types. From v9.0.0 onwards, the only supported values for this setting are `multi-node` (the default) and `single-node`.
-
-*Impact* +
-Remove any value for `discovery.type` from your `elasticsearch.yml` configuration file.
-====
-
-[discrete]
-[[breaking_90_ingest_changes]]
-==== Ingest changes
-
-[[remove_ecs_option_on_user_agent_processor]]
-.Remove `ecs` option on `user_agent` processor
-[%collapsible]
-====
-*Details* +
-The `user_agent` ingest processor no longer accepts the `ecs` option. (It was previously deprecated and ignored.)
-
-*Impact* +
-Users should stop using the `ecs` option when creating instances of the `user_agent` ingest processor. The option will be removed from existing processors stored in the cluster state on upgrade.
-====
-
-[[remove_ignored_fallback_option_on_geoip_processor]]
-.Remove ignored fallback option on GeoIP processor
-[%collapsible]
-====
-*Details* +
-The option fallback_to_default_databases on the geoip ingest processor has been removed. (It was deprecated and ignored since 8.0.0.)
-
-*Impact* +
-Customers should stop remove the noop fallback_to_default_databases option on any geoip ingest processors.
-====
-
-[discrete]
-[[breaking_90_mapping_changes]]
-==== Mapping changes
-
-[[remove_support_for_type_fields_copy_to_boost_in_metadata_field_definition]]
-.Remove support for type, fields, copy_to and boost in metadata field definition
-[%collapsible]
-====
-*Details* +
-The type, fields, copy_to and boost parameters are no longer supported in metadata field definition
-
-*Impact* +
-Users providing type, fields, copy_to or boost as part of metadata field definition should remove them from their mappings.
-====
-
-[discrete]
-[[breaking_90_rest_api_changes]]
-==== REST API changes
-
-[[apply_more_strict_parsing_of_actions_in_bulk_api]]
-.Apply more strict parsing of actions in bulk API
-[%collapsible]
-====
-*Details* +
-Previously, the following classes of malformed input were deprecated but not rejected in the action lines of the a bulk request: missing closing brace; additional keys after the action (which were ignored); additional data after the closing brace (which was ignored). They will now be considered errors and rejected.
-
-*Impact* +
-Users must provide well-formed input when using the bulk API. (They can request REST API compatibility with v8 to get the previous behaviour back as an interim measure.)
-====
-
-[[error_json_structure_has_changed_when_detailed_errors_are_disabled]]
-.Error JSON structure has changed when detailed errors are disabled
-[%collapsible]
-====
-*Details* +
-This change modifies the JSON format of error messages returned to REST clients
-when detailed messages are turned off.
-Previously, JSON returned when an exception occurred, and `http.detailed_errors.enabled: false` was set,
-just consisted of a single `"error"` text field with some basic information.
-Setting `http.detailed_errors.enabled: true` (the default) changed this field
-to an object with more detailed information.
-With this change, non-detailed errors now have the same structure as detailed errors. `"error"` will now always
-be an object with, at a minimum, a `"type"` and `"reason"` field. Additional fields are included when detailed
-errors are enabled.
-To use the previous structure for non-detailed errors, use the v8 REST API.
-
-*Impact* +
-If you have set `http.detailed_errors.enabled: false` (the default is `true`)
-the structure of JSON when any exceptions occur now matches the structure when
-detailed errors are enabled.
-To use the previous structure for non-detailed errors, use the v8 REST API.
-====
-
-[[remove_cluster_state_from_cluster_reroute_response]]
-.Remove cluster state from `/_cluster/reroute` response
-[%collapsible]
-====
-*Details* +
-The `POST /_cluster/reroute` API no longer returns the cluster state in its response. The `?metric` query parameter to this API now has no effect and its use will be forbidden in a future version.
-
-*Impact* +
-Cease usage of the `?metric` query parameter when calling the `POST /_cluster/reroute` API.
-====
-
-[[remove_deprecated_local_attribute_from_alias_apis]]
-.Remove deprecated local attribute from alias APIs
-[%collapsible]
-====
-*Details* +
-The following APIs no longer accept the `?local` query parameter: `GET /_alias`, `GET /_aliases`, `GET /_alias/{name}`, `HEAD /_alias/{name}`, `GET /{index}/_alias`, `HEAD /{index}/_alias`, `GET /{index}/_alias/{name}`, `HEAD /{index}/_alias/{name}`, `GET /_cat/aliases`, and `GET /_cat/aliases/{alias}`. This parameter has been deprecated and ignored since version 8.12.
-
-*Impact* +
-Cease usage of the `?local` query parameter when calling the listed APIs.
-====
-
-[[remove_legacy_params_from_range_query]]
-.Remove legacy params from range query
-[%collapsible]
-====
-*Details* +
-The deprecated range query parameters `to`, `from`, `include_lower`, and `include_upper` are no longer supported.
-
-*Impact* +
-Users should use `lt`, `lte`, `gt`, and `gte` query parameters instead.
-====
-
-[[remove_support_for_deprecated_force_source_highlighting_parameter]]
-.Remove support for deprecated `force_source` highlighting parameter
-[%collapsible]
-====
-*Details* +
-The deprecated highlighting `force_source` parameter is no longer supported.
-
-*Impact* +
-Users should remove usages of the `force_source` parameter from their search requests.
-====
-
-[discrete]
-[[breaking_90_transforms_changes]]
-==== {transforms-cap} changes
-
-[[updating_deprecated_transform_roles]]
-.Updating deprecated {transform} roles (`data_frame_transforms_admin` and `data_frame_transforms_user`)
-[%collapsible]
-====
-*Details* +
-The `data_frame_transforms_admin` and `data_frame_transforms_user` {transform} roles have been deprecated.
-
-*Impact* +
-Users must update any existing {transforms} that use deprecated {transform} roles (`data_frame_transforms_admin` or `data_frame_transforms_user`) to use the new equivalent {transform} roles (`transform_admin` or `transform_user`).
-To update the {transform} roles:
-
-1. Switch to a user with the `transform_admin` role (to replace `data_frame_transforms_admin`) or the `transform_user` role (to replace `data_frame_transforms_user`).
-2. Call the <<update-transform, update {transforms} API>> with that user.
-====
-
-
-[discrete]
-[[deprecated-9.0]]
-=== Deprecations
-
-The following functionality has been deprecated in {es} 9.0
-and will be removed in a future version.
-While this won't have an immediate impact on your applications,
-we strongly encourage you to take the described steps to update your code
-after upgrading to 9.0.
-
-To find out if you are using any deprecated functionality,
-enable <<deprecation-logging, deprecation logging>>.
-
-[discrete]
-[[deprecations_90_mapping]]
-==== Mapping deprecations
-
-[[deprecate_source_mode_in_mappings]]
-.Deprecate `_source.mode` in mappings
-[%collapsible]
-====
-*Details* +
-Configuring `_source.mode` in mappings is deprecated and will be removed in future versions. Use `index.mapping.source.mode` index setting instead.
-
-*Impact* +
-Use `index.mapping.source.mode` index setting instead
-====
-
-[discrete]
-[[deprecations_90_rest_api]]
-==== REST API deprecations
-
-[[document_type_deprecated_on_simulate_pipeline_api]]
-.Document `_type` deprecated on simulate pipeline API
-[%collapsible]
-====
-*Details* +
-Passing a document with a `_type` property is deprecated in the `/_ingest/pipeline/{id}/_simulate` and `/_ingest/pipeline/_simulate` APIs.
-
-*Impact* +
-Users should already have stopped using mapping types, which were deprecated in {es} 7. This deprecation warning will fire if they specify mapping types on documents pass to the simulate pipeline API.
-====
-
-[[inference_api_deprecate_elser_service]]
-.[Inference API] Deprecate elser service
-[%collapsible]
-====
-*Details* +
-The `elser` service of the inference API will be removed in an upcoming release. Please use the elasticsearch service instead.
-
-*Impact* +
-In the current version there is no impact. In a future version, users of the `elser` service will no longer be able to use it, and will be required to use the `elasticsearch` service to access elser through the inference API.
-====
-

--- a/docs/reference/migration/migrate_9_0.asciidoc
+++ b/docs/reference/migration/migrate_9_0.asciidoc
@@ -95,7 +95,7 @@ The response contains the list of critical deprecation warnings in the `index_se
 
 [source,console-result]
 ------------------------------------------------------------
-...
+(...)
 "index_settings" : {
     ".ml-anomalies-shared" : [
       {
@@ -107,7 +107,7 @@ The response contains the list of critical deprecation warnings in the `index_se
       }
     ]
   },
-...
+(...)
 ------------------------------------------------------------
 // NOTCONSOLE
 

--- a/docs/reference/migration/migrate_9_0.asciidoc
+++ b/docs/reference/migration/migrate_9_0.asciidoc
@@ -323,11 +323,21 @@ In the current version there is no impact. In a future version, users of the `el
 [[breaking_90_anomaly_detection_results]]
 === Anomaly detection results migration
 
-[[prepare_anomaly_detection_result_indices_for_upgrade]]
-.Preparing anomaly detection result indices for upgrade
+The {anomaly-detect} result indices `.ml-anomalies-*` created in {es} 7.x must be either reindexed, marked read-only, or deleted before upgrading to 9.x. 
+
+**Reindexing**: While anomaly detection results are being reindexed, jobs continue to run and process new data.
+However, you cannot completely delete an {anomaly-job} that stores results in this index until the reindexing is complete.
+
+**Marking indices as read-only**: This is useful for large indexes that contain the results of only one or a few {anomaly-jobs}.
+If you delete these jobs later, you will not be able to create a new job with the same name.
+
+**Deleting**: Delete jobs that are no longer needed in the {ml-app} in {kib}.
+The result index is deleted when all jobs that store results in it have been deleted.
+
+[[which_indices_require_attention]]
+.Which indices require attention?
 [%collapsible]
 ====
-The {anomaly-detect} result indices `.ml-anomalies-*` created in {es} 7.x must be either reindexed, marked read-only, or deleted before upgrading to 9.x. 
 
 To identify indices that require action, use the <<migration-api-deprecation,Deprecation info API>>:
 
@@ -355,17 +365,10 @@ The response contains the list of critical deprecation warnings in the `index_se
 ------------------------------------------------------------
 // NOTCONSOLE
 
-**Reindexing**: While anomaly detection results are being reindexed, jobs continue to run and process new data.
-However, you cannot completely delete an {anomaly-job} that stores results in this index until the reindexing is complete.
 
-**Marking indices as read-only**: This is useful for large indexes that contain the results of only one or a few {anomaly-jobs}.
-If you delete these jobs later, you will not be able to create a new job with the same name.
-
-**Deleting**: Delete jobs that are no longer needed in the {ml-app} in {kib}.
-The result index is deleted when all jobs that store results in it have been deleted.
 ====
 
-[[reindex_anomaly_result_index_read_only]]
+[[reindex_anomaly_result_index]]
 .Reindexing anomaly result indices
 [%collapsible]
 ====
@@ -586,6 +589,26 @@ POST _aliases
 --
 ====
 
+[[mark_anomaly_result_index_read_only]]
+.Marking anomaly result indices as read-only
+[%collapsible]
+====
+Legacy indexes created in {es} 7.x can be made read-only and supported in {es} 9.x.
+Making an index with a large amount of historical results read-only allows for a quick migration to the next major release, since you don't have to wait for the data to be reindexed into the new format.
+However, it has the limitation that even after deleting an {anomaly-job}, the historical results associated with this job are not completely deleted.
+Therefore, the system will prevent you from creating a new job with the same name.
+
+To set the index as read-only, add the `write` block to the index:
+
+[source,console]
+------------------------------------------------------------
+PUT .ml-anomalies-custom-example/_block/write
+------------------------------------------------------------
+// TEST[skip:TBD]
+
+Indices created in {es} 7.x that have a `write` block will not raise a critical deprecation warning.
+====
+
 [[delete_anomaly_result_index]]
 .Deleting anomaly result indices
 [%collapsible]
@@ -612,24 +635,4 @@ GET .ml-anomalies-custom-example/_search
 
 The jobs can be deleted in the UI.
 After the last job is deleted, the index will be deleted as well.
-====
-
-[[mark_anomaly_result_index_read_only]]
-.Marking anomaly result indices as read-only
-[%collapsible]
-====
-Legacy indexes created in {es} 7.x can be made read-only and supported in {es} 9.x.
-Making an index with a large amount of historical results read-only allows for a quick migration to the next major release, since you don't have to wait for the data to be reindexed into the new format.
-However, it has the limitation that even after deleting an {anomaly-job}, the historical results associated with this job are not completely deleted.
-Therefore, the system will prevent you from creating a new job with the same name.
-
-To set the index as read-only, add the `write` block to the index:
-
-[source,console]
-------------------------------------------------------------
-PUT .ml-anomalies-custom-example/_block/write
-------------------------------------------------------------
-// TEST[skip:TBD]
-
-Indices created in {es} 7.x that have a `write` block will not raise a critical deprecation warning.
 ====

--- a/docs/reference/migration/migrate_9_0.asciidoc
+++ b/docs/reference/migration/migrate_9_0.asciidoc
@@ -95,6 +95,7 @@ The response contains the list of critical deprecation warnings in the `index_se
 
 [source,console-result]
 ------------------------------------------------------------
+{
 (...)
 "index_settings" : {
     ".ml-anomalies-shared" : [
@@ -108,6 +109,7 @@ The response contains the list of critical deprecation warnings in the `index_se
     ]
   },
 (...)
+}
 ------------------------------------------------------------
 // NOTCONSOLE
 

--- a/docs/reference/migration/migrate_9_0.asciidoc
+++ b/docs/reference/migration/migrate_9_0.asciidoc
@@ -474,7 +474,7 @@ GET _tasks/<task_id>
 PUT /.reindexed-v9-ml-anomalies-custom-example/_settings
 {
   "index": {
-    "number_of_replicas": <original_number_of_replicas>
+    "number_of_replicas": "<original_number_of_replicas>"
   }
 }
 ------------------------------------------------------------

--- a/docs/reference/migration/migrate_9_0.asciidoc
+++ b/docs/reference/migration/migrate_9_0.asciidoc
@@ -95,8 +95,6 @@ The response contains the list of critical deprecation warnings in the `index_se
 
 [source,console-result]
 ------------------------------------------------------------
-{
-(...)
 "index_settings" : {
     ".ml-anomalies-shared" : [
       {
@@ -109,7 +107,6 @@ The response contains the list of critical deprecation warnings in the `index_se
     ]
   },
 (...)
-}
 ------------------------------------------------------------
 // NOTCONSOLE
 

--- a/docs/reference/migration/migrate_9_0.asciidoc
+++ b/docs/reference/migration/migrate_9_0.asciidoc
@@ -351,7 +351,7 @@ The response contains the list of critical deprecation warnings in the `index_se
         "resolve_during_rolling_upgrade": false
       }
     ]
-  }
+  },
 (...)
 ------------------------------------------------------------
 // NOTCONSOLE

--- a/docs/reference/migration/migrate_9_0.asciidoc
+++ b/docs/reference/migration/migrate_9_0.asciidoc
@@ -351,8 +351,7 @@ The response contains the list of critical deprecation warnings in the `index_se
         "resolve_during_rolling_upgrade": false
       }
     ]
-  },
-(...)
+  }
 ------------------------------------------------------------
 // NOTCONSOLE
 

--- a/docs/reference/migration/migrate_9_0.asciidoc
+++ b/docs/reference/migration/migrate_9_0.asciidoc
@@ -74,6 +74,324 @@ The change is small and should generally provide better analysis results. Existi
 ====
 
 [discrete]
+[[breaking_90_anomaly_detection_results]]
+==== Anomaly detection results
+
+[[prepare_anomaly_detection_result_indices_for_upgrade]]
+.Preparing anomaly detection result indices for upgrade
+[%collapsible]
+====
+The {anomaly-detect} result indices `.ml-anomalies-*` created in {es} 7.x must be either reindexed, marked read-only, or deleted before upgrading to 9.x. 
+
+To identify indices that require action, use the <<migration-api-deprecation,Deprecation info API>>:
+
+[source,console]
+------------------------------------------------------------
+GET /.ml-anomalies-*/_migration/deprecations
+------------------------------------------------------------
+// TEST[skip:TBD]
+
+The response contains the list of critical deprecation warnings in the `index_settings` section:
+
+[source,console-result]
+------------------------------------------------------------
+...
+"index_settings" : {
+    ".ml-anomalies-shared" : [
+      {
+        "level" : "critical",
+        "message" : "Index created before 8.0",
+        "url" : "https://ela.st/es-deprecation-8-reindex",
+        "details" : "This index was created with version 7.8.23 and is not compatible with 9.0. Reindex or remove the index before upgrading.",
+        "resolve_during_rolling_upgrade" : false
+      }
+    ]
+  },
+...
+------------------------------------------------------------
+// NOTCONSOLE
+
+**Reindexing**: While anomaly detection results are being reindexed, jobs continue to run and process new data.
+However, you cannot completely delete an {anomaly-job} that stores results in this index until the reindexing is complete.
+
+**Marking indices as read-only**: This is useful for large indexes that contain the results of only one or a few {anomaly-jobs}.
+If you delete these jobs later, you will not be able to create a new job with the same name.
+
+**Deleting**: Delete jobs that are no longer needed in the {ml-app} in {kib}.
+The result index is deleted when all jobs that store results in it have been deleted.
+====
+
+[[reindex_anomaly_result_index_read_only]]
+.Reindexing anomaly result indices
+[%collapsible]
+====
+For an index with less than 10GB that contains results from multiple jobs that are still required, we recommend reindexing into a new format using UI.
+You can use the <<cat-indices>> to obtain the size of an index:
+
+[source,console]
+------------------------------------------------------------
+GET _cat/indices/.ml-anomalies-custom-example?v&h=index,store.size
+------------------------------------------------------------
+// TEST[skip:TBD]
+
+The reindexing can be initiated in the Kibana Upgrade Assistant.
+
+If an index size is greater than 10 GB it is recommended to use the Reindex API.
+Reindexing consists of the following steps:
+
+. Set the original index to read-only.
++
+--
+[source,console]
+------------------------------------------------------------
+PUT .ml-anomalies-custom-example/_block/read_only
+------------------------------------------------------------
+// TEST[skip:TBD]
+--
+
+. Create a new index from the legacy index.
++
+--
+[source,console]
+------------------------------------------------------------
+POST _create_from/.ml-anomalies-custom-example/.reindexed-v9-ml-anomalies-custom-example
+------------------------------------------------------------
+// TEST[skip:TBD]
+--
+
+. Reindex documents.
+To accelerate the reindexing process, it is recommended that the number of replicas be set to `0` before the reindexing and then set back to the original number once it is completed.
+.. Get the number of replicas.
++
+--
+[source,console]
+------------------------------------------------------------
+GET /.reindexed-v9-ml-anomalies-custom-example/_settings
+------------------------------------------------------------
+// TEST[skip:TBD]
+Note the number of replicas in the response. For example:
+[source,console-result]
+------------------------------------------------------------
+{
+  ".reindexed-v9-ml-anomalies-custom-example": {
+    "settings": {
+      "index": {
+        "number_of_replicas": "1",
+        "number_of_shards": "1"
+      }
+    }
+  }
+}
+------------------------------------------------------------
+// NOTCONSOLE
+--
+.. Set the number of replicas to `0`.
++
+--
+[source,console]
+------------------------------------------------------------
+PUT /.reindexed-v9-ml-anomalies-custom-example/_settings
+{
+  "index": {
+    "number_of_replicas": 0
+  }
+}
+------------------------------------------------------------
+// TEST[skip:TBD]
+--
+.. Start the reindexing process in asynchronous mode.
++
+--
+[source,console]
+------------------------------------------------------------
+POST _reindex?wait_for_completion=false
+{
+  "source": {
+    "index": ".ml-anomalies-custom-example"
+  },
+  "dest": {
+    "index": ".reindexed-v9-ml-anomalies-custom-example"
+  }
+}
+------------------------------------------------------------
+// TEST[skip:TBD]
+The response will contain a task_id. You can check when the task is completed using the following command:
+[source,console]
+------------------------------------------------------------
+GET _tasks/<task_id>
+------------------------------------------------------------
+// TEST[skip:TBD]
+--
+.. Set the number of replicas to the original number when the reindexing is finished.
++
+--
+[source,console]
+------------------------------------------------------------
+PUT /.reindexed-v9-ml-anomalies-custom-example/_settings
+{
+  "index": {
+    "number_of_replicas": <original_number_of_replicas>
+  }
+}
+------------------------------------------------------------
+// TEST[skip:TBD]
+--
+
+. Get the aliases the original index is pointing to.
++
+--
+[source,console]
+------------------------------------------------------------
+GET .ml-anomalies-custom-example/_alias
+------------------------------------------------------------
+// TEST[skip:TBD]
+
+The response may contain multiple aliases if the results of multiple jobs are stored in the same index.
+
+[source,console-result]
+------------------------------------------------------------
+{
+  ".ml-anomalies-custom-example": {
+    "aliases": {
+      ".ml-anomalies-example1": {
+        "filter": {
+          "term": {
+            "job_id": {
+              "value": "example1"
+            }
+          }
+        },
+        "is_hidden": true
+      },
+      ".ml-anomalies-example2": {
+        "filter": {
+          "term": {
+            "job_id": {
+              "value": "example2"
+            }
+          }
+        },
+        "is_hidden": true
+      }
+    }
+  }
+}
+------------------------------------------------------------
+// NOTCONSOLE
+--
+
+. Now you can reassign the aliases to the new index and delete the original index in one step.
+Note that when adding the new index to the aliases, you must use the same filter and is_hidden parameters as for the original index.
++
+--
+[source,console]
+------------------------------------------------------------
+POST _aliases
+{
+  "actions": [
+    {
+      "add": {
+        "index": ".reindexed-v9-ml-anomalies-custom-example",
+        "alias": ".ml-anomalies-example1",
+        "filter": {
+          "term": {
+            "job_id": {
+              "value": "example1"
+            }
+          }
+        },
+        "is_hidden": true
+      }
+    },
+    {
+      "add": {
+        "index": ".reindexed-v9-ml-anomalies-custom-example",
+        "alias": ".ml-anomalies-example2",
+        "filter": {
+          "term": {
+            "job_id": {
+              "value": "example2"
+            }
+          }
+        },
+        "is_hidden": true
+      }
+    },
+    {
+      "remove": {
+        "index": ".ml-anomalies-custom-example",
+        "aliases": ".ml-anomalies-*"
+      }
+    },
+    {
+      "remove_index": {
+        "index": ".ml-anomalies-custom-example"
+      }
+    },
+    {
+      "add": {
+        "index": ".reindexed-v9-ml-anomalies-custom-example",
+        "alias": ".ml-anomalies-custom-example",
+        "is_hidden": true
+      }
+    }
+  ]
+}
+------------------------------------------------------------
+// TEST[skip:TBD]
+--
+====
+
+[[delete_anomaly_result_index]]
+.Deleting anomaly result indices
+[%collapsible]
+====
+If an index contains results of the jobs that are no longer required.
+To list all jobs that stored results in an index, use the terms aggregation:
+
+[source,console]
+------------------------------------------------------------
+GET .ml-anomalies-custom-example/_search
+{
+  "size": 0, 
+  "aggs": {
+    "job_ids": {
+      "terms": {
+        "field": "job_id", 
+        "size": 100 
+      }
+    }
+  }
+}
+------------------------------------------------------------
+// TEST[skip:TBD]
+
+The jobs can be deleted in the UI.
+After the last job is deleted, the index will be deleted as well.
+====
+
+[[mark_anomaly_result_index_read_only]]
+.Marking anomaly result indices as read-only
+[%collapsible]
+====
+Legacy indexes created in {es} 7.x can be made read-only and supported in {es} 9.x.
+Making an index with a large amount of historical results read-only allows for a quick migration to the next major release, since you don't have to wait for the data to be reindexed into the new format.
+However, it has the limitation that even after deleting an {anomaly-job}, the historical results associated with this job are not completely deleted.
+Therefore, the system will prevent you from creating a new job with the same name.
+
+To set the index as read-only, add the `write` block to the index:
+
+[source,console]
+------------------------------------------------------------
+PUT .ml-anomalies-custom-example/_block/write
+------------------------------------------------------------
+// TEST[skip:TBD]
+
+Indices created in {es} 7.x that have a `write` block will not raise a critical deprecation warning.
+====
+
+
+[discrete]
 [[breaking_90_cluster_and_node_setting_changes]]
 ==== Cluster and node setting changes
 


### PR DESCRIPTION
## Overview

This PR adds instructions on what to do with anomaly result indices for a 9.0 upgrade.

### Preview

[Anomaly detection results](https://elasticsearch_bk_121015.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-9.0.html#breaking_90_anomaly_detection_results)