### PR TITLE
[8.x] Analyze API to return 400 for wrong custom analyzer (#121568)

### DIFF
--- a/docs/changelog/121568.yaml
+++ b/docs/changelog/121568.yaml
@@ -1,0 +1,6 @@
+pr: 121568
+summary: Analyze API to return 400 for wrong custom analyzer
+area: Analysis
+type: bug
+issues:
+ - 121443

--- a/modules/analysis-common/build.gradle
+++ b/modules/analysis-common/build.gradle
@@ -20,7 +20,7 @@ esplugin {
 
 restResources {
   restApi {
-    include '_common', 'indices', 'index', 'cluster', 'search', 'nodes', 'bulk', 'termvectors', 'explain', 'count'
+    include '_common', 'indices', 'index', 'cluster', 'search', 'nodes', 'bulk', 'termvectors', 'explain', 'count', 'capabilities'
   }
 }
 

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/15_analyze.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/15_analyze.yml
@@ -59,3 +59,28 @@
     - match:  { detail.tokenizer.tokens.0.token: ABc }
     - match:  { detail.tokenfilters.0.name: lowercase }
     - match:  { detail.tokenfilters.0.tokens.0.token: abc }
+
+---
+"Custom analyzer is not buildable":
+  - requires:
+      test_runner_features: [ capabilities ]
+      reason: This capability required to run test
+      capabilities:
+        - method: GET
+          path: /_analyze
+          capabilities: [ wrong_custom_analyzer_returns_400 ]
+
+  - do:
+      catch: bad_request
+      indices.analyze:
+        body:
+          text: the foxes jumping quickly
+          tokenizer:
+            standard
+          filter:
+            type: hunspell
+            locale: en_US
+
+  - match: { status: 400 }
+  - match: { error.type: illegal_argument_exception }
+  - match: { error.reason: "Can not build a custom analyzer" }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeCapabilities.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.analyze;
+
+import java.util.Set;
+
+public final class AnalyzeCapabilities {
+    private AnalyzeCapabilities() {}
+
+    private static final String WRONG_CUSTOM_ANALYZER_RETURNS_400_CAPABILITY = "wrong_custom_analyzer_returns_400";
+
+    public static final Set<String> CAPABILITIES = Set.of(WRONG_CUSTOM_ANALYZER_RETURNS_400_CAPABILITY);
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -144,6 +144,8 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
             if (analyzer != null) {
                 return analyze(request, analyzer, maxTokenCount);
             }
+        } catch (IllegalStateException e) {
+            throw new IllegalArgumentException("Can not build a custom analyzer", e);
         }
 
         // Otherwise we use a built-in analyzer, which should not be closed

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.rest.action.admin.indices;
 
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
+import org.elasticsearch.action.admin.indices.analyze.AnalyzeCapabilities;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -19,6 +20,7 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
@@ -47,6 +49,11 @@ public class RestAnalyzeAction extends BaseRestHandler {
             AnalyzeAction.Request analyzeRequest = AnalyzeAction.Request.fromXContent(parser, request.param("index"));
             return channel -> client.admin().indices().analyze(analyzeRequest, new RestToXContentListener<>(channel));
         }
+    }
+
+    @Override
+    public Set<String> supportedCapabilities() {
+        return AnalyzeCapabilities.CAPABILITIES;
     }
 
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Analyze API to return 400 for wrong custom analyzer (#121568)