### PR TITLE
[8.16] Use links when possible when installing test cluster modules (#121067)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -328,15 +328,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                         IOUtils.deleteWithRetry(distributionDir);
                     }
 
-                    try {
-                        IOUtils.syncWithLinks(distributionDescriptor.getDistributionDir(), distributionDir);
-                    } catch (IOUtils.LinkCreationException e) {
-                        // Note does not work for network drives, e.g. Vagrant
-                        LOGGER.info("Failed to create working dir using hard links. Falling back to copy", e);
-                        // ensure we get a clean copy
-                        IOUtils.deleteWithRetry(distributionDir);
-                        IOUtils.syncWithCopy(distributionDescriptor.getDistributionDir(), distributionDir);
-                    }
+                    IOUtils.syncMaybeWithLinks(distributionDescriptor.getDistributionDir(), distributionDir);
                 }
                 Files.createDirectories(repoDir);
                 Files.createDirectories(dataDir);
@@ -708,7 +700,8 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
 
                 });
 
-                IOUtils.syncWithCopy(modulePath, destination);
+                IOUtils.syncMaybeWithLinks(modulePath, destination);
+
                 try {
                     if (installSpec.entitlementsOverride != null) {
                         Path entitlementsFile = modulePath.resolve(ENTITLEMENT_POLICY_YAML);


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Use links when possible when installing test cluster modules (#121067)