### PR TITLE
[8.18] Make entitlement IT tests reflective (#121355)

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/EntitlementTest.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/EntitlementTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.qa.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EntitlementTest {
+    enum ExpectedAccess {
+        PLUGINS,
+        ES_MODULES_ONLY,
+        ALWAYS_DENIED
+    }
+
+    ExpectedAccess expectedAccess();
+
+    int fromJavaVersion() default -1;
+}

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
@@ -22,6 +22,8 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.Scanner;
 
+import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
+
 @SuppressForbidden(reason = "Explicitly checking APIs that are forbidden")
 class FileCheckActions {
 
@@ -43,38 +45,47 @@ class FileCheckActions {
         return testRootDir.resolve("read_write_file");
     }
 
+    @EntitlementTest(expectedAccess = PLUGINS)
     static void createScannerFile() throws FileNotFoundException {
         new Scanner(readFile().toFile());
     }
 
+    @EntitlementTest(expectedAccess = PLUGINS)
     static void createScannerFileWithCharset() throws IOException {
         new Scanner(readFile().toFile(), StandardCharsets.UTF_8);
     }
 
+    @EntitlementTest(expectedAccess = PLUGINS)
     static void createScannerFileWithCharsetName() throws FileNotFoundException {
         new Scanner(readFile().toFile(), "UTF-8");
     }
 
+    @EntitlementTest(expectedAccess = PLUGINS)
     static void createFileOutputStreamString() throws IOException {
         new FileOutputStream(readWriteFile().toString()).close();
     }
 
+    @EntitlementTest(expectedAccess = PLUGINS)
     static void createFileOutputStreamStringWithAppend() throws IOException {
         new FileOutputStream(readWriteFile().toString(), false).close();
     }
 
+    @EntitlementTest(expectedAccess = PLUGINS)
     static void createFileOutputStreamFile() throws IOException {
         new FileOutputStream(readWriteFile().toFile()).close();
     }
 
+    @EntitlementTest(expectedAccess = PLUGINS)
     static void createFileOutputStreamFileWithAppend() throws IOException {
         new FileOutputStream(readWriteFile().toFile(), false).close();
     }
 
+    @EntitlementTest(expectedAccess = PLUGINS)
     static void filesProbeContentType() throws IOException {
         Files.probeContentType(readFile());
     }
 
+    @EntitlementTest(expectedAccess = PLUGINS)
     static void filesSetOwner() throws IOException {
         UserPrincipal owner = EntitledActions.getFileOwner(readWriteFile());
         Files.setOwner(readWriteFile(), owner); // set to existing owner, just trying to execute the method

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
@@ -33,6 +33,9 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.HttpURLConnection;
@@ -51,8 +54,10 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.spi.URLStreamHandlerProvider;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -61,6 +66,7 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 
 import static java.util.Map.entry;
+import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 import static org.elasticsearch.entitlement.qa.test.RestEntitlementsCheckAction.CheckAction.alwaysDenied;
 import static org.elasticsearch.entitlement.qa.test.RestEntitlementsCheckAction.CheckAction.deniedToPlugins;
 import static org.elasticsearch.entitlement.qa.test.RestEntitlementsCheckAction.CheckAction.forPlugins;
@@ -88,143 +94,185 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
         }
     }
 
-    private static final Map<String, CheckAction> checkActions = Stream.<Map.Entry<String, CheckAction>>of(
-        entry("runtime_exit", deniedToPlugins(RestEntitlementsCheckAction::runtimeExit)),
-        entry("runtime_halt", deniedToPlugins(RestEntitlementsCheckAction::runtimeHalt)),
-        entry("system_exit", deniedToPlugins(RestEntitlementsCheckAction::systemExit)),
-        entry("create_classloader", forPlugins(RestEntitlementsCheckAction::createClassLoader)),
-        entry("processBuilder_start", deniedToPlugins(RestEntitlementsCheckAction::processBuilder_start)),
-        entry("processBuilder_startPipeline", deniedToPlugins(RestEntitlementsCheckAction::processBuilder_startPipeline)),
-        entry("set_https_connection_properties", forPlugins(RestEntitlementsCheckAction::setHttpsConnectionProperties)),
-        entry("set_default_ssl_socket_factory", alwaysDenied(RestEntitlementsCheckAction::setDefaultSSLSocketFactory)),
-        entry("set_default_hostname_verifier", alwaysDenied(RestEntitlementsCheckAction::setDefaultHostnameVerifier)),
-        entry("set_default_ssl_context", alwaysDenied(RestEntitlementsCheckAction::setDefaultSSLContext)),
-        entry("system_setIn", alwaysDenied(RestEntitlementsCheckAction::system$$setIn)),
-        entry("system_setOut", alwaysDenied(RestEntitlementsCheckAction::system$$setOut)),
-        entry("system_setErr", alwaysDenied(RestEntitlementsCheckAction::system$$setErr)),
-        entry("runtime_addShutdownHook", alwaysDenied(RestEntitlementsCheckAction::runtime$addShutdownHook)),
-        entry("runtime_removeShutdownHook", alwaysDenied(RestEntitlementsCheckAction::runtime$$removeShutdownHook)),
-        entry(
-            "thread_setDefaultUncaughtExceptionHandler",
-            alwaysDenied(RestEntitlementsCheckAction::thread$$setDefaultUncaughtExceptionHandler)
+    private static final Map<String, CheckAction> checkActions = Stream.concat(
+        Stream.<Entry<String, CheckAction>>of(
+            entry("runtime_exit", deniedToPlugins(RestEntitlementsCheckAction::runtimeExit)),
+            entry("runtime_halt", deniedToPlugins(RestEntitlementsCheckAction::runtimeHalt)),
+            entry("system_exit", deniedToPlugins(RestEntitlementsCheckAction::systemExit)),
+            entry("create_classloader", forPlugins(RestEntitlementsCheckAction::createClassLoader)),
+            entry("processBuilder_start", deniedToPlugins(RestEntitlementsCheckAction::processBuilder_start)),
+            entry("processBuilder_startPipeline", deniedToPlugins(RestEntitlementsCheckAction::processBuilder_startPipeline)),
+            entry("set_https_connection_properties", forPlugins(RestEntitlementsCheckAction::setHttpsConnectionProperties)),
+            entry("set_default_ssl_socket_factory", alwaysDenied(RestEntitlementsCheckAction::setDefaultSSLSocketFactory)),
+            entry("set_default_hostname_verifier", alwaysDenied(RestEntitlementsCheckAction::setDefaultHostnameVerifier)),
+            entry("set_default_ssl_context", alwaysDenied(RestEntitlementsCheckAction::setDefaultSSLContext)),
+            entry("system_setIn", alwaysDenied(RestEntitlementsCheckAction::system$$setIn)),
+            entry("system_setOut", alwaysDenied(RestEntitlementsCheckAction::system$$setOut)),
+            entry("system_setErr", alwaysDenied(RestEntitlementsCheckAction::system$$setErr)),
+            entry("runtime_addShutdownHook", alwaysDenied(RestEntitlementsCheckAction::runtime$addShutdownHook)),
+            entry("runtime_removeShutdownHook", alwaysDenied(RestEntitlementsCheckAction::runtime$$removeShutdownHook)),
+            entry(
+                "thread_setDefaultUncaughtExceptionHandler",
+                alwaysDenied(RestEntitlementsCheckAction::thread$$setDefaultUncaughtExceptionHandler)
+            ),
+            entry("localeServiceProvider", alwaysDenied(RestEntitlementsCheckAction::localeServiceProvider$)),
+            entry("breakIteratorProvider", alwaysDenied(RestEntitlementsCheckAction::breakIteratorProvider$)),
+            entry("collatorProvider", alwaysDenied(RestEntitlementsCheckAction::collatorProvider$)),
+            entry("dateFormatProvider", alwaysDenied(RestEntitlementsCheckAction::dateFormatProvider$)),
+            entry("dateFormatSymbolsProvider", alwaysDenied(RestEntitlementsCheckAction::dateFormatSymbolsProvider$)),
+            entry("decimalFormatSymbolsProvider", alwaysDenied(RestEntitlementsCheckAction::decimalFormatSymbolsProvider$)),
+            entry("numberFormatProvider", alwaysDenied(RestEntitlementsCheckAction::numberFormatProvider$)),
+            entry("calendarDataProvider", alwaysDenied(RestEntitlementsCheckAction::calendarDataProvider$)),
+            entry("calendarNameProvider", alwaysDenied(RestEntitlementsCheckAction::calendarNameProvider$)),
+            entry("currencyNameProvider", alwaysDenied(RestEntitlementsCheckAction::currencyNameProvider$)),
+            entry("localeNameProvider", alwaysDenied(RestEntitlementsCheckAction::localeNameProvider$)),
+            entry("timeZoneNameProvider", alwaysDenied(RestEntitlementsCheckAction::timeZoneNameProvider$)),
+            entry("logManager", alwaysDenied(RestEntitlementsCheckAction::logManager$)),
+
+            entry("locale_setDefault", alwaysDenied(WritePropertiesCheckActions::setDefaultLocale)),
+            entry("locale_setDefaultForCategory", alwaysDenied(WritePropertiesCheckActions::setDefaultLocaleForCategory)),
+            entry("timeZone_setDefault", alwaysDenied(WritePropertiesCheckActions::setDefaultTimeZone)),
+
+            entry("system_setProperty", forPlugins(WritePropertiesCheckActions::setSystemProperty)),
+            entry("system_clearProperty", forPlugins(WritePropertiesCheckActions::clearSystemProperty)),
+            entry("system_setSystemProperties", alwaysDenied(WritePropertiesCheckActions::setSystemProperties)),
+
+            // This group is a bit nasty: if entitlements don't prevent these, then networking is
+            // irreparably borked for the remainder of the test run.
+            entry(
+                "datagramSocket_setDatagramSocketImplFactory",
+                alwaysDenied(RestEntitlementsCheckAction::datagramSocket$$setDatagramSocketImplFactory)
+            ),
+            entry("httpURLConnection_setFollowRedirects", alwaysDenied(RestEntitlementsCheckAction::httpURLConnection$$setFollowRedirects)),
+            entry("serverSocket_setSocketFactory", alwaysDenied(RestEntitlementsCheckAction::serverSocket$$setSocketFactory)),
+            entry("socket_setSocketImplFactory", alwaysDenied(RestEntitlementsCheckAction::socket$$setSocketImplFactory)),
+            entry("url_setURLStreamHandlerFactory", alwaysDenied(RestEntitlementsCheckAction::url$$setURLStreamHandlerFactory)),
+            entry("urlConnection_setFileNameMap", alwaysDenied(RestEntitlementsCheckAction::urlConnection$$setFileNameMap)),
+            entry(
+                "urlConnection_setContentHandlerFactory",
+                alwaysDenied(RestEntitlementsCheckAction::urlConnection$$setContentHandlerFactory)
+            ),
+
+            entry("proxySelector_setDefault", alwaysDenied(RestEntitlementsCheckAction::setDefaultProxySelector)),
+            entry("responseCache_setDefault", alwaysDenied(RestEntitlementsCheckAction::setDefaultResponseCache)),
+            entry(
+                "createInetAddressResolverProvider",
+                new CheckAction(VersionSpecificNetworkChecks::createInetAddressResolverProvider, true, 18)
+            ),
+            entry("createURLStreamHandlerProvider", alwaysDenied(RestEntitlementsCheckAction::createURLStreamHandlerProvider)),
+            entry("createURLWithURLStreamHandler", alwaysDenied(RestEntitlementsCheckAction::createURLWithURLStreamHandler)),
+            entry("createURLWithURLStreamHandler2", alwaysDenied(RestEntitlementsCheckAction::createURLWithURLStreamHandler2)),
+            entry("datagram_socket_bind", forPlugins(RestEntitlementsCheckAction::bindDatagramSocket)),
+            entry("datagram_socket_connect", forPlugins(RestEntitlementsCheckAction::connectDatagramSocket)),
+            entry("datagram_socket_send", forPlugins(RestEntitlementsCheckAction::sendDatagramSocket)),
+            entry("datagram_socket_receive", forPlugins(RestEntitlementsCheckAction::receiveDatagramSocket)),
+            entry("datagram_socket_join_group", forPlugins(RestEntitlementsCheckAction::joinGroupDatagramSocket)),
+            entry("datagram_socket_leave_group", forPlugins(RestEntitlementsCheckAction::leaveGroupDatagramSocket)),
+
+            entry("create_socket_with_proxy", forPlugins(NetworkAccessCheckActions::createSocketWithProxy)),
+            entry("socket_bind", forPlugins(NetworkAccessCheckActions::socketBind)),
+            entry("socket_connect", forPlugins(NetworkAccessCheckActions::socketConnect)),
+            entry("server_socket_bind", forPlugins(NetworkAccessCheckActions::serverSocketBind)),
+            entry("server_socket_accept", forPlugins(NetworkAccessCheckActions::serverSocketAccept)),
+
+            entry("url_open_connection_proxy", forPlugins(NetworkAccessCheckActions::urlOpenConnectionWithProxy)),
+            entry("http_client_send", forPlugins(VersionSpecificNetworkChecks::httpClientSend)),
+            entry("http_client_send_async", forPlugins(VersionSpecificNetworkChecks::httpClientSendAsync)),
+            entry("create_ldap_cert_store", forPlugins(NetworkAccessCheckActions::createLDAPCertStore)),
+
+            entry("server_socket_channel_bind", forPlugins(NetworkAccessCheckActions::serverSocketChannelBind)),
+            entry("server_socket_channel_bind_backlog", forPlugins(NetworkAccessCheckActions::serverSocketChannelBindWithBacklog)),
+            entry("server_socket_channel_accept", forPlugins(NetworkAccessCheckActions::serverSocketChannelAccept)),
+            entry("asynchronous_server_socket_channel_bind", forPlugins(NetworkAccessCheckActions::asynchronousServerSocketChannelBind)),
+            entry(
+                "asynchronous_server_socket_channel_bind_backlog",
+                forPlugins(NetworkAccessCheckActions::asynchronousServerSocketChannelBindWithBacklog)
+            ),
+            entry(
+                "asynchronous_server_socket_channel_accept",
+                forPlugins(NetworkAccessCheckActions::asynchronousServerSocketChannelAccept)
+            ),
+            entry(
+                "asynchronous_server_socket_channel_accept_with_handler",
+                forPlugins(NetworkAccessCheckActions::asynchronousServerSocketChannelAcceptWithHandler)
+            ),
+            entry("socket_channel_bind", forPlugins(NetworkAccessCheckActions::socketChannelBind)),
+            entry("socket_channel_connect", forPlugins(NetworkAccessCheckActions::socketChannelConnect)),
+            entry("asynchronous_socket_channel_bind", forPlugins(NetworkAccessCheckActions::asynchronousSocketChannelBind)),
+            entry("asynchronous_socket_channel_connect", forPlugins(NetworkAccessCheckActions::asynchronousSocketChannelConnect)),
+            entry(
+                "asynchronous_socket_channel_connect_with_completion",
+                forPlugins(NetworkAccessCheckActions::asynchronousSocketChannelConnectWithCompletion)
+            ),
+            entry("datagram_channel_bind", forPlugins(NetworkAccessCheckActions::datagramChannelBind)),
+            entry("datagram_channel_connect", forPlugins(NetworkAccessCheckActions::datagramChannelConnect)),
+            entry("datagram_channel_send", forPlugins(NetworkAccessCheckActions::datagramChannelSend)),
+            entry("datagram_channel_receive", forPlugins(NetworkAccessCheckActions::datagramChannelReceive)),
+
+            entry("runtime_load", forPlugins(LoadNativeLibrariesCheckActions::runtimeLoad)),
+            entry("runtime_load_library", forPlugins(LoadNativeLibrariesCheckActions::runtimeLoadLibrary)),
+            entry("system_load", forPlugins(LoadNativeLibrariesCheckActions::systemLoad)),
+            entry("system_load_library", forPlugins(LoadNativeLibrariesCheckActions::systemLoadLibrary)),
+            entry("enable_native_access", new CheckAction(VersionSpecificNativeChecks::enableNativeAccess, false, 22)),
+            entry("address_target_layout", new CheckAction(VersionSpecificNativeChecks::addressLayoutWithTargetLayout, false, 22)),
+            entry("donwncall_handle", new CheckAction(VersionSpecificNativeChecks::linkerDowncallHandle, false, 22)),
+            entry(
+                "donwncall_handle_with_address",
+                new CheckAction(VersionSpecificNativeChecks::linkerDowncallHandleWithAddress, false, 22)
+            ),
+            entry("upcall_stub", new CheckAction(VersionSpecificNativeChecks::linkerUpcallStub, false, 22)),
+            entry("reinterpret", new CheckAction(VersionSpecificNativeChecks::memorySegmentReinterpret, false, 22)),
+            entry("reinterpret_cleanup", new CheckAction(VersionSpecificNativeChecks::memorySegmentReinterpretWithCleanup, false, 22)),
+            entry(
+                "reinterpret_size_cleanup",
+                new CheckAction(VersionSpecificNativeChecks::memorySegmentReinterpretWithSizeAndCleanup, false, 22)
+            ),
+            entry("symbol_lookup_name", new CheckAction(VersionSpecificNativeChecks::symbolLookupWithName, false, 22)),
+            entry("symbol_lookup_path", new CheckAction(VersionSpecificNativeChecks::symbolLookupWithPath, false, 22))
         ),
-        entry("localeServiceProvider", alwaysDenied(RestEntitlementsCheckAction::localeServiceProvider$)),
-        entry("breakIteratorProvider", alwaysDenied(RestEntitlementsCheckAction::breakIteratorProvider$)),
-        entry("collatorProvider", alwaysDenied(RestEntitlementsCheckAction::collatorProvider$)),
-        entry("dateFormatProvider", alwaysDenied(RestEntitlementsCheckAction::dateFormatProvider$)),
-        entry("dateFormatSymbolsProvider", alwaysDenied(RestEntitlementsCheckAction::dateFormatSymbolsProvider$)),
-        entry("decimalFormatSymbolsProvider", alwaysDenied(RestEntitlementsCheckAction::decimalFormatSymbolsProvider$)),
-        entry("numberFormatProvider", alwaysDenied(RestEntitlementsCheckAction::numberFormatProvider$)),
-        entry("calendarDataProvider", alwaysDenied(RestEntitlementsCheckAction::calendarDataProvider$)),
-        entry("calendarNameProvider", alwaysDenied(RestEntitlementsCheckAction::calendarNameProvider$)),
-        entry("currencyNameProvider", alwaysDenied(RestEntitlementsCheckAction::currencyNameProvider$)),
-        entry("localeNameProvider", alwaysDenied(RestEntitlementsCheckAction::localeNameProvider$)),
-        entry("timeZoneNameProvider", alwaysDenied(RestEntitlementsCheckAction::timeZoneNameProvider$)),
-        entry("logManager", alwaysDenied(RestEntitlementsCheckAction::logManager$)),
-
-        entry("locale_setDefault", alwaysDenied(WritePropertiesCheckActions::setDefaultLocale)),
-        entry("locale_setDefaultForCategory", alwaysDenied(WritePropertiesCheckActions::setDefaultLocaleForCategory)),
-        entry("timeZone_setDefault", alwaysDenied(WritePropertiesCheckActions::setDefaultTimeZone)),
-
-        entry("system_setProperty", forPlugins(WritePropertiesCheckActions::setSystemProperty)),
-        entry("system_clearProperty", forPlugins(WritePropertiesCheckActions::clearSystemProperty)),
-        entry("system_setSystemProperties", alwaysDenied(WritePropertiesCheckActions::setSystemProperties)),
-
-        // This group is a bit nasty: if entitlements don't prevent these, then networking is
-        // irreparably borked for the remainder of the test run.
-        entry(
-            "datagramSocket_setDatagramSocketImplFactory",
-            alwaysDenied(RestEntitlementsCheckAction::datagramSocket$$setDatagramSocketImplFactory)
-        ),
-        entry("httpURLConnection_setFollowRedirects", alwaysDenied(RestEntitlementsCheckAction::httpURLConnection$$setFollowRedirects)),
-        entry("serverSocket_setSocketFactory", alwaysDenied(RestEntitlementsCheckAction::serverSocket$$setSocketFactory)),
-        entry("socket_setSocketImplFactory", alwaysDenied(RestEntitlementsCheckAction::socket$$setSocketImplFactory)),
-        entry("url_setURLStreamHandlerFactory", alwaysDenied(RestEntitlementsCheckAction::url$$setURLStreamHandlerFactory)),
-        entry("urlConnection_setFileNameMap", alwaysDenied(RestEntitlementsCheckAction::urlConnection$$setFileNameMap)),
-        entry("urlConnection_setContentHandlerFactory", alwaysDenied(RestEntitlementsCheckAction::urlConnection$$setContentHandlerFactory)),
-
-        entry("proxySelector_setDefault", alwaysDenied(RestEntitlementsCheckAction::setDefaultProxySelector)),
-        entry("responseCache_setDefault", alwaysDenied(RestEntitlementsCheckAction::setDefaultResponseCache)),
-        entry(
-            "createInetAddressResolverProvider",
-            new CheckAction(VersionSpecificNetworkChecks::createInetAddressResolverProvider, true, 18)
-        ),
-        entry("createURLStreamHandlerProvider", alwaysDenied(RestEntitlementsCheckAction::createURLStreamHandlerProvider)),
-        entry("createURLWithURLStreamHandler", alwaysDenied(RestEntitlementsCheckAction::createURLWithURLStreamHandler)),
-        entry("createURLWithURLStreamHandler2", alwaysDenied(RestEntitlementsCheckAction::createURLWithURLStreamHandler2)),
-        entry("datagram_socket_bind", forPlugins(RestEntitlementsCheckAction::bindDatagramSocket)),
-        entry("datagram_socket_connect", forPlugins(RestEntitlementsCheckAction::connectDatagramSocket)),
-        entry("datagram_socket_send", forPlugins(RestEntitlementsCheckAction::sendDatagramSocket)),
-        entry("datagram_socket_receive", forPlugins(RestEntitlementsCheckAction::receiveDatagramSocket)),
-        entry("datagram_socket_join_group", forPlugins(RestEntitlementsCheckAction::joinGroupDatagramSocket)),
-        entry("datagram_socket_leave_group", forPlugins(RestEntitlementsCheckAction::leaveGroupDatagramSocket)),
-
-        entry("create_socket_with_proxy", forPlugins(NetworkAccessCheckActions::createSocketWithProxy)),
-        entry("socket_bind", forPlugins(NetworkAccessCheckActions::socketBind)),
-        entry("socket_connect", forPlugins(NetworkAccessCheckActions::socketConnect)),
-        entry("server_socket_bind", forPlugins(NetworkAccessCheckActions::serverSocketBind)),
-        entry("server_socket_accept", forPlugins(NetworkAccessCheckActions::serverSocketAccept)),
-
-        entry("url_open_connection_proxy", forPlugins(NetworkAccessCheckActions::urlOpenConnectionWithProxy)),
-        entry("http_client_send", forPlugins(VersionSpecificNetworkChecks::httpClientSend)),
-        entry("http_client_send_async", forPlugins(VersionSpecificNetworkChecks::httpClientSendAsync)),
-        entry("create_ldap_cert_store", forPlugins(NetworkAccessCheckActions::createLDAPCertStore)),
-
-        entry("server_socket_channel_bind", forPlugins(NetworkAccessCheckActions::serverSocketChannelBind)),
-        entry("server_socket_channel_bind_backlog", forPlugins(NetworkAccessCheckActions::serverSocketChannelBindWithBacklog)),
-        entry("server_socket_channel_accept", forPlugins(NetworkAccessCheckActions::serverSocketChannelAccept)),
-        entry("asynchronous_server_socket_channel_bind", forPlugins(NetworkAccessCheckActions::asynchronousServerSocketChannelBind)),
-        entry(
-            "asynchronous_server_socket_channel_bind_backlog",
-            forPlugins(NetworkAccessCheckActions::asynchronousServerSocketChannelBindWithBacklog)
-        ),
-        entry("asynchronous_server_socket_channel_accept", forPlugins(NetworkAccessCheckActions::asynchronousServerSocketChannelAccept)),
-        entry(
-            "asynchronous_server_socket_channel_accept_with_handler",
-            forPlugins(NetworkAccessCheckActions::asynchronousServerSocketChannelAcceptWithHandler)
-        ),
-        entry("socket_channel_bind", forPlugins(NetworkAccessCheckActions::socketChannelBind)),
-        entry("socket_channel_connect", forPlugins(NetworkAccessCheckActions::socketChannelConnect)),
-        entry("asynchronous_socket_channel_bind", forPlugins(NetworkAccessCheckActions::asynchronousSocketChannelBind)),
-        entry("asynchronous_socket_channel_connect", forPlugins(NetworkAccessCheckActions::asynchronousSocketChannelConnect)),
-        entry(
-            "asynchronous_socket_channel_connect_with_completion",
-            forPlugins(NetworkAccessCheckActions::asynchronousSocketChannelConnectWithCompletion)
-        ),
-        entry("datagram_channel_bind", forPlugins(NetworkAccessCheckActions::datagramChannelBind)),
-        entry("datagram_channel_connect", forPlugins(NetworkAccessCheckActions::datagramChannelConnect)),
-        entry("datagram_channel_send", forPlugins(NetworkAccessCheckActions::datagramChannelSend)),
-        entry("datagram_channel_receive", forPlugins(NetworkAccessCheckActions::datagramChannelReceive)),
-
-        entry("runtime_load", forPlugins(LoadNativeLibrariesCheckActions::runtimeLoad)),
-        entry("runtime_load_library", forPlugins(LoadNativeLibrariesCheckActions::runtimeLoadLibrary)),
-        entry("system_load", forPlugins(LoadNativeLibrariesCheckActions::systemLoad)),
-        entry("system_load_library", forPlugins(LoadNativeLibrariesCheckActions::systemLoadLibrary)),
-        entry("enable_native_access", new CheckAction(VersionSpecificNativeChecks::enableNativeAccess, false, 22)),
-        entry("address_target_layout", new CheckAction(VersionSpecificNativeChecks::addressLayoutWithTargetLayout, false, 22)),
-        entry("donwncall_handle", new CheckAction(VersionSpecificNativeChecks::linkerDowncallHandle, false, 22)),
-        entry("donwncall_handle_with_address", new CheckAction(VersionSpecificNativeChecks::linkerDowncallHandleWithAddress, false, 22)),
-        entry("upcall_stub", new CheckAction(VersionSpecificNativeChecks::linkerUpcallStub, false, 22)),
-        entry("reinterpret", new CheckAction(VersionSpecificNativeChecks::memorySegmentReinterpret, false, 22)),
-        entry("reinterpret_cleanup", new CheckAction(VersionSpecificNativeChecks::memorySegmentReinterpretWithCleanup, false, 22)),
-        entry(
-            "reinterpret_size_cleanup",
-            new CheckAction(VersionSpecificNativeChecks::memorySegmentReinterpretWithSizeAndCleanup, false, 22)
-        ),
-        entry("symbol_lookup_name", new CheckAction(VersionSpecificNativeChecks::symbolLookupWithName, false, 22)),
-        entry("symbol_lookup_path", new CheckAction(VersionSpecificNativeChecks::symbolLookupWithPath, false, 22)),
-        entry("create_scanner", forPlugins(FileCheckActions::createScannerFile)),
-        entry("create_scanner_with_charset", forPlugins(FileCheckActions::createScannerFileWithCharset)),
-        entry("create_scanner_with_charset_name", forPlugins(FileCheckActions::createScannerFileWithCharsetName)),
-        entry("create_file_output_stream_string", forPlugins(FileCheckActions::createFileOutputStreamString)),
-        entry("create_file_output_stream_string_with_append", forPlugins(FileCheckActions::createFileOutputStreamStringWithAppend)),
-        entry("create_file_output_stream_file", forPlugins(FileCheckActions::createFileOutputStreamFile)),
-        entry("create_file_output_stream_file_with_append", forPlugins(FileCheckActions::createFileOutputStreamFileWithAppend)),
-        entry("files_probe_content_type", forPlugins(FileCheckActions::filesProbeContentType)),
-        entry("files_set_owner", forPlugins(FileCheckActions::filesSetOwner))
+        getTestEntries(FileCheckActions.class)
     )
         .filter(entry -> entry.getValue().fromJavaVersion() == null || Runtime.version().feature() >= entry.getValue().fromJavaVersion())
-        .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+        .collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue));
+
+    @SuppressForbidden(reason = "Need package private methods so we don't have to make them all public")
+    private static Method[] getDeclaredMethods(Class<?> clazz) {
+        return clazz.getDeclaredMethods();
+    }
+
+    private static Stream<Entry<String, CheckAction>> getTestEntries(Class<?> actionsClass) {
+        List<Entry<String, CheckAction>> entries = new ArrayList<>();
+        for (var method : getDeclaredMethods(actionsClass)) {
+            var testAnnotation = method.getAnnotation(EntitlementTest.class);
+            if (testAnnotation == null) {
+                continue;
+            }
+            if (Modifier.isStatic(method.getModifiers()) == false) {
+                throw new AssertionError("Entitlement test method [" + method + "] must be static");
+            }
+            if (method.getParameterTypes().length != 0) {
+                throw new AssertionError("Entitlement test method [" + method + "] must not have parameters");
+            }
+
+            CheckedRunnable<Exception> runnable = () -> {
+                try {
+                    method.invoke(null);
+                } catch (IllegalAccessException e) {
+                    throw new AssertionError(e);
+                } catch (InvocationTargetException e) {
+                    if (e.getCause() instanceof Exception exc) {
+                        throw exc;
+                    } else {
+                        throw new AssertionError(e);
+                    }
+                }
+            };
+            boolean deniedToPlugins = testAnnotation.expectedAccess() == PLUGINS;
+            Integer fromJavaVersion = testAnnotation.fromJavaVersion() == -1 ? null : testAnnotation.fromJavaVersion();
+            entries.add(entry(method.getName(), new CheckAction(runnable, deniedToPlugins, fromJavaVersion)));
+        }
+        return entries.stream();
+    }
 
     private static void createURLStreamHandlerProvider() {
         var x = new URLStreamHandlerProvider() {
@@ -470,7 +518,7 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
         return checkActions.entrySet()
             .stream()
             .filter(kv -> kv.getValue().isAlwaysDeniedToPlugins() == false)
-            .map(Map.Entry::getKey)
+            .map(Entry::getKey)
             .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Make entitlement IT tests reflective (#121355)