### PR TITLE
[8.x] Remove feature flag check in BaseTransportInferenceAction and rely on Noop implementation (#121270)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/BaseTransportInferenceAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/BaseTransportInferenceAction.java
@@ -55,7 +55,6 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.inference.InferencePlugin.INFERENCE_API_FEATURE;
-import static org.elasticsearch.xpack.inference.common.InferenceAPIClusterAwareRateLimitingFeature.INFERENCE_API_CLUSTER_AWARE_RATE_LIMITING_FEATURE_FLAG;
 import static org.elasticsearch.xpack.inference.telemetry.InferenceStats.modelAttributes;
 import static org.elasticsearch.xpack.inference.telemetry.InferenceStats.responseAttributes;
 
@@ -188,10 +187,6 @@ public abstract class BaseTransportInferenceAction<Request extends BaseInference
     }
 
     private NodeRoutingDecision determineRouting(String serviceName, Request request, UnparsedModel unparsedModel) {
-        if (INFERENCE_API_CLUSTER_AWARE_RATE_LIMITING_FEATURE_FLAG.isEnabled() == false) {
-            return NodeRoutingDecision.handleLocally();
-        }
-
         var modelTaskType = unparsedModel.taskType();
 
         // Rerouting not supported or request was already rerouted


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Remove feature flag check in BaseTransportInferenceAction and rely on Noop implementation (#121270)](https://github.com/elastic/elasticsearch/pull/121270)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)