### PR TITLE
Migrate to v9 transport handshake

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -44,13 +44,13 @@ final class TransportHandshaker {
      * ignores the body of the request. After the handshake, the OutboundHandler uses the min(local,remote) protocol version for all later
      * messages.
      *
-     * This version supports two handshake protocols, v7170099 and v8800000, which respectively have the same message structure
-     * as the transport protocols of v7.17.0, and v8.18.0. This node only sends v8800000 requests, but it can send a valid response
-     * to any v7170099 requests that it receives.
+     * This version supports two handshake protocols, v7170099 and v8800000, which respectively have the same message structure as the
+     * transport protocols of v7.17.0, and v8.18.0. This node only sends v8800000 requests, but it can send a valid response to any v7170099
+     * requests that it receives.
      *
      * Note that these are not really TransportVersion constants as used elsewhere in ES, they're independent things that just happen to be
-     * stored in the same location in the message header and which roughly match the same ID numbering scheme. Older versions of ES did
-     * rely on them matching the real transport protocol (which itself matched the release version numbers), but these days that's no longer
+     * stored in the same location in the message header and which roughly match the same ID numbering scheme. Older versions of ES did rely
+     * on them matching the real transport protocol (which itself matched the release version numbers), but these days that's no longer
      * true.
      *
      * Here are some example messages, broken down to show their structure. See TransportHandshakerRawMessageTests for supporting tests.

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -44,9 +44,9 @@ final class TransportHandshaker {
      * ignores the body of the request. After the handshake, the OutboundHandler uses the min(local,remote) protocol version for all later
      * messages.
      *
-     * This version supports three handshake protocols, v6080099, v7170099 and v8800000, which respectively have the same message structure
-     * as the transport protocols of v6.8.0, v7.17.0, and v8.18.0. This node only sends v7170099 requests, but it can send a valid response
-     * to any v6080099 or v8800000 requests that it receives.
+     * This version supports two handshake protocols, v7170099 and v8800000, which respectively have the same message structure
+     * as the transport protocols of v7.17.0, and v8.18.0. This node only sends v8800000 requests, but it can send a valid response
+     * to any v7170099 requests that it receives.
      *
      * Note that these are not really TransportVersion constants as used elsewhere in ES, they're independent things that just happen to be
      * stored in the same location in the message header and which roughly match the same ID numbering scheme. Older versions of ES did
@@ -54,38 +54,6 @@ final class TransportHandshaker {
      * true.
      *
      * Here are some example messages, broken down to show their structure. See TransportHandshakerRawMessageTests for supporting tests.
-     *
-     * ## v6080099 Request:
-     *
-     * 45 53                            -- 'ES' marker
-     * 00 00 00 34                      -- total message length
-     *    00 00 00 00 00 00 00 01       -- request ID
-     *    08                            -- status flags (0b1000 == handshake request)
-     *    00 5c c6 63                   -- handshake protocol version (0x5cc663 == 6080099)
-     *    00                            -- no request headers [1]
-     *    00                            -- no response headers [1]
-     *    01                            -- one feature [2]
-     *       06                         -- feature name length
-     *          78 2d 70 61 63 6b       -- feature name 'x-pack'
-     *    16                            -- action string size
-     *       69 6e 74 65 72 6e 61 6c    }
-     *       3a 74 63 70 2f 68 61 6e    }- ASCII representation of HANDSHAKE_ACTION_NAME
-     *       64 73 68 61 6b 65          }
-     *    00                            -- no parent task ID [3]
-     *    04                            -- payload length
-     *       8b d5 b5 03                -- max acceptable protocol version (vInt: 00000011 10110101 11010101 10001011 == 7170699)
-     *
-     * ## v6080099 Response:
-     *
-     * 45 53                            -- 'ES' marker
-     * 00 00 00 13                      -- total message length
-     *    00 00 00 00 00 00 00 01       -- request ID (copied from request)
-     *    09                            -- status flags (0b1001 == handshake response)
-     *    00 5c c6 63                   -- handshake protocol version (0x5cc663 == 6080099, copied from request)
-     *    00                            -- no request headers [1]
-     *    00                            -- no response headers [1]
-     *    c3 f9 eb 03                   -- max acceptable protocol version (vInt: 00000011 11101011 11111001 11000011 == 8060099)
-     *
      *
      * ## v7170099 Requests:
      *
