### PR TITLE
[8.x] Fix incorrect use of "updateable" flag in synonyms documentation (#120866)

### DIFF
--- a/docs/reference/search/search-your-data/search-with-synonyms.asciidoc
+++ b/docs/reference/search/search-your-data/search-with-synonyms.asciidoc
@@ -145,15 +145,35 @@ The following example adds `my_analyzer` as a search analyzer to the `title` fie
 
 [source,JSON]
 ----
+{
   "mappings": {
     "properties": {
       "title": {
         "type": "text",
-        "search_analyzer": "my_analyzer",
-        "updateable": true
+        "search_analyzer": "my_analyzer"
+      }
+    }
+  },
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "my_analyzer": {
+          "tokenizer": "whitespace",
+          "filter": [
+            "synonyms_filter"
+          ]
+        }
+      },
+      "filter": {
+        "synonyms_filter": {
+          "type": "synonym",
+          "synonyms_path": "analysis/synonym-set.txt",
+          "updateable": true
+        }
       }
     }
   }
+}
 ----
 
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix incorrect use of "updateable" flag in synonyms documentation (#120866)