### PR TITLE
Unmute org.elasticsearch.ingest.geoip.FullClusterRestartIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -293,9 +293,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
   issue: https://github.com/elastic/elasticsearch/issues/120950
-- class: org.elasticsearch.ingest.geoip.FullClusterRestartIT
-  method: testGeoIpSystemFeaturesMigration {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/121115
 
 # Examples:
 #


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/121115

This test can just be unmuted now that #121119 has been merged (which reverted #120168).