### PR TITLE
[8.x] Add a user-configurable timeout parameter to the `_resolve/cluster` API (#120542)

### DIFF
--- a/docs/changelog/120542.yaml
+++ b/docs/changelog/120542.yaml
@@ -1,0 +1,6 @@
+pr: 120542
+summary: "Feat: add a user-configurable timeout parameter to the `_resolve/cluster`\
+  \ API"
+area: Search
+type: enhancement
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ResolveClusterTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ResolveClusterTimeoutIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.indices.cluster;
+
+import org.elasticsearch.action.admin.indices.resolve.ResolveClusterActionRequest;
+import org.elasticsearch.action.admin.indices.resolve.ResolveClusterActionResponse;
+import org.elasticsearch.action.admin.indices.resolve.ResolveClusterInfo;
+import org.elasticsearch.action.admin.indices.resolve.TransportResolveClusterAction;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.AbstractMultiClustersTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ResolveClusterTimeoutIT extends AbstractMultiClustersTestCase {
+    private static final String REMOTE_CLUSTER_1 = "cluster-a";
+
+    @Override
+    protected List<String> remoteClusterAlias() {
+        return List.of(REMOTE_CLUSTER_1);
+    }
+
+    public void testTimeoutParameter() {
+        long maxTimeoutInMillis = 500;
+
+        // First part: we query _resolve/cluster without stalling a remote.
+        ResolveClusterActionRequest resolveClusterActionRequest;
+        if (randomBoolean()) {
+            resolveClusterActionRequest = new ResolveClusterActionRequest(new String[0], IndicesOptions.DEFAULT, true, true);
+        } else {
+            resolveClusterActionRequest = new ResolveClusterActionRequest(new String[] { "*:*" });
+        }
+
+        // We set a timeout but since we don't stall any cluster, we should always get back response just fine before the timeout.
+        resolveClusterActionRequest.setTimeout(TimeValue.timeValueSeconds(10));
+        ResolveClusterActionResponse clusterActionResponse = safeGet(
+            client().execute(TransportResolveClusterAction.TYPE, resolveClusterActionRequest)
+        );
+        Map<String, ResolveClusterInfo> clusterInfo = clusterActionResponse.getResolveClusterInfo();
+
+        // Remote is connected and error message is null.
+        assertThat(clusterInfo.get(REMOTE_CLUSTER_1).isConnected(), equalTo(true));
+        assertThat(clusterInfo.get(REMOTE_CLUSTER_1).getError(), is(nullValue()));
+
+        // Second part: now we stall the remote and utilise the timeout feature.
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Add an override so that the remote cluster receives the TransportResolveClusterAction request but stalls.
+        for (var nodes : cluster(REMOTE_CLUSTER_1).getNodeNames()) {
+            ((MockTransportService) cluster(REMOTE_CLUSTER_1).getInstance(TransportService.class, nodes)).addRequestHandlingBehavior(
+                TransportResolveClusterAction.REMOTE_TYPE.name(),
+                (requestHandler, transportRequest, transportChannel, transportTask) -> {
+                    // Wait until the TransportResolveRequestAction times out following which the latch is released.
+                    latch.await();
+                    requestHandler.messageReceived(transportRequest, transportChannel, transportTask);
+                }
+            );
+        }
+
+        long randomlyChosenTimeout = randomLongBetween(100, maxTimeoutInMillis);
+        // We now randomly choose a timeout which is guaranteed to hit since the remote is stalled.
+        resolveClusterActionRequest.setTimeout(TimeValue.timeValueMillis(randomlyChosenTimeout));
+
+        clusterActionResponse = safeGet(client().execute(TransportResolveClusterAction.TYPE, resolveClusterActionRequest));
+        latch.countDown();
+
+        clusterInfo = clusterActionResponse.getResolveClusterInfo();
+
+        // Ensure that the request timed out and that the remote is marked as not connected.
+        assertThat(clusterInfo.get(REMOTE_CLUSTER_1).isConnected(), equalTo(false));
+        assertThat(
+            clusterInfo.get(REMOTE_CLUSTER_1).getError(),
+            equalTo("Request timed out before receiving a response from the remote cluster")
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -175,6 +175,7 @@ public class TransportVersions {
     public static final TransportVersion INGEST_REQUEST_INCLUDE_SOURCE_ON_ERROR = def(8_835_00_0);
     public static final TransportVersion RESOURCE_DEPRECATION_CHECKS = def(8_836_00_0);
     public static final TransportVersion LINEAR_RETRIEVER_SUPPORT = def(8_837_00_0);
+    public static final TransportVersion TIMEOUT_GET_PARAM_FOR_RESOLVE_CLUSTER = def(8_838_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
@@ -51,6 +52,7 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
      */
     private boolean localIndicesRequested = false;
     private IndicesOptions indicesOptions;
+    private TimeValue timeout;
 
     // true if the user did not provide any index expression - they only want cluster level info, not index matching
     private final boolean clusterInfoOnly;
@@ -89,6 +91,9 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
             this.clusterInfoOnly = false;
             this.isQueryingCluster = false;
         }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.TIMEOUT_GET_PARAM_FOR_RESOLVE_CLUSTER)) {
+            this.timeout = in.readOptionalTimeValue();
+        }
     }
 
     @Override
@@ -102,6 +107,9 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
         if (out.getTransportVersion().onOrAfter(TransportVersions.RESOLVE_CLUSTER_NO_INDEX_EXPRESSION)) {
             out.writeBoolean(clusterInfoOnly);
             out.writeBoolean(isQueryingCluster);
+        }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.TIMEOUT_GET_PARAM_FOR_RESOLVE_CLUSTER)) {
+            out.writeOptionalTimeValue(timeout);
         }
     }
 
@@ -124,12 +132,14 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ResolveClusterActionRequest request = (ResolveClusterActionRequest) o;
-        return Arrays.equals(names, request.names) && indicesOptions.equals(request.indicesOptions());
+        return Arrays.equals(names, request.names)
+            && indicesOptions.equals(request.indicesOptions())
+            && Objects.equals(timeout, request.timeout);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(indicesOptions);
+        int result = Objects.hash(indicesOptions, timeout);
         result = 31 * result + Arrays.hashCode(names);
         return result;
     }
@@ -137,6 +147,10 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
     @Override
     public String[] indices() {
         return names;
+    }
+
+    public TimeValue getTimeout() {
+        return timeout;
     }
 
     public boolean clusterInfoOnly() {
@@ -200,6 +214,10 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
             }
         }
         return false;
+    }
+
+    public void setTimeout(TimeValue timeout) {
+        this.timeout = timeout;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestResolveClusterAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestResolveClusterAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
@@ -71,6 +72,12 @@ public class RestResolveClusterAction extends BaseRestHandler {
             clusterInfoOnly,
             true
         );
+
+        String timeout = request.param("timeout");
+        if (timeout != null) {
+            resolveRequest.setTimeout(TimeValue.parseTimeValue(timeout, "timeout"));
+        }
+
         return channel -> new RestCancellableNodeClient(client, request.getHttpChannel()).admin()
             .indices()
             .execute(TransportResolveClusterAction.TYPE, resolveRequest, new RestToXContentListener<>(channel));


### PR DESCRIPTION
This will backport the following commits from `main` to `8.x`:
 - [Add a user-configurable timeout parameter to the &#x60;_resolve/cluster&#x60; API (#120542)](https://github.com/elastic/elasticsearch/pull/120542)