### PR TITLE
Remove outdated assertion from #118214

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -143,9 +143,6 @@ tests:
 - class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
   method: test {p0=data_stream/120_data_streams_stats/Multiple data stream}
   issue: https://github.com/elastic/elasticsearch/issues/118217
-- class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
-  method: testBottomFieldSort
-  issue: https://github.com/elastic/elasticsearch/issues/118214
 - class: org.elasticsearch.xpack.searchablesnapshots.RetrySearchIntegTests
   method: testSearcherId
   issue: https://github.com/elastic/elasticsearch/issues/118374

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -220,7 +220,6 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
                 assertFalse(canReturnNullResponse.get());
                 assertThat(numWithTopDocs.get(), equalTo(0));
             } else {
-                assertTrue(canReturnNullResponse.get());
                 if (withCollapse) {
                     assertThat(numWithTopDocs.get(), equalTo(0));
                 } else {


### PR DESCRIPTION
Asserting that we definitely saw the "received a single result" flag and can now deal with null responses, isn't applicable after a few recent fixes. New requests are sent out before responses are fully processed to keep data nodes in a tighter loop (as well as other relaxed ordering relative to when this assertion was added) so the flag is not guaranteed to show up as true for lower numbers of shard requests any longer.
Lets just remove it, it was always best effort and accidental that this worked for the numbers the test randomizes over.
