### PR TITLE
Revert "Remove INDEX_REFRESH_BLOCK after index becomes searchable (#120807)"

### DIFF
--- a/docs/changelog/120807.yaml
+++ b/docs/changelog/120807.yaml
@@ -1,5 +1,0 @@
-pr: 120807
-summary: Remove INDEX_REFRESH_BLOCK after index becomes searchable
-area: CRUD
-type: enhancement
-issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -23,8 +23,6 @@ import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.NotMasterException;
-import org.elasticsearch.cluster.block.ClusterBlock;
-import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -72,7 +70,6 @@ import java.util.Set;
 
 import static org.apache.logging.log4j.Level.DEBUG;
 import static org.apache.logging.log4j.Level.ERROR;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_REFRESH_BLOCK;
 import static org.elasticsearch.cluster.service.MasterService.isPublishFailureException;
 import static org.elasticsearch.core.Strings.format;
 
@@ -622,7 +619,6 @@ public class ShardStateAction {
             List<TaskContext<StartedShardUpdateTask>> tasksToBeApplied = new ArrayList<>();
             List<ShardRouting> shardRoutingsToBeApplied = new ArrayList<>(batchExecutionContext.taskContexts().size());
             Set<ShardRouting> seenShardRoutings = new HashSet<>(); // to prevent duplicates
-            Set<Index> indicesWithUnpromotableShardsStarted = null;
             final Map<Index, ClusterStateTimeRanges> updatedTimestampRanges = new HashMap<>();
             final ClusterState initialState = batchExecutionContext.initialState();
             for (var taskContext : batchExecutionContext.taskContexts()) {
@@ -741,14 +737,6 @@ public class ShardStateAction {
                                     new ClusterStateTimeRanges(newTimestampMillisRange, newEventIngestedMillisRange)
                                 );
                             }
-
-                            if (matched.isPromotableToPrimary() == false
-                                && initialState.blocks().hasIndexBlock(index.getName(), INDEX_REFRESH_BLOCK)) {
-                                if (indicesWithUnpromotableShardsStarted == null) {
-                                    indicesWithUnpromotableShardsStarted = new HashSet<>();
-                                }
-                                indicesWithUnpromotableShardsStarted.add(index);
-                            }
                         }
                     }
                 }
@@ -772,10 +760,7 @@ public class ShardStateAction {
                     maybeUpdatedState = ClusterState.builder(maybeUpdatedState).metadata(metadataBuilder).build();
                 }
 
-                maybeUpdatedState = maybeRemoveIndexRefreshBlocks(maybeUpdatedState, indicesWithUnpromotableShardsStarted);
-
                 assert assertStartedIndicesHaveCompleteTimestampRanges(maybeUpdatedState);
-                assert assertRefreshBlockIsNotPresentWhenTheIndexIsSearchable(maybeUpdatedState);
 
                 for (final var taskContext : tasksToBeApplied) {
                     final var task = taskContext.getTask();
@@ -789,36 +774,6 @@ public class ShardStateAction {
             }
 
             return maybeUpdatedState;
-        }
-
-        private static ClusterState maybeRemoveIndexRefreshBlocks(
-            ClusterState clusterState,
-            @Nullable Set<Index> indicesWithUnpromotableShardsStarted
-        ) {
-            // The provided cluster state must include the newly STARTED unpromotable shards
-            if (indicesWithUnpromotableShardsStarted == null) {
-                return clusterState;
-            }
-
-            ClusterBlocks.Builder clusterBlocksBuilder = null;
-            for (Index indexWithUnpromotableShardsStarted : indicesWithUnpromotableShardsStarted) {
-                String indexName = indexWithUnpromotableShardsStarted.getName();
-                assert clusterState.blocks().hasIndexBlock(indexName, INDEX_REFRESH_BLOCK) : indexWithUnpromotableShardsStarted;
-
-                var indexRoutingTable = clusterState.routingTable().index(indexWithUnpromotableShardsStarted);
-                if (indexRoutingTable.readyForSearch()) {
-                    if (clusterBlocksBuilder == null) {
-                        clusterBlocksBuilder = ClusterBlocks.builder(clusterState.blocks());
-                    }
-                    clusterBlocksBuilder.removeIndexBlock(indexName, INDEX_REFRESH_BLOCK);
-                }
-            }
-
-            if (clusterBlocksBuilder == null) {
-                return clusterState;
-            }
-
-            return ClusterState.builder(clusterState).blocks(clusterBlocksBuilder).build();
         }
 
         private static boolean assertStartedIndicesHaveCompleteTimestampRanges(ClusterState clusterState) {
@@ -840,16 +795,6 @@ public class ShardStateAction {
                         + clusterState.metadata().index(cursor.getKey()).getEventIngestedRange()
                         + " for "
                         + cursor.getValue().prettyPrint();
-            }
-            return true;
-        }
-
-        private static boolean assertRefreshBlockIsNotPresentWhenTheIndexIsSearchable(ClusterState clusterState) {
-            for (Map.Entry<String, Set<ClusterBlock>> indexBlock : clusterState.blocks().indices().entrySet()) {
-                if (indexBlock.getValue().contains(INDEX_REFRESH_BLOCK)) {
-                    assert clusterState.routingTable().index(indexBlock.getKey()).readyForSearch() == false
-                        : "Index [" + indexBlock.getKey() + "] is searchable but has an INDEX_REFRESH_BLOCK";
-                }
             }
             return true;
         }

