### PR TITLE
[8.x] Remove redundant LatchedActionListener from ESIntegTestCase (#121244)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainRequest;
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainResponse;
 import org.elasticsearch.action.admin.cluster.allocation.TransportClusterAllocationExplainAction;
@@ -1711,7 +1712,8 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 logger.info("Index [{}] docs async: [{}] bulk: [{}]", builders.size(), true, false);
                 for (IndexRequestBuilder indexRequestBuilder : builders) {
                     indexRequestBuilder.execute(
-                        new LatchedActionListener<DocWriteResponse>(newLatch(inFlightAsyncOperations)).delegateResponse((l, e) -> fail(e))
+                        new LatchedActionListener<DocWriteResponse>(ActionListener.noop(), newLatch(inFlightAsyncOperations))
+                            .delegateResponse((l, e) -> fail(e))
                     );
                     postIndexAsyncActions(indicesArray, inFlightAsyncOperations, maybeFlush);
                 }
@@ -1803,17 +1805,17 @@ public abstract class ESIntegTestCase extends ESTestCase {
             if (rarely()) {
                 indicesAdmin().prepareRefresh(indices)
                     .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-                    .execute(new LatchedActionListener<>(newLatch(inFlightAsyncOperations)));
+                    .execute(new LatchedActionListener<>(ActionListener.noop(), newLatch(inFlightAsyncOperations)));
             } else if (maybeFlush && rarely()) {
                 indicesAdmin().prepareFlush(indices)
                     .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-                    .execute(new LatchedActionListener<>(newLatch(inFlightAsyncOperations)));
+                    .execute(new LatchedActionListener<>(ActionListener.noop(), newLatch(inFlightAsyncOperations)));
             } else if (rarely()) {
                 indicesAdmin().prepareForceMerge(indices)
                     .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                     .setMaxNumSegments(between(1, 10))
                     .setFlush(maybeFlush && randomBoolean())
-                    .execute(new LatchedActionListener<>(newLatch(inFlightAsyncOperations)));
+                    .execute(new LatchedActionListener<>(ActionListener.noop(), newLatch(inFlightAsyncOperations)));
             }
         }
         while (inFlightAsyncOperations.size() > MAX_IN_FLIGHT_ASYNC_INDEXES) {
@@ -1895,32 +1897,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
          * negative value means that the number of client nodes will be randomized.
          */
         int numClientNodes() default InternalTestCluster.DEFAULT_NUM_CLIENT_NODES;
-    }
-
-    private class LatchedActionListener<Response> implements ActionListener<Response> {
-        private final CountDownLatch latch;
-
-        LatchedActionListener(CountDownLatch latch) {
-            this.latch = latch;
-        }
-
-        @Override
-        public final void onResponse(Response response) {
-            latch.countDown();
-        }
-
-        @Override
-        public final void onFailure(Exception t) {
-            try {
-                logger.info("Action Failed", t);
-                addError(t);
-            } finally {
-                latch.countDown();
-            }
-        }
-
-        protected void addError(Exception e) {}
-
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Remove redundant LatchedActionListener from ESIntegTestCase (#121244)