### PR TITLE
Relax translog assertion for inference fields

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -255,11 +255,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test070BindMountCustomPathConfAndJvmOptions
   issue: https://github.com/elastic/elasticsearch/issues/120910
-- class: org.elasticsearch.xpack.esql.qa.multi_node.RestEsqlIT
-  issue: https://github.com/elastic/elasticsearch/issues/120948
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
-  issue: https://github.com/elastic/elasticsearch/issues/120950
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test071BindMountCustomPathWithDifferentUID
   issue: https://github.com/elastic/elasticsearch/issues/120918
@@ -283,9 +278,6 @@ tests:
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testSuggestProfilesWithName
   issue: https://github.com/elastic/elasticsearch/issues/121022
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testBulkOperations {p0=true}
-  issue: https://github.com/elastic/elasticsearch/issues/120969
 
 # Examples:
 #

--- a/server/src/main/java/org/elasticsearch/index/engine/TranslogDirectoryReader.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/TranslogDirectoryReader.java
@@ -97,7 +97,7 @@ final class TranslogDirectoryReader extends DirectoryReader {
             // When using synthetic source, the translog operation must always be reindexed into an in-memory Lucene to ensure consistent
             // output for realtime-get operations. However, this can degrade the performance of realtime-get and update operations.
             // If slight inconsistencies in realtime-get operations are acceptable, the translog operation can be reindexed lazily.
-            if (mappingLookup.isSourceSynthetic()) {
+            if (mappingLookup.isSourceSynthetic() || mappingLookup.inferenceFields().isEmpty() == false) {
                 onSegmentCreated.run();
                 leafReader = createInMemoryReader(shardId, engineConfig, directory, documentParser, mappingLookup, false, operation);
             } else {


### PR DESCRIPTION
The inference fields are synthesized from doc_values, regardless of whether the synthetic source is enabled. This change relaxes the translog assertions, allowing inference fields in the same way as we did with the synthetic source.

Relates #120045

Closes #120979
Closes #121007
Closes #120980
Closes #120975