### PR TITLE
[8.x] Disable the test in release for now (#121051)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.action;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionFuture;
@@ -265,6 +266,7 @@ public class CrossClusterAsyncQueryIT extends AbstractMultiClustersTestCase {
     }
 
     public void testStopQuery() throws Exception {
+        assumeTrue("Pragme does not work in release builds", Build.current().isSnapshot());
         Map<String, Object> testClusterInfo = setupClusters(3);
         int localNumShards = (Integer) testClusterInfo.get("local.num_shards");
         int remote1NumShards = (Integer) testClusterInfo.get("remote1.num_shards");


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Disable the test in release for now (#121051)](https://github.com/elastic/elasticsearch/pull/121051)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)