### PR TITLE
[Inference API] Put back legacy EIS URL setting

### DIFF
--- a/docs/changelog/121207.yaml
+++ b/docs/changelog/121207.yaml
@@ -1,0 +1,5 @@
+pr: 121207
+summary: "[Inference API] Put back legacy EIS URL setting"
+area: Inference
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSettings.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.elastic;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.core.ssl.SSLConfigurationSettings;
@@ -30,9 +31,13 @@ public class ElasticInferenceServiceSettings {
         Setting.Property.NodeScope
     );
 
+    @Deprecated
+    private final String eisGatewayUrl;
+
     private final String elasticInferenceServiceUrl;
 
     public ElasticInferenceServiceSettings(Settings settings) {
+        eisGatewayUrl = EIS_GATEWAY_URL.get(settings);
         elasticInferenceServiceUrl = ELASTIC_INFERENCE_SERVICE_URL.get(settings);
     }
 
@@ -58,7 +63,7 @@ public class ElasticInferenceServiceSettings {
     }
 
     public String getElasticInferenceServiceUrl() {
-        return elasticInferenceServiceUrl;
+        return Strings.isEmpty(elasticInferenceServiceUrl) ? eisGatewayUrl : elasticInferenceServiceUrl;
     }
 
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSettings.java
@@ -22,6 +22,9 @@ public class ElasticInferenceServiceSettings {
 
     public static final String ELASTIC_INFERENCE_SERVICE_SSL_CONFIGURATION_PREFIX = "xpack.inference.elastic.http.ssl.";
 
+    @Deprecated
+    static final Setting<String> EIS_GATEWAY_URL = Setting.simpleString("xpack.inference.eis.gateway.url", Setting.Property.NodeScope);
+
     static final Setting<String> ELASTIC_INFERENCE_SERVICE_URL = Setting.simpleString(
         "xpack.inference.elastic.url",
         Setting.Property.NodeScope
@@ -46,6 +49,7 @@ public class ElasticInferenceServiceSettings {
 
     public static List<Setting<?>> getSettingsDefinitions() {
         ArrayList<Setting<?>> settings = new ArrayList<>();
+        settings.add(EIS_GATEWAY_URL);
         settings.add(ELASTIC_INFERENCE_SERVICE_URL);
         settings.add(ELASTIC_INFERENCE_SERVICE_SSL_ENABLED);
         settings.addAll(ELASTIC_INFERENCE_SERVICE_SSL_CONFIGURATION_SETTINGS.getEnabledSettings());

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSettingsTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.services.elastic;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ElasticInferenceServiceSettingsTests extends ESTestCase {
+
+    private static final String ELASTIC_INFERENCE_SERVICE_URL = "http://elastic-inference-service";
+    private static final String ELASTIC_INFERENCE_SERVICE_LEGACY_URL = "http://elastic-inference-service-legacy";
+
+    public void testGetElasticInferenceServiceUrl_WithUrlSetting() {
+        var settings = Settings.builder()
+            .put(ElasticInferenceServiceSettings.ELASTIC_INFERENCE_SERVICE_URL.getKey(), ELASTIC_INFERENCE_SERVICE_URL)
+            .build();
+
+        var eisSettings = new ElasticInferenceServiceSettings(settings);
+
+        assertThat(eisSettings.getElasticInferenceServiceUrl(), equalTo(ELASTIC_INFERENCE_SERVICE_URL));
+    }
+
+    public void testGetElasticInferenceServiceUrl_WithLegacyUrlSetting() {
+        var settings = Settings.builder()
+            .put(ElasticInferenceServiceSettings.EIS_GATEWAY_URL.getKey(), ELASTIC_INFERENCE_SERVICE_LEGACY_URL)
+            .build();
+
+        var eisSettings = new ElasticInferenceServiceSettings(settings);
+
+        assertThat(eisSettings.getElasticInferenceServiceUrl(), equalTo(ELASTIC_INFERENCE_SERVICE_LEGACY_URL));
+    }
+
+    public void testGetElasticInferenceServiceUrl_WithUrlSetting_TakesPrecedenceOverLegacyUrlSetting() {
+        var settings = Settings.builder()
+            .put(ElasticInferenceServiceSettings.EIS_GATEWAY_URL.getKey(), ELASTIC_INFERENCE_SERVICE_LEGACY_URL)
+            .put(ElasticInferenceServiceSettings.ELASTIC_INFERENCE_SERVICE_URL.getKey(), ELASTIC_INFERENCE_SERVICE_URL)
+            .build();
+
+        var eisSettings = new ElasticInferenceServiceSettings(settings);
+
+        assertThat(eisSettings.getElasticInferenceServiceUrl(), equalTo(ELASTIC_INFERENCE_SERVICE_URL));
+    }
+
+    public void testGetElasticInferenceServiceUrl_WithoutUrlSetting() {
+        var eisSettings = new ElasticInferenceServiceSettings(Settings.EMPTY);
+
+        assertThat(eisSettings.getElasticInferenceServiceUrl(), equalTo(""));
+    }
+
+}


### PR DESCRIPTION
Fix after https://github.com/elastic/elasticsearch/pull/120842. Putting back obsolete setting while Cloud is still setting it.