### PR TITLE
[9.0] [Inference API] Unmute failing inference rate limiting integration tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -318,8 +318,6 @@ tests:
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/index-modules/slowlog/line_102}
   issue: https://github.com/elastic/elasticsearch/issues/121288
-- class: org.elasticsearch.xpack.inference.common.InferenceServiceNodeLocalRateLimitCalculatorTests
-  issue: https://github.com/elastic/elasticsearch/issues/121294
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testSuggestProfilesWithHint
   issue: https://github.com/elastic/elasticsearch/issues/121116


### PR DESCRIPTION
Unmutes failing tests from https://github.com/elastic/elasticsearch/issues/121292, https://github.com/elastic/elasticsearch/issues/121293 and https://github.com/elastic/elasticsearch/issues/121294