### PR TITLE
Relax translog assertion for inference fields (#121092)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -456,34 +456,20 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
   issue: https://github.com/elastic/elasticsearch/issues/120973
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testBulkOperations {p0=false}
-  issue: https://github.com/elastic/elasticsearch/issues/120975
 - class: org.elasticsearch.packaging.test.DockerTests
   issue: https://github.com/elastic/elasticsearch/issues/120978
-- class: org.elasticsearch.xpack.esql.qa.multi_node.RestEsqlIT
-  method: testInternalRange {ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/120979
-- class: org.elasticsearch.xpack.esql.qa.multi_node.RestEsqlIT
-  method: testWarningHeadersOnFailedConversions {ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/120980
 - class: org.elasticsearch.xpack.security.authc.jwt.JwtRealmSingleNodeTests
   method: testActivateProfileForJWT
   issue: https://github.com/elastic/elasticsearch/issues/120983
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testProfileIndexAutoCreation
   issue: https://github.com/elastic/elasticsearch/issues/120987
-- class: org.elasticsearch.xpack.esql.qa.multi_node.RestEsqlIT
-  method: testOutOfRangeComparisons {ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/121007
 - class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
   method: testAuthenticateShouldNotFallThroughInCaseOfFailure
   issue: https://github.com/elastic/elasticsearch/issues/120902
 - class: org.elasticsearch.xpack.security.FileSettingsRoleMappingsRestartIT
   method: testReservedStatePersistsOnRestart
   issue: https://github.com/elastic/elasticsearch/issues/120923
-- class: org.elasticsearch.xpack.esql.qa.multi_node.RestEsqlIT
-  issue: https://github.com/elastic/elasticsearch/issues/120948
 - class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
   method: test {p0=data_stream/140_data_stream_aliases/Create data stream alias}
   issue: https://github.com/elastic/elasticsearch/issues/120920

--- a/server/src/main/java/org/elasticsearch/index/engine/TranslogDirectoryReader.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/TranslogDirectoryReader.java
@@ -96,7 +96,7 @@ final class TranslogDirectoryReader extends DirectoryReader {
             // When using synthetic source, the translog operation must always be reindexed into an in-memory Lucene to ensure consistent
             // output for realtime-get operations. However, this can degrade the performance of realtime-get and update operations.
             // If slight inconsistencies in realtime-get operations are acceptable, the translog operation can be reindexed lazily.
-            if (mappingLookup.isSourceSynthetic()) {
+            if (mappingLookup.isSourceSynthetic() || mappingLookup.inferenceFields().isEmpty() == false) {
                 onSegmentCreated.run();
                 leafReader = createInMemoryReader(shardId, engineConfig, directory, documentParser, mappingLookup, false, operation);
             } else {


### PR DESCRIPTION
Backport of #121092 to 8.18

The inference fields are synthesized from doc_values, regardless of whether the synthetic source is enabled. This change relaxes the translog assertions, allowing inference fields in the same way as we did with the synthetic source.

Relates #120045

Closes #120979
Closes #121007
Closes #120980
Closes #120975
