### PR TITLE
[8.18] Rename AggregateDoubleMetric to *MetricDouble (#121254)

### DIFF
--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AggregateMetricFieldValueFetcher.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AggregateMetricFieldValueFetcher.java
@@ -10,18 +10,18 @@ package org.elasticsearch.xpack.downsample;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType;
 
 public final class AggregateMetricFieldValueFetcher extends FieldValueFetcher {
 
-    private final AggregateDoubleMetricFieldType aggMetricFieldType;
+    private final AggregateMetricDoubleFieldType aggMetricFieldType;
 
     private final AbstractDownsampleFieldProducer fieldProducer;
 
     AggregateMetricFieldValueFetcher(
         MappedFieldType fieldType,
-        AggregateDoubleMetricFieldType aggMetricFieldType,
+        AggregateMetricDoubleFieldType aggMetricFieldType,
         IndexFieldData<?> fieldData
     ) {
         super(fieldType.name(), fieldType, fieldData);
@@ -34,7 +34,7 @@ public final class AggregateMetricFieldValueFetcher extends FieldValueFetcher {
     }
 
     private AbstractDownsampleFieldProducer createFieldProducer() {
-        AggregateDoubleMetricFieldMapper.Metric metric = null;
+        AggregateMetricDoubleFieldMapper.Metric metric = null;
         for (var e : aggMetricFieldType.getMetricFields().entrySet()) {
             NumberFieldMapper.NumberFieldType metricSubField = e.getValue();
             if (metricSubField.name().equals(name())) {
@@ -52,7 +52,7 @@ public final class AggregateMetricFieldValueFetcher extends FieldValueFetcher {
                 case min -> new MetricFieldProducer.Min();
                 case sum -> new MetricFieldProducer.Sum();
                 // To compute value_count summary, we must sum all field values
-                case value_count -> new MetricFieldProducer.Sum(AggregateDoubleMetricFieldMapper.Metric.value_count.name());
+                case value_count -> new MetricFieldProducer.Sum(AggregateMetricDoubleFieldMapper.Metric.value_count.name());
             };
             return new MetricFieldProducer.GaugeMetricFieldProducer(aggMetricFieldType.name(), metricOperation);
         } else {

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
@@ -15,7 +15,7 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -82,7 +82,7 @@ class FieldValueFetcher {
             MappedFieldType fieldType = context.getFieldType(field);
             assert fieldType != null : "Unknown field type for field: [" + field + "]";
 
-            if (fieldType instanceof AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType aggMetricFieldType) {
+            if (fieldType instanceof AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType aggMetricFieldType) {
                 // If the field is an aggregate_metric_double field, we should load all its subfields
                 // This is a downsample-of-downsample case
                 for (NumberFieldMapper.NumberFieldType metricSubField : aggMetricFieldType.getMetricFields().values()) {

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/LabelFieldProducer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/LabelFieldProducer.java
@@ -12,7 +12,7 @@ import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.HistogramValue;
 import org.elasticsearch.index.mapper.flattened.FlattenedFieldSyntheticWriterHelper;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -76,7 +76,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.downsample.DownsampleShardPersistentTaskState;
 import org.elasticsearch.xpack.core.downsample.DownsampleShardTask;
@@ -755,9 +755,9 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
             final String[] supportedAggsArray = metricType.supportedAggs();
             // We choose max as the default metric
             final String defaultMetric = List.of(supportedAggsArray).contains("max") ? "max" : supportedAggsArray[0];
-            builder.field("type", AggregateDoubleMetricFieldMapper.CONTENT_TYPE)
-                .array(AggregateDoubleMetricFieldMapper.Names.METRICS, supportedAggsArray)
-                .field(AggregateDoubleMetricFieldMapper.Names.DEFAULT_METRIC, defaultMetric)
+            builder.field("type", AggregateMetricDoubleFieldMapper.CONTENT_TYPE)
+                .array(AggregateMetricDoubleFieldMapper.Names.METRICS, supportedAggsArray)
+                .field(AggregateMetricDoubleFieldMapper.Names.DEFAULT_METRIC, defaultMetric)
                 .field(TIME_SERIES_METRIC_PARAM, metricType);
         }
         builder.endObject();

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/AggregateMetricMapperPlugin.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/AggregateMetricMapperPlugin.java
@@ -17,7 +17,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.metrics.AggregateMetricsAggregatorsRegistrar;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 
@@ -32,7 +32,7 @@ public class AggregateMetricMapperPlugin extends Plugin implements MapperPlugin,
 
     @Override
     public Map<String, Mapper.TypeParser> getMappers() {
-        return singletonMap(AggregateDoubleMetricFieldMapper.CONTENT_TYPE, AggregateDoubleMetricFieldMapper.PARSER);
+        return singletonMap(AggregateMetricDoubleFieldMapper.CONTENT_TYPE, AggregateMetricDoubleFieldMapper.PARSER);
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedAvgAggregator.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedAvgAggregator.java
@@ -24,14 +24,14 @@ import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.support.AggregateMetricsValuesSource;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.Map;
 
 class AggregateMetricBackedAvgAggregator extends NumericMetricsAggregator.SingleValue {
 
-    final AggregateMetricsValuesSource.AggregateDoubleMetric valuesSource;
+    final AggregateMetricsValuesSource.AggregateMetricDouble valuesSource;
 
     LongArray counts;
     DoubleArray sums;
@@ -47,7 +47,7 @@ class AggregateMetricBackedAvgAggregator extends NumericMetricsAggregator.Single
     ) throws IOException {
         super(name, context, parent, metadata);
         assert valuesSourceConfig.hasValues();
-        this.valuesSource = (AggregateMetricsValuesSource.AggregateDoubleMetric) valuesSourceConfig.getValuesSource();
+        this.valuesSource = (AggregateMetricsValuesSource.AggregateMetricDouble) valuesSourceConfig.getValuesSource();
         final BigArrays bigArrays = context.bigArrays();
         counts = bigArrays.newLongArray(1, true);
         sums = bigArrays.newDoubleArray(1, true);

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMaxAggregator.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMaxAggregator.java
@@ -24,14 +24,14 @@ import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.support.AggregateMetricsValuesSource;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.Map;
 
 class AggregateMetricBackedMaxAggregator extends NumericMetricsAggregator.SingleValue {
 
-    private final AggregateMetricsValuesSource.AggregateDoubleMetric valuesSource;
+    private final AggregateMetricsValuesSource.AggregateMetricDouble valuesSource;
     final DocValueFormat formatter;
     DoubleArray maxes;
 
@@ -44,7 +44,7 @@ class AggregateMetricBackedMaxAggregator extends NumericMetricsAggregator.Single
     ) throws IOException {
         super(name, context, parent, metadata);
         assert config.hasValues();
-        this.valuesSource = (AggregateMetricsValuesSource.AggregateDoubleMetric) config.getValuesSource();
+        this.valuesSource = (AggregateMetricsValuesSource.AggregateMetricDouble) config.getValuesSource();
         maxes = context.bigArrays().newDoubleArray(1, false);
         maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
         this.formatter = config.format();

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMinAggregator.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMinAggregator.java
@@ -24,14 +24,14 @@ import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.support.AggregateMetricsValuesSource;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.Map;
 
 class AggregateMetricBackedMinAggregator extends NumericMetricsAggregator.SingleValue {
 
-    private final AggregateMetricsValuesSource.AggregateDoubleMetric valuesSource;
+    private final AggregateMetricsValuesSource.AggregateMetricDouble valuesSource;
     final DocValueFormat format;
     DoubleArray mins;
 
@@ -44,7 +44,7 @@ class AggregateMetricBackedMinAggregator extends NumericMetricsAggregator.Single
     ) throws IOException {
         super(name, context, parent, metadata);
         assert config.hasValues();
-        this.valuesSource = (AggregateMetricsValuesSource.AggregateDoubleMetric) config.getValuesSource();
+        this.valuesSource = (AggregateMetricsValuesSource.AggregateMetricDouble) config.getValuesSource();
         mins = context.bigArrays().newDoubleArray(1, false);
         mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
         this.format = config.format();

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedSumAggregator.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedSumAggregator.java
@@ -23,14 +23,14 @@ import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.support.AggregateMetricsValuesSource;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.Map;
 
 class AggregateMetricBackedSumAggregator extends NumericMetricsAggregator.SingleValue {
 
-    private final AggregateMetricsValuesSource.AggregateDoubleMetric valuesSource;
+    private final AggregateMetricsValuesSource.AggregateMetricDouble valuesSource;
     private final DocValueFormat format;
 
     private DoubleArray sums;
@@ -45,7 +45,7 @@ class AggregateMetricBackedSumAggregator extends NumericMetricsAggregator.Single
     ) throws IOException {
         super(name, context, parent, metadata);
         assert valuesSourceConfig.hasValues();
-        this.valuesSource = (AggregateMetricsValuesSource.AggregateDoubleMetric) valuesSourceConfig.getValuesSource();
+        this.valuesSource = (AggregateMetricsValuesSource.AggregateMetricDouble) valuesSourceConfig.getValuesSource();
         sums = context.bigArrays().newDoubleArray(1, true);
         compensations = context.bigArrays().newDoubleArray(1, true);
         this.format = valuesSourceConfig.format();

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedValueCountAggregator.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedValueCountAggregator.java
@@ -20,7 +20,7 @@ import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.support.AggregateMetricsValuesSource;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper;
 
 import java.io.IOException;
 import java.util.Map;
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 class AggregateMetricBackedValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
-    private final AggregateMetricsValuesSource.AggregateDoubleMetric valuesSource;
+    private final AggregateMetricsValuesSource.AggregateMetricDouble valuesSource;
 
     // a count per bucket
     LongArray counts;
@@ -46,7 +46,7 @@ class AggregateMetricBackedValueCountAggregator extends NumericMetricsAggregator
     ) throws IOException {
         super(name, aggregationContext, parent, metadata);
         assert valuesSourceConfig.hasValues();
-        this.valuesSource = (AggregateMetricsValuesSource.AggregateDoubleMetric) valuesSourceConfig.getValuesSource();
+        this.valuesSource = (AggregateMetricsValuesSource.AggregateMetricDouble) valuesSourceConfig.getValuesSource();
         counts = bigArrays().newLongArray(1, true);
     }
 
@@ -55,7 +55,7 @@ class AggregateMetricBackedValueCountAggregator extends NumericMetricsAggregator
         final BigArrays bigArrays = bigArrays();
         final SortedNumericDoubleValues values = valuesSource.getAggregateMetricValues(
             aggCtx.getLeafReaderContext(),
-            AggregateDoubleMetricFieldMapper.Metric.value_count
+            AggregateMetricDoubleFieldMapper.Metric.value_count
         );
 
         return new LeafBucketCollectorBase(sub, values) {

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/support/AggregateMetricsValuesSource.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/support/AggregateMetricsValuesSource.java
@@ -13,23 +13,23 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.aggregations.AggregationErrors;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.xpack.aggregatemetric.fielddata.IndexAggregateDoubleMetricFieldData;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.fielddata.IndexAggregateMetricDoubleFieldData;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.function.Function;
 
 public class AggregateMetricsValuesSource {
-    public abstract static class AggregateDoubleMetric extends org.elasticsearch.search.aggregations.support.ValuesSource {
+    public abstract static class AggregateMetricDouble extends org.elasticsearch.search.aggregations.support.ValuesSource {
 
         public abstract SortedNumericDoubleValues getAggregateMetricValues(LeafReaderContext context, Metric metric) throws IOException;
 
-        public static class Fielddata extends AggregateDoubleMetric {
+        public static class Fielddata extends AggregateMetricDouble {
 
-            protected final IndexAggregateDoubleMetricFieldData indexFieldData;
+            protected final IndexAggregateMetricDoubleFieldData indexFieldData;
 
-            public Fielddata(IndexAggregateDoubleMetricFieldData indexFieldData) {
+            public Fielddata(IndexAggregateMetricDoubleFieldData indexFieldData) {
                 this.indexFieldData = indexFieldData;
             }
 
@@ -51,7 +51,7 @@ public class AggregateMetricsValuesSource {
 
             @Override
             protected Function<Rounding, Rounding.Prepared> roundingPreparer(AggregationContext context) throws IOException {
-                throw AggregationErrors.unsupportedRounding(AggregateDoubleMetricFieldMapper.CONTENT_TYPE);
+                throw AggregationErrors.unsupportedRounding(AggregateMetricDoubleFieldMapper.CONTENT_TYPE);
             }
 
             public SortedNumericDoubleValues getAggregateMetricValues(LeafReaderContext context, Metric metric) throws IOException {

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/support/AggregateMetricsValuesSourceType.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/support/AggregateMetricsValuesSourceType.java
@@ -15,7 +15,7 @@ import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
-import org.elasticsearch.xpack.aggregatemetric.fielddata.IndexAggregateDoubleMetricFieldData;
+import org.elasticsearch.xpack.aggregatemetric.fielddata.IndexAggregateMetricDoubleFieldData;
 
 import java.util.Locale;
 import java.util.function.LongSupplier;
@@ -43,7 +43,7 @@ public enum AggregateMetricsValuesSourceType implements ValuesSourceType {
         public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
             final IndexFieldData<?> indexFieldData = fieldContext.indexFieldData();
 
-            if ((indexFieldData instanceof IndexAggregateDoubleMetricFieldData) == false) {
+            if ((indexFieldData instanceof IndexAggregateMetricDoubleFieldData) == false) {
                 throw new IllegalArgumentException(
                     "Expected aggregate_metric_double type on field ["
                         + fieldContext.field()
@@ -52,7 +52,7 @@ public enum AggregateMetricsValuesSourceType implements ValuesSourceType {
                         + "]"
                 );
             }
-            return new AggregateMetricsValuesSource.AggregateDoubleMetric.Fielddata((IndexAggregateDoubleMetricFieldData) indexFieldData);
+            return new AggregateMetricsValuesSource.AggregateMetricDouble.Fielddata((IndexAggregateMetricDoubleFieldData) indexFieldData);
         }
 
         @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/fielddata/IndexAggregateMetricDoubleFieldData.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/fielddata/IndexAggregateMetricDoubleFieldData.java
@@ -13,12 +13,12 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 /**
  * Specialization of {@link IndexFieldData} for aggregate_metric.
  */
-public abstract class IndexAggregateDoubleMetricFieldData implements IndexFieldData<LeafAggregateDoubleMetricFieldData> {
+public abstract class IndexAggregateMetricDoubleFieldData implements IndexFieldData<LeafAggregateMetricDoubleFieldData> {
 
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
 
-    public IndexAggregateDoubleMetricFieldData(String fieldName, ValuesSourceType valuesSourceType) {
+    public IndexAggregateMetricDoubleFieldData(String fieldName, ValuesSourceType valuesSourceType) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
     }

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/fielddata/LeafAggregateMetricDoubleFieldData.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/fielddata/LeafAggregateMetricDoubleFieldData.java
@@ -8,12 +8,12 @@ package org.elasticsearch.xpack.aggregatemetric.fielddata;
 
 import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 /**
- * {@link LeafFieldData} specialization for aggregate_double_metric data.
+ * {@link LeafFieldData} specialization for aggregate_metric_double data.
  */
-public interface LeafAggregateDoubleMetricFieldData extends LeafFieldData {
+public interface LeafAggregateMetricDoubleFieldData extends LeafFieldData {
 
     /**
      * Return aggregate_metric of double values for a given metric

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
@@ -59,8 +59,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentSubParser;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.support.AggregateMetricsValuesSourceType;
-import org.elasticsearch.xpack.aggregatemetric.fielddata.IndexAggregateDoubleMetricFieldData;
-import org.elasticsearch.xpack.aggregatemetric.fielddata.LeafAggregateDoubleMetricFieldData;
+import org.elasticsearch.xpack.aggregatemetric.fielddata.IndexAggregateMetricDoubleFieldData;
+import org.elasticsearch.xpack.aggregatemetric.fielddata.LeafAggregateMetricDoubleFieldData;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -78,15 +78,15 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /** A {@link FieldMapper} for a field containing aggregate metrics such as min/max/value_count etc. */
-public class AggregateDoubleMetricFieldMapper extends FieldMapper {
+public class AggregateMetricDoubleFieldMapper extends FieldMapper {
 
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(AggregateDoubleMetricFieldMapper.class);
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(AggregateMetricDoubleFieldMapper.class);
 
     public static final String CONTENT_TYPE = "aggregate_metric_double";
     public static final String SUBFIELD_SEPARATOR = ".";
 
-    private static AggregateDoubleMetricFieldMapper toType(FieldMapper in) {
-        return (AggregateDoubleMetricFieldMapper) in;
+    private static AggregateMetricDoubleFieldMapper toType(FieldMapper in) {
+        return (AggregateMetricDoubleFieldMapper) in;
     }
 
     /**
@@ -97,7 +97,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
      * @return the name of the subfield
      */
     public static String subfieldName(String fieldName, Metric metric) {
-        return fieldName + AggregateDoubleMetricFieldMapper.SUBFIELD_SEPARATOR + metric.name();
+        return fieldName + AggregateMetricDoubleFieldMapper.SUBFIELD_SEPARATOR + metric.name();
     }
 
     /**
@@ -150,7 +150,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
 
         /**
          * Parameter that marks this field as a time series metric defining its time series metric type.
-         * For {@link AggregateDoubleMetricFieldMapper} fields gauge, counter and summary metric types are
+         * For {@link AggregateMetricDoubleFieldMapper} fields gauge, counter and summary metric types are
          * supported.
          */
         private final Parameter<MetricType> timeSeriesMetric;
@@ -194,7 +194,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         }
 
         @Override
-        public AggregateDoubleMetricFieldMapper build(MapperBuilderContext context) {
+        public AggregateMetricDoubleFieldMapper build(MapperBuilderContext context) {
             if (multiFieldsBuilder.hasMultiFields()) {
                 DEPRECATION_LOGGER.warn(
                     DeprecationCategory.MAPPINGS,
@@ -261,7 +261,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
                     throw new IllegalArgumentException("Duplicate keys " + l + "and " + r + ".");
                 }, () -> new EnumMap<>(Metric.class)));
 
-            AggregateDoubleMetricFieldType metricFieldType = new AggregateDoubleMetricFieldType(
+            AggregateMetricDoubleFieldType metricFieldType = new AggregateMetricDoubleFieldType(
                 context.buildFullName(leafName()),
                 meta.getValue(),
                 timeSeriesMetric.getValue()
@@ -269,7 +269,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
             metricFieldType.setMetricFields(metricFields);
             metricFieldType.setDefaultMetric(defaultMetric.getValue());
 
-            return new AggregateDoubleMetricFieldMapper(leafName(), metricFieldType, metricMappers, builderParams(this, context), this);
+            return new AggregateMetricDoubleFieldMapper(leafName(), metricFieldType, metricMappers, builderParams(this, context), this);
         }
     }
 
@@ -278,7 +278,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         notInMultiFields(CONTENT_TYPE)
     );
 
-    public static final class AggregateDoubleMetricFieldType extends SimpleMappedFieldType {
+    public static final class AggregateMetricDoubleFieldType extends SimpleMappedFieldType {
 
         private EnumMap<Metric, NumberFieldMapper.NumberFieldType> metricFields;
 
@@ -286,11 +286,11 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
 
         private final MetricType metricType;
 
-        public AggregateDoubleMetricFieldType(String name) {
+        public AggregateMetricDoubleFieldType(String name) {
             this(name, Collections.emptyMap(), null);
         }
 
-        public AggregateDoubleMetricFieldType(String name, Map<String, String> meta, MetricType metricType) {
+        public AggregateMetricDoubleFieldType(String name, Map<String, String> meta, MetricType metricType) {
             super(name, true, false, true, TextSearchInfo.SIMPLE_MATCH_WITHOUT_TERMS, meta);
             this.metricType = metricType;
         }
@@ -326,7 +326,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
 
         public void addMetricField(Metric m, NumberFieldMapper.NumberFieldType subfield) {
             if (metricFields == null) {
-                metricFields = new EnumMap<>(AggregateDoubleMetricFieldMapper.Metric.class);
+                metricFields = new EnumMap<>(AggregateMetricDoubleFieldMapper.Metric.class);
             }
 
             if (name() == null) {
@@ -408,13 +408,13 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
 
         @Override
         public IndexFieldData.Builder fielddataBuilder(FieldDataContext fieldDataContext) {
-            return (cache, breakerService) -> new IndexAggregateDoubleMetricFieldData(
+            return (cache, breakerService) -> new IndexAggregateMetricDoubleFieldData(
                 name(),
                 AggregateMetricsValuesSourceType.AGGREGATE_METRIC
             ) {
                 @Override
-                public LeafAggregateDoubleMetricFieldData load(LeafReaderContext context) {
-                    return new LeafAggregateDoubleMetricFieldData() {
+                public LeafAggregateMetricDoubleFieldData load(LeafReaderContext context) {
+                    return new LeafAggregateMetricDoubleFieldData() {
                         @Override
                         public SortedNumericDoubleValues getAggregateMetricValues(final Metric metric) {
                             try {
@@ -476,7 +476,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
                 }
 
                 @Override
-                public LeafAggregateDoubleMetricFieldData loadDirect(LeafReaderContext context) {
+                public LeafAggregateMetricDoubleFieldData loadDirect(LeafReaderContext context) {
                     return load(context);
                 }
 
@@ -677,7 +677,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
 
     private final IndexMode indexMode;
 
-    private AggregateDoubleMetricFieldMapper(
+    private AggregateMetricDoubleFieldMapper(
         String simpleName,
         MappedFieldType mappedFieldType,
         EnumMap<Metric, NumberFieldMapper> metricFieldMappers,
@@ -705,8 +705,8 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
     }
 
     @Override
-    public AggregateDoubleMetricFieldType fieldType() {
-        return (AggregateDoubleMetricFieldType) super.fieldType();
+    public AggregateMetricDoubleFieldType fieldType() {
+        return (AggregateMetricDoubleFieldType) super.fieldType();
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedAvgAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedAvgAggregatorTests.java
@@ -27,15 +27,15 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.aggregatemetric.AggregateMetricMapperPlugin;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.support.AggregateMetricsValuesSourceType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
 
 import static java.util.Collections.singleton;
-import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.subfieldName;
+import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.subfieldName;
 
 public class AggregateMetricBackedAvgAggregatorTests extends AggregatorTestCase {
 
@@ -116,8 +116,8 @@ public class AggregateMetricBackedAvgAggregatorTests extends AggregatorTestCase 
      * @param fieldName the name of the field
      * @return the created field type
      */
-    private AggregateDoubleMetricFieldType createDefaultFieldType(String fieldName) {
-        AggregateDoubleMetricFieldType fieldType = new AggregateDoubleMetricFieldType(fieldName);
+    private AggregateMetricDoubleFieldType createDefaultFieldType(String fieldName) {
+        AggregateMetricDoubleFieldType fieldType = new AggregateMetricDoubleFieldType(fieldName);
 
         for (Metric m : List.of(Metric.value_count, Metric.sum)) {
             String subfieldName = subfieldName(fieldName, m);

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMaxAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMaxAggregatorTests.java
@@ -27,15 +27,15 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.aggregatemetric.AggregateMetricMapperPlugin;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.support.AggregateMetricsValuesSourceType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
 
 import static java.util.Collections.singleton;
-import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.subfieldName;
+import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.subfieldName;
 
 public class AggregateMetricBackedMaxAggregatorTests extends AggregatorTestCase {
 
@@ -116,8 +116,8 @@ public class AggregateMetricBackedMaxAggregatorTests extends AggregatorTestCase 
      * @param fieldName the name of the field
      * @return the created field type
      */
-    private AggregateDoubleMetricFieldType createDefaultFieldType(String fieldName) {
-        AggregateDoubleMetricFieldType fieldType = new AggregateDoubleMetricFieldType(fieldName);
+    private AggregateMetricDoubleFieldType createDefaultFieldType(String fieldName) {
+        AggregateMetricDoubleFieldType fieldType = new AggregateMetricDoubleFieldType(fieldName);
 
         for (Metric m : List.of(Metric.min, Metric.max)) {
             String subfieldName = subfieldName(fieldName, m);

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMinAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMinAggregatorTests.java
@@ -27,15 +27,15 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.aggregatemetric.AggregateMetricMapperPlugin;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.support.AggregateMetricsValuesSourceType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
 
 import static java.util.Collections.singleton;
-import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.subfieldName;
+import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.subfieldName;
 
 public class AggregateMetricBackedMinAggregatorTests extends AggregatorTestCase {
 
@@ -116,8 +116,8 @@ public class AggregateMetricBackedMinAggregatorTests extends AggregatorTestCase 
      * @param fieldName the name of the field
      * @return the created field type
      */
-    private AggregateDoubleMetricFieldType createDefaultFieldType(String fieldName) {
-        AggregateDoubleMetricFieldType fieldType = new AggregateDoubleMetricFieldType(fieldName);
+    private AggregateMetricDoubleFieldType createDefaultFieldType(String fieldName) {
+        AggregateMetricDoubleFieldType fieldType = new AggregateMetricDoubleFieldType(fieldName);
 
         for (Metric m : List.of(Metric.min, Metric.max)) {
             String subfieldName = subfieldName(fieldName, m);

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedSumAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedSumAggregatorTests.java
@@ -27,15 +27,15 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.aggregatemetric.AggregateMetricMapperPlugin;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.support.AggregateMetricsValuesSourceType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
 
 import static java.util.Collections.singleton;
-import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.subfieldName;
+import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.subfieldName;
 
 public class AggregateMetricBackedSumAggregatorTests extends AggregatorTestCase {
 
@@ -116,8 +116,8 @@ public class AggregateMetricBackedSumAggregatorTests extends AggregatorTestCase 
      * @param fieldName the name of the field
      * @return the created field type
      */
-    private AggregateDoubleMetricFieldType createDefaultFieldType(String fieldName) {
-        AggregateDoubleMetricFieldType fieldType = new AggregateDoubleMetricFieldType(fieldName);
+    private AggregateMetricDoubleFieldType createDefaultFieldType(String fieldName) {
+        AggregateMetricDoubleFieldType fieldType = new AggregateMetricDoubleFieldType(fieldName);
 
         for (Metric m : List.of(Metric.value_count, Metric.sum)) {
             String subfieldName = subfieldName(fieldName, m);

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedValueCountAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedValueCountAggregatorTests.java
@@ -27,15 +27,15 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.aggregatemetric.AggregateMetricMapperPlugin;
 import org.elasticsearch.xpack.aggregatemetric.aggregations.support.AggregateMetricsValuesSourceType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
 
 import static java.util.Collections.singleton;
-import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.subfieldName;
+import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.subfieldName;
 
 public class AggregateMetricBackedValueCountAggregatorTests extends AggregatorTestCase {
 
@@ -115,8 +115,8 @@ public class AggregateMetricBackedValueCountAggregatorTests extends AggregatorTe
      * @param fieldName the name of the field
      * @return the created field type
      */
-    private AggregateDoubleMetricFieldType createDefaultFieldType(String fieldName) {
-        AggregateDoubleMetricFieldType fieldType = new AggregateDoubleMetricFieldType(fieldName);
+    private AggregateMetricDoubleFieldType createDefaultFieldType(String fieldName) {
+        AggregateMetricDoubleFieldType fieldType = new AggregateMetricDoubleFieldType(fieldName);
 
         for (Metric m : List.of(Metric.value_count, Metric.sum)) {
             String subfieldName = subfieldName(fieldName, m);

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapperTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapperTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.aggregatemetric.AggregateMetricMapperPlugin;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 import org.hamcrest.Matchers;
 import org.junit.AssumptionViolatedException;
 
@@ -38,18 +38,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Names.IGNORE_MALFORMED;
-import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Names.METRICS;
+import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Names.IGNORE_MALFORMED;
+import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Names.METRICS;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
-public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
+public class AggregateMetricDoubleFieldMapperTests extends MapperTestCase {
 
     public static final String METRICS_FIELD = METRICS;
-    public static final String CONTENT_TYPE = AggregateDoubleMetricFieldMapper.CONTENT_TYPE;
-    public static final String DEFAULT_METRIC = AggregateDoubleMetricFieldMapper.Names.DEFAULT_METRIC;
+    public static final String CONTENT_TYPE = AggregateMetricDoubleFieldMapper.CONTENT_TYPE;
+    public static final String DEFAULT_METRIC = AggregateMetricDoubleFieldMapper.Names.DEFAULT_METRIC;
 
     @Override
     protected Collection<? extends Plugin> getPlugins() {
@@ -109,7 +109,7 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
         assertEquals("DoubleField <field.min:-10.1>", doc.rootDoc().getField("field.min").toString());
 
         Mapper fieldMapper = mapper.mappers().getMapper("field");
-        assertThat(fieldMapper, instanceOf(AggregateDoubleMetricFieldMapper.class));
+        assertThat(fieldMapper, instanceOf(AggregateMetricDoubleFieldMapper.class));
     }
 
     /**
@@ -325,8 +325,8 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
         );
 
         Mapper fieldMapper = mapper.mappers().getMapper("field");
-        assertThat(fieldMapper, instanceOf(AggregateDoubleMetricFieldMapper.class));
-        assertEquals(Metric.sum, ((AggregateDoubleMetricFieldMapper) fieldMapper).defaultMetric());
+        assertThat(fieldMapper, instanceOf(AggregateMetricDoubleFieldMapper.class));
+        assertEquals(Metric.sum, ((AggregateMetricDoubleFieldMapper) fieldMapper).defaultMetric());
     }
 
     /**
@@ -338,8 +338,8 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
         );
 
         Mapper fieldMapper = mapper.mappers().getMapper("field");
-        assertThat(fieldMapper, instanceOf(AggregateDoubleMetricFieldMapper.class));
-        assertEquals(Metric.value_count, ((AggregateDoubleMetricFieldMapper) fieldMapper).defaultMetric);
+        assertThat(fieldMapper, instanceOf(AggregateMetricDoubleFieldMapper.class));
+        assertEquals(Metric.value_count, ((AggregateMetricDoubleFieldMapper) fieldMapper).defaultMetric);
     }
 
     /**
@@ -348,8 +348,8 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
     public void testImplicitDefaultMetric() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         Mapper fieldMapper = mapper.mappers().getMapper("field");
-        assertThat(fieldMapper, instanceOf(AggregateDoubleMetricFieldMapper.class));
-        assertEquals(Metric.max, ((AggregateDoubleMetricFieldMapper) fieldMapper).defaultMetric);
+        assertThat(fieldMapper, instanceOf(AggregateMetricDoubleFieldMapper.class));
+        assertEquals(Metric.max, ((AggregateMetricDoubleFieldMapper) fieldMapper).defaultMetric);
     }
 
     /**
@@ -418,7 +418,7 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
         );
 
         Mapper fieldMapper = mapper.mappers().getMapper("field.subfield");
-        assertThat(fieldMapper, instanceOf(AggregateDoubleMetricFieldMapper.class));
+        assertThat(fieldMapper, instanceOf(AggregateMetricDoubleFieldMapper.class));
         ParsedDocument doc = mapper.parse(
             source(
                 b -> b.startObject("field")
@@ -462,7 +462,7 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
     protected void assertExistsQuery(MappedFieldType fieldType, Query query, LuceneDocument fields) {
         assertThat(query, Matchers.instanceOf(FieldExistsQuery.class));
         FieldExistsQuery fieldExistsQuery = (FieldExistsQuery) query;
-        String defaultMetric = ((AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType) fieldType).getDefaultMetric().name();
+        String defaultMetric = ((AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType) fieldType).getDefaultMetric().name();
         assertEquals("field." + defaultMetric, fieldExistsQuery.getField());
         assertNoFieldNamesField(fields);
     }
@@ -488,10 +488,10 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
     public void testMetricType() throws IOException {
         // Test default setting
         MapperService mapperService = createMapperService(fieldMapping(b -> minimalMapping(b)));
-        AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType ft =
-            (AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType) mapperService.fieldType("field");
+        AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType ft =
+            (AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType) mapperService.fieldType("field");
         assertNull(ft.getMetricType());
-        assertMetricType("gauge", AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType::getMetricType);
+        assertMetricType("gauge", AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType::getMetricType);
 
         {
             // Test invalid metric type for this field type
@@ -519,7 +519,7 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport(boolean ignoreMalformed) {
-        return new AggregateDoubleMetricSyntheticSourceSupport(ignoreMalformed);
+        return new AggregateMetricDoubleSyntheticSourceSupport(ignoreMalformed);
     }
 
     @Override
@@ -564,11 +564,11 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
         assertEquals(Strings.toString(expected), syntheticSource);
     }
 
-    protected final class AggregateDoubleMetricSyntheticSourceSupport implements SyntheticSourceSupport {
+    protected final class AggregateMetricDoubleSyntheticSourceSupport implements SyntheticSourceSupport {
         private final boolean malformedExample;
         private final EnumSet<Metric> storedMetrics;
 
-        public AggregateDoubleMetricSyntheticSourceSupport(boolean malformedExample) {
+        public AggregateMetricDoubleSyntheticSourceSupport(boolean malformedExample) {
             this.malformedExample = malformedExample;
             this.storedMetrics = EnumSet.copyOf(randomNonEmptySubsetOf(Arrays.asList(Metric.values())));
         }

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldTypeTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldTypeTests.java
@@ -27,8 +27,8 @@ import org.elasticsearch.script.DocReader;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.lookup.SearchLookup;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType;
-import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType;
+import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -36,20 +36,20 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
-import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.subfieldName;
+import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.subfieldName;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AggregateDoubleMetricFieldTypeTests extends FieldTypeTestCase {
+public class AggregateMetricDoubleFieldTypeTests extends FieldTypeTestCase {
 
-    protected AggregateDoubleMetricFieldType createDefaultFieldType(String name, Map<String, String> meta, Metric defaultMetric) {
-        AggregateDoubleMetricFieldType fieldType = new AggregateDoubleMetricFieldType(name, meta, null);
-        for (AggregateDoubleMetricFieldMapper.Metric m : List.of(
-            AggregateDoubleMetricFieldMapper.Metric.min,
-            AggregateDoubleMetricFieldMapper.Metric.max
+    protected AggregateMetricDoubleFieldType createDefaultFieldType(String name, Map<String, String> meta, Metric defaultMetric) {
+        AggregateMetricDoubleFieldType fieldType = new AggregateMetricDoubleFieldType(name, meta, null);
+        for (AggregateMetricDoubleFieldMapper.Metric m : List.of(
+            AggregateMetricDoubleFieldMapper.Metric.min,
+            AggregateMetricDoubleFieldMapper.Metric.max
         )) {
             String subfieldName = subfieldName(fieldType.name(), m);
             NumberFieldMapper.NumberFieldType subfield = new NumberFieldMapper.NumberFieldType(


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Rename AggregateDoubleMetric to *MetricDouble (#121254)