### PR TITLE
Fix syntax errors in the rescore retriever example

### DIFF
--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -433,10 +433,13 @@ GET movies/_search
   "retriever": {
     "rescorer": { <2>
       "rescore": {
-        "query": { <3>
-          "window_size": 50, <4>
+        "window_size": 50, <3>
+        "query": { <4>
           "rescore_query": {
             "script_score": {
+              "query": {
+                "match_all": {}
+              },
               "script": {
                 "source": "cosineSimilarity(params.queryVector, 'product-vector_final_stage') + 1.0",
                 "params": {
@@ -493,8 +496,8 @@ GET movies/_search
 // TEST[skip:uses ELSER]
 <1> Specifies the number of top documents to return in the final response.
 <2> A `rescorer` retriever applied as the final step.
-<3> The definition of the `query` rescorer.
-<4> Defines the number of documents to rescore from the child retriever.
+<3> Defines the number of documents to rescore from the child retriever.
+<4> The definition of the `query` rescorer.
 <5> Specifies the child retriever definition.
 <6> Defines the number of documents returned by the `rrf` retriever, which limits the available documents to
 


### PR DESCRIPTION
I have tried the rescore retriever on serverless and the example in the documentation contains some minor syntax errors. 

1. `window_size` is part of the `rescore` object and not the `rescore.query` 
2. `query` is missing the `script_score` query, which causes it to fail. 