### PR TITLE
Fix relocation targets in FieldCapabilitiesIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -215,8 +215,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncEnrichStopIT
   method: testEnrichAfterStop
   issue: https://github.com/elastic/elasticsearch/issues/120757
-- class: org.elasticsearch.search.fieldcaps.FieldCapabilitiesIT
-  issue: https://github.com/elastic/elasticsearch/issues/120772
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
   issue: https://github.com/elastic/elasticsearch/issues/120810


### PR DESCRIPTION
> [NO(a copy of this shard is already allocated to this node [[old_index][8], node[ZJUe-uOqSlacF9TFuAD7Zg], [R], recovery_source[peer recovery], s[INITIALIZING], a[id=QDYUE42mRQKKHDRI8KhRSQ], unassigned_info[[reason=INDEX_CREATED], at[2025-01-24T06:55:51.352Z], delayed=false, allocation_status[no_attempt]], failed_attempts[0]])]


The test failed because we tried to move a shard to a node that already has a copy. This change prevents that from happening.

Closes #119280
Closes #120772