### PR TITLE
Fix cleanup for skipped test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -280,12 +280,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.parser.StatementParserTests
   method: testNamedFunctionArgumentInMap
   issue: https://github.com/elastic/elasticsearch/issues/121020
-- class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityEsqlIT
-  method: testCrossClusterAsyncQuery
-  issue: https://github.com/elastic/elasticsearch/issues/121021
-- class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityEsqlIT
-  method: testCrossClusterAsyncQueryStop
-  issue: https://github.com/elastic/elasticsearch/issues/121021
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testSuggestProfilesWithName
   issue: https://github.com/elastic/elasticsearch/issues/121022

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
@@ -344,13 +344,24 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
         return otherUser;
     }
 
+    private void performRequestWithAdminUserIgnoreNotFound(RestClient targetFulfillingClusterClient, Request request) throws IOException {
+        try {
+            performRequestWithAdminUser(targetFulfillingClusterClient, request);
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                throw e;
+            }
+            logger.info("Ignored \"not found\" exception", e);
+        }
+    }
+
     @After
     public void wipeData() throws Exception {
         CheckedConsumer<RestClient, IOException> wipe = client -> {
-            performRequestWithAdminUser(client, new Request("DELETE", "/employees"));
-            performRequestWithAdminUser(client, new Request("DELETE", "/employees2"));
-            performRequestWithAdminUser(client, new Request("DELETE", "/employees3"));
-            performRequestWithAdminUser(client, new Request("DELETE", "/_enrich/policy/countries"));
+            performRequestWithAdminUserIgnoreNotFound(client, new Request("DELETE", "/employees"));
+            performRequestWithAdminUserIgnoreNotFound(client, new Request("DELETE", "/employees2"));
+            performRequestWithAdminUserIgnoreNotFound(client, new Request("DELETE", "/employees3"));
+            performRequestWithAdminUserIgnoreNotFound(client, new Request("DELETE", "/_enrich/policy/countries"));
         };
         wipe.accept(fulfillingClusterClient);
         wipe.accept(client());


### PR DESCRIPTION
We should not check that deleted index exists if the tests could be skipped. 

Fixes https://github.com/elastic/elasticsearch/issues/121021