### PR TITLE
[ML] Fix infer on and elasticsearch service endpoint created with a deployment id

### DIFF
--- a/docs/changelog/121428.yaml
+++ b/docs/changelog/121428.yaml
@@ -1,0 +1,6 @@
+pr: 121428
+summary: Fix infer on and elasticsearch service endpoint created with a deployment
+  id
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
@@ -40,6 +40,14 @@ public class CreateFromDeploymentIT extends InferenceBaseRestTest {
             is(Map.of("num_allocations", 1, "num_threads", 1, "model_id", "attach_to_deployment", "deployment_id", "existing_deployment"))
         );
 
+        var getModel = getModel(inferenceId);
+        serviceSettings = getModel.get("service_settings");
+        assertThat(
+            getModel.toString(),
+            serviceSettings,
+            is(Map.of("num_allocations", 1, "num_threads", 1, "model_id", "attach_to_deployment", "deployment_id", "existing_deployment"))
+        );
+
         var results = infer(inferenceId, List.of("washing machine"));
         assertNotNull(results.get("sparse_embedding"));
 
@@ -83,6 +91,25 @@ public class CreateFromDeploymentIT extends InferenceBaseRestTest {
         var serviceSettings = putModel.get("service_settings");
         assertThat(
             putModel.toString(),
+            serviceSettings,
+            is(
+                Map.of(
+                    "num_allocations",
+                    1,
+                    "num_threads",
+                    1,
+                    "model_id",
+                    "attach_with_model_id",
+                    "deployment_id",
+                    "existing_deployment_with_model_id"
+                )
+            )
+        );
+
+        var getModel = getModel(inferenceId);
+        serviceSettings = getModel.get("service_settings");
+        assertThat(
+            getModel.toString(),
             serviceSettings,
             is(
                 Map.of(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalServiceSettings.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 
 import java.io.IOException;
 
@@ -18,15 +17,6 @@ public class CustomElandInternalServiceSettings extends ElasticsearchInternalSer
 
     public CustomElandInternalServiceSettings(ElasticsearchInternalServiceSettings other) {
         super(other);
-    }
-
-    public CustomElandInternalServiceSettings(
-        Integer numAllocations,
-        int numThreads,
-        String modelId,
-        AdaptiveAllocationsSettings adaptiveAllocationsSettings
-    ) {
-        super(numAllocations, numThreads, modelId, adaptiveAllocationsSettings);
     }
 
     public CustomElandInternalServiceSettings(StreamInput in) throws IOException {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalTextEmbeddingServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalTextEmbeddingServiceSettings.java
@@ -11,6 +11,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.SimilarityMeasure;
@@ -105,33 +106,17 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
     private final SimilarityMeasure similarityMeasure;
     private final DenseVectorFieldMapper.ElementType elementType;
 
-    public CustomElandInternalTextEmbeddingServiceSettings(
-        int numAllocations,
-        int numThreads,
-        String modelId,
-        AdaptiveAllocationsSettings adaptiveAllocationsSettings
-    ) {
-        this(
-            numAllocations,
-            numThreads,
-            modelId,
-            adaptiveAllocationsSettings,
-            null,
-            SimilarityMeasure.COSINE,
-            DenseVectorFieldMapper.ElementType.FLOAT
-        );
-    }
-
-    public CustomElandInternalTextEmbeddingServiceSettings(
+    CustomElandInternalTextEmbeddingServiceSettings(
         int numAllocations,
         int numThreads,
         String modelId,
         AdaptiveAllocationsSettings adaptiveAllocationsSettings,
+        @Nullable String deploymentId,
         Integer dimensions,
         SimilarityMeasure similarityMeasure,
         DenseVectorFieldMapper.ElementType elementType
     ) {
-        super(numAllocations, numThreads, modelId, adaptiveAllocationsSettings);
+        super(numAllocations, numThreads, modelId, adaptiveAllocationsSettings, deploymentId);
         this.dimensions = dimensions;
         this.similarityMeasure = Objects.requireNonNull(similarityMeasure);
         this.elementType = Objects.requireNonNull(elementType);
@@ -159,7 +144,8 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
             commonFields.internalServiceSettings.getNumAllocations(),
             commonFields.internalServiceSettings.getNumThreads(),
             commonFields.internalServiceSettings.modelId(),
-            commonFields.internalServiceSettings.getAdaptiveAllocationsSettings()
+            commonFields.internalServiceSettings.getAdaptiveAllocationsSettings(),
+            commonFields.internalServiceSettings.getDeploymentId()
         );
         this.dimensions = dimensions;
         similarityMeasure = commonFields.similarityMeasure;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettings.java
@@ -14,21 +14,27 @@ import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsS
 import java.io.IOException;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.RERANKER_ID;
+
 public class ElasticRerankerServiceSettings extends ElasticsearchInternalServiceSettings {
 
     public static final String NAME = "elastic_reranker_service_settings";
+
+    public static ElasticRerankerServiceSettings defaultEndpointSettings() {
+        return new ElasticRerankerServiceSettings(null, 1, RERANKER_ID, new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 32));
+    }
 
     public ElasticRerankerServiceSettings(ElasticsearchInternalServiceSettings other) {
         super(other);
     }
 
-    public ElasticRerankerServiceSettings(
+    private ElasticRerankerServiceSettings(
         Integer numAllocations,
         int numThreads,
         String modelId,
         AdaptiveAllocationsSettings adaptiveAllocationsSettings
     ) {
-        super(numAllocations, numThreads, modelId, adaptiveAllocationsSettings);
+        super(numAllocations, numThreads, modelId, adaptiveAllocationsSettings, null);
     }
 
     public ElasticRerankerServiceSettings(StreamInput in) throws IOException {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -39,7 +39,6 @@ import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.action.GetDeploymentStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
 import org.elasticsearch.xpack.core.ml.action.InferModelAction;
-import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AssignmentStats;
 import org.elasticsearch.xpack.core.ml.inference.results.ErrorInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.results.MlTextEmbeddingResults;
@@ -562,6 +561,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
             model.getServiceSettings().getNumThreads(),
             model.getServiceSettings().modelId(),
             model.getServiceSettings().getAdaptiveAllocationsSettings(),
+            model.getServiceSettings().getDeploymentId(),
             embeddingSize,
             model.getServiceSettings().similarity(),
             model.getServiceSettings().elementType()
@@ -903,12 +903,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
             DEFAULT_ELSER_ID,
             TaskType.SPARSE_EMBEDDING,
             NAME,
-            new ElserInternalServiceSettings(
-                null,
-                1,
-                useLinuxOptimizedModel ? ELSER_V2_MODEL_LINUX_X86 : ELSER_V2_MODEL,
-                new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 32)
-            ),
+            ElserInternalServiceSettings.defaultEndpointSettings(useLinuxOptimizedModel),
             ElserMlNodeTaskSettings.DEFAULT,
             ChunkingSettingsBuilder.DEFAULT_SETTINGS
         );
@@ -916,19 +911,14 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
             DEFAULT_E5_ID,
             TaskType.TEXT_EMBEDDING,
             NAME,
-            new MultilingualE5SmallInternalServiceSettings(
-                null,
-                1,
-                useLinuxOptimizedModel ? MULTILINGUAL_E5_SMALL_MODEL_ID_LINUX_X86 : MULTILINGUAL_E5_SMALL_MODEL_ID,
-                new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 32)
-            ),
+            MultilingualE5SmallInternalServiceSettings.defaultEndpointSettings(useLinuxOptimizedModel),
             ChunkingSettingsBuilder.DEFAULT_SETTINGS
         );
         var defaultRerank = new ElasticRerankerModel(
             DEFAULT_RERANK_ID,
             TaskType.RERANK,
             NAME,
-            new ElasticRerankerServiceSettings(null, 1, RERANKER_ID, new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 32)),
+            ElasticRerankerServiceSettings.defaultEndpointSettings(),
             RerankTaskSettings.DEFAULT_SETTINGS
         );
         return List.of(defaultElser, defaultE5, defaultRerank);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
@@ -12,6 +12,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -112,21 +113,8 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
         Integer numAllocations,
         int numThreads,
         String modelId,
-        AdaptiveAllocationsSettings adaptiveAllocationsSettings
-    ) {
-        this.numAllocations = numAllocations;
-        this.numThreads = numThreads;
-        this.modelId = Objects.requireNonNull(modelId);
-        this.adaptiveAllocationsSettings = adaptiveAllocationsSettings;
-        this.deploymentId = null;
-    }
-
-    public ElasticsearchInternalServiceSettings(
-        Integer numAllocations,
-        int numThreads,
-        String modelId,
         AdaptiveAllocationsSettings adaptiveAllocationsSettings,
-        String deploymentId
+        @Nullable String deploymentId
     ) {
         this.numAllocations = numAllocations;
         this.numThreads = numThreads;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettings.java
@@ -9,14 +9,14 @@ package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.inference.MinimalServiceSettings;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Map;
+
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.ELSER_V2_MODEL;
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.ELSER_V2_MODEL_LINUX_X86;
 
 public class ElserInternalServiceSettings extends ElasticsearchInternalServiceSettings {
 
@@ -26,37 +26,26 @@ public class ElserInternalServiceSettings extends ElasticsearchInternalServiceSe
         return MinimalServiceSettings.sparseEmbedding();
     }
 
-    public static Builder fromRequestMap(Map<String, Object> map) {
-        ValidationException validationException = new ValidationException();
-        var baseSettings = ElasticsearchInternalServiceSettings.fromMap(map, validationException);
-
-        String modelId = baseSettings.getModelId();
-        if (modelId != null && ElserModels.isValidModel(modelId) == false) {
-            var ve = new ValidationException();
-            ve.addValidationError(
-                "Unknown ELSER model ID [" + modelId + "]. Valid models are " + Arrays.toString(ElserModels.VALID_ELSER_MODEL_IDS.toArray())
-            );
-            throw ve;
-        }
-
-        if (validationException.validationErrors().isEmpty() == false) {
-            throw validationException;
-        }
-
-        return baseSettings;
+    public static ElserInternalServiceSettings defaultEndpointSettings(boolean useLinuxOptimizedModel) {
+        return new ElserInternalServiceSettings(
+            null,
+            1,
+            useLinuxOptimizedModel ? ELSER_V2_MODEL_LINUX_X86 : ELSER_V2_MODEL,
+            new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 32)
+        );
     }
 
     public ElserInternalServiceSettings(ElasticsearchInternalServiceSettings other) {
         super(other);
     }
 
-    public ElserInternalServiceSettings(
+    private ElserInternalServiceSettings(
         Integer numAllocations,
         int numThreads,
         String modelId,
         AdaptiveAllocationsSettings adaptiveAllocationsSettings
     ) {
-        this(new ElasticsearchInternalServiceSettings(numAllocations, numThreads, modelId, adaptiveAllocationsSettings));
+        this(new ElasticsearchInternalServiceSettings(numAllocations, numThreads, modelId, adaptiveAllocationsSettings, null));
     }
 
     public ElserInternalServiceSettings(StreamInput in) throws IOException {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettings.java
@@ -18,6 +18,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID;
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID_LINUX_X86;
+
 public class MultilingualE5SmallInternalServiceSettings extends ElasticsearchInternalServiceSettings {
 
     public static final String NAME = "multilingual_e5_small_service_settings";
@@ -29,17 +32,26 @@ public class MultilingualE5SmallInternalServiceSettings extends ElasticsearchInt
         return MinimalServiceSettings.textEmbedding(DIMENSIONS, SIMILARITY, DenseVectorFieldMapper.ElementType.FLOAT);
     }
 
+    public static MultilingualE5SmallInternalServiceSettings defaultEndpointSettings(boolean useLinuxOptimizedModel) {
+        return new MultilingualE5SmallInternalServiceSettings(
+            null,
+            1,
+            useLinuxOptimizedModel ? MULTILINGUAL_E5_SMALL_MODEL_ID_LINUX_X86 : MULTILINGUAL_E5_SMALL_MODEL_ID,
+            new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 32)
+        );
+    }
+
     public MultilingualE5SmallInternalServiceSettings(ElasticsearchInternalServiceSettings other) {
         super(other);
     }
 
-    public MultilingualE5SmallInternalServiceSettings(
+    MultilingualE5SmallInternalServiceSettings(
         Integer numAllocations,
         int numThreads,
         String modelId,
         AdaptiveAllocationsSettings adaptiveAllocationsSettings
     ) {
-        super(numAllocations, numThreads, modelId, adaptiveAllocationsSettings);
+        super(numAllocations, numThreads, modelId, adaptiveAllocationsSettings, null);
     }
 
     public MultilingualE5SmallInternalServiceSettings(StreamInput in) throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalTextEmbeddingServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalTextEmbeddingServiceSettingsTests.java
@@ -48,6 +48,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
             numThreads,
             modelId,
             null,
+            null,
             dims,
             similarityMeasure,
             elementType
@@ -86,6 +87,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
                     modelId,
                     null,
                     null,
+                    null,
                     SimilarityMeasure.DOT_PRODUCT,
                     DenseVectorFieldMapper.ElementType.FLOAT
                 )
@@ -109,6 +111,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
                     numAllocations,
                     numThreads,
                     modelId,
+                    null,
                     null,
                     null,
                     SimilarityMeasure.COSINE,
@@ -152,6 +155,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
                     modelId,
                     null,
                     null,
+                    null,
                     SimilarityMeasure.DOT_PRODUCT,
                     DenseVectorFieldMapper.ElementType.FLOAT
                 )
@@ -192,6 +196,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
                     numThreads,
                     modelId,
                     null,
+                    null,
                     1,
                     SimilarityMeasure.DOT_PRODUCT,
                     DenseVectorFieldMapper.ElementType.FLOAT
@@ -205,6 +210,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
             1,
             1,
             "model_id",
+            null,
             null,
             100,
             SimilarityMeasure.COSINE,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettingsTests.java
@@ -103,7 +103,7 @@ public class ElasticsearchInternalServiceSettingsTests extends AbstractWireSeria
                 )
             )
         ).build();
