### PR TITLE
[ML] Unmute InferenceCrudIT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -191,9 +191,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testProcessFileChanges
   issue: https://github.com/elastic/elasticsearch/issues/115280
-- class: org.elasticsearch.xpack.inference.InferenceCrudIT
-  method: testSupportedStream
-  issue: https://github.com/elastic/elasticsearch/issues/113430
 - class: org.elasticsearch.xpack.spatial.search.GeoGridAggAndQueryConsistencyIT
   method: testGeoShapeGeoHash
   issue: https://github.com/elastic/elasticsearch/issues/115664
@@ -400,9 +397,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {date_nanos.Bucket Date nanos by 10 minutes}
   issue: https://github.com/elastic/elasticsearch/issues/120162
-- class: org.elasticsearch.xpack.inference.InferenceCrudIT
-  method: testGetServicesWithCompletionTaskType
-  issue: https://github.com/elastic/elasticsearch/issues/119959
 - class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
   method: testRandomDirectoryIOExceptions
   issue: https://github.com/elastic/elasticsearch/issues/118733


### PR DESCRIPTION
This PR unmutes some `InferenceCrudIT` tests for 8.x only (they aren't muted in main). These have actually been fixed previously but I forgot to unmute the tests.

