### PR TITLE
[9.0] Enable New Semantic Text Format Only On Newly Created Indices (#121556)

### DIFF
--- a/docs/changelog/121556.yaml
+++ b/docs/changelog/121556.yaml
@@ -1,0 +1,5 @@
+pr: 121556
+summary: Enable New Semantic Text Format Only On Newly Created Indices
+area: Mapping
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
@@ -55,6 +55,24 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
         assertTrue(InferenceMetadataFieldsMapper.isEnabled(settings));
     }
 
+    public void testIsEnabledByDefault() {
+        var settings = Settings.builder()
+            .put(
+                IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
+                IndexVersionUtils.getPreviousVersion(InferenceMetadataFieldsMapper.USE_NEW_SEMANTIC_TEXT_FORMAT_BY_DEFAULT)
+            )
+            .build();
+        assertFalse(InferenceMetadataFieldsMapper.isEnabled(settings));
+
+        settings = Settings.builder()
+            .put(
+                IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
+                InferenceMetadataFieldsMapper.USE_NEW_SEMANTIC_TEXT_FORMAT_BY_DEFAULT
+            )
+            .build();
+        assertTrue(InferenceMetadataFieldsMapper.isEnabled(settings));
+    }
+
     @Override
     public void testFieldHasValue() {
         assertTrue(


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Enable New Semantic Text Format Only On Newly Created Indices (#121556)