### PR TITLE
[8.x] Set default reranker for text similarity reranker (#120551)

### DIFF
--- a/docs/changelog/120551.yaml
+++ b/docs/changelog/120551.yaml
@@ -1,0 +1,5 @@
+pr: 120551
+summary: Set default reranker for text similarity reranker to Elastic reranker
+area: Ranking
+type: enhancement
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import static org.elasticsearch.search.rank.RankBuilder.DEFAULT_RANK_WINDOW_SIZE;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.DEFAULT_RERANK_ID;
 
 /**
  * A {@code RetrieverBuilder} for parsing and constructing a text similarity reranker retriever.
@@ -57,10 +58,11 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
     public static final ConstructingObjectParser<TextSimilarityRankRetrieverBuilder, RetrieverParserContext> PARSER =
         new ConstructingObjectParser<>(TextSimilarityRankBuilder.NAME, args -> {
             RetrieverBuilder retrieverBuilder = (RetrieverBuilder) args[0];
-            String inferenceId = (String) args[1];
+            String inferenceId = args[1] == null ? DEFAULT_RERANK_ID : (String) args[1];
             String inferenceText = (String) args[2];
             String field = (String) args[3];
             int rankWindowSize = args[4] == null ? DEFAULT_RANK_WINDOW_SIZE : (int) args[4];
+
             return new TextSimilarityRankRetrieverBuilder(retrieverBuilder, inferenceId, inferenceText, field, rankWindowSize);
         });
 
@@ -70,7 +72,7 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
             c.trackRetrieverUsage(innerRetriever.getName());
             return innerRetriever;
         }, RETRIEVER_FIELD);
-        PARSER.declareString(constructorArg(), INFERENCE_ID_FIELD);
+        PARSER.declareString(optionalConstructorArg(), INFERENCE_ID_FIELD);
         PARSER.declareString(constructorArg(), INFERENCE_TEXT_FIELD);
         PARSER.declareString(constructorArg(), FIELD_FIELD);
         PARSER.declareInt(optionalConstructorArg(), RANK_WINDOW_SIZE_FIELD);
@@ -187,6 +189,10 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
     @Override
     public String getName() {
         return TextSimilarityRankBuilder.NAME;
+    }
+
+    public String inferenceId() {
+        return inferenceId;
     }
 
     public int rankWindowSize() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilderTests.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.search.rank.RankBuilder.DEFAULT_RANK_WINDOW_SIZE;
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.DEFAULT_RERANK_ID;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -112,7 +113,6 @@ public class TextSimilarityRankRetrieverBuilderTests extends AbstractXContentTes
                 }
               },
               "field": "my-field",
-              "inference_id": "my-inference-id",
               "inference_text": "my-inference-text"
             }""";
 
@@ -122,6 +122,7 @@ public class TextSimilarityRankRetrieverBuilderTests extends AbstractXContentTes
                 new RetrieverParserContext(new SearchUsage(), nf -> true)
             );
             assertEquals(DEFAULT_RANK_WINDOW_SIZE, parsed.rankWindowSize());
+            assertEquals(DEFAULT_RERANK_ID, parsed.inferenceId());
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Set default reranker for text similarity reranker (#120551)