### PR TITLE
[Entitlements] Fix EntitlementInitialization to work across multiple versions

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -32,6 +32,8 @@ import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,6 +50,7 @@ public class EntitlementInitialization {
 
     private static final String AGENTS_PACKAGE_NAME = "co.elastic.apm.agent";
     private static final Module ENTITLEMENTS_MODULE = PolicyManager.class.getModule();
+    private static final int MINIMUM_SUPPORTED_JAVA_VERSION = 21;
 
     private static ElasticsearchEntitlementChecker manager;
 
@@ -60,11 +63,21 @@ public class EntitlementInitialization {
     public static void initialize(Instrumentation inst) throws Exception {
         manager = initChecker();
 
-        Map<MethodKey, CheckMethod> checkMethods = INSTRUMENTER_FACTORY.lookupMethods(EntitlementChecker.class);
+        Map<MethodKey, CheckMethod> checkMethods = new HashMap<>();
+        int javaVersion = Runtime.version().feature();
+        Set<Class<?>> interfaces = new HashSet<>();
+        for (int i = MINIMUM_SUPPORTED_JAVA_VERSION; i <= javaVersion; ++ i) {
+            interfaces.add(getVersionSpecificCheckerClass(i, "org.elasticsearch.entitlement.bridge", "EntitlementChecker"));
+        }
+        for (var checkerInterface: interfaces) {
+            checkMethods.putAll(INSTRUMENTER_FACTORY.lookupMethods(checkerInterface));
+        }
 
+        var latestCheckerInterface = getVersionSpecificCheckerClass(
+            javaVersion, "org.elasticsearch.entitlement.bridge", "EntitlementChecker");
         var classesToTransform = checkMethods.keySet().stream().map(MethodKey::className).collect(Collectors.toSet());
 
-        Instrumenter instrumenter = INSTRUMENTER_FACTORY.newInstrumenter(EntitlementChecker.class, checkMethods);
+        Instrumenter instrumenter = INSTRUMENTER_FACTORY.newInstrumenter(latestCheckerInterface, checkMethods);
         inst.addTransformer(new Transformer(instrumenter, classesToTransform), true);
         inst.retransformClasses(findClassesToRetransform(inst.getAllLoadedClasses(), classesToTransform));
     }
@@ -114,20 +127,11 @@ public class EntitlementInitialization {
     private static ElasticsearchEntitlementChecker initChecker() {
         final PolicyManager policyManager = createPolicyManager();
 
-        int javaVersion = Runtime.version().feature();
-        final String classNamePrefix;
-        if (javaVersion >= 23) {
-            classNamePrefix = "Java23";
-        } else {
-            classNamePrefix = "";
-        }
-        final String className = "org.elasticsearch.entitlement.runtime.api." + classNamePrefix + "ElasticsearchEntitlementChecker";
-        Class<?> clazz;
-        try {
-            clazz = Class.forName(className);
-        } catch (ClassNotFoundException e) {
-            throw new AssertionError("entitlement lib cannot find entitlement impl", e);
-        }
+        Class<?> clazz = getVersionSpecificCheckerClass(
+            Runtime.version().feature(),
+            "org.elasticsearch.entitlement.runtime.api",
+            "ElasticsearchEntitlementChecker"
+        );
         Constructor<?> constructor;
         try {
             constructor = clazz.getConstructor(PolicyManager.class);
@@ -139,6 +143,24 @@ public class EntitlementInitialization {
         } catch (IllegalAccessException | InvocationTargetException | InstantiationException e) {
             throw new AssertionError(e);
         }
+    }
+
+    private static Class<?> getVersionSpecificCheckerClass(int javaVersion, String packageName, String baseClassName) {
+        final String classNamePrefix;
+        if (javaVersion >= 23) {
+            classNamePrefix = "Java23";
+        }
+        else {
+            classNamePrefix = "";
+        }
+        final String className = packageName + "." + classNamePrefix + baseClassName;
+        Class<?> clazz;
+        try {
+            clazz = Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError("entitlement lib cannot find entitlement class " + className, e);
+        }
+        return clazz;
     }
 
     private static final InstrumentationService INSTRUMENTER_FACTORY = new ProviderLocator<>(

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -66,15 +66,18 @@ public class EntitlementInitialization {
         Map<MethodKey, CheckMethod> checkMethods = new HashMap<>();
         int javaVersion = Runtime.version().feature();
         Set<Class<?>> interfaces = new HashSet<>();
-        for (int i = MINIMUM_SUPPORTED_JAVA_VERSION; i <= javaVersion; ++ i) {
+        for (int i = MINIMUM_SUPPORTED_JAVA_VERSION; i <= javaVersion; ++i) {
             interfaces.add(getVersionSpecificCheckerClass(i, "org.elasticsearch.entitlement.bridge", "EntitlementChecker"));
         }
-        for (var checkerInterface: interfaces) {
+        for (var checkerInterface : interfaces) {
             checkMethods.putAll(INSTRUMENTER_FACTORY.lookupMethods(checkerInterface));
         }
 
         var latestCheckerInterface = getVersionSpecificCheckerClass(
-            javaVersion, "org.elasticsearch.entitlement.bridge", "EntitlementChecker");
+            javaVersion,
+            "org.elasticsearch.entitlement.bridge",
+            "EntitlementChecker"
+        );
         var classesToTransform = checkMethods.keySet().stream().map(MethodKey::className).collect(Collectors.toSet());
 
         Instrumenter instrumenter = INSTRUMENTER_FACTORY.newInstrumenter(latestCheckerInterface, checkMethods);
@@ -149,8 +152,7 @@ public class EntitlementInitialization {
         final String classNamePrefix;
         if (javaVersion >= 23) {
             classNamePrefix = "Java23";
-        }
-        else {
+        } else {
             classNamePrefix = "";
         }
         final String className = packageName + "." + classNamePrefix + baseClassName;


### PR DESCRIPTION
This PR fixes an issue that become apparent with https://github.com/elastic/elasticsearch/pull/121017: when we initialize Entitlements, and we get the list of methods to instrument, and instrument them, we need to get them from all the "versioned" interfaces compatible with the current runtime version. We also need to use the most specific (latest) "versioned" interface in the instrumentation code.

To do that, I cherry picked the changes to `EntitlementInitialization` in https://github.com/elastic/elasticsearch/pull/121017, and adapted it to the current layout in `main` (where we just support Java >= 21)
