### PR TITLE
[8.x] Tweak copy_to handling in synthetic _source to account for nested objects (#120974)

### DIFF
--- a/docs/changelog/120974.yaml
+++ b/docs/changelog/120974.yaml
@@ -1,0 +1,6 @@
+pr: 120974
+summary: Tweak `copy_to` handling in synthetic `_source` to account for nested objects
+area: Mapping
+type: bug
+issues:
+ - 120831

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -1696,6 +1696,74 @@ synthetic_source with copy_to pointing inside object:
           c.copy: [ "100", "hello", "zap" ]
 
 ---
+synthetic_source with copy_to inside nested object:
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              name:
+                type: keyword
+              my_values:
+                type: nested
+                properties:
+                  k:
+                    type: keyword
+                    copy_to: my_values.copy
+                  second_level:
+                    type: nested
+                    properties:
+                      k2:
+                        type: keyword
+                        copy_to: my_values.copy
+                  copy:
+                    type: keyword
+              dummy:
+                type: keyword
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          name: "A"
+          my_values:
+            k: "hello"
+
+  - do:
+      index:
+        index: test
+        id: 2
+        refresh: true
+        body:
+          name: "B"
+          my_values:
+            second_level:
+              k2: "hello"
+
+  - do:
+      search:
+        index: test
+        sort: name
+
+  - match:
+      hits.hits.0._source:
+        name: "A"
+        my_values:
+          k: "hello"
+  - match:
+      hits.hits.1._source:
+        name: "B"
+        my_values:
+          second_level:
+            k2: "hello"
+
+---
 synthetic_source with copy_to pointing to ambiguous field:
   - requires:
       cluster_features: ["mapper.source.synthetic_source_copy_to_inside_objects_fix"]

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -25,8 +25,6 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -159,33 +157,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
             return;
         }
 
-        Collection<NameValue> ignoredValuesToWrite = context.getIgnoredFieldValues();
-        if (context.getCopyToFields().isEmpty() == false && indexSettings.getSkipIgnoredSourceWrite() == false) {
-            /*
-            Mark fields as containing copied data meaning they should not be present
-            in synthetic _source (to be consistent with stored _source).
-            Ignored source values take precedence over standard synthetic source implementation
-            so by adding the `XContentDataHelper.voidValue()` entry we disable the field in synthetic source.
-            Otherwise, it would be constructed f.e. from doc_values which leads to duplicate values
-            in copied field after reindexing.
-            */
-            var mutableList = new ArrayList<>(ignoredValuesToWrite);
-            for (String copyToField : context.getCopyToFields()) {
-                ObjectMapper parent = context.parent().findParentMapper(copyToField);
-                if (parent == null) {
-                    // There are scenarios when this can happen:
-                    // 1. all values of the field that is the source of copy_to are null
-                    // 2. copy_to points at a field inside a disabled object
-                    // 3. copy_to points at dynamic field which is not yet applied to mapping, we will process it properly on re-parse.
-                    continue;
-                }
-                int offset = parent.isRoot() ? 0 : parent.fullPath().length() + 1;
-                mutableList.add(new IgnoredSourceFieldMapper.NameValue(copyToField, offset, XContentDataHelper.voidValue(), context.doc()));
-            }
-            ignoredValuesToWrite = mutableList;
-        }
-
-        for (NameValue nameValue : ignoredValuesToWrite) {
+        for (NameValue nameValue : context.getIgnoredFieldValues()) {
             nameValue.doc().add(new StoredField(NAME, encode(nameValue)));
         }
     }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Tweak copy_to handling in synthetic _source to account for nested objects (#120974)