### PR TITLE
Remove reflection tests from entitlements REST tests

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/DummyImplementations.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/DummyImplementations.java
@@ -52,9 +52,10 @@ import javax.net.ssl.SSLSocketFactory;
  * <p>
  * A bit like Mockito but way more painful.
  */
-public class DummyImplementations {
+class DummyImplementations {
 
-    public static class DummyLocaleServiceProvider extends LocaleServiceProvider {
+    static class DummyLocaleServiceProvider extends LocaleServiceProvider {
+
         @Override
         public Locale[] getAvailableLocales() {
             throw unexpected();

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
@@ -96,9 +96,6 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
 
     private static final Map<String, CheckAction> checkActions = Stream.concat(
         Stream.<Entry<String, CheckAction>>of(
-            entry("static_reflection", deniedToPlugins(RestEntitlementsCheckAction::staticMethodNeverEntitledViaReflection)),
-            entry("nonstatic_reflection", deniedToPlugins(RestEntitlementsCheckAction::nonstaticMethodNeverEntitledViaReflection)),
-            entry("constructor_reflection", deniedToPlugins(RestEntitlementsCheckAction::constructorNeverEntitledViaReflection)),
             entry("runtime_exit", deniedToPlugins(RestEntitlementsCheckAction::runtimeExit)),
             entry("runtime_halt", deniedToPlugins(RestEntitlementsCheckAction::runtimeHalt)),
             entry("system_exit", deniedToPlugins(RestEntitlementsCheckAction::systemExit)),
@@ -341,11 +338,6 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
         System.exit(123);
     }
 
-    private static void staticMethodNeverEntitledViaReflection() throws Exception {
-        Method systemExit = System.class.getMethod("exit", int.class);
-        systemExit.invoke(null, 123);
-    }
-
     private static void createClassLoader() throws IOException {
         try (var classLoader = new URLClassLoader("test", new URL[0], RestEntitlementsCheckAction.class.getClassLoader())) {
             logger.info("Created URLClassLoader [{}]", classLoader.getName());
@@ -354,11 +346,6 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
 
     private static void processBuilder_start() throws IOException {
         new ProcessBuilder("").start();
-    }
-
-    private static void nonstaticMethodNeverEntitledViaReflection() throws Exception {
-        Method processBuilderStart = ProcessBuilder.class.getMethod("start");
-        processBuilderStart.invoke(new ProcessBuilder(""));
     }
 
     private static void processBuilder_startPipeline() throws IOException {
@@ -397,10 +384,6 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
 
     private static void localeServiceProvider$() {
         new DummyLocaleServiceProvider();
-    }
-
-    private static void constructorNeverEntitledViaReflection() throws Exception {
-        DummyLocaleServiceProvider.class.getConstructor().newInstance();
     }
 
     private static void breakIteratorProvider$() {


### PR DESCRIPTION
This is best tested in unit tests, not REST actions.

It turns out we already test reflection by necessity for static methods [here](https://github.com/elastic/elasticsearch/blob/92d1d31eea496a014bd400dea727fe572f74a521/libs/entitlement/asm-provider/src/test/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterTests.java#L359-L371) anyway.

This reverts part of #121436.