### PR TITLE
Entitlements for thread properties

### DIFF
--- a/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterImpl.java
+++ b/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterImpl.java
@@ -152,14 +152,13 @@ public class InstrumenterImpl implements Instrumenter {
             if (isAnnotationPresent == false) {
                 boolean isStatic = (access & ACC_STATIC) != 0;
                 boolean isCtor = "<init>".equals(name);
-                boolean hasReceiver = (isStatic || isCtor) == false;
                 var key = new MethodKey(className, name, Stream.of(Type.getArgumentTypes(descriptor)).map(Type::getInternalName).toList());
                 var instrumentationMethod = checkMethods.get(key);
                 if (instrumentationMethod != null) {
-                    // LOGGER.debug("Will instrument method {}", key);
+                    // System.out.println("Will instrument method " + key);
                     return new EntitlementMethodVisitor(Opcodes.ASM9, mv, isStatic, isCtor, descriptor, instrumentationMethod);
                 } else {
-                    // LOGGER.trace("Will not instrument method {}", key);
+                    // System.out.println("Will not instrument method " + key);
                 }
             }
             return mv;

--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -58,7 +58,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -507,4 +513,121 @@ public interface EntitlementChecker {
 
     // file system providers
     void checkNewInputStream(Class<?> callerClass, FileSystemProvider that, Path path, OpenOption... options);
+
+    ////////////////////
+    //
+    // Setting thread properties
+    //
+
+    void check$java_lang_Thread$setContextClassLoader(Class<?> callerClass, Thread thread, ClassLoader cl);
+
+    void check$java_lang_Thread$(Class<?> callerClass);
+
+    void check$java_lang_Thread$(Class<?> callerClass, Runnable task);
+
+    void check$java_lang_Thread$(Class<?> callerClass, ThreadGroup group, Runnable task);
+
+    void check$java_lang_Thread$(Class<?> callerClass, String name);
+
+    // TODO: Causes mysterious test failure even if the check does nothing
+    // void check$java_lang_Thread$(Class<?> callerClass, ThreadGroup group, String name);
+
+    void check$java_lang_Thread$(Class<?> callerClass, Runnable task, String name);
+
+    void check$java_lang_Thread$(Class<?> callerClass, ThreadGroup group, Runnable task, String name);
+
+    void check$java_lang_Thread$(Class<?> callerClass, ThreadGroup group, Runnable task, String name, long stackSize);
+
+    void check$java_lang_Thread$(
+        Class<?> callerClass,
+        ThreadGroup group,
+        Runnable task,
+        String name,
+        long stackSize,
+        boolean inheritInheritableThreadLocals
+    );
+
+    void check$java_lang_ThreadBuilders$PlatformThreadBuilder$unstarted(Class<?> callerClass, Thread.Builder builder, Runnable task);
+
+    void check$java_lang_ThreadBuilders$PlatformThreadFactory$newThread(Class<?> callerClass, ThreadFactory threadFactory, Runnable task);
+
+    void check$java_lang_ThreadGroup$(Class<?> callerClass, String name);
+
+    void check$java_lang_ThreadGroup$(Class<?> callerClass, ThreadGroup parent, String name);
+
+    void check$java_util_concurrent_ForkJoinPool$(Class<?> callerClass);
+
+    void check$java_util_concurrent_ForkJoinPool$(Class<?> callerClass, int parallelism);
+
+    void check$java_util_concurrent_ForkJoinPool$(
+        Class<?> callerClass,
+        int parallelism,
+        ForkJoinPool.ForkJoinWorkerThreadFactory factory,
+        Thread.UncaughtExceptionHandler handler,
+        boolean asyncMode
+    );
+
+    void check$java_util_concurrent_ForkJoinPool$(
+        Class<?> callerClass,
+        int parallelism,
+        ForkJoinPool.ForkJoinWorkerThreadFactory factory,
+        Thread.UncaughtExceptionHandler handler,
+        boolean asyncMode,
+        int corePoolSize,
+        int maximumPoolSize,
+        int minimumRunnable,
+        Predicate<? super ForkJoinPool> saturate,
+        long keepAliveTime,
+        TimeUnit unit
+    );
+
+    void check$java_util_concurrent_ForkJoinPool$DefaultForkJoinWorkerThreadFactory$newThread(
+        Class<?> callerClass,
+        ForkJoinPool.ForkJoinWorkerThreadFactory factory,
+        ForkJoinPool pool
+    );
+
+    void check$java_util_concurrent_ForkJoinWorkerThread$(
+        Class<?> callerClass,
+        ThreadGroup group,
+        ForkJoinPool pool,
+        boolean preserveThreadLocals
+    );
+
+    void check$java_util_concurrent_ForkJoinWorkerThread$(Class<?> callerClass, ForkJoinPool pool);
+
+    void check$java_lang_Thread$setDaemon(Class<?> callerClass, Thread thread, boolean on);
+
+    void check$java_lang_ThreadGroup$setDaemon(Class<?> callerClass, ThreadGroup threadGroup, boolean daemon);
+
+    void check$java_util_concurrent_ForkJoinPool$setParallelism(Class<?> callerClass, ForkJoinPool forkJoinPool, int size);
+
+    void check$java_lang_Thread$interrupt(Class<?> callerClass, Thread thread);
+
+    void check$java_lang_ThreadGroup$interrupt(Class<?> callerClass, ThreadGroup threadGroup);
+
+    void check$java_util_concurrent_ForkJoinPool$close(Class<?> callerClass, ForkJoinPool forkJoinPool);
+
+    void check$java_util_concurrent_ForkJoinPool$shutdown(Class<?> callerClass, ForkJoinPool forkJoinPool);
+
+    void check$java_util_concurrent_ForkJoinPool$shutdownNow(Class<?> callerClass, ForkJoinPool forkJoinPool);
+
+    void check$java_util_concurrent_ThreadPerTaskExecutor$close(Class<?> callerClass, Executor executor);
+
+    void check$java_util_concurrent_ThreadPerTaskExecutor$shutdown(Class<?> callerClass, Executor executor);
+
+    void check$java_util_concurrent_ThreadPerTaskExecutor$shutdownNow(Class<?> callerClass, Executor executor);
+
+    void check$java_util_concurrent_ThreadPoolExecutor$shutdown(Class<?> callerClass, ThreadPoolExecutor threadPoolExecutor);
+
+    void check$java_util_concurrent_ThreadPoolExecutor$shutdownNow(Class<?> callerClass, ThreadPoolExecutor threadPoolExecutor);
+
+    void check$java_lang_Thread$setName(Class<?> callerClass, Thread thread, String name);
+
+    void check$java_lang_Thread$setPriority(Class<?> callerClass, Thread thread, int newPriority);
+
+    void check$java_lang_Thread$setUncaughtExceptionHandler(Class<?> callerClass, Thread thread, Thread.UncaughtExceptionHandler ueh);
+
+    void check$java_lang_ThreadGroup$setMaxPriority(Class<?> callerClass, ThreadGroup threadGroup, int pri);
+
 }

--- a/libs/entitlement/qa/entitled-plugin/src/main/java/org/elasticsearch/entitlement/qa/entitled/EntitledActions.java
+++ b/libs/entitlement/qa/entitled-plugin/src/main/java/org/elasticsearch/entitlement/qa/entitled/EntitledActions.java
@@ -9,8 +9,6 @@
 
 package org.elasticsearch.entitlement.qa.entitled;
 
-import org.elasticsearch.core.SuppressForbidden;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,9 +17,8 @@ import java.nio.file.attribute.UserPrincipal;
 public final class EntitledActions {
     private EntitledActions() {}
 
-    @SuppressForbidden(reason = "Exposes forbidden APIs for testing purposes")
-    static void System_clearProperty(String key) {
-        System.clearProperty(key);
+    public static Thread newThread(Runnable runnable, String name) {
+        return new Thread(runnable, name);
     }
 
     public static UserPrincipal getFileOwner(Path path) throws IOException {

--- a/libs/entitlement/qa/entitled-plugin/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/libs/entitlement/qa/entitled-plugin/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,4 +1,2 @@
 org.elasticsearch.entitlement.qa.entitled:
-  - write_system_properties:
-      properties:
-        - org.elasticsearch.entitlement.qa.selfTest
+  - create_thread

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
@@ -205,12 +205,16 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
             entry("symbol_lookup_name", new CheckAction(VersionSpecificNativeChecks::symbolLookupWithName, false, 22)),
             entry("symbol_lookup_path", new CheckAction(VersionSpecificNativeChecks::symbolLookupWithPath, false, 22)),
 
-            entry("java_lang_Thread$setContextClassLoader", forPlugins(RestEntitlementsCheckAction::java_lang_Thread$setContextClassLoader)),
+            entry(
+                "java_lang_Thread$setContextClassLoader",
+                forPlugins(RestEntitlementsCheckAction::java_lang_Thread$setContextClassLoader)
+            ),
             entry("java_lang_Thread$_1", deniedToPlugins(RestEntitlementsCheckAction::java_lang_Thread$_1)),
             entry("java_lang_Thread$_2", deniedToPlugins(RestEntitlementsCheckAction::java_lang_Thread$_2)),
             entry("java_lang_Thread$_3", deniedToPlugins(RestEntitlementsCheckAction::java_lang_Thread$_3)),
             entry("java_lang_Thread$_4", deniedToPlugins(RestEntitlementsCheckAction::java_lang_Thread$_4)),
-            // entry("java_lang_Thread$_5", deniedToPlugins(RestEntitlementsCheckAction::java_lang_Thread$_5)), // This check is not yet active
+            // entry("java_lang_Thread$_5", deniedToPlugins(RestEntitlementsCheckAction::java_lang_Thread$_5)), // This check is not yet
+            // active
             entry("java_lang_Thread$_6", deniedToPlugins(RestEntitlementsCheckAction::java_lang_Thread$_6)),
             entry("java_lang_Thread$_7", deniedToPlugins(RestEntitlementsCheckAction::java_lang_Thread$_7)),
             entry(
@@ -223,10 +227,22 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
             ),
             entry("java_lang_ThreadGroup$_1", deniedToPlugins(RestEntitlementsCheckAction::java_lang_ThreadGroup$_1)),
             entry("java_lang_ThreadGroup$_2", deniedToPlugins(RestEntitlementsCheckAction::java_lang_ThreadGroup$_2)),
-            entry("java_util_concurrent_ForkJoinPool$_1", deniedToPlugins(RestEntitlementsCheckAction::java_util_concurrent_ForkJoinPool$_1)),
-            entry("java_util_concurrent_ForkJoinPool$_2", deniedToPlugins(RestEntitlementsCheckAction::java_util_concurrent_ForkJoinPool$_2)),
-            entry("java_util_concurrent_ForkJoinPool$_3", deniedToPlugins(RestEntitlementsCheckAction::java_util_concurrent_ForkJoinPool$_3)),
-            entry("java_util_concurrent_ForkJoinPool$_4", deniedToPlugins(RestEntitlementsCheckAction::java_util_concurrent_ForkJoinPool$_4)),
+            entry(
+                "java_util_concurrent_ForkJoinPool$_1",
+                deniedToPlugins(RestEntitlementsCheckAction::java_util_concurrent_ForkJoinPool$_1)
+            ),
+            entry(
+                "java_util_concurrent_ForkJoinPool$_2",
+                deniedToPlugins(RestEntitlementsCheckAction::java_util_concurrent_ForkJoinPool$_2)
+            ),
+            entry(
+                "java_util_concurrent_ForkJoinPool$_3",
+                deniedToPlugins(RestEntitlementsCheckAction::java_util_concurrent_ForkJoinPool$_3)
+            ),
+            entry(
+                "java_util_concurrent_ForkJoinPool$_4",
+                deniedToPlugins(RestEntitlementsCheckAction::java_util_concurrent_ForkJoinPool$_4)
+            ),
             entry(
                 "java_util_concurrent_ForkJoinPool$DefaultForkJoinWorkerThreadFactory$newThread",
                 deniedToPlugins(RestEntitlementsCheckAction::java_util_concurrent_ForkJoinPool$DefaultForkJoinWorkerThreadFactory$newThread)
@@ -285,7 +301,10 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
                 "java_lang_Thread$setUncaughtExceptionHandler",
                 deniedToPlugins(RestEntitlementsCheckAction::java_lang_Thread$setUncaughtExceptionHandler)
             ),
-            entry("java_lang_ThreadGroup$setMaxPriority", deniedToPlugins(RestEntitlementsCheckAction::java_lang_ThreadGroup$setMaxPriority))
+            entry(
+                "java_lang_ThreadGroup$setMaxPriority",
+                deniedToPlugins(RestEntitlementsCheckAction::java_lang_ThreadGroup$setMaxPriority)
+            )
         ),
         getTestEntries(FileCheckActions.class),
         getTestEntries(SpiActions.class),

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/SystemActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/SystemActions.java
@@ -11,6 +11,7 @@ package org.elasticsearch.entitlement.qa.test;
 
 import org.elasticsearch.core.SuppressForbidden;
 
+import static org.elasticsearch.entitlement.qa.entitled.EntitledActions.newThread;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_DENIED;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.SERVER_ONLY;
 
@@ -51,7 +52,7 @@ class SystemActions {
         System.setErr(System.err);
     }
 
-    private static final Thread NO_OP_SHUTDOWN_HOOK = new Thread(() -> {}, "Shutdown hook for testing");
+    private static final Thread NO_OP_SHUTDOWN_HOOK = newThread(() -> {}, "Shutdown hook for testing");
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
     static void runtimeAddShutdownHook() {

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/AbstractEntitlementsIT.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/AbstractEntitlementsIT.java
@@ -28,6 +28,7 @@ public abstract class AbstractEntitlementsIT extends ESRestTestCase {
         builder.value("inbound_network");
         builder.value("outbound_network");
         builder.value("load_native_libraries");
+        builder.value("set_thread_context_class_loader");
         builder.value(
             Map.of(
                 "write_system_properties",

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsTestRule.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsTestRule.java
@@ -56,6 +56,8 @@ class EntitlementsTestRule implements TestRule {
             .systemProperty("es.entitlements.enabled", "true")
             .systemProperty("es.entitlements.testdir", () -> testDir.getRoot().getAbsolutePath())
             .setting("xpack.security.enabled", "false")
+            // Logs in libs/entitlement/qa/build/test-results/javaRestTest/TEST-org.elasticsearch.entitlement.qa.EntitlementsXXX.xml
+            // .setting("logger.org.elasticsearch.entitlement", "DEBUG")
             .build();
         ruleChain = RuleChain.outerRule(testDir).around(tempDirSetup).around(cluster);
     }

--- a/libs/entitlement/src/main/java/module-info.java
+++ b/libs/entitlement/src/main/java/module-info.java
@@ -19,10 +19,10 @@ module org.elasticsearch.entitlement {
 
     exports org.elasticsearch.entitlement.runtime.api;
     exports org.elasticsearch.entitlement.runtime.policy;
-    exports org.elasticsearch.entitlement.runtime.policy.entitlements to org.elasticsearch.server;
     exports org.elasticsearch.entitlement.instrumentation;
     exports org.elasticsearch.entitlement.bootstrap to org.elasticsearch.server;
     exports org.elasticsearch.entitlement.initialization to java.base;
+    exports org.elasticsearch.entitlement.runtime.policy.entitlements to org.elasticsearch.server;
 
     uses org.elasticsearch.entitlement.instrumentation.InstrumentationService;
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -128,7 +128,15 @@ public class EntitlementInitialization {
                 ),
                 new Scope("org.apache.httpcomponents.httpclient", List.of(new OutboundNetworkEntitlement())),
                 new Scope("io.netty.transport", List.of(new InboundNetworkEntitlement(), new OutboundNetworkEntitlement())),
-                new Scope("org.apache.lucene.core", List.of(new LoadNativeLibrariesEntitlement(), new CreateThreadEntitlement(), new InterruptThreadEntitlement())),
+                new Scope(
+                    "org.apache.lucene.core",
+                    List.of(
+                        new LoadNativeLibrariesEntitlement(),
+                        new CreateThreadEntitlement(),
+                        new InterruptThreadEntitlement(),
+                        new SetThreadPropertyEntitlement()
+                    )
+                ),
                 new Scope("org.elasticsearch.nativeaccess", List.of(new LoadNativeLibrariesEntitlement()))
             )
         );

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -128,7 +128,7 @@ public class EntitlementInitialization {
                 ),
                 new Scope("org.apache.httpcomponents.httpclient", List.of(new OutboundNetworkEntitlement())),
                 new Scope("io.netty.transport", List.of(new InboundNetworkEntitlement(), new OutboundNetworkEntitlement())),
-                new Scope("org.apache.lucene.core", List.of(new LoadNativeLibrariesEntitlement(), new InterruptThreadEntitlement())),
+                new Scope("org.apache.lucene.core", List.of(new LoadNativeLibrariesEntitlement(), new CreateThreadEntitlement(), new InterruptThreadEntitlement())),
                 new Scope("org.elasticsearch.nativeaccess", List.of(new LoadNativeLibrariesEntitlement()))
             )
         );

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -128,7 +128,7 @@ public class EntitlementInitialization {
                 ),
                 new Scope("org.apache.httpcomponents.httpclient", List.of(new OutboundNetworkEntitlement())),
                 new Scope("io.netty.transport", List.of(new InboundNetworkEntitlement(), new OutboundNetworkEntitlement())),
-                new Scope("org.apache.lucene.core", List.of(new LoadNativeLibrariesEntitlement())),
+                new Scope("org.apache.lucene.core", List.of(new LoadNativeLibrariesEntitlement(), new InterruptThreadEntitlement())),
                 new Scope("org.elasticsearch.nativeaccess", List.of(new LoadNativeLibrariesEntitlement()))
             )
         );

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -22,11 +22,15 @@ import org.elasticsearch.entitlement.runtime.policy.Policy;
 import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
 import org.elasticsearch.entitlement.runtime.policy.Scope;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.CreateClassLoaderEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.CreateThreadEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.Entitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.ExitVMEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.InboundNetworkEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.InterruptThreadEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.LoadNativeLibrariesEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.OutboundNetworkEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.SetThreadContextClassLoaderEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.SetThreadPropertyEntitlement;
 
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Constructor;
@@ -115,7 +119,11 @@ public class EntitlementInitialization {
                         new CreateClassLoaderEntitlement(),
                         new InboundNetworkEntitlement(),
                         new OutboundNetworkEntitlement(),
-                        new LoadNativeLibrariesEntitlement()
+                        new LoadNativeLibrariesEntitlement(),
+                        new CreateThreadEntitlement(),
+                        new InterruptThreadEntitlement(),
+                        new SetThreadContextClassLoaderEntitlement(),
+                        new SetThreadPropertyEntitlement()
                     )
                 ),
                 new Scope("org.apache.httpcomponents.httpclient", List.of(new OutboundNetworkEntitlement())),

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -63,7 +63,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -970,5 +976,244 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     @Override
     public void checkNewInputStream(Class<?> callerClass, FileSystemProvider that, Path path, OpenOption... options) {
         // TODO: policyManger.checkFileSystemRead(path);
+    }
+
+    // Thread properties
+
+    public void check$java_lang_Thread$setContextClassLoader(Class<?> callerClass, Thread thread, ClassLoader cl) {
+        policyManager.checkSetThreadContextClassLoader(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$(Class<?> callerClass) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$(Class<?> callerClass, Runnable task) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$(Class<?> callerClass, ThreadGroup group, Runnable task) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$(Class<?> callerClass, String name) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    // @Override
+    public void check$java_lang_Thread$(Class<?> callerClass, ThreadGroup group, String name) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$(Class<?> callerClass, Runnable task, String name) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$(Class<?> callerClass, ThreadGroup group, Runnable task, String name) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$(Class<?> callerClass, ThreadGroup group, Runnable task, String name, long stackSize) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$(
+        Class<?> callerClass,
+        ThreadGroup group,
+        Runnable task,
+        String name,
+        long stackSize,
+        boolean inheritInheritableThreadLocals
+    ) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_ThreadBuilders$PlatformThreadBuilder$unstarted(
+        Class<?> callerClass,
+        Thread.Builder builder,
+        Runnable task
+    ) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_ThreadBuilders$PlatformThreadFactory$newThread(
+        Class<?> callerClass,
+        ThreadFactory threadFactory,
+        Runnable task
+    ) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_ThreadGroup$(Class<?> callerClass, String name) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_ThreadGroup$(Class<?> callerClass, ThreadGroup parent, String name) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ForkJoinPool$(Class<?> callerClass) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ForkJoinPool$(Class<?> callerClass, int parallelism) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ForkJoinPool$(
+        Class<?> callerClass,
+        int parallelism,
+        ForkJoinPool.ForkJoinWorkerThreadFactory factory,
+        Thread.UncaughtExceptionHandler handler,
+        boolean asyncMode
+    ) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ForkJoinPool$(
+        Class<?> callerClass,
+        int parallelism,
+        ForkJoinPool.ForkJoinWorkerThreadFactory factory,
+        Thread.UncaughtExceptionHandler handler,
+        boolean asyncMode,
+        int corePoolSize,
+        int maximumPoolSize,
+        int minimumRunnable,
+        Predicate<? super ForkJoinPool> saturate,
+        long keepAliveTime,
+        TimeUnit unit
+    ) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ForkJoinPool$DefaultForkJoinWorkerThreadFactory$newThread(
+        Class<?> callerClass,
+        ForkJoinPool.ForkJoinWorkerThreadFactory factory,
+        ForkJoinPool pool
+    ) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ForkJoinWorkerThread$(
+        Class<?> callerClass,
+        ThreadGroup group,
+        ForkJoinPool pool,
+        boolean preserveThreadLocals
+    ) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ForkJoinWorkerThread$(Class<?> callerClass, ForkJoinPool pool) {
+        policyManager.checkCreateThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$setDaemon(Class<?> callerClass, Thread thread, boolean on) {
+        policyManager.checkSetThreadProperty(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_ThreadGroup$setDaemon(Class<?> callerClass, ThreadGroup threadGroup, boolean daemon) {
+        policyManager.checkSetThreadProperty(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ForkJoinPool$setParallelism(Class<?> callerClass, ForkJoinPool forkJoinPool, int size) {
+        policyManager.checkSetThreadProperty(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$interrupt(Class<?> callerClass, Thread thread) {
+        policyManager.checkInterruptThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_ThreadGroup$interrupt(Class<?> callerClass, ThreadGroup threadGroup) {
+        // Note: not checking for interrupt entitlement. ThreadGroup.interrupt is very
+        // disruptive--so much so that it's hard to test--and nobody needs this anyway.
+        policyManager.checkDisruptiveThreadAction(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ForkJoinPool$close(Class<?> callerClass, ForkJoinPool forkJoinPool) {
+        policyManager.checkInterruptThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ForkJoinPool$shutdown(Class<?> callerClass, ForkJoinPool forkJoinPool) {
+        policyManager.checkInterruptThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ForkJoinPool$shutdownNow(Class<?> callerClass, ForkJoinPool forkJoinPool) {
+        policyManager.checkInterruptThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ThreadPerTaskExecutor$close(Class<?> callerClass, Executor executor) {
+        policyManager.checkInterruptThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ThreadPerTaskExecutor$shutdown(Class<?> callerClass, Executor executor) {
+        policyManager.checkInterruptThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ThreadPerTaskExecutor$shutdownNow(Class<?> callerClass, Executor executor) {
+        policyManager.checkInterruptThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ThreadPoolExecutor$shutdown(Class<?> callerClass, ThreadPoolExecutor threadPoolExecutor) {
+        policyManager.checkInterruptThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_util_concurrent_ThreadPoolExecutor$shutdownNow(Class<?> callerClass, ThreadPoolExecutor threadPoolExecutor) {
+        policyManager.checkInterruptThreadEntitlement(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$setName(Class<?> callerClass, Thread thread, String name) {
+        policyManager.checkSetThreadProperty(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$setPriority(Class<?> callerClass, Thread thread, int newPriority) {
+        policyManager.checkSetThreadProperty(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_Thread$setUncaughtExceptionHandler(
+        Class<?> callerClass,
+        Thread thread,
+        Thread.UncaughtExceptionHandler ueh
+    ) {
+        policyManager.checkSetThreadProperty(callerClass);
+    }
+
+    @Override
+    public void check$java_lang_ThreadGroup$setMaxPriority(Class<?> callerClass, ThreadGroup threadGroup, int pri) {
+        policyManager.checkSetThreadProperty(callerClass);
     }
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -233,7 +233,11 @@ public class PolicyManager {
         // Look up the check$ method to compose an informative error message.
         // This way, we don't need to painstakingly describe every individual global-state change.
         return StackWalker.getInstance()
-            .walk(frames -> frames.map(StackFrame::getMethodName).dropWhile(not(methodName -> methodName.startsWith(InstrumentationService.CHECK_METHOD_PREFIX))).findFirst())
+            .walk(
+                frames -> frames.map(StackFrame::getMethodName)
+                    .dropWhile(not(methodName -> methodName.startsWith(InstrumentationService.CHECK_METHOD_PREFIX)))
+                    .findFirst()
+            )
             .map(this::operationDescription);
     }
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -99,9 +99,9 @@ public class PolicyManager {
 
     final Map<Module, ModuleEntitlements> moduleEntitlementsMap = new ConcurrentHashMap<>();
 
-    protected final Map<String, List<Entitlement>> serverEntitlements;
-    protected final List<Entitlement> apmAgentEntitlements;
-    protected final Map<String, Map<String, List<Entitlement>>> pluginsEntitlements;
+    private final Map<String, List<Entitlement>> serverEntitlements;
+    private final List<Entitlement> apmAgentEntitlements;
+    private final Map<String, Map<String, List<Entitlement>>> pluginsEntitlements;
     private final Function<Class<?>, String> pluginResolver;
 
     public static final String ALL_UNNAMED = "ALL-UNNAMED";

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
@@ -108,7 +108,9 @@ public class PolicyParser {
                     return;
                 }
             }
-            throw new AssertionError("External entitlement class must have a constructor or factory method with @ExternalEntitlement annotation: " + type);
+            throw new AssertionError(
+                "External entitlement class must have a constructor or factory method with @ExternalEntitlement annotation: " + type
+            );
         });
         return externalEntitlements;
     }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
@@ -80,7 +80,10 @@ public class PolicyParser {
         }
 
         var strippedClassName = entitlementClassName.substring(0, entitlementClassName.indexOf("Entitlement"));
-        return Arrays.stream(strippedClassName.split("(?=\\p{Lu})"))
+        // Identify word boundaries by uppercase letters with \p{Lu}, but retain those
+        // characters, rather than discarding them as separators, with (?=).
+        String[] words = strippedClassName.split("(?=\\p{Lu})");
+        return Arrays.stream(words)
             .filter(Predicate.not(String::isEmpty))
             .map(s -> s.toLowerCase(Locale.ROOT))
             .collect(Collectors.joining("_"));

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
@@ -102,7 +102,13 @@ public class PolicyParser {
                     return;
                 }
             }
-            throw new AssertionError("External entitlement class must have a constructor with @ExternalEntitlement annotation: " + type);
+            for (var m : type.getMethods()) {
+                if (Modifier.isStatic(m.getModifiers()) && m.isAnnotationPresent(ExternalEntitlement.class)) {
+                    // All is well
+                    return;
+                }
+            }
+            throw new AssertionError("External entitlement class must have a constructor or factory method with @ExternalEntitlement annotation: " + type);
         });
         return externalEntitlements;
     }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/CreateThreadEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/CreateThreadEntitlement.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy.entitlements;
+
+import org.elasticsearch.entitlement.runtime.policy.ExternalEntitlement;
+
+public record CreateThreadEntitlement() implements Entitlement {
+    @ExternalEntitlement
+    public CreateThreadEntitlement {}
+}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/InterruptThreadEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/InterruptThreadEntitlement.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy.entitlements;
+
+import org.elasticsearch.entitlement.runtime.policy.ExternalEntitlement;
+
+public record InterruptThreadEntitlement() implements Entitlement {
+    @ExternalEntitlement
+    public InterruptThreadEntitlement {}
+}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/SetThreadContextClassLoaderEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/SetThreadContextClassLoaderEntitlement.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy.entitlements;
+
+import org.elasticsearch.entitlement.runtime.policy.ExternalEntitlement;
+
+public record SetThreadContextClassLoaderEntitlement() implements Entitlement {
+    @ExternalEntitlement(esModulesOnly = false)
+    public SetThreadContextClassLoaderEntitlement {}
+}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/SetThreadPropertyEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/SetThreadPropertyEntitlement.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy.entitlements;
+
+import org.elasticsearch.entitlement.runtime.policy.ExternalEntitlement;
+
+public record SetThreadPropertyEntitlement() implements Entitlement {
+    @ExternalEntitlement
+    public SetThreadPropertyEntitlement {}
+}

--- a/modules/reindex/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/reindex/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,2 +1,3 @@
 ALL-UNNAMED:
+  - create_thread
   - outbound_network

--- a/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
@@ -6,6 +6,7 @@ org.apache.httpcomponents.httpclient:
   - set_thread_property
 org.apache.httpcomponents.httpcore.nio:
   - outbound_network
+  - create_thread
 unboundid.ldapsdk:
   - write_system_properties:
       properties:

--- a/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
@@ -7,6 +7,8 @@ org.apache.httpcomponents.httpclient:
 org.apache.httpcomponents.httpcore.nio:
   - outbound_network
   - create_thread
+org.elasticsearch.xcore:
+  - set_thread_context_class_loader
 unboundid.ldapsdk:
   - write_system_properties:
       properties:

--- a/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,5 +1,6 @@
 org.apache.httpcomponents.httpclient:
   - outbound_network # For SamlRealm
+  - create_thread # For IdleConnectionEvictor
 org.apache.httpcomponents.httpcore.nio:
   - outbound_network
 unboundid.ldapsdk:

--- a/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,6 +1,9 @@
 org.apache.httpcomponents.httpclient:
-  - outbound_network # For SamlRealm
-  - create_thread # For IdleConnectionEvictor
+  # For SamlRealm
+  - outbound_network
+  # For IdleConnectionEvictor
+  - create_thread
+  - set_thread_property
 org.apache.httpcomponents.httpcore.nio:
   - outbound_network
 unboundid.ldapsdk:

--- a/x-pack/plugin/ml/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/ml/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,0 +1,2 @@
+org.elasticsearch.ml:
+  - create_thread

--- a/x-pack/plugin/ml/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/ml/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,2 +1,3 @@
 org.elasticsearch.ml:
   - create_thread
+  - set_thread_property

--- a/x-pack/plugin/watcher/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/watcher/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,2 +1,3 @@
 ALL-UNNAMED:
   - create_thread
+  - set_thread_property

--- a/x-pack/plugin/watcher/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/watcher/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,0 +1,2 @@
+ALL-UNNAMED:
+  - create_thread


### PR DESCRIPTION
Adds five entitlements:
1. `create_thread`. Added to `Thread` constructors. (This one is debatable, partly because we're not sure we want to instrument `Thread` creation at all, and partly because even if we do, the constructors don't create the thread: that's done by `Thread.start()`.)
2. `interrupt_thread`
3. `set_thread_context_class_loader`. This is the only one of the thread properties that's set by a plugin (namely `repository-hdfs`).
4. `set_thread_property`. This is for all other sensitive thread properties, like name and priority.
5. (Never entitled) "Disruptive thread action". Used for `ThreadGroup.interrupt()`.

See ES-10358.