### PR TITLE
Disable the test in release for now

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -224,9 +224,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncEnrichStopIT
   method: testEnrichAfterStop
   issue: https://github.com/elastic/elasticsearch/issues/120757
-- class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryIT
-  method: testStopQuery
-  issue: https://github.com/elastic/elasticsearch/issues/120767
 - class: org.elasticsearch.search.fieldcaps.FieldCapabilitiesIT
   issue: https://github.com/elastic/elasticsearch/issues/120772
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.action;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionFuture;
@@ -265,6 +266,7 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
     }
 
     public void testStopQuery() throws Exception {
+        assumeTrue("Pragme does not work in release builds", Build.current().isSnapshot());
         Map<String, Object> testClusterInfo = setupClusters(3);
         int localNumShards = (Integer) testClusterInfo.get("local.num_shards");
         int remote1NumShards = (Integer) testClusterInfo.get("remote1.num_shards");


### PR DESCRIPTION
Pragmas do not work in release version, we need to see a better way to ensure the test is stable. 

Fixes https://github.com/elastic/elasticsearch/issues/120767