### PR TITLE
Fix docs.testFilterToday JDBC test

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
@@ -3353,7 +3353,7 @@ Alejandro
 Amabile
 Anoosh
 Basil
-Brendon
+Cristinel
 // end::filterToday
 ;
 


### PR DESCRIPTION
The test uses the condition `hire_date > now() - INTERVAL 35 YEARS`.
One of the records has hire_date = 1990-02-01T00:00:00Z, so it started failing.


I'll unmute the test with a different PR, to make the automatic backport easier.