-        assertEquals(new ElasticsearchInternalServiceSettings(1, 4, ".elser_model_1", null), serviceSettings);
+        assertEquals(new ElasticsearchInternalServiceSettings(1, 4, ".elser_model_1", null, null), serviceSettings);
     }
 
     public void testFromMapMissingOptions() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -351,7 +351,9 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                 )
             );
 
-            var elserServiceSettings = new ElserInternalServiceSettings(1, 4, ElserModels.ELSER_V2_MODEL, null);
+            var elserServiceSettings = new ElserInternalServiceSettings(
+                new ElasticsearchInternalServiceSettings(1, 4, ElserModels.ELSER_V2_MODEL, null, null)
+            );
 
             service.parseRequestConfig(
                 randomInferenceEntityId,
@@ -381,7 +383,9 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                 )
             );
 
-            var elserServiceSettings = new ElserInternalServiceSettings(1, 4, ElserModels.ELSER_V2_MODEL, null);
+            var elserServiceSettings = new ElserInternalServiceSettings(
+                new ElasticsearchInternalServiceSettings(1, 4, ElserModels.ELSER_V2_MODEL, null, null)
+            );
 
             String criticalWarning =
                 "Putting elasticsearch service inference endpoints (including elser service) without a model_id field is"
@@ -450,7 +454,9 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
             );
             config.put(ModelConfigurations.CHUNKING_SETTINGS, createRandomChunkingSettingsMap());
 
