### PR TITLE
[BACKPORT] Automatically opening closed indices when reindexing data streams (#120970)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecatedIndexPredicate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecatedIndexPredicate.java
@@ -50,7 +50,6 @@ public class DeprecatedIndexPredicate {
     public static boolean reindexRequired(IndexMetadata indexMetadata, boolean filterToBlockedStatus) {
         return creationVersionBeforeMinimumWritableVersion(indexMetadata)
             && isNotSearchableSnapshot(indexMetadata)
-            && isNotClosed(indexMetadata)
             && matchBlockedStatus(indexMetadata, filterToBlockedStatus);
     }
 
@@ -60,10 +59,6 @@ public class DeprecatedIndexPredicate {
 
     private static boolean creationVersionBeforeMinimumWritableVersion(IndexMetadata metadata) {
         return metadata.getCreationVersion().before(MINIMUM_WRITEABLE_VERSION_AFTER_UPGRADE);
-    }
-
-    private static boolean isNotClosed(IndexMetadata indexMetadata) {
-        return indexMetadata.getState().equals(IndexMetadata.State.CLOSE) == false;
     }
 
     private static boolean matchBlockedStatus(IndexMetadata indexMetadata, boolean filterToBlockedStatus) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
@@ -9,9 +9,11 @@ package org.elasticsearch.xpack.core.security.user;
 
 import org.elasticsearch.action.admin.cluster.shards.TransportClusterSearchShardsAction;
 import org.elasticsearch.action.admin.indices.analyze.TransportReloadAnalyzersAction;
+import org.elasticsearch.action.admin.indices.close.TransportCloseIndexAction;
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeAction;
+import org.elasticsearch.action.admin.indices.open.OpenIndexAction;
 import org.elasticsearch.action.admin.indices.readonly.TransportAddIndexBlockAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.rollover.LazyRolloverAction;
@@ -206,6 +208,8 @@ public class InternalUsers {
                         "indices:admin/data_stream/index/reindex",
                         "indices:admin/index/create_from_source",
                         TransportAddIndexBlockAction.TYPE.name(),
+                        OpenIndexAction.NAME,
+                        TransportCloseIndexAction.NAME,
                         TransportCreateIndexAction.TYPE.name(),
                         TransportClusterSearchShardsAction.TYPE.name(),
                         TransportUpdateSettingsAction.TYPE.name(),

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -45,6 +45,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             .settings(settings(createdWith))
             .numberOfShards(1)
             .numberOfReplicas(0)
+            .state(randomBoolean() ? IndexMetadata.State.OPEN : IndexMetadata.State.CLOSE) // does not matter if its open or closed
             .build();
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
             .metadata(Metadata.builder().put(indexMetadata, true))
@@ -114,22 +115,6 @@ public class IndexDeprecationChecksTests extends ESTestCase {
 
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetadata, clusterState));
 
-        assertThat(issues, empty());
-    }
-
-    public void testOldIndicesCheckClosedIgnored() {
-        IndexVersion createdWith = IndexVersion.fromId(7170099);
-        Settings.Builder settings = settings(createdWith);
-        IndexMetadata indexMetadata = IndexMetadata.builder("test")
-            .settings(settings)
-            .numberOfShards(1)
-            .numberOfReplicas(0)
-            .state(IndexMetadata.State.CLOSE)
-            .build();
-        ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().put(indexMetadata, true))
-            .build();
-        List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetadata, clusterState));
         assertThat(issues, empty());
     }
 

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -11,7 +11,13 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
+import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
+import org.elasticsearch.action.admin.indices.close.TransportCloseIndexAction;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.open.OpenIndexAction;
+import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
+import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
 import org.elasticsearch.action.admin.indices.readonly.AddIndexBlockRequest;
 import org.elasticsearch.action.admin.indices.readonly.AddIndexBlockResponse;
 import org.elasticsearch.action.admin.indices.readonly.TransportAddIndexBlockAction;
@@ -139,16 +145,49 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
             listener.onFailure(new ElasticsearchException(errorMessage));
             return;
         }
-
+        final boolean wasClosed = isClosed(sourceIndex);
         SubscribableListener.<AcknowledgedResponse>newForked(l -> setBlockWrites(sourceIndexName, l, taskId))
