### PR TITLE
[8.x] Fix matching of half_float and scaled_float values in LogsDB tests (#121098)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldType.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldType.java
@@ -13,9 +13,11 @@ import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.ByteFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.DoubleFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.FloatFieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.fields.leaf.HalfFloatFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.IntegerFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.KeywordFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.LongFieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.fields.leaf.ScaledFloatFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.ShortFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.UnsignedLongFieldDataGenerator;
 
@@ -30,7 +32,9 @@ public enum FieldType {
     SHORT("short"),
     BYTE("byte"),
     DOUBLE("double"),
-    FLOAT("float");
+    FLOAT("float"),
+    HALF_FLOAT("half_float"),
+    SCALED_FLOAT("scaled_float");
 
     private final String name;
 
@@ -48,6 +52,8 @@ public enum FieldType {
             case BYTE -> new ByteFieldDataGenerator(fieldName, dataSource);
             case DOUBLE -> new DoubleFieldDataGenerator(fieldName, dataSource);
             case FLOAT -> new FloatFieldDataGenerator(fieldName, dataSource);
+            case HALF_FLOAT -> new HalfFloatFieldDataGenerator(fieldName, dataSource);
+            case SCALED_FLOAT -> new ScaledFloatFieldDataGenerator(fieldName, dataSource);
         };
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -32,7 +32,8 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
 
         return new DataSourceResponse.LeafMappingParametersGenerator(switch (request.fieldType()) {
             case KEYWORD -> keywordMapping(request, map);
-            case LONG, INTEGER, SHORT, BYTE, DOUBLE, FLOAT, UNSIGNED_LONG -> plain(map);
+            case LONG, INTEGER, SHORT, BYTE, DOUBLE, FLOAT, HALF_FLOAT, UNSIGNED_LONG -> plain(map);
+            case SCALED_FLOAT -> scaledFloatMapping(map);
         });
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/SourceMatcher.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/SourceMatcher.java
@@ -159,10 +159,6 @@ public class SourceMatcher extends GenericEqualsMatcher<List<Map<String, Object>
             }
         }
 
-        if (sourceMatchesExactly(expectedFieldMapping, expectedValues)) {
-            return Optional.empty();
-        }
-
         var fieldSpecificMatcher = fieldSpecificMatchers.get(actualFieldType);
         if (fieldSpecificMatcher == null) {
             return Optional.empty();
@@ -175,13 +171,6 @@ public class SourceMatcher extends GenericEqualsMatcher<List<Map<String, Object>
             expectedFieldMapping.mappingParameters()
         );
         return Optional.of(matched);
-    }
-
-    // Checks for scenarios when source is stored exactly and therefore can be compared without special logic.
-    private boolean sourceMatchesExactly(MappingTransforms.FieldMapping mapping, List<Object> expectedValues) {
-        return mapping.parentMappingParameters().stream().anyMatch(m -> m.getOrDefault("enabled", "true").equals("false"))
-            || mapping.mappingParameters().getOrDefault("synthetic_source_keep", "none").equals("all")
-            || expectedValues.size() > 1 && mapping.mappingParameters().getOrDefault("synthetic_source_keep", "none").equals("arrays");
     }
 
     private MatchResult matchWithGenericMatcher(List<Object> actualValues, List<Object> expectedValues) {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix matching of half_float and scaled_float values in LogsDB tests (#121098)