### PR TITLE
[8.x] [ML] Adding fields for Inference service configuration API (#121103)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchService.java
@@ -409,7 +409,7 @@ public class AlibabaCloudSearchService extends SenderService {
                     HTTP_SCHEMA_NAME,
                     new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("")
                         .setLabel("HTTP Schema")
-                        .setRequired(true)
+                        .setRequired(false)
                         .setSensitive(false)
                         .setUpdatable(false)
                         .setType(SettingsConfigurationFieldType.STRING)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockService.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
@@ -410,6 +411,20 @@ public class AmazonBedrockService extends SenderService {
                         .setSensitive(false)
                         .setUpdatable(false)
                         .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    DIMENSIONS,
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING)).setDescription(
+                        "The number of dimensions the resulting embeddings should have. For more information refer to "
+                            + "https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html."
+                    )
+                        .setLabel("Dimensions")
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setUpdatable(false)
+                        .setType(SettingsConfigurationFieldType.INTEGER)
                         .build()
                 );
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioService.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
@@ -438,6 +439,20 @@ public class AzureAiStudioService extends SenderService {
                         .setSensitive(false)
                         .setUpdatable(false)
                         .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    DIMENSIONS,
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING)).setDescription(
+                        "The number of dimensions the resulting embeddings should have. For more information refer to "
+                            + "https://learn.microsoft.com/en-us/azure/ai-studio/reference/reference-model-inference-embeddings."
+                    )
+                        .setLabel("Dimensions")
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setUpdatable(false)
+                        .setType(SettingsConfigurationFieldType.INTEGER)
                         .build()
                 );
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiService.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
@@ -379,6 +380,20 @@ public class AzureOpenAiService extends SenderService {
                         .setSensitive(false)
                         .setUpdatable(false)
                         .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    DIMENSIONS,
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING)).setDescription(
+                        "The number of dimensions the resulting embeddings should have. For more information refer to "
+                            + "https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#request-body-1."
+                    )
+                        .setLabel("Dimensions")
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setUpdatable(false)
+                        .setType(SettingsConfigurationFieldType.INTEGER)
                         .build()
                 );
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
@@ -25,6 +25,7 @@ import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.chunking.EmbeddingRequestChunker;
@@ -51,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
@@ -362,6 +364,19 @@ public class CohereService extends SenderService {
         private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
             () -> {
                 var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    MODEL_ID,
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
+                        "The name of the model to use for the inference task."
+                    )
+                        .setLabel("Model ID")
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setUpdatable(false)
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
 
                 configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration(supportedTaskTypes));
                 configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(supportedTaskTypes));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiService.java
@@ -327,6 +327,8 @@ public class GoogleVertexAiService extends SenderService {
             () -> {
                 var configurationMap = new HashMap<String, SettingsConfiguration>();
 
+                // TODO whether the model ID is required or not depends on the task type
+                // For rerank it is optional, for text_embedding it is required
                 configurationMap.put(
                     MODEL_ID,
                     new SettingsConfiguration.Builder(supportedTaskTypes).setDescription("ID of the LLM you're using.")

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIService.java
@@ -25,6 +25,7 @@ import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.chunking.EmbeddingRequestChunker;
@@ -49,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
@@ -338,6 +340,33 @@ public class JinaAIService extends SenderService {
         private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
             () -> {
                 var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    JinaAIServiceSettings.MODEL_ID,
+                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
+                        "The name of the model to use for the inference task."
+                    )
+                        .setLabel("Model ID")
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setUpdatable(false)
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    DIMENSIONS,
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING)).setDescription(
+                        "The number of dimensions the resulting embeddings should have. For more information refer to "
+                            + "https://api.jina.ai/redoc#tag/embeddings/operation/create_embedding_v1_embeddings_post."
+                    )
+                        .setLabel("Dimensions")
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setUpdatable(false)
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
 
                 configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration(supportedTaskTypes));
                 configurationMap.putAll(RateLimitSettings.toSettingsConfiguration(supportedTaskTypes));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
@@ -56,8 +56,8 @@ import java.util.Set;
 
 import static org.elasticsearch.xpack.inference.external.action.ActionUtils.constructFailedToSendRequestMessage;
 import static org.elasticsearch.xpack.inference.external.action.openai.OpenAiActionCreator.COMPLETION_ERROR_PREFIX;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
-import static org.elasticsearch.xpack.inference.services.ServiceFields.URL;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
@@ -440,19 +440,16 @@ public class OpenAiService extends SenderService {
                 );
 
                 configurationMap.put(
-                    URL,
-                    new SettingsConfiguration.Builder(SUPPORTED_TASK_TYPES_FOR_SERVICES_API).setDefaultValue(
-                        "https://api.openai.com/v1/chat/completions"
+                    DIMENSIONS,
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING)).setDescription(
+                        "The number of dimensions the resulting embeddings should have. For more information refer to "
+                            + "https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-dimensions."
                     )
-                        .setDescription(
-                            "The OpenAI API endpoint URL. For more information on the URL, refer to the "
-                                + "https://platform.openai.com/docs/api-reference."
-                        )
-                        .setLabel("URL")
-                        .setRequired(true)
+                        .setLabel("Dimensions")
+                        .setRequired(false)
                         .setSensitive(false)
                         .setUpdatable(false)
-                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setType(SettingsConfigurationFieldType.INTEGER)
                         .build()
                 );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchServiceTests.java
