### PR TITLE
[8.18] Remvoe some more dead code from o.e.search.aggregations (#121498)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -211,9 +211,9 @@ public abstract class InternalMultiBucketAggregation<
         List<B> reducedBuckets = new ArrayList<>();
         for (B bucket : getBuckets()) {
             List<InternalAggregation> aggs = new ArrayList<>();
-            for (Aggregation agg : bucket.getAggregations()) {
+            for (InternalAggregation agg : bucket.getAggregations()) {
                 PipelineTree subTree = pipelineTree.subTree(agg.getName());
-                aggs.add(((InternalAggregation) agg).reducePipelines((InternalAggregation) agg, reduceContext, subTree));
+                aggs.add(agg.reducePipelines(agg, reduceContext, subTree));
             }
             reducedBuckets.add(createBucket(InternalAggregations.from(aggs), bucket));
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InvalidAggregationPathException.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InvalidAggregationPathException.java
@@ -20,10 +20,6 @@ public class InvalidAggregationPathException extends ElasticsearchException {
         super(msg);
     }
 
-    public InvalidAggregationPathException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
     public InvalidAggregationPathException(StreamInput in) throws IOException {
         super(in);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -461,7 +461,7 @@ public final class CompositeAggregator extends BucketsAggregator implements Size
             // Visit documents sorted by the leading source of the composite definition and terminates
             // when the leading source value is guaranteed to be greater than the lowest composite bucket
             // in the queue.
-            DocIdSet docIdSet = sortedDocsProducer.processLeaf(topLevelQuery(), queue, aggCtx.getLeafReaderContext(), fillDocIdSet);
+            DocIdSet docIdSet = sortedDocsProducer.processLeaf(queue, aggCtx.getLeafReaderContext(), fillDocIdSet);
             if (fillDocIdSet) {
                 entries.add(new Entry(aggCtx, docIdSet));
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/PointsSortedDocsProducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/PointsSortedDocsProducer.java
@@ -13,7 +13,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.DocIdSet;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.util.DocIdSetBuilder;
 
 import java.io.IOException;
@@ -36,8 +35,7 @@ class PointsSortedDocsProducer extends SortedDocsProducer {
     }
 
     @Override
-    DocIdSet processLeaf(Query query, CompositeValuesCollectorQueue queue, LeafReaderContext context, boolean fillDocIdSet)
-        throws IOException {
+    DocIdSet processLeaf(CompositeValuesCollectorQueue queue, LeafReaderContext context, boolean fillDocIdSet) throws IOException {
         final PointValues values = context.reader().getPointValues(field);
         if (values == null) {
             // no value for the field

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/SortedDocsProducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/SortedDocsProducer.java
@@ -12,7 +12,6 @@ package org.elasticsearch.search.aggregations.bucket.composite;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.DocIdSetBuilder;
 import org.elasticsearch.core.Nullable;
@@ -99,6 +98,5 @@ abstract class SortedDocsProducer {
      * Returns the {@link DocIdSet} of the documents that contain a top composite bucket in this leaf or
      * {@link DocIdSet#EMPTY} if <code>fillDocIdSet</code> is false.
      */
-    abstract DocIdSet processLeaf(Query query, CompositeValuesCollectorQueue queue, LeafReaderContext context, boolean fillDocIdSet)
-        throws IOException;
+    abstract DocIdSet processLeaf(CompositeValuesCollectorQueue queue, LeafReaderContext context, boolean fillDocIdSet) throws IOException;
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/TermsSortedDocsProducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/TermsSortedDocsProducer.java
@@ -14,7 +14,6 @@ import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.DocIdSet;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.DocIdSetBuilder;
 
@@ -29,8 +28,7 @@ class TermsSortedDocsProducer extends SortedDocsProducer {
     }
 
     @Override
-    DocIdSet processLeaf(Query query, CompositeValuesCollectorQueue queue, LeafReaderContext context, boolean fillDocIdSet)
-        throws IOException {
+    DocIdSet processLeaf(CompositeValuesCollectorQueue queue, LeafReaderContext context, boolean fillDocIdSet) throws IOException {
         final Terms terms = context.reader().terms(field);
         if (terms == null) {
             // no value for the field

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRange.java
@@ -25,15 +25,7 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
 
     public static class Bucket extends InternalRange.Bucket {
 
-        public Bucket(
-            String key,
-            double from,
-            double to,
-            long docCount,
-            List<InternalAggregation> aggregations,
-            boolean keyed,
-            DocValueFormat formatter
-        ) {
+        public Bucket(String key, double from, double to, long docCount, List<InternalAggregation> aggregations, DocValueFormat formatter) {
             super(key, from, to, docCount, InternalAggregations.from(aggregations), formatter);
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BytesKeyedBucketOrds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BytesKeyedBucketOrds.java
@@ -75,24 +75,6 @@ public abstract class BytesKeyedBucketOrds implements Releasable {
          * Read the current value.
          */
         void readValue(BytesRef dest);
-
-        /**
-         * An {@linkplain BucketOrdsEnum} that is empty.
-         */
-        BucketOrdsEnum EMPTY = new BucketOrdsEnum() {
-            @Override
-            public boolean next() {
-                return false;
-            }
-
-            @Override
-            public long ord() {
-                return 0;
-            }
-
-            @Override
-            public void readValue(BytesRef dest) {}
-        };
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
@@ -72,7 +72,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
         /**
          * Read from a stream.
          */
-        protected Bucket(StreamInput in, DocValueFormat format) {
+        protected Bucket(DocValueFormat format) {
             this.format = format;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTerms.java
@@ -37,7 +37,7 @@ public class SignificantLongTerms extends InternalMappedSignificantTerms<Signifi
         }
 
         Bucket(StreamInput in, DocValueFormat format) throws IOException {
-            super(in, format);
+            super(format);
             subsetDf = in.readVLong();
             supersetDf = in.readVLong();
             term = in.readLong();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTerms.java
@@ -48,7 +48,7 @@ public class SignificantStringTerms extends InternalMappedSignificantTerms<Signi
          * Read from a stream.
          */
         public Bucket(StreamInput in, DocValueFormat format) throws IOException {
-            super(in, format);
+            super(format);
             termBytes = in.readBytesRef();
             subsetDf = in.readVLong();
             supersetDf = in.readVLong();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
@@ -108,8 +108,7 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
         if (bucketOrd >= states.size()) {
             return null;
         }
-        final DoubleHistogram state = states.get(bucketOrd);
-        return state;
+        return states.get(bucketOrd);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHyperLogLogPlusPlus.java
@@ -44,9 +44,6 @@ public abstract class AbstractHyperLogLogPlusPlus extends AbstractCardinalityAlg
     /** Get HyperLogLog algorithm */
     protected abstract AbstractHyperLogLog.RunLenIterator getHyperLogLog(long bucketOrd);
 
-    /** Get the number of data structures */
-    public abstract long maxOrd();
-
     /** Collect a value in the given bucket */
     public abstract void collect(long bucketOrd, long hash);
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractLinearCounting.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractLinearCounting.java
@@ -39,11 +39,6 @@ public abstract class AbstractLinearCounting extends AbstractCardinalityAlgorith
      */
     protected abstract int size(long bucketOrd);
 
-    /**
-     * return the current values in the counter.
-     */
-    protected abstract HashesIterator values(long bucketOrd);
-
     public int collect(long bucketOrd, long hash) {
         final int k = encodeHash(hash, p);
         return addEncoded(bucketOrd, k);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStats.java
@@ -69,11 +69,6 @@ public interface ExtendedStats extends Stats {
     String getStdDeviationSamplingAsString();
 
     /**
-     * The upper or lower bounds of stdDev of the collected values as a String.
-     */
-    String getStdDeviationBoundAsString(Bounds bound);
-
-    /**
      * The sum of the squares of the collected values as a String.
      */
     String getSumOfSquaresAsString();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -87,7 +87,6 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         this.algorithm = algorithm;
     }
 
-    @Override
     public long maxOrd() {
         return hll.maxOrd();
     }
@@ -322,8 +321,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
             return size;
         }
 
-        @Override
-        protected HashesIterator values(long bucketOrd) {
+        private HashesIterator values(long bucketOrd) {
             // Make a fresh BytesRef for reading scratch work because this method can be called on many threads
             return new LinearCountingIterator(this, new BytesRef(), bucketOrd);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusSparse.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusSparse.java
@@ -36,11 +36,6 @@ final class HyperLogLogPlusPlusSparse extends AbstractHyperLogLogPlusPlus implem
         this.lc = new LinearCounting(precision, bigArrays, initialBuckets);
     }
 
-    @Override
-    public long maxOrd() {
-        return lc.sizes.size();
-    }
-
     /** Needs to be called before adding elements into a bucket */
     protected void ensureCapacity(long bucketOrd, long size) {
         lc.ensureCapacity(bucketOrd, size);
@@ -135,8 +130,7 @@ final class HyperLogLogPlusPlusSparse extends AbstractHyperLogLogPlusPlus implem
             return size;
         }
 
-        @Override
-        protected HashesIterator values(long bucketOrd) {
+        private HashesIterator values(long bucketOrd) {
             return new LinearCountingIterator(values.get(bucketOrd), size(bucketOrd));
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalBounds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalBounds.java
@@ -73,9 +73,8 @@ public abstract class InternalBounds<T extends SpatialPoint> extends InternalAgg
             };
         } else if (path.size() == 2) {
             BoundingBox<T> bbox = resolveBoundingBox();
-            T cornerPoint = null;
             String cornerString = path.get(0);
-            cornerPoint = switch (cornerString) {
+            T cornerPoint = switch (cornerString) {
                 case "top_left" -> bbox.topLeft();
                 case "bottom_right" -> bbox.bottomRight();
                 default -> throw new IllegalArgumentException("Found unknown path element [" + cornerString + "] in [" + getName() + "]");

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
@@ -245,8 +245,7 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
         return valueAsString(Metrics.std_deviation_sampling.name());
     }
 
-    @Override
-    public String getStdDeviationBoundAsString(Bounds bound) {
+    private String getStdDeviationBoundAsString(Bounds bound) {
         return switch (bound) {
             case UPPER -> valueAsString(Metrics.std_upper.name());
             case LOWER -> valueAsString(Metrics.std_lower.name());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -90,15 +90,6 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
             super(in);
         }
 
-        /**
-         * Read from a stream.
-         *
-         * @param readFormat whether to read the "format" field
-         */
-        protected MultiValue(StreamInput in, boolean readFormat) throws IOException {
-            super(in, readFormat);
-        }
-
         public abstract double value(String name);
 
         public String valueAsString(String name) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -662,7 +662,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
                     factory.fetchSource(FetchSourceContext.fromXContent(parser));
                 } else if (SearchSourceBuilder.SCRIPT_FIELDS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     List<ScriptField> scriptFields = new ArrayList<>();
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
                         String scriptFieldName = parser.currentName();
                         token = parser.nextToken();
                         if (token == XContentParser.Token.START_OBJECT) {
@@ -740,12 +740,12 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
                         parser
                     );
                 } else if (SearchSourceBuilder.DOCVALUE_FIELDS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         FieldAndFormat ff = FieldAndFormat.fromXContent(parser);
                         factory.docValueField(ff.field, ff.format);
                     }
                 } else if (SearchSourceBuilder.FETCH_FIELDS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         FieldAndFormat ff = FieldAndFormat.fromXContent(parser);
                         factory.fetchField(ff);
                     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/AbstractPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/AbstractPipelineAggregationBuilder.java
@@ -68,8 +68,7 @@ public abstract class AbstractPipelineAggregationBuilder<PAB extends AbstractPip
      */
     @Override
     public final PipelineAggregator create() {
-        PipelineAggregator aggregator = createInternal(this.metadata);
-        return aggregator;
+        return createInternal(this.metadata);
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsParser.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsParser.java
@@ -56,7 +56,7 @@ public abstract class BucketMetricsParser implements PipelineAggregator.Parser {
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if (BUCKETS_PATH.match(currentFieldName, parser.getDeprecationHandler())) {
                     List<String> paths = new ArrayList<>();
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         String path = parser.text();
                         paths.add(path);
                     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalBucketMetricValue.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalBucketMetricValue.java
@@ -28,8 +28,8 @@ public class InternalBucketMetricValue extends InternalNumericMetricsAggregation
     public static final String NAME = "bucket_metric_value";
     static final ParseField KEYS_FIELD = new ParseField("keys");
 
-    private double value;
-    private String[] keys;
+    private final double value;
+    private final String[] keys;
 
     public InternalBucketMetricValue(String name, String[] keys, double value, DocValueFormat formatter, Map<String, Object> metadata) {
         super(name, formatter, metadata);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucket.java
@@ -26,9 +26,9 @@ import java.util.Map;
 import java.util.Objects;
 
 public class InternalPercentilesBucket extends InternalNumericMetricsAggregation.MultiValue implements PercentilesBucket {
-    private double[] percentiles;
-    private double[] percents;
-    private boolean keyed = true;
+    private final double[] percentiles;
+    private final double[] percents;
+    private final boolean keyed;
 
     private final transient Map<Double, Double> percentileLookups = new HashMap<>();
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregator.java
@@ -21,7 +21,7 @@ import java.util.Map;
 public class PercentilesBucketPipelineAggregator extends BucketMetricsPipelineAggregator {
 
     private final double[] percents;
-    private boolean keyed = true;
+    private final boolean keyed;
     private List<Double> data;
 
     PercentilesBucketPipelineAggregator(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregationBuilder.java
@@ -12,6 +12,7 @@ package org.elasticsearch.search.aggregations.pipeline;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
@@ -169,11 +170,11 @@ public class SerialDiffPipelineAggregationBuilder extends AbstractPipelineAggreg
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if (BUCKETS_PATH.match(currentFieldName, parser.getDeprecationHandler())) {
                     List<String> paths = new ArrayList<>();
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         String path = parser.text();
                         paths.add(path);
                     }
-                    bucketsPaths = paths.toArray(new String[paths.size()]);
+                    bucketsPaths = paths.toArray(Strings.EMPTY_ARRAY);
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.DocCountFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.Rewriteable;
@@ -308,14 +307,6 @@ public abstract class AggregationContext implements Releasable {
     public abstract boolean isInSortOrderExecutionRequired();
 
     public abstract Set<String> sourcePath(String fullName);
-
-    /**
-     * Returns the MappingLookup for the index, if one is initialized.
-     */
-    @Nullable
-    public MappingLookup getMappingLookup() {
-        return null;
-    }
 
     /**
      * Does this index have a {@code _doc_count} field in any segment?
@@ -619,11 +610,6 @@ public abstract class AggregationContext implements Releasable {
         @Override
         public Set<String> sourcePath(String fullName) {
             return context.sourcePath(fullName);
-        }
-
-        @Override
-        public MappingLookup getMappingLookup() {
-            return context.getMappingLookup();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationUsageService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationUsageService.java
@@ -19,8 +19,6 @@ import java.util.concurrent.atomic.LongAdder;
 
 public class AggregationUsageService implements ReportingService<AggregationInfo> {
     private static final String ES_SEARCH_QUERY_AGGREGATIONS_TOTAL_COUNT = "es.search.query.aggregations.total";
-    private final String AGGREGATION_NAME_KEY = "aggregation_name";
-    private final String VALUES_SOURCE_KEY = "values_source";
     private final LongCounter aggregationsUsageCounter;
     private final Map<String, Map<String, LongAdder>> aggs;
     private final AggregationInfo info;
@@ -83,6 +81,8 @@ public class AggregationUsageService implements ReportingService<AggregationInfo
         }
         assert valuesSourceMap != null : "Unknown aggregation [" + aggregationName + "][" + valuesSourceType + "]";
         // tests will have a no-op implementation here
+        String VALUES_SOURCE_KEY = "values_source";
+        String AGGREGATION_NAME_KEY = "aggregation_name";
         aggregationsUsageCounter.incrementBy(1, Map.of(AGGREGATION_NAME_KEY, aggregationName, VALUES_SOURCE_KEY, valuesSourceType));
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceParseHelper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceParseHelper.java
@@ -57,10 +57,9 @@ public final class MultiValuesSourceParseHelper {
      * @param timezoneAware - allows specifying timezone
      * @param filterable - allows specifying filters on the values
      * @param heterogeneous - allows specifying value-source specific format and user value type hint
-     * @param <VS> - values source type
      * @param <T> - parser context
      */
-    public static <VS extends ValuesSource, T> void declareField(
+    public static <T> void declareField(
         String fieldName,
         AbstractObjectParser<? extends MultiValuesSourceAggregationBuilder<?>, T> objectParser,
         boolean scriptable,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/TimeSeriesIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/TimeSeriesIndexSearcher.java
@@ -263,11 +263,7 @@ public class TimeSeriesIndexSearcher {
 
         // true if the TSID ord has changed since the last time we checked
         boolean shouldPop() throws IOException {
-            if (tsidOrd != tsids.ordValue()) {
-                return true;
-            } else {
-                return false;
-            }
+            return tsidOrd != tsids.ordValue();
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueueTests.java
@@ -333,10 +333,7 @@ public class CompositeValuesCollectorQueueTests extends AggregatorTestCase {
                     final SortedDocsProducer docsProducer = sources[0].createSortedDocsProducerOrNull(reader, new MatchAllDocsQuery());
                     for (LeafReaderContext leafReaderContext : reader.leaves()) {
                         if (docsProducer != null && withProducer) {
-                            assertEquals(
-                                DocIdSet.EMPTY,
-                                docsProducer.processLeaf(new MatchAllDocsQuery(), queue, leafReaderContext, false)
-                            );
+                            assertEquals(DocIdSet.EMPTY, docsProducer.processLeaf(queue, leafReaderContext, false));
                         } else {
                             final LeafBucketCollector leafCollector = new LeafBucketCollector() {
                                 @Override


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Remvoe some more dead code from o.e.search.aggregations (#121498)