### PR TITLE
Do not set source index to verified read-only as will be ignored by future runs.

### DIFF
--- a/docs/changelog/121554.yaml
+++ b/docs/changelog/121554.yaml
@@ -1,0 +1,6 @@
+pr: 121554
+summary: Do not set source index to verified read-only as will be ignored by future
+  runs
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -342,6 +342,7 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
         TaskId parentTaskId
     ) {
         AddIndexBlockRequest addIndexBlockRequest = new AddIndexBlockRequest(block, index);
+        addIndexBlockRequest.markVerified(false);
         addIndexBlockRequest.setParentTask(parentTaskId);
         client.admin().indices().execute(TransportAddIndexBlockAction.TYPE, addIndexBlockRequest, listener);
     }


### PR DESCRIPTION
ReindexDataStreamIndex sets the source index to read-only (actually adds a write block) so that documents are not added during reindexing. This was being set to verified_read_only. This will cause future runs of the task to ignore the index incorrectly, because verified_read_only indices do not need to be upgraded. 