### PR TITLE
Track queued merges in ElasticsearchMergeScheduler and InternalEngine

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
@@ -59,6 +59,11 @@ public class ElasticsearchConcurrentMergeScheduler extends ConcurrentMergeSchedu
         return mergeTracking.onGoingMerges();
     }
 
+    @Override
+    public Set<OnGoingMerge> queuedMerges() {
+        return mergeTracking.queuedMerges();
+    }
+
     /** We're currently only interested in messages with this prefix. */
     private static final String MERGE_THREAD_MESSAGE_PREFIX = "merge thread";
 

--- a/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchMergeScheduler.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchMergeScheduler.java
@@ -19,6 +19,8 @@ public interface ElasticsearchMergeScheduler {
 
     Set<OnGoingMerge> onGoingMerges();
 
+    Set<OnGoingMerge> queuedMerges();
+
     MergeStats stats();
 
     void refreshConfig();

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -3006,6 +3006,14 @@ public class InternalEngine extends Engine {
         return mergeScheduler.stats();
     }
 
+    public boolean hasQueuedOrOnGoingMerges() {
+        return hasQueuedMerges() || mergeScheduler.onGoingMerges().isEmpty() == false;
+    }
+
+    public boolean hasQueuedMerges() {
+        return mergeScheduler.queuedMerges().isEmpty() == false;
+    }
+
     protected LocalCheckpointTracker getLocalCheckpointTracker() {
         return localCheckpointTracker;
     }


### PR DESCRIPTION
This commit adds tracking for merges that are queued for future execution.

Relates ES-10570
