### PR TITLE
Clarify model support for AWS Bedrock

### DIFF
--- a/docs/reference/inference/service-amazon-bedrock.asciidoc
+++ b/docs/reference/inference/service-amazon-bedrock.asciidoc
@@ -100,8 +100,9 @@ Supported providers include:
 
 `model`:::
 (Required, string)
-The base model ID or an ARN to a custom model based on a foundational model.
+The base model ID or an ARN to a custom model based on a foundation model.
 The base model IDs can be found in the https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html[Amazon Bedrock model IDs] documentation.
+The foundation models can be found in the https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html[Amazon Bedrock supported foundation models] documentation.
 Note that the model ID must be available for the provider chosen, and your IAM user must have access to the model.
 
 `region`:::


### PR DESCRIPTION
1.  Renamed foundational model to foundation model to match AWS terminology.

2. Added a reference link to the list of AWS Bedrock supported foundation models.