-            var elserServiceSettings = new ElserInternalServiceSettings(1, 4, ElserModels.ELSER_V2_MODEL, null);
+            var elserServiceSettings = new ElserInternalServiceSettings(
+                new ElasticsearchInternalServiceSettings(1, 4, ElserModels.ELSER_V2_MODEL, null, null)
+            );
 
             service.parseRequestConfig(
                 randomInferenceEntityId,
@@ -486,7 +492,9 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                 )
             );
 
-            var elserServiceSettings = new ElserInternalServiceSettings(1, 4, ElserModels.ELSER_V2_MODEL, null);
+            var elserServiceSettings = new ElserInternalServiceSettings(
+                new ElasticsearchInternalServiceSettings(1, 4, ElserModels.ELSER_V2_MODEL, null, null)
+            );
 
             service.parseRequestConfig(
                 randomInferenceEntityId,
@@ -742,7 +750,16 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                 TaskType.TEXT_EMBEDDING,
                 settings
             );
-            var elandServiceSettings = new CustomElandInternalTextEmbeddingServiceSettings(1, 4, "invalid", null);
+            var elandServiceSettings = new CustomElandInternalTextEmbeddingServiceSettings(
+                1,
+                4,
+                "invalid",
+                null,
+                null,
+                null,
+                SimilarityMeasure.COSINE,
+                DenseVectorFieldMapper.ElementType.FLOAT
+            );
             assertEquals(
                 new CustomElandEmbeddingModel(
                     randomInferenceEntityId,
@@ -933,7 +950,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
             "foo",
             TaskType.SPARSE_EMBEDDING,
             "elasticsearch",
-            new ElasticsearchInternalServiceSettings(1, 1, "model-id", null),
+            new ElasticsearchInternalServiceSettings(1, 1, "model-id", null, null),
             chunkingSettings
         );
         var service = createService(client);
@@ -1003,7 +1020,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
             "foo",
             TaskType.SPARSE_EMBEDDING,
             "elasticsearch",
-            new ElserInternalServiceSettings(1, 1, "model-id", null),
+            new ElserInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 1, "model-id", null, null)),
             new ElserMlNodeTaskSettings(),
             chunkingSettings
         );
