### PR TITLE
Fix relocation targets in FieldCapabilitiesIT (#121606)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -362,9 +362,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set}
   issue: https://github.com/elastic/elasticsearch/issues/116777
-- class: org.elasticsearch.search.fieldcaps.FieldCapabilitiesIT
-  method: testRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/119280
 - class: org.elasticsearch.xpack.esql.action.EsqlNodeFailureIT
   method: testFailureLoadingFields
   issue: https://github.com/elastic/elasticsearch/issues/118000


### PR DESCRIPTION
The test failed because we tried to move a shard to a node that already has a copy. This change prevents that from happening.

Closes #119280
Closes #120772
