### PR TITLE
[Deprecation] Add transform_ids to outdated index (#120821)

### DIFF
--- a/docs/changelog/120821.yaml
+++ b/docs/changelog/120821.yaml
@@ -1,0 +1,5 @@
+pr: 120821
+summary: "[Deprecation] Add `transform_ids` to outdated index"
+area: Transform
+type: enhancement
+issues: []

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecker.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.core.deprecation.DeprecatedIndexPredicate;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -39,21 +38,13 @@ import static org.elasticsearch.xpack.deprecation.LegacyTiersDetection.DEPRECATI
 public class IndexDeprecationChecker implements ResourceDeprecationChecker {
 
     public static final String NAME = "index_settings";
-    private static final List<BiFunction<IndexMetadata, ClusterState, DeprecationIssue>> INDEX_SETTINGS_CHECKS = List.of(
-        IndexDeprecationChecker::oldIndicesCheck,
-        IndexDeprecationChecker::ignoredOldIndicesCheck,
-        IndexDeprecationChecker::translogRetentionSettingCheck,
-        IndexDeprecationChecker::checkIndexDataPath,
-        IndexDeprecationChecker::storeTypeSettingCheck,
-        IndexDeprecationChecker::frozenIndexSettingCheck,
-        IndexDeprecationChecker::deprecatedCamelCasePattern,
-        IndexDeprecationChecker::legacyRoutingSettingCheck
-    );
 
     private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final Map<String, List<String>> indexToTransformIds;
 
-    public IndexDeprecationChecker(IndexNameExpressionResolver indexNameExpressionResolver) {
+    public IndexDeprecationChecker(IndexNameExpressionResolver indexNameExpressionResolver, Map<String, List<String>> indexToTransformIds) {
         this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.indexToTransformIds = indexToTransformIds;
     }
 
     @Override
@@ -62,7 +53,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
         String[] concreteIndexNames = indexNameExpressionResolver.concreteIndexNames(clusterState, request);
         for (String concreteIndex : concreteIndexNames) {
             IndexMetadata indexMetadata = clusterState.getMetadata().index(concreteIndex);
-            List<DeprecationIssue> singleIndexIssues = filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetadata, clusterState));
+            List<DeprecationIssue> singleIndexIssues = filterChecks(indexSettingsChecks(), c -> c.apply(indexMetadata, clusterState));
             if (singleIndexIssues.isEmpty() == false) {
                 indexSettingsIssues.put(concreteIndex, singleIndexIssues);
             }
@@ -73,12 +64,25 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
         return indexSettingsIssues;
     }
 
+    private List<BiFunction<IndexMetadata, ClusterState, DeprecationIssue>> indexSettingsChecks() {
+        return List.of(
+            this::oldIndicesCheck,
+            this::ignoredOldIndicesCheck,
+            IndexDeprecationChecker::translogRetentionSettingCheck,
+            IndexDeprecationChecker::checkIndexDataPath,
+            IndexDeprecationChecker::storeTypeSettingCheck,
+            IndexDeprecationChecker::frozenIndexSettingCheck,
+            IndexDeprecationChecker::deprecatedCamelCasePattern,
+            IndexDeprecationChecker::legacyRoutingSettingCheck
+        );
+    }
+
     @Override
     public String getName() {
         return NAME;
     }
 
-    static DeprecationIssue oldIndicesCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
+    private DeprecationIssue oldIndicesCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
         // TODO: this check needs to be revised. It's trivially true right now.
         IndexVersion currentCompatibilityVersion = indexMetadata.getCompatibilityVersion();
         // We intentionally exclude indices that are in data streams because they will be picked up by DataStreamDeprecationChecks
@@ -89,13 +93,22 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
                 "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking-changes-8.0",
                 "This index has version: " + currentCompatibilityVersion.toReleaseVersion(),
                 false,
-                Collections.singletonMap("reindex_required", true)
+                meta(indexMetadata)
             );
         }
         return null;
     }
 
