### PR TITLE
Add initial file entitlement check (#120243)

### DIFF
--- a/libs/entitlement/bridge/build.gradle
+++ b/libs/entitlement/bridge/build.gradle
@@ -25,6 +25,9 @@ tasks.named('jar').configure {
   }
 }
 
+// The bridge only uses things within the jdk, but the checker
+// needs to have many forbidden apis in its signatures. Suppressing
+// each use of forbidden apis would be tedious and not useful.
 tasks.withType(CheckForbiddenApisTask).configureEach {
-  replaceSignatureFiles 'jdk-signatures'
+  enabled = false
 }

--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.entitlement.bridge;
 
+import java.io.File;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -40,6 +41,9 @@ import java.nio.channels.CompletionHandler;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.attribute.UserPrincipal;
 import java.security.cert.CertStoreParameters;
 import java.util.List;
 import java.util.Locale;
@@ -54,7 +58,7 @@ import javax.net.ssl.SSLSocketFactory;
 @SuppressWarnings("unused") // Called from instrumentation code inserted by the Entitlements agent
 public interface EntitlementChecker {
 
-    ////////////////////
+    /// /////////////////
     //
     // Exit the JVM process
     //
@@ -65,7 +69,7 @@ public interface EntitlementChecker {
 
     void check$java_lang_System$$exit(Class<?> callerClass, int status);
 
-    ////////////////////
+    /// /////////////////
     //
     // ClassLoader ctor
     //
@@ -76,7 +80,7 @@ public interface EntitlementChecker {
 
     void check$java_lang_ClassLoader$(Class<?> callerClass, String name, ClassLoader parent);
 
-    ////////////////////
+    /// /////////////////
     //
     // SecureClassLoader ctor
     //
@@ -87,7 +91,7 @@ public interface EntitlementChecker {
 
     void check$java_security_SecureClassLoader$(Class<?> callerClass, String name, ClassLoader parent);
 
-    ////////////////////
+    /// /////////////////
     //
     // URLClassLoader constructors
     //
@@ -102,7 +106,7 @@ public interface EntitlementChecker {
 
     void check$java_net_URLClassLoader$(Class<?> callerClass, String name, URL[] urls, ClassLoader parent, URLStreamHandlerFactory factory);
 
-    ////////////////////
+    /// /////////////////
     //
     // "setFactory" methods
     //
@@ -115,7 +119,7 @@ public interface EntitlementChecker {
 
     void check$javax_net_ssl_SSLContext$$setDefault(Class<?> callerClass, SSLContext context);
 
-    ////////////////////
+    /// /////////////////
     //
     // Process creation
     //
@@ -124,7 +128,7 @@ public interface EntitlementChecker {
 
     void check$java_lang_ProcessBuilder$$startPipeline(Class<?> callerClass, List<ProcessBuilder> builders);
 
-    ////////////////////
+    /// /////////////////
     //
     // System Properties and similar
     //
@@ -133,7 +137,7 @@ public interface EntitlementChecker {
 
     void check$java_lang_System$$clearProperty(Class<?> callerClass, String key);
 
-    ////////////////////
+    /// /////////////////
     //
     // JVM-wide state changes
     //
@@ -210,7 +214,7 @@ public interface EntitlementChecker {
 
     void check$java_net_URLConnection$$setContentHandlerFactory(Class<?> callerClass, ContentHandlerFactory fac);
 
-    ////////////////////
+    /// /////////////////
     //
     // Network access
     //
@@ -407,7 +411,7 @@ public interface EntitlementChecker {
 
     void check$sun_nio_ch_DatagramChannelImpl$receive(Class<?> callerClass, DatagramChannel that, ByteBuffer dst);
 
-    ////////////////////
+    /// /////////////////
     //
     // Load native libraries
     //
@@ -421,4 +425,27 @@ public interface EntitlementChecker {
     void check$java_lang_System$$loadLibrary(Class<?> callerClass, String libname);
 
     void check$java_lang_ModuleLayer$Controller$enableNativeAccess(Class<?> callerClass, ModuleLayer.Controller that, Module target);
+
+    /// /////////////////
+    //
+    // File access
+    //
+
+    void check$java_util_Scanner$(Class<?> callerClass, File source);
+
+    void check$java_util_Scanner$(Class<?> callerClass, File source, String charsetName);
+
+    void check$java_util_Scanner$(Class<?> callerClass, File source, Charset charset);
+
+    void check$java_io_FileOutputStream$(Class<?> callerClass, String name);
+
+    void check$java_io_FileOutputStream$(Class<?> callerClass, String name, boolean append);
+
+    void check$java_io_FileOutputStream$(Class<?> callerClass, File file);
+
+    void check$java_io_FileOutputStream$(Class<?> callerClass, File file, boolean append);
+
+    void check$java_nio_file_Files$$probeContentType(Class<?> callerClass, Path path);
+
+    void check$java_nio_file_Files$$setOwner(Class<?> callerClass, Path path, UserPrincipal principal);
 }

--- a/libs/entitlement/qa/entitled-plugin/src/main/java/org/elasticsearch/entitlement/qa/entitled/EntitledActions.java
+++ b/libs/entitlement/qa/entitled-plugin/src/main/java/org/elasticsearch/entitlement/qa/entitled/EntitledActions.java
@@ -11,6 +11,11 @@ package org.elasticsearch.entitlement.qa.entitled;
 
 import org.elasticsearch.core.SuppressForbidden;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.UserPrincipal;
+
 public final class EntitledActions {
     private EntitledActions() {}
 
@@ -19,4 +24,7 @@ public final class EntitledActions {
         System.clearProperty(key);
     }
 
+    public static UserPrincipal getFileOwner(Path path) throws IOException {
+        return Files.getOwner(path);
+    }
 }

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.qa.test;
+
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.entitlement.qa.entitled.EntitledActions;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.Scanner;
+
+@SuppressForbidden(reason = "Explicitly checking APIs that are forbidden")
+class FileCheckActions {
+
+    private static Path testRootDir = Paths.get(System.getProperty("es.entitlements.testdir"));
+
+    private static Path readDir() {
+        return testRootDir.resolve("read_dir");
+    }
+
+    private static Path readWriteDir() {
+        return testRootDir.resolve("read_write_dir");
+    }
+
+    private static Path readFile() {
+        return testRootDir.resolve("read_file");
+    }
+
+    private static Path readWriteFile() {
+        return testRootDir.resolve("read_write_file");
+    }
+
+    static void createScannerFile() throws FileNotFoundException {
+        new Scanner(readFile().toFile());
+    }
+
+    static void createScannerFileWithCharset() throws IOException {
+        new Scanner(readFile().toFile(), StandardCharsets.UTF_8);
+    }
+
+    static void createScannerFileWithCharsetName() throws FileNotFoundException {
+        new Scanner(readFile().toFile(), "UTF-8");
+    }
+
+    static void createFileOutputStreamString() throws IOException {
+        new FileOutputStream(readWriteFile().toString()).close();
+    }
+
+    static void createFileOutputStreamStringWithAppend() throws IOException {
+        new FileOutputStream(readWriteFile().toString(), false).close();
+    }
+
+    static void createFileOutputStreamFile() throws IOException {
+        new FileOutputStream(readWriteFile().toFile()).close();
+    }
+
+    static void createFileOutputStreamFileWithAppend() throws IOException {
+        new FileOutputStream(readWriteFile().toFile(), false).close();
+    }
+
+    static void filesProbeContentType() throws IOException {
+        Files.probeContentType(readFile());
+    }
+
+    static void filesSetOwner() throws IOException {
+        UserPrincipal owner = EntitledActions.getFileOwner(readWriteFile());
+        Files.setOwner(readWriteFile(), owner); // set to existing owner, just trying to execute the method
+    }
+
+    private FileCheckActions() {}
+}

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
@@ -200,7 +200,6 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
         entry("runtime_load_library", forPlugins(LoadNativeLibrariesCheckActions::runtimeLoadLibrary)),
         entry("system_load", forPlugins(LoadNativeLibrariesCheckActions::systemLoad)),
         entry("system_load_library", forPlugins(LoadNativeLibrariesCheckActions::systemLoadLibrary)),
-
         entry("enable_native_access", new CheckAction(VersionSpecificNativeChecks::enableNativeAccess, false, 22)),
         entry("address_target_layout", new CheckAction(VersionSpecificNativeChecks::addressLayoutWithTargetLayout, false, 22)),
         entry("donwncall_handle", new CheckAction(VersionSpecificNativeChecks::linkerDowncallHandle, false, 22)),
@@ -213,7 +212,16 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
             new CheckAction(VersionSpecificNativeChecks::memorySegmentReinterpretWithSizeAndCleanup, false, 22)
         ),
         entry("symbol_lookup_name", new CheckAction(VersionSpecificNativeChecks::symbolLookupWithName, false, 22)),
-        entry("symbol_lookup_path", new CheckAction(VersionSpecificNativeChecks::symbolLookupWithPath, false, 22))
+        entry("symbol_lookup_path", new CheckAction(VersionSpecificNativeChecks::symbolLookupWithPath, false, 22)),
+        entry("create_scanner", forPlugins(FileCheckActions::createScannerFile)),
+        entry("create_scanner_with_charset", forPlugins(FileCheckActions::createScannerFileWithCharset)),
+        entry("create_scanner_with_charset_name", forPlugins(FileCheckActions::createScannerFileWithCharsetName)),
+        entry("create_file_output_stream_string", forPlugins(FileCheckActions::createFileOutputStreamString)),
+        entry("create_file_output_stream_string_with_append", forPlugins(FileCheckActions::createFileOutputStreamStringWithAppend)),
+        entry("create_file_output_stream_file", forPlugins(FileCheckActions::createFileOutputStreamFile)),
+        entry("create_file_output_stream_file_with_append", forPlugins(FileCheckActions::createFileOutputStreamFileWithAppend)),
+        entry("files_probe_content_type", forPlugins(FileCheckActions::filesProbeContentType)),
+        entry("files_set_owner", forPlugins(FileCheckActions::filesSetOwner))
     )
         .filter(entry -> entry.getValue().fromJavaVersion() == null || Runtime.version().feature() >= entry.getValue().fromJavaVersion())
         .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/AbstractEntitlementsIT.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/AbstractEntitlementsIT.java
@@ -34,6 +34,11 @@ public abstract class AbstractEntitlementsIT extends ESRestTestCase {
                 Map.of("properties", List.of("es.entitlements.checkSetSystemProperty", "es.entitlements.checkClearSystemProperty"))
             )
         );
+
+        builder.value(Map.of("file", Map.of("path", tempDir.resolve("read_dir"), "mode", "read")));
+        builder.value(Map.of("file", Map.of("path", tempDir.resolve("read_write_dir"), "mode", "read_write")));
+        builder.value(Map.of("file", Map.of("path", tempDir.resolve("read_file"), "mode", "read")));
+        builder.value(Map.of("file", Map.of("path", tempDir.resolve("read_write_file"), "mode", "read_write")));
     };
 
     private final String actionName;

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsTestRule.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsTestRule.java
@@ -15,6 +15,7 @@ import org.elasticsearch.test.cluster.local.PluginInstallSpec;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.yaml.YamlXContent;
+import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
@@ -23,6 +24,7 @@ import org.junit.runners.model.Statement;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 class EntitlementsTestRule implements TestRule {
@@ -38,6 +40,16 @@ class EntitlementsTestRule implements TestRule {
     @SuppressWarnings("this-escape")
     EntitlementsTestRule(boolean modular, PolicyBuilder policyBuilder) {
         testDir = new TemporaryFolder();
+        var tempDirSetup = new ExternalResource() {
+            @Override
+            protected void before() throws Throwable {
+                Path testPath = testDir.getRoot().toPath();
+                Files.createDirectory(testPath.resolve("read_dir"));
+                Files.createDirectory(testPath.resolve("read_write_dir"));
+                Files.writeString(testPath.resolve("read_file"), "");
+                Files.writeString(testPath.resolve("read_write_file"), "");
+            }
+        };
         cluster = ElasticsearchCluster.local()
             .module("entitled")
             .module("entitlement-test-plugin", spec -> setupEntitlements(spec, modular, policyBuilder))
@@ -45,7 +57,7 @@ class EntitlementsTestRule implements TestRule {
             .systemProperty("es.entitlements.testdir", () -> testDir.getRoot().getAbsolutePath())
             .setting("xpack.security.enabled", "false")
             .build();
-        ruleChain = RuleChain.outerRule(testDir).around(cluster);
+        ruleChain = RuleChain.outerRule(testDir).around(tempDirSetup).around(cluster);
     }
 
     @Override
@@ -62,6 +74,7 @@ class EntitlementsTestRule implements TestRule {
                         builder.startObject();
                         builder.field(moduleName);
                         builder.startArray();
+
                         policyBuilder.build(builder, testDir.getRoot().toPath());
                         builder.endArray();
                         builder.endObject();

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -9,9 +9,11 @@
 
 package org.elasticsearch.entitlement.runtime.api;
 
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.entitlement.bridge.EntitlementChecker;
 import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
 
+import java.io.File;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -44,6 +46,9 @@ import java.nio.channels.CompletionHandler;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.attribute.UserPrincipal;
 import java.security.cert.CertStoreParameters;
 import java.util.List;
 import java.util.Locale;
@@ -60,6 +65,7 @@ import javax.net.ssl.SSLSocketFactory;
  * API methods for managing the checks.
  * The trampoline module loads this object via SPI.
  */
+@SuppressForbidden(reason = "Explicitly checking APIs that are forbidden")
 public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     protected final PolicyManager policyManager;
@@ -779,5 +785,50 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Module target
     ) {
         policyManager.checkLoadingNativeLibraries(callerClass);
+    }
+
+    @Override
+    public void check$java_util_Scanner$(Class<?> callerClass, File source) {
+        policyManager.checkFileRead(callerClass, source);
+    }
+
+    @Override
+    public void check$java_util_Scanner$(Class<?> callerClass, File source, String charsetName) {
+        policyManager.checkFileRead(callerClass, source);
+    }
+
+    @Override
+    public void check$java_util_Scanner$(Class<?> callerClass, File source, Charset charset) {
+        policyManager.checkFileRead(callerClass, source);
+    }
+
+    @Override
+    public void check$java_io_FileOutputStream$(Class<?> callerClass, String name) {
+        policyManager.checkFileWrite(callerClass, new File(name));
+    }
+
+    @Override
+    public void check$java_io_FileOutputStream$(Class<?> callerClass, String name, boolean append) {
+        policyManager.checkFileWrite(callerClass, new File(name));
+    }
+
+    @Override
+    public void check$java_io_FileOutputStream$(Class<?> callerClass, File file) {
+        policyManager.checkFileWrite(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_FileOutputStream$(Class<?> callerClass, File file, boolean append) {
+        policyManager.checkFileWrite(callerClass, file);
+    }
+
+    @Override
+    public void check$java_nio_file_Files$$probeContentType(Class<?> callerClass, Path path) {
+        policyManager.checkFileRead(callerClass, path);
+    }
+
+    @Override
+    public void check$java_nio_file_Files$$setOwner(Class<?> callerClass, Path path, UserPrincipal principal) {
+        policyManager.checkFileWrite(callerClass, path);
     }
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy;
+
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+final class FileAccessTree {
+    static final FileAccessTree EMPTY = new FileAccessTree(List.of());
+
+    private final String[] readPaths;
+    private final String[] writePaths;
+
+    FileAccessTree(List<FileEntitlement> fileEntitlements) {
+        List<String> readPaths = new ArrayList<>();
+        List<String> writePaths = new ArrayList<>();
+        for (FileEntitlement fileEntitlement : fileEntitlements) {
+            var mode = fileEntitlement.mode();
+            if (mode == FileEntitlement.Mode.READ_WRITE) {
+                writePaths.add(fileEntitlement.path());
+            }
+            readPaths.add(fileEntitlement.path());
+        }
+
+        readPaths.sort(String::compareTo);
+        writePaths.sort(String::compareTo);
+
+        this.readPaths = readPaths.toArray(new String[0]);
+        this.writePaths = writePaths.toArray(new String[0]);
+    }
+
+    boolean canRead(Path path) {
+        return checkPath(normalize(path), readPaths);
+    }
+
+    @SuppressForbidden(reason = "Explicitly checking File apis")
+    boolean canRead(File file) {
+        return checkPath(normalize(file.toPath()), readPaths);
+    }
+
+    boolean canWrite(Path path) {
+        return checkPath(normalize(path), writePaths);
+    }
+
+    @SuppressForbidden(reason = "Explicitly checking File apis")
+    boolean canWrite(File file) {
+        return checkPath(normalize(file.toPath()), writePaths);
+    }
+
+    private static String normalize(Path path) {
+        return path.toAbsolutePath().normalize().toString();
+    }
+
+    private static boolean checkPath(String path, String[] paths) {
+        if (paths.length == 0) {
+            return false;
+        }
+        int ndx = Arrays.binarySearch(paths, path);
+        if (ndx < -1) {
+            String maybeParent = paths[-ndx - 2];
+            return path.startsWith(maybeParent);
+        }
+        return ndx >= 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        FileAccessTree that = (FileAccessTree) o;
+        return Objects.deepEquals(readPaths, that.readPaths) && Objects.deepEquals(writePaths, that.writePaths);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Arrays.hashCode(readPaths), Arrays.hashCode(writePaths));
+    }
+}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileEntitlement.java
@@ -9,62 +9,38 @@
 
 package org.elasticsearch.entitlement.runtime.policy;
 
-import java.util.List;
-import java.util.Objects;
+import java.nio.file.Paths;
 
 /**
- * Describes a file entitlement with a path and actions.
+ * Describes a file entitlement with a path and mode.
  */
-public class FileEntitlement implements Entitlement {
+public record FileEntitlement(String path, Mode mode) implements Entitlement {
 
-    public static final int READ_ACTION = 0x1;
-    public static final int WRITE_ACTION = 0x2;
+    public enum Mode {
+        READ,
+        READ_WRITE
+    }
 
-    public static final String READ = "read";
-    public static final String WRITE = "write";
+    public FileEntitlement {
+        path = normalizePath(path);
+    }
 
-    private final String path;
-    private final int actions;
+    private static String normalizePath(String path) {
+        return Paths.get(path).toAbsolutePath().normalize().toString();
+    }
 
-    @ExternalEntitlement(parameterNames = { "path", "actions" }, esModulesOnly = false)
-    public FileEntitlement(String path, List<String> actionsList) {
-        this.path = path;
-        int actionsInt = 0;
-
-        for (String actionString : actionsList) {
-            if (READ.equals(actionString)) {
-                if ((actionsInt & READ_ACTION) == READ_ACTION) {
-                    throw new IllegalArgumentException("file action [read] specified multiple times");
-                }
-                actionsInt |= READ_ACTION;
-            } else if (WRITE.equals(actionString)) {
-                if ((actionsInt & WRITE_ACTION) == WRITE_ACTION) {
-                    throw new IllegalArgumentException("file action [write] specified multiple times");
-                }
-                actionsInt |= WRITE_ACTION;
-            } else {
-                throw new IllegalArgumentException("unknown file action [" + actionString + "]");
-            }
+    private static Mode parseMode(String mode) {
+        if (mode.equals("read")) {
+            return Mode.READ;
+        } else if (mode.equals("read_write")) {
+            return Mode.READ_WRITE;
+        } else {
+            throw new PolicyValidationException("invalid mode: " + mode + ", valid values: [read, read_write]");
         }
-
-        this.actions = actionsInt;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        FileEntitlement that = (FileEntitlement) o;
-        return actions == that.actions && Objects.equals(path, that.path);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(path, actions);
-    }
-
-    @Override
-    public String toString() {
-        return "FileEntitlement{" + "path='" + path + '\'' + ", actions=" + actions + '}';
+    @ExternalEntitlement(parameterNames = { "path", "mode" }, esModulesOnly = false)
+    public FileEntitlement(String path, String mode) {
+        this(path, parseMode(mode));
     }
 }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.BeforeClass;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+public class FileAccessTreeTests extends ESTestCase {
+
+    static Path root;
+
+    @BeforeClass
+    public static void setupRoot() {
+        root = createTempDir();
+    }
+
+    private static Path path(String s) {
+        return root.resolve(s);
+    }
+
+    public void testEmpty() {
+        var tree = new FileAccessTree(List.of());
+        assertThat(tree.canRead(path("path")), is(false));
+        assertThat(tree.canWrite(path("path")), is(false));
+    }
+
+    public void testRead() {
+        var tree = new FileAccessTree(List.of(entitlement("foo", "read")));
+        assertThat(tree.canRead(path("foo")), is(true));
+        assertThat(tree.canRead(path("foo/subdir")), is(true));
+        assertThat(tree.canWrite(path("foo")), is(false));
+
+        assertThat(tree.canRead(path("before")), is(false));
+        assertThat(tree.canRead(path("later")), is(false));
+    }
+
+    public void testWrite() {
+        var tree = new FileAccessTree(List.of(entitlement("foo", "read_write")));
+        assertThat(tree.canWrite(path("foo")), is(true));
+        assertThat(tree.canWrite(path("foo/subdir")), is(true));
+        assertThat(tree.canRead(path("foo")), is(true));
+
+        assertThat(tree.canWrite(path("before")), is(false));
+        assertThat(tree.canWrite(path("later")), is(false));
+    }
+
+    public void testTwoPaths() {
+        var tree = new FileAccessTree(List.of(entitlement("foo", "read"), entitlement("bar", "read")));
+        assertThat(tree.canRead(path("a")), is(false));
+        assertThat(tree.canRead(path("bar")), is(true));
+        assertThat(tree.canRead(path("bar/subdir")), is(true));
+        assertThat(tree.canRead(path("c")), is(false));
+        assertThat(tree.canRead(path("foo")), is(true));
+        assertThat(tree.canRead(path("foo/subdir")), is(true));
+        assertThat(tree.canRead(path("z")), is(false));
+    }
+
+    public void testReadWriteUnderRead() {
+        var tree = new FileAccessTree(List.of(entitlement("foo", "read"), entitlement("foo/bar", "read_write")));
+        assertThat(tree.canRead(path("foo")), is(true));
+        assertThat(tree.canWrite(path("foo")), is(false));
+        assertThat(tree.canRead(path("foo/bar")), is(true));
+        assertThat(tree.canWrite(path("foo/bar")), is(true));
+    }
+
+    public void testNormalizePath() {
+        var tree = new FileAccessTree(List.of(entitlement("foo/../bar", "read")));
+        assertThat(tree.canRead(path("foo/../bar")), is(true));
+        assertThat(tree.canRead(path("foo")), is(false));
+        assertThat(tree.canRead(path("")), is(false));
+    }
+
+    FileEntitlement entitlement(String path, String mode) {
+        Path p = path(path);
+        return new FileEntitlement(p.toString(), mode);
+    }
+}

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
@@ -31,10 +31,7 @@ import java.util.stream.Stream;
 
 import static java.util.Map.entry;
 import static org.elasticsearch.entitlement.runtime.policy.PolicyManager.ALL_UNNAMED;
-import static org.elasticsearch.test.LambdaMatchers.transformedMatch;
 import static org.hamcrest.Matchers.aMapWithSize;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
@@ -204,10 +201,8 @@ public class PolicyManagerTests extends ESTestCase {
 
         var entitlements = policyManager.getEntitlements(mockPluginClass);
         assertThat(entitlements.hasEntitlement(CreateClassLoaderEntitlement.class), is(true));
-        assertThat(
-            entitlements.getEntitlements(FileEntitlement.class).toList(),
-            contains(transformedMatch(FileEntitlement::toString, containsString("/test/path")))
-        );
+        // TODO: this can't work on Windows, we need to have the root be unknown
+        // assertThat(entitlements.fileAccess().canRead("/test/path"), is(true));
     }
 
     public void testGetEntitlementsResultIsCached() {
@@ -324,7 +319,7 @@ public class PolicyManagerTests extends ESTestCase {
                 .map(
                     name -> new Scope(
                         name,
-                        List.of(new FileEntitlement("/test/path", List.of(FileEntitlement.READ)), new CreateClassLoaderEntitlement())
+                        List.of(new FileEntitlement("/test/path", FileEntitlement.Mode.READ), new CreateClassLoaderEntitlement())
                     )
                 )
                 .toList()

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserFailureTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserFailureTests.java
@@ -55,7 +55,7 @@ public class PolicyParserFailureTests extends ESTestCase {
             """.getBytes(StandardCharsets.UTF_8)), "test-failure-policy.yaml", false).parsePolicy());
         assertEquals(
             "[4:1] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
-                + "for entitlement type [file]: missing entitlement parameter [actions]",
+                + "for entitlement type [file]: missing entitlement parameter [mode]",
             ppe.getMessage()
         );
     }
@@ -65,12 +65,11 @@ public class PolicyParserFailureTests extends ESTestCase {
             entitlement-module-name:
               - file:
                   path: test-path
-                  actions:
-                    - read
+                  mode: read
                   extra: test
             """.getBytes(StandardCharsets.UTF_8)), "test-failure-policy.yaml", false).parsePolicy());
         assertEquals(
-            "[7:1] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
+            "[6:1] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
                 + "for entitlement type [file]: extraneous entitlement parameter(s) {extra=test}",
             ppe.getMessage()
         );

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
@@ -47,7 +47,7 @@ public class PolicyParserTests extends ESTestCase {
             .parsePolicy();
         Policy expected = new Policy(
             "test-policy.yaml",
-            List.of(new Scope("entitlement-module-name", List.of(new FileEntitlement("test/path/to/file", List.of("read", "write")))))
+            List.of(new Scope("entitlement-module-name", List.of(new FileEntitlement("test/path/to/file", "read_write"))))
         );
         assertEquals(expected, parsedPolicy);
     }
@@ -57,7 +57,7 @@ public class PolicyParserTests extends ESTestCase {
             .parsePolicy();
         Policy expected = new Policy(
             "test-policy.yaml",
-            List.of(new Scope("entitlement-module-name", List.of(new FileEntitlement("test/path/to/file", List.of("read", "write")))))
+            List.of(new Scope("entitlement-module-name", List.of(new FileEntitlement("test/path/to/file", "read_write"))))
         );
         assertEquals(expected, parsedPolicy);
     }

--- a/libs/entitlement/src/test/resources/org/elasticsearch/entitlement/runtime/policy/test-policy.yaml
+++ b/libs/entitlement/src/test/resources/org/elasticsearch/entitlement/runtime/policy/test-policy.yaml
@@ -1,6 +1,4 @@
 entitlement-module-name:
   - file:
       path: "test/path/to/file"
-      actions:
-        - "read"
-        - "write"
+      mode: "read_write"


### PR DESCRIPTION
This commit adds FileEntitlement to entitlements. It does not add checks for all file access methods yet, instead opting for example read and write methods.

Each module contains a sorted array of paths with read and write permissions. Binary search is used to quickly identify the closest path to determine whether a target path can be read or written.

Some important things about FileEntitlement are the path can either be a file or a directory. All directories grant recursive permission. The mode is either read or read_write. All operations like create or delete are considered write.

relates ES-10354