### PR TITLE
[Backport] Passing parent task id to the refresh request within reindex data streams (#121533)

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -368,26 +368,24 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
     ) {
         if (Assertions.ENABLED) {
             logger.debug("Comparing source [{}] and dest [{}] doc counts", sourceIndexName, destIndexName);
-            client.execute(
-                RefreshAction.INSTANCE,
-                new RefreshRequest(destIndexName),
-                listener.delegateFailureAndWrap((delegate, ignored) -> {
-                    getIndexDocCount(sourceIndexName, parentTaskId, delegate.delegateFailureAndWrap((delegate1, sourceCount) -> {
-                        getIndexDocCount(destIndexName, parentTaskId, delegate1.delegateFailureAndWrap((delegate2, destCount) -> {
-                            assert Objects.equals(sourceCount, destCount)
-                                : String.format(
-                                    Locale.ROOT,
-                                    "source index [%s] has %d docs and dest [%s] has %d docs",
-                                    sourceIndexName,
-                                    sourceCount,
-                                    destIndexName,
-                                    destCount
-                                );
-                            delegate2.onResponse(null);
-                        }));
+            RefreshRequest refreshRequest = new RefreshRequest(destIndexName);
+            refreshRequest.setParentTask(parentTaskId);
+            client.execute(RefreshAction.INSTANCE, refreshRequest, listener.delegateFailureAndWrap((delegate, ignored) -> {
+                getIndexDocCount(sourceIndexName, parentTaskId, delegate.delegateFailureAndWrap((delegate1, sourceCount) -> {
+                    getIndexDocCount(destIndexName, parentTaskId, delegate1.delegateFailureAndWrap((delegate2, destCount) -> {
+                        assert Objects.equals(sourceCount, destCount)
+                            : String.format(
+                                Locale.ROOT,
+                                "source index [%s] has %d docs and dest [%s] has %d docs",
+                                sourceIndexName,
+                                sourceCount,
+                                destIndexName,
+                                destCount
+                            );
+                        delegate2.onResponse(null);
                     }));
-                })
-            );
+                }));
+            }));
         } else {
             listener.onResponse(null);
         }


### PR DESCRIPTION
We need to pass the parent task id to the refresh request in reindex data streams so that it is cancellable.