### PR TITLE
Critically deprecate internal monitoring configurations

### DIFF
--- a/docs/changelog/121099.yaml
+++ b/docs/changelog/121099.yaml
@@ -1,0 +1,11 @@
+pr: 121099
+summary: Critically deprecate internal monitoring configurations
+area: Monitoring
+type: deprecation
+issues: []
+deprecation:
+  title: Critically deprecate internal monitoring configurations
+  area: Monitoring
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -102,6 +102,12 @@ tasks.named("yamlRestCompatTestTransform").configure({ task ->
   task.skipTest("esql/190_lookup_join/alias-pattern-multiple", "LOOKUP JOIN does not support index aliases for now")
   task.skipTest("esql/190_lookup_join/alias-pattern-single", "LOOKUP JOIN does not support index aliases for now")
   task.skipTest("esql/180_match_operator/match with disjunctions", "Disjunctions in full text functions work now")
+  task.skipTest("monitoring/bulk/10_basic/Bulk indexing of monitoring data", "We emit a deprecation warning that older tests do not anticipate")
+  task.skipTest(
+    "monitoring/bulk/10_basic/Bulk indexing of monitoring data on closed indices should throw an export exception",
+    "We emit a deprecation warning that older tests do not anticipate"
+  )
+  task.skipTest("monitoring/bulk/20_privileges/Monitoring Bulk API", "We emit a deprecation warning that older tests do not anticipate")
 })
 
 tasks.named('yamlRestCompatTest').configure {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/MonitoringDeprecatedSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/MonitoringDeprecatedSettings.java
@@ -26,17 +26,17 @@ public final class MonitoringDeprecatedSettings {
     public static final Setting.AffixSetting<Boolean> TEMPLATE_CREATE_LEGACY_VERSIONS_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "index.template.create_legacy_templates",
-        (key) -> Setting.boolSetting(key, true, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning)
+        (key) -> Setting.boolSetting(key, true, Property.Dynamic, Property.NodeScope, Property.Deprecated)
     );
     public static final Setting.AffixSetting<Boolean> USE_INGEST_PIPELINE_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "use_ingest",
-        key -> Setting.boolSetting(key, true, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning)
+        key -> Setting.boolSetting(key, true, Property.Dynamic, Property.NodeScope, Property.Deprecated)
     );
     public static final Setting.AffixSetting<TimeValue> PIPELINE_CHECK_TIMEOUT_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "index.pipeline.master_timeout",
