### PR TITLE
[8.x] Fix cleanup for skipped test (#121073)

### DIFF
--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
@@ -344,13 +344,24 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
         return otherUser;
     }
 
+    private void performRequestWithAdminUserIgnoreNotFound(RestClient targetFulfillingClusterClient, Request request) throws IOException {
+        try {
+            performRequestWithAdminUser(targetFulfillingClusterClient, request);
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                throw e;
+            }
+            logger.info("Ignored \"not found\" exception", e);
+        }
+    }
+
     @After
     public void wipeData() throws Exception {
         CheckedConsumer<RestClient, IOException> wipe = client -> {
-            performRequestWithAdminUser(client, new Request("DELETE", "/employees"));
-            performRequestWithAdminUser(client, new Request("DELETE", "/employees2"));
-            performRequestWithAdminUser(client, new Request("DELETE", "/employees3"));
-            performRequestWithAdminUser(client, new Request("DELETE", "/_enrich/policy/countries"));
+            performRequestWithAdminUserIgnoreNotFound(client, new Request("DELETE", "/employees"));
+            performRequestWithAdminUserIgnoreNotFound(client, new Request("DELETE", "/employees2"));
+            performRequestWithAdminUserIgnoreNotFound(client, new Request("DELETE", "/employees3"));
+            performRequestWithAdminUserIgnoreNotFound(client, new Request("DELETE", "/_enrich/policy/countries"));
         };
         wipe.accept(fulfillingClusterClient);
         wipe.accept(client());


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix cleanup for skipped test (#121073)](https://github.com/elastic/elasticsearch/pull/121073)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)