### PR TITLE
Remove `combineValueCount` from code generation

### DIFF
--- a/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Aggregator.java
+++ b/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Aggregator.java
@@ -37,11 +37,6 @@ import java.lang.annotation.Target;
  *     are ever collected.
  * </p>
  * <p>
- *     The generation code will also look for a method called {@code combineValueCount}
- *     which is called once per received block with a count of values. NOTE: We may
- *     not need this after we convert AVG into a composite operation.
- * </p>
- * <p>
  *     The generation code also looks for the optional methods {@code combineIntermediate}
  *     and {@code evaluateFinal} which are used to combine intermediate states and
  *     produce the final output. If the first is missing then the generated code will

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
@@ -78,7 +78,6 @@ public class AggregatorImplementer {
     private final List<TypeMirror> warnExceptions;
     private final ExecutableElement init;
     private final ExecutableElement combine;
-    private final ExecutableElement combineValueCount;
     private final ExecutableElement combineIntermediate;
     private final ExecutableElement evaluateFinal;
     private final ClassName implementation;
@@ -115,7 +114,6 @@ public class AggregatorImplementer {
             TypeName firstParamType = TypeName.get(e.getParameters().get(0).asType());
             return firstParamType.isPrimitive() || firstParamType.toString().equals(stateType.toString());
         });
-        this.combineValueCount = findMethod(declarationType, "combineValueCount");
         this.combineIntermediate = findMethod(declarationType, "combineIntermediate");
         this.evaluateFinal = findMethod(declarationType, "evaluateFinal");
         this.createParameters = init.getParameters()
@@ -415,9 +413,6 @@ public class AggregatorImplementer {
             combineRawInput(builder, "vector");
         }
         builder.endControlFlow();
-        if (combineValueCount != null) {
-            builder.addStatement("$T.combineValueCount(state, vector.getPositionCount())", declarationType);
-        }
         return builder.build();
     }
 
@@ -459,9 +454,6 @@ public class AggregatorImplementer {
             }
         }
         builder.endControlFlow();
-        if (combineValueCount != null) {
-            builder.addStatement("$T.combineValueCount(state, block.getTotalValueCount())", declarationType);
-        }
         return builder.build();
     }
 


### PR DESCRIPTION
`combineValueCount` is described as something that might no longer be needed and has zero actual usages. 
Removing it in order to simplify code generation.