### PR TITLE
Fix serverless test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -14,6 +14,12 @@ setup:
             - synonyms: "bye => goodbye"
               id: "synonym-rule-2"
 
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms
+        wait_for_status: green
+
   # Create synonyms synonyms_set2
   - do:
       synonyms.put_synonym:
@@ -24,12 +30,6 @@ setup:
               id: "synonym-rule-1"
             - synonyms: "bye => goodbye"
               id: "synonym-rule-2"
-
-  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
-  - do:
-      cluster.health:
-        index: .synonyms
-        wait_for_status: green
 
   # Create my_index1 with synonym_filter that uses synonyms_set1
   - do:


### PR DESCRIPTION
This test fails on serverless, as the wait for index to be green happened after the second insertion into the synonyms index. It should happen after the first to ensure the index has been created and search shards are available in order to perform the second insert.