### PR TITLE
[8.18] Make test setup more reliable #121110

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int4_flat.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int4_flat.yml
@@ -62,6 +62,17 @@ setup:
   - do:
       indices.refresh: {}
 
+  # For added test reliability, pending the resolution of https://github.com/elastic/elasticsearch/issues/109416.
+  - do:
+      indices.forcemerge:
+        max_num_segments: 1
+        index: int4_flat
+  - do:
+      indices.refresh: {}
+  - do:
+      indices.forcemerge:
+        max_num_segments: 1
+        index: int4_flat
 ---
 "kNN search only":
   - do:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Make test setup more reliable #121110](https://github.com/elastic/elasticsearch/pull/121110)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)