### PR TITLE
[8.18] Fix LambdaMatchers.transformedMatch to handle null values (#121371)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/LambdaMatchers.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/LambdaMatchers.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
 
 public class LambdaMatchers {
 
-    private static class TransformMatcher<T, U> extends BaseMatcher<T> {
+    private static class TransformMatcher<T, U> extends TypeSafeMatcher<T> {
         private final Matcher<U> matcher;
         private final Function<T, U> transform;
 
@@ -33,24 +33,21 @@ public class LambdaMatchers {
         }
 
         @Override
-        @SuppressWarnings("unchecked")
-        public boolean matches(Object actual) {
+        protected boolean matchesSafely(T item) {
             U u;
             try {
-                u = transform.apply((T) actual);
+                u = transform.apply(item);
             } catch (ClassCastException e) {
                 throw new AssertionError(e);
             }
-
             return matcher.matches(u);
         }
 
         @Override
-        @SuppressWarnings("unchecked")
-        public void describeMismatch(Object item, Description description) {
+        protected void describeMismatchSafely(T item, Description description) {
             U u;
             try {
-                u = transform.apply((T) item);
+                u = transform.apply(item);
             } catch (ClassCastException e) {
                 description.appendValue(item).appendText(" is not of the correct type (").appendText(e.getMessage()).appendText(")");
                 return;

--- a/test/framework/src/test/java/org/elasticsearch/test/LambdaMatchersTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/LambdaMatchersTests.java
@@ -19,11 +19,13 @@ import static org.elasticsearch.test.LambdaMatchers.transformedArrayItemsMatch;
 import static org.elasticsearch.test.LambdaMatchers.transformedItemsMatch;
 import static org.elasticsearch.test.LambdaMatchers.transformedMatch;
 import static org.elasticsearch.test.LambdaMatchers.trueWith;
+import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public class LambdaMatchersTests extends ESTestCase {
@@ -56,6 +58,7 @@ public class LambdaMatchersTests extends ESTestCase {
         assertThat(new A("1"), transformedMatch(a -> a.str, equalTo("1")));
         assertThat(new B("1"), transformedMatch((A a) -> a.str, equalTo("1")));
 
+        assertMismatch((A) null, transformedMatch(A::toString, anything()), is("was null"));
         assertMismatch(new A("1"), transformedMatch(a -> a.str, emptyString()), equalTo("transformed value was \"1\""));
     }
 


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix LambdaMatchers.transformedMatch to handle null values (#121371)