### PR TITLE
Update ESRestTestCase's ROLLUP_REQUESTS_OPTIONS

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -169,14 +169,16 @@ public abstract class ESRestTestCase extends ESTestCase {
     private static final String EXPECTED_ROLLUP_WARNING_MESSAGE =
         "The rollup functionality will be removed in Elasticsearch 10.0. See docs for more information.";
     public static final RequestOptions.Builder ROLLUP_REQUESTS_OPTIONS = RequestOptions.DEFAULT.toBuilder().setWarningsHandler(warnings -> {
-        // Either no warning, because of bwc integration test OR
-        // the expected warning, because on current version
         if (warnings.isEmpty()) {
             return false;
-        } else if (warnings.size() == 1 && EXPECTED_ROLLUP_WARNING_MESSAGE.equals(warnings.get(0))) {
-            return false;
         } else {
-            return true;
+            // Sometimes multiple rollup deprecation warnings. Transport actions can be invoked multiple time on different nodes.
+            for (String warning : warnings) {
+                if (EXPECTED_ROLLUP_WARNING_MESSAGE.equals(warning) == false) {
+                    return true;
+                }
+            }
+            return false;
         }
     });
 


### PR DESCRIPTION
Sometimes there are multiple warning.

Example failure: https://gradle-enterprise.elastic.co/s/4utkph35cf24q/tests/task/:x-pack:plugin:esql:qa:server:mixed-cluster:v9.0.0%23javaRestTest/details/org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT/testIntFieldWithByteSubfield?expanded-stacktrace=WyIwIl0&top-execution=1