### PR TITLE
[8.x] Fix counted_keyword support in arrays of objects (#121558)

### DIFF
--- a/x-pack/plugin/mapper-counted-keyword/src/main/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-counted-keyword/src/main/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapper.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.countedkeyword;
 
-import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
@@ -19,6 +18,7 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -31,6 +31,7 @@ import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.plain.AbstractIndexOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
+import org.elasticsearch.index.mapper.CustomDocValuesField;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
@@ -437,15 +438,17 @@ public class CountedKeywordFieldMapper extends FieldMapper {
             return;
         }
 
-        int i = 0;
-        int[] counts = new int[values.size()];
-        for (Map.Entry<String, Integer> value : values.entrySet()) {
-            context.doc().add(new KeywordFieldMapper.KeywordField(fullPath(), new BytesRef(value.getKey()), fieldType));
-            counts[i++] = value.getValue();
+        for (String value : values.keySet()) {
+            context.doc().add(new KeywordFieldMapper.KeywordField(fullPath(), new BytesRef(value), fieldType));
         }
-        BytesStreamOutput streamOutput = new BytesStreamOutput();
-        streamOutput.writeVIntArray(counts);
-        context.doc().add(new BinaryDocValuesField(countFieldMapper.fullPath(), streamOutput.bytes().toBytesRef()));
+        CountsBinaryDocValuesField field = (CountsBinaryDocValuesField) context.doc().getByKey(countFieldMapper.fieldType().name());
+        if (field == null) {
+            field = new CountsBinaryDocValuesField(countFieldMapper.fieldType().name());
+            field.add(values);
+            context.doc().addWithKey(countFieldMapper.fieldType().name(), field);
+        } else {
+            field.add(values);
+        }
     }
 
     private void parseArray(DocumentParserContext context, SortedMap<String, Integer> values) throws IOException {
@@ -510,6 +513,39 @@ public class CountedKeywordFieldMapper extends FieldMapper {
         return new SyntheticSourceSupport.Native(
             () -> new CountedKeywordFieldSyntheticSourceLoader(fullPath(), countFieldMapper.fullPath(), leafName())
         );
+    }
+
+    private class CountsBinaryDocValuesField extends CustomDocValuesField {
+        private final SortedMap<String, Integer> counts;
+
+        CountsBinaryDocValuesField(String name) {
+            super(name);
+            counts = new TreeMap<>();
+        }
+
+        public void add(SortedMap<String, Integer> newCounts) {
+            for (Map.Entry<String, Integer> currCount : newCounts.entrySet()) {
+                this.counts.put(currCount.getKey(), this.counts.getOrDefault(currCount.getKey(), 0) + currCount.getValue());
+            }
+        }
+
+        @Override
+        public BytesRef binaryValue() {
+            try {
+                int maxBytesPerVInt = 5;
+                int bytesSize = (counts.size() + 1) * maxBytesPerVInt;
+                BytesStreamOutput out = new BytesStreamOutput(bytesSize);
+                int countsArr[] = new int[counts.size()];
+                int i = 0;
+                for (Integer currCount : counts.values()) {
+                    countsArr[i++] = currCount;
+                }
+                out.writeVIntArray(countsArr);
+                return out.bytes().toBytesRef();
+            } catch (IOException e) {
+                throw new ElasticsearchException("Failed to get binary value", e);
+            }
+        }
     }
 
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/counted_keyword/30_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/counted_keyword/30_synthetic_source.yml
@@ -15,51 +15,26 @@
               events:
                 type: counted_keyword
 
-
   - do:
-      index:
+      bulk:
         index: test-events
-        id: "1"
-        body: { "events": [ "a", "b", "a", "c" ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "2"
-        body: { "events": ["b", "b", "c", "a", "b"] }
-
-  - do:
-      index:
-        index: test-events
-        id: "3"
-        body: { "events": ["c", "a", null, "b", null, "c"]}
-
-  - do:
-      index:
-        index: test-events
-        id: "4"
-        body: { "events": ["a"]}
-
-  - do:
-      index:
-        index: test-events
-        id: "5"
-        body: { "events": []}
-
-  - do:
-      index:
-        index: test-events
-        id: "6"
-        body: { "events": [null, null]}
-
-  - do:
-      index:
-        index: test-events
-        id: "7"
-        body: { "events": [["a", "b"], "a", ["c"], [["b"], "c"]]}
-
-  - do:
-      indices.refresh: { }
+        refresh: true
+        body:
+          - '{"create":{"_id": "1"}}'
+          - '{"events": [ "a", "b", "a", "c" ] }'
+          - '{"create":{"_id": "2"}}'
+          - '{"events": ["b", "b", "c", "a", "b"] }'
+          - '{"create":{"_id": "3"}}'
+          - '{"events": ["c", "a", null, "b", null, "c"] }'
+          - '{"create":{"_id": "4"}}'
+          - '{"events": ["a"] }'
+          - '{"create":{"_id": "5"}}'
+          - '{"events": [] }'
+          - '{"create":{"_id": "6"}}'
+          - '{"events": [null, null] }'
+          - '{"create":{"_id": "7"}}'
+          - '{"events": [["a", "b"], "a", ["c"], [["b"], "c"]] }'
+          - '{"create": {"_id": "8"}}'
 
   - do:
       search:
@@ -157,49 +132,24 @@
                 synthetic_source_keep: all
 
   - do:
-      index:
+      bulk:
         index: test-events
-        id: "1"
-        body: { "events": [ "a", "b", "a", "c" ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "2"
-        body: { "events": [ "b", "b", "c", "a", "b" ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "3"
-        body: { "events": [ "c", "a", null, "b", null, "c" ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "4"
-        body: { "events": [ "a" ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "5"
-        body: { "events": [ ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "6"
-        body: { "events": [ null, null ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "7"
-        body: { "events": [["a", "b"], "a", ["c"], [["b"], "c"]]}
-
-  - do:
-      indices.refresh: { }
+        refresh: true
+        body:
+          - '{"create":{"_id": "1"}}'
+          - '{"events": [ "a", "b", "a", "c" ] }'
+          - '{"create":{"_id": "2"}}'
+          - '{"events": ["b", "b", "c", "a", "b"] }'
+          - '{"create":{"_id": "3"}}'
+          - '{"events": ["c", "a", null, "b", null, "c"] }'
+          - '{"create":{"_id": "4"}}'
+          - '{"events": ["a"] }'
+          - '{"create":{"_id": "5"}}'
+          - '{"events": [] }'
+          - '{"create":{"_id": "6"}}'
+          - '{"events": [null, null] }'
+          - '{"create":{"_id": "7"}}'
+          - '{"events": [["a", "b"], "a", ["c"], [["b"], "c"]] }'
 
   - do:
       search:
@@ -303,50 +253,26 @@
                     properties:
                       events:
                         type: counted_keyword
-  - do:
-      index:
-        index: test-events
-        id: "1"
-        body: { "event-object": { "event-object-2": { "events": [ "a", "b", "a", "c" ] } } }
 
   - do:
-      index:
+      bulk:
         index: test-events
-        id: "2"
-        body: { "event-object": { "event-object-2": { "events": [ "b", "b", "c", "a", "b" ] } } }
-
-  - do:
-      index:
-        index: test-events
-        id: "3"
-        body: { "event-object": { "event-object-2": { "events": [ "c", "a", null, "b", null, "c" ] } } }
-
-  - do:
-      index:
-        index: test-events
-        id: "4"
-        body: { "event-object": { "event-object-2": { "events": [ "a" ] } } }
-
-  - do:
-      index:
-        index: test-events
-        id: "5"
-        body: { "event-object": { "event-object-2": { "events": [ ] } } }
-
-  - do:
-      index:
-        index: test-events
-        id: "6"
-        body: { "event-object": { "event-object-2": { "events": [ null, null ] } } }
-
-  - do:
-      index:
-        index: test-events
-        id: "7"
-        body: { "event-object": { "event-object-2": { "events": [["a", "b"], "a", ["c"], [["b"], "c"]] } } }
-
-  - do:
-      indices.refresh: { }
+        refresh: true
+        body:
+          - '{"create":{"_id": "1"}}'
+          - '{ "event-object": { "event-object-2": { "events": [ "a", "b", "a", "c" ] } } }'
+          - '{"create":{"_id": "2"}}'
+          - '{ "event-object": { "event-object-2": { "events": [ "b", "b", "c", "a", "b" ] } } }'
+          - '{"create":{"_id": "3"}}'
+          - '{ "event-object": { "event-object-2": { "events": [ "c", "a", null, "b", null, "c" ] } } }'
+          - '{"create":{"_id": "4"}}'
+          - '{ "event-object": { "event-object-2": { "events": [ "a" ] } } }'
+          - '{"create":{"_id": "5"}}'
+          - '{ "event-object": { "event-object-2": { "events": [ ] } } }'
+          - '{"create":{"_id": "6"}}'
+          - '{ "event-object": { "event-object-2": { "events": [ null, null ] } } }'
+          - '{"create":{"_id": "7"}}'
+          - '{ "event-object": { "event-object-2": { "events": [["a", "b"], "a", ["c"], [["b"], "c"]] } } }'
 
   - do:
       search:
@@ -452,51 +378,25 @@
             properties:
               events:
                 type: counted_keyword
-
   - do:
-      index:
+      bulk:
         index: test-events
-        id: "1"
-        body: { "events": [ "a", "b", "a", "c" ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "2"
-        body: { "events": [ "b", "b", "c", "a", "b" ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "3"
-        body: { "events": [ "c", "a", null, "b", null, "c" ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "4"
-        body: { "events": [ "a" ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "5"
-        body: { "events": [ ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "6"
-        body: { "events": [ null, null ] }
-
-  - do:
-      index:
-        index: test-events
-        id: "7"
-        body: { "events": [ [ "a", "b" ], "a", [ "c" ], [ [ "b" ], "c" ] ] }
-
-  - do:
-      indices.refresh: { }
+        refresh: true
+        body:
+          - '{"create":{"_id": "1"}}'
+          - '{"events": [ "a", "b", "a", "c" ] }'
+          - '{"create":{"_id": "2"}}'
+          - '{"events": ["b", "b", "c", "a", "b"] }'
+          - '{"create":{"_id": "3"}}'
+          - '{"events": ["c", "a", null, "b", null, "c"] }'
+          - '{"create":{"_id": "4"}}'
+          - '{"events": ["a"] }'
+          - '{"create":{"_id": "5"}}'
+          - '{"events": [] }'
+          - '{"create":{"_id": "6"}}'
+          - '{"events": [null, null] }'
+          - '{"create":{"_id": "7"}}'
+          - '{"events": [["a", "b"], "a", ["c"], [["b"], "c"]] }'
 
   - do:
       search:
@@ -574,3 +474,125 @@
   - match:
       hits.hits.0._source:
         events: [["a", "b"], "a", ["c"], [["b"], "c"]]
+
+---
+
+"synthetic source arrays moved to leaf fields":
+  - requires:
+      cluster_features: ["mapper.counted_keyword.synthetic_source_native_support"]
+      reason: "Feature implemented"
+
+  - do:
+      indices.create:
+        index: test-events
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              event-object:
+                type: object
+                properties:
+                  events:
+                    type: counted_keyword
+
+  - do:
+      bulk:
+        index: test-events
+        refresh: true
+        body:
+          - '{"create":{"_id": "1"}}'
+          - '{ "event-object": [ { "events": [ "a", "b"] }, { "events": [ "a", "c" ] } ] }'
+          - '{"create":{"_id": "2"}}'
+          - '{ "event-object": [ { "events": [ "b", "b"] }, { "events": "c" }, { "events": [ "a", "b" ] } ] }'
+          - '{"create":{"_id": "3"}}'
+          - '{ "event-object": [ { "events": [ "c", "a", null ] }, { "events": [ "b", null, "c" ] } ] }'
+          - '{"create":{"_id": "4"}}'
+          - '{ "event-object": [ { "events": [ "a" ] }, { "events": [] }, { "events": [ null ] } ] }'
+          - '{"create":{"_id": "5"}}'
+          - '{ "event-object": [] }'
+          - '{"create":{"_id": "6"}}'
+          - '{ "event-object": [ { "events": [ null ] }, { "events": null } ] }'
+          - '{"create":{"_id": "7"}}'
+          - '{ "event-object": [ { "events": [["a", "b"], "a"]}, { "events": [["c"], [["b"], "c"]] } ] }'
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 1 ]
+  - match:
+      hits.hits.0._source:
+        event-object:
+          events: [ "a", "a", "b", "c" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 2 ]
+  - match:
+      hits.hits.0._source:
+        event-object:
+          events: [ "a", "b", "b", "b", "c" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 3 ]
+  - match:
+      hits.hits.0._source:
+        event-object:
+          events: [ "a", "b", "c", "c" ]
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 4 ]
+  - match:
+      hits.hits.0._source:
+        event-object:
+          events: "a"
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 5 ]
+  - match:
+      hits.hits.0._source: {}
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 6 ]
+  - match:
+      hits.hits.0._source: {}
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 7 ]
+  - match:
+      hits.hits.0._source:
+        event-object:
+          events: [ "a", "a", "b", "b", "c", "c" ]

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/counted_keyword/40_multiple_subobjects.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/counted_keyword/40_multiple_subobjects.yml
@@ -1,0 +1,33 @@
+"multiple subobjects":
+  - requires:
+      cluster_features: ["gte_v8.12.0"]
+      reason: "counted_keyword was added in 8.12"
+
+  - do:
+      indices.create:
+        index: test-events
+        body:
+          mappings:
+            properties:
+              parent:
+                type: object
+                properties:
+                  child:
+                    type: counted_keyword
+
+  - do:
+      index:
+        index: test-events
+        id: "1"
+        refresh: true
+        body: '{"parent": [{"child": "foo"}, {"child": "bar"}]}'
+
+  - do:
+      search:
+        index: test-events
+        body:
+          query:
+            ids:
+              values: [ 1 ]
+  - match:
+      hits.hits.0._source: {"parent": [{"child": "foo"}, {"child": "bar"}]}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix counted_keyword support in arrays of objects (#121558)](https://github.com/elastic/elasticsearch/pull/121558)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)