### PR TITLE
[8.x] [ML] Skip Usage stats update when ML is disabled (#121559)

### DIFF
--- a/docs/changelog/121559.yaml
+++ b/docs/changelog/121559.yaml
@@ -1,0 +1,6 @@
+pr: 121559
+summary: Skip Usage stats update when ML is disabled
+area: Machine Learning
+type: bug
+issues:
+ - 121532


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Skip Usage stats update when ML is disabled (#121559)