### PR TITLE
[8.17] (Doc+) Clarify dimension field requirements for time_series aggregation (#119442)

### DIFF
--- a/docs/reference/aggregations/bucket/time-series-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/time-series-aggregation.asciidoc
@@ -6,8 +6,13 @@
 
 preview::[]
 
-The time series aggregation queries data created using a time series index. This is typically data such as metrics
+The time series aggregation queries data created using a <<tsds,Time series data stream (TSDS)>>. This is typically data such as metrics
 or other data streams with a time component, and requires creating an index using the time series mode.
+
+[NOTE]
+====
+Refer to the <<differences-from-regular-data-stream, TSDS documentation>> to learn more about the key differences from regular data streams.
+====
 
 //////////////////////////
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [(Doc+) Clarify dimension field requirements for time_series aggregation (#119442)](https://github.com/elastic/elasticsearch/pull/119442)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)