@@ -1328,11 +1345,20 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                 randomInferenceEntityId,
                 taskType,
                 ElasticsearchInternalService.NAME,
-                new CustomElandInternalServiceSettings(1, 4, "custom-model", null),
+                new CustomElandInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 4, "custom-model", null, null)),
                 RerankTaskSettings.DEFAULT_SETTINGS
             );
         } else if (taskType == TaskType.TEXT_EMBEDDING) {
-            var serviceSettings = new CustomElandInternalTextEmbeddingServiceSettings(1, 4, "custom-model", null);
+            var serviceSettings = new CustomElandInternalTextEmbeddingServiceSettings(
+                1,
+                4,
+                "custom-model",
+                null,
+                null,
+                null,
+                SimilarityMeasure.COSINE,
+                DenseVectorFieldMapper.ElementType.FLOAT
+            );
 
             expectedModel = new CustomElandEmbeddingModel(
                 randomInferenceEntityId,
@@ -1346,7 +1372,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                 randomInferenceEntityId,
                 taskType,
                 ElasticsearchInternalService.NAME,
-                new CustomElandInternalServiceSettings(1, 4, "custom-model", null),
+                new CustomElandInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 4, "custom-model", null, null)),
                 (ChunkingSettings) null
             );
         }
@@ -1438,6 +1464,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
             4,
             "custom-model",
             null,
