### PR TITLE
[8.x] Use the system index descriptor in the snapshot blob cache cleanup task (#120937)

### DIFF
--- a/docs/changelog/120937.yaml
+++ b/docs/changelog/120937.yaml
@@ -1,0 +1,6 @@
+pr: 120937
+summary: Use the system index descriptor in the snapshot blob cache cleanup task
+area: Snapshot/Restore
+type: bug
+issues:
+ - 120518

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -339,7 +339,14 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             final BlobStoreCacheService blobStoreCacheService = new BlobStoreCacheService(client, SNAPSHOT_BLOB_CACHE_INDEX);
             this.blobStoreCacheService.set(blobStoreCacheService);
             clusterService.addListener(
-                new BlobStoreCacheMaintenanceService(settings, clusterService, threadPool, client, SNAPSHOT_BLOB_CACHE_INDEX)
+                new BlobStoreCacheMaintenanceService(
+                    settings,
+                    clusterService,
+                    threadPool,
+                    client,
+                    services.systemIndices(),
+                    SNAPSHOT_BLOB_CACHE_INDEX
+                )
             );
             components.add(blobStoreCacheService);
         } else {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Use the system index descriptor in the snapshot blob cache cleanup task (#120937)