### PR TITLE
[8.17] Add missing apm-server tail sampling monitoring metrics to stack monitoring mapping (#121543)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json
@@ -786,6 +786,45 @@
                     },
                     "sampling": {
                       "properties": {
+                        "tail": {
+                          "properties": {
+                            "dynamic_service_groups": {
+                              "type": "long"
+                            },
+                            "events": {
+                              "properties": {
+                                "dropped": {
+                                  "type": "long"
+                                },
+                                "failed_writes": {
+                                  "type": "long"
+                                },
+                                "head_unsampled": {
+                                  "type": "long"
+                                },
+                                "processed": {
+                                  "type": "long"
+                                },
+                                "sampled": {
+                                  "type": "long"
+                                },
+                                "stored": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "storage": {
+                              "properties": {
+                                "lsm_size": {
+                                  "type": "long"
+                                },
+                                "value_log_size": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        },
                         "transactions_dropped": {
                           "type": "long"
                         }
@@ -2219,6 +2258,54 @@
                     },
                     "sampling": {
                       "properties": {
+                        "tail": {
+                          "properties": {
+                            "dynamic_service_groups": {
+                              "type": "alias",
+                              "path": "beat.stats.apm_server.sampling.tail.dynamic_service_groups"
+                            },
+                            "events": {
+                              "properties": {
+                                "dropped": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.events.dropped"
+                                },
+                                "failed_writes": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.events.failed_writes"
+                                },
+                                "head_unsampled": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.events.head_unsampled"
+                                },
+                                "processed": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.events.processed"
+                                },
+                                "sampled": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.events.sampled"
+                                },
+                                "stored": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.events.stored"
+                                }
+                              }
+                            },
+                            "storage": {
+                              "properties": {
+                                "lsm_size": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.storage.lsm_size"
+                                },
+                                "value_log_size": {
+                                  "type": "alias",
+                                  "path": "beat.stats.apm_server.sampling.tail.storage.value_log_size"
+                                }
+                              }
+                            }
+                          }
+                        },
                         "transactions_dropped": {
                           "type": "alias",
                           "path": "beat.stats.apm_server.sampling.transactions_dropped"

--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json
@@ -966,6 +966,45 @@
                     },
                     "sampling": {
                       "properties": {
+                        "tail": {
+                          "properties": {
+                            "dynamic_service_groups": {
+                              "type": "long"
+                            },
+                            "events": {
+                              "properties": {
+                                "dropped": {
+                                  "type": "long"
+                                },
+                                "failed_writes": {
+                                  "type": "long"
+                                },
+                                "head_unsampled": {
+                                  "type": "long"
+                                },
+                                "processed": {
+                                  "type": "long"
+                                },
+                                "sampled": {
+                                  "type": "long"
+                                },
+                                "stored": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "storage": {
+                              "properties": {
+                                "lsm_size": {
+                                  "type": "long"
+                                },
+                                "value_log_size": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        },
                         "transactions_dropped": {
                           "type": "long"
                         }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -77,7 +77,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 19;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 21;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Add missing apm-server tail sampling monitoring metrics to stack monitoring mapping (#121543)](https://github.com/elastic/elasticsearch/pull/121543)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)