@@ -490,7 +490,7 @@ public class AlibabaCloudSearchServiceTests extends ESTestCase {
                          "http_schema": {
                            "description": "",
                            "label": "HTTP Schema",
-                           "required": true,
+                           "required": false,
                            "sensitive": false,
                            "updatable": false,
                            "type": "str",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
@@ -154,69 +154,80 @@ public class AmazonBedrockServiceTests extends ESTestCase {
     @SuppressWarnings("checkstyle:LineLength")
     public void testGetConfiguration() throws Exception {
         try (var service = createAmazonBedrockService()) {
-            String content = XContentHelper.stripWhitespace("""
-                {
-                     "service": "amazonbedrock",
-                     "name": "Amazon Bedrock",
-                     "task_types": ["text_embedding", "completion"],
-                     "configurations": {
-                         "secret_key": {
-                             "description": "A valid AWS secret key that is paired with the access_key.",
-                             "label": "Secret Key",
-                             "required": true,
-                             "sensitive": true,
-                             "updatable": true,
-                             "type": "str",
-                             "supported_task_types": ["text_embedding", "completion"]
-                         },
-                         "provider": {
-                             "description": "The model provider for your deployment.",
-                             "label": "Provider",
-                             "required": true,
-                             "sensitive": false,
-                             "updatable": false,
-                             "type": "str",
-                             "supported_task_types": ["text_embedding", "completion"]
-                         },
-                         "access_key": {
-                             "description": "A valid AWS access key that has permissions to use Amazon Bedrock.",
-                             "label": "Access Key",
-                             "required": true,
-                             "sensitive": true,
-                             "updatable": true,
-                             "type": "str",
-                             "supported_task_types": ["text_embedding", "completion"]
-                         },
-                         "model": {
-                             "description": "The base model ID or an ARN to a custom model based on a foundational model.",
-                             "label": "Model",
-                             "required": true,
-                             "sensitive": false,
-                             "updatable": false,
-                             "type": "str",
-                             "supported_task_types": ["text_embedding", "completion"]
-                         },
-                         "rate_limit.requests_per_minute": {
-                             "description": "By default, the amazonbedrock service sets the number of requests allowed per minute to 240.",
-                             "label": "Rate Limit",
-                             "required": false,
-                             "sensitive": false,
-                             "updatable": false,
-                             "type": "int",
-                             "supported_task_types": ["text_embedding", "completion"]
-                         },
-                         "region": {
-                             "description": "The region that your model or ARN is deployed in.",
-                             "label": "Region",
-                             "required": true,
-                             "sensitive": false,
-                             "updatable": false,
-                             "type": "str",
-                             "supported_task_types": ["text_embedding", "completion"]
+            String content = XContentHelper.stripWhitespace(
+                """
+                    {
+                         "service": "amazonbedrock",
+                         "name": "Amazon Bedrock",
+                         "task_types": ["text_embedding", "completion"],
+                         "configurations": {
+                              "dimensions": {
+                                 "description": "The number of dimensions the resulting embeddings should have. For more information refer to https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html.",
+                                 "label": "Dimensions",
+                                 "required": false,
+                                 "sensitive": false,
+                                 "updatable": false,
+                                 "type": "int",
+                                 "supported_task_types": ["text_embedding"]
+                             },
+                             "secret_key": {
+                                 "description": "A valid AWS secret key that is paired with the access_key.",
+                                 "label": "Secret Key",
+                                 "required": true,
+                                 "sensitive": true,
+                                 "updatable": true,
+                                 "type": "str",
+                                 "supported_task_types": ["text_embedding", "completion"]
+                             },
+                             "provider": {
+                                 "description": "The model provider for your deployment.",
+                                 "label": "Provider",
+                                 "required": true,
+                                 "sensitive": false,
+                                 "updatable": false,
+                                 "type": "str",
+                                 "supported_task_types": ["text_embedding", "completion"]
+                             },
+                             "access_key": {
+                                 "description": "A valid AWS access key that has permissions to use Amazon Bedrock.",
+                                 "label": "Access Key",
+                                 "required": true,
+                                 "sensitive": true,
+                                 "updatable": true,
+                                 "type": "str",
+                                 "supported_task_types": ["text_embedding", "completion"]
+                             },
+                             "model": {
+                                 "description": "The base model ID or an ARN to a custom model based on a foundational model.",
+                                 "label": "Model",
+                                 "required": true,
+                                 "sensitive": false,
+                                 "updatable": false,
+                                 "type": "str",
+                                 "supported_task_types": ["text_embedding", "completion"]
+                             },
+                             "rate_limit.requests_per_minute": {
+                                 "description": "By default, the amazonbedrock service sets the number of requests allowed per minute to 240.",
+                                 "label": "Rate Limit",
+                                 "required": false,
+                                 "sensitive": false,
+                                 "updatable": false,
+                                 "type": "int",
+                                 "supported_task_types": ["text_embedding", "completion"]
+                             },
+                             "region": {
+                                 "description": "The region that your model or ARN is deployed in.",
+                                 "label": "Region",
+                                 "required": true,
+                                 "sensitive": false,
+                                 "updatable": false,
+                                 "type": "str",
+                                 "supported_task_types": ["text_embedding", "completion"]
+                             }
                          }
                      }
-                 }
-                """);
+                    """
+            );
             InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
                 new BytesArray(content),
                 XContentType.JSON

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioServiceTests.java
@@ -1388,60 +1388,71 @@ public class AzureAiStudioServiceTests extends ESTestCase {
     @SuppressWarnings("checkstyle:LineLength")
     public void testGetConfiguration() throws Exception {
         try (var service = createService()) {
-            String content = XContentHelper.stripWhitespace("""
-                {
-                    "service": "azureaistudio",
-                    "name": "Azure AI Studio",
-                    "task_types": ["text_embedding", "completion"],
-                    "configurations": {
-                        "endpoint_type": {
-                            "description": "Specifies the type of endpoint that is used in your model deployment.",
-                            "label": "Endpoint Type",
-                            "required": true,
-                            "sensitive": false,
-                            "updatable": false,
-                            "type": "str",
-                            "supported_task_types": ["text_embedding", "completion"]
-                        },
-                        "provider": {
-                            "description": "The model provider for your deployment.",
-                            "label": "Provider",
-                            "required": true,
-                            "sensitive": false,
-                            "updatable": false,
-                            "type": "str",
-                            "supported_task_types": ["text_embedding", "completion"]
-                        },
-                        "api_key": {
-                            "description": "API Key for the provider you're connecting to.",
-                            "label": "API Key",
-                            "required": true,
-                            "sensitive": true,
-                            "updatable": true,
-                            "type": "str",
-                            "supported_task_types": ["text_embedding", "completion"]
-                        },
-                        "rate_limit.requests_per_minute": {
-                            "description": "Minimize the number of rate limit errors.",
-                            "label": "Rate Limit",
-                            "required": false,
-                            "sensitive": false,
-                            "updatable": false,
-                            "type": "int",
-                            "supported_task_types": ["text_embedding", "completion"]
-                        },
-                        "target": {
-                            "description": "The target URL of your Azure AI Studio model deployment.",
-                            "label": "Target",
-                            "required": true,
-                            "sensitive": false,
-                            "updatable": false,
-                            "type": "str",
-                            "supported_task_types": ["text_embedding", "completion"]
+            String content = XContentHelper.stripWhitespace(
+                """
+                    {
+                        "service": "azureaistudio",
+                        "name": "Azure AI Studio",
+                        "task_types": ["text_embedding", "completion"],
+                        "configurations": {
+                            "dimensions": {
+                                "description": "The number of dimensions the resulting embeddings should have. For more information refer to https://learn.microsoft.com/en-us/azure/ai-studio/reference/reference-model-inference-embeddings.",
+                                "label": "Dimensions",
+                                "required": false,
+                                "sensitive": false,
+                                "updatable": false,
+                                "type": "int",
+                                "supported_task_types": ["text_embedding"]
+                            },
+                            "endpoint_type": {
+                                "description": "Specifies the type of endpoint that is used in your model deployment.",
+                                "label": "Endpoint Type",
+                                "required": true,
+                                "sensitive": false,
+                                "updatable": false,
+                                "type": "str",
+                                "supported_task_types": ["text_embedding", "completion"]
+                            },
+                            "provider": {
+                                "description": "The model provider for your deployment.",
+                                "label": "Provider",
+                                "required": true,
+                                "sensitive": false,
+                                "updatable": false,
+                                "type": "str",
+                                "supported_task_types": ["text_embedding", "completion"]
+                            },
+                            "api_key": {
+                                "description": "API Key for the provider you're connecting to.",
+                                "label": "API Key",
+                                "required": true,
+                                "sensitive": true,
+                                "updatable": true,
+                                "type": "str",
+                                "supported_task_types": ["text_embedding", "completion"]
+                            },
+                            "rate_limit.requests_per_minute": {
+                                "description": "Minimize the number of rate limit errors.",
+                                "label": "Rate Limit",
+                                "required": false,
+                                "sensitive": false,
+                                "updatable": false,
+                                "type": "int",
+                                "supported_task_types": ["text_embedding", "completion"]
+                            },
+                            "target": {
+                                "description": "The target URL of your Azure AI Studio model deployment.",
+                                "label": "Target",
+                                "required": true,
+                                "sensitive": false,
+                                "updatable": false,
+                                "type": "str",
+                                "supported_task_types": ["text_embedding", "completion"]
+                            }
                         }
                     }
-                }
-                """);
+                    """
+            );
             InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
                 new BytesArray(content),
                 XContentType.JSON

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
@@ -1472,6 +1472,15 @@ public class AzureOpenAiServiceTests extends ESTestCase {
                                     "type": "str",
                                     "supported_task_types": ["text_embedding", "completion"]
                                 },
+                                "dimensions": {
+                                    "description": "The number of dimensions the resulting embeddings should have. For more information refer to https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#request-body-1.",
+                                    "label": "Dimensions",
+                                    "required": false,
+                                    "sensitive": false,
+                                    "updatable": false,
+                                    "type": "int",
+                                    "supported_task_types": ["text_embedding"]
+                                },
                                 "entra_id": {
                                     "description": "You must provide either an API key or an Entra ID.",
                                     "label": "Entra ID",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
@@ -1646,6 +1646,15 @@ public class CohereServiceTests extends ESTestCase {
                                 "type": "str",
                                 "supported_task_types": ["text_embedding", "rerank", "completion"]
                             },
+                            "model_id": {
+                                "description": "The name of the model to use for the inference task.",
+                                "label": "Model ID",
+                                "required": false,
+                                "sensitive": false,
+                                "updatable": false,
+                                "type": "str",
+                                "supported_task_types": ["text_embedding", "rerank", "completion"]
+                            },
                             "rate_limit.requests_per_minute": {
                                 "description": "Minimize the number of rate limit errors.",
                                 "label": "Rate Limit",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
@@ -1831,33 +1831,53 @@ public class JinaAIServiceTests extends ESTestCase {
     @SuppressWarnings("checkstyle:LineLength")
     public void testGetConfiguration() throws Exception {
         try (var service = createJinaAIService()) {
-            String content = XContentHelper.stripWhitespace("""
-                {
-                        "service": "jinaai",
-                        "name": "Jina AI",
-                        "task_types": ["text_embedding", "rerank"],
-                        "configurations": {
-                            "api_key": {
-                                "description": "API Key for the provider you're connecting to.",
-                                "label": "API Key",
-                                "required": true,
-                                "sensitive": true,
-                                "updatable": true,
-                                "type": "str",
-                                "supported_task_types": ["text_embedding", "rerank"]
-                            },
-                            "rate_limit.requests_per_minute": {
-                                "description": "Minimize the number of rate limit errors.",
-                                "label": "Rate Limit",
-                                "required": false,
-                                "sensitive": false,
-                                "updatable": false,
-                                "type": "int",
-                                "supported_task_types": ["text_embedding", "rerank"]
+            String content = XContentHelper.stripWhitespace(
+                """
+                    {
+                            "service": "jinaai",
+                            "name": "Jina AI",
+                            "task_types": ["text_embedding", "rerank"],
+                            "configurations": {
+                                "api_key": {
+                                    "description": "API Key for the provider you're connecting to.",
+                                    "label": "API Key",
+                                    "required": true,
+                                    "sensitive": true,
+                                    "updatable": true,
+                                    "type": "str",
+                                    "supported_task_types": ["text_embedding", "rerank"]
+                                },
+                                "dimensions": {
+                                    "description": "The number of dimensions the resulting embeddings should have. For more information refer to https://api.jina.ai/redoc#tag/embeddings/operation/create_embedding_v1_embeddings_post.",
+                                    "label": "Dimensions",
+                                    "required": false,
+                                    "sensitive": false,
+                                    "updatable": false,
+                                    "type": "int",
+                                    "supported_task_types": ["text_embedding"]
+                                },
+                                "model_id": {
+                                    "description": "The name of the model to use for the inference task.",
+                                    "label": "Model ID",
+                                    "required": true,
+                                    "sensitive": false,
+                                    "updatable": false,
+                                    "type": "str",
+                                    "supported_task_types": ["text_embedding", "rerank"]
+                                },
+                                "rate_limit.requests_per_minute": {
+                                    "description": "Minimize the number of rate limit errors.",
+                                    "label": "Rate Limit",
+                                    "required": false,
+                                    "sensitive": false,
+                                    "updatable": false,
+                                    "type": "int",
+                                    "supported_task_types": ["text_embedding", "rerank"]
+                                }
                             }
                         }
-                    }
-                """);
+                    """
+            );
             InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
                 new BytesArray(content),
                 XContentType.JSON

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
@@ -1751,6 +1751,15 @@ public class OpenAiServiceTests extends ESTestCase {
                                     "type": "str",
                                     "supported_task_types": ["text_embedding", "completion", "chat_completion"]
                                 },
+                                "dimensions": {
+                                    "description": "The number of dimensions the resulting embeddings should have. For more information refer to https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-dimensions.",
+                                    "label": "Dimensions",
+                                    "required": false,
+                                    "sensitive": false,
+                                    "updatable": false,
+                                    "type": "int",
+                                    "supported_task_types": ["text_embedding"]
+                                },
                                 "organization_id": {
                                     "description": "The unique identifier of your organization.",
                                     "label": "Organization ID",
@@ -1772,16 +1781,6 @@ public class OpenAiServiceTests extends ESTestCase {
                                 "model_id": {
                                     "description": "The name of the model to use for the inference task.",
                                     "label": "Model ID",
-                                    "required": true,
-                                    "sensitive": false,
-                                    "updatable": false,
-                                    "type": "str",
-                                    "supported_task_types": ["text_embedding", "completion", "chat_completion"]
-                                },
-                                "url": {
-                                    "default_value": "https://api.openai.com/v1/chat/completions",
-                                    "description": "The OpenAI API endpoint URL. For more information on the URL, refer to the https://platform.openai.com/docs/api-reference.",
-                                    "label": "URL",
                                     "required": true,
                                     "sensitive": false,
                                     "updatable": false,


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Adding fields for Inference service configuration API (#121103)