### PR TITLE
ESQL: Reenable heap attacks

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -387,9 +387,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
   method: testDependentVariableIsAliasToNested
   issue: https://github.com/elastic/elasticsearch/issues/121415
-- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
-  method: testLookupExplosionBigStringManyMatches
-  issue: https://github.com/elastic/elasticsearch/issues/121465
 - class: org.elasticsearch.xpack.security.authc.jwt.JwtRealmSingleNodeTests
   method: testClientSecretRotation
   issue: https://github.com/elastic/elasticsearch/issues/120985
@@ -399,9 +396,6 @@ tests:
 - class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
   method: test {yaml=cluster.health/10_basic/cluster health basic test}
   issue: https://github.com/elastic/elasticsearch/issues/121478
-- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
-  method: testLookupExplosionManyMatches
-  issue: https://github.com/elastic/elasticsearch/issues/121481
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testGetUsersWithProfileUid
   issue: https://github.com/elastic/elasticsearch/issues/121483

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -636,7 +636,8 @@ public class HeapAttackIT extends ESRestTestCase {
 
     public void testLookupExplosionManyMatches() throws IOException {
         assertCircuitBreaks(() -> {
-            Map<?, ?> result = lookupExplosion(1500, 10000);
+            // 1500, 10000 is enough locally, but some CI machines need more.
+            Map<?, ?> result = lookupExplosion(2000, 10000);
             logger.error("should have failed but got {}", result);
         });
     }
@@ -664,7 +665,8 @@ public class HeapAttackIT extends ESRestTestCase {
 
     public void testLookupExplosionBigStringManyMatches() throws IOException {
         assertCircuitBreaks(() -> {
-            Map<?, ?> result = lookupExplosionBigString(500, 1);
+            // 500, 1 is enough to make it fail locally but some CI needs more
+            Map<?, ?> result = lookupExplosionBigString(800, 1);
             logger.error("should have failed but got {}", result);
         });
     }


### PR DESCRIPTION
Reenables some heap attack tests, bumping their memory requirements to try and force a failure on all CI machines. Previously some CI machines weren't failing, invalidating the test on those machines.

Close #121481
Close #121465