### PR TITLE
[8.x] Fix ChangeDetectorTests::testMultipleChanges (#121137)

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangeDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangeDetectorTests.java
@@ -192,7 +192,7 @@ public class ChangeDetectorTests extends AggregatorTestCase {
             ChangeType type = new ChangeDetector(bucketValues).detect(0.05);
             tp += type instanceof ChangeType.TrendChange ? 1 : 0;
         }
-        assertThat(tp, greaterThan(90));
+        assertThat(tp, greaterThan(80));
     }
 
     public void testProblemDistributionChange() {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix ChangeDetectorTests::testMultipleChanges (#121137)