### PR TITLE
Change PolicyManager so pluginResolver overrides agent settings

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -398,7 +398,9 @@ public class PolicyManager {
         var pluginName = pluginResolver.apply(requestingClass);
         if (pluginName != null) {
             var pluginEntitlements = pluginsEntitlements.get(pluginName);
-            if (pluginEntitlements != null) {
+            if (pluginEntitlements == null) {
+                return ModuleEntitlements.NONE;
+            } else {
                 final String scopeName;
                 if (requestingModule.isNamed() == false) {
                     scopeName = ALL_UNNAMED;


### PR DESCRIPTION
If the `pluginResolver` function returns a non-null plugin name, that means the class comes from a plugin, and so under no circumstances should we be falling back to the (more permissive) agent policy, which the current logic does if the plugin doesn't have its own policy.