@@ -158,14 +126,9 @@ final class TransportHandshaker {
      * [3] Parent task ID should be empty; see org.elasticsearch.tasks.TaskId.writeTo for its structure.
      */
 
-    static final TransportVersion V7_HANDSHAKE_VERSION = TransportVersion.fromId(6_08_00_99);
     static final TransportVersion V8_HANDSHAKE_VERSION = TransportVersion.fromId(7_17_00_99);
     static final TransportVersion V9_HANDSHAKE_VERSION = TransportVersion.fromId(8_800_00_0);
-    static final Set<TransportVersion> ALLOWED_HANDSHAKE_VERSIONS = Set.of(
-        V7_HANDSHAKE_VERSION,
-        V8_HANDSHAKE_VERSION,
-        V9_HANDSHAKE_VERSION
-    );
+    static final Set<TransportVersion> ALLOWED_HANDSHAKE_VERSIONS = Set.of(V8_HANDSHAKE_VERSION, V9_HANDSHAKE_VERSION);
 
     static final String HANDSHAKE_ACTION_NAME = "internal:tcp/handshake";
     private final ConcurrentMap<Long, HandshakeResponseHandler> pendingHandshakes = new ConcurrentHashMap<>();
@@ -203,7 +166,7 @@ final class TransportHandshaker {
         );
         boolean success = false;
         try {
-            handshakeRequestSender.sendRequest(node, channel, requestId, V8_HANDSHAKE_VERSION);
+            handshakeRequestSender.sendRequest(node, channel, requestId, V9_HANDSHAKE_VERSION);
 
             threadPool.schedule(
                 () -> handler.handleLocalException(new ConnectTransportException(node, "handshake_timeout[" + timeout + "]")),

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.transport.InboundDecoder.ChannelType;
@@ -122,105 +121,6 @@ public class InboundDecoderTests extends ESTestCase {
             assertTrue(releasable2.hasReferences());
             assertTrue(releasable2.decRef());
             assertEquals(InboundDecoder.END_CONTENT, endMarker);
-        }
-
-    }
-
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA) // can delete test in v9
-    public void testDecodePreHeaderSizeVariableInt() throws IOException {
-        Compression.Scheme compressionScheme = randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.DEFLATE, null);
-        String action = "test-request";
-        long requestId = randomNonNegativeLong();
-        final TransportVersion preHeaderVariableInt = TransportHandshaker.V7_HANDSHAKE_VERSION;
-        final String contentValue = randomAlphaOfLength(100);
-        // 8.0 is only compatible with handshakes on a pre-variable int version
-        final OutboundMessage message = new OutboundMessage.Request(
-            threadContext,
-            new TestRequest(contentValue),
-            preHeaderVariableInt,
-            action,
-            requestId,
-            true,
-            compressionScheme
-        );
-
-        try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
-            final BytesReference totalBytes = message.serialize(os);
-            int partialHeaderSize = TcpHeader.headerSize(preHeaderVariableInt);
-
-            InboundDecoder decoder = new InboundDecoder(recycler);
-            final ArrayList<Object> fragments = new ArrayList<>();
-            final ReleasableBytesReference releasable1 = wrapAsReleasable(totalBytes);
-            int bytesConsumed = decoder.decode(releasable1, fragments::add);
-            assertEquals(partialHeaderSize, bytesConsumed);
-            assertTrue(releasable1.hasReferences());
-
-            final Header header = (Header) fragments.get(0);
-            assertEquals(requestId, header.getRequestId());
-            assertEquals(preHeaderVariableInt, header.getVersion());
-            if (compressionScheme == null) {
-                assertFalse(header.isCompressed());
-            } else {
-                assertTrue(header.isCompressed());
-            }
-            assertTrue(header.isHandshake());
-            assertTrue(header.isRequest());
-            assertTrue(header.needsToReadVariableHeader());
-            fragments.clear();
-
-            final BytesReference bytes2 = totalBytes.slice(bytesConsumed, totalBytes.length() - bytesConsumed);
-            final ReleasableBytesReference releasable2 = wrapAsReleasable(bytes2);
-            int bytesConsumed2 = decoder.decode(releasable2, fragments::add);
-            if (compressionScheme == null) {
-                assertEquals(2, fragments.size());
-            } else {
-                assertEquals(3, fragments.size());
-                final Object body = fragments.get(1);
-                assertThat(body, instanceOf(ReleasableBytesReference.class));
-                ((ReleasableBytesReference) body).close();
-            }
-            assertEquals(InboundDecoder.END_CONTENT, fragments.get(fragments.size() - 1));
-            assertEquals(totalBytes.length() - bytesConsumed, bytesConsumed2);
-        }
-    }
-
-    public void testDecodeHandshakeV7Compatibility() throws IOException {
-        String action = "test-request";
-        long requestId = randomNonNegativeLong();
-        final String headerKey = randomAlphaOfLength(10);
-        final String headerValue = randomAlphaOfLength(20);
-        threadContext.putHeader(headerKey, headerValue);
-        TransportVersion handshakeCompat = TransportHandshaker.V7_HANDSHAKE_VERSION;
-        OutboundMessage message = new OutboundMessage.Request(
-            threadContext,
-            new TestRequest(randomAlphaOfLength(100)),
-            handshakeCompat,
-            action,
-            requestId,
-            true,
-            null
-        );
-
-        try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
-            final BytesReference bytes = message.serialize(os);
-            int totalHeaderSize = TcpHeader.headerSize(handshakeCompat);
-
-            InboundDecoder decoder = new InboundDecoder(recycler);
-            final ArrayList<Object> fragments = new ArrayList<>();
-            final ReleasableBytesReference releasable1 = wrapAsReleasable(bytes);
-            int bytesConsumed = decoder.decode(releasable1, fragments::add);
-            assertEquals(totalHeaderSize, bytesConsumed);
-            assertTrue(releasable1.hasReferences());
-
-            final Header header = (Header) fragments.get(0);
-            assertEquals(requestId, header.getRequestId());
-            assertEquals(handshakeCompat, header.getVersion());
-            assertFalse(header.isCompressed());
-            assertTrue(header.isHandshake());
-            assertTrue(header.isRequest());
-            // TODO: On 9.0 this will be true because all compatible versions with contain the variable header int
-            assertTrue(header.needsToReadVariableHeader());
-            fragments.clear();
         }
 
     }
