### PR TITLE
Make knn quantized tests more reliable

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
@@ -71,6 +71,13 @@ setup:
       indices.flush:
         index: bbq_hnsw
 
+  # For added test reliability, pending the resolution of https://github.com/elastic/elasticsearch/issues/109416.
+  - do:
+      indices.forcemerge:
+        index: bbq_hnsw
+        max_num_segments: 1
+  - do:
+      indices.refresh: {}
   - do:
       indices.forcemerge:
         index: bbq_hnsw

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized.yml
@@ -67,6 +67,13 @@ setup:
       indices.flush:
         index: hnsw_byte_quantized
 
+  # For added test reliability, pending the resolution of https://github.com/elastic/elasticsearch/issues/109416.
+  - do:
+      indices.forcemerge:
+        index: hnsw_byte_quantized
+        max_num_segments: 1
+  - do:
+      indices.refresh: {}
   - do:
       indices.forcemerge:
         index: hnsw_byte_quantized

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_half_byte_quantized.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_half_byte_quantized.yml
@@ -60,6 +60,7 @@ setup:
           vector: [0.5, 111.3, -13.0, 14.8]
           another_vector: [-0.5, 11.0, 0, 12]
 
+  # For added test reliability, pending the resolution of https://github.com/elastic/elasticsearch/issues/109416.
   - do:
       indices.forcemerge:
         index: hnsw_byte_quantized
@@ -67,6 +68,11 @@ setup:
 
   - do:
       indices.refresh: {}
+
+  - do:
+      indices.forcemerge:
+        index: hnsw_byte_quantized
+        max_num_segments: 1
 
 ---
 "kNN search only":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat.yml
@@ -70,6 +70,13 @@ setup:
       indices.flush:
         index: bbq_flat
 
+  # For added test reliability, pending the resolution of https://github.com/elastic/elasticsearch/issues/109416.
+  - do:
+      indices.forcemerge:
+        index: bbq_flat
+        max_num_segments: 1
+  - do:
+      indices.refresh: {}
   - do:
       indices.forcemerge:
         index: bbq_flat

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int8_flat.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int8_flat.yml
@@ -57,8 +57,17 @@ setup:
           vector: [0.5, 111.3, -13.0, 14.8, -156.0]
           another_vector: [-0.5, 11.0, 0, 12, 111.0]
 
+  # For added test reliability, pending the resolution of https://github.com/elastic/elasticsearch/issues/109416.
+  - do:
+      indices.forcemerge:
+        index: int8_flat
+        max_num_segments: 1
   - do:
       indices.refresh: {}
+  - do:
+      indices.forcemerge:
+        index: int8_flat
+        max_num_segments: 1
 
 ---
 "kNN search only":


### PR DESCRIPTION
Follow up to https://github.com/elastic/elasticsearch/pull/121110

This adds the same pattern for fixing knn quantized indices issues, mostly found during cross cluster search related errors:
- Force merge to 1 segment
- Refresh indices
- Force merge to 1 segment

This tries to avoid having a single vector in a shard, which doesn't work well with quantization.

This can be removed when https://github.com/elastic/elasticsearch/issues/109416 is resolved.

This is needed to close https://github.com/elastic/elasticsearch/issues/120441