+            .<OpenIndexResponse>andThen(l -> openIndexIfClosed(sourceIndexName, wasClosed, l, taskId))
             .<BroadcastResponse>andThen(l -> refresh(sourceIndexName, l, taskId))
             .<AcknowledgedResponse>andThen(l -> deleteDestIfExists(destIndexName, l, taskId))
             .<AcknowledgedResponse>andThen(l -> createIndex(sourceIndex, destIndexName, l, taskId))
             .<BulkByScrollResponse>andThen(l -> reindex(sourceIndexName, destIndexName, l, taskId))
             .<AcknowledgedResponse>andThen(l -> copyOldSourceSettingsToDest(settingsBefore, destIndexName, l, taskId))
             .<AcknowledgedResponse>andThen(l -> sanityCheck(sourceIndexName, destIndexName, l, taskId))
+            .<CloseIndexResponse>andThen(l -> closeIndexIfWasClosed(destIndexName, wasClosed, l, taskId))
             .andThenApply(ignored -> new ReindexDataStreamIndexAction.Response(destIndexName))
             .addListener(listener);
+    }
+
+    private void openIndexIfClosed(String indexName, boolean isClosed, ActionListener<OpenIndexResponse> listener, TaskId parentTaskId) {
+        if (isClosed) {
+            logger.debug("Opening index [{}]", indexName);
+            var request = new OpenIndexRequest(indexName);
+            request.setParentTask(parentTaskId);
+            client.execute(OpenIndexAction.INSTANCE, request, listener);
+        } else {
+            listener.onResponse(null);
+        }
+    }
+
+    private void closeIndexIfWasClosed(
+        String indexName,
+        boolean wasClosed,
+        ActionListener<CloseIndexResponse> listener,
+        TaskId parentTaskId
+    ) {
+        if (wasClosed) {
+            logger.debug("Closing index [{}]", indexName);
+            var request = new CloseIndexRequest(indexName);
+            request.setParentTask(parentTaskId);
+            client.execute(TransportCloseIndexAction.TYPE, request, listener);
+        } else {
+            listener.onResponse(null);
+        }
+    }
+
+    private static boolean isClosed(IndexMetadata indexMetadata) {
+        return indexMetadata.getState().equals(IndexMetadata.State.CLOSE);
     }
 
     private void setBlockWrites(String sourceIndexName, ActionListener<AcknowledgedResponse> listener, TaskId parentTaskId) {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -30,7 +30,6 @@ import org.hamcrest.Matchers;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -264,15 +263,10 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
 
     private void upgradeDataStream(String dataStreamName, int numRolloversOnOldCluster) throws Exception {
         Set<String> indicesNeedingUpgrade = getDataStreamIndices(dataStreamName);
-        Set<String> closedOldIndices = getClosedIndices(dataStreamName);
         final int explicitRolloverOnNewClusterCount = randomIntBetween(0, 2);
         for (int i = 0; i < explicitRolloverOnNewClusterCount; i++) {
             String oldIndexName = rollover(dataStreamName);
             if (randomBoolean()) {
-                if (i == 0) {
-                    // Since this is the first rollover on the new cluster, the old index came from the old cluster
-                    closedOldIndices.add(oldIndexName);
-                }
                 closeIndex(oldIndexName);
             }
         }
@@ -300,39 +294,51 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
                     statusResponse.getEntity().getContent(),
                     false
                 );
+                String statusResponseString = statusResponseMap.keySet()
+                    .stream()
+                    .map(key -> key + "=" + statusResponseMap.get(key))
+                    .collect(Collectors.joining(", ", "{", "}"));
                 assertOK(statusResponse);
-                assertThat(statusResponseMap.get("complete"), equalTo(true));
+                assertThat(statusResponseString, statusResponseMap.get("complete"), equalTo(true));
                 final int originalWriteIndex = 1;
                 if (isOriginalClusterSameMajorVersionAsCurrent()) {
                     assertThat(
+                        statusResponseString,
                         statusResponseMap.get("total_indices_in_data_stream"),
                         equalTo(originalWriteIndex + numRolloversOnOldCluster + explicitRolloverOnNewClusterCount)
                     );
                     // If the original cluster was the same as this one, we don't want any indices reindexed:
-                    assertThat(statusResponseMap.get("total_indices_requiring_upgrade"), equalTo(0));
-                    assertThat(statusResponseMap.get("successes"), equalTo(0));
+                    assertThat(statusResponseString, statusResponseMap.get("total_indices_requiring_upgrade"), equalTo(0));
+                    assertThat(statusResponseString, statusResponseMap.get("successes"), equalTo(0));
                 } else {
                     // The number of rollovers that will have happened when we call reindex:
                     final int rolloversPerformedByReindex = explicitRolloverOnNewClusterCount == 0 ? 1 : 0;
                     final int expectedTotalIndicesInDataStream = originalWriteIndex + numRolloversOnOldCluster
                         + explicitRolloverOnNewClusterCount + rolloversPerformedByReindex;
-                    assertThat(statusResponseMap.get("total_indices_in_data_stream"), equalTo(expectedTotalIndicesInDataStream));
+                    assertThat(
+                        statusResponseString,
+                        statusResponseMap.get("total_indices_in_data_stream"),
+                        equalTo(expectedTotalIndicesInDataStream)
+                    );
                     /*
                      * total_indices_requiring_upgrade is made up of: (the original write index) + numRolloversOnOldCluster. The number of
                      * rollovers on the upgraded cluster is irrelevant since those will not be reindexed.
                      */
                     assertThat(
+                        statusResponseString,
                         statusResponseMap.get("total_indices_requiring_upgrade"),
-                        equalTo(originalWriteIndex + numRolloversOnOldCluster - closedOldIndices.size())
+                        equalTo(originalWriteIndex + numRolloversOnOldCluster)
                     );
-                    assertThat(statusResponseMap.get("successes"), equalTo(numRolloversOnOldCluster + 1 - closedOldIndices.size()));
+                    assertThat(statusResponseString, statusResponseMap.get("successes"), equalTo(numRolloversOnOldCluster + 1));
                     // We expect all the original indices to have been deleted
                     for (String oldIndex : indicesNeedingUpgrade) {
-                        if (closedOldIndices.contains(oldIndex) == false) {
-                            assertThat(indexExists(oldIndex), equalTo(false));
-                        }
+                        assertThat(statusResponseString, indexExists(oldIndex), equalTo(false));
                     }
-                    assertThat(getDataStreamIndices(dataStreamName).size(), equalTo(expectedTotalIndicesInDataStream));
+                    assertThat(
+                        statusResponseString,
+                        getDataStreamIndices(dataStreamName).size(),
+                        equalTo(expectedTotalIndicesInDataStream)
+                    );
                 }
             }, 60, TimeUnit.SECONDS);
             Request cancelRequest = new Request("POST", "_migration/reindex/" + dataStreamName + "/_cancel");