@@ -451,46 +351,6 @@ public class InboundDecoderTests extends ESTestCase {
             assertEquals(InboundDecoder.END_CONTENT, endMarker);
         }
 
-    }
-
-    public void testCompressedDecodeHandshakeCompatibility() throws IOException {
-        String action = "test-request";
-        long requestId = randomNonNegativeLong();
-        final String headerKey = randomAlphaOfLength(10);
-        final String headerValue = randomAlphaOfLength(20);
-        threadContext.putHeader(headerKey, headerValue);
-        TransportVersion handshakeCompat = TransportHandshaker.V7_HANDSHAKE_VERSION;
-        OutboundMessage message = new OutboundMessage.Request(
-            threadContext,
-            new TestRequest(randomAlphaOfLength(100)),
-            handshakeCompat,
-            action,
-            requestId,
-            true,
-            Compression.Scheme.DEFLATE
-        );
-
-        try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
-            final BytesReference bytes = message.serialize(os);
-            int totalHeaderSize = TcpHeader.headerSize(handshakeCompat);
-
-            InboundDecoder decoder = new InboundDecoder(recycler);
-            final ArrayList<Object> fragments = new ArrayList<>();
-            final ReleasableBytesReference releasable1 = wrapAsReleasable(bytes);
-            int bytesConsumed = decoder.decode(releasable1, fragments::add);
-            assertEquals(totalHeaderSize, bytesConsumed);
-            assertTrue(releasable1.hasReferences());
-
-            final Header header = (Header) fragments.get(0);
-            assertEquals(requestId, header.getRequestId());
-            assertEquals(handshakeCompat, header.getVersion());
-            assertTrue(header.isCompressed());
-            assertTrue(header.isHandshake());
-            assertTrue(header.isRequest());
-            // TODO: On 9.0 this will be true because all compatible versions with contain the variable header int
-            assertTrue(header.needsToReadVariableHeader());
-            fragments.clear();
-        }
     }
 
     public void testVersionIncompatibilityDecodeException() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2758,8 +2758,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportStats transportStats = serviceC.transport.getStats(); // we did a single round-trip to do the initial handshake
                 assertEquals(1, transportStats.getRxCount());
                 assertEquals(1, transportStats.getTxCount());