+            null,
             1,
             SimilarityMeasure.COSINE,
             DenseVectorFieldMapper.ElementType.FLOAT
@@ -1461,6 +1488,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                     1,
                     4,
                     "custom-model",
+                    null,
                     null,
                     null,
                     SimilarityMeasure.COSINE,
@@ -1511,7 +1539,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
             EmbeddingRequestChunker.EmbeddingType.SPARSE,
             ElasticsearchInternalService.embeddingTypeFromTaskTypeAndSettings(
                 TaskType.SPARSE_EMBEDDING,
-                new ElasticsearchInternalServiceSettings(1, 1, "foo", null)
+                new ElasticsearchInternalServiceSettings(1, 1, "foo", null, null)
             )
         );
         assertEquals(
@@ -1526,7 +1554,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
             ElasticsearchStatusException.class,
             () -> ElasticsearchInternalService.embeddingTypeFromTaskTypeAndSettings(
                 TaskType.COMPLETION,
-                new ElasticsearchInternalServiceSettings(1, 1, "foo", null)
+                new ElasticsearchInternalServiceSettings(1, 1, "foo", null, null)
             )
         );
         assertThat(e1.getMessage(), containsString("Chunking is not supported for task type [completion]"));
@@ -1535,7 +1563,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
             ElasticsearchStatusException.class,
             () -> ElasticsearchInternalService.embeddingTypeFromTaskTypeAndSettings(
                 TaskType.RERANK,
-                new ElasticsearchInternalServiceSettings(1, 1, "foo", null)
+                new ElasticsearchInternalServiceSettings(1, 1, "foo", null, null)
             )
         );
         assertThat(e2.getMessage(), containsString("Chunking is not supported for task type [rerank]"));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalModelTests.java