-    static DeprecationIssue ignoredOldIndicesCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
+    private Map<String, Object> meta(IndexMetadata indexMetadata) {
+        var transforms = indexToTransformIds.getOrDefault(indexMetadata.getIndex().getName(), List.of());
+        if (transforms.isEmpty()) {
+            return Map.of("reindex_required", true);
+        } else {
+            return Map.of("reindex_required", true, "transform_ids", transforms);
+        }
+    }
+
+    private DeprecationIssue ignoredOldIndicesCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
         IndexVersion currentCompatibilityVersion = indexMetadata.getCompatibilityVersion();
         // We intentionally exclude indices that are in data streams because they will be picked up by DataStreamDeprecationChecks
         if (DeprecatedIndexPredicate.reindexRequired(indexMetadata, true) && isNotDataStreamIndex(indexMetadata, clusterState)) {
@@ -107,7 +120,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
                     + currentCompatibilityVersion.toReleaseVersion()
                     + " and will be supported as read-only in 9.0",
                 false,
-                Collections.singletonMap("reindex_required", true)
+                meta(indexMetadata)
             );
         }
         return null;
@@ -117,7 +130,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
         return clusterState.metadata().findDataStreams(indexMetadata.getIndex().getName()).isEmpty();
     }
 
-    static DeprecationIssue translogRetentionSettingCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
+    private static DeprecationIssue translogRetentionSettingCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
         final boolean softDeletesEnabled = IndexSettings.INDEX_SOFT_DELETES_SETTING.get(indexMetadata.getSettings());
         if (softDeletesEnabled) {
             if (IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexMetadata.getSettings())
@@ -144,7 +157,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
         return null;
     }
 
