### PR TITLE
Fix inference update API calls with task_type in body or deployment_id defined (#121231)

### DIFF
--- a/docs/changelog/121231.yaml
+++ b/docs/changelog/121231.yaml
@@ -1,0 +1,6 @@
+pr: 121231
+summary: Fix inference update API calls with `task_type` in body or `deployment_id`
+  defined
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
@@ -43,6 +43,24 @@ public class CreateFromDeploymentIT extends InferenceBaseRestTest {
         var results = infer(inferenceId, List.of("washing machine"));
         assertNotNull(results.get("sparse_embedding"));
 
+        var updatedNumAllocations = randomIntBetween(1, 10);
+        var updatedEndpointConfig = updateEndpoint(inferenceId, updatedEndpointConfig(updatedNumAllocations), TaskType.SPARSE_EMBEDDING);
+        assertThat(
+            updatedEndpointConfig.get("service_settings"),
+            is(
+                Map.of(
+                    "num_allocations",
+                    updatedNumAllocations,
+                    "num_threads",
+                    1,
+                    "model_id",
+                    "attach_to_deployment",
+                    "deployment_id",
+                    "existing_deployment"
+                )
+            )
+        );
+
         deleteModel(inferenceId);
         // assert deployment not stopped
         var stats = (List<Map<String, Object>>) getTrainedModelStats(modelId).get("trained_model_stats");
@@ -82,6 +100,24 @@ public class CreateFromDeploymentIT extends InferenceBaseRestTest {
 
         var results = infer(inferenceId, List.of("washing machine"));
         assertNotNull(results.get("sparse_embedding"));
+
+        var updatedNumAllocations = randomIntBetween(1, 10);
+        var updatedEndpointConfig = updateEndpoint(inferenceId, updatedEndpointConfig(updatedNumAllocations), TaskType.SPARSE_EMBEDDING);
+        assertThat(
+            updatedEndpointConfig.get("service_settings"),
+            is(
+                Map.of(
+                    "num_allocations",
+                    updatedNumAllocations,
+                    "num_threads",
+                    1,
+                    "model_id",
+                    "attach_with_model_id",
+                    "deployment_id",
+                    "existing_deployment_with_model_id"
+                )
+            )
+        );
 
         stopMlNodeDeployment(deploymentId);
     }
@@ -187,6 +223,16 @@ public class CreateFromDeploymentIT extends InferenceBaseRestTest {
               }
             }
             """, modelId, deploymentId);
+    }
+
+    private String updatedEndpointConfig(int numAllocations) {
+        return Strings.format("""
+            {
+              "service_settings": {
+                "num_allocations": %d
+              }
+            }
+            """, numAllocations);
     }
 
     private Response startMlNodeDeploymemnt(String modelId, String deploymentId) throws IOException {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -235,6 +235,11 @@ public class InferenceBaseRestTest extends ESRestTestCase {
         return putRequest(endpoint, modelConfig);
     }
 
+    static Map<String, Object> updateEndpoint(String inferenceID, String modelConfig) throws IOException {
+        String endpoint = Strings.format("_inference/%s/_update", inferenceID);
+        return putRequest(endpoint, modelConfig);
+    }
+
     protected Map<String, Object> putPipeline(String pipelineId, String modelId) throws IOException {
         String endpoint = Strings.format("_ingest/pipeline/%s", pipelineId);
         String body = """
@@ -266,7 +271,7 @@ public class InferenceBaseRestTest extends ESRestTestCase {
         return putRequest(endpoint, modelConfig);
     }
 
-    Map<String, Object> putRequest(String endpoint, String body) throws IOException {
+    static Map<String, Object> putRequest(String endpoint, String body) throws IOException {
         var request = new Request("PUT", endpoint);
         request.setJsonEntity(body);
         var response = client().performRequest(request);

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
@@ -335,6 +335,61 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
         }
     }
 
+    public void testUpdateEndpointWithWrongTaskTypeInURL() throws IOException {
+        putModel("sparse_embedding_model", mockSparseServiceModelConfig(), TaskType.SPARSE_EMBEDDING);
+        var e = expectThrows(
+            ResponseException.class,
+            () -> updateEndpoint(
+                "sparse_embedding_model",
+                updateConfig(null, randomAlphaOfLength(10), randomIntBetween(1, 10)),
+                TaskType.TEXT_EMBEDDING
+            )
+        );
+        assertThat(e.getMessage(), containsString("Task type must match the task type of the existing endpoint"));
+    }
+
+    public void testUpdateEndpointWithWrongTaskTypeInBody() throws IOException {
+        putModel("sparse_embedding_model", mockSparseServiceModelConfig(), TaskType.SPARSE_EMBEDDING);
+        var e = expectThrows(
+            ResponseException.class,
+            () -> updateEndpoint(
+                "sparse_embedding_model",
+                updateConfig(TaskType.TEXT_EMBEDDING, randomAlphaOfLength(10), randomIntBetween(1, 10))
+            )
+        );
+        assertThat(e.getMessage(), containsString("Task type must match the task type of the existing endpoint"));
+    }
+
+    public void testUpdateEndpointWithTaskTypeInURL() throws IOException {
+        testUpdateEndpoint(false, true);
+    }
+
+    public void testUpdateEndpointWithTaskTypeInBody() throws IOException {
+        testUpdateEndpoint(true, false);
+    }
+
+    public void testUpdateEndpointWithTaskTypeInBodyAndURL() throws IOException {
+        testUpdateEndpoint(true, true);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void testUpdateEndpoint(boolean taskTypeInBody, boolean taskTypeInURL) throws IOException {
+        String endpointId = "sparse_embedding_model";
+        putModel(endpointId, mockSparseServiceModelConfig(), TaskType.SPARSE_EMBEDDING);
+
+        int temperature = randomIntBetween(1, 10);
+        var expectedConfig = updateConfig(taskTypeInBody ? TaskType.SPARSE_EMBEDDING : null, randomAlphaOfLength(1), temperature);
+        Map<String, Object> updatedEndpoint;
+        if (taskTypeInURL) {
+            updatedEndpoint = updateEndpoint(endpointId, expectedConfig, TaskType.SPARSE_EMBEDDING);
+        } else {
+            updatedEndpoint = updateEndpoint(endpointId, expectedConfig);
+        }
+
+        Map<String, Objects> updatedTaskSettings = (Map<String, Objects>) updatedEndpoint.get("task_settings");
+        assertEquals(temperature, updatedTaskSettings.get("temperature"));
+    }
+
     public void testGetZeroModels() throws IOException {
         var models = getModels("_all", TaskType.RERANK);
         assertThat(models, empty());

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestUpdateInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestUpdateInferenceModelAction.java
@@ -7,12 +7,10 @@
 
 package org.elasticsearch.xpack.inference.rest;
 
-import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.RestUtils;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
@@ -47,7 +45,8 @@ public class RestUpdateInferenceModelAction extends BaseRestHandler {
             inferenceEntityId = restRequest.param(INFERENCE_ID);
             taskType = TaskType.fromStringOrStatusException(restRequest.param(TASK_TYPE_OR_INFERENCE_ID));
         } else {
-            throw new ElasticsearchStatusException("Inference ID must be provided in the path", RestStatus.BAD_REQUEST);
+            inferenceEntityId = restRequest.param(TASK_TYPE_OR_INFERENCE_ID);
+            taskType = TaskType.ANY;
         }
 
         var request = new UpdateInferenceModelAction.Request(


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/121231