### PR TITLE
[8.x] Adjusted alias doc for clarity (#120437)

### DIFF
--- a/docs/reference/alias.asciidoc
+++ b/docs/reference/alias.asciidoc
@@ -2,12 +2,14 @@
 [[aliases]]
 = Aliases
 
-An alias is a secondary name for a group of data streams or indices. Most {es}
+An alias points to one or more indices or data streams. Most {es}
 APIs accept an alias in place of a data stream or index name.
 
-You can change the data streams or indices of an alias at any time. If you use
-aliases in your application's {es} requests, you can reindex data with no
-downtime or changes to your app's code.
+Aliases enable you to:
+
+* Query multiple indices/data streams together with a single name
+* Change which indices/data streams your application uses in real time
+* <<docs-reindex,Reindex>> data without downtime
 
 [discrete]
 [[alias-types]]


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Adjusted alias doc for clarity (#120437)