@@ -16,7 +16,7 @@ public class ElserInternalModelTests extends ESTestCase {
             "foo",
             TaskType.SPARSE_EMBEDDING,
             ElasticsearchInternalService.NAME,
-            new ElserInternalServiceSettings(null, 1, "elser", null),
+            new ElserInternalServiceSettings(new ElasticsearchInternalServiceSettings(null, 1, "elser", null, null)),
             new ElserMlNodeTaskSettings(),
             null
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettingsTests.java
@@ -24,12 +24,12 @@ public class ElserInternalServiceSettingsTests extends AbstractWireSerializingTe
 
     public void testBwcWrite() throws IOException {
         {
-            var settings = new ElserInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 1, ".elser_model_1", null));
+            var settings = new ElserInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 1, ".elser_model_1", null, null));
             var copy = copyInstance(settings, TransportVersions.V_8_12_0);
             assertEquals(settings, copy);
         }
         {
-            var settings = new ElserInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 1, ".elser_model_1", null));
+            var settings = new ElserInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 1, ".elser_model_1", null, null));
             var copy = copyInstance(settings, TransportVersions.V_8_11_X);
             assertEquals(settings, copy);
         }
@@ -53,6 +53,7 @@ public class ElserInternalServiceSettingsTests extends AbstractWireSerializingTe
                     instance.getNumAllocations() == null ? 1 : instance.getNumAllocations() + 1,
                     instance.getNumThreads(),
                     instance.modelId(),
+                    null,
                     null
                 )
             );
@@ -61,6 +62,7 @@ public class ElserInternalServiceSettingsTests extends AbstractWireSerializingTe
                     instance.getNumAllocations(),
                     instance.getNumThreads() + 1,
                     instance.modelId(),
+                    null,
                     null
                 )
             );
@@ -72,6 +74,7 @@ public class ElserInternalServiceSettingsTests extends AbstractWireSerializingTe
                         instance.getNumAllocations(),
                         instance.getNumThreads(),
                         versions.iterator().next(),
+                        null,
                         null
                     )
                 );


### PR DESCRIPTION
When creating an inference endpoint with the Elasticsearch service the `deployment_id` service setting can be used connect to an existing ml trained model deployment. A bug was found where inference on an endpoint created this way would fail with the error `Could not find trained model [X]`. The problem was that the `deployment_id` setting was lost when updating the service settings with the text embedding dimensions. 

The bug only applied to Text Embedding models uploaded with the Eland `eland_import_hub_model` script. 

The bug could be easily reproduced with these steps:
```
# Upload a model from HuggingFace
docker run -it --rm docker.elastic.co/eland/eland \
    eland_import_hub_model \
      --url 'http://host.docker.internal:9200' \
      --hub-model-id intfloat/multilingual-e5-small \
      --task-type text_embedding \
      --insecure 

# Deploy that model
POST _ml/trained_models/intfloat__multilingual-e5-small/deployment/_start

# Create an inference endpoint referencing the deployment
PUT _inference/text_embedding/hf
{
  "service": "elasticsearch",
  "service_settings": {
    "deployment_id": "intfloat__multilingual-e5-small" 
  }
}

# Inference fails with resource not found
POST /_inference/text_embedding/hf
{
  "input": "The sky above the port was the color of television tuned to a dead channel.",
  "task_settings": {
    "input_type": "ingest"
  }
}
```
