### PR TITLE
Unwrap failure in testCancelRequestWhenFailingFetchingPages

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -128,9 +128,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.RegressionIT
   method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
   issue: https://github.com/elastic/elasticsearch/issues/117805
-- class: org.elasticsearch.xpack.esql.action.EsqlActionTaskIT
-  method: testCancelRequestWhenFailingFetchingPages
-  issue: https://github.com/elastic/elasticsearch/issues/118193
 - class: org.elasticsearch.packaging.test.ArchiveTests
   method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
   issue: https://github.com/elastic/elasticsearch/issues/118208

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
@@ -462,7 +462,9 @@ public class EsqlActionTaskIT extends AbstractPausableIntegTestCase {
             }
             Exception failure = expectThrows(Exception.class, () -> future.actionGet().close());
             EsqlTestUtils.assertEsqlFailure(failure);
-            assertThat(failure.getMessage(), containsString("failed to fetch pages"));
+            Throwable cause = ExceptionsHelper.unwrap(failure, IOException.class);
+            assertNotNull(cause);
+            assertThat(cause.getMessage(), containsString("failed to fetch pages"));
             // If we proceed without waiting for pages, we might cancel the main request before starting the data-node request.
             // As a result, the exchange sinks on data-nodes won't be removed until the inactive_timeout elapses, which is
             // longer than the assertBusy timeout.


### PR DESCRIPTION
The thrown exception may be wrapped in an ExecutionException; therefore, we need to unwrap it before verification.

Closes #121596 
Closes #118193