### PR TITLE
[8.17] [Connectors][Docs] Fix docker image name (#121778)

### DIFF
--- a/docs/reference/connector/docs/_connectors-docker-instructions.asciidoc
+++ b/docs/reference/connector/docs/_connectors-docker-instructions.asciidoc
@@ -59,7 +59,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/enterprise-search/elastic-connectors:{version}.0 \
+docker.elastic.co/enterprise-search/elastic-connectors:{version} \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ----

--- a/docs/reference/connector/docs/connectors-run-from-docker.asciidoc
+++ b/docs/reference/connector/docs/connectors-run-from-docker.asciidoc
@@ -62,7 +62,7 @@ docker run \
 --rm \
 --tty -i \
 --network host \
-docker.elastic.co/enterprise-search/elastic-connectors:{version}.0 \
+docker.elastic.co/enterprise-search/elastic-connectors:{version} \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ----
@@ -70,7 +70,7 @@ docker.elastic.co/enterprise-search/elastic-connectors:{version}.0 \
 [TIP]
 ====
 For unreleased versions, append the `-SNAPSHOT` suffix to the version number.
-For example, `docker.elastic.co/enterprise-search/elastic-connectors:8.14.0.0-SNAPSHOT`.
+For example, `docker.elastic.co/enterprise-search/elastic-connectors:8.17.0-SNAPSHOT`.
 ====
 
 Find all available Docker images in the https://www.docker.elastic.co/r/enterprise-search/elastic-connectors[official registry].


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [Connectors][Docs] Fix docker image name (#121778)