-        (key) -> Setting.timeSetting(key, TimeValue.MINUS_ONE, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning)
+        (key) -> Setting.timeSetting(key, TimeValue.MINUS_ONE, Property.Dynamic, Property.NodeScope, Property.Deprecated)
     );
     // ===================
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/MonitoringField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/MonitoringField.java
@@ -34,7 +34,7 @@ public final class MonitoringField {
         HISTORY_DURATION_MINIMUM,         // minimum value
         Setting.Property.Dynamic,
         Setting.Property.NodeScope,
-        Setting.Property.DeprecatedWarning
+        Setting.Property.Deprecated
     );
 
     private MonitoringField() {}

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -45,7 +45,6 @@ public class DeprecationChecks {
                 NodeDeprecationChecks::checkExporterPipelineMasterTimeoutSetting,
                 NodeDeprecationChecks::checkExporterCreateLegacyTemplateSetting,
                 NodeDeprecationChecks::checkMonitoringSettingHistoryDuration,
-                NodeDeprecationChecks::checkMonitoringSettingHistoryDuration,
                 NodeDeprecationChecks::checkMonitoringSettingCollectIndexRecovery,
                 NodeDeprecationChecks::checkMonitoringSettingCollectIndices,
                 NodeDeprecationChecks::checkMonitoringSettingCollectCcrTimeout,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -46,7 +46,8 @@ public class NodeDeprecationChecks {
         final Settings nodeSettings,
         final Setting<?> deprecatedSetting,
         final String url,
-        final String whenRemoved
+        final String whenRemoved,
+        final DeprecationIssue.Level level
     ) {
         if (deprecatedSetting.exists(clusterSettings) == false && deprecatedSetting.exists(nodeSettings) == false) {
             return null;
@@ -66,7 +67,7 @@ public class NodeDeprecationChecks {
             deprecatedSettingKey,
             value
         );
-        return new DeprecationIssue(DeprecationIssue.Level.WARNING, message, url, details, false, null);
+        return new DeprecationIssue(level, message, url, details, false, null);
     }
 
     private static Map<String, Object> createMetaMapForRemovableSettings(boolean canAutoRemoveSetting, String removableSetting) {
@@ -365,7 +366,8 @@ public class NodeDeprecationChecks {
             nodeSettings,
             deprecated,
             MONITORING_SETTING_DEPRECATION_LINK,
-            MONITORING_SETTING_REMOVAL_TIME
+            MONITORING_SETTING_REMOVAL_TIME,
+            DeprecationIssue.Level.CRITICAL
         );
     }
 
@@ -382,7 +384,7 @@ public class NodeDeprecationChecks {
             ),
             "Remove the following settings: [%s]",
             MONITORING_SETTING_DEPRECATION_LINK,
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterSettings,
             nodeSettings
         );
@@ -397,7 +399,7 @@ public class NodeDeprecationChecks {
             Setting.affixKeySetting("xpack.monitoring.exporters.", deprecatedSuffix, k -> SecureSetting.secureString(k, null)),
             "Remove the following settings from the keystore: [%s]",
             MONITORING_SETTING_DEPRECATION_LINK,
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterSettings,
             nodeSettings
         );
@@ -412,7 +414,7 @@ public class NodeDeprecationChecks {
             Setting.affixKeySetting("xpack.monitoring.exporters.", deprecatedSuffix, k -> Setting.groupSetting(k + ".")),
             "Remove the following settings: [%s]",
             MONITORING_SETTING_DEPRECATION_LINK,
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterSettings,
             nodeSettings
         );
@@ -711,7 +713,7 @@ public class NodeDeprecationChecks {
             MonitoringDeprecatedSettings.USE_INGEST_PIPELINE_SETTING,
             "Remove the following settings: [%s]",
             "https://ela.st/es-deprecation-7-monitoring-exporter-use-ingest-setting",
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterState.metadata().settings(),
             settings
         );
@@ -727,7 +729,7 @@ public class NodeDeprecationChecks {
             MonitoringDeprecatedSettings.PIPELINE_CHECK_TIMEOUT_SETTING,
             "Remove the following settings: [%s]",
             "https://ela.st/es-deprecation-7-monitoring-exporter-pipeline-timeout-setting",
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterState.metadata().settings(),
             settings
         );
@@ -743,7 +745,7 @@ public class NodeDeprecationChecks {
             MonitoringDeprecatedSettings.TEMPLATE_CREATE_LEGACY_VERSIONS_SETTING,
             "Remove the following settings: [%s]",
             "https://ela.st/es-deprecation-7-monitoring-exporter-create-legacy-template-setting",
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterState.metadata().settings(),
             settings
         );

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -244,7 +244,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             issues,
             hasItem(
                 new DeprecationIssue(
-                    DeprecationIssue.Level.WARNING,
+                    DeprecationIssue.Level.CRITICAL,
                     "setting [" + settingKey + "] is deprecated and will be removed after 8.0",
                     expectedUrl,
                     "the setting [" + settingKey + "] is currently set to [" + value + "], remove this setting",
@@ -268,7 +268,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             issues,
             hasItem(
                 new DeprecationIssue(
-                    DeprecationIssue.Level.WARNING,
+                    DeprecationIssue.Level.CRITICAL,
                     "The [" + settingKey + "] settings are deprecated and will be removed after 8.0",
                     expectedUrl,
                     "Remove the following settings: [" + settingKey + "]",
@@ -293,7 +293,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             issues,
             hasItem(
                 new DeprecationIssue(
-                    DeprecationIssue.Level.WARNING,
+                    DeprecationIssue.Level.CRITICAL,
                     "The [" + settingKey + ".*] settings are deprecated and will be removed after 8.0",
                     expectedUrl,
                     "Remove the following settings: [" + subSettingKey + "]",
@@ -319,7 +319,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             issues,
             hasItem(
                 new DeprecationIssue(
-                    DeprecationIssue.Level.WARNING,
+                    DeprecationIssue.Level.CRITICAL,
                     "The [" + settingKey + "] settings are deprecated and will be removed after 8.0",
                     expectedUrl,
                     "Remove the following settings from the keystore: [" + settingKey + "]",
@@ -467,7 +467,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             issues,
             hasItem(
                 new DeprecationIssue(
-                    DeprecationIssue.Level.WARNING,
+                    DeprecationIssue.Level.CRITICAL,
                     "The [xpack.monitoring.exporters.test.use_ingest] settings are deprecated and will be removed after 8.0",
                     expectedUrl,
                     "Remove the following settings: [xpack.monitoring.exporters.test.use_ingest]",
@@ -493,7 +493,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             issues,
             hasItem(
                 new DeprecationIssue(
-                    DeprecationIssue.Level.WARNING,
+                    DeprecationIssue.Level.CRITICAL,
                     "The [xpack.monitoring.exporters.test.index.pipeline.master_timeout] "
                         + "settings are deprecated and will be removed after 8.0",
                     expectedUrl,
@@ -518,7 +518,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             issues,
             hasItem(
                 new DeprecationIssue(
-                    DeprecationIssue.Level.WARNING,
+                    DeprecationIssue.Level.CRITICAL,
                     "The [xpack.monitoring.exporters.test.index.template.create_legacy_templates] settings are deprecated and will be "
                         + "removed after 8.0",
                     expectedUrl,
@@ -806,7 +806,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
         Map<String, Object> meta = null;
         final DeprecationIssue expected = new DeprecationIssue(
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             "The [" + concreteSettingKey + "] settings are deprecated and will be removed after 8.0",
             "https://ela.st/es-deprecation-7-monitoring-exporter-use-ingest-setting",
             "Remove the following settings: [" + concreteSettingKey + "]",

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/Monitoring.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/Monitoring.java
@@ -80,7 +80,7 @@ public class Monitoring extends Plugin implements ActionPlugin, ReloadablePlugin
         false,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope,
-        Setting.Property.DeprecatedWarning
+        Setting.Property.Deprecated
     );
 
     public static final LicensedFeature.Momentary MONITORING_CLUSTER_ALERTS_FEATURE = LicensedFeature.momentary(

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringService.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringService.java
@@ -62,7 +62,7 @@ public class MonitoringService extends AbstractLifecycleComponent {
         true,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope,
-        Setting.Property.DeprecatedWarning
+        Setting.Property.Deprecated
     );
 
     /**
@@ -74,7 +74,7 @@ public class MonitoringService extends AbstractLifecycleComponent {
         false,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope,
-        Setting.Property.DeprecatedWarning
+        Setting.Property.Deprecated
     );
 
     /**
@@ -86,7 +86,7 @@ public class MonitoringService extends AbstractLifecycleComponent {
         MIN_INTERVAL,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope,
-        Setting.Property.DeprecatedWarning
+        Setting.Property.Deprecated
     );
 
     /** State of the monitoring service, either started or stopped **/

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/Collector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/Collector.java
@@ -41,7 +41,7 @@ public abstract class Collector {
         collectionSetting("indices"),
         Property.Dynamic,
         Property.NodeScope,
-        Setting.Property.DeprecatedWarning
+        Property.Deprecated
     );
 
     private final String name;
@@ -176,6 +176,6 @@ public abstract class Collector {
 
     protected static Setting<TimeValue> collectionTimeoutSetting(final String settingName) {
         String name = collectionSetting(settingName);
-        return timeSetting(name, TimeValue.timeValueSeconds(10), Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning);
+        return timeSetting(name, TimeValue.timeValueSeconds(10), Property.Dynamic, Property.NodeScope, Property.Deprecated);
     }
 }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollector.java
@@ -47,7 +47,7 @@ public class IndexRecoveryCollector extends Collector {
         false,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope,
-        Setting.Property.DeprecatedWarning
+        Setting.Property.Deprecated
     );
 
     private final Client client;

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporter.java
@@ -33,7 +33,7 @@ public abstract class Exporter implements AutoCloseable {
     private static final Setting.AffixSetting<Boolean> ENABLED_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "enabled",
-        key -> Setting.boolSetting(key, true, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        key -> Setting.boolSetting(key, true, Property.Dynamic, Property.NodeScope, Property.Deprecated),
         TYPE_DEPENDENCY
     );
 
@@ -79,7 +79,7 @@ public abstract class Exporter implements AutoCloseable {
                 return settings.iterator();
             }
 
-        }, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning)
+        }, Property.Dynamic, Property.NodeScope, Property.Deprecated)
     );
     /**
      * Every {@code Exporter} allows users to explicitly disable cluster alerts.
@@ -87,7 +87,7 @@ public abstract class Exporter implements AutoCloseable {
     public static final Setting.AffixSetting<Boolean> CLUSTER_ALERTS_MANAGEMENT_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "cluster_alerts.management.enabled",
-        key -> Setting.boolSetting(key, false, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        key -> Setting.boolSetting(key, false, Property.Dynamic, Property.NodeScope, Property.Deprecated),
         TYPE_DEPENDENCY
     );
     /**
@@ -98,7 +98,7 @@ public abstract class Exporter implements AutoCloseable {
     public static final Setting.AffixSetting<List<String>> CLUSTER_ALERTS_BLACKLIST_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "cluster_alerts.management.blacklist",
-        key -> Setting.stringListSetting(key, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        key -> Setting.stringListSetting(key, Property.Dynamic, Property.NodeScope, Property.Deprecated),
         TYPE_DEPENDENCY
     );
 
@@ -114,7 +114,7 @@ public abstract class Exporter implements AutoCloseable {
             DateFormatter::forPattern,
             Property.Dynamic,
             Property.NodeScope,
-            Property.DeprecatedWarning
+            Property.Deprecated
         ),
         TYPE_DEPENDENCY
     );

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
@@ -156,7 +156,7 @@ public class HttpExporter extends Exporter {
                 return settings.iterator();
             }
 
-        }, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        }, Property.Dynamic, Property.NodeScope, Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
 
@@ -166,7 +166,7 @@ public class HttpExporter extends Exporter {
     public static final Setting.AffixSetting<TimeValue> BULK_TIMEOUT_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "bulk.timeout",
-        (key) -> Setting.timeSetting(key, TimeValue.MINUS_ONE, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        (key) -> Setting.timeSetting(key, TimeValue.MINUS_ONE, Property.Dynamic, Property.NodeScope, Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
     /**
@@ -175,7 +175,7 @@ public class HttpExporter extends Exporter {
     public static final Setting.AffixSetting<TimeValue> CONNECTION_TIMEOUT_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "connection.timeout",
-        (key) -> Setting.timeSetting(key, TimeValue.timeValueSeconds(6), Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        (key) -> Setting.timeSetting(key, TimeValue.timeValueSeconds(6), Property.Dynamic, Property.NodeScope, Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
     /**
@@ -184,7 +184,7 @@ public class HttpExporter extends Exporter {
     public static final Setting.AffixSetting<TimeValue> CONNECTION_READ_TIMEOUT_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "connection.read_timeout",
-        (key) -> Setting.timeSetting(key, TimeValue.timeValueSeconds(60), Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        (key) -> Setting.timeSetting(key, TimeValue.timeValueSeconds(60), Property.Dynamic, Property.NodeScope, Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
     /**
@@ -223,7 +223,7 @@ public class HttpExporter extends Exporter {
                 return settings.iterator();
             }
 
-        }, Property.Dynamic, Property.NodeScope, Property.Filtered, Property.DeprecatedWarning),
+        }, Property.Dynamic, Property.NodeScope, Property.Filtered, Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
     /**
@@ -232,7 +232,7 @@ public class HttpExporter extends Exporter {
     public static final Setting.AffixSetting<SecureString> AUTH_SECURE_PASSWORD_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "auth.secure_password",
-        key -> SecureSetting.secureString(key, null, Setting.Property.DeprecatedWarning),
+        key -> SecureSetting.secureString(key, null, Setting.Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
     /**
@@ -243,7 +243,7 @@ public class HttpExporter extends Exporter {
     public static final Setting.AffixSetting<Settings> SSL_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "ssl",
-        (key) -> Setting.groupSetting(key + ".", Property.Dynamic, Property.NodeScope, Property.Filtered, Property.DeprecatedWarning),
+        (key) -> Setting.groupSetting(key + ".", Property.Dynamic, Property.NodeScope, Property.Filtered, Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
 
@@ -262,7 +262,7 @@ public class HttpExporter extends Exporter {
                     throw new SettingsException("[" + concreteSetting.getKey() + "] is malformed [" + value + "]", e);
                 }
             }
-        }, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        }, Property.Dynamic, Property.NodeScope, Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
     /**
@@ -271,7 +271,7 @@ public class HttpExporter extends Exporter {
     public static final Setting.AffixSetting<Boolean> SNIFF_ENABLED_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "sniff.enabled",
-        (key) -> Setting.boolSetting(key, false, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        (key) -> Setting.boolSetting(key, false, Property.Dynamic, Property.NodeScope, Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
     /**
@@ -292,7 +292,7 @@ public class HttpExporter extends Exporter {
                     throw new SettingsException("headers must have values, missing for setting [" + fullSetting + "]");
                 }
             }
-        }, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        }, Property.Dynamic, Property.NodeScope, Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
     /**
@@ -307,7 +307,7 @@ public class HttpExporter extends Exporter {
     public static final Setting.AffixSetting<TimeValue> TEMPLATE_CHECK_TIMEOUT_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "index.template.master_timeout",
-        (key) -> Setting.timeSetting(key, TimeValue.MINUS_ONE, Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        (key) -> Setting.timeSetting(key, TimeValue.MINUS_ONE, Property.Dynamic, Property.NodeScope, Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
     /**

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
@@ -88,7 +88,7 @@ public final class LocalExporter extends Exporter implements ClusterStateListene
     public static final Setting.AffixSetting<TimeValue> WAIT_MASTER_TIMEOUT_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "wait_master.timeout",
-        (key) -> Setting.timeSetting(key, TimeValue.timeValueSeconds(30), Property.Dynamic, Property.NodeScope, Property.DeprecatedWarning),
+        (key) -> Setting.timeSetting(key, TimeValue.timeValueSeconds(30), Property.Dynamic, Property.NodeScope, Property.Deprecated),
         TYPE_DEPENDENCY
     );
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkAction.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkAction.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestMonitoringBulkAction extends BaseRestHandler {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(MonitoringBulkAction.class);
     private static final String DEPRECATION_ID = "xpack_monitoring_bulk_api_removal";
-    private static final String DEPRECATION_MESSAGE =
+    public static final String DEPRECATION_MESSAGE =
         "The xpack monitoring bulk action is deprecated and will be removed in the next major release.";
 
     public static final String MONITORING_ID = "system_id";

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkAction.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkAction.java
@@ -10,6 +10,8 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
@@ -17,6 +19,7 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.RestBuilderListener;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.monitoring.MonitoredSystem;
+import org.elasticsearch.xpack.core.monitoring.action.MonitoringBulkAction;
 import org.elasticsearch.xpack.core.monitoring.action.MonitoringBulkRequestBuilder;
 import org.elasticsearch.xpack.core.monitoring.action.MonitoringBulkResponse;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
@@ -32,6 +35,10 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 public class RestMonitoringBulkAction extends BaseRestHandler {
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(MonitoringBulkAction.class);
+    private static final String DEPRECATION_ID = "xpack_monitoring_bulk_api_removal";
+    private static final String DEPRECATION_MESSAGE =
+        "The xpack monitoring bulk action is deprecated and will be removed in the next major release.";
 
     public static final String MONITORING_ID = "system_id";
     public static final String MONITORING_VERSION = "system_api_version";
@@ -63,6 +70,7 @@ public class RestMonitoringBulkAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        deprecationLogger.critical(DeprecationCategory.API, DEPRECATION_ID, DEPRECATION_MESSAGE);
 
         final String id = request.param(MONITORING_ID);
         if (Strings.isEmpty(id)) {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringMigrateAlertsAction.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringMigrateAlertsAction.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.monitoring.rest.action;
 
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
@@ -16,6 +18,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestBuilderListener;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.monitoring.action.MonitoringBulkAction;
 import org.elasticsearch.xpack.core.monitoring.action.MonitoringMigrateAlertsAction;
 import org.elasticsearch.xpack.core.monitoring.action.MonitoringMigrateAlertsRequest;
 import org.elasticsearch.xpack.core.monitoring.action.MonitoringMigrateAlertsResponse;
@@ -26,6 +29,10 @@ import java.util.List;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestMonitoringMigrateAlertsAction extends BaseRestHandler {
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(MonitoringBulkAction.class);
+    private static final String DEPRECATION_ID = "xpack_monitoring_migrate_alerts_api_removal";
+    private static final String DEPRECATION_MESSAGE =
+        "The xpack monitoring migrate alerts action is deprecated and will be removed in the next major release.";
 
     @Override
     public List<Route> routes() {
@@ -39,6 +46,7 @@ public class RestMonitoringMigrateAlertsAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        deprecationLogger.critical(DeprecationCategory.API, DEPRECATION_ID, DEPRECATION_MESSAGE);
         MonitoringMigrateAlertsRequest migrateRequest = new MonitoringMigrateAlertsRequest();
         return channel -> client.execute(MonitoringMigrateAlertsAction.INSTANCE, migrateRequest, getRestBuilderListener(channel));
     }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkActionTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
@@ -28,6 +29,7 @@ import org.elasticsearch.xpack.core.monitoring.action.MonitoringBulkResponse;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils.TEMPLATE_VERSION;
@@ -39,6 +41,11 @@ import static org.mockito.Mockito.when;
 public class RestMonitoringBulkActionTests extends ESTestCase {
 
     private final RestMonitoringBulkAction action = new RestMonitoringBulkAction();
+
+    @Override
+    protected List<String> filteredWarnings() {
+        return CollectionUtils.appendToCopy(super.filteredWarnings(), RestMonitoringBulkAction.DEPRECATION_MESSAGE);
+    }
 
     public void testGetName() {
         // Are you sure that you want to change the name?

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
@@ -12,6 +12,8 @@
             xpack.monitoring.collection.enabled: true
 
   - do:
+      allowed_warnings:
+        - "The xpack monitoring bulk action is deprecated and will be removed in the next major release."
       monitoring.bulk:
         system_id:          "kibana"
         system_api_version: "7"
@@ -48,6 +50,8 @@
   - match: { hits.total: 2 }
 
   - do:
+      allowed_warnings:
+        - "The xpack monitoring bulk action is deprecated and will be removed in the next major release."
       monitoring.bulk:
         system_id:          "kibana"
         system_api_version: "7"
@@ -96,6 +100,8 @@
 
   # Old system_api_version should still be accepted
   - do:
+      allowed_warnings:
+        - "The xpack monitoring bulk action is deprecated and will be removed in the next major release."
       monitoring.bulk:
         system_id:          "kibana"
         system_api_version: "6"
@@ -141,6 +147,8 @@
 
   # Missing a system_id causes it to fail
   - do:
+      allowed_warnings:
+        - "The xpack monitoring bulk action is deprecated and will be removed in the next major release."
       catch: bad_request
       monitoring.bulk:
         system_api_version: "7"
@@ -151,6 +159,8 @@
 
   # Missing a system_api_version causes it to fail
   - do:
+      allowed_warnings:
+        - "The xpack monitoring bulk action is deprecated and will be removed in the next major release."
       catch: bad_request
       monitoring.bulk:
         system_id:          "kibana"
@@ -161,6 +171,8 @@
 
   # Missing an interval causes it to fail
   - do:
+      allowed_warnings:
+        - "The xpack monitoring bulk action is deprecated and will be removed in the next major release."
       catch: bad_request
       monitoring.bulk:
         system_id:          "kibana"
@@ -183,6 +195,8 @@
             xpack.monitoring.collection.enabled: true
 
   - do:
+      allowed_warnings:
+        - "The xpack monitoring bulk action is deprecated and will be removed in the next major release."
       monitoring.bulk:
         system_id:          "beats"
         system_api_version: "7"
@@ -215,6 +229,8 @@
         index: .monitoring-beats-*
 
   - do:
+      allowed_warnings:
+        - "The xpack monitoring bulk action is deprecated and will be removed in the next major release."
       catch: /export_exception/
       monitoring.bulk:
         system_id:          "beats"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/20_privileges.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/20_privileges.yml
@@ -87,6 +87,8 @@ teardown:
             xpack.monitoring.collection.enabled: true
 
   - do:
+      allowed_warnings:
+        - "The xpack monitoring bulk action is deprecated and will be removed in the next major release."
       headers:
         # Authorization: logstash_agent
         Authorization: "Basic bG9nc3Rhc2hfYWdlbnQ6czNrcml0LXBhc3N3b3Jk"
@@ -124,6 +126,8 @@ teardown:
   - match: { hits.total: 0 }
 
   - do:
+      allowed_warnings:
+        - "The xpack monitoring bulk action is deprecated and will be removed in the next major release."
       catch: forbidden
       headers:
         # Authorization: unknown_agent


### PR DESCRIPTION
Updates the internal monitoring settings' deprecations to be critical deprecations. Updates the node deprecation checks for these settings to critical-level deprecations. Adds critical deprecation logging to the rest actions that will be removed from the plugin.