### PR TITLE
[9.0] [Inference API] Fix node local rate limit calculator tests for non-snapshot builds (#121527)

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/InferenceServiceNodeLocalRateLimitCalculatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/InferenceServiceNodeLocalRateLimitCalculatorTests.java
@@ -33,6 +33,11 @@ public class InferenceServiceNodeLocalRateLimitCalculatorTests extends ESIntegTe
 
     public void setUp() throws Exception {
         super.setUp();
+        assumeTrue(
+            "If inference_cluster_aware_rate_limiting_feature_flag_enabled=false we'll fallback to "
+                + "NoopNodeLocalRateLimitCalculator, which shouldn't be tested by this class.",
+            InferenceAPIClusterAwareRateLimitingFeature.INFERENCE_API_CLUSTER_AWARE_RATE_LIMITING_FEATURE_FLAG.isEnabled()
+        );
     }
 
     public void testInitialClusterGrouping_Correct() throws Exception {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Inference API] Fix node local rate limit calculator tests for non-snapshot builds (#121527)](https://github.com/elastic/elasticsearch/pull/121527)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)