### PR TITLE
[8.x] [ML] Update Inference Update API documentation to use the correct PUT method (#121048)

### DIFF
--- a/docs/changelog/121048.yaml
+++ b/docs/changelog/121048.yaml
@@ -1,0 +1,5 @@
+pr: 121048
+summary: Updating Inference Update API documentation to have the correct PUT method
+area: Machine Learning
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.update.json
@@ -14,7 +14,7 @@
       "paths": [
         {
           "path": "/_inference/{inference_id}/_update",
-          "methods": ["POST"],
+          "methods": ["PUT"],
           "parts": {
             "inference_id": {
               "type": "string",
@@ -24,7 +24,7 @@
         },
         {
           "path": "/_inference/{task_type}/{inference_id}/_update",
-          "methods": ["POST"],
+          "methods": ["PUT"],
           "parts": {
             "task_type": {
               "type": "string",


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Update Inference Update API documentation to use the correct PUT method (#121048)