### PR TITLE
[8.x] Return 404 if source index missing in ReindexDataStreamIndexAction (#120971)

### DIFF
--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.migrate.action;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
@@ -150,6 +151,15 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
         var indexReq = new IndexRequest(sourceIndex).source(jsonBuilder().startObject().field("field", "1").endObject());
         assertThrows(ClusterBlockException.class, () -> client().index(indexReq).actionGet());
         assertHitCount(prepareSearch(sourceIndex).setSize(0), 0);
+    }
+
+    public void testMissingSourceIndex() {
+        var nonExistentSourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        assertThrows(
+            ResourceNotFoundException.class,
+            () -> client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(nonExistentSourceIndex))
+                .actionGet()
+        );
     }
 
     public void testSettingsAddedBeforeReindex() throws Exception {

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.readonly.AddIndexBlockRequest;
@@ -117,6 +118,11 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
         var destIndexName = generateDestIndexName(sourceIndexName);
         TaskId taskId = new TaskId(clusterService.localNode().getId(), task.getId());
         IndexMetadata sourceIndex = clusterService.state().getMetadata().index(sourceIndexName);
+        if (sourceIndex == null) {
+            listener.onFailure(new ResourceNotFoundException("source index [{}] does not exist", sourceIndexName));
+            return;
+        }
+
         Settings settingsBefore = sourceIndex.getSettings();
 
         var hasOldVersion = DeprecatedIndexPredicate.getReindexRequiredPredicate(clusterService.state().metadata(), false);


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Return 404 if source index missing in ReindexDataStreamIndexAction (#120971)