### PR TITLE
[8.x] Support ignore_above for keywords in test data generation (#119416)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -65,7 +65,7 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
             }
 
             if (ESTestCase.randomDouble() <= 0.2) {
-                injected.put("ignore_above", ESTestCase.randomIntBetween(1, 10000));
+                injected.put("ignore_above", ESTestCase.randomIntBetween(1, 100));
             }
 
             return injected;

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -64,6 +64,10 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
                 }
             }
 
+            if (ESTestCase.randomDouble() <= 0.2) {
+                injected.put("ignore_above", ESTestCase.randomIntBetween(1, 10000));
+            }
+
             return injected;
         };
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Support ignore_above for keywords in test data generation (#119416)](https://github.com/elastic/elasticsearch/pull/119416)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)