### PR TITLE
Always use String getLogger with log4j (#121250) (#121400)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/internal/LoggerFactoryImpl.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/internal/LoggerFactoryImpl.java
@@ -22,6 +22,12 @@ public class LoggerFactoryImpl extends LoggerFactory {
 
     @Override
     public Logger getLogger(Class<?> clazz) {
-        return new LoggerImpl(LogManager.getLogger(clazz));
+        // Elasticsearch configures logging at the root level, it does not support
+        // programmatic configuration at the logger level. Log4j's method for
+        // getting a logger by Class doesn't just use the class name, but also
+        // scans the classloader hierarchy for programmatic configuration. Here we
+        // just delegate to use the String class name so that regardless of which
+        // classloader a class comes from, we will use the root logging config.
+        return getLogger(clazz.getName());
     }
 }


### PR DESCRIPTION
This commit forces the delegate for ES logging to always use the String version of LogManager.getLogger instead of the one taking a Class. The reason is that if a classloader is not in the hierarchy of the app classloader, the ES logging configuration will not be found. By using the String variant, the app classloader is always used.

Backport of #121400.