### PR TITLE
Fix ClusterRequestTests (#121570)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -269,9 +269,6 @@ tests:
 - class: org.elasticsearch.threadpool.SimpleThreadPoolIT
   method: testThreadPoolMetrics
   issue: https://github.com/elastic/elasticsearch/issues/108320
-- class: org.elasticsearch.xpack.esql.plugin.ClusterRequestTests
-  method: testFallbackIndicesOptions
-  issue: https://github.com/elastic/elasticsearch/issues/117937
 - class: org.elasticsearch.gradle.internal.info.BuildParameterExtensionSpec
   method: getBwcVersionsProvider is cached anc concurrently accessible
   issue: https://github.com/elastic/elasticsearch/issues/119172

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ClusterRequestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ClusterRequestTests.java
@@ -156,15 +156,14 @@ public class ClusterRequestTests extends AbstractWireSerializingTestCase<Cluster
 
     public void testFallbackIndicesOptions() throws Exception {
         ClusterComputeRequest request = createTestInstance();
-        var version = TransportVersionUtils.randomVersionBetween(
+        var oldVersion = TransportVersionUtils.randomVersionBetween(
             random(),
             TransportVersions.V_8_14_0,
             TransportVersionUtils.getPreviousVersion(TransportVersions.ESQL_ORIGINAL_INDICES)
         );
-        ClusterComputeRequest cloned = copyInstance(request, version);
+        ClusterComputeRequest cloned = copyInstance(request, oldVersion);
         assertThat(cloned.clusterAlias(), equalTo(request.clusterAlias()));
         assertThat(cloned.sessionId(), equalTo(request.sessionId()));
-        assertThat(cloned.configuration(), equalTo(request.configuration()));
         RemoteClusterPlan plan = cloned.remoteClusterPlan();
         assertThat(plan.plan(), equalTo(request.remoteClusterPlan().plan()));
         assertThat(plan.targetIndices(), equalTo(request.remoteClusterPlan().targetIndices()));


### PR DESCRIPTION
The upper bound of randomVersionBetween is inclusive; therefore, for testing the fallback version of the request, we need to use the version preceding 8.16.0 rather than 8.16.0 itself.

Closes #117937