### PR TITLE
[9.0] Wait for exchange source to complete before verifying results (#121603)

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -436,8 +436,8 @@ public class ExchangeServiceTests extends ESTestCase {
             exchangeSink
         );
         assertThat(actualSeqNos, equalTo(expectedSeqNos));
+        safeGet(sourceCompletionFuture);
         assertThat(completedSinks.get() + failedSinks.get(), equalTo(totalSinks.get()));
-        sourceCompletionFuture.actionGet();
         if (failedRequests.get() > 0) {
             assertThat(failedSinks.get(), greaterThan(0));
         } else {


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Wait for exchange source to complete before verifying results (#121603)