### PR TITLE
[9.0] Unmute EsqlNodeFailureIT (#121707)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -153,9 +153,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/118914
 - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectoryRunAsIT
   issue: https://github.com/elastic/elasticsearch/issues/115727
-- class: org.elasticsearch.xpack.esql.action.EsqlNodeFailureIT
-  method: testFailureLoadingFields
-  issue: https://github.com/elastic/elasticsearch/issues/118000
 - class: org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapperTests
   method: testCartesianBoundsBlockLoader
   issue: https://github.com/elastic/elasticsearch/issues/119201


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Unmute EsqlNodeFailureIT (#121707)