### PR TITLE
unmute SearchWithMinCompatibleSearchNodeIT failing tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -17,12 +17,6 @@ tests:
 - class: org.elasticsearch.upgrades.SecurityIndexRolesMetadataMigrationIT
   method: testMetadataMigratedAfterUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/110232
-- class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
-  method: testMinVersionAsNewVersion
-  issue: https://github.com/elastic/elasticsearch/issues/95384
-- class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
-  method: testCcsMinimizeRoundtripsIsFalse
-  issue: https://github.com/elastic/elasticsearch/issues/101974
 - class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
   issue: "https://github.com/elastic/elasticsearch/issues/110408"
   method: "testCreateAndRestorePartialSearchableSnapshot"


### PR DESCRIPTION
I couldn't reproduce the failure. Please check the [comment](https://github.com/elastic/elasticsearch/issues/119425#issuecomment-2626913481) for details. 
I unmute the failing tests to verify if they are still failing and, if so, to have a fresher failure to analyze.
