### PR TITLE
[8.18] Fix NPE in deprecation API (#121263)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -507,6 +507,3 @@ tests:
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testSuggestProfileWithData
   issue: https://github.com/elastic/elasticsearch/issues/121258
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
-  issue: https://github.com/elastic/elasticsearch/issues/120950

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -507,3 +507,6 @@ tests:
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testSuggestProfileWithData
   issue: https://github.com/elastic/elasticsearch/issues/121258
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
+  issue: https://github.com/elastic/elasticsearch/issues/120950

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -353,7 +353,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
     }
 
     /**
-     *
+     * Removes the skipped settings from the selected indices and the component and index templates.
      * @param state The cluster state to modify
      * @param indexNames The names of the indexes whose settings need to be filtered
      * @param skipTheseDeprecatedSettings The settings that will be removed from cluster metadata and the index metadata of all the
@@ -405,7 +405,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
             String templateName = entry.getKey();
             ComposableIndexTemplate indexTemplate = entry.getValue();
             Template template = indexTemplate.template();
-            if (templateName == null || template.settings() == null || template.settings().isEmpty()) {
+            if (template == null || template.settings() == null || template.settings().isEmpty()) {
                 return Tuple.tuple(templateName, indexTemplate);
             }
             return Tuple.tuple(

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationInfoActionResponseTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationInfoActionResponseTests.java
@@ -362,7 +362,14 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
             .put(IndexMetadata.builder("test").settings(inputSettings).numberOfShards(1).numberOfReplicas(0))
             .put(dataStreamIndexMetadata, true)
             .put(DataStream.builder("ds-test", List.of(dataStreamIndexMetadata.getIndex())).build())
-            .indexTemplates(Map.of("my-index-template", indexTemplate))
+            .indexTemplates(
+                Map.of(
+                    "my-index-template",
+                    indexTemplate,
+                    "empty-template",
+                    ComposableIndexTemplate.builder().indexPatterns(List.of("random")).build()
+                )
+            )
             .componentTemplates(Map.of("my-component-template", componentTemplate))
             .persistentSettings(inputSettings)
             .build();
@@ -391,7 +398,11 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
                 .componentTemplates()
                 .values()
                 .forEach(template -> visibleComponentTemplateSettings.set(template.template().settings()));
-            cs.metadata().templatesV2().values().forEach(template -> visibleIndexTemplateSettings.set(template.template().settings()));
+            cs.metadata().templatesV2().values().forEach(template -> {
+                if (template.template() != null && template.template().settings() != null) {
+                    visibleIndexTemplateSettings.set(template.template().settings());
+                }
+            });
             return Map.of();
         }));
 


### PR DESCRIPTION
Backports the following commits to 8.18 :

Fix NPE in deprecation API (https://github.com/elastic/elasticsearch/pull/121263)