--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
@@ -12,31 +12,24 @@ package org.elasticsearch.cluster.action.shard;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionTestUtils;
-import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.action.shard.ShardStateAction.StartedShardEntry;
 import org.elasticsearch.cluster.action.shard.ShardStateAction.StartedShardUpdateTask;
-import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.routing.AllocationId;
-import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
-import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.shard.IndexLongFieldRange;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardLongFieldRange;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -44,11 +37,9 @@ import static org.elasticsearch.action.support.replication.ClusterStateCreationU
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.stateWithActivePrimary;
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.stateWithAssignedPrimariesAndReplicas;
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.stateWithNoShard;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_REFRESH_BLOCK;
 import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES_SETTING;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestCase {
@@ -486,114 +477,6 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
         final IndexMetadata latestIndexMetadata = resultingState.metadata().index(indexName);
         assertThat(latestIndexMetadata.getTimestampRange(), sameInstance(IndexLongFieldRange.UNKNOWN));
         assertThat(latestIndexMetadata.getEventIngestedRange(), sameInstance(IndexLongFieldRange.UNKNOWN));
-    }
-
-    public void testIndexRefreshBlockIsClearedOnceTheIndexIsReadyToBeSearched() throws Exception {
-        final var indexName = "test";
-        final var numberOfShards = randomIntBetween(1, 4);
-        final var numberOfReplicas = randomIntBetween(1, 4);
-        var clusterState = ClusterStateCreationUtils.stateWithAssignedPrimariesAndReplicasWithState(
-            new String[] { indexName },
-            numberOfShards,
-            ShardRouting.Role.INDEX_ONLY,
-            IntStream.range(0, numberOfReplicas)
-                .mapToObj(unused -> Tuple.tuple(ShardRoutingState.UNASSIGNED, ShardRouting.Role.SEARCH_ONLY))
-                .toList()
-        );
-
-        clusterState = ClusterState.builder(clusterState)
-            .metadata(Metadata.builder(clusterState.metadata()).put(withActiveShardsInSyncAllocationIds(clusterState, indexName)))
-            .blocks(ClusterBlocks.builder(clusterState.blocks()).addIndexBlock(indexName, INDEX_REFRESH_BLOCK))
-            .build();
-
-        while (clusterState.blocks().hasIndexBlock(indexName, INDEX_REFRESH_BLOCK)) {
-            clusterState = maybeInitializeUnassignedReplicaShard(clusterState);
-
-            final IndexMetadata indexMetadata = clusterState.metadata().index(indexName);
-
-            final var initializingReplicaShardOpt = clusterState.routingTable()
-                .allShards()
-                .filter(shardRouting -> shardRouting.isPromotableToPrimary() == false)
-                .filter(shardRouting -> shardRouting.state().equals(ShardRoutingState.INITIALIZING))
-                .findFirst();
-
-            assertThat(clusterState.routingTable().allShards().toList().toString(), initializingReplicaShardOpt.isPresent(), is(true));
-
-            var initializingReplicaShard = initializingReplicaShardOpt.get();
-
-            final var shardId = initializingReplicaShard.shardId();
-            final var primaryTerm = indexMetadata.primaryTerm(shardId.id());
-            final var replicaAllocationId = initializingReplicaShard.allocationId().getId();
-            final var task = new StartedShardUpdateTask(
-                new StartedShardEntry(
-                    shardId,
-                    replicaAllocationId,
-                    primaryTerm,
-                    "test",
-                    ShardLongFieldRange.UNKNOWN,
-                    ShardLongFieldRange.UNKNOWN
-                ),
-                createTestListener()
-            );
-
-            final var resultingState = executeTasks(clusterState, List.of(task));
-            assertNotSame(clusterState, resultingState);
-
-            clusterState = resultingState;
-        }
-
-        var indexRoutingTable = clusterState.routingTable().index(indexName);
-        assertThat(indexRoutingTable.readyForSearch(), is(true));
-        for (int i = 0; i < numberOfShards; i++) {
-            var shardRoutingTable = indexRoutingTable.shard(i);
-            assertThat(shardRoutingTable, is(notNullValue()));
-            // Ensure that at least one unpromotable shard is either STARTED or RELOCATING
-            assertThat(shardRoutingTable.unpromotableShards().isEmpty(), is(false));
-        }
-        assertThat(clusterState.blocks().hasIndexBlock(indexName, INDEX_REFRESH_BLOCK), is(false));
-    }
-
-    private static ClusterState maybeInitializeUnassignedReplicaShard(ClusterState clusterState) {
-        var unassignedShardRoutingOpt = clusterState.routingTable()
-            .allShards()
-            .filter(shardRouting -> shardRouting.state().equals(ShardRoutingState.UNASSIGNED))
-            .findFirst();
-
-        if (unassignedShardRoutingOpt.isEmpty()) {
-            return clusterState;
-        }
-
-        var unassignedShardRouting = unassignedShardRoutingOpt.get();
-        var initializedShard = unassignedShardRouting.initialize(randomUUID(), null, 1);
-
-        RoutingTable routingTable = clusterState.routingTable();
-        IndexRoutingTable indexRoutingTable = routingTable.index(unassignedShardRouting.getIndexName());
-        IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
-        for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
-            IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
-            for (int copy = 0; copy < shardRoutingTable.size(); copy++) {
-                ShardRouting shardRouting = shardRoutingTable.shard(copy);
-                newIndexRoutingTable.addShard(shardRouting == unassignedShardRouting ? initializedShard : shardRouting);
-            }
-        }
-        routingTable = RoutingTable.builder(routingTable).add(newIndexRoutingTable).build();
-        return ClusterState.builder(clusterState).routingTable(routingTable).build();
-    }
-
-    private static IndexMetadata.Builder withActiveShardsInSyncAllocationIds(ClusterState clusterState, String indexName) {
-        IndexMetadata.Builder indexMetadataBuilder = new IndexMetadata.Builder(clusterState.metadata().index(indexName));
-        var indexRoutingTable = clusterState.routingTable().index(indexName);
-        for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable.allShards().toList()) {
-            indexMetadataBuilder.putInSyncAllocationIds(
-                indexShardRoutingTable.shardId().getId(),
-                indexShardRoutingTable.activeShards()
-                    .stream()
-                    .map(ShardRouting::allocationId)
-                    .map(AllocationId::getId)
-                    .collect(Collectors.toSet())
-            );
-        }
-        return indexMetadataBuilder;
     }
 
     private ClusterState executeTasks(final ClusterState state, final List<StartedShardUpdateTask> tasks) throws Exception {


### PR DESCRIPTION
This reverts commit ae0f1a64b571c319e33a24bc8a05a1fa1d1668b9.

The refresh block would be removed in a subsequent cluster state update instead of removing it immediately after an index is ready for searches.

Closes ES-10697
