### PR TITLE
ReindexDataStreamIndex bug in assertion caused by reference equality

### DIFF
--- a/docs/changelog/121325.yaml
+++ b/docs/changelog/121325.yaml
@@ -1,0 +1,5 @@
+pr: 121325
+summary: '`ReindexDataStreamIndex` bug in assertion caused by reference equality'
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -54,6 +54,7 @@ import org.elasticsearch.xpack.core.deprecation.DeprecatedIndexPredicate;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.APIBlock.WRITE;
 
@@ -372,7 +373,7 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
                 listener.delegateFailureAndWrap((delegate, ignored) -> {
                     getIndexDocCount(sourceIndexName, parentTaskId, delegate.delegateFailureAndWrap((delegate1, sourceCount) -> {
                         getIndexDocCount(destIndexName, parentTaskId, delegate1.delegateFailureAndWrap((delegate2, destCount) -> {
-                            assert sourceCount == destCount
+                            assert Objects.equals(sourceCount, destCount)
                                 : String.format(
                                     Locale.ROOT,
                                     "source index [%s] has %d docs and dest [%s] has %d docs",


### PR DESCRIPTION
Assertion was using reference equality on two boxed longs. So assertion could produce false positives. Change to Objects.equals to check value and avoid null check.
