### PR TITLE
[8.x] Fix typo in docs example (#121206)

### DIFF
--- a/docs/reference/esql/esql-async-query-stop-api.asciidoc
+++ b/docs/reference/esql/esql-async-query-stop-api.asciidoc
@@ -23,7 +23,7 @@ field set to `true`.
 
 [source,console]
 ----
-POST /query/async/FkpMRkJGS1gzVDRlM3g4ZzMyRGlLbkEaTXlJZHdNT09TU2VTZVBoNDM3cFZMUToxMDM=/stop
+POST /_query/async/FkpMRkJGS1gzVDRlM3g4ZzMyRGlLbkEaTXlJZHdNT09TU2VTZVBoNDM3cFZMUToxMDM=/stop
 ----
 // TEST[skip: no access to query ID]
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix typo in docs example (#121206)](https://github.com/elastic/elasticsearch/pull/121206)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)