### PR TITLE
[8.x] ESQL: Make all LOOKUP JOIN caps depend on the V12 one (#120894)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -582,7 +582,7 @@ public class EsqlCapabilities {
         /**
          * LOOKUP JOIN with TEXT fields on the right (right side of the join) (#119473)
          */
-        LOOKUP_JOIN_TEXT(Build.current().isSnapshot()),
+        LOOKUP_JOIN_TEXT(JOIN_LOOKUP_V12.isEnabled()),
 
         /**
          * LOOKUP JOIN without MV matching (https://github.com/elastic/elasticsearch/issues/118780)


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Make all LOOKUP JOIN caps depend on the V12 one (#120894)