### PR TITLE
Unmute ES|QL EsqlClientYamlAsync*IT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -372,14 +372,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/121293
 - class: org.elasticsearch.xpack.inference.common.InferenceServiceNodeLocalRateLimitCalculatorTests
   issue: https://github.com/elastic/elasticsearch/issues/121294
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlClientYamlIT
-  issue: https://github.com/elastic/elasticsearch/issues/121352
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlClientYamlAsyncSubmitAndFetchIT
-  issue: https://github.com/elastic/elasticsearch/issues/121353
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
-  issue: https://github.com/elastic/elasticsearch/issues/121352
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlClientYamlAsyncIT
-  issue: https://github.com/elastic/elasticsearch/issues/121354
 
 # Examples:
 #


### PR DESCRIPTION
Should be fixed by https://github.com/elastic/elasticsearch/pull/121342

Closes https://github.com/elastic/elasticsearch/issues/121352, #121353, #121354