### PR TITLE
Enable a doc values sparse index on the timestamp field

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -134,6 +134,7 @@ public class IndexVersions {
     public static final IndexVersion UPGRADE_TO_LUCENE_9_12_1 = def(8_523_0_00, parseUnchecked("9.12.1"));
     public static final IndexVersion INFERENCE_METADATA_FIELDS_BACKPORT = def(8_524_0_00, parseUnchecked("9.12.1"));
     public static final IndexVersion LOGSB_OPTIONAL_SORTING_ON_HOST_NAME_BACKPORT = def(8_525_0_00, parseUnchecked("9.12.1"));
+    public static final IndexVersion TIMESTAMP_DOC_VALUES_SPARSE_INDEX_BACKPORT = def(8_526_0_00, parseUnchecked("9.12.1"));
     public static final IndexVersion UPGRADE_TO_LUCENE_10_0_0 = def(9_000_0_00, Version.LUCENE_10_0_0);
     public static final IndexVersion LOGSDB_DEFAULT_IGNORE_DYNAMIC_BEYOND_LIMIT = def(9_001_0_00, Version.LUCENE_10_0_0);
     public static final IndexVersion TIME_BASED_K_ORDERED_DOC_ID = def(9_002_0_00, Version.LUCENE_10_0_0);
@@ -144,6 +145,7 @@ public class IndexVersions {
     public static final IndexVersion SOURCE_MAPPER_MODE_ATTRIBUTE_NOOP = def(9_007_0_00, Version.LUCENE_10_0_0);
     public static final IndexVersion HOSTNAME_DOC_VALUES_SPARSE_INDEX = def(9_008_0_00, Version.LUCENE_10_0_0);
     public static final IndexVersion UPGRADE_TO_LUCENE_10_1_0 = def(9_009_0_00, Version.LUCENE_10_1_0);
+    public static final IndexVersion TIMESTAMP_DOC_VALUES_SPARSE_INDEX = def(9_010_0_00, Version.LUCENE_10_1_0);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -402,7 +402,9 @@ final class DynamicFieldsBuilder {
                     dateTimeFormatter,
                     ScriptCompiler.NONE,
                     ignoreMalformed,
-                    context.indexSettings().getIndexVersionCreated()
+                    context.indexSettings().getIndexVersionCreated(),
+                    context.indexSettings().getMode(),
+                    context.indexSettings().getIndexSortConfig()
                 ),
                 context
             );

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
@@ -63,6 +63,7 @@ public class ExtendedStatsAggregatorTests extends AggregatorTestCase {
             true,
             false,
             true,
+            false,
             DateFormatter.forPattern("epoch_millis"),
             DateFieldMapper.Resolution.MILLISECONDS,
             null,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
@@ -83,6 +83,7 @@ public class StatsAggregatorTests extends AggregatorTestCase {
             true,
             false,
             true,
+            false,
             DateFormatter.forPattern("epoch_millis"),
             DateFieldMapper.Resolution.MILLISECONDS,
             null,

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -720,6 +720,17 @@ public final class DataStreamTestHelper {
         Map<String, Object> fieldsMapping = new HashMap<>();
         fieldsMapping.put("enabled", true);
         MappingParserContext mockedParserContext = mock(MappingParserContext.class);
+        when(mockedParserContext.getIndexSettings()).thenReturn(
+            new IndexSettings(
+                IndexMetadata.builder("_na_")
+                    .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()))
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .creationDate(System.currentTimeMillis())
+                    .build(),
+                Settings.EMPTY
+            )
+        );
         return DataStreamTimestampFieldMapper.PARSER.parse("field", fieldsMapping, mockedParserContext).build();
     }
 


### PR DESCRIPTION
This PR introduces support for a sparse doc values index for the `@timestamp` field in `DateFieldMapper` when specific conditions are met:

* The index mode is set to LOGSDB.
* The field name is `@timestamp` and mapped as a date field.
* The field is included in the primary sort configuration.
* The field has doc values and indexing is not disabled explicitly (not `index: false`).

When all the conditions above hold true, we:
* We use the corresponding Sorted Set doc values format with indexing enabled (DocValuesSkipIndexType.RANGE is used in Lucene as the only available sparse index at the moment).
* Disable indexing of the `@timestamp` field, dropping the inverted index in favor of the sparse doc values index.

Some queries might experience slower performance as a result of using a doc values sparse index instead of an inverted index.

Disabling the inverted index on the `@timestamp` field while enabling the sparse doc values index is expected to:

* Reduce the storage footprint depending on the size of the inverted index relative to the sparse index.
* Improve indexing throughput by reducing the amount of data written during segment flushes.