-                assertEquals(29, transportStats.getRxSize().getBytes());
-                assertEquals(55, transportStats.getTxSize().getBytes());
+                assertEquals(35, transportStats.getRxSize().getBytes());
+                assertEquals(60, transportStats.getTxSize().getBytes());
             });
             serviceC.sendRequest(
                 connection,
@@ -2773,16 +2773,16 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportStats transportStats = serviceC.transport.getStats(); // request has been send
                 assertEquals(1, transportStats.getRxCount());
                 assertEquals(2, transportStats.getTxCount());
-                assertEquals(29, transportStats.getRxSize().getBytes());
-                assertEquals(114, transportStats.getTxSize().getBytes());
+                assertEquals(35, transportStats.getRxSize().getBytes());
+                assertEquals(119, transportStats.getTxSize().getBytes());
             });
             sendResponseLatch.countDown();
             responseLatch.await();
             stats = serviceC.transport.getStats(); // response has been received
             assertEquals(2, stats.getRxCount());
             assertEquals(2, stats.getTxCount());
-            assertEquals(54, stats.getRxSize().getBytes());
-            assertEquals(114, stats.getTxSize().getBytes());
+            assertEquals(60, stats.getRxSize().getBytes());
+            assertEquals(119, stats.getTxSize().getBytes());
         } finally {
             serviceC.close();
         }
@@ -2873,8 +2873,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportStats transportStats = serviceC.transport.getStats(); // request has been sent
                 assertEquals(1, transportStats.getRxCount());
                 assertEquals(1, transportStats.getTxCount());
-                assertEquals(29, transportStats.getRxSize().getBytes());
-                assertEquals(55, transportStats.getTxSize().getBytes());
+                assertEquals(35, transportStats.getRxSize().getBytes());
+                assertEquals(60, transportStats.getTxSize().getBytes());
             });
             serviceC.sendRequest(
                 connection,
@@ -2888,8 +2888,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportStats transportStats = serviceC.transport.getStats(); // request has been sent
                 assertEquals(1, transportStats.getRxCount());
                 assertEquals(2, transportStats.getTxCount());
-                assertEquals(29, transportStats.getRxSize().getBytes());
-                assertEquals(114, transportStats.getTxSize().getBytes());
+                assertEquals(35, transportStats.getRxSize().getBytes());
+                assertEquals(119, transportStats.getTxSize().getBytes());
             });
             sendResponseLatch.countDown();
             responseLatch.await();
@@ -2904,8 +2904,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             String failedMessage = "Unexpected read bytes size. The transport exception that was received=" + exception;
             // 57 bytes are the non-exception message bytes that have been received. It should include the initial
             // handshake message and the header, version, etc bytes in the exception message.
-            assertEquals(failedMessage, 57 + streamOutput.bytes().length(), stats.getRxSize().getBytes());
-            assertEquals(114, stats.getTxSize().getBytes());
+            assertEquals(failedMessage, 63 + streamOutput.bytes().length(), stats.getRxSize().getBytes());
+            assertEquals(119, stats.getTxSize().getBytes());
         } finally {
             serviceC.close();
         }


### PR DESCRIPTION
This commit moves to sending out a v9-format handshake (with apparent
transport version `8_800_00_0`) and drops support for handshakes from v7
nodes.