### PR TITLE
[8.x] Fix check for sort fields being in nested objects (#121084)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
@@ -203,6 +203,47 @@ non-default sort settings:
   - match: { test-sort.settings.index.sort.mode.1: "max" }
 
 ---
+non-default sort settings with presence of nested:
+  - requires:
+      cluster_features: [ "mapper.nested.sorting_fields_check_fix" ]
+      reason: "Fixed behavior"
+
+  - do:
+      indices.create:
+        index: test-sort
+        body:
+          settings:
+            index:
+              mode: logsdb
+              number_of_shards: 2
+              number_of_replicas: 0
+              sort:
+                field: [ "agent_id", "@timestamp" ]
+                order: [ "asc", "desc" ]
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              agent_id:
+                type: keyword
+              agent:
+                type: nested
+                properties:
+                  id:
+                    type: keyword
+
+  - do:
+      indices.get_settings:
+        index: test-sort
+
+  - is_true: test-sort
+  - match: { test-sort.settings.index.mode: "logsdb" }
+  - match: { test-sort.settings.index.sort.field.0: "agent_id" }
+  - match: { test-sort.settings.index.sort.field.1: "@timestamp" }
+  - match: { test-sort.settings.index.sort.order.0: "asc" }
+  - match: { test-sort.settings.index.sort.order.1: "desc" }
+
+---
 override sort order settings:
   - requires:
       cluster_features: [ "index.logsdb_no_host_name_field" ]

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -167,12 +167,12 @@ public class DocumentMapper {
                 throw new IllegalArgumentException("cannot have nested fields when index sort is activated");
             }
             for (String field : settings.getValue(IndexSortConfig.INDEX_SORT_FIELD_SETTING)) {
-                for (NestedObjectMapper nestedObjectMapper : mappers().nestedLookup().getNestedMappers().values()) {
-                    if (field.startsWith(nestedObjectMapper.fullPath())) {
-                        throw new IllegalArgumentException(
-                            "cannot apply index sort to field [" + field + "] under nested object [" + nestedObjectMapper.fullPath() + "]"
-                        );
-                    }
+                NestedObjectMapper nestedMapper = mappers().nestedLookup().getNestedMappers().get(field);
+                String nestedParent = nestedMapper != null ? nestedMapper.fullPath() : mappers().nestedLookup().getNestedParent(field);
+                if (nestedParent != null) {
+                    throw new IllegalArgumentException(
+                        "cannot apply index sort to field [" + field + "] under nested object [" + nestedParent + "]"
+                    );
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -61,6 +61,7 @@ public class MapperFeatures implements FeatureSpecification {
 
     public static final NodeFeature META_FETCH_FIELDS_ERROR_CODE_CHANGED = new NodeFeature("meta_fetch_fields_error_code_changed");
     public static final NodeFeature SPARSE_VECTOR_STORE_SUPPORT = new NodeFeature("mapper.sparse_vector.store_support");
+    public static final NodeFeature SORT_FIELDS_CHECK_FOR_NESTED_OBJECT_FIX = new NodeFeature("mapper.nested.sorting_fields_check_fix");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -75,6 +76,7 @@ public class MapperFeatures implements FeatureSpecification {
             CONSTANT_KEYWORD_SYNTHETIC_SOURCE_WRITE_FIX,
             META_FETCH_FIELDS_ERROR_CODE_CHANGED,
             SPARSE_VECTOR_STORE_SUPPORT,
+            SORT_FIELDS_CHECK_FOR_NESTED_OBJECT_FIX,
             COUNTED_KEYWORD_SYNTHETIC_SOURCE_NATIVE_SUPPORT,
             SourceFieldMapper.SYNTHETIC_RECOVERY_SOURCE,
             ObjectMapper.SUBOBJECTS_FALSE_MAPPING_UPDATE_FIX


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix check for sort fields being in nested objects (#121084)