-    static DeprecationIssue checkIndexDataPath(IndexMetadata indexMetadata, ClusterState clusterState) {
+    private static DeprecationIssue checkIndexDataPath(IndexMetadata indexMetadata, ClusterState clusterState) {
         if (IndexMetadata.INDEX_DATA_PATH_SETTING.exists(indexMetadata.getSettings())) {
             final String message = String.format(
                 Locale.ROOT,
@@ -159,7 +172,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
         return null;
     }
 
-    static DeprecationIssue storeTypeSettingCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
+    private static DeprecationIssue storeTypeSettingCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
         final String storeType = IndexModule.INDEX_STORE_TYPE_SETTING.get(indexMetadata.getSettings());
         if (IndexModule.Type.SIMPLEFS.match(storeType)) {
             return new DeprecationIssue(
@@ -176,7 +189,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
         return null;
     }
 
-    static DeprecationIssue frozenIndexSettingCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
+    private static DeprecationIssue frozenIndexSettingCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
         Boolean isIndexFrozen = FrozenEngine.INDEX_FROZEN.get(indexMetadata.getSettings());
         if (Boolean.TRUE.equals(isIndexFrozen)) {
             String indexName = indexMetadata.getIndex().getName();
@@ -194,7 +207,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
         return null;
     }
 
-    static DeprecationIssue legacyRoutingSettingCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
+    private static DeprecationIssue legacyRoutingSettingCheck(IndexMetadata indexMetadata, ClusterState clusterState) {
         List<String> deprecatedSettings = LegacyTiersDetection.getDeprecatedFilteredAllocationSettings(indexMetadata.getSettings());
         if (deprecatedSettings.isEmpty()) {
             return null;
@@ -228,7 +241,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
      * @return a list of issues found in fields
      */
     @SuppressWarnings("unchecked")
-    static List<String> findInPropertiesRecursively(
+    private static List<String> findInPropertiesRecursively(
         String type,
         Map<String, Object> parentMap,
         Function<Map<?, ?>, Boolean> predicate,
@@ -282,7 +295,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
         return issues;
     }
 
-    static DeprecationIssue deprecatedCamelCasePattern(IndexMetadata indexMetadata, ClusterState clusterState) {
+    private static DeprecationIssue deprecatedCamelCasePattern(IndexMetadata indexMetadata, ClusterState clusterState) {
         List<String> fields = new ArrayList<>();
         fieldLevelMappingIssue(
             indexMetadata,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.injection.guice.Inject;
@@ -28,19 +29,23 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+import org.elasticsearch.xpack.core.transform.action.GetTransformAction;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.deprecation.DeprecationChecks.CLUSTER_SETTINGS_CHECKS;
 
 public class TransportDeprecationInfoAction extends TransportMasterNodeReadAction<
     DeprecationInfoAction.Request,
     DeprecationInfoAction.Response> {
-    private static final List<DeprecationChecker> PLUGIN_CHECKERS = List.of(new MlDeprecationChecker(), new TransformDeprecationChecker());
+    private static final DeprecationChecker ML_CHECKER = new MlDeprecationChecker();
     private static final Logger logger = LogManager.getLogger(TransportDeprecationInfoAction.class);
 
     private final NodeClient client;
@@ -48,7 +53,6 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
     private final Settings settings;
     private final NamedXContentRegistry xContentRegistry;
     private volatile List<String> skipTheseDeprecations;
-    private final List<ResourceDeprecationChecker> resourceDeprecationCheckers;
 
     @Inject
     public TransportDeprecationInfoAction(
@@ -75,12 +79,6 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.settings = settings;
         this.xContentRegistry = xContentRegistry;
-        this.resourceDeprecationCheckers = List.of(
-            new IndexDeprecationChecker(indexNameExpressionResolver),
-            new DataStreamDeprecationChecker(indexNameExpressionResolver),
-            new TemplateDeprecationChecker(),
-            new IlmPolicyDeprecationChecker()
-        );
         skipTheseDeprecations = DeprecationChecks.SKIP_DEPRECATIONS_SETTING.get(settings);
         // Safe to register this here because it happens synchronously before the cluster service is started:
         clusterService.getClusterSettings()
@@ -110,7 +108,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
             ClientHelper.DEPRECATION_ORIGIN,
             NodesDeprecationCheckAction.INSTANCE,
             nodeDepReq,
-            listener.delegateFailureAndWrap((delegate, response) -> {
+            listener.delegateFailureAndWrap((l, response) -> {
                 if (response.hasFailures()) {
                     List<String> failedNodeIds = response.failures()
                         .stream()
@@ -121,31 +119,37 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                         logger.debug("node {} failed to run deprecation checks: {}", failure.nodeId(), failure);
                     }
                 }
-
-                DeprecationChecker.Components components = new DeprecationChecker.Components(
-                    xContentRegistry,
-                    settings,
-                    new OriginSettingClient(client, ClientHelper.DEPRECATION_ORIGIN)
-                );
-                pluginSettingIssues(
-                    PLUGIN_CHECKERS,
-                    components,
-                    new ThreadedActionListener<>(
-                        client.threadPool().generic(),
-                        delegate.map(
-                            deprecationIssues -> DeprecationInfoAction.Response.from(
-                                state,
-                                indexNameExpressionResolver,
-                                request,
-                                response,
-                                CLUSTER_SETTINGS_CHECKS,
-                                deprecationIssues,
-                                skipTheseDeprecations,
-                                resourceDeprecationCheckers
+                transformConfigs(l.delegateFailureAndWrap((ll, transformConfigs) -> {
+                    DeprecationChecker.Components components = new DeprecationChecker.Components(
+                        xContentRegistry,
+                        settings,
+                        new OriginSettingClient(client, ClientHelper.DEPRECATION_ORIGIN)
+                    );
+                    pluginSettingIssues(
+                        List.of(ML_CHECKER, new TransformDeprecationChecker(transformConfigs)),
+                        components,
+                        new ThreadedActionListener<>(
+                            client.threadPool().generic(),
+                            ll.map(
+                                deprecationIssues -> DeprecationInfoAction.Response.from(
+                                    state,
+                                    indexNameExpressionResolver,
+                                    request,
+                                    response,
+                                    CLUSTER_SETTINGS_CHECKS,
+                                    deprecationIssues,
+                                    skipTheseDeprecations,
+                                    List.of(
+                                        new IndexDeprecationChecker(indexNameExpressionResolver, indexToTransformIds(transformConfigs)),
+                                        new DataStreamDeprecationChecker(indexNameExpressionResolver),
+                                        new TemplateDeprecationChecker(),
+                                        new IlmPolicyDeprecationChecker()
+                                    )
+                                )
                             )
                         )
-                    )
-                );
+                    );
+                }));
             })
         );
     }
@@ -174,6 +178,48 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
         for (DeprecationChecker checker : checkers) {
             checker.check(components, groupedActionListener);
         }
+    }
+
+    private void transformConfigs(ActionListener<List<TransformConfig>> transformConfigsListener) {
+        transformConfigs(new PageParams(0, PageParams.DEFAULT_SIZE), transformConfigsListener.map(Stream::toList));
+    }
+
+    private void transformConfigs(PageParams currentPage, ActionListener<Stream<TransformConfig>> currentPageListener) {
+        var request = new GetTransformAction.Request(Metadata.ALL);
+        request.setPageParams(currentPage);
+        request.setAllowNoResources(true);
+
+        client.execute(
+            GetTransformAction.INSTANCE,
+            request,
+            new ThreadedActionListener<>(
+                threadPool.generic(),
+                currentPageListener.delegateFailureAndWrap((delegate, getTransformConfigResponse) -> {
+                    var currentPageOfConfigs = getTransformConfigResponse.getTransformConfigurations().stream();
+                    var currentPageSize = currentPage.getFrom() + currentPage.getSize();
+                    var totalTransformConfigCount = getTransformConfigResponse.getTransformConfigurationCount();
+                    if (totalTransformConfigCount >= currentPageSize) {
+                        var nextPage = new PageParams(currentPageSize, PageParams.DEFAULT_SIZE);
+                        transformConfigs(
+                            nextPage,
+                            delegate.map(nextPageOfConfigs -> Stream.concat(currentPageOfConfigs, nextPageOfConfigs))
+                        );
+                    } else {
+                        delegate.onResponse(currentPageOfConfigs);
+                    }
+                })
+            )
+        );
+    }
+
+    private Map<String, List<String>> indexToTransformIds(List<TransformConfig> transformConfigs) {
+        return transformConfigs.stream()
+            .collect(
+                Collectors.groupingBy(
+                    config -> config.getDestination().getIndex(),
+                    Collectors.mapping(TransformConfig::getId, Collectors.toList())
+                )
+            );
     }
 
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamMetadata;
 import org.elasticsearch.cluster.metadata.DataStreamOptions;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataIndexStateService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -38,12 +39,14 @@ import static org.hamcrest.Matchers.hasItem;
 
 public class IndexDeprecationCheckerTests extends ESTestCase {
 
-    private final IndexDeprecationChecker checker = new IndexDeprecationChecker(TestIndexNameExpressionResolver.newInstance());
+    private static final IndexVersion OLD_VERSION = IndexVersion.fromId(7170099);
+
+    private final IndexNameExpressionResolver indexNameExpressionResolver = TestIndexNameExpressionResolver.newInstance();
+    private final IndexDeprecationChecker checker = new IndexDeprecationChecker(indexNameExpressionResolver, Map.of());
 
     public void testOldIndicesCheck() {
-        IndexVersion createdWith = IndexVersion.fromId(7170099);
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
-            .settings(settings(createdWith))
+            .settings(settings(OLD_VERSION))
             .numberOfShards(1)
             .numberOfReplicas(0)
             .state(randomBoolean() ? IndexMetadata.State.OPEN : IndexMetadata.State.CLOSE) // does not matter if its open or closed
@@ -55,7 +58,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             DeprecationIssue.Level.CRITICAL,
             "Old index with a compatibility version < 8.0",
             "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking-changes-8.0",
-            "This index has version: " + createdWith.toReleaseVersion(),
+            "This index has version: " + OLD_VERSION.toReleaseVersion(),
             false,
             singletonMap("reindex_required", true)
         );
@@ -67,10 +70,86 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
         assertEquals(singletonList(expected), issues);
     }
 
+    public void testOldTransformIndicesCheck() {
+        var checker = new IndexDeprecationChecker(indexNameExpressionResolver, Map.of("test", List.of("test-transform")));
+        var indexMetadata = indexMetadata("test", OLD_VERSION);
+        var clusterState = ClusterState.builder(ClusterState.EMPTY_STATE).metadata(Metadata.builder().put(indexMetadata, true)).build();
+        var expected = new DeprecationIssue(
+            DeprecationIssue.Level.CRITICAL,
+            "Old index with a compatibility version < 8.0",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking-changes-8.0",
+            "This index has version: " + OLD_VERSION.toReleaseVersion(),
+            false,
+            Map.of("reindex_required", true, "transform_ids", List.of("test-transform"))
+        );
+        var issuesByIndex = checker.check(clusterState, new DeprecationInfoAction.Request(TimeValue.THIRTY_SECONDS));
+        assertEquals(singletonList(expected), issuesByIndex.get("test"));
+    }
+
+    public void testOldIndicesCheckWithMultipleTransforms() {
+        var checker = new IndexDeprecationChecker(
+            indexNameExpressionResolver,
+            Map.of("test", List.of("test-transform1", "test-transform2"))
+        );
+        var indexMetadata = indexMetadata("test", OLD_VERSION);
+        var clusterState = ClusterState.builder(ClusterState.EMPTY_STATE).metadata(Metadata.builder().put(indexMetadata, true)).build();
+        var expected = new DeprecationIssue(
+            DeprecationIssue.Level.CRITICAL,
+            "Old index with a compatibility version < 8.0",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking-changes-8.0",
+            "This index has version: " + OLD_VERSION.toReleaseVersion(),
+            false,
+            Map.of("reindex_required", true, "transform_ids", List.of("test-transform1", "test-transform2"))
+        );
+        var issuesByIndex = checker.check(clusterState, new DeprecationInfoAction.Request(TimeValue.THIRTY_SECONDS));
+        assertEquals(singletonList(expected), issuesByIndex.get("test"));
+    }
+
+    public void testMultipleOldIndicesCheckWithTransforms() {
+        var checker = new IndexDeprecationChecker(
+            indexNameExpressionResolver,
+            Map.of("test1", List.of("test-transform1"), "test2", List.of("test-transform2"))
+        );
+        var indexMetadata1 = indexMetadata("test1", OLD_VERSION);
+        var indexMetadata2 = indexMetadata("test2", OLD_VERSION);
+        var clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(Metadata.builder().put(indexMetadata1, true).put(indexMetadata2, true))
+            .build();
+        var expected = Map.of(
+            "test1",
+            List.of(
+                new DeprecationIssue(
+                    DeprecationIssue.Level.CRITICAL,
+                    "Old index with a compatibility version < 8.0",
+                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking-changes-8.0",
+                    "This index has version: " + OLD_VERSION.toReleaseVersion(),
+                    false,
+                    Map.of("reindex_required", true, "transform_ids", List.of("test-transform1"))
+                )
+            ),
+            "test2",
+            List.of(
+                new DeprecationIssue(
+                    DeprecationIssue.Level.CRITICAL,
+                    "Old index with a compatibility version < 8.0",
+                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking-changes-8.0",
+                    "This index has version: " + OLD_VERSION.toReleaseVersion(),
+                    false,
+                    Map.of("reindex_required", true, "transform_ids", List.of("test-transform2"))
+                )
+            )
+        );
+        var issuesByIndex = checker.check(clusterState, new DeprecationInfoAction.Request(TimeValue.THIRTY_SECONDS));
+        assertEquals(expected, issuesByIndex);
+    }
+
+    private IndexMetadata indexMetadata(String indexName, IndexVersion indexVersion) {
+        return IndexMetadata.builder(indexName).settings(settings(indexVersion)).numberOfShards(1).numberOfReplicas(0).build();
+    }
+
     public void testOldIndicesCheckDataStreamIndex() {
-        IndexVersion createdWith = IndexVersion.fromId(7170099);
         IndexMetadata indexMetadata = IndexMetadata.builder(".ds-test")
-            .settings(settings(createdWith).put("index.hidden", true))
+            .settings(settings(OLD_VERSION).put("index.hidden", true))
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
@@ -113,8 +192,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
     }
 
     public void testOldIndicesCheckSnapshotIgnored() {
-        IndexVersion createdWith = IndexVersion.fromId(7170099);
-        Settings.Builder settings = settings(createdWith);
+        Settings.Builder settings = settings(OLD_VERSION);
         settings.put(INDEX_STORE_TYPE_SETTING.getKey(), SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE);
         IndexMetadata indexMetadata = IndexMetadata.builder("test").settings(settings).numberOfShards(1).numberOfReplicas(0).build();
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
@@ -129,8 +207,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
     }
 
     public void testOldIndicesIgnoredWarningCheck() {
-        IndexVersion createdWith = IndexVersion.fromId(7170099);
-        Settings.Builder settings = settings(createdWith).put(MetadataIndexStateService.VERIFIED_READ_ONLY_SETTING.getKey(), true);
+        Settings.Builder settings = settings(OLD_VERSION).put(MetadataIndexStateService.VERIFIED_READ_ONLY_SETTING.getKey(), true);
         IndexMetadata indexMetadata = IndexMetadata.builder("test").settings(settings).numberOfShards(1).numberOfReplicas(0).build();
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
             .metadata(Metadata.builder().put(indexMetadata, true))
@@ -139,7 +216,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             DeprecationIssue.Level.WARNING,
             "Old index with a compatibility version < 8.0 Has Been Ignored",
             "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking-changes-8.0",
-            "This read-only index has version: " + createdWith.toReleaseVersion() + " and will be supported as read-only in 9.0",
+            "This read-only index has version: " + OLD_VERSION.toReleaseVersion() + " and will be supported as read-only in 9.0",
             false,
             singletonMap("reindex_required", true)
         );


### PR DESCRIPTION
When a transform is writing to an outdated destination index, the transform's id will show up in the index's deprecation warning under `index_settings._meta.transform_ids`.