### PR TITLE
Use links when possible when installing test cluster modules

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -350,15 +350,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                         IOUtils.deleteWithRetry(distributionDir);
                     }
 
-                    try {
-                        IOUtils.syncWithLinks(distributionDescriptor.getDistributionDir(), distributionDir);
-                    } catch (IOUtils.LinkCreationException e) {
-                        // Note does not work for network drives, e.g. Vagrant
-                        LOGGER.info("Failed to create working dir using hard links. Falling back to copy", e);
-                        // ensure we get a clean copy
-                        IOUtils.deleteWithRetry(distributionDir);
-                        IOUtils.syncWithCopy(distributionDescriptor.getDistributionDir(), distributionDir);
-                    }
+                    IOUtils.syncMaybeWithLinks(distributionDescriptor.getDistributionDir(), distributionDir);
                 }
                 Files.createDirectories(repoDir);
                 Files.createDirectories(dataDir);
@@ -773,7 +765,8 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
 
                 });
 
-                IOUtils.syncWithCopy(modulePath, destination);
+                IOUtils.syncMaybeWithLinks(modulePath, destination);
+
                 try {
                     if (installSpec.entitlementsOverride != null) {
                         Path entitlementsFile = modulePath.resolve(ENTITLEMENT_POLICY_YAML);

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
@@ -56,7 +56,7 @@ public final class IOUtils {
     }
 
     /**
-     * Attempts to do a copy via linking, calling back to a normal copy if an exception is encountered.
+     * Attempts to do a copy via linking, falling back to a normal copy if an exception is encountered.
      *
      * @see #syncWithLinks(Path, Path)
      * @see #syncWithCopy(Path, Path)
@@ -71,11 +71,11 @@ public final class IOUtils {
             LOGGER.info("Failed to sync using hard links. Falling back to copy.", e);
             // ensure we get a clean copy
             try {
-                IOUtils.deleteWithRetry(destinationRoot);
+                deleteWithRetry(destinationRoot);
             } catch (IOException ex) {
                 throw new UncheckedIOException(ex);
             }
-            IOUtils.syncWithCopy(sourceRoot, destinationRoot);
+            syncWithCopy(sourceRoot, destinationRoot);
         }
     }
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
@@ -9,6 +9,9 @@
 
 package org.elasticsearch.test.cluster.util;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -20,6 +23,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 public final class IOUtils {
+    private static final Logger LOGGER = LogManager.getLogger(IOUtils.class);
     private static final int RETRY_DELETE_MILLIS = OS.current() == OS.WINDOWS ? 500 : 0;
     private static final int MAX_RETRY_DELETE_TIMES = OS.current() == OS.WINDOWS ? 15 : 0;
 
@@ -48,6 +52,30 @@ public final class IOUtils {
             throw new UncheckedIOException(e);
         } catch (InterruptedException x) {
             throw new UncheckedIOException("Interrupted while deleting.", new IOException());
+        }
+    }
+
+    /**
+     * Attempts to do a copy via linking, calling back to a normal copy if an exception is encountered.
+     *
+     * @see #syncWithLinks(Path, Path)
+     * @see #syncWithCopy(Path, Path)
+     * @param sourceRoot      where to copy from
+     * @param destinationRoot destination to link to
+     */
+    public static void syncMaybeWithLinks(Path sourceRoot, Path destinationRoot) {
+        try {
+            syncWithLinks(sourceRoot, destinationRoot);
+        } catch (LinkCreationException e) {
+            // Note does not work for network drives, e.g. Vagrant
+            LOGGER.info("Failed to sync using hard links. Falling back to copy.", e);
+            // ensure we get a clean copy
+            try {
+                IOUtils.deleteWithRetry(destinationRoot);
+            } catch (IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
+            IOUtils.syncWithCopy(sourceRoot, destinationRoot);
         }
     }
 


### PR DESCRIPTION
When we install modules into test clusters we do a full copy instead of links. This both eats up more IO and disk space unnecessarily.