### PR TITLE
[8.x] ReindexDataStreamIndex bug in assertion caused by reference equality (#121325)

### DIFF
--- a/docs/changelog/121325.yaml
+++ b/docs/changelog/121325.yaml
@@ -1,0 +1,5 @@
+pr: 121325
+summary: '`ReindexDataStreamIndex` bug in assertion caused by reference equality'
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -54,6 +54,7 @@ import org.elasticsearch.xpack.core.deprecation.DeprecatedIndexPredicate;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.APIBlock.WRITE;
 
@@ -372,7 +373,7 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
                 listener.delegateFailureAndWrap((delegate, ignored) -> {
                     getIndexDocCount(sourceIndexName, parentTaskId, delegate.delegateFailureAndWrap((delegate1, sourceCount) -> {
                         getIndexDocCount(destIndexName, parentTaskId, delegate1.delegateFailureAndWrap((delegate2, destCount) -> {
-                            assert sourceCount == destCount
+                            assert Objects.equals(sourceCount, destCount)
                                 : String.format(
                                     Locale.ROOT,
                                     "source index [%s] has %d docs and dest [%s] has %d docs",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [ReindexDataStreamIndex bug in assertion caused by reference equality (#121325)](https://github.com/elastic/elasticsearch/pull/121325)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)