### PR TITLE
[8.17] Cheaper snapshot-related `toString()` impls (#121283)

### DIFF
--- a/docs/changelog/121283.yaml
+++ b/docs/changelog/121283.yaml
@@ -1,0 +1,5 @@
+pr: 121283
+summary: Cheaper snapshot-related `toString()` impls
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -605,6 +605,11 @@ public final class RepositoryData {
         return Objects.hash(snapshotIds, snapshotsDetails, indices, indexSnapshots, shardGenerations, indexMetaDataGenerations);
     }
 
+    @Override
+    public String toString() {
+        return Strings.format("RepositoryData[uuid=%s,gen=%s]", uuid, genId);
+    }
+
     /**
      * Resolve the index name to the index id specific to the repository,
      * throwing an exception if the index could not be resolved.

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -3894,6 +3894,11 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
             logSnapshotFailure("create", snapshot, e);
             listener.onFailure(e);
         }
+
+        @Override
+        public String toString() {
+            return "CreateSnapshotTask{repository=" + repository.getMetadata().name() + ", snapshot=" + snapshot + '}';
+        }
     }
 
     private static void logSnapshotFailure(String operation, Snapshot snapshot, Exception e) {

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -40,9 +40,12 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.repositories.RepositoryData.EMPTY_REPO_GEN;
 import static org.elasticsearch.repositories.RepositoryData.MISSING_UUID;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Tests for the {@link RepositoryData} class.
@@ -428,6 +431,19 @@ public class RepositoryDataTests extends ESTestCase {
                 equalTo("this snapshot repository format requires Elasticsearch version [" + futureVersion + "] or later")
             );
         }
+    }
+
+    public void testToString() {
+        final var repositoryData = generateRandomRepoData();
+        assertThat(
+            repositoryData.toString(),
+            allOf(
+                containsString("RepositoryData"),
+                containsString(repositoryData.getUuid()),
+                containsString(Long.toString(repositoryData.getGenId())),
+                not(containsString("@")) // not the default Object#toString which does a very expensive hashcode computation
+            )
+        );
     }
 
     public static RepositoryData generateRandomRepoData() {


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Cheaper snapshot-related `toString()` impls (#121283)