### PR TITLE
Fix synthetic source issue with deeply nested ignored source fields

### DIFF
--- a/docs/changelog/121715.yaml
+++ b/docs/changelog/121715.yaml
@@ -1,0 +1,5 @@
+pr: 121715
+summary: Fix synthetic source issue with deeply nested ignored source fields
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -1127,7 +1127,7 @@ public class ObjectMapper extends Mapper {
             for (SourceLoader.SyntheticFieldLoader loader : fields) {
                 ignoredValuesPresent |= loader.setIgnoredValues(objectsWithIgnoredFields);
             }
-            return this.ignoredValues != null;
+            return ignoredValuesPresent;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -2420,6 +2420,34 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             {"outer":{"inner":[{"a.b":"a.b","a.c":"a.c"}]}}""", syntheticSource);
     }
 
+    public void testSingleDeepIgnoredField() throws IOException {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
+            b.startObject("top");
+            b.startObject("properties");
+            {
+                b.startObject("level1").startObject("properties");
+                {
+                    b.startObject("level2").startObject("properties");
+                    {
+                        b.startObject("n")
+                            .field("type", "integer")
+                            .field("doc_values", "false")
+                            .field("synthetic_source_keep", "all")
+                            .endObject();
+                    }
+                    b.endObject().endObject();
+                }
+                b.endObject().endObject();
+            }
+            b.endObject().endObject();
+        })).documentMapper();
+
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.startObject("top").startObject("level1").startObject("level2").field("n", 25).endObject().endObject().endObject();
+        });
+        assertEquals("{\"top\":{\"level1\":{\"level2\":{\"n\":25}}}}", syntheticSource);
+    }
+
     protected void validateRoundTripReader(String syntheticSource, DirectoryReader reader, DirectoryReader roundTripReader)
         throws IOException {
         // We exclude ignored source field since in some cases it contains an exact copy of a part of document source.


### PR DESCRIPTION
This is an accidental discovery from new block loader tests.

Randomized tests will eventually catch this but it is rare. It requires:
1. Deep-ish object hierarchy
2. No other synthetic field loaders being present in children of the last object. E.g. in this case if the field had doc values, it would not reproduce.

The problem is that `ignoredValuesPresent` signals when _any children_ have ignored values. Existing `this.ignoredValues != null` check is weaker and only signals when _immediate children_ have ignored values. This causes an erroneous decision that there are no ignored values in the hierarchy.