### PR TITLE
[9.0] Add classifier to version specific jar artifacts (#121083)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/MrjarPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/MrjarPlugin.java
@@ -163,6 +163,7 @@ public class MrjarPlugin implements Plugin<Project> {
         project.getConfigurations().register("java" + javaVersion);
         TaskProvider<Jar> jarTask = project.getTasks().register("java" + javaVersion + "Jar", Jar.class, task -> {
             task.from(sourceSet.getOutput());
+            task.getArchiveClassifier().set("java" + javaVersion);
         });
         project.getArtifacts().add("java" + javaVersion, jarTask);
     }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Add classifier to version specific jar artifacts (#121083)