@@ -349,29 +355,6 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
         Map<String, Object> dataStream = dataStreams.get(0);
         List<Map<String, Object>> indices = (List<Map<String, Object>>) dataStream.get("indices");
         return indices.stream().map(index -> index.get("index_name").toString()).collect(Collectors.toSet());
-    }
-
-    @SuppressWarnings("unchecked")
-    private Set<String> getClosedIndices(String dataStreamName) throws IOException {
-        Set<String> allIndices = getDataStreamIndices(dataStreamName);
-        Set<String> closedIndices = new HashSet<>();
-        Response response = client().performRequest(new Request("GET", "_cluster/state/blocks/indices"));
-        Map<String, Object> responseMap = XContentHelper.convertToMap(JsonXContent.jsonXContent, response.getEntity().getContent(), false);
-        Map<String, Object> blocks = (Map<String, Object>) responseMap.get("blocks");
-        Map<String, Object> indices = (Map<String, Object>) blocks.get("indices");
-        for (Map.Entry<String, Object> indexEntry : indices.entrySet()) {
-            String indexName = indexEntry.getKey();
-            if (allIndices.contains(indexName)) {
-                Map<String, Object> blocksForIndex = (Map<String, Object>) indexEntry.getValue();
-                for (Map.Entry<String, Object> blockEntry : blocksForIndex.entrySet()) {
-                    Map<String, String> block = (Map<String, String>) blockEntry.getValue();
-                    if ("index closed".equals(block.get("description"))) {
-                        closedIndices.add(indexName);
-                    }
-                }
-            }
-        }
-        return closedIndices;
     }
 
     /*


### PR DESCRIPTION
Previously we had been not returning closed indices from the deprecation info api checks for indices that needed upgrading, including indices in data streams. This changes it so that those indices _are_ returned. And since a closed index can now require reindexing, this changes the data stream reindexing code to open a closed source index, reindex it, and then close the destination index (note that on failure, the source index will remain open and stay that way unless a user manually closes it again).