### PR TITLE
Enable New Semantic Text Format Only On Newly Created Indices

### DIFF
--- a/docs/changelog/121556.yaml
+++ b/docs/changelog/121556.yaml
@@ -1,0 +1,5 @@
+pr: 121556
+summary: Enable New Semantic Text Format Only On Newly Created Indices
+area: Relevance
+type: bug
+issues: []

--- a/docs/changelog/121556.yaml
+++ b/docs/changelog/121556.yaml
@@ -1,5 +1,5 @@
 pr: 121556
 summary: Enable New Semantic Text Format Only On Newly Created Indices
-area: Relevance
+area: Mapping
 type: bug
 issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/InferenceMetadataFieldsMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/InferenceMetadataFieldsMapper.java
@@ -36,16 +36,15 @@ public abstract class InferenceMetadataFieldsMapper extends MetadataFieldMapper 
      */
     public static final Setting<Boolean> USE_LEGACY_SEMANTIC_TEXT_FORMAT = Setting.boolSetting(
         "index.mapping.semantic_text.use_legacy_format",
-        s -> {
-            // Check index version SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP because that index version was added in the same serverless promotion
-            // where the new format was enabled by default
-            IndexVersion indexVersion = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(s);
-            return Boolean.toString(indexVersion.before(IndexVersions.SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP));
-        },
+        false,
         Setting.Property.Final,
         Setting.Property.IndexScope,
         Setting.Property.InternalIndex
     );
+
+    // Check index version SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP because that index version was added in the same serverless promotion
+    // where the new format was enabled by default
+    public static final IndexVersion USE_NEW_FORMAT_BY_DEFAULT = IndexVersions.SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP;
 
     public static final String NAME = "_inference_fields";
     public static final String CONTENT_TYPE = "_inference_fields";
