### PR TITLE
[9.0][Test] Remove ASYNC translog durability in N-2 bwc upgrade tests (#121278)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -334,8 +334,6 @@ tests:
 - class: org.elasticsearch.upgrades.VectorSearchIT
   method: testBBQVectorSearch {upgradedNodes=0}
   issue: https://github.com/elastic/elasticsearch/issues/121253
-- class: org.elasticsearch.lucene.FullClusterRestartLuceneIndexCompatibilityIT
-  issue: https://github.com/elastic/elasticsearch/issues/121257
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/121269
 - class: org.elasticsearch.upgrades.VectorSearchIT
@@ -366,23 +364,12 @@ tests:
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testSuggestProfilesWithHint
   issue: https://github.com/elastic/elasticsearch/issues/121116
-- class: org.elasticsearch.upgrades.AddIndexBlockRollingUpgradeIT
-  method: testAddBlock {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/121365
-- class: org.elasticsearch.upgrades.AddIndexBlockRollingUpgradeIT
-  method: testAddBlock {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/121366
-- class: org.elasticsearch.upgrades.AddIndexBlockRollingUpgradeIT
-  method: testAddBlock {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/121367
 - class: org.elasticsearch.env.NodeEnvironmentTests
   method: testGetBestDowngradeVersion
   issue: https://github.com/elastic/elasticsearch/issues/121316
 - class: org.elasticsearch.ingest.geoip.FullClusterRestartIT
   method: testGeoIpSystemFeaturesMigration {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/121115
-- class: org.elasticsearch.lucene.RollingUpgradeLuceneIndexCompatibilityTestCase
-  issue: https://github.com/elastic/elasticsearch/issues/121423
 - class: org.elasticsearch.index.engine.ShuffleForcedMergePolicyTests
   method: testDiagnostics
   issue: https://github.com/elastic/elasticsearch/issues/121336

--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartLuceneIndexCompatibilityIT.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartLuceneIndexCompatibilityIT.java
@@ -11,8 +11,6 @@ package org.elasticsearch.lucene;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.test.cluster.util.Version;
 
@@ -184,7 +182,6 @@ public class FullClusterRestartLuceneIndexCompatibilityIT extends FullClusterRes
                 Settings.builder()
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomInt(2))
-                    .put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), randomFrom(Translog.Durability.values()))
                     .build()
             );
             indexDocs(index, numDocs);

--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeLuceneIndexCompatibilityTestCase.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeLuceneIndexCompatibilityTestCase.java
@@ -13,8 +13,6 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.test.cluster.util.Version;
 
@@ -189,11 +187,7 @@ public class RollingUpgradeLuceneIndexCompatibilityTestCase extends RollingUpgra
             createIndex(
                 client(),
                 index,
-                Settings.builder()
-                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-                    .put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), randomFrom(Translog.Durability.values()))
-                    .build()
+                Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build()
             );
             indexDocs(index, numDocs);
             return;


### PR DESCRIPTION
When adding support for upgrading closed indices in
    N-2 version, I randomized the Translog.Durability setting
    of the closed index with the aim to test the 2 phases
    closing process.
    
    This caused at least 1 test failure on Windows with the
    index being closed and the cluster upgraded before the
    synchronization of the translog had a chance to be
    executed. I think this cause the engine to be reset on
    the replica that is promoted as a primary, causing the
    loss of the operations that were not yet persisted.
    
    Closes #121257
    Closes #121365
    Closes #121423
