### PR TITLE
[9.0] Use NavigableSet for representing test version sets, rather than List (#121266)

### DIFF
--- a/server/src/main/java/org/elasticsearch/ReleaseVersions.java
+++ b/server/src/main/java/org/elasticsearch/ReleaseVersions.java
@@ -78,10 +78,10 @@ public class ReleaseVersions {
             // replace all version lists with the smallest & greatest versions
             versions.replaceAll((k, v) -> {
                 if (v.size() == 1) {
-                    return List.of(v.get(0));
+                    return List.of(v.getFirst());
                 } else {
                     v.sort(Comparator.naturalOrder());
-                    return List.of(v.get(0), v.get(v.size() - 1));
+                    return List.of(v.getFirst(), v.getLast());
                 }
             });
 
@@ -100,14 +100,14 @@ public class ReleaseVersions {
 
             String lowerBound, upperBound;
             if (versionRange != null) {
-                lowerBound = versionRange.get(0).toString();
-                upperBound = lastItem(versionRange).toString();
+                lowerBound = versionRange.getFirst().toString();
+                upperBound = versionRange.getLast().toString();
             } else {
                 // infer the bounds from the surrounding entries
                 var lowerRange = versions.lowerEntry(id);
                 if (lowerRange != null) {
                     // the next version is just a guess - might be a newer revision, might be a newer minor or major...
-                    lowerBound = nextVersion(lastItem(lowerRange.getValue())).toString();
+                    lowerBound = nextVersion(lowerRange.getValue().getLast()).toString();
                 } else {
                     // a really old version we don't have a record for
                     // assume it's an old version id - we can just return it directly
@@ -122,7 +122,7 @@ public class ReleaseVersions {
                 var upperRange = versions.higherEntry(id);
                 if (upperRange != null) {
                     // too hard to guess what version this id might be for using the next version - just use it directly
-                    upperBound = upperRange.getValue().get(0).toString();
+                    upperBound = upperRange.getValue().getFirst().toString();
                 } else {
                     // a newer version than all we know about? Can't map it...
                     upperBound = "[" + id + "]";
@@ -131,10 +131,6 @@ public class ReleaseVersions {
 
             return lowerBound.equals(upperBound) ? lowerBound : lowerBound + "-" + upperBound;
         };
-    }
-
-    private static <T> T lastItem(List<T> list) {
-        return list.get(list.size() - 1);
     }
 
     private static Version nextVersion(Version version) {

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.IntFunction;
-import java.util.stream.Collectors;
 
 @SuppressWarnings("deprecation")
 public class IndexVersions {
@@ -248,10 +247,6 @@ public class IndexVersions {
         }
 
         return Collections.unmodifiableNavigableMap(builder);
-    }
-
-    static Collection<IndexVersion> getAllWriteVersions() {
-        return VERSION_IDS.values().stream().filter(v -> v.onOrAfter(IndexVersions.MINIMUM_COMPATIBLE)).collect(Collectors.toSet());
     }
 
     static Collection<IndexVersion> getAllVersions() {

--- a/server/src/main/java/org/elasticsearch/internal/VersionExtension.java
+++ b/server/src/main/java/org/elasticsearch/internal/VersionExtension.java
@@ -12,16 +12,16 @@ package org.elasticsearch.internal;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.index.IndexVersion;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  * Allows plugging in current version elements.
  */
 public interface VersionExtension {
     /**
-     * Returns list of {@link TransportVersion} defined by extension
+     * Returns additional {@link TransportVersion} defined by extension
      */
-    List<TransportVersion> getTransportVersions();
+    Collection<TransportVersion> getTransportVersions();
 
     /**
      * Returns the {@link IndexVersion} that Elasticsearch should use.

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -13,15 +13,13 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 
 import java.lang.reflect.Modifier;
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
@@ -69,13 +67,11 @@ public class TransportVersionTests extends ESTestCase {
     public void testStaticTransportVersionChecks() {
         assertThat(
             TransportVersions.collectAllVersionIdsDefinedInClass(CorrectFakeVersion.class),
-            equalTo(
-                List.of(
-                    CorrectFakeVersion.V_0_000_002,
-                    CorrectFakeVersion.V_0_000_003,
-                    CorrectFakeVersion.V_0_000_004,
-                    CorrectFakeVersion.V_0_00_01
-                )
+            contains(
+                CorrectFakeVersion.V_0_000_002,
+                CorrectFakeVersion.V_0_000_003,
+                CorrectFakeVersion.V_0_000_004,
+                CorrectFakeVersion.V_0_00_01
             )
         );
         AssertionError e = expectThrows(
@@ -184,7 +180,7 @@ public class TransportVersionTests extends ESTestCase {
     }
 
     public void testCURRENTIsLatest() {
-        assertThat(Collections.max(TransportVersion.getAllVersions()), is(TransportVersion.current()));
+        assertThat(TransportVersion.getAllVersions().getLast(), is(TransportVersion.current()));
     }
 
     public void testPatchVersionsStillAvailable() {

--- a/test/framework/src/main/java/org/elasticsearch/index/KnownIndexVersions.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/KnownIndexVersions.java
@@ -9,7 +9,9 @@
 
 package org.elasticsearch.index;
 
-import java.util.List;
+import java.util.Collections;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 
 /**
  * Provides access to all known index versions
@@ -18,10 +20,12 @@ public class KnownIndexVersions {
     /**
      * A sorted list of all known index versions
      */
-    public static final List<IndexVersion> ALL_VERSIONS = List.copyOf(IndexVersions.getAllVersions());
+    public static final NavigableSet<IndexVersion> ALL_VERSIONS = Collections.unmodifiableNavigableSet(
+        new TreeSet<>(IndexVersions.getAllVersions())
+    );
 
     /**
      * A sorted list of all known index versions that can be written to
      */
-    public static final List<IndexVersion> ALL_WRITE_VERSIONS = List.copyOf(IndexVersions.getAllWriteVersions());
+    public static final NavigableSet<IndexVersion> ALL_WRITE_VERSIONS = ALL_VERSIONS.tailSet(IndexVersions.MINIMUM_COMPATIBLE, true);
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBWCSerializationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBWCSerializationTestCase.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
 
 import static org.elasticsearch.test.BWCVersions.DEFAULT_BWC_VERSIONS;
 
@@ -28,7 +28,7 @@ public abstract class AbstractBWCSerializationTestCase<T extends Writeable & ToX
     /**
      * The bwc versions to test serialization against
      */
-    protected List<TransportVersion> bwcVersions() {
+    protected Collection<TransportVersion> bwcVersions() {
         return DEFAULT_BWC_VERSIONS;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/BWCVersions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/BWCVersions.java
@@ -12,17 +12,14 @@ package org.elasticsearch.test;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.NavigableSet;
 
 public final class BWCVersions {
     private BWCVersions() {}
 
-    public static List<TransportVersion> getAllBWCVersions() {
-        List<TransportVersion> allVersions = TransportVersion.getAllVersions();
-        int minCompatVersion = Collections.binarySearch(allVersions, TransportVersions.MINIMUM_COMPATIBLE);
-        return allVersions.subList(minCompatVersion, allVersions.size());
+    public static NavigableSet<TransportVersion> getAllBWCVersions() {
+        return TransportVersionUtils.allReleasedVersions().tailSet(TransportVersions.MINIMUM_COMPATIBLE, true);
     }
 
-    public static final List<TransportVersion> DEFAULT_BWC_VERSIONS = getAllBWCVersions();
+    public static final NavigableSet<TransportVersion> DEFAULT_BWC_VERSIONS = getAllBWCVersions();
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/index/IndexVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/index/IndexVersionUtils.java
@@ -14,41 +14,43 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.KnownIndexVersions;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.NavigableSet;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.lucene.tests.util.LuceneTestCase.random;
+
 public class IndexVersionUtils {
 
-    private static final List<IndexVersion> ALL_VERSIONS = KnownIndexVersions.ALL_VERSIONS;
-    private static final List<IndexVersion> ALL_WRITE_VERSIONS = KnownIndexVersions.ALL_WRITE_VERSIONS;
+    private static final NavigableSet<IndexVersion> ALL_VERSIONS = KnownIndexVersions.ALL_VERSIONS;
+    private static final NavigableSet<IndexVersion> ALL_WRITE_VERSIONS = KnownIndexVersions.ALL_WRITE_VERSIONS;
 
     /** Returns all released versions */
-    public static List<IndexVersion> allReleasedVersions() {
+    public static NavigableSet<IndexVersion> allReleasedVersions() {
         return ALL_VERSIONS;
     }
 
     /** Returns the oldest known {@link IndexVersion}. This version can only be read from and not written to */
     public static IndexVersion getLowestReadCompatibleVersion() {
-        return ALL_VERSIONS.get(0);
+        return ALL_VERSIONS.getFirst();
     }
 
     /** Returns the oldest known {@link IndexVersion} that can be written to */
     public static IndexVersion getLowestWriteCompatibleVersion() {
-        return ALL_WRITE_VERSIONS.get(0);
+        return ALL_WRITE_VERSIONS.getFirst();
     }
 
     /** Returns a random {@link IndexVersion} from all available versions. */
     public static IndexVersion randomVersion() {
-        return ESTestCase.randomFrom(ALL_VERSIONS);
+        return VersionUtils.randomFrom(random(), ALL_VERSIONS, IndexVersion::fromId);
     }
 
     /** Returns a random {@link IndexVersion} from all versions that can be written to. */
     public static IndexVersion randomWriteVersion() {
-        return ESTestCase.randomFrom(ALL_WRITE_VERSIONS);
+        return VersionUtils.randomFrom(random(), ALL_WRITE_VERSIONS, IndexVersion::fromId);
     }
 
     /** Returns a random {@link IndexVersion} from all available versions without the ignore set */
@@ -62,23 +64,21 @@ public class IndexVersionUtils {
             throw new IllegalArgumentException("maxVersion [" + maxVersion + "] cannot be less than minVersion [" + minVersion + "]");
         }
 
-        int minVersionIndex = 0;
+        NavigableSet<IndexVersion> versions = allReleasedVersions();
         if (minVersion != null) {
-            minVersionIndex = Collections.binarySearch(ALL_VERSIONS, minVersion);
+            if (versions.contains(minVersion) == false) {
+                throw new IllegalArgumentException("minVersion [" + minVersion + "] does not exist.");
+            }
+            versions = versions.tailSet(minVersion, true);
         }
-        int maxVersionIndex = ALL_VERSIONS.size() - 1;
         if (maxVersion != null) {
-            maxVersionIndex = Collections.binarySearch(ALL_VERSIONS, maxVersion);
+            if (versions.contains(maxVersion) == false) {
+                throw new IllegalArgumentException("maxVersion [" + maxVersion + "] does not exist.");
+            }
+            versions = versions.headSet(maxVersion, true);
         }
-        if (minVersionIndex < 0) {
-            throw new IllegalArgumentException("minVersion [" + minVersion + "] does not exist.");
-        } else if (maxVersionIndex < 0) {
-            throw new IllegalArgumentException("maxVersion [" + maxVersion + "] does not exist.");
-        } else {
-            // minVersionIndex is inclusive so need to add 1 to this index
-            int range = maxVersionIndex + 1 - minVersionIndex;
-            return ALL_VERSIONS.get(minVersionIndex + random.nextInt(range));
-        }
+
+        return VersionUtils.randomFrom(random, versions, IndexVersion::fromId);
     }
 
     public static IndexVersion getPreviousVersion() {
@@ -88,16 +88,11 @@ public class IndexVersionUtils {
     }
 
     public static IndexVersion getPreviousVersion(IndexVersion version) {
-        int place = Collections.binarySearch(ALL_VERSIONS, version);
-        if (place < 0) {
-            // version does not exist - need the item before the index this version should be inserted
-            place = -(place + 1);
-        }
-
-        if (place < 1) {
+        IndexVersion lower = allReleasedVersions().lower(version);
+        if (lower == null) {
             throw new IllegalArgumentException("couldn't find any released versions before [" + version + "]");
         }
-        return ALL_VERSIONS.get(place - 1);
+        return lower;
     }
 
     public static IndexVersion getPreviousMajorVersion(IndexVersion version) {
@@ -105,19 +100,11 @@ public class IndexVersionUtils {
     }
 
     public static IndexVersion getNextVersion(IndexVersion version) {
-        int place = Collections.binarySearch(ALL_VERSIONS, version);
-        if (place < 0) {
-            // version does not exist - need the item at the index this version should be inserted
-            place = -(place + 1);
-        } else {
-            // need the *next* version
-            place++;
-        }
-
-        if (place < 0 || place >= ALL_VERSIONS.size()) {
+        IndexVersion higher = allReleasedVersions().higher(version);
+        if (higher == null) {
             throw new IllegalArgumentException("couldn't find any released versions after [" + version + "]");
         }
-        return ALL_VERSIONS.get(place);
+        return higher;
     }
 
     /** Returns a random {@code IndexVersion} that is compatible with {@link IndexVersion#current()} */

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -21,13 +21,6 @@ import static org.elasticsearch.Version.fromId;
  */
 public class VersionUtilsTests extends ESTestCase {
 
-    public void testAllVersionsSorted() {
-        List<Version> allVersions = VersionUtils.allVersions();
-        for (int i = 0, j = 1; j < allVersions.size(); ++i, ++j) {
-            assertTrue(allVersions.get(i).before(allVersions.get(j)));
-        }
-    }
-
     public void testRandomVersionBetween() {
         // TODO: rework this test to use a dummy Version class so these don't need to change with each release
         // full range
@@ -50,9 +43,9 @@ public class VersionUtilsTests extends ESTestCase {
         got = VersionUtils.randomVersionBetween(random(), null, fromId(7000099));
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
         assertTrue(got.onOrBefore(fromId(7000099)));
-        got = VersionUtils.randomVersionBetween(random(), null, VersionUtils.allVersions().get(0));
+        got = VersionUtils.randomVersionBetween(random(), null, VersionUtils.allVersions().getFirst());
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
-        assertTrue(got.onOrBefore(VersionUtils.allVersions().get(0)));
+        assertTrue(got.onOrBefore(VersionUtils.allVersions().getFirst()));
 
         // unbounded upper
         got = VersionUtils.randomVersionBetween(random(), VersionUtils.getFirstVersion(), null);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/AbstractBWCWireSerializationTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/AbstractBWCWireSerializationTestCase.java
@@ -12,7 +12,7 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
 
 import static org.elasticsearch.test.BWCVersions.DEFAULT_BWC_VERSIONS;
 
@@ -26,7 +26,7 @@ public abstract class AbstractBWCWireSerializationTestCase<T extends Writeable> 
     /**
      * The bwc versions to test serialization against
      */
-    protected List<TransportVersion> bwcVersions() {
+    protected Collection<TransportVersion> bwcVersions() {
         return DEFAULT_BWC_VERSIONS;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/AbstractChunkedBWCSerializationTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/AbstractChunkedBWCSerializationTestCase.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
 
 import static org.elasticsearch.test.BWCVersions.DEFAULT_BWC_VERSIONS;
 
@@ -28,7 +28,7 @@ public abstract class AbstractChunkedBWCSerializationTestCase<T extends ChunkedT
     /**
      * The bwc versions to test serialization against
      */
-    protected List<TransportVersion> bwcVersions() {
+    protected Collection<TransportVersion> bwcVersions() {
         return DEFAULT_BWC_VERSIONS;
     }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/AbstractBWCSerializationTestCase.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/AbstractBWCSerializationTestCase.java
@@ -10,23 +10,21 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
+import java.util.NavigableSet;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public abstract class AbstractBWCSerializationTestCase<T extends Writeable & ToXContent> extends AbstractXContentSerializingTestCase<T> {
 
-    private static List<TransportVersion> getAllBWCVersions() {
-        List<TransportVersion> allVersions = TransportVersion.getAllVersions();
-        int minCompatVersion = Collections.binarySearch(allVersions, TransportVersions.MINIMUM_COMPATIBLE);
-        return allVersions.subList(minCompatVersion, allVersions.size());
+    private static NavigableSet<TransportVersion> getAllBWCVersions() {
+        return TransportVersionUtils.allReleasedVersions().tailSet(TransportVersions.MINIMUM_COMPATIBLE, true);
     }
 
-    private static final List<TransportVersion> DEFAULT_BWC_VERSIONS = getAllBWCVersions();
+    private static final NavigableSet<TransportVersion> DEFAULT_BWC_VERSIONS = getAllBWCVersions();
 
     protected abstract T mutateInstanceForVersion(T instance, TransportVersion version);
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/AbstractBWCWireSerializingTestCase.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/AbstractBWCWireSerializingTestCase.java
@@ -10,22 +10,20 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
+import java.util.NavigableSet;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public abstract class AbstractBWCWireSerializingTestCase<T extends Writeable> extends AbstractWireSerializingTestCase<T> {
 
-    private static List<TransportVersion> getAllBWCVersions() {
-        List<TransportVersion> allVersions = TransportVersion.getAllVersions();
-        int minCompatVersion = Collections.binarySearch(allVersions, TransportVersions.MINIMUM_COMPATIBLE);
-        return allVersions.subList(minCompatVersion, allVersions.size());
+    private static NavigableSet<TransportVersion> getAllBWCVersions() {
+        return TransportVersionUtils.allReleasedVersions().tailSet(TransportVersions.MINIMUM_COMPATIBLE, true);
     }
 
-    private static final List<TransportVersion> DEFAULT_BWC_VERSIONS = getAllBWCVersions();
+    private static final NavigableSet<TransportVersion> DEFAULT_BWC_VERSIONS = getAllBWCVersions();
 
     protected abstract T mutateInstanceForVersion(T instance, TransportVersion version);
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Use NavigableSet for representing test version sets, rather than List (#121266)