### PR TITLE
[9.0] Fix rare failures in YAML xContent roundtrip tests (#121515)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
@@ -145,8 +145,21 @@ public abstract class AbstractXContentTestCase<T extends ToXContent> extends EST
         public void test() throws IOException {
             for (int runs = 0; runs < numberOfTestRuns; runs++) {
                 XContentType xContentType = randomFrom(XContentType.values()).canonical();
-                T testInstance = instanceSupplier.apply(xContentType);
+                T testInstance = null;
                 try {
+                    if (xContentType.equals(XContentType.YAML)) {
+                        testInstance = randomValueOtherThanMany(instance -> {
+                            // unicode character U+0085 (NEXT LINE (NEL)) doesn't survive YAML round trip tests (see #97716)
+                            // get a new random instance if we detect this character in the xContent output
+                            try {
+                                return toXContent.apply(instance, xContentType).utf8ToString().contains("\u0085");
+                            } catch (IOException e) {
+                                throw new AssertionError(e);
+                            }
+                        }, () -> instanceSupplier.apply(xContentType));
+                    } else {
+                        testInstance = instanceSupplier.apply(xContentType);
+                    }
                     BytesReference originalXContent = toXContent.apply(testInstance, xContentType);
                     BytesReference shuffledContent = insertRandomFieldsAndShuffle(
                         originalXContent,
@@ -173,7 +186,9 @@ public abstract class AbstractXContentTestCase<T extends ToXContent> extends EST
                         dispose.accept(parsed);
                     }
                 } finally {
-                    dispose.accept(testInstance);
+                    if (testInstance != null) {
+                        dispose.accept(testInstance);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Fix rare failures in YAML xContent roundtrip tests (#121515)