### PR TITLE
Fix rate failures in YAML xContent roundtrip tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
@@ -145,8 +145,21 @@ public abstract class AbstractXContentTestCase<T extends ToXContent> extends EST
         public void test() throws IOException {
             for (int runs = 0; runs < numberOfTestRuns; runs++) {
                 XContentType xContentType = randomFrom(XContentType.values()).canonical();
-                T testInstance = instanceSupplier.apply(xContentType);
+                T testInstance = null;
                 try {
+                    if (xContentType.equals(XContentType.YAML)) {
+                        testInstance = randomValueOtherThanMany(instance -> {
+                            // unicode character U+0085 (NEXT LINE (NEL)) doesn't survive YAML round trip tests (see #97716)
+                            // get a new random instance if we detect this character in the xContent output
+                            try {
+                                return toXContent.apply(instance, xContentType).utf8ToString().contains("\u0085");
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }, () -> instanceSupplier.apply(xContentType));
+                    } else {
+                        testInstance = instanceSupplier.apply(xContentType);
+                    }
                     BytesReference originalXContent = toXContent.apply(testInstance, xContentType);
                     BytesReference shuffledContent = insertRandomFieldsAndShuffle(
                         originalXContent,
@@ -173,7 +186,9 @@ public abstract class AbstractXContentTestCase<T extends ToXContent> extends EST
                         dispose.accept(parsed);
                     }
                 } finally {
-                    dispose.accept(testInstance);
+                    if (testInstance != null) {
+                        dispose.accept(testInstance);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Under very unfortunate conditions tests that check xContent objects roundtrip parsing 
(like i.e. [SearchHitsTests testFromXContent](https://github.com/elastic/elasticsearch/issues/97716) can fail when we happen to randomly pick YAML xContent type and create random (realistic)Unicode character sequences that
may contain the character U+0085 (133) from the [Latin1 code page](https://de.wikipedia.org/wiki/Unicodeblock_Lateinisch-1,_Erg%C3%A4nzung).

That specific character doesn't get parsed back to its original form for YAML xContent, which can lead to
[rare but hard to diagnose test failures](https://github.com/elastic/elasticsearch/issues/97716#issuecomment-2464465939).

This change adds logic to AbstractXContentTestCase#test() which lies at the core of most of our 
xContent roundtrip tests that disallows test instances containing that particular character 
when using YAML xContent type.


Closes #97716