### PR TITLE
Move scroll + dfs reduce code from SearchPhaseController to actual users (#119726)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -18,8 +18,6 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.io.stream.DelayableWriteable;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
-import org.elasticsearch.core.Releasable;
-import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.SearchShardTarget;
@@ -31,7 +29,6 @@ import org.elasticsearch.search.rank.context.QueryPhaseRankCoordinatorContext;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -66,8 +63,25 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
     private final boolean hasAggs;
     private final boolean performFinalReduce;
 
-    private final PendingMerges pendingMerges;
     private final Consumer<Exception> onPartialMergeFailure;
+
+    private final int batchReduceSize;
+    private List<QuerySearchResult> buffer = new ArrayList<>();
+    private List<SearchShard> emptyResults = new ArrayList<>();
+    // the memory that is accounted in the circuit breaker for this consumer
+    private volatile long circuitBreakerBytes;
+    // the memory that is currently used in the buffer
+    private volatile long aggsCurrentBufferSize;
+    private volatile long maxAggsCurrentBufferSize = 0;
+
+    private final ArrayDeque<MergeTask> queue = new ArrayDeque<>();
+    private final AtomicReference<MergeTask> runningTask = new AtomicReference<>();
+    private final AtomicReference<Exception> failure = new AtomicReference<>();
+
+    private final TopDocsStats topDocsStats;
+    private volatile MergeResult mergeResult;
+    private volatile boolean hasPartialReduce;
+    private volatile int numReducePhases;
 
     /**
      * Creates a {@link QueryPhaseResultConsumer} that incrementally reduces aggregation results
@@ -100,13 +114,31 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         this.hasTopDocs = (source == null || size != 0) && queryPhaseRankCoordinatorContext == null;
         this.hasAggs = source != null && source.aggregations() != null;
         this.aggReduceContextBuilder = hasAggs ? controller.getReduceContext(isCanceled, source.aggregations()) : null;
-        int batchReduceSize = (hasAggs || hasTopDocs) ? Math.min(request.getBatchedReduceSize(), expectedResultSize) : expectedResultSize;
-        this.pendingMerges = new PendingMerges(batchReduceSize, request.resolveTrackTotalHitsUpTo());
+        batchReduceSize = (hasAggs || hasTopDocs) ? Math.min(request.getBatchedReduceSize(), expectedResultSize) : expectedResultSize;
+        topDocsStats = new TopDocsStats(request.resolveTrackTotalHitsUpTo());
     }
 
     @Override
-    protected void doClose() {
-        pendingMerges.close();
+    protected synchronized void doClose() {
+        assert assertFailureAndBreakerConsistent();
+        releaseBuffer();
+        circuitBreaker.addWithoutBreaking(-circuitBreakerBytes);
+        circuitBreakerBytes = 0;
+
+        if (hasPendingMerges()) {
+            // This is a theoretically unreachable exception.
+            throw new IllegalStateException("Attempted to close with partial reduce in-flight");
+        }
+    }
+
+    private boolean assertFailureAndBreakerConsistent() {
+        boolean hasFailure = failure.get() != null;
+        if (hasFailure) {
+            assert circuitBreakerBytes == 0;
+        } else {
+            assert circuitBreakerBytes >= 0;
+        }
+        return true;
     }
 
     @Override
@@ -114,42 +146,74 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         super.consumeResult(result, () -> {});
         QuerySearchResult querySearchResult = result.queryResult();
         progressListener.notifyQueryResult(querySearchResult.getShardIndex(), querySearchResult);
-        pendingMerges.consume(querySearchResult, next);
+        consume(querySearchResult, next);
     }
 
     @Override
     public SearchPhaseController.ReducedQueryPhase reduce() throws Exception {
-        if (pendingMerges.hasPendingMerges()) {
+        if (hasPendingMerges()) {
             throw new AssertionError("partial reduce in-flight");
-        } else if (pendingMerges.hasFailure()) {
-            throw pendingMerges.getFailure();
         }
-
+        Exception f = failure.get();
+        if (f != null) {
+            throw f;
+        }
+        List<QuerySearchResult> buffer;
+        synchronized (this) {
+            // final reduce, we're done with the buffer so we just null it out and continue with a local variable to
+            // save field references. The synchronized block is never contended but needed to have a memory barrier and sync buffer's
+            // contents with all the previous writers to it
+            buffer = this.buffer;
+            buffer = buffer == null ? Collections.emptyList() : buffer;
+            this.buffer = null;
+        }
         // ensure consistent ordering
-        pendingMerges.sortBuffer();
-        final TopDocsStats topDocsStats = pendingMerges.consumeTopDocsStats();
-        final List<TopDocs> topDocsList = pendingMerges.consumeTopDocs();
+        buffer.sort(RESULT_COMPARATOR);
+        final TopDocsStats topDocsStats = this.topDocsStats;
+        var mergeResult = this.mergeResult;
+        this.mergeResult = null;
+        final int resultSize = buffer.size() + (mergeResult == null ? 0 : 1);
+        final List<TopDocs> topDocsList = hasTopDocs ? new ArrayList<>(resultSize) : null;
+        final List<DelayableWriteable<InternalAggregations>> aggsList = hasAggs ? new ArrayList<>(resultSize) : null;
+        if (mergeResult != null) {
+            if (topDocsList != null) {
+                topDocsList.add(mergeResult.reducedTopDocs);
+            }
+            if (aggsList != null) {
+                aggsList.add(DelayableWriteable.referencing(mergeResult.reducedAggs));
+            }
+        }
+        for (QuerySearchResult result : buffer) {
+            topDocsStats.add(result.topDocs(), result.searchTimedOut(), result.terminatedEarly());
+            if (topDocsList != null) {
+                TopDocsAndMaxScore topDocs = result.consumeTopDocs();
+                setShardIndex(topDocs.topDocs, result.getShardIndex());
+                topDocsList.add(topDocs.topDocs);
+            }
+            if (aggsList != null) {
+                aggsList.add(result.getAggs());
+            }
+        }
         SearchPhaseController.ReducedQueryPhase reducePhase;
-        long breakerSize = pendingMerges.circuitBreakerBytes;
+        long breakerSize = circuitBreakerBytes;
         try {
-            final List<DelayableWriteable<InternalAggregations>> aggsList = pendingMerges.getAggs();
-            if (hasAggs) {
+            if (aggsList != null) {
                 // Add an estimate of the final reduce size
-                breakerSize = pendingMerges.addEstimateAndMaybeBreak(PendingMerges.estimateRamBytesUsedForReduce(breakerSize));
+                breakerSize = addEstimateAndMaybeBreak(estimateRamBytesUsedForReduce(breakerSize));
             }
             reducePhase = SearchPhaseController.reducedQueryPhase(
                 results.asList(),
                 aggsList,
-                topDocsList,
+                topDocsList == null ? Collections.emptyList() : topDocsList,
                 topDocsStats,
-                pendingMerges.numReducePhases,
+                numReducePhases,
                 false,
                 aggReduceContextBuilder,
                 queryPhaseRankCoordinatorContext,
                 performFinalReduce
             );
         } finally {
-            pendingMerges.releaseAggs();
+            releaseAggs(buffer);
         }
         if (hasAggs
             // reduced aggregations can be null if all shards failed
@@ -157,8 +221,8 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
 
             // Update the circuit breaker to replace the estimation with the serialized size of the newly reduced result
             long finalSize = DelayableWriteable.getSerializedSize(reducePhase.aggregations()) - breakerSize;
-            pendingMerges.addWithoutBreaking(finalSize);
-            logger.trace("aggs final reduction [{}] max [{}]", pendingMerges.aggsCurrentBufferSize, pendingMerges.maxAggsCurrentBufferSize);
+            addWithoutBreaking(finalSize);
+            logger.trace("aggs final reduction [{}] max [{}]", aggsCurrentBufferSize, maxAggsCurrentBufferSize);
         }
         if (progressListener != SearchProgressListener.NOOP) {
             progressListener.notifyFinalReduce(
@@ -169,363 +233,292 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
             );
         }
         return reducePhase;
+
     }
 
     private static final Comparator<QuerySearchResult> RESULT_COMPARATOR = Comparator.comparingInt(QuerySearchResult::getShardIndex);
 
     private MergeResult partialReduce(
-        QuerySearchResult[] toConsume,
-        List<SearchShard> emptyResults,
+        List<QuerySearchResult> toConsume,
+        List<SearchShard> processedShards,
         TopDocsStats topDocsStats,
         MergeResult lastMerge,
         int numReducePhases
     ) {
         // ensure consistent ordering
-        Arrays.sort(toConsume, RESULT_COMPARATOR);
-
-        for (QuerySearchResult result : toConsume) {
-            topDocsStats.add(result.topDocs(), result.searchTimedOut(), result.terminatedEarly());
-        }
+        toConsume.sort(RESULT_COMPARATOR);
 
         final TopDocs newTopDocs;
+        final InternalAggregations newAggs;
+        final List<DelayableWriteable<InternalAggregations>> aggsList;
+        final int resultSetSize = toConsume.size() + (lastMerge != null ? 1 : 0);
+        if (hasAggs) {
+            aggsList = new ArrayList<>(resultSetSize);
+            if (lastMerge != null) {
+                aggsList.add(DelayableWriteable.referencing(lastMerge.reducedAggs));
+            }
+        } else {
+            aggsList = null;
+        }
+        List<TopDocs> topDocsList;
         if (hasTopDocs) {
-            List<TopDocs> topDocsList = new ArrayList<>();
+            topDocsList = new ArrayList<>(resultSetSize);
             if (lastMerge != null) {
                 topDocsList.add(lastMerge.reducedTopDocs);
             }
-            for (QuerySearchResult result : toConsume) {
-                TopDocsAndMaxScore topDocs = result.consumeTopDocs();
-                setShardIndex(topDocs.topDocs, result.getShardIndex());
-                topDocsList.add(topDocs.topDocs);
-            }
-            newTopDocs = mergeTopDocs(
-                topDocsList,
-                // we have to merge here in the same way we collect on a shard
-                topNSize,
-                0
-            );
         } else {
-            newTopDocs = null;
+            topDocsList = null;
         }
-
-        final InternalAggregations newAggs;
-        if (hasAggs) {
-            try {
-                final List<DelayableWriteable<InternalAggregations>> aggsList = new ArrayList<>();
-                if (lastMerge != null) {
-                    aggsList.add(DelayableWriteable.referencing(lastMerge.reducedAggs));
-                }
-                for (QuerySearchResult result : toConsume) {
+        try {
+            for (QuerySearchResult result : toConsume) {
+                topDocsStats.add(result.topDocs(), result.searchTimedOut(), result.terminatedEarly());
+                SearchShardTarget target = result.getSearchShardTarget();
+                processedShards.add(new SearchShard(target.getClusterAlias(), target.getShardId()));
+                if (aggsList != null) {
                     aggsList.add(result.getAggs());
                 }
-                newAggs = InternalAggregations.topLevelReduceDelayable(aggsList, aggReduceContextBuilder.forPartialReduction());
-            } finally {
-                for (QuerySearchResult result : toConsume) {
-                    result.releaseAggs();
+                if (topDocsList != null) {
+                    TopDocsAndMaxScore topDocs = result.consumeTopDocs();
+                    setShardIndex(topDocs.topDocs, result.getShardIndex());
+                    topDocsList.add(topDocs.topDocs);
                 }
             }
-        } else {
-            newAggs = null;
+            // we have to merge here in the same way we collect on a shard
+            newTopDocs = topDocsList == null ? null : mergeTopDocs(topDocsList, topNSize, 0);
+            newAggs = aggsList == null
+                ? null
+                : InternalAggregations.topLevelReduceDelayable(aggsList, aggReduceContextBuilder.forPartialReduction());
+        } finally {
+            releaseAggs(toConsume);
         }
-        List<SearchShard> processedShards = new ArrayList<>(emptyResults);
         if (lastMerge != null) {
             processedShards.addAll(lastMerge.processedShards);
-        }
-        for (QuerySearchResult result : toConsume) {
-            SearchShardTarget target = result.getSearchShardTarget();
-            processedShards.add(new SearchShard(target.getClusterAlias(), target.getShardId()));
         }
         if (progressListener != SearchProgressListener.NOOP) {
             progressListener.notifyPartialReduce(processedShards, topDocsStats.getTotalHits(), newAggs, numReducePhases);
         }
         // we leave the results un-serialized because serializing is slow but we compute the serialized
         // size as an estimate of the memory used by the newly reduced aggregations.
-        long serializedSize = hasAggs ? DelayableWriteable.getSerializedSize(newAggs) : 0;
-        return new MergeResult(processedShards, newTopDocs, newAggs, hasAggs ? serializedSize : 0);
+        return new MergeResult(processedShards, newTopDocs, newAggs, newAggs != null ? DelayableWriteable.getSerializedSize(newAggs) : 0);
     }
 
     public int getNumReducePhases() {
-        return pendingMerges.numReducePhases;
+        return numReducePhases;
     }
 
-    private class PendingMerges implements Releasable {
-        private final int batchReduceSize;
-        private final List<QuerySearchResult> buffer = new ArrayList<>();
-        private final List<SearchShard> emptyResults = new ArrayList<>();
-        // the memory that is accounted in the circuit breaker for this consumer
-        private volatile long circuitBreakerBytes;
-        // the memory that is currently used in the buffer
-        private volatile long aggsCurrentBufferSize;
-        private volatile long maxAggsCurrentBufferSize = 0;
+    private boolean hasFailure() {
+        return failure.get() != null;
+    }
 
-        private final ArrayDeque<MergeTask> queue = new ArrayDeque<>();
-        private final AtomicReference<MergeTask> runningTask = new AtomicReference<>();
-        private final AtomicReference<Exception> failure = new AtomicReference<>();
+    private boolean hasPendingMerges() {
+        return queue.isEmpty() == false || runningTask.get() != null;
+    }
 
-        private final TopDocsStats topDocsStats;
-        private volatile MergeResult mergeResult;
-        private volatile boolean hasPartialReduce;
-        private volatile int numReducePhases;
+    private synchronized void addWithoutBreaking(long size) {
+        circuitBreaker.addWithoutBreaking(size);
+        circuitBreakerBytes += size;
+        maxAggsCurrentBufferSize = Math.max(maxAggsCurrentBufferSize, circuitBreakerBytes);
+    }
 
-        PendingMerges(int batchReduceSize, int trackTotalHitsUpTo) {
-            this.batchReduceSize = batchReduceSize;
-            this.topDocsStats = new TopDocsStats(trackTotalHitsUpTo);
-        }
+    private synchronized long addEstimateAndMaybeBreak(long estimatedSize) {
+        circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedSize, "<reduce_aggs>");
+        circuitBreakerBytes += estimatedSize;
+        maxAggsCurrentBufferSize = Math.max(maxAggsCurrentBufferSize, circuitBreakerBytes);
+        return circuitBreakerBytes;
+    }
 
-        @Override
-        public synchronized void close() {
-            if (hasFailure()) {
-                assert circuitBreakerBytes == 0;
-            } else {
-                assert circuitBreakerBytes >= 0;
-            }
+    /**
+     * Returns the size of the serialized aggregation that is contained in the
+     * provided {@link QuerySearchResult}.
+     */
+    private long ramBytesUsedQueryResult(QuerySearchResult result) {
+        return hasAggs ? result.aggregations().getSerializedSize() : 0;
+    }
 
-            releaseBuffer();
-            circuitBreaker.addWithoutBreaking(-circuitBreakerBytes);
-            circuitBreakerBytes = 0;
+    /**
+     * Returns an estimation of the size that a reduce of the provided size
+     * would take on memory.
+     * This size is estimated as roughly 1.5 times the size of the serialized
+     * aggregations that need to be reduced. This estimation can be completely
+     * off for some aggregations but it is corrected with the real size after
+     * the reduce completes.
+     */
+    private static long estimateRamBytesUsedForReduce(long size) {
+        return Math.round(1.5d * size - size);
+    }
 
-            if (hasPendingMerges()) {
-                // This is a theoretically unreachable exception.
-                throw new IllegalStateException("Attempted to close with partial reduce in-flight");
-            }
-        }
-
-        synchronized Exception getFailure() {
-            return failure.get();
-        }
-
-        boolean hasFailure() {
-            return failure.get() != null;
-        }
-
-        boolean hasPendingMerges() {
-            return queue.isEmpty() == false || runningTask.get() != null;
-        }
-
-        void sortBuffer() {
-            if (buffer.size() > 0) {
-                buffer.sort(RESULT_COMPARATOR);
-            }
-        }
-
-        synchronized void addWithoutBreaking(long size) {
-            circuitBreaker.addWithoutBreaking(size);
-            circuitBreakerBytes += size;
-            maxAggsCurrentBufferSize = Math.max(maxAggsCurrentBufferSize, circuitBreakerBytes);
-        }
-
-        synchronized long addEstimateAndMaybeBreak(long estimatedSize) {
-            circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedSize, "<reduce_aggs>");
-            circuitBreakerBytes += estimatedSize;
-            maxAggsCurrentBufferSize = Math.max(maxAggsCurrentBufferSize, circuitBreakerBytes);
-            return circuitBreakerBytes;
-        }
-
-        /**
-         * Returns the size of the serialized aggregation that is contained in the
-         * provided {@link QuerySearchResult}.
-         */
-        long ramBytesUsedQueryResult(QuerySearchResult result) {
-            return hasAggs ? result.aggregations().getSerializedSize() : 0;
-        }
-
-        /**
-         * Returns an estimation of the size that a reduce of the provided size
-         * would take on memory.
-         * This size is estimated as roughly 1.5 times the size of the serialized
-         * aggregations that need to be reduced. This estimation can be completely
-         * off for some aggregations but it is corrected with the real size after
-         * the reduce completes.
-         */
-        static long estimateRamBytesUsedForReduce(long size) {
-            return Math.round(1.5d * size - size);
-        }
-
-        public void consume(QuerySearchResult result, Runnable next) {
-            boolean executeNextImmediately = true;
+    private void consume(QuerySearchResult result, Runnable next) {
+        if (hasFailure()) {
+            result.consumeAll();
+            next.run();
+        } else if (result.isNull()) {
+            result.consumeAll();
+            SearchShardTarget target = result.getSearchShardTarget();
+            SearchShard searchShard = new SearchShard(target.getClusterAlias(), target.getShardId());
             synchronized (this) {
-                if (hasFailure() || result.isNull()) {
-                    result.consumeAll();
-                    if (result.isNull()) {
-                        SearchShardTarget target = result.getSearchShardTarget();
-                        emptyResults.add(new SearchShard(target.getClusterAlias(), target.getShardId()));
-                    }
+                emptyResults.add(searchShard);
+            }
+            next.run();
+        } else {
+            final long aggsSize = ramBytesUsedQueryResult(result);
+            boolean executeNextImmediately = true;
+            boolean hasFailure = false;
+            synchronized (this) {
+                if (hasFailure()) {
+                    hasFailure = true;
                 } else {
                     if (hasAggs) {
-                        long aggsSize = ramBytesUsedQueryResult(result);
                         try {
                             addEstimateAndMaybeBreak(aggsSize);
                         } catch (Exception exc) {
-                            result.releaseAggs();
                             releaseBuffer();
                             onMergeFailure(exc);
-                            next.run();
-                            return;
+                            hasFailure = true;
                         }
+                    }
+                    if (hasFailure == false) {
+                        var b = buffer;
                         aggsCurrentBufferSize += aggsSize;
+                        // add one if a partial merge is pending
+                        int size = b.size() + (hasPartialReduce ? 1 : 0);
+                        if (size >= batchReduceSize) {
+                            hasPartialReduce = true;
+                            executeNextImmediately = false;
+                            MergeTask task = new MergeTask(b, aggsCurrentBufferSize, emptyResults, next);
+                            b = buffer = new ArrayList<>();
+                            emptyResults = new ArrayList<>();
+                            aggsCurrentBufferSize = 0;
+                            queue.add(task);
+                            tryExecuteNext();
+                        }
+                        b.add(result);
                     }
-                    // add one if a partial merge is pending
-                    int size = buffer.size() + (hasPartialReduce ? 1 : 0);
-                    if (size >= batchReduceSize) {
-                        hasPartialReduce = true;
-                        executeNextImmediately = false;
-                        QuerySearchResult[] clone = buffer.toArray(QuerySearchResult[]::new);
-                        MergeTask task = new MergeTask(clone, aggsCurrentBufferSize, new ArrayList<>(emptyResults), next);
-                        aggsCurrentBufferSize = 0;
-                        buffer.clear();
-                        emptyResults.clear();
-                        queue.add(task);
-                        tryExecuteNext();
-                    }
-                    buffer.add(result);
                 }
+            }
+            if (hasFailure) {
+                result.consumeAll();
             }
             if (executeNextImmediately) {
                 next.run();
             }
         }
+    }
 
-        private void releaseBuffer() {
-            buffer.forEach(QuerySearchResult::releaseAggs);
-            buffer.clear();
-        }
-
-        private synchronized void onMergeFailure(Exception exc) {
-            if (hasFailure()) {
-                assert circuitBreakerBytes == 0;
-                return;
-            }
-            assert circuitBreakerBytes >= 0;
-            if (circuitBreakerBytes > 0) {
-                // make sure that we reset the circuit breaker
-                circuitBreaker.addWithoutBreaking(-circuitBreakerBytes);
-                circuitBreakerBytes = 0;
-            }
-            failure.compareAndSet(null, exc);
-            final List<Releasable> toCancels = new ArrayList<>();
-            toCancels.add(() -> onPartialMergeFailure.accept(exc));
-            final MergeTask task = runningTask.getAndSet(null);
-            if (task != null) {
-                toCancels.add(task::cancel);
-            }
-            MergeTask mergeTask;
-            while ((mergeTask = queue.pollFirst()) != null) {
-                toCancels.add(mergeTask::cancel);
-            }
-            mergeResult = null;
-            Releasables.close(toCancels);
-        }
-
-        private void onAfterMerge(MergeTask task, MergeResult newResult, long estimatedSize) {
-            synchronized (this) {
-                if (hasFailure()) {
-                    return;
-                }
-                runningTask.compareAndSet(task, null);
-                mergeResult = newResult;
-                if (hasAggs) {
-                    // Update the circuit breaker to remove the size of the source aggregations
-                    // and replace the estimation with the serialized size of the newly reduced result.
-                    long newSize = mergeResult.estimatedSize - estimatedSize;
-                    addWithoutBreaking(newSize);
-                    logger.trace(
-                        "aggs partial reduction [{}->{}] max [{}]",
-                        estimatedSize,
-                        mergeResult.estimatedSize,
-                        maxAggsCurrentBufferSize
-                    );
-                }
-                task.consumeListener();
+    private void releaseBuffer() {
+        var b = buffer;
+        if (b != null) {
+            this.buffer = null;
+            for (QuerySearchResult querySearchResult : b) {
+                querySearchResult.releaseAggs();
             }
         }
+    }
 
-        private void tryExecuteNext() {
-            final MergeTask task;
-            synchronized (this) {
-                if (queue.isEmpty() || hasFailure() || runningTask.get() != null) {
-                    return;
-                }
-                task = queue.poll();
-                runningTask.compareAndSet(null, task);
-            }
+    private synchronized void onMergeFailure(Exception exc) {
+        if (failure.compareAndSet(null, exc) == false) {
+            assert circuitBreakerBytes == 0;
+            return;
+        }
+        assert circuitBreakerBytes >= 0;
+        if (circuitBreakerBytes > 0) {
+            // make sure that we reset the circuit breaker
+            circuitBreaker.addWithoutBreaking(-circuitBreakerBytes);
+            circuitBreakerBytes = 0;
+        }
+        onPartialMergeFailure.accept(exc);
+        final MergeTask task = runningTask.getAndSet(null);
+        if (task != null) {
+            task.cancel();
+        }
+        MergeTask mergeTask;
+        while ((mergeTask = queue.pollFirst()) != null) {
+            mergeTask.cancel();
+        }
+        mergeResult = null;
+    }
 
-            executor.execute(new AbstractRunnable() {
-                @Override
-                protected void doRun() {
+    private void tryExecuteNext() {
+        assert Thread.holdsLock(this);
+        final MergeTask task;
+        if (hasFailure() || runningTask.get() != null) {
+            return;
+        }
+        task = queue.poll();
+        runningTask.set(task);
+        if (task == null) {
+            return;
+        }
+
+        executor.execute(new AbstractRunnable() {
+            @Override
+            protected void doRun() {
+                MergeTask mergeTask = task;
+                List<QuerySearchResult> toConsume = mergeTask.consumeBuffer();
+                while (mergeTask != null) {
                     final MergeResult thisMergeResult = mergeResult;
-                    long estimatedTotalSize = (thisMergeResult != null ? thisMergeResult.estimatedSize : 0) + task.aggsBufferSize;
+                    long estimatedTotalSize = (thisMergeResult != null ? thisMergeResult.estimatedSize : 0) + mergeTask.aggsBufferSize;
                     final MergeResult newMerge;
-                    final QuerySearchResult[] toConsume = task.consumeBuffer();
-                    if (toConsume == null) {
-                        return;
-                    }
                     try {
                         long estimatedMergeSize = estimateRamBytesUsedForReduce(estimatedTotalSize);
                         addEstimateAndMaybeBreak(estimatedMergeSize);
                         estimatedTotalSize += estimatedMergeSize;
                         ++numReducePhases;
-                        newMerge = partialReduce(toConsume, task.emptyResults, topDocsStats, thisMergeResult, numReducePhases);
+                        newMerge = partialReduce(toConsume, mergeTask.emptyResults, topDocsStats, thisMergeResult, numReducePhases);
                     } catch (Exception t) {
-                        for (QuerySearchResult result : toConsume) {
-                            result.releaseAggs();
-                        }
+                        QueryPhaseResultConsumer.releaseAggs(toConsume);
                         onMergeFailure(t);
                         return;
                     }
-                    onAfterMerge(task, newMerge, estimatedTotalSize);
-                    tryExecuteNext();
-                }
-
-                @Override
-                public void onFailure(Exception exc) {
-                    onMergeFailure(exc);
-                }
-            });
-        }
-
-        public synchronized TopDocsStats consumeTopDocsStats() {
-            for (QuerySearchResult result : buffer) {
-                topDocsStats.add(result.topDocs(), result.searchTimedOut(), result.terminatedEarly());
-            }
-            return topDocsStats;
-        }
-
-        public synchronized List<TopDocs> consumeTopDocs() {
-            if (hasTopDocs == false) {
-                return Collections.emptyList();
-            }
-            List<TopDocs> topDocsList = new ArrayList<>();
-            if (mergeResult != null) {
-                topDocsList.add(mergeResult.reducedTopDocs);
-            }
-            for (QuerySearchResult result : buffer) {
-                TopDocsAndMaxScore topDocs = result.consumeTopDocs();
-                setShardIndex(topDocs.topDocs, result.getShardIndex());
-                topDocsList.add(topDocs.topDocs);
-            }
-            return topDocsList;
-        }
-
-        public synchronized List<DelayableWriteable<InternalAggregations>> getAggs() {
-            if (hasAggs == false) {
-                return Collections.emptyList();
-            }
-            List<DelayableWriteable<InternalAggregations>> aggsList = new ArrayList<>();
-            if (mergeResult != null) {
-                aggsList.add(DelayableWriteable.referencing(mergeResult.reducedAggs));
-            }
-            for (QuerySearchResult result : buffer) {
-                aggsList.add(result.getAggs());
-            }
-            return aggsList;
-        }
-
-        public synchronized void releaseAggs() {
-            if (hasAggs) {
-                for (QuerySearchResult result : buffer) {
-                    result.releaseAggs();
+                    synchronized (QueryPhaseResultConsumer.this) {
+                        if (hasFailure()) {
+                            return;
+                        }
+                        mergeResult = newMerge;
+                        if (hasAggs) {
+                            // Update the circuit breaker to remove the size of the source aggregations
+                            // and replace the estimation with the serialized size of the newly reduced result.
+                            long newSize = mergeResult.estimatedSize - estimatedTotalSize;
+                            addWithoutBreaking(newSize);
+                            if (logger.isTraceEnabled()) {
+                                logger.trace(
+                                    "aggs partial reduction [{}->{}] max [{}]",
+                                    estimatedTotalSize,
+                                    mergeResult.estimatedSize,
+                                    maxAggsCurrentBufferSize
+                                );
+                            }
+                        }
+                    }
+                    Runnable r = mergeTask.consumeListener();
+                    synchronized (QueryPhaseResultConsumer.this) {
+                        while (true) {
+                            mergeTask = queue.poll();
+                            runningTask.set(mergeTask);
+                            if (mergeTask == null) {
+                                break;
+                            }
+                            toConsume = mergeTask.consumeBuffer();
+                            if (toConsume != null) {
+                                break;
+                            }
+                        }
+                    }
+                    if (r != null) {
+                        r.run();
+                    }
                 }
             }
+
+            @Override
+            public void onFailure(Exception exc) {
+                onMergeFailure(exc);
+            }
+        });
+    }
+
+    private static void releaseAggs(List<QuerySearchResult> toConsume) {
+        for (QuerySearchResult result : toConsume) {
+            result.releaseAggs();
         }
     }
 
@@ -538,38 +531,38 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
 
     private static class MergeTask {
         private final List<SearchShard> emptyResults;
-        private QuerySearchResult[] buffer;
+        private List<QuerySearchResult> buffer;
         private final long aggsBufferSize;
         private Runnable next;
 
-        private MergeTask(QuerySearchResult[] buffer, long aggsBufferSize, List<SearchShard> emptyResults, Runnable next) {
+        private MergeTask(List<QuerySearchResult> buffer, long aggsBufferSize, List<SearchShard> emptyResults, Runnable next) {
             this.buffer = buffer;
             this.aggsBufferSize = aggsBufferSize;
             this.emptyResults = emptyResults;
             this.next = next;
         }
 
-        public synchronized QuerySearchResult[] consumeBuffer() {
-            QuerySearchResult[] toRet = buffer;
+        public synchronized List<QuerySearchResult> consumeBuffer() {
+            List<QuerySearchResult> toRet = buffer;
             buffer = null;
             return toRet;
         }
 
-        public void consumeListener() {
-            if (next != null) {
-                next.run();
-                next = null;
-            }
+        public synchronized Runnable consumeListener() {
+            Runnable n = next;
+            next = null;
+            return n;
         }
 
-        public synchronized void cancel() {
-            QuerySearchResult[] buffer = consumeBuffer();
+        public void cancel() {
+            List<QuerySearchResult> buffer = consumeBuffer();
             if (buffer != null) {
-                for (QuerySearchResult result : buffer) {
-                    result.releaseAggs();
-                }
+                releaseAggs(buffer);
             }
-            consumeListener();
+            Runnable next = consumeListener();
+            if (next != null) {
+                next.run();
+            }
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -10,6 +10,13 @@
 package org.elasticsearch.action.search;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.CollectionStatistics;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TermStatistics;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
@@ -17,12 +24,16 @@ import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.dfs.AggregatedDfs;
 import org.elasticsearch.search.dfs.DfsKnnResults;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.transport.Transport;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -93,12 +104,11 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
     @Override
     protected SearchPhase getNextPhase() {
         final List<DfsSearchResult> dfsSearchResults = results.getAtomicArray().asList();
-        final AggregatedDfs aggregatedDfs = SearchPhaseController.aggregateDfs(dfsSearchResults);
-        final List<DfsKnnResults> mergedKnnResults = SearchPhaseController.mergeKnnResults(getRequest(), dfsSearchResults);
+        final AggregatedDfs aggregatedDfs = aggregateDfs(dfsSearchResults);
         return new DfsQueryPhase(
             dfsSearchResults,
             aggregatedDfs,
-            mergedKnnResults,
+            mergeKnnResults(getRequest(), dfsSearchResults),
             queryPhaseResultConsumer,
             (queryResults) -> SearchQueryThenFetchAsyncAction.nextPhase(client, this, queryResults, aggregatedDfs),
             this
@@ -108,5 +118,96 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
     @Override
     protected void onShardGroupFailure(int shardIndex, SearchShardTarget shardTarget, Exception exc) {
         progressListener.notifyQueryFailure(shardIndex, shardTarget, exc);
+    }
+
+    private static List<DfsKnnResults> mergeKnnResults(SearchRequest request, List<DfsSearchResult> dfsSearchResults) {
+        if (request.hasKnnSearch() == false) {
+            return null;
+        }
+        SearchSourceBuilder source = request.source();
+        List<List<TopDocs>> topDocsLists = new ArrayList<>(source.knnSearch().size());
+        List<SetOnce<String>> nestedPath = new ArrayList<>(source.knnSearch().size());
+        for (int i = 0; i < source.knnSearch().size(); i++) {
+            topDocsLists.add(new ArrayList<>());
+            nestedPath.add(new SetOnce<>());
+        }
+
+        for (DfsSearchResult dfsSearchResult : dfsSearchResults) {
+            if (dfsSearchResult.knnResults() != null) {
+                for (int i = 0; i < dfsSearchResult.knnResults().size(); i++) {
+                    DfsKnnResults knnResults = dfsSearchResult.knnResults().get(i);
+                    ScoreDoc[] scoreDocs = knnResults.scoreDocs();
+                    TotalHits totalHits = new TotalHits(scoreDocs.length, TotalHits.Relation.EQUAL_TO);
+                    TopDocs shardTopDocs = new TopDocs(totalHits, scoreDocs);
+                    SearchPhaseController.setShardIndex(shardTopDocs, dfsSearchResult.getShardIndex());
+                    topDocsLists.get(i).add(shardTopDocs);
+                    nestedPath.get(i).trySet(knnResults.getNestedPath());
+                }
+            }
+        }
+
+        List<DfsKnnResults> mergedResults = new ArrayList<>(source.knnSearch().size());
+        for (int i = 0; i < source.knnSearch().size(); i++) {
+            TopDocs mergedTopDocs = TopDocs.merge(source.knnSearch().get(i).k(), topDocsLists.get(i).toArray(new TopDocs[0]));
+            mergedResults.add(new DfsKnnResults(nestedPath.get(i).get(), mergedTopDocs.scoreDocs));
+        }
+        return mergedResults;
+    }
+
+    private static AggregatedDfs aggregateDfs(Collection<DfsSearchResult> results) {
+        Map<Term, TermStatistics> termStatistics = new HashMap<>();
+        Map<String, CollectionStatistics> fieldStatistics = new HashMap<>();
+        long aggMaxDoc = 0;
+        for (DfsSearchResult lEntry : results) {
+            final Term[] terms = lEntry.terms();
+            final TermStatistics[] stats = lEntry.termStatistics();
+            assert terms.length == stats.length;
+            for (int i = 0; i < terms.length; i++) {
+                assert terms[i] != null;
+                if (stats[i] == null) {
+                    continue;
+                }
+                TermStatistics existing = termStatistics.get(terms[i]);
+                if (existing != null) {
+                    assert terms[i].bytes().equals(existing.term());
+                    termStatistics.put(
+                        terms[i],
+                        new TermStatistics(
+                            existing.term(),
+                            existing.docFreq() + stats[i].docFreq(),
+                            existing.totalTermFreq() + stats[i].totalTermFreq()
+                        )
+                    );
+                } else {
+                    termStatistics.put(terms[i], stats[i]);
+                }
+
+            }
+
+            assert lEntry.fieldStatistics().containsKey(null) == false;
+            for (var entry : lEntry.fieldStatistics().entrySet()) {
+                String key = entry.getKey();
+                CollectionStatistics value = entry.getValue();
+                if (value == null) {
+                    continue;
+                }
+                assert key != null;
+                CollectionStatistics existing = fieldStatistics.get(key);
+                if (existing != null) {
+                    CollectionStatistics merged = new CollectionStatistics(
+                        key,
+                        existing.maxDoc() + value.maxDoc(),
+                        existing.docCount() + value.docCount(),
+                        existing.sumTotalTermFreq() + value.sumTotalTermFreq(),
+                        existing.sumDocFreq() + value.sumDocFreq()
+                    );
+                    fieldStatistics.put(key, merged);
+                } else {
+                    fieldStatistics.put(key, value);
+                }
+            }
+            aggMaxDoc += lEntry.maxDoc();
+        }
+        return new AggregatedDfs(termStatistics, fieldStatistics, aggMaxDoc);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -9,20 +9,16 @@
 
 package org.elasticsearch.action.search;
 
-import org.apache.lucene.index.Term;
-import org.apache.lucene.search.CollectionStatistics;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.SortedSetSortField;
-import org.apache.lucene.search.TermStatistics;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.TotalHits.Relation;
-import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.DelayableWriteable;
 import org.elasticsearch.common.lucene.Lucene;
@@ -41,9 +37,6 @@ import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.dfs.AggregatedDfs;
-import org.elasticsearch.search.dfs.DfsKnnResults;
-import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.profile.SearchProfileQueryPhaseResult;
@@ -81,97 +74,6 @@ public final class SearchPhaseController {
         BiFunction<Supplier<Boolean>, AggregatorFactories.Builder, AggregationReduceContext.Builder> requestToAggReduceContextBuilder
     ) {
         this.requestToAggReduceContextBuilder = requestToAggReduceContextBuilder;
-    }
-
-    public static AggregatedDfs aggregateDfs(Collection<DfsSearchResult> results) {
-        Map<Term, TermStatistics> termStatistics = new HashMap<>();
-        Map<String, CollectionStatistics> fieldStatistics = new HashMap<>();
-        long aggMaxDoc = 0;
-        for (DfsSearchResult lEntry : results) {
-            final Term[] terms = lEntry.terms();
-            final TermStatistics[] stats = lEntry.termStatistics();
-            assert terms.length == stats.length;
-            for (int i = 0; i < terms.length; i++) {
-                assert terms[i] != null;
-                if (stats[i] == null) {
-                    continue;
-                }
-                TermStatistics existing = termStatistics.get(terms[i]);
-                if (existing != null) {
-                    assert terms[i].bytes().equals(existing.term());
-                    termStatistics.put(
-                        terms[i],
-                        new TermStatistics(
-                            existing.term(),
-                            existing.docFreq() + stats[i].docFreq(),
-                            existing.totalTermFreq() + stats[i].totalTermFreq()
-                        )
-                    );
-                } else {
-                    termStatistics.put(terms[i], stats[i]);
-                }
-
-            }
-
-            assert lEntry.fieldStatistics().containsKey(null) == false;
-            for (var entry : lEntry.fieldStatistics().entrySet()) {
-                String key = entry.getKey();
-                CollectionStatistics value = entry.getValue();
-                if (value == null) {
-                    continue;
-                }
-                assert key != null;
-                CollectionStatistics existing = fieldStatistics.get(key);
-                if (existing != null) {
-                    CollectionStatistics merged = new CollectionStatistics(
-                        key,
-                        existing.maxDoc() + value.maxDoc(),
-                        existing.docCount() + value.docCount(),
-                        existing.sumTotalTermFreq() + value.sumTotalTermFreq(),
-                        existing.sumDocFreq() + value.sumDocFreq()
-                    );
-                    fieldStatistics.put(key, merged);
-                } else {
-                    fieldStatistics.put(key, value);
-                }
-            }
-            aggMaxDoc += lEntry.maxDoc();
-        }
-        return new AggregatedDfs(termStatistics, fieldStatistics, aggMaxDoc);
-    }
-
-    public static List<DfsKnnResults> mergeKnnResults(SearchRequest request, List<DfsSearchResult> dfsSearchResults) {
-        if (request.hasKnnSearch() == false) {
-            return null;
-        }
-        SearchSourceBuilder source = request.source();
-        List<List<TopDocs>> topDocsLists = new ArrayList<>(source.knnSearch().size());
-        List<SetOnce<String>> nestedPath = new ArrayList<>(source.knnSearch().size());
-        for (int i = 0; i < source.knnSearch().size(); i++) {
-            topDocsLists.add(new ArrayList<>());
-            nestedPath.add(new SetOnce<>());
-        }
-
-        for (DfsSearchResult dfsSearchResult : dfsSearchResults) {
-            if (dfsSearchResult.knnResults() != null) {
-                for (int i = 0; i < dfsSearchResult.knnResults().size(); i++) {
-                    DfsKnnResults knnResults = dfsSearchResult.knnResults().get(i);
-                    ScoreDoc[] scoreDocs = knnResults.scoreDocs();
-                    TotalHits totalHits = new TotalHits(scoreDocs.length, Relation.EQUAL_TO);
-                    TopDocs shardTopDocs = new TopDocs(totalHits, scoreDocs);
-                    setShardIndex(shardTopDocs, dfsSearchResult.getShardIndex());
-                    topDocsLists.get(i).add(shardTopDocs);
-                    nestedPath.get(i).trySet(knnResults.getNestedPath());
-                }
-            }
-        }
-
-        List<DfsKnnResults> mergedResults = new ArrayList<>(source.knnSearch().size());
-        for (int i = 0; i < source.knnSearch().size(); i++) {
-            TopDocs mergedTopDocs = TopDocs.merge(source.knnSearch().get(i).k(), topDocsLists.get(i).toArray(new TopDocs[0]));
-            mergedResults.add(new DfsKnnResults(nestedPath.get(i).get(), mergedTopDocs.scoreDocs));
-        }
-        return mergedResults;
     }
 
     /**
@@ -492,48 +394,6 @@ public final class SearchPhaseController {
             sortedTopDocs.sortFields,
             sortedTopDocs.collapseField,
             sortedTopDocs.collapseValues
-        );
-    }
-
-    /**
-     * Reduces the given query results and consumes all aggregations and profile results.
-     * @param queryResults a list of non-null query shard results
-     */
-    static ReducedQueryPhase reducedScrollQueryPhase(Collection<? extends SearchPhaseResult> queryResults) {
-        AggregationReduceContext.Builder aggReduceContextBuilder = new AggregationReduceContext.Builder() {
-            @Override
-            public AggregationReduceContext forPartialReduction() {
-                throw new UnsupportedOperationException("Scroll requests don't have aggs");
-            }
-
-            @Override
-            public AggregationReduceContext forFinalReduction() {
-                throw new UnsupportedOperationException("Scroll requests don't have aggs");
-            }
-        };
-        final TopDocsStats topDocsStats = new TopDocsStats(SearchContext.TRACK_TOTAL_HITS_ACCURATE);
-        final List<TopDocs> topDocs = new ArrayList<>();
-        for (SearchPhaseResult sortedResult : queryResults) {
-            QuerySearchResult queryResult = sortedResult.queryResult();
-            final TopDocsAndMaxScore td = queryResult.consumeTopDocs();
-            assert td != null;
-            topDocsStats.add(td, queryResult.searchTimedOut(), queryResult.terminatedEarly());
-            // make sure we set the shard index before we add it - the consumer didn't do that yet
-            if (td.topDocs.scoreDocs.length > 0) {
-                setShardIndex(td.topDocs, queryResult.getShardIndex());
-                topDocs.add(td.topDocs);
-            }
-        }
-        return reducedQueryPhase(
-            queryResults,
-            Collections.emptyList(),
-            topDocs,
-            topDocsStats,
-            0,
-            true,
-            aggReduceContextBuilder,
-            null,
-            true
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
@@ -10,21 +10,27 @@
 package org.elasticsearch.action.search;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.internal.InternalScrollSearchRequest;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchContextId;
+import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.Transport;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -300,5 +306,49 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
 
     protected Transport.Connection getConnection(String clusterAlias, DiscoveryNode node) {
         return searchTransportService.getConnection(clusterAlias, node);
+    }
+
+    /**
+     * Reduces the given query results and consumes all aggregations and profile results.
+     * @param queryResults a list of non-null query shard results
+     */
+    protected static SearchPhaseController.ReducedQueryPhase reducedScrollQueryPhase(Collection<? extends SearchPhaseResult> queryResults) {
+        AggregationReduceContext.Builder aggReduceContextBuilder = new AggregationReduceContext.Builder() {
+            @Override
+            public AggregationReduceContext forPartialReduction() {
+                throw new UnsupportedOperationException("Scroll requests don't have aggs");
+            }
+
+            @Override
+            public AggregationReduceContext forFinalReduction() {
+                throw new UnsupportedOperationException("Scroll requests don't have aggs");
+            }
+        };
+        final SearchPhaseController.TopDocsStats topDocsStats = new SearchPhaseController.TopDocsStats(
+            SearchContext.TRACK_TOTAL_HITS_ACCURATE
+        );
+        final List<TopDocs> topDocs = new ArrayList<>();
+        for (SearchPhaseResult sortedResult : queryResults) {
+            QuerySearchResult queryResult = sortedResult.queryResult();
+            final TopDocsAndMaxScore td = queryResult.consumeTopDocs();
+            assert td != null;
+            topDocsStats.add(td, queryResult.searchTimedOut(), queryResult.terminatedEarly());
+            // make sure we set the shard index before we add it - the consumer didn't do that yet
+            if (td.topDocs.scoreDocs.length > 0) {
+                SearchPhaseController.setShardIndex(td.topDocs, queryResult.getShardIndex());
+                topDocs.add(td.topDocs);
+            }
+        }
+        return SearchPhaseController.reducedQueryPhase(
+            queryResults,
+            null,
+            topDocs,
+            topDocsStats,
+            0,
+            true,
+            aggReduceContextBuilder,
+            null,
+            true
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollQueryAndFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollQueryAndFetchAsyncAction.java
@@ -51,7 +51,7 @@ final class SearchScrollQueryAndFetchAsyncAction extends SearchScrollAsyncAction
 
     @Override
     protected SearchPhase moveToNextPhase(BiFunction<String, String, DiscoveryNode> clusterNodeLookup) {
-        return sendResponsePhase(SearchPhaseController.reducedScrollQueryPhase(queryFetchResults.asList()), queryFetchResults);
+        return sendResponsePhase(reducedScrollQueryPhase(queryFetchResults.asList()), queryFetchResults);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
@@ -66,9 +66,7 @@ final class SearchScrollQueryThenFetchAsyncAction extends SearchScrollAsyncActio
         return new SearchPhase("fetch") {
             @Override
             public void run() {
-                final SearchPhaseController.ReducedQueryPhase reducedQueryPhase = SearchPhaseController.reducedScrollQueryPhase(
-                    queryResults.asList()
-                );
+                final SearchPhaseController.ReducedQueryPhase reducedQueryPhase = reducedScrollQueryPhase(queryResults.asList());
                 ScoreDoc[] scoreDocs = reducedQueryPhase.sortedTopDocs().scoreDocs();
                 if (scoreDocs.length == 0) {
                     sendResponse(reducedQueryPhase, fetchResults);


### PR DESCRIPTION

No need to have this logic live in `SearchPhaseController` when it only has a single callsite elsewhere.
