### PR TITLE
[8.18] [Inference API] Unmute failing inference rate limiting integration tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -492,14 +492,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/42_knn_search_int4_flat/Vector similarity with filter only}
   issue: https://github.com/elastic/elasticsearch/issues/121412
-- class: org.elasticsearch.xpack.inference.common.InferenceServiceNodeLocalRateLimitCalculatorTests
-  issue: https://github.com/elastic/elasticsearch/issues/121294
-- class: org.elasticsearch.xpack.inference.action.TransportInferenceActionTests
-  method: testRerouting_HandlesTransportException_FromOtherNode
-  issue: https://github.com/elastic/elasticsearch/issues/121292
-- class: org.elasticsearch.xpack.inference.action.TransportInferenceActionTests
-  method: testRerouting_ToOtherNode
-  issue: https://github.com/elastic/elasticsearch/issues/121293
 - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
   method: testStopAndRestart
   issue: https://github.com/elastic/elasticsearch/issues/121433


### PR DESCRIPTION
Unmutes failing tests from https://github.com/elastic/elasticsearch/issues/121292, https://github.com/elastic/elasticsearch/issues/121293 and https://github.com/elastic/elasticsearch/issues/121294