@@ -92,10 +91,12 @@ public abstract class InferenceMetadataFieldsMapper extends MetadataFieldMapper 
      */
     public static boolean isEnabled(Settings settings) {
         var version = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(settings);
-        if (version.before(IndexVersions.INFERENCE_METADATA_FIELDS)
-            && version.between(IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT, IndexVersions.UPGRADE_TO_LUCENE_10_0_0) == false) {
+        if ((version.before(IndexVersions.INFERENCE_METADATA_FIELDS)
+            && version.between(IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT, IndexVersions.UPGRADE_TO_LUCENE_10_0_0) == false)
+            || (version.before(USE_NEW_FORMAT_BY_DEFAULT) && USE_LEGACY_SEMANTIC_TEXT_FORMAT.exists(settings) == false)) {
             return false;
         }
+
         return USE_LEGACY_SEMANTIC_TEXT_FORMAT.get(settings) == false;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/InferenceMetadataFieldsMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/InferenceMetadataFieldsMapper.java
@@ -15,6 +15,7 @@ import org.apache.lucene.search.join.BitSetProducer;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
@@ -35,7 +36,12 @@ public abstract class InferenceMetadataFieldsMapper extends MetadataFieldMapper 
      */
     public static final Setting<Boolean> USE_LEGACY_SEMANTIC_TEXT_FORMAT = Setting.boolSetting(
         "index.mapping.semantic_text.use_legacy_format",
-        false,
+        s -> {
+            // Check index version SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP because that index version was added in the same serverless promotion
+            // where the new format was enabled by default
+            IndexVersion indexVersion = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(s);
+            return Boolean.toString(indexVersion.before(IndexVersions.SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP));
+        },
         Setting.Property.Final,
         Setting.Property.IndexScope,
         Setting.Property.InternalIndex

--- a/server/src/main/java/org/elasticsearch/index/mapper/InferenceMetadataFieldsMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/InferenceMetadataFieldsMapper.java
@@ -44,7 +44,7 @@ public abstract class InferenceMetadataFieldsMapper extends MetadataFieldMapper 
 
     // Check index version SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP because that index version was added in the same serverless promotion
     // where the new format was enabled by default
-    public static final IndexVersion USE_NEW_FORMAT_BY_DEFAULT = IndexVersions.SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP;
+    public static final IndexVersion USE_NEW_SEMANTIC_TEXT_FORMAT_BY_DEFAULT = IndexVersions.SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP;
 
     public static final String NAME = "_inference_fields";
     public static final String CONTENT_TYPE = "_inference_fields";
@@ -93,7 +93,7 @@ public abstract class InferenceMetadataFieldsMapper extends MetadataFieldMapper 
         var version = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(settings);
         if ((version.before(IndexVersions.INFERENCE_METADATA_FIELDS)
             && version.between(IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT, IndexVersions.UPGRADE_TO_LUCENE_10_0_0) == false)
-            || (version.before(USE_NEW_FORMAT_BY_DEFAULT) && USE_LEGACY_SEMANTIC_TEXT_FORMAT.exists(settings) == false)) {
+            || (version.before(USE_NEW_SEMANTIC_TEXT_FORMAT_BY_DEFAULT) && USE_LEGACY_SEMANTIC_TEXT_FORMAT.exists(settings) == false)) {
             return false;
         }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
@@ -56,18 +56,16 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
     }
 
     public void testIsEnabledByDefault() {
-        // Check index version SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP because that index version was added in the same serverless promotion
-        // where the new format was enabled by default
         var settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
-                IndexVersionUtils.getPreviousVersion(IndexVersions.SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP)
+                IndexVersionUtils.getPreviousVersion(InferenceMetadataFieldsMapper.USE_NEW_FORMAT_BY_DEFAULT)
             )
             .build();
         assertFalse(InferenceMetadataFieldsMapper.isEnabled(settings));
 
         settings = Settings.builder()
-            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), IndexVersions.SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP)
+            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), InferenceMetadataFieldsMapper.USE_NEW_FORMAT_BY_DEFAULT)
             .build();
         assertTrue(InferenceMetadataFieldsMapper.isEnabled(settings));
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
@@ -55,6 +55,23 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
         assertTrue(InferenceMetadataFieldsMapper.isEnabled(settings));
     }
 
+    public void testIsEnabledByDefault() {
+        // Check index version SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP because that index version was added in the same serverless promotion
+        // where the new format was enabled by default
+        var settings = Settings.builder()
+            .put(
+                IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
+                IndexVersionUtils.getPreviousVersion(IndexVersions.SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP)
+            )
+            .build();
+        assertFalse(InferenceMetadataFieldsMapper.isEnabled(settings));
+
+        settings = Settings.builder()
+            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), IndexVersions.SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP)
+            .build();
+        assertTrue(InferenceMetadataFieldsMapper.isEnabled(settings));
+    }
+
     @Override
     public void testFieldHasValue() {
         assertTrue(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
@@ -59,13 +59,16 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
         var settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
-                IndexVersionUtils.getPreviousVersion(InferenceMetadataFieldsMapper.USE_NEW_FORMAT_BY_DEFAULT)
+                IndexVersionUtils.getPreviousVersion(InferenceMetadataFieldsMapper.USE_NEW_SEMANTIC_TEXT_FORMAT_BY_DEFAULT)
             )
             .build();
         assertFalse(InferenceMetadataFieldsMapper.isEnabled(settings));
 
         settings = Settings.builder()
-            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), InferenceMetadataFieldsMapper.USE_NEW_FORMAT_BY_DEFAULT)
+            .put(
+                IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
+                InferenceMetadataFieldsMapper.USE_NEW_SEMANTIC_TEXT_FORMAT_BY_DEFAULT
+            )
             .build();
         assertTrue(InferenceMetadataFieldsMapper.isEnabled(settings));
     }


### PR DESCRIPTION
Fixes a bug where the new semantic text format was retroactively enabled on existing indices in serverless