### PR TITLE
[ML] Unmuting inference get service config tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -261,8 +261,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test171AdditionalCliOptionsAreForwarded
   issue: https://github.com/elastic/elasticsearch/issues/120925
-- class: org.elasticsearch.xpack.inference.InferenceGetServicesIT
-  issue: https://github.com/elastic/elasticsearch/issues/120986
 - class: org.elasticsearch.action.search.SearchProgressActionListenerIT
   method: testSearchProgressWithQuery
   issue: https://github.com/elastic/elasticsearch/issues/120994


### PR DESCRIPTION
This PR reenables the integration tests for the get services API that were muted here: https://github.com/elastic/elasticsearch/issues/120986

The underlying failure was because the url settings were recognized. I believe this was because the tests were conditionally setting the url value during bootup based on whether EIS was enabled via the feature flag. The feature flag for EIS has been removed so the settings should always be valid.

PR to remove the feature flags: https://github.com/elastic/elasticsearch/pull/120842

It doesn't look like the tests were muted in 8.18 so I'm only putting this in 9.0.