### PR TITLE
[TEST] wait for all active shards when indexing data

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -46,9 +46,6 @@ tests:
 - class: org.elasticsearch.packaging.test.WindowsServiceTests
   method: test81JavaOptsInJvmOptions
   issue: https://github.com/elastic/elasticsearch/issues/113313
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
-  issue: https://github.com/elastic/elasticsearch/issues/113325
 - class: org.elasticsearch.xpack.transform.integration.TransformIT
   method: testStopWaitForCheckpoint
   issue: https://github.com/elastic/elasticsearch/issues/106113

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mtermvectors/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mtermvectors/10_basic.yml
@@ -3,6 +3,7 @@ setup:
   - do:
       indices.create:
           index: testidx
+          wait_for_active_shards: all
           body:
             mappings:
               properties:
@@ -80,6 +81,7 @@ setup:
   - do:
       indices.create:
           index: testidx2
+          wait_for_active_shards: all
 
   - do:
       indices.put_alias:


### PR DESCRIPTION
This attempts to fix a flay test where the term_freq returned by the multiple terms vectors API was `null`.
I was not able to reproduce this test but this proposes a fix based on the following running theory:
- an Elasticsearch cluster comprised of at least 2 nodes
- we create a couple of indices with 1 primary and 1 replica
- we index a document that was acknowledged only by the primary (because `wait_for_active_shards` defaults to `1`)
- the test executes the multiple terms vectors API and it hits the node hosting the replica shard, which hasn't yet received the document we ingested in the primary shard.

This race condition between the document replication and the test running the terms vectors API on the replica shard could yield a `null` value for the the term's `term_freq` (as the replica shard contains 0 documents).

This PR proposes we change the `wait_for_active_shards` value to `all` so each write is acknowledged by all replicas before the client receives the response.

Fixes #113325