### PR TITLE
Fix SearchResponse leak in CrossClusterSearchUnavailableClusterIT

### DIFF
--- a/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
+++ b/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
@@ -101,8 +101,8 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
                 TransportSearchAction.TYPE.name(),
                 EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 SearchRequest::new,
-                (request, channel, task) -> channel.sendResponse(
-                    new SearchResponse(
+                (request, channel, task) -> {
+                    var searchResponse = new SearchResponse(
                         SearchHits.empty(new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN),
                         InternalAggregations.EMPTY,
                         null,
@@ -117,8 +117,13 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
                         100,
                         ShardSearchFailure.EMPTY_ARRAY,
                         SearchResponse.Clusters.EMPTY
-                    )
-                )
+                    );
+                    try {
+                        channel.sendResponse(searchResponse);
+                    } finally {
+                        searchResponse.decRef();
+                    }
+                }
             );
             newService.registerRequestHandler(
                 ClusterStateAction.NAME,


### PR DESCRIPTION
Fixing an obvious leak where we fail to count down 1 for a new search response.

closes https://github.com/elastic/elasticsearch/issues/121497