### PR TITLE
Rename environment dir accessors (#121803)

### DIFF
--- a/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/AddFileKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/AddFileKeyStoreCommand.java
@@ -74,7 +74,7 @@ class AddFileKeyStoreCommand extends BaseKeyStoreCommand {
             keyStore.setFile(setting, Files.readAllBytes(file));
         }
 
-        keyStore.save(env.configFile(), getKeyStorePassword().getChars());
+        keyStore.save(env.configDir(), getKeyStorePassword().getChars());
     }
 
     @SuppressForbidden(reason = "file arg for cli")

--- a/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/AddStringKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/AddStringKeyStoreCommand.java
@@ -100,7 +100,7 @@ class AddStringKeyStoreCommand extends BaseKeyStoreCommand {
             }
         }
 
-        keyStore.save(env.configFile(), getKeyStorePassword().getChars());
+        keyStore.save(env.configDir(), getKeyStorePassword().getChars());
     }
 
 }

--- a/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/BaseKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/BaseKeyStoreCommand.java
@@ -39,14 +39,14 @@ public abstract class BaseKeyStoreCommand extends KeyStoreAwareCommand {
     @Override
     public final void execute(Terminal terminal, OptionSet options, Environment env, ProcessInfo processInfo) throws Exception {
         try {
-            final Path configFile = env.configFile();
+            final Path configFile = env.configDir();
             keyStore = KeyStoreWrapper.load(configFile);
             if (keyStore == null) {
                 if (keyStoreMustExist) {
                     throw new UserException(
                         ExitCodes.DATA_ERROR,
                         "Elasticsearch keystore not found at ["
-                            + KeyStoreWrapper.keystorePath(env.configFile())
+                            + KeyStoreWrapper.keystorePath(env.configDir())
                             + "]. Use 'create' command to create one."
                     );
                 } else if (options.has(forceOption) == false) {

--- a/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/ChangeKeyStorePasswordCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/ChangeKeyStorePasswordCommand.java
@@ -31,7 +31,7 @@ class ChangeKeyStorePasswordCommand extends BaseKeyStoreCommand {
     protected void executeCommand(Terminal terminal, OptionSet options, Environment env) throws Exception {
         try (SecureString newPassword = readPassword(terminal, true)) {
             final KeyStoreWrapper keyStore = getKeyStore();
-            keyStore.save(env.configFile(), newPassword.getChars());
+            keyStore.save(env.configDir(), newPassword.getChars());
             terminal.println("Elasticsearch keystore password changed successfully.");
         } catch (SecurityException e) {
             throw new UserException(ExitCodes.DATA_ERROR, e.getMessage());

--- a/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/CreateKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/CreateKeyStoreCommand.java
@@ -40,7 +40,7 @@ class CreateKeyStoreCommand extends KeyStoreAwareCommand {
     @Override
     public void execute(Terminal terminal, OptionSet options, Environment env, ProcessInfo processInfo) throws Exception {
         try (SecureString password = options.has(passwordOption) ? readPassword(terminal, true) : new SecureString(new char[0])) {
-            Path keystoreFile = KeyStoreWrapper.keystorePath(env.configFile());
+            Path keystoreFile = KeyStoreWrapper.keystorePath(env.configDir());
             if (Files.exists(keystoreFile)) {
                 if (terminal.promptYesNo("An elasticsearch keystore already exists. Overwrite?", false) == false) {
                     terminal.println("Exiting without creating keystore.");
@@ -48,8 +48,8 @@ class CreateKeyStoreCommand extends KeyStoreAwareCommand {
                 }
             }
             KeyStoreWrapper keystore = KeyStoreWrapper.create();
-            keystore.save(env.configFile(), password.getChars());
-            terminal.println("Created elasticsearch keystore in " + KeyStoreWrapper.keystorePath(env.configFile()));
+            keystore.save(env.configDir(), password.getChars());
+            terminal.println("Created elasticsearch keystore in " + KeyStoreWrapper.keystorePath(env.configDir()));
         } catch (SecurityException e) {
             throw new UserException(ExitCodes.IO_ERROR, "Error creating the elasticsearch keystore.");
         }

--- a/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/HasPasswordKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/HasPasswordKeyStoreCommand.java
@@ -32,7 +32,7 @@ public class HasPasswordKeyStoreCommand extends KeyStoreAwareCommand {
 
     @Override
     public void execute(Terminal terminal, OptionSet options, Environment env, ProcessInfo processInfo) throws Exception {
-        final Path configFile = env.configFile();
+        final Path configFile = env.configDir();
         final KeyStoreWrapper keyStore = KeyStoreWrapper.load(configFile);
 
         // We handle error printing here so we can respect the "--silent" flag

--- a/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/RemoveSettingKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/RemoveSettingKeyStoreCommand.java
@@ -45,6 +45,6 @@ class RemoveSettingKeyStoreCommand extends BaseKeyStoreCommand {
             }
             keyStore.remove(setting);
         }
-        keyStore.save(env.configFile(), getKeyStorePassword().getChars());
+        keyStore.save(env.configDir(), getKeyStorePassword().getChars());
     }
 }

--- a/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/UpgradeKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/UpgradeKeyStoreCommand.java
@@ -26,7 +26,7 @@ public class UpgradeKeyStoreCommand extends BaseKeyStoreCommand {
 
     @Override
     protected void executeCommand(final Terminal terminal, final OptionSet options, final Environment env) throws Exception {
-        KeyStoreWrapper.upgrade(getKeyStore(), env.configFile(), getKeyStorePassword().getChars());
+        KeyStoreWrapper.upgrade(getKeyStore(), env.configDir(), getKeyStorePassword().getChars());
     }
 
 }

--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/AddFileKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/AddFileKeyStoreCommandTests.java
@@ -46,14 +46,14 @@ public class AddFileKeyStoreCommandTests extends KeyStoreCommandTestCase {
         for (int i = 0; i < length; ++i) {
             bytes[i] = randomByte();
         }
-        Path file = env.configFile().resolve(randomAlphaOfLength(16));
+        Path file = env.configDir().resolve(randomAlphaOfLength(16));
         Files.write(file, bytes);
         return file;
     }
 
     private void addFile(KeyStoreWrapper keystore, String setting, Path file, String password) throws Exception {
         keystore.setFile(setting, Files.readAllBytes(file));
-        keystore.save(env.configFile(), password.toCharArray());
+        keystore.save(env.configDir(), password.toCharArray());
     }
 
     public void testMissingCreateWithEmptyPasswordWhenPrompted() throws Exception {
@@ -77,7 +77,7 @@ public class AddFileKeyStoreCommandTests extends KeyStoreCommandTestCase {
         terminal.addSecretInput(randomFrom("", "keystorepassword"));
         terminal.addTextInput("n"); // explicit no
         execute("foo");
-        assertNull(KeyStoreWrapper.load(env.configFile()));
+        assertNull(KeyStoreWrapper.load(env.configDir()));
     }
 
     public void testOverwritePromptDefault() throws Exception {

--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/AddStringKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/AddStringKeyStoreCommandTests.java
@@ -83,7 +83,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
     public void testMissingNoCreate() throws Exception {
         terminal.addTextInput("n"); // explicit no
         execute("foo");
-        assertNull(KeyStoreWrapper.load(env.configFile()));
+        assertNull(KeyStoreWrapper.load(env.configDir()));
     }
 
     public void testOverwritePromptDefault() throws Exception {
@@ -143,7 +143,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testPromptForValue() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         terminal.addSecretInput("secret value");
         execute("foo");
@@ -152,7 +152,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testPromptForMultipleValues() throws Exception {
         final String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         terminal.addSecretInput("bar1");
         terminal.addSecretInput("bar2");
@@ -165,7 +165,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinShort() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("secret value 1");
         execute("-x", "foo");
@@ -174,7 +174,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinLong() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("secret value 2");
         execute("--stdin", "foo");
@@ -183,7 +183,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinNoInput() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("");
         execute("-x", "foo");
@@ -192,7 +192,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinInputWithLineBreaks() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("Typedthisandhitenter\n");
         execute("-x", "foo");
@@ -201,7 +201,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinInputWithCarriageReturn() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("Typedthisandhitenter\r");
         execute("-x", "foo");
@@ -210,7 +210,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinWithMultipleValues() throws Exception {
         final String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("bar1\nbar2\nbar3");
         execute(randomFrom("-x", "--stdin"), "foo1", "foo2", "foo3");
@@ -221,7 +221,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testAddUtf8String() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         final int stringSize = randomIntBetween(8, 16);
         try (CharArrayWriter secretChars = new CharArrayWriter(stringSize)) {

--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/BootstrapTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/BootstrapTests.java
@@ -42,7 +42,7 @@ public class BootstrapTests extends ESTestCase {
 
     public void testLoadSecureSettings() throws Exception {
         final char[] password = KeyStoreWrapperTests.getPossibleKeystorePassword();
-        final Path configPath = env.configFile();
+        final Path configPath = env.configDir();
         final SecureString seed;
         try (KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.create()) {
             seed = KeyStoreWrapper.SEED_SETTING.get(Settings.builder().setSecureSettings(keyStoreWrapper).build());

--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/CreateKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/CreateKeyStoreCommandTests.java
@@ -48,7 +48,7 @@ public class CreateKeyStoreCommandTests extends KeyStoreCommandTestCase {
     public void testDefaultNotPromptForPassword() throws Exception {
         assumeFalse("Cannot open unprotected keystore on FIPS JVM", inFipsJvm());
         execute();
-        Path configDir = env.configFile();
+        Path configDir = env.configDir();
         assertNotNull(KeyStoreWrapper.load(configDir));
     }
 
@@ -63,7 +63,7 @@ public class CreateKeyStoreCommandTests extends KeyStoreCommandTestCase {
         } else {
             execute();
         }
-        Path configDir = env.configFile();
+        Path configDir = env.configDir();
         assertNotNull(KeyStoreWrapper.load(configDir));
     }
 
@@ -79,13 +79,13 @@ public class CreateKeyStoreCommandTests extends KeyStoreCommandTestCase {
         } else {
             execute();
         }
-        Path configDir = env.configFile();
+        Path configDir = env.configDir();
         assertNotNull(KeyStoreWrapper.load(configDir));
     }
 
     public void testOverwrite() throws Exception {
         String password = getPossibleKeystorePassword();
-        Path keystoreFile = KeyStoreWrapper.keystorePath(env.configFile());
+        Path keystoreFile = KeyStoreWrapper.keystorePath(env.configDir());
         byte[] content = "not a keystore".getBytes(StandardCharsets.UTF_8);
         Files.write(keystoreFile, content);
 
@@ -110,6 +110,6 @@ public class CreateKeyStoreCommandTests extends KeyStoreCommandTestCase {
         } else {
             execute();
         }
-        assertNotNull(KeyStoreWrapper.load(env.configFile()));
+        assertNotNull(KeyStoreWrapper.load(env.configDir()));
     }
 }

--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/KeyStoreCommandTestCase.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/KeyStoreCommandTestCase.java
@@ -77,11 +77,11 @@ public abstract class KeyStoreCommandTestCase extends CommandTestCase {
     }
 
     void saveKeystore(KeyStoreWrapper keystore, String password) throws Exception {
-        keystore.save(env.configFile(), password.toCharArray());
+        keystore.save(env.configDir(), password.toCharArray());
     }
 
     KeyStoreWrapper loadKeystore(String password) throws Exception {
-        KeyStoreWrapper keystore = KeyStoreWrapper.load(env.configFile());
+        KeyStoreWrapper keystore = KeyStoreWrapper.load(env.configDir());
         keystore.decrypt(password.toCharArray());
         return keystore;
     }

--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/UpgradeKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/UpgradeKeyStoreCommandTests.java
@@ -62,11 +62,11 @@ public class UpgradeKeyStoreCommandTests extends KeyStoreCommandTestCase {
     }
 
     private void assertKeystoreUpgrade(String file, int version, @Nullable String password) throws Exception {
-        final Path keystore = KeyStoreWrapper.keystorePath(env.configFile());
+        final Path keystore = KeyStoreWrapper.keystorePath(env.configDir());
         try (InputStream is = KeyStoreWrapperTests.class.getResourceAsStream(file); OutputStream os = Files.newOutputStream(keystore)) {
             is.transferTo(os);
         }
-        try (KeyStoreWrapper beforeUpgrade = KeyStoreWrapper.load(env.configFile())) {
+        try (KeyStoreWrapper beforeUpgrade = KeyStoreWrapper.load(env.configDir())) {
             assertNotNull(beforeUpgrade);
             assertThat(beforeUpgrade.getFormatVersion(), equalTo(version));
         }
@@ -77,7 +77,7 @@ public class UpgradeKeyStoreCommandTests extends KeyStoreCommandTestCase {
         execute();
         terminal.reset();
 
-        try (KeyStoreWrapper afterUpgrade = KeyStoreWrapper.load(env.configFile())) {
+        try (KeyStoreWrapper afterUpgrade = KeyStoreWrapper.load(env.configDir())) {
             assertNotNull(afterUpgrade);
             assertThat(afterUpgrade.getFormatVersion(), equalTo(KeyStoreWrapper.CURRENT_VERSION));
             afterUpgrade.decrypt(password != null ? password.toCharArray() : new char[0]);
@@ -87,6 +87,6 @@ public class UpgradeKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testKeystoreDoesNotExist() {
         final UserException e = expectThrows(UserException.class, this::execute);
-        assertThat(e, hasToString(containsString("keystore not found at [" + KeyStoreWrapper.keystorePath(env.configFile()) + "]")));
+        assertThat(e, hasToString(containsString("keystore not found at [" + KeyStoreWrapper.keystorePath(env.configDir()) + "]")));
     }
 }

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
@@ -249,8 +249,8 @@ public class InstallPluginAction implements Closeable {
                 final List<Path> deleteOnFailure = new ArrayList<>();
                 deleteOnFailures.put(pluginId, deleteOnFailure);
 
-                final Path pluginZip = download(plugin, env.tmpFile());
-                final Path extractedZip = unzip(pluginZip, env.pluginsFile());
+                final Path pluginZip = download(plugin, env.tmpDir());
+                final Path extractedZip = unzip(pluginZip, env.pluginsDir());
                 deleteOnFailure.add(extractedZip);
                 final PluginDescriptor pluginDescriptor = installPlugin(plugin, extractedZip, deleteOnFailure);
                 terminal.println(logPrefix + "Installed " + pluginDescriptor.getName());
@@ -868,14 +868,14 @@ public class InstallPluginAction implements Closeable {
         PluginsUtils.verifyCompatibility(info);
 
         // checking for existing version of the plugin
-        verifyPluginName(env.pluginsFile(), info.getName());
+        verifyPluginName(env.pluginsDir(), info.getName());
 
-        PluginsUtils.checkForFailedPluginRemovals(env.pluginsFile());
+        PluginsUtils.checkForFailedPluginRemovals(env.pluginsDir());
 
         terminal.println(VERBOSE, info.toString());
 
         // check for jar hell before any copying
-        jarHellCheck(info, pluginRoot, env.pluginsFile(), env.modulesFile());
+        jarHellCheck(info, pluginRoot, env.pluginsDir(), env.modulesDir());
 
         if (info.isStable() && hasNamedComponentFile(pluginRoot) == false) {
             generateNameComponentFile(pluginRoot);
@@ -922,9 +922,9 @@ public class InstallPluginAction implements Closeable {
      */
     private PluginDescriptor installPlugin(InstallablePlugin descriptor, Path tmpRoot, List<Path> deleteOnFailure) throws Exception {
         final PluginDescriptor info = loadPluginInfo(tmpRoot);
-        PluginPolicyInfo pluginPolicy = PolicyUtil.getPluginPolicyInfo(tmpRoot, env.tmpFile());
+        PluginPolicyInfo pluginPolicy = PolicyUtil.getPluginPolicyInfo(tmpRoot, env.tmpDir());
         if (pluginPolicy != null) {
-            Set<String> permissions = PluginSecurity.getPermissionDescriptions(pluginPolicy, env.tmpFile());
+            Set<String> permissions = PluginSecurity.getPermissionDescriptions(pluginPolicy, env.tmpDir());
             PluginSecurity.confirmPolicyExceptions(terminal, permissions, batch);
         }
 
@@ -938,14 +938,14 @@ public class InstallPluginAction implements Closeable {
             );
         }
 
-        final Path destination = env.pluginsFile().resolve(info.getName());
+        final Path destination = env.pluginsDir().resolve(info.getName());
         deleteOnFailure.add(destination);
 
         installPluginSupportFiles(
             info,
             tmpRoot,
-            env.binFile().resolve(info.getName()),
-            env.configFile().resolve(info.getName()),
+            env.binDir().resolve(info.getName()),
+            env.configDir().resolve(info.getName()),
             deleteOnFailure
         );
         movePlugin(tmpRoot, destination);

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/ListPluginsCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/ListPluginsCommand.java
@@ -40,13 +40,13 @@ class ListPluginsCommand extends EnvironmentAwareCommand {
 
     @Override
     public void execute(Terminal terminal, OptionSet options, Environment env, ProcessInfo processInfo) throws Exception {
-        if (Files.exists(env.pluginsFile()) == false) {
-            throw new IOException("Plugins directory missing: " + env.pluginsFile());
+        if (Files.exists(env.pluginsDir()) == false) {
+            throw new IOException("Plugins directory missing: " + env.pluginsDir());
         }
 
-        terminal.println(Terminal.Verbosity.VERBOSE, "Plugins directory: " + env.pluginsFile());
+        terminal.println(Terminal.Verbosity.VERBOSE, "Plugins directory: " + env.pluginsDir());
         final List<Path> plugins = new ArrayList<>();
-        try (DirectoryStream<Path> paths = Files.newDirectoryStream(env.pluginsFile())) {
+        try (DirectoryStream<Path> paths = Files.newDirectoryStream(env.pluginsDir())) {
             for (Path path : paths) {
                 if (path.getFileName().toString().equals(ELASTICSEARCH_PLUGINS_YML_CACHE) == false) {
                     plugins.add(path);
@@ -61,7 +61,7 @@ class ListPluginsCommand extends EnvironmentAwareCommand {
 
     private static void printPlugin(Environment env, Terminal terminal, Path plugin, String prefix) throws IOException {
         terminal.println(Terminal.Verbosity.SILENT, prefix + plugin.getFileName().toString());
-        PluginDescriptor info = PluginDescriptor.readFromProperties(env.pluginsFile().resolve(plugin));
+        PluginDescriptor info = PluginDescriptor.readFromProperties(env.pluginsDir().resolve(plugin));
         terminal.println(Terminal.Verbosity.VERBOSE, info.toString(prefix));
 
         // When PluginDescriptor#getElasticsearchVersion returns a string, we can revisit the need

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginAction.java
@@ -93,7 +93,7 @@ public class RemovePluginAction {
         // We build a new map where the keys are plugins that extend plugins
         // we want to remove and the values are the plugins we can't remove
         // because of this dependency
-        Map<String, List<String>> pluginDependencyMap = PluginsUtils.getDependencyMapView(env.pluginsFile());
+        Map<String, List<String>> pluginDependencyMap = PluginsUtils.getDependencyMapView(env.pluginsDir());
         for (Map.Entry<String, List<String>> entry : pluginDependencyMap.entrySet()) {
             for (String extendedPlugin : entry.getValue()) {
                 for (InstallablePlugin plugin : plugins) {
@@ -121,9 +121,9 @@ public class RemovePluginAction {
     private void checkCanRemove(InstallablePlugin plugin) throws UserException {
         String pluginId = plugin.getId();
 
-        final Path pluginDir = env.pluginsFile().resolve(pluginId);
-        final Path pluginConfigDir = env.configFile().resolve(pluginId);
-        final Path removing = env.pluginsFile().resolve(".removing-" + pluginId);
+        final Path pluginDir = env.pluginsDir().resolve(pluginId);
+        final Path pluginConfigDir = env.configDir().resolve(pluginId);
+        final Path removing = env.pluginsDir().resolve(".removing-" + pluginId);
 
         /*
          * If the plugin does not exist and the plugin config does not exist, fail to the user that the plugin is not found, unless there's
@@ -147,7 +147,7 @@ public class RemovePluginAction {
             }
         }
 
-        final Path pluginBinDir = env.binFile().resolve(pluginId);
+        final Path pluginBinDir = env.binDir().resolve(pluginId);
         if (Files.exists(pluginBinDir)) {
             if (Files.isDirectory(pluginBinDir) == false) {
                 throw new UserException(ExitCodes.IO_ERROR, "bin dir for " + pluginId + " is not a directory");
@@ -157,9 +157,9 @@ public class RemovePluginAction {
 
     private void removePlugin(InstallablePlugin plugin) throws IOException {
         final String pluginId = plugin.getId();
-        final Path pluginDir = env.pluginsFile().resolve(pluginId);
-        final Path pluginConfigDir = env.configFile().resolve(pluginId);
-        final Path removing = env.pluginsFile().resolve(".removing-" + pluginId);
+        final Path pluginDir = env.pluginsDir().resolve(pluginId);
+        final Path pluginConfigDir = env.configDir().resolve(pluginId);
+        final Path removing = env.pluginsDir().resolve(".removing-" + pluginId);
 
         terminal.println("-> removing [" + pluginId + "]...");
 
@@ -176,7 +176,7 @@ public class RemovePluginAction {
             terminal.println(VERBOSE, "removing [" + pluginDir + "]");
         }
 
-        final Path pluginBinDir = env.binFile().resolve(pluginId);
+        final Path pluginBinDir = env.binDir().resolve(pluginId);
         if (Files.exists(pluginBinDir)) {
             try (Stream<Path> paths = Files.list(pluginBinDir)) {
                 pluginPaths.addAll(paths.toList());

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/SyncPluginsAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/SyncPluginsAction.java
@@ -61,7 +61,7 @@ public class SyncPluginsAction {
      * @throws UserException if a plugins config file is found.
      */
     public static void ensureNoConfigFile(Environment env) throws UserException {
-        final Path pluginsConfig = env.configFile().resolve(ELASTICSEARCH_PLUGINS_YML);
+        final Path pluginsConfig = env.configDir().resolve(ELASTICSEARCH_PLUGINS_YML);
         if (Files.exists(pluginsConfig)) {
             throw new UserException(
                 ExitCodes.USAGE,
@@ -79,16 +79,16 @@ public class SyncPluginsAction {
      * @throws Exception if anything goes wrong
      */
     public void execute() throws Exception {
-        final Path configPath = this.env.configFile().resolve(ELASTICSEARCH_PLUGINS_YML);
-        final Path previousConfigPath = this.env.pluginsFile().resolve(ELASTICSEARCH_PLUGINS_YML_CACHE);
+        final Path configPath = this.env.configDir().resolve(ELASTICSEARCH_PLUGINS_YML);
+        final Path previousConfigPath = this.env.pluginsDir().resolve(ELASTICSEARCH_PLUGINS_YML_CACHE);
 
         if (Files.exists(configPath) == false) {
             // The `PluginsManager` will have checked that this file exists before invoking the action.
             throw new PluginSyncException("Plugins config does not exist: " + configPath.toAbsolutePath());
         }
 
-        if (Files.exists(env.pluginsFile()) == false) {
-            throw new PluginSyncException("Plugins directory missing: " + env.pluginsFile());
+        if (Files.exists(env.pluginsDir()) == false) {
+            throw new PluginSyncException("Plugins directory missing: " + env.pluginsDir());
         }
 
         // Parse descriptor file
@@ -267,14 +267,14 @@ public class SyncPluginsAction {
         final List<PluginDescriptor> plugins = new ArrayList<>();
 
         try {
-            try (DirectoryStream<Path> paths = Files.newDirectoryStream(env.pluginsFile())) {
+            try (DirectoryStream<Path> paths = Files.newDirectoryStream(env.pluginsDir())) {
                 for (Path pluginPath : paths) {
                     String filename = pluginPath.getFileName().toString();
                     if (filename.startsWith(".")) {
                         continue;
                     }
 
-                    PluginDescriptor info = PluginDescriptor.readFromProperties(env.pluginsFile().resolve(pluginPath));
+                    PluginDescriptor info = PluginDescriptor.readFromProperties(env.pluginsDir().resolve(pluginPath));
                     plugins.add(info);
 
                     // Check for a version mismatch, unless it's an official plugin since we can upgrade them.

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/SyncPluginsCliProvider.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/SyncPluginsCliProvider.java
@@ -37,7 +37,7 @@ public class SyncPluginsCliProvider implements CliToolProvider {
             @Override
             public void execute(Terminal terminal, OptionSet options, Environment env, ProcessInfo processInfo) throws Exception {
                 var action = new SyncPluginsAction(terminal, env);
-                if (Files.exists(env.configFile().resolve(ELASTICSEARCH_PLUGINS_YML)) == false) {
+                if (Files.exists(env.configDir().resolve(ELASTICSEARCH_PLUGINS_YML)) == false) {
                     return;
                 }
                 if (Build.current().type() != Build.Type.DOCKER) {

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
@@ -65,7 +65,7 @@ public class ListPluginsCommandTests extends CommandTestCase {
         final boolean hasNativeController
     ) throws IOException {
         PluginTestUtil.writePluginProperties(
-            env.pluginsFile().resolve(name),
+            env.pluginsDir().resolve(name),
             "description",
             description,
             "name",
@@ -84,9 +84,9 @@ public class ListPluginsCommandTests extends CommandTestCase {
     }
 
     public void testPluginsDirMissing() throws Exception {
-        Files.delete(env.pluginsFile());
+        Files.delete(env.pluginsDir());
         IOException e = expectThrows(IOException.class, () -> execute());
-        assertEquals("Plugins directory missing: " + env.pluginsFile(), e.getMessage());
+        assertEquals("Plugins directory missing: " + env.pluginsDir(), e.getMessage());
     }
 
     public void testNoPlugins() throws Exception {
@@ -112,7 +112,7 @@ public class ListPluginsCommandTests extends CommandTestCase {
         execute("-v");
         assertEquals(
             buildMultiline(
-                "Plugins directory: " + env.pluginsFile(),
+                "Plugins directory: " + env.pluginsDir(),
                 "fake_plugin",
                 "- Plugin information:",
                 "Name: fake_plugin",
@@ -134,7 +134,7 @@ public class ListPluginsCommandTests extends CommandTestCase {
         execute("-v");
         assertEquals(
             buildMultiline(
-                "Plugins directory: " + env.pluginsFile(),
+                "Plugins directory: " + env.pluginsDir(),
                 "fake_plugin1",
                 "- Plugin information:",
                 "Name: fake_plugin1",
@@ -157,7 +157,7 @@ public class ListPluginsCommandTests extends CommandTestCase {
         execute("-v");
         assertEquals(
             buildMultiline(
-                "Plugins directory: " + env.pluginsFile(),
+                "Plugins directory: " + env.pluginsDir(),
                 "fake_plugin1",
                 "- Plugin information:",
                 "Name: fake_plugin1",
@@ -193,14 +193,14 @@ public class ListPluginsCommandTests extends CommandTestCase {
     }
 
     public void testPluginWithoutDescriptorFile() throws Exception {
-        final Path pluginDir = env.pluginsFile().resolve("fake1");
+        final Path pluginDir = env.pluginsDir().resolve("fake1");
         Files.createDirectories(pluginDir);
         var e = expectThrows(IllegalStateException.class, () -> execute());
         assertThat(e.getMessage(), equalTo("Plugin [fake1] is missing a descriptor properties file."));
     }
 
     public void testPluginWithWrongDescriptorFile() throws Exception {
-        final Path pluginDir = env.pluginsFile().resolve("fake1");
+        final Path pluginDir = env.pluginsDir().resolve("fake1");
         PluginTestUtil.writePluginProperties(pluginDir, "description", "fake desc");
         var e = expectThrows(IllegalArgumentException.class, () -> execute());
         assertThat(e.getMessage(), startsWith("property [name] is missing for plugin"));
@@ -208,7 +208,7 @@ public class ListPluginsCommandTests extends CommandTestCase {
 
     public void testExistingIncompatiblePlugin() throws Exception {
         PluginTestUtil.writePluginProperties(
-            env.pluginsFile().resolve("fake_plugin1"),
+            env.pluginsDir().resolve("fake_plugin1"),
             "description",
             "fake desc 1",
             "name",

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/SyncPluginsActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/SyncPluginsActionTests.java
@@ -55,10 +55,10 @@ public class SyncPluginsActionTests extends ESTestCase {
         Path home = createTempDir();
         Settings settings = Settings.builder().put("path.home", home).build();
         env = TestEnvironment.newEnvironment(settings);
-        Files.createDirectories(env.binFile());
-        Files.createFile(env.binFile().resolve("elasticsearch"));
-        Files.createDirectories(env.configFile());
-        Files.createDirectories(env.pluginsFile());
+        Files.createDirectories(env.binDir());
+        Files.createFile(env.binDir().resolve("elasticsearch"));
+        Files.createDirectories(env.configDir());
+        Files.createDirectories(env.pluginsDir());
 
         terminal = MockTerminal.create();
         action = new SyncPluginsAction(terminal, env);
@@ -78,7 +78,7 @@ public class SyncPluginsActionTests extends ESTestCase {
      * then an exception is thrown.
      */
     public void test_ensureNoConfigFile_withConfig_throwsException() throws Exception {
-        Files.createFile(env.configFile().resolve("elasticsearch-plugins.yml"));
+        Files.createFile(env.configDir().resolve("elasticsearch-plugins.yml"));
         final UserException e = expectThrows(UserException.class, () -> SyncPluginsAction.ensureNoConfigFile(env));
 
         assertThat(e.getMessage(), Matchers.matchesPattern("^Plugins config \\[.*] exists.*$"));
@@ -354,7 +354,7 @@ public class SyncPluginsActionTests extends ESTestCase {
 
     private void createPlugin(String name, String version) throws IOException {
         PluginTestUtil.writePluginProperties(
-            env.pluginsFile().resolve(name),
+            env.pluginsDir().resolve(name),
             "description",
             "dummy",
             "name",

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/KeyStoreLoader.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/KeyStoreLoader.java
@@ -24,7 +24,7 @@ public class KeyStoreLoader implements SecureSettingsLoader {
     @Override
     public LoadedSecrets load(Environment environment, Terminal terminal) throws Exception {
         // See if we have a keystore already present
-        KeyStoreWrapper secureSettings = KeyStoreWrapper.load(environment.configFile());
+        KeyStoreWrapper secureSettings = KeyStoreWrapper.load(environment.configDir());
         // If there's no keystore or the keystore has no password, set an empty password
         var password = (secureSettings == null || secureSettings.hasPassword() == false)
             ? new SecureString(new char[0])
@@ -35,7 +35,7 @@ public class KeyStoreLoader implements SecureSettingsLoader {
 
     @Override
     public SecureSettings bootstrap(Environment environment, SecureString password) throws Exception {
-        return KeyStoreWrapper.bootstrap(environment.configFile(), () -> password);
+        return KeyStoreWrapper.bootstrap(environment.configDir(), () -> password);
     }
 
     @Override

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
@@ -150,7 +150,7 @@ class ServerCli extends EnvironmentAwareCommand {
             throw new UserException(ExitCodes.USAGE, "Multiple --enrollment-token parameters are not allowed");
         }
 
-        Path log4jConfig = env.configFile().resolve("log4j2.properties");
+        Path log4jConfig = env.configDir().resolve("log4j2.properties");
         if (Files.exists(log4jConfig) == false) {
             throw new UserException(ExitCodes.CONFIG, "Missing logging config file at " + log4jConfig);
         }
@@ -239,7 +239,7 @@ class ServerCli extends EnvironmentAwareCommand {
             }
             validatePidFile(pidFile);
         }
-        return new ServerArgs(daemonize, quiet, pidFile, secrets, env.settings(), env.configFile(), env.logsFile());
+        return new ServerArgs(daemonize, quiet, pidFile, secrets, env.settings(), env.configDir(), env.logsDir());
     }
 
     @Override

--- a/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceDaemon.java
+++ b/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/WindowsServiceDaemon.java
@@ -43,8 +43,8 @@ class WindowsServiceDaemon extends EnvironmentAwareCommand {
     @Override
     public void execute(Terminal terminal, OptionSet options, Environment env, ProcessInfo processInfo) throws Exception {
         // the Windows service daemon doesn't support secure settings implementations other than the keystore
-        try (var loadedSecrets = KeyStoreWrapper.bootstrap(env.configFile(), () -> new SecureString(new char[0]))) {
-            var args = new ServerArgs(false, true, null, loadedSecrets, env.settings(), env.configFile(), env.logsFile());
+        try (var loadedSecrets = KeyStoreWrapper.bootstrap(env.configDir(), () -> new SecureString(new char[0]))) {
+            var args = new ServerArgs(false, true, null, loadedSecrets, env.settings(), env.configDir(), env.logsDir());
             var tempDir = ServerProcessUtils.setupTempDir(processInfo);
             var jvmOptions = JvmOptionsParser.determineJvmOptions(args, processInfo, tempDir, new MachineDependentHeap());
             var serverProcessBuilder = new ServerProcessBuilder().withTerminal(terminal)

--- a/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadAnalyzerTests.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadAnalyzerTests.java
@@ -207,7 +207,7 @@ public class ReloadAnalyzerTests extends ESSingleNodeTestCase {
     public void testUpdateableSynonymsRejectedAtIndexTime() throws FileNotFoundException, IOException {
         String synonymsFileName = "synonyms.txt";
         setupResourceFile(synonymsFileName, "foo, baz");
-        Path configDir = node().getEnvironment().configFile();
+        Path configDir = node().getEnvironment().configDir();
         if (Files.exists(configDir) == false) {
             Files.createDirectory(configDir);
         }
@@ -319,7 +319,7 @@ public class ReloadAnalyzerTests extends ESSingleNodeTestCase {
     }
 
     private Path setupResourceFile(String fileName, String... content) throws IOException {
-        Path configDir = node().getEnvironment().configFile();
+        Path configDir = node().getEnvironment().configDir();
         if (Files.exists(configDir) == false) {
             Files.createDirectory(configDir);
         }

--- a/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadSynonymAnalyzerIT.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadSynonymAnalyzerIT.java
@@ -57,7 +57,7 @@ public class ReloadSynonymAnalyzerIT extends ESIntegTestCase {
     }
 
     private void testSynonymsUpdate(boolean preview) throws FileNotFoundException, IOException, InterruptedException {
-        Path config = internalCluster().getInstance(Environment.class).configFile();
+        Path config = internalCluster().getInstance(Environment.class).configDir();
         String synonymsFileName = "synonyms.txt";
         Path synonymsFile = config.resolve(synonymsFileName);
         writeFile(synonymsFile, "foo, baz");
@@ -106,7 +106,7 @@ public class ReloadSynonymAnalyzerIT extends ESIntegTestCase {
         final String synonymsFileName = "synonyms.txt";
         final String fieldName = "field";
 
-        Path config = internalCluster().getInstance(Environment.class).configFile();
+        Path config = internalCluster().getInstance(Environment.class).configDir();
         Path synonymsFile = config.resolve(synonymsFileName);
         writeFile(synonymsFile, "foo, baz");
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/HyphenationCompoundWordTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/HyphenationCompoundWordTokenFilterFactory.java
@@ -40,7 +40,7 @@ public class HyphenationCompoundWordTokenFilterFactory extends AbstractCompoundW
             throw new IllegalArgumentException("hyphenation_patterns_path is a required setting.");
         }
 
-        Path hyphenationPatternsFile = env.configFile().resolve(hyphenationPatternsPath);
+        Path hyphenationPatternsFile = env.configDir().resolve(hyphenationPatternsPath);
 
         try {
             InputStream in = Files.newInputStream(hyphenationPatternsFile);

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamGetWriteIndexTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamGetWriteIndexTests.java
@@ -248,7 +248,7 @@ public class DataStreamGetWriteIndexTests extends ESTestCase {
         MetadataCreateIndexService createIndexService;
         {
             Environment env = mock(Environment.class);
-            when(env.sharedDataFile()).thenReturn(null);
+            when(env.sharedDataDir()).thenReturn(null);
             AllocationService allocationService = mock(AllocationService.class);
             when(allocationService.reroute(any(ClusterState.class), any(String.class), any())).then(i -> i.getArguments()[0]);
             when(allocationService.getShardRoutingRoleStrategy()).thenReturn(TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY);

--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -678,7 +678,7 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
             .map(DiscoveryNode::getId)
             .collect(Collectors.toSet());
         // All nodes share the same geoip base dir in the shared tmp dir:
-        Path geoipBaseTmpDir = internalCluster().getDataNodeInstance(Environment.class).tmpFile().resolve("geoip-databases");
+        Path geoipBaseTmpDir = internalCluster().getDataNodeInstance(Environment.class).tmpDir().resolve("geoip-databases");
         assertThat(Files.exists(geoipBaseTmpDir), is(true));
         final List<Path> geoipTmpDirs;
         try (Stream<Path> files = Files.list(geoipBaseTmpDir)) {
@@ -690,7 +690,7 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
 
     private void setupDatabasesInConfigDirectory() throws Exception {
         StreamSupport.stream(internalCluster().getInstances(Environment.class).spliterator(), false)
-            .map(Environment::configFile)
+            .map(Environment::configDir)
             .map(path -> path.resolve("ingest-geoip"))
             .distinct()
             .forEach(path -> {
@@ -718,7 +718,7 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
 
     private void deleteDatabasesInConfigDirectory() throws Exception {
         StreamSupport.stream(internalCluster().getInstances(Environment.class).spliterator(), false)
-            .map(Environment::configFile)
+            .map(Environment::configDir)
             .map(path -> path.resolve("ingest-geoip"))
             .distinct()
             .forEach(path -> {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/ConfigDatabases.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/ConfigDatabases.java
@@ -42,7 +42,7 @@ final class ConfigDatabases implements Closeable {
     private final ConcurrentMap<String, DatabaseReaderLazyLoader> configDatabases;
 
     ConfigDatabases(Environment environment, GeoIpCache cache) {
-        this(environment.configFile().resolve("ingest-geoip"), cache);
+        this(environment.configDir().resolve("ingest-geoip"), cache);
     }
 
     ConfigDatabases(Path geoipConfigDir, GeoIpCache cache) {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
@@ -114,7 +114,7 @@ public final class DatabaseNodeService implements IpDatabaseProvider {
         ClusterService clusterService
     ) {
         this(
-            environment.tmpFile(),
+            environment.tmpDir(),
             new OriginSettingClient(client, IngestService.INGEST_ORIGIN),
             cache,
             new ConfigDatabases(environment, cache),

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/IngestUserAgentPlugin.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/IngestUserAgentPlugin.java
@@ -38,7 +38,7 @@ public class IngestUserAgentPlugin extends Plugin implements IngestPlugin {
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
-        Path userAgentConfigDirectory = parameters.env.configFile().resolve("ingest-user-agent");
+        Path userAgentConfigDirectory = parameters.env.configDir().resolve("ingest-user-agent");
 
         if (Files.exists(userAgentConfigDirectory) == false && Files.isDirectory(userAgentConfigDirectory)) {
             throw new IllegalStateException(

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexSslConfig.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexSslConfig.java
@@ -106,7 +106,7 @@ public class ReindexSslConfig {
                 return settings.getAsList(key);
             }
         };
-        configuration = loader.load(environment.configFile());
+        configuration = loader.load(environment.configDir());
         reload();
 
         final FileChangesListener listener = new FileChangesListener() {

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -358,7 +358,7 @@ class S3Service implements Closeable {
             }
             // Make sure that a readable symlink to the token file exists in the plugin config directory
             // AWS_WEB_IDENTITY_TOKEN_FILE exists but we only use Web Identity Tokens if a corresponding symlink exists and is readable
-            Path webIdentityTokenFileSymlink = environment.configFile().resolve(WEB_IDENTITY_TOKEN_FILE_LOCATION);
+            Path webIdentityTokenFileSymlink = environment.configDir().resolve(WEB_IDENTITY_TOKEN_FILE_LOCATION);
             if (Files.exists(webIdentityTokenFileSymlink) == false) {
                 LOGGER.warn(
                     "Cannot use AWS Web Identity Tokens: AWS_WEB_IDENTITY_TOKEN_FILE is defined but no corresponding symlink exists "

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/CustomWebIdentityTokenCredentialsProviderTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/CustomWebIdentityTokenCredentialsProviderTests.java
@@ -65,7 +65,7 @@ public class CustomWebIdentityTokenCredentialsProviderTests extends ESTestCase {
         Files.createDirectory(configDirectory.resolve("repository-s3"));
         Files.writeString(configDirectory.resolve("repository-s3/aws-web-identity-token-file"), "YXdzLXdlYi1pZGVudGl0eS10b2tlbi1maWxl");
         Environment environment = Mockito.mock(Environment.class);
-        Mockito.when(environment.configFile()).thenReturn(configDirectory);
+        Mockito.when(environment.configDir()).thenReturn(configDirectory);
         return environment;
     }
 
@@ -212,7 +212,7 @@ public class CustomWebIdentityTokenCredentialsProviderTests extends ESTestCase {
                     latch.countDown();
                 }
             });
-            Files.writeString(environment.configFile().resolve("repository-s3/aws-web-identity-token-file"), newWebIdentityToken);
+            Files.writeString(environment.configDir().resolve("repository-s3/aws-web-identity-token-file"), newWebIdentityToken);
 
             safeAwait(latch);
             assertCredentials(awsCredentialsProvider.getCredentials());

--- a/modules/repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
@@ -158,7 +158,7 @@ public class URLRepository extends BlobStoreRepository {
                 if (normalizedUrl == null) {
                     String logMessage = "The specified url [{}] doesn't start with any repository paths specified by the "
                         + "path.repo setting or by {} setting: [{}] ";
-                    logger.warn(logMessage, urlToCheck, ALLOWED_URLS_SETTING.getKey(), environment.repoFiles());
+                    logger.warn(logMessage, urlToCheck, ALLOWED_URLS_SETTING.getKey(), environment.repoDirs());
                     String exceptionMessage = "file url ["
                         + urlToCheck
                         + "] doesn't match any of the locations specified by path.repo or "

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/IcuCollationTokenFilterFactory.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/IcuCollationTokenFilterFactory.java
@@ -51,7 +51,7 @@ public class IcuCollationTokenFilterFactory extends AbstractTokenFilterFactory {
         if (rules != null) {
             Exception failureToResolve = null;
             try {
-                rules = Streams.copyToString(Files.newBufferedReader(environment.configFile().resolve(rules), Charset.forName("UTF-8")));
+                rules = Streams.copyToString(Files.newBufferedReader(environment.configDir().resolve(rules), Charset.forName("UTF-8")));
             } catch (IOException | SecurityException | InvalidPathException e) {
                 failureToResolve = e;
             }

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/IcuTokenizerFactory.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/IcuTokenizerFactory.java
@@ -99,7 +99,7 @@ public class IcuTokenizerFactory extends AbstractTokenizerFactory {
     // parse a single RBBi rule file
     private static BreakIterator parseRules(String filename, Environment env) throws IOException {
 
-        final Path path = env.configFile().resolve(filename);
+        final Path path = env.configDir().resolve(filename);
         String rules = Files.readAllLines(path).stream().filter((v) -> v.startsWith("#") == false).collect(Collectors.joining("\n"));
 
         return new RuleBasedBreakIterator(rules.toString());

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsSecurityContext.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsSecurityContext.java
@@ -81,7 +81,7 @@ class HdfsSecurityContext {
      * Expects keytab file to exist at {@code $CONFIG_DIR$/repository-hdfs/krb5.keytab}
      */
     static Path locateKeytabFile(Environment environment) {
-        Path keytabPath = environment.configFile().resolve("repository-hdfs").resolve("krb5.keytab");
+        Path keytabPath = environment.configDir().resolve("repository-hdfs").resolve("krb5.keytab");
         try {
             if (Files.exists(keytabPath) == false) {
                 throw new RuntimeException("Could not locate keytab at [" + keytabPath + "].");

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilSecurityTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilSecurityTests.java
@@ -103,23 +103,23 @@ public class EvilSecurityTests extends ESTestCase {
         // check that all directories got permissions:
 
         // bin file: ro
-        assertExactPermissions(new FilePermission(environment.binFile().toString(), "read,readlink"), permissions);
+        assertExactPermissions(new FilePermission(environment.binDir().toString(), "read,readlink"), permissions);
         // lib file: ro
-        assertExactPermissions(new FilePermission(environment.libFile().toString(), "read,readlink"), permissions);
+        assertExactPermissions(new FilePermission(environment.libDir().toString(), "read,readlink"), permissions);
         // modules file: ro
-        assertExactPermissions(new FilePermission(environment.modulesFile().toString(), "read,readlink"), permissions);
+        assertExactPermissions(new FilePermission(environment.modulesDir().toString(), "read,readlink"), permissions);
         // config file: ro
-        assertExactPermissions(new FilePermission(environment.configFile().toString(), "read,readlink"), permissions);
+        assertExactPermissions(new FilePermission(environment.configDir().toString(), "read,readlink"), permissions);
         // plugins: ro
-        assertExactPermissions(new FilePermission(environment.pluginsFile().toString(), "read,readlink"), permissions);
+        assertExactPermissions(new FilePermission(environment.pluginsDir().toString(), "read,readlink"), permissions);
 
         // data paths: r/w
-        for (Path dataPath : environment.dataFiles()) {
+        for (Path dataPath : environment.dataDirs()) {
             assertExactPermissions(new FilePermission(dataPath.toString(), "read,readlink,write,delete"), permissions);
         }
-        assertExactPermissions(new FilePermission(environment.sharedDataFile().toString(), "read,readlink,write,delete"), permissions);
+        assertExactPermissions(new FilePermission(environment.sharedDataDir().toString(), "read,readlink,write,delete"), permissions);
         // logs: r/w
-        assertExactPermissions(new FilePermission(environment.logsFile().toString(), "read,readlink,write,delete"), permissions);
+        assertExactPermissions(new FilePermission(environment.logsDir().toString(), "read,readlink,write,delete"), permissions);
         // temp dir: r/w
         assertExactPermissions(new FilePermission(fakeTmpDir.toString(), "read,readlink,write,delete"), permissions);
     }

--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -81,8 +81,8 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
         Environment environment = TestEnvironment.newEnvironment(settings);
 
         // This plugin will NOT have a controller daemon
-        Path plugin = environment.modulesFile().resolve("a_plugin");
-        Files.createDirectories(environment.modulesFile());
+        Path plugin = environment.modulesDir().resolve("a_plugin");
+        Files.createDirectories(environment.modulesDir());
         Files.createDirectories(plugin);
         PluginTestUtil.writePluginProperties(
             plugin,
@@ -112,8 +112,8 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
      * Two plugins - one with a controller daemon and one without.
      */
     public void testControllerSpawn() throws Exception {
-        assertControllerSpawns(Environment::pluginsFile, false);
-        assertControllerSpawns(Environment::modulesFile, true);
+        assertControllerSpawns(Environment::pluginsDir, false);
+        assertControllerSpawns(Environment::modulesDir, true);
     }
 
     private void assertControllerSpawns(final Function<Environment, Path> pluginsDirFinder, boolean expectSpawn) throws Exception {
@@ -132,8 +132,8 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
 
         // this plugin will have a controller daemon
         Path plugin = pluginsDirFinder.apply(environment).resolve("test_plugin");
-        Files.createDirectories(environment.modulesFile());
-        Files.createDirectories(environment.pluginsFile());
+        Files.createDirectories(environment.modulesDir());
+        Files.createDirectories(environment.pluginsDir());
         Files.createDirectories(plugin);
         PluginTestUtil.writePluginProperties(
             plugin,
@@ -218,7 +218,7 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
 
         Environment environment = TestEnvironment.newEnvironment(settings);
 
-        Path plugin = environment.modulesFile().resolve("test_plugin");
+        Path plugin = environment.modulesDir().resolve("test_plugin");
         Files.createDirectories(plugin);
         PluginTestUtil.writePluginProperties(
             plugin,
@@ -251,10 +251,10 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
 
         final Environment environment = TestEnvironment.newEnvironment(settings);
 
-        Files.createDirectories(environment.modulesFile());
-        Files.createDirectories(environment.pluginsFile());
+        Files.createDirectories(environment.modulesDir());
+        Files.createDirectories(environment.pluginsDir());
 
-        final Path desktopServicesStore = environment.modulesFile().resolve(".DS_Store");
+        final Path desktopServicesStore = environment.modulesDir().resolve(".DS_Store");
         Files.createFile(desktopServicesStore);
 
         final Spawner spawner = new Spawner();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
@@ -85,7 +85,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         final Environment environment = internalCluster().getInstance(Environment.class);
         final AtomicReference<AssertionError> reloadSettingsError = new AtomicReference<>();
         // keystore file should be missing for this test case
-        Files.deleteIfExists(KeyStoreWrapper.keystorePath(environment.configFile()));
+        Files.deleteIfExists(KeyStoreWrapper.keystorePath(environment.configDir()));
         final int initialReloadCount = mockReloadablePlugin.getReloadCount();
         final CountDownLatch latch = new CountDownLatch(1);
         executeReloadSecureSettings(Strings.EMPTY_ARRAY, emptyPassword(), new ActionListener<>() {
@@ -129,10 +129,10 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         final int initialReloadCount = mockReloadablePlugin.getReloadCount();
         // invalid "keystore" file should be present in the config dir
         try (InputStream keystore = ReloadSecureSettingsIT.class.getResourceAsStream("invalid.txt.keystore")) {
-            if (Files.exists(environment.configFile()) == false) {
-                Files.createDirectory(environment.configFile());
+            if (Files.exists(environment.configDir()) == false) {
+                Files.createDirectory(environment.configDir());
             }
-            Files.copy(keystore, KeyStoreWrapper.keystorePath(environment.configFile()), StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(keystore, KeyStoreWrapper.keystorePath(environment.configDir()), StandardCopyOption.REPLACE_EXISTING);
         }
         final CountDownLatch latch = new CountDownLatch(1);
         executeReloadSecureSettings(Strings.EMPTY_ARRAY, emptyPassword(), new ActionListener<>() {
@@ -363,7 +363,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
 
         try (KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.create()) {
             keyStoreWrapper.setString(VALID_SECURE_SETTING_NAME, new char[0]);
-            keyStoreWrapper.save(environment.configFile(), new char[0], false);
+            keyStoreWrapper.save(environment.configDir(), new char[0], false);
         }
 
         PlainActionFuture<NodesReloadSecureSettingsResponse> actionFuture = new PlainActionFuture<>();
@@ -374,7 +374,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         try (KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.create()) {
             assertThat(keyStoreWrapper, notNullValue());
             keyStoreWrapper.setString("some.setting.that.does.not.exist", new char[0]);
-            keyStoreWrapper.save(environment.configFile(), new char[0], false);
+            keyStoreWrapper.save(environment.configDir(), new char[0], false);
         }
 
         actionFuture = new PlainActionFuture<>();
@@ -432,7 +432,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
 
     private SecureSettings writeEmptyKeystore(Environment environment, char[] password) throws Exception {
         final KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.create();
-        keyStoreWrapper.save(environment.configFile(), password, false);
+        keyStoreWrapper.save(environment.configDir(), password, false);
         return keyStoreWrapper;
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -98,7 +98,6 @@ import static org.elasticsearch.cluster.routing.TestShardRouting.shardRoutingBui
 import static org.elasticsearch.index.shard.IndexShardTestCase.closeShardNoCheck;
 import static org.elasticsearch.index.shard.IndexShardTestCase.getTranslog;
 import static org.elasticsearch.index.shard.IndexShardTestCase.recoverFromStore;
-import static org.elasticsearch.indices.cluster.AbstractIndicesClusterStateServiceTestCase.awaitIndexShardCloseAsyncTasks;
 import static org.elasticsearch.test.LambdaMatchers.falseWith;
 import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -221,7 +220,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
 
     public void testIndexDirIsDeletedWhenShardRemoved() throws Exception {
         Environment env = getInstanceFromNode(Environment.class);
-        Path idxPath = env.sharedDataFile().resolve(randomAlphaOfLength(10));
+        Path idxPath = env.sharedDataDir().resolve(randomAlphaOfLength(10));
         logger.info("--> idxPath: [{}]", idxPath);
         Settings idxSettings = Settings.builder().put(IndexMetadata.SETTING_DATA_PATH, idxPath).build();
         createIndex("test", idxSettings);
@@ -255,7 +254,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
 
     public void testIndexCanChangeCustomDataPath() throws Exception {
         final String index = "test-custom-data-path";
-        final Path sharedDataPath = getInstanceFromNode(Environment.class).sharedDataFile().resolve(randomAsciiLettersOfLength(10));
+        final Path sharedDataPath = getInstanceFromNode(Environment.class).sharedDataDir().resolve(randomAsciiLettersOfLength(10));
         final Path indexDataPath = sharedDataPath.resolve("start-" + randomAsciiLettersOfLength(10));
 
         logger.info("--> creating index [{}] with data_path [{}]", index, indexDataPath);

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
@@ -562,7 +562,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
             command.findAndProcessShardPath(
                 options,
                 environmentByNodeName.get(nodeName),
-                environmentByNodeName.get(nodeName).dataFiles(),
+                environmentByNodeName.get(nodeName).dataDirs(),
                 state,
                 shardPath -> assertThat(shardPath.resolveIndex(), equalTo(indexPath))
             );

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MultiClusterRepoAccessIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MultiClusterRepoAccessIT.java
@@ -195,7 +195,7 @@ public class MultiClusterRepoAccessIT extends AbstractSnapshotIntegTestCase {
         );
 
         assertAcked(clusterAdmin().prepareDeleteRepository(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, repoName));
-        IOUtils.rm(internalCluster().getCurrentMasterNodeInstance(Environment.class).resolveRepoFile(repoPath.toString()));
+        IOUtils.rm(internalCluster().getCurrentMasterNodeInstance(Environment.class).resolveRepoDir(repoPath.toString()));
         createRepository(repoName, "fs", repoPath);
         createFullSnapshot(repoName, "snap-1");
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
@@ -108,7 +108,7 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
         Task task
     ) {
         // We default to using an empty string as the keystore password so that we mimic pre 7.3 API behavior
-        try (KeyStoreWrapper keystore = KeyStoreWrapper.load(environment.configFile())) {
+        try (KeyStoreWrapper keystore = KeyStoreWrapper.load(environment.configDir())) {
             // reread keystore from config file
             if (keystore == null) {
                 return new NodesReloadSecureSettingsResponse.NodeResponse(

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapUtil.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapUtil.java
@@ -24,7 +24,7 @@ public class BootstrapUtil {
 
     public static SecureSettings loadSecureSettings(Environment initialEnv, SecureString keystorePassword) throws BootstrapException {
         try {
-            return KeyStoreWrapper.bootstrap(initialEnv.configFile(), () -> keystorePassword);
+            return KeyStoreWrapper.bootstrap(initialEnv.configDir(), () -> keystorePassword);
         } catch (Exception e) {
             throw new BootstrapException(e);
         }

--- a/server/src/main/java/org/elasticsearch/bootstrap/ConsoleLoader.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/ConsoleLoader.java
@@ -52,7 +52,7 @@ public class ConsoleLoader {
     }
 
     private static ClassLoader buildClassLoader(Environment env) {
-        final Path libDir = env.libFile().resolve("tools").resolve("ansi-console");
+        final Path libDir = env.libDir().resolve("tools").resolve("ansi-console");
 
         try (var libDirFilesStream = Files.list(libDir)) {
             final URL[] urls = libDirFilesStream.filter(each -> each.getFileName().toString().endsWith(".jar"))

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -185,7 +185,7 @@ class Elasticsearch {
 
         nodeEnv.validateNativesConfig(); // temporary directories are important for JNA
         initializeNatives(
-            nodeEnv.tmpFile(),
+            nodeEnv.tmpDir(),
             BootstrapSettings.MEMORY_LOCK_SETTING.get(args.nodeSettings()),
             true, // always install system call filters, not user-configurable since 8.0.0
             BootstrapSettings.CTRLHANDLER_SETTING.get(args.nodeSettings())
@@ -217,8 +217,8 @@ class Elasticsearch {
         );
 
         // load the plugin Java modules and layers now for use in entitlements
-        var modulesBundles = PluginsLoader.loadModulesBundles(nodeEnv.modulesFile());
-        var pluginsBundles = PluginsLoader.loadPluginsBundles(nodeEnv.pluginsFile());
+        var modulesBundles = PluginsLoader.loadModulesBundles(nodeEnv.modulesDir());
+        var pluginsBundles = PluginsLoader.loadPluginsBundles(nodeEnv.pluginsDir());
 
         final PluginsLoader pluginsLoader;
 
@@ -239,9 +239,9 @@ class Elasticsearch {
             EntitlementBootstrap.bootstrap(
                 pluginPolicies,
                 pluginsResolver::resolveClassToPluginName,
-                nodeEnv.dataFiles(),
-                nodeEnv.configFile(),
-                nodeEnv.tmpFile()
+                nodeEnv.dataDirs(),
+                nodeEnv.configDir(),
+                nodeEnv.tmpDir()
             );
         } else if (RuntimeVersionFeature.isSecurityManagerAvailable()) {
             // no need to explicitly enable native access for legacy code

--- a/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -69,14 +69,14 @@ final class Spawner implements Closeable {
         if (spawned.compareAndSet(false, true) == false) {
             throw new IllegalStateException("native controllers already spawned");
         }
-        if (Files.exists(environment.modulesFile()) == false) {
-            throw new IllegalStateException("modules directory [" + environment.modulesFile() + "] not found");
+        if (Files.exists(environment.modulesDir()) == false) {
+            throw new IllegalStateException("modules directory [" + environment.modulesDir() + "] not found");
         }
         /*
          * For each module, attempt to spawn the controller daemon. Silently ignore any module that doesn't include a controller for the
          * correct platform.
          */
-        List<Path> paths = PluginsUtils.findPluginDirs(environment.modulesFile());
+        List<Path> paths = PluginsUtils.findPluginDirs(environment.modulesDir());
         for (final Path modules : paths) {
             final PluginDescriptor info = PluginDescriptor.readFromProperties(modules);
             final Path spawnPath = Platforms.nativeControllerPath(modules);
@@ -91,7 +91,7 @@ final class Spawner implements Closeable {
                 );
                 throw new IllegalArgumentException(message);
             }
-            final Process process = spawnNativeController(spawnPath, environment.tmpFile());
+            final Process process = spawnNativeController(spawnPath, environment.tmpDir());
             // The process _shouldn't_ write any output via its stdout or stderr, but if it does then
             // it will block if nothing is reading that output. To avoid this we can pipe the
             // outputs and create pump threads to write any messages there to the ES log.

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1445,7 +1445,7 @@ public class MetadataCreateIndexService {
     }
 
     List<String> getIndexSettingsValidationErrors(final Settings settings, final boolean forbidPrivateIndexSettings) {
-        List<String> validationErrors = validateIndexCustomPath(settings, env.sharedDataFile());
+        List<String> validationErrors = validateIndexCustomPath(settings, env.sharedDataDir());
         if (forbidPrivateIndexSettings) {
             validationErrors.addAll(validatePrivateSettingsNotExplicitlySet(settings, indexScopedSettings));
         }

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -127,7 +127,7 @@ public class LogConfigurator {
             StatusLogger.getLogger().removeListener(ERROR_LISTENER);
         }
         configureESLogging();
-        configure(environment.settings(), environment.configFile(), environment.logsFile(), useConsole);
+        configure(environment.settings(), environment.configDir(), environment.logsDir(), useConsole);
         initializeStatics();
         // creates a permanent status logger that can watch for StatusLogger events and forward to a real logger
         configureStatusLoggerForwarder();

--- a/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
@@ -142,7 +142,7 @@ public final class LocallyMountedSecrets implements SecureSettings {
      * @return Secrets directory within an Elasticsearch environment
      */
     public static Path resolveSecretsDir(Environment environment) {
-        return environment.configFile().toAbsolutePath().resolve(SECRETS_DIRECTORY);
+        return environment.configDir().toAbsolutePath().resolve(SECRETS_DIRECTORY);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -47,28 +47,28 @@ public class Environment {
 
     private final Settings settings;
 
-    private final Path[] dataFiles;
+    private final Path[] dataDirs;
 
-    private final Path[] repoFiles;
+    private final Path[] repoDirs;
 
-    private final Path configFile;
+    private final Path configDir;
 
-    private final Path pluginsFile;
+    private final Path pluginsDir;
 
-    private final Path modulesFile;
+    private final Path modulesDir;
 
-    private final Path sharedDataFile;
+    private final Path sharedDataDir;
 
     /** location of bin/, used by plugin manager */
-    private final Path binFile;
+    private final Path binDir;
 
     /** location of lib/, */
-    private final Path libFile;
+    private final Path libDir;
 
-    private final Path logsFile;
+    private final Path logsDir;
 
     /** Path to the temporary file directory used by the JDK */
-    private final Path tmpFile;
+    private final Path tmpDir;
 
     public Environment(final Settings settings, final Path configPath) {
         this(settings, configPath, PathUtils.get(System.getProperty("java.io.tmpdir")));
@@ -84,67 +84,67 @@ public class Environment {
         }
 
         if (configPath != null) {
-            configFile = configPath.toAbsolutePath().normalize();
+            configDir = configPath.toAbsolutePath().normalize();
         } else {
-            configFile = homeFile.resolve("config");
+            configDir = homeFile.resolve("config");
         }
 
-        tmpFile = Objects.requireNonNull(tmpPath);
+        tmpDir = Objects.requireNonNull(tmpPath);
 
-        pluginsFile = homeFile.resolve("plugins");
+        pluginsDir = homeFile.resolve("plugins");
 
         List<String> dataPaths = PATH_DATA_SETTING.get(settings);
         if (dataPaths.isEmpty() == false) {
-            dataFiles = new Path[dataPaths.size()];
+            dataDirs = new Path[dataPaths.size()];
             for (int i = 0; i < dataPaths.size(); i++) {
-                dataFiles[i] = PathUtils.get(dataPaths.get(i)).toAbsolutePath().normalize();
+                dataDirs[i] = PathUtils.get(dataPaths.get(i)).toAbsolutePath().normalize();
             }
         } else {
-            dataFiles = new Path[] { homeFile.resolve("data") };
+            dataDirs = new Path[] { homeFile.resolve("data") };
         }
         if (PATH_SHARED_DATA_SETTING.exists(settings)) {
-            sharedDataFile = PathUtils.get(PATH_SHARED_DATA_SETTING.get(settings)).toAbsolutePath().normalize();
+            sharedDataDir = PathUtils.get(PATH_SHARED_DATA_SETTING.get(settings)).toAbsolutePath().normalize();
         } else {
-            sharedDataFile = null;
+            sharedDataDir = null;
         }
         List<String> repoPaths = PATH_REPO_SETTING.get(settings);
         if (repoPaths.isEmpty()) {
-            repoFiles = EMPTY_PATH_ARRAY;
+            repoDirs = EMPTY_PATH_ARRAY;
         } else {
-            repoFiles = new Path[repoPaths.size()];
+            repoDirs = new Path[repoPaths.size()];
             for (int i = 0; i < repoPaths.size(); i++) {
-                repoFiles[i] = PathUtils.get(repoPaths.get(i)).toAbsolutePath().normalize();
+                repoDirs[i] = PathUtils.get(repoPaths.get(i)).toAbsolutePath().normalize();
             }
         }
 
         // this is trappy, Setting#get(Settings) will get a fallback setting yet return false for Settings#exists(Settings)
         if (PATH_LOGS_SETTING.exists(settings)) {
-            logsFile = PathUtils.get(PATH_LOGS_SETTING.get(settings)).toAbsolutePath().normalize();
+            logsDir = PathUtils.get(PATH_LOGS_SETTING.get(settings)).toAbsolutePath().normalize();
         } else {
-            logsFile = homeFile.resolve("logs");
+            logsDir = homeFile.resolve("logs");
         }
 
-        binFile = homeFile.resolve("bin");
-        libFile = homeFile.resolve("lib");
-        modulesFile = homeFile.resolve("modules");
+        binDir = homeFile.resolve("bin");
+        libDir = homeFile.resolve("lib");
+        modulesDir = homeFile.resolve("modules");
 
         final Settings.Builder finalSettings = Settings.builder().put(settings);
         if (PATH_DATA_SETTING.exists(settings)) {
             if (dataPathUsesList(settings)) {
-                finalSettings.putList(PATH_DATA_SETTING.getKey(), Arrays.stream(dataFiles).map(Path::toString).toList());
+                finalSettings.putList(PATH_DATA_SETTING.getKey(), Arrays.stream(dataDirs).map(Path::toString).toList());
             } else {
-                assert dataFiles.length == 1;
-                finalSettings.put(PATH_DATA_SETTING.getKey(), dataFiles[0]);
+                assert dataDirs.length == 1;
+                finalSettings.put(PATH_DATA_SETTING.getKey(), dataDirs[0]);
             }
         }
         finalSettings.put(PATH_HOME_SETTING.getKey(), homeFile);
-        finalSettings.put(PATH_LOGS_SETTING.getKey(), logsFile.toString());
+        finalSettings.put(PATH_LOGS_SETTING.getKey(), logsDir.toString());
         if (PATH_REPO_SETTING.exists(settings)) {
-            finalSettings.putList(Environment.PATH_REPO_SETTING.getKey(), Arrays.stream(repoFiles).map(Path::toString).toList());
+            finalSettings.putList(Environment.PATH_REPO_SETTING.getKey(), Arrays.stream(repoDirs).map(Path::toString).toList());
         }
         if (PATH_SHARED_DATA_SETTING.exists(settings)) {
-            assert sharedDataFile != null;
-            finalSettings.put(Environment.PATH_SHARED_DATA_SETTING.getKey(), sharedDataFile.toString());
+            assert sharedDataDir != null;
+            finalSettings.put(Environment.PATH_SHARED_DATA_SETTING.getKey(), sharedDataDir.toString());
         }
 
         this.settings = finalSettings.build();
@@ -160,22 +160,22 @@ public class Environment {
     /**
      * The data location.
      */
-    public Path[] dataFiles() {
-        return dataFiles;
+    public Path[] dataDirs() {
+        return dataDirs;
     }
 
     /**
      * The shared data location
      */
-    public Path sharedDataFile() {
-        return sharedDataFile;
+    public Path sharedDataDir() {
+        return sharedDataDir;
     }
 
     /**
      * The shared filesystem repo locations.
      */
-    public Path[] repoFiles() {
-        return repoFiles;
+    public Path[] repoDirs() {
+        return repoDirs;
     }
 
     /**
@@ -183,8 +183,8 @@ public class Environment {
      *
      * If the specified location doesn't match any of the roots, returns null.
      */
-    public Path resolveRepoFile(String location) {
-        return PathUtils.get(repoFiles, location);
+    public Path resolveRepoDir(String location) {
+        return PathUtils.get(repoDirs, location);
     }
 
     /**
@@ -198,7 +198,7 @@ public class Environment {
             if ("file".equalsIgnoreCase(url.getProtocol())) {
                 if (url.getHost() == null || "".equals(url.getHost())) {
                     // only local file urls are supported
-                    Path path = PathUtils.get(repoFiles, url.toURI());
+                    Path path = PathUtils.get(repoDirs, url.toURI());
                     if (path == null) {
                         // Couldn't resolve against known repo locations
                         return null;
@@ -237,45 +237,45 @@ public class Environment {
     /**
      * The config directory.
      */
-    public Path configFile() {
-        return configFile;
+    public Path configDir() {
+        return configDir;
     }
 
-    public Path pluginsFile() {
-        return pluginsFile;
+    public Path pluginsDir() {
+        return pluginsDir;
     }
 
-    public Path binFile() {
-        return binFile;
+    public Path binDir() {
+        return binDir;
     }
 
-    public Path libFile() {
-        return libFile;
+    public Path libDir() {
+        return libDir;
     }
 
-    public Path modulesFile() {
-        return modulesFile;
+    public Path modulesDir() {
+        return modulesDir;
     }
 
-    public Path logsFile() {
-        return logsFile;
+    public Path logsDir() {
+        return logsDir;
     }
 
     /** Path to the default temp directory used by the JDK */
-    public Path tmpFile() {
-        return tmpFile;
+    public Path tmpDir() {
+        return tmpDir;
     }
 
     /** Ensure the configured temp directory is a valid directory */
-    public void validateTmpFile() throws IOException {
-        validateTemporaryDirectory("Temporary directory", tmpFile);
+    public void validateTmpDir() throws IOException {
+        validateTemporaryDirectory("Temporary directory", tmpDir);
     }
 
     /**
      * Ensure the temp directories needed for JNA are set up correctly.
      */
     public void validateNativesConfig() throws IOException {
-        validateTmpFile();
+        validateTmpDir();
         if (Constants.LINUX) {
             validateTemporaryDirectory(LIBFFI_TMPDIR_ENVIRONMENT_VARIABLE + " environment variable", getLibffiTemporaryDirectory());
         }
@@ -336,15 +336,15 @@ public class Environment {
      * object which may contain different setting)
      */
     public static void assertEquivalent(Environment actual, Environment expected) {
-        assertEquals(actual.dataFiles(), expected.dataFiles(), "dataFiles");
-        assertEquals(actual.repoFiles(), expected.repoFiles(), "repoFiles");
-        assertEquals(actual.configFile(), expected.configFile(), "configFile");
-        assertEquals(actual.pluginsFile(), expected.pluginsFile(), "pluginsFile");
-        assertEquals(actual.binFile(), expected.binFile(), "binFile");
-        assertEquals(actual.libFile(), expected.libFile(), "libFile");
-        assertEquals(actual.modulesFile(), expected.modulesFile(), "modulesFile");
-        assertEquals(actual.logsFile(), expected.logsFile(), "logsFile");
-        assertEquals(actual.tmpFile(), expected.tmpFile(), "tmpFile");
+        assertEquals(actual.dataDirs(), expected.dataDirs(), "dataDirs");
+        assertEquals(actual.repoDirs(), expected.repoDirs(), "repoDirs");
+        assertEquals(actual.configDir(), expected.configDir(), "configDir");
+        assertEquals(actual.pluginsDir(), expected.pluginsDir(), "pluginsDir");
+        assertEquals(actual.binDir(), expected.binDir(), "binDir");
+        assertEquals(actual.libDir(), expected.libDir(), "libDir");
+        assertEquals(actual.modulesDir(), expected.modulesDir(), "modulesDir");
+        assertEquals(actual.logsDir(), expected.logsDir(), "logsDir");
+        assertEquals(actual.tmpDir(), expected.tmpDir(), "tmpDir");
     }
 
     private static void assertEquals(Object actual, Object expected, String name) {

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -217,10 +217,10 @@ public final class NodeEnvironment implements Closeable {
             final CheckedFunction<Path, Boolean, IOException> pathFunction,
             final Function<Path, Path> subPathMapping
         ) throws IOException {
-            dataPaths = new DataPath[environment.dataFiles().length];
+            dataPaths = new DataPath[environment.dataDirs().length];
             locks = new Lock[dataPaths.length];
             try {
-                final Path[] dataPaths = environment.dataFiles();
+                final Path[] dataPaths = environment.dataDirs();
                 for (int dirIndex = 0; dirIndex < dataPaths.length; dirIndex++) {
                     Path dataDir = dataPaths[dirIndex];
                     Path dir = subPathMapping.apply(dataDir);
@@ -269,9 +269,9 @@ public final class NodeEnvironment implements Closeable {
         boolean success = false;
 
         try {
-            sharedDataPath = environment.sharedDataFile();
+            sharedDataPath = environment.sharedDataDir();
 
-            for (Path path : environment.dataFiles()) {
+            for (Path path : environment.dataDirs()) {
                 if (Files.exists(path)) {
                     // Call to toRealPath required to resolve symlinks.
                     // We let it fall through to create directories to ensure the symlink
@@ -289,7 +289,7 @@ public final class NodeEnvironment implements Closeable {
                     Locale.ROOT,
                     "failed to obtain node locks, tried %s;"
                         + " maybe these locations are not writable or multiple nodes were started on the same data path?",
-                    Arrays.toString(environment.dataFiles())
+                    Arrays.toString(environment.dataDirs())
                 );
                 throw new IllegalStateException(message, e);
             }
@@ -312,7 +312,7 @@ public final class NodeEnvironment implements Closeable {
             }
 
             // versions 7.x and earlier put their data under ${path.data}/nodes/; leave a file at that location to prevent downgrades
-            for (Path dataPath : environment.dataFiles()) {
+            for (Path dataPath : environment.dataDirs()) {
                 final Path legacyNodesPath = dataPath.resolve("nodes");
                 if (Files.isRegularFile(legacyNodesPath) == false) {
                     final String content = "written by Elasticsearch "
@@ -351,7 +351,7 @@ public final class NodeEnvironment implements Closeable {
         boolean upgradeNeeded = false;
 
         // check if we can do an auto-upgrade
-        for (Path path : environment.dataFiles()) {
+        for (Path path : environment.dataDirs()) {
             final Path nodesFolderPath = path.resolve("nodes");
             if (Files.isDirectory(nodesFolderPath)) {
                 final List<Integer> nodeLockIds = new ArrayList<>();
@@ -394,7 +394,7 @@ public final class NodeEnvironment implements Closeable {
             return false;
         }
 
-        logger.info("upgrading legacy data folders: {}", Arrays.toString(environment.dataFiles()));
+        logger.info("upgrading legacy data folders: {}", Arrays.toString(environment.dataDirs()));
 
         // acquire locks on legacy path for duration of upgrade (to ensure there is no older ES version running on this path)
         final NodeLock legacyNodeLock;
@@ -405,7 +405,7 @@ public final class NodeEnvironment implements Closeable {
                 Locale.ROOT,
                 "failed to obtain legacy node locks, tried %s;"
                     + " maybe these locations are not writable or multiple nodes were started on the same data path?",
-                Arrays.toString(environment.dataFiles())
+                Arrays.toString(environment.dataDirs())
             );
             throw new IllegalStateException(message, e);
         }
@@ -496,7 +496,7 @@ public final class NodeEnvironment implements Closeable {
         }
 
         // upgrade successfully completed, remove legacy nodes folders
-        IOUtils.rm(Stream.of(environment.dataFiles()).map(path -> path.resolve("nodes")).toArray(Path[]::new));
+        IOUtils.rm(Stream.of(environment.dataDirs()).map(path -> path.resolve("nodes")).toArray(Path[]::new));
 
         return true;
     }

--- a/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -247,7 +247,7 @@ public class Analysis {
             }
         }
 
-        final Path path = env.configFile().resolve(wordListPath);
+        final Path path = env.configDir().resolve(wordListPath);
 
         try {
             return loadWordList(path, removeComments);
@@ -351,7 +351,7 @@ public class Analysis {
         if (filePath == null) {
             return null;
         }
-        final Path path = env.configFile().resolve(filePath);
+        final Path path = env.configDir().resolve(filePath);
         try {
             return Files.newBufferedReader(path, StandardCharsets.UTF_8);
         } catch (CharacterCodingException ex) {

--- a/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
@@ -122,7 +122,7 @@ public final class HunspellService {
     }
 
     private static Path resolveHunspellDirectory(Environment env) {
-        return env.configFile().resolve("hunspell");
+        return env.configDir().resolve("hunspell");
     }
 
     /**
@@ -193,7 +193,7 @@ public final class HunspellService {
 
             affixStream = Files.newInputStream(affixFiles[0]);
 
-            try (Directory tmp = new NIOFSDirectory(env.tmpFile())) {
+            try (Directory tmp = new NIOFSDirectory(env.tmpDir())) {
                 return new Dictionary(tmp, "hunspell", affixStream, dicStreams, ignoreCase);
             }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -766,7 +766,7 @@ public class Node implements Closeable {
      * Writes a file to the logs dir containing the ports for the given transport type
      */
     private void writePortsFile(String type, BoundTransportAddress boundAddress) {
-        Path tmpPortsFile = environment.logsFile().resolve(type + ".ports.tmp");
+        Path tmpPortsFile = environment.logsDir().resolve(type + ".ports.tmp");
         try (BufferedWriter writer = Files.newBufferedWriter(tmpPortsFile, Charset.forName("UTF-8"))) {
             for (TransportAddress address : boundAddress.boundAddresses()) {
                 InetAddress inetAddress = InetAddress.getByName(address.getAddress());
@@ -775,7 +775,7 @@ public class Node implements Closeable {
         } catch (IOException e) {
             throw new RuntimeException("Failed to write ports file", e);
         }
-        Path portsFile = environment.logsFile().resolve(type + ".ports");
+        Path portsFile = environment.logsDir().resolve(type + ".ports");
         try {
             Files.move(tmpPortsFile, portsFile, StandardCopyOption.ATOMIC_MOVE);
         } catch (IOException e) {

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -445,7 +445,7 @@ class NodeConstruction {
             );
         }
 
-        if (initialEnvironment.dataFiles().length > 1) {
+        if (initialEnvironment.dataDirs().length > 1) {
             // NOTE: we use initialEnvironment here, but assertEquivalent below ensures the data paths do not change
             deprecationLogger.warn(
                 DeprecationCategory.SETTINGS,
@@ -466,10 +466,10 @@ class NodeConstruction {
         if (logger.isDebugEnabled()) {
             logger.debug(
                 "using config [{}], data [{}], logs [{}], plugins [{}]",
-                initialEnvironment.configFile(),
-                Arrays.toString(initialEnvironment.dataFiles()),
-                initialEnvironment.logsFile(),
-                initialEnvironment.pluginsFile()
+                initialEnvironment.configDir(),
+                Arrays.toString(initialEnvironment.dataDirs()),
+                initialEnvironment.logsDir(),
+                initialEnvironment.pluginsDir()
             );
         }
 
@@ -486,7 +486,7 @@ class NodeConstruction {
          * Create the environment based on the finalized view of the settings. This is to ensure that components get the same setting
          * values, no matter they ask for them from.
          */
-        environment = new Environment(settings, initialEnvironment.configFile());
+        environment = new Environment(settings, initialEnvironment.configDir());
         Environment.assertEquivalent(initialEnvironment, environment);
         modules.bindToInstance(Environment.class, environment);
 
@@ -1623,7 +1623,7 @@ class NodeConstruction {
             pluginsService.filterPlugins(DiscoveryPlugin.class).toList(),
             pluginsService.filterPlugins(ClusterCoordinationPlugin.class).toList(),
             allocationService,
-            environment.configFile(),
+            environment.configDir(),
             gatewayMetaState,
             rerouteService,
             fsHealthService,

--- a/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
@@ -54,7 +54,7 @@ class NodeServiceProvider {
 
     PluginsService newPluginService(Environment initialEnvironment, PluginsLoader pluginsLoader) {
         // this creates a PluginsService with an empty list of classpath plugins
-        return new PluginsService(initialEnvironment.settings(), initialEnvironment.configFile(), pluginsLoader);
+        return new PluginsService(initialEnvironment.settings(), initialEnvironment.configDir(), pluginsLoader);
     }
 
     ScriptService newScriptService(

--- a/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -92,13 +92,13 @@ public class FsRepository extends BlobStoreRepository {
             );
             throw new RepositoryException(metadata.name(), "missing location");
         }
-        Path locationFile = environment.resolveRepoFile(location);
+        Path locationFile = environment.resolveRepoDir(location);
         if (locationFile == null) {
-            if (environment.repoFiles().length > 0) {
+            if (environment.repoDirs().length > 0) {
                 logger.warn(
                     "The specified location [{}] doesn't start with any " + "repository paths specified by the path.repo setting: [{}] ",
                     location,
-                    environment.repoFiles()
+                    environment.repoDirs()
                 );
                 throw new RepositoryException(
                     metadata.name(),
@@ -127,7 +127,7 @@ public class FsRepository extends BlobStoreRepository {
     @Override
     protected BlobStore createBlobStore() throws Exception {
         final String location = REPOSITORIES_LOCATION_SETTING.get(getMetadata().settings());
-        final Path locationFile = environment.resolveRepoFile(location);
+        final Path locationFile = environment.resolveRepoDir(location);
         return new FsBlobStore(bufferSize, locationFile, isReadOnly());
     }
 

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -59,7 +59,7 @@ public class FileSettingsService extends MasterNodeFileWatchingService implement
      * @param environment we need the environment to pull the location of the config and operator directories
      */
     public FileSettingsService(ClusterService clusterService, ReservedClusterStateService stateService, Environment environment) {
-        super(clusterService, environment.configFile().toAbsolutePath().resolve(OPERATOR_DIRECTORY).resolve(SETTINGS_FILE_NAME));
+        super(clusterService, environment.configDir().toAbsolutePath().resolve(OPERATOR_DIRECTORY).resolve(SETTINGS_FILE_NAME));
         this.stateService = stateService;
     }
 

--- a/server/src/test/java/org/elasticsearch/common/file/AbstractFileWatchingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/file/AbstractFileWatchingServiceTests.java
@@ -104,7 +104,7 @@ public class AbstractFileWatchingServiceTests extends ESTestCase {
 
         env = newEnvironment(Settings.EMPTY);
 
-        Files.createDirectories(env.configFile());
+        Files.createDirectories(env.configDir());
 
         fileWatchingService = new TestFileWatchingService(getWatchedFilePath(env));
     }
@@ -203,7 +203,7 @@ public class AbstractFileWatchingServiceTests extends ESTestCase {
     }
 
     private static Path getWatchedFilePath(Environment env) {
-        return env.configFile().toAbsolutePath().resolve("test").resolve("test.json");
+        return env.configDir().toAbsolutePath().resolve("test").resolve("test.json");
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/common/settings/LocallyMountedSecretsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/LocallyMountedSecretsTests.java
@@ -97,7 +97,7 @@ public class LocallyMountedSecretsTests extends ESTestCase {
     }
 
     public void testProcessSettingsFile() throws Exception {
-        writeTestFile(env.configFile().resolve("secrets").resolve("secrets.json"), testJSON);
+        writeTestFile(env.configDir().resolve("secrets").resolve("secrets.json"), testJSON);
         LocallyMountedSecrets secrets = new LocallyMountedSecrets(env);
         assertTrue(secrets.isLoaded());
         assertThat(secrets.getVersion(), equalTo(1L));
@@ -109,7 +109,7 @@ public class LocallyMountedSecretsTests extends ESTestCase {
     }
 
     public void testProcessDeprecatedSettingsFile() throws Exception {
-        writeTestFile(env.configFile().resolve("secrets").resolve("secrets.json"), testJSONDepricated);
+        writeTestFile(env.configDir().resolve("secrets").resolve("secrets.json"), testJSONDepricated);
         LocallyMountedSecrets secrets = new LocallyMountedSecrets(env);
         assertTrue(secrets.isLoaded());
         assertThat(secrets.getVersion(), equalTo(1L));
@@ -119,7 +119,7 @@ public class LocallyMountedSecretsTests extends ESTestCase {
     }
 
     public void testDuplicateSettingKeys() throws Exception {
-        writeTestFile(env.configFile().resolve("secrets").resolve("secrets.json"), testJSONDuplicateKeys);
+        writeTestFile(env.configDir().resolve("secrets").resolve("secrets.json"), testJSONDuplicateKeys);
         Exception e = expectThrows(Exception.class, () -> new LocallyMountedSecrets(env));
         assertThat(e, instanceOf(XContentParseException.class));
         assertThat(e.getMessage(), containsString("failed to parse field"));
@@ -134,7 +134,7 @@ public class LocallyMountedSecretsTests extends ESTestCase {
     }
 
     public void testSettingsGetFile() throws IOException, GeneralSecurityException {
-        writeTestFile(env.configFile().resolve("secrets").resolve("secrets.json"), testJSON);
+        writeTestFile(env.configDir().resolve("secrets").resolve("secrets.json"), testJSON);
         LocallyMountedSecrets secrets = new LocallyMountedSecrets(env);
         assertTrue(secrets.isLoaded());
         assertThat(secrets.getSettingNames(), containsInAnyOrder("aaa", "ccc", "eee"));
@@ -165,7 +165,7 @@ public class LocallyMountedSecretsTests extends ESTestCase {
     }
 
     public void testSettingsSHADigest() throws IOException, GeneralSecurityException {
-        writeTestFile(env.configFile().resolve("secrets").resolve("secrets.json"), testJSON);
+        writeTestFile(env.configDir().resolve("secrets").resolve("secrets.json"), testJSON);
         LocallyMountedSecrets secrets = new LocallyMountedSecrets(env);
         assertTrue(secrets.isLoaded());
         assertThat(secrets.getSettingNames(), containsInAnyOrder("aaa", "ccc", "eee"));
@@ -178,7 +178,7 @@ public class LocallyMountedSecretsTests extends ESTestCase {
     }
 
     public void testProcessBadSettingsFile() throws IOException {
-        writeTestFile(env.configFile().resolve("secrets").resolve("secrets.json"), noMetadataJSON);
+        writeTestFile(env.configDir().resolve("secrets").resolve("secrets.json"), noMetadataJSON);
         assertThat(
             expectThrows(IllegalArgumentException.class, () -> new LocallyMountedSecrets(env)).getMessage(),
             containsString("Required [metadata]")
@@ -186,7 +186,7 @@ public class LocallyMountedSecretsTests extends ESTestCase {
     }
 
     public void testSerializationWithSecrets() throws Exception {
-        writeTestFile(env.configFile().resolve("secrets").resolve("secrets.json"), testJSON);
+        writeTestFile(env.configDir().resolve("secrets").resolve("secrets.json"), testJSON);
         LocallyMountedSecrets secrets = new LocallyMountedSecrets(env);
 
         final BytesStreamOutput out = new BytesStreamOutput();
@@ -213,7 +213,7 @@ public class LocallyMountedSecretsTests extends ESTestCase {
     }
 
     public void testClose() throws IOException {
-        writeTestFile(env.configFile().resolve("secrets").resolve("secrets.json"), testJSON);
+        writeTestFile(env.configDir().resolve("secrets").resolve("secrets.json"), testJSON);
         LocallyMountedSecrets secrets = new LocallyMountedSecrets(env);
         assertEquals("bbb", secrets.getString("aaa").toString());
         assertEquals("ddd", secrets.getString("ccc").toString());

--- a/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -34,20 +34,20 @@ public class EnvironmentTests extends ESTestCase {
 
     public void testRepositoryResolution() throws IOException {
         Environment environment = newEnvironment();
-        assertThat(environment.resolveRepoFile("/test/repos/repo1"), nullValue());
-        assertThat(environment.resolveRepoFile("test/repos/repo1"), nullValue());
+        assertThat(environment.resolveRepoDir("/test/repos/repo1"), nullValue());
+        assertThat(environment.resolveRepoDir("test/repos/repo1"), nullValue());
         environment = newEnvironment(
             Settings.builder()
                 .putList(Environment.PATH_REPO_SETTING.getKey(), "/test/repos", "/another/repos", "/test/repos/../other")
                 .build()
         );
-        assertThat(environment.resolveRepoFile("/test/repos/repo1"), notNullValue());
-        assertThat(environment.resolveRepoFile("test/repos/repo1"), notNullValue());
-        assertThat(environment.resolveRepoFile("/another/repos/repo1"), notNullValue());
-        assertThat(environment.resolveRepoFile("/test/repos/../repo1"), nullValue());
-        assertThat(environment.resolveRepoFile("/test/repos/../repos/repo1"), notNullValue());
-        assertThat(environment.resolveRepoFile("/somethingeles/repos/repo1"), nullValue());
-        assertThat(environment.resolveRepoFile("/test/other/repo"), notNullValue());
+        assertThat(environment.resolveRepoDir("/test/repos/repo1"), notNullValue());
+        assertThat(environment.resolveRepoDir("test/repos/repo1"), notNullValue());
+        assertThat(environment.resolveRepoDir("/another/repos/repo1"), notNullValue());
+        assertThat(environment.resolveRepoDir("/test/repos/../repo1"), nullValue());
+        assertThat(environment.resolveRepoDir("/test/repos/../repos/repo1"), notNullValue());
+        assertThat(environment.resolveRepoDir("/somethingeles/repos/repo1"), nullValue());
+        assertThat(environment.resolveRepoDir("/test/other/repo"), notNullValue());
 
         assertThat(environment.resolveRepoURL(new URL("file:///test/repos/repo1")), notNullValue());
         assertThat(environment.resolveRepoURL(new URL("file:/test/repos/repo1")), notNullValue());
@@ -66,7 +66,7 @@ public class EnvironmentTests extends ESTestCase {
         final Path pathHome = createTempDir().toAbsolutePath();
         final Settings settings = Settings.builder().put("path.home", pathHome).build();
         final Environment environment = new Environment(settings, null);
-        assertThat(environment.dataFiles(), equalTo(new Path[] { pathHome.resolve("data") }));
+        assertThat(environment.dataDirs(), equalTo(new Path[] { pathHome.resolve("data") }));
     }
 
     public void testPathDataNotSetInEnvironmentIfNotSet() {
@@ -82,41 +82,41 @@ public class EnvironmentTests extends ESTestCase {
             .put("path.data", createTempDir().toAbsolutePath() + "," + createTempDir().toAbsolutePath())
             .build();
         final Environment environment = new Environment(settings, null);
-        assertThat(environment.dataFiles(), arrayWithSize(2));
+        assertThat(environment.dataDirs(), arrayWithSize(2));
     }
 
     public void testPathLogsWhenNotSet() {
         final Path pathHome = createTempDir().toAbsolutePath();
         final Settings settings = Settings.builder().put("path.home", pathHome).build();
         final Environment environment = new Environment(settings, null);
-        assertThat(environment.logsFile(), equalTo(pathHome.resolve("logs")));
+        assertThat(environment.logsDir(), equalTo(pathHome.resolve("logs")));
     }
 
     public void testDefaultConfigPath() {
         final Path path = createTempDir().toAbsolutePath();
         final Settings settings = Settings.builder().put("path.home", path).build();
         final Environment environment = new Environment(settings, null);
-        assertThat(environment.configFile(), equalTo(path.resolve("config")));
+        assertThat(environment.configDir(), equalTo(path.resolve("config")));
     }
 
     public void testConfigPath() {
         final Path configPath = createTempDir().toAbsolutePath();
         final Settings settings = Settings.builder().put("path.home", createTempDir().toAbsolutePath()).build();
         final Environment environment = new Environment(settings, configPath);
-        assertThat(environment.configFile(), equalTo(configPath));
+        assertThat(environment.configDir(), equalTo(configPath));
     }
 
     public void testConfigPathWhenNotSet() {
         final Path pathHome = createTempDir().toAbsolutePath();
         final Settings settings = Settings.builder().put("path.home", pathHome).build();
         final Environment environment = new Environment(settings, null);
-        assertThat(environment.configFile(), equalTo(pathHome.resolve("config")));
+        assertThat(environment.configDir(), equalTo(pathHome.resolve("config")));
     }
 
     public void testNonExistentTempPathValidation() {
         Settings build = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir()).build();
         Environment environment = new Environment(build, null, createTempDir().resolve("this_does_not_exist"));
-        FileNotFoundException e = expectThrows(FileNotFoundException.class, environment::validateTmpFile);
+        FileNotFoundException e = expectThrows(FileNotFoundException.class, environment::validateTmpDir);
         assertThat(e.getMessage(), startsWith("Temporary directory ["));
         assertThat(e.getMessage(), endsWith("this_does_not_exist] does not exist or is not accessible"));
     }
@@ -124,7 +124,7 @@ public class EnvironmentTests extends ESTestCase {
     public void testTempPathValidationWhenRegularFile() throws IOException {
         Settings build = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir()).build();
         Environment environment = new Environment(build, null, createTempFile("something", ".test"));
-        IOException e = expectThrows(IOException.class, environment::validateTmpFile);
+        IOException e = expectThrows(IOException.class, environment::validateTmpDir);
         assertThat(e.getMessage(), startsWith("Temporary directory ["));
         assertThat(e.getMessage(), endsWith(".test] is not a directory"));
     }

--- a/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
@@ -131,7 +131,7 @@ public class NodeRepurposeCommandTests extends ESTestCase {
         boolean hasClusterState = randomBoolean();
         createIndexDataFiles(dataMasterSettings, shardCount, hasClusterState);
 
-        String messageText = NodeRepurposeCommand.noMasterMessage(1, environment.dataFiles().length * shardCount, 0);
+        String messageText = NodeRepurposeCommand.noMasterMessage(1, environment.dataDirs().length * shardCount, 0);
 
         Matcher<String> outputMatcher = allOf(
             containsString(messageText),
@@ -157,7 +157,7 @@ public class NodeRepurposeCommandTests extends ESTestCase {
         createIndexDataFiles(dataMasterSettings, shardCount, hasClusterState);
 
         Matcher<String> matcher = allOf(
-            containsString(NodeRepurposeCommand.shardMessage(environment.dataFiles().length * shardCount, 1)),
+            containsString(NodeRepurposeCommand.shardMessage(environment.dataDirs().length * shardCount, 1)),
             conditionalNot(containsString("testUUID"), verbose == false),
             conditionalNot(containsString("testIndex"), verbose == false || hasClusterState == false),
             conditionalNot(containsString("no name for uuid: testUUID"), verbose == false || hasClusterState)
@@ -271,7 +271,7 @@ public class NodeRepurposeCommandTests extends ESTestCase {
 
     private long digestPaths() {
         // use a commutative digest to avoid dependency on file system order.
-        return Arrays.stream(environment.dataFiles()).mapToLong(this::digestPath).sum();
+        return Arrays.stream(environment.dataDirs()).mapToLong(this::digestPath).sum();
     }
 
     private long digestPath(Path path) {

--- a/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
@@ -454,7 +454,7 @@ public class AnalysisModuleTests extends ESTestCase {
         InputStream aff = getClass().getResourceAsStream("/indices/analyze/conf_dir/hunspell/en_US/en_US.aff");
         InputStream dic = getClass().getResourceAsStream("/indices/analyze/conf_dir/hunspell/en_US/en_US.dic");
         Dictionary dictionary;
-        try (Directory tmp = newFSDirectory(environment.tmpFile())) {
+        try (Directory tmp = newFSDirectory(environment.tmpDir())) {
             dictionary = new Dictionary(tmp, "hunspell", aff, dic);
         }
         AnalysisModule module = new AnalysisModule(environment, singletonList(new AnalysisPlugin() {

--- a/server/src/test/java/org/elasticsearch/node/InternalSettingsPreparerTests.java
+++ b/server/src/test/java/org/elasticsearch/node/InternalSettingsPreparerTests.java
@@ -57,7 +57,7 @@ public class InternalSettingsPreparerTests extends ESTestCase {
         assertEquals(defaultNodeName, settings.get("node.name"));
         assertNotNull(settings.get(ClusterName.CLUSTER_NAME_SETTING.getKey())); // a cluster name was set
         String home = Environment.PATH_HOME_SETTING.get(baseEnvSettings);
-        String configDir = env.configFile().toString();
+        String configDir = env.configDir().toString();
         assertTrue(configDir, configDir.startsWith(home));
         assertEquals("elasticsearch", settings.get("cluster.name"));
     }

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsLoaderTests.java
@@ -52,7 +52,7 @@ public class PluginsLoaderTests extends ESTestCase {
     static PluginsLoader newPluginsLoader(Settings settings) {
         return PluginsLoader.createPluginsLoader(
             Set.of(),
-            PluginsLoader.loadPluginsBundles(TestEnvironment.newEnvironment(settings).pluginsFile()),
+            PluginsLoader.loadPluginsBundles(TestEnvironment.newEnvironment(settings).pluginsDir()),
             Map.of(),
             false
         );
@@ -121,7 +121,7 @@ public class PluginsLoaderTests extends ESTestCase {
 
         var pluginsLoader = PluginsLoader.createPluginsLoader(
             Set.of(),
-            PluginsLoader.loadPluginsBundles(TestEnvironment.newEnvironment(settings).pluginsFile()),
+            PluginsLoader.loadPluginsBundles(TestEnvironment.newEnvironment(settings).pluginsDir()),
             Map.of(STABLE_PLUGIN_NAME, Set.of(STABLE_PLUGIN_MODULE_NAME)),
             false
         );
@@ -182,7 +182,7 @@ public class PluginsLoaderTests extends ESTestCase {
 
         var pluginsLoader = PluginsLoader.createPluginsLoader(
             Set.of(),
-            PluginsLoader.loadPluginsBundles(TestEnvironment.newEnvironment(settings).pluginsFile()),
+            PluginsLoader.loadPluginsBundles(TestEnvironment.newEnvironment(settings).pluginsDir()),
             Map.of(MODULAR_PLUGIN_NAME, Set.of(MODULAR_PLUGIN_MODULE_NAME)),
             false
         );

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -70,7 +70,7 @@ public class PluginsServiceTests extends ESTestCase {
             null,
             PluginsLoader.createPluginsLoader(
                 Set.of(),
-                PluginsLoader.loadPluginsBundles(TestEnvironment.newEnvironment(settings).pluginsFile()),
+                PluginsLoader.loadPluginsBundles(TestEnvironment.newEnvironment(settings).pluginsDir()),
                 Map.of(),
                 false
             )

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -113,7 +113,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         clusterService.getMasterService().setClusterStateSupplier(() -> clusterState);
         env = newEnvironment(Settings.EMPTY);
 
-        Files.createDirectories(env.configFile());
+        Files.createDirectories(env.configDir());
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
@@ -159,7 +159,7 @@ public class FileSettingsServiceTests extends ESTestCase {
 
     public void testOperatorDirName() {
         Path operatorPath = fileSettingsService.watchedFileDir();
-        assertTrue(operatorPath.startsWith(env.configFile()));
+        assertTrue(operatorPath.startsWith(env.configDir()));
         assertTrue(operatorPath.endsWith("operator"));
 
         Path operatorSettingsFile = fileSettingsService.watchedFile();

--- a/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
@@ -94,7 +94,7 @@ public class DiskUsageIntegTestCase extends ESIntegTestCase {
     }
 
     public TestFileStore getTestFileStore(String nodeName) {
-        return fileSystemProvider.getTestFileStore(internalCluster().getInstance(Environment.class, nodeName).dataFiles()[0]);
+        return fileSystemProvider.getTestFileStore(internalCluster().getInstance(Environment.class, nodeName).dataDirs()[0]);
     }
 
     protected static class TestFileStore extends FilterFileStore {

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -671,7 +671,7 @@ public final class DataStreamTestHelper {
         ).build(MapperBuilderContext.root(false, true));
         ClusterService clusterService = ClusterServiceUtils.createClusterService(testThreadPool);
         Environment env = mock(Environment.class);
-        when(env.sharedDataFile()).thenReturn(null);
+        when(env.sharedDataDir()).thenReturn(null);
         AllocationService allocationService = mock(AllocationService.class);
         when(allocationService.reroute(any(ClusterState.class), any(String.class), any())).then(i -> i.getArguments()[0]);
         when(allocationService.getShardRoutingRoleStrategy()).thenReturn(TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY);

--- a/test/framework/src/main/java/org/elasticsearch/plugins/MockPluginsService.java
+++ b/test/framework/src/main/java/org/elasticsearch/plugins/MockPluginsService.java
@@ -42,11 +42,7 @@ public class MockPluginsService extends PluginsService {
      * @param classpathPlugins Plugins that exist in the classpath which should be loaded
      */
     public MockPluginsService(Settings settings, Environment environment, Collection<Class<? extends Plugin>> classpathPlugins) {
-        super(
-            settings,
-            environment.configDir(),
-            new PluginsLoader(Collections.emptySet(), Collections.emptySet(), Collections.emptyMap())
-        );
+        super(settings, environment.configDir(), new PluginsLoader(Collections.emptySet(), Collections.emptySet(), Collections.emptyMap()));
 
         List<LoadedPlugin> pluginsLoaded = new ArrayList<>();
 

--- a/test/framework/src/main/java/org/elasticsearch/plugins/MockPluginsService.java
+++ b/test/framework/src/main/java/org/elasticsearch/plugins/MockPluginsService.java
@@ -44,14 +44,14 @@ public class MockPluginsService extends PluginsService {
     public MockPluginsService(Settings settings, Environment environment, Collection<Class<? extends Plugin>> classpathPlugins) {
         super(
             settings,
-            environment.configFile(),
+            environment.configDir(),
             new PluginsLoader(Collections.emptySet(), Collections.emptySet(), Collections.emptyMap())
         );
 
         List<LoadedPlugin> pluginsLoaded = new ArrayList<>();
 
         for (Class<? extends Plugin> pluginClass : classpathPlugins) {
-            Plugin plugin = loadPlugin(pluginClass, settings, environment.configFile());
+            Plugin plugin = loadPlugin(pluginClass, settings, environment.configDir());
             PluginDescriptor pluginInfo = new PluginDescriptor(
                 pluginClass.getName(),
                 "classpath plugin",

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -2221,7 +2221,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
      */
     public static Path randomRepoPath(Settings settings) {
         Environment environment = TestEnvironment.newEnvironment(settings);
-        Path[] repoFiles = environment.repoFiles();
+        Path[] repoFiles = environment.repoDirs();
         assert repoFiles.length > 0;
         Path path;
         do {

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1803,7 +1803,7 @@ public final class InternalTestCluster extends TestCluster {
                     .distinct()
                     .collect(Collectors.toList());
                 Set<Path> configPaths = Stream.concat(currentNodes.stream(), newNodes.stream())
-                    .map(nac -> nac.node.getEnvironment().configFile())
+                    .map(nac -> nac.node.getEnvironment().configDir())
                     .collect(Collectors.toSet());
                 logger.debug("configuring discovery with {} at {}", discoveryFileContents, configPaths);
                 for (final Path configPath : configPaths) {
@@ -1817,7 +1817,7 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     public Collection<Path> configPaths() {
-        return nodes.values().stream().map(nac -> nac.node.getEnvironment().configFile()).toList();
+        return nodes.values().stream().map(nac -> nac.node.getEnvironment().configDir()).toList();
     }
 
     private void stopNodesAndClient(NodeAndClient nodeAndClient) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -412,9 +412,9 @@ public class XPackPlugin extends XPackClientPlugin
     }
 
     public static Path resolveConfigFile(Environment env, String name) {
-        Path config = env.configFile().resolve(name);
+        Path config = env.configDir().resolve(name);
         if (Files.exists(config) == false) {
-            Path legacyConfig = env.configFile().resolve("x-pack").resolve(name);
+            Path legacyConfig = env.configDir().resolve("x-pack").resolve(name);
             if (Files.exists(legacyConfig)) {
                 deprecationLogger.warn(
                     DeprecationCategory.OTHER,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/CertParsingUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/CertParsingUtils.java
@@ -146,7 +146,7 @@ public class CertParsingUtils {
         boolean acceptNonSecurePasswords
     ) {
         final SslSettingsLoader settingsLoader = new SslSettingsLoader(settings, prefix, acceptNonSecurePasswords);
-        return settingsLoader.buildKeyConfig(environment.configFile());
+        return settingsLoader.buildKeyConfig(environment.configDir());
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SslSettingsLoader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SslSettingsLoader.java
@@ -128,7 +128,7 @@ public final class SslSettingsLoader extends SslConfigurationLoader {
     }
 
     public SslConfiguration load(Environment env) {
-        return load(env.configFile());
+        return load(env.configDir());
     }
 
     public static SslConfiguration load(Settings settings, String prefix, Environment env) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackPluginTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackPluginTests.java
@@ -143,7 +143,7 @@ public class XPackPluginTests extends ESTestCase {
 
         Environment mockEnvironment = mock(Environment.class);
         when(mockEnvironment.settings()).thenReturn(Settings.builder().build());
-        when(mockEnvironment.configFile()).thenReturn(PathUtils.get(""));
+        when(mockEnvironment.configDir()).thenReturn(PathUtils.get(""));
         // ensure createComponents does not influence the results
         Plugin.PluginServices services = mock(Plugin.PluginServices.class);
         when(services.clusterService()).thenReturn(mock(ClusterService.class));
@@ -187,7 +187,7 @@ public class XPackPluginTests extends ESTestCase {
         });
         Environment mockEnvironment = mock(Environment.class);
         when(mockEnvironment.settings()).thenReturn(Settings.builder().build());
-        when(mockEnvironment.configFile()).thenReturn(PathUtils.get(""));
+        when(mockEnvironment.configDir()).thenReturn(PathUtils.get(""));
         Plugin.PluginServices services = mock(Plugin.PluginServices.class);
         when(services.clusterService()).thenReturn(mock(ClusterService.class));
         when(services.threadPool()).thenReturn(mock(ThreadPool.class));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SslSettingsLoaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SslSettingsLoaderTests.java
@@ -347,10 +347,7 @@ public class SslSettingsLoaderTests extends ESTestCase {
         SslConfiguration sslConfiguration = getSslConfiguration(settings);
         assertThat(sslConfiguration.keyConfig(), instanceOf(StoreKeyConfig.class));
         StoreKeyConfig ksKeyInfo = (StoreKeyConfig) sslConfiguration.keyConfig();
-        assertThat(
-            ksKeyInfo,
-            equalTo(new StoreKeyConfig(path, PASSWORD, type, null, KEYPASS, KEY_MGR_ALGORITHM, environment.configDir()))
-        );
+        assertThat(ksKeyInfo, equalTo(new StoreKeyConfig(path, PASSWORD, type, null, KEYPASS, KEY_MGR_ALGORITHM, environment.configDir())));
     }
 
     public void testThatEmptySettingsAreEqual() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SslSettingsLoaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SslSettingsLoaderTests.java
@@ -229,7 +229,7 @@ public class SslSettingsLoaderTests extends ESTestCase {
         StoreKeyConfig ksKeyInfo = (StoreKeyConfig) sslConfiguration.keyConfig();
         assertThat(
             ksKeyInfo,
-            equalTo(new StoreKeyConfig("path", PASSWORD, "type", null, PASSWORD, KEY_MGR_ALGORITHM, environment.configFile()))
+            equalTo(new StoreKeyConfig("path", PASSWORD, "type", null, PASSWORD, KEY_MGR_ALGORITHM, environment.configDir()))
         );
     }
 
@@ -244,7 +244,7 @@ public class SslSettingsLoaderTests extends ESTestCase {
         StoreKeyConfig ksKeyInfo = (StoreKeyConfig) sslConfiguration.keyConfig();
         assertThat(
             ksKeyInfo,
-            equalTo(new StoreKeyConfig("path", PASSWORD, "type", null, PASSWORD, KEY_MGR_ALGORITHM, environment.configFile()))
+            equalTo(new StoreKeyConfig("path", PASSWORD, "type", null, PASSWORD, KEY_MGR_ALGORITHM, environment.configDir()))
         );
         assertSettingDeprecationsAndWarnings(new Setting<?>[] { configurationSettings.x509KeyPair.legacyKeystorePassword });
     }
@@ -263,7 +263,7 @@ public class SslSettingsLoaderTests extends ESTestCase {
         StoreKeyConfig ksKeyInfo = (StoreKeyConfig) sslConfiguration.keyConfig();
         assertThat(
             ksKeyInfo,
-            equalTo(new StoreKeyConfig("path", PASSWORD, "type", null, KEYPASS, KEY_MGR_ALGORITHM, environment.configFile()))
+            equalTo(new StoreKeyConfig("path", PASSWORD, "type", null, KEYPASS, KEY_MGR_ALGORITHM, environment.configDir()))
         );
     }
 
@@ -279,7 +279,7 @@ public class SslSettingsLoaderTests extends ESTestCase {
         StoreKeyConfig ksKeyInfo = (StoreKeyConfig) sslConfiguration.keyConfig();
         assertThat(
             ksKeyInfo,
-            equalTo(new StoreKeyConfig("path", PASSWORD, "type", null, KEYPASS, KEY_MGR_ALGORITHM, environment.configFile()))
+            equalTo(new StoreKeyConfig("path", PASSWORD, "type", null, KEYPASS, KEY_MGR_ALGORITHM, environment.configDir()))
         );
         assertSettingDeprecationsAndWarnings(
             new Setting<?>[] {
@@ -298,7 +298,7 @@ public class SslSettingsLoaderTests extends ESTestCase {
         StoreKeyConfig ksKeyInfo = (StoreKeyConfig) sslConfiguration.keyConfig();
         assertThat(
             ksKeyInfo,
-            equalTo(new StoreKeyConfig("xpack/tls/path.jks", PASSWORD, "jks", null, KEYPASS, KEY_MGR_ALGORITHM, environment.configFile()))
+            equalTo(new StoreKeyConfig("xpack/tls/path.jks", PASSWORD, "jks", null, KEYPASS, KEY_MGR_ALGORITHM, environment.configDir()))
         );
     }
 
@@ -314,7 +314,7 @@ public class SslSettingsLoaderTests extends ESTestCase {
         StoreKeyConfig ksKeyInfo = (StoreKeyConfig) sslConfiguration.keyConfig();
         assertThat(
             ksKeyInfo,
-            equalTo(new StoreKeyConfig(path, PASSWORD, "PKCS12", null, KEYPASS, KEY_MGR_ALGORITHM, environment.configFile()))
+            equalTo(new StoreKeyConfig(path, PASSWORD, "PKCS12", null, KEYPASS, KEY_MGR_ALGORITHM, environment.configDir()))
         );
     }
 
@@ -328,7 +328,7 @@ public class SslSettingsLoaderTests extends ESTestCase {
         StoreKeyConfig ksKeyInfo = (StoreKeyConfig) sslConfiguration.keyConfig();
         assertThat(
             ksKeyInfo,
-            equalTo(new StoreKeyConfig("xpack/tls/path.foo", PASSWORD, "jks", null, KEYPASS, KEY_MGR_ALGORITHM, environment.configFile()))
+            equalTo(new StoreKeyConfig("xpack/tls/path.foo", PASSWORD, "jks", null, KEYPASS, KEY_MGR_ALGORITHM, environment.configDir()))
         );
     }
 
@@ -349,7 +349,7 @@ public class SslSettingsLoaderTests extends ESTestCase {
         StoreKeyConfig ksKeyInfo = (StoreKeyConfig) sslConfiguration.keyConfig();
         assertThat(
             ksKeyInfo,
-            equalTo(new StoreKeyConfig(path, PASSWORD, type, null, KEYPASS, KEY_MGR_ALGORITHM, environment.configFile()))
+            equalTo(new StoreKeyConfig(path, PASSWORD, type, null, KEYPASS, KEY_MGR_ALGORITHM, environment.configDir()))
         );
     }
 

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
@@ -109,7 +109,7 @@ public class MachineLearningPackageLoader extends Plugin implements ActionPlugin
             @Override
             public BootstrapCheckResult check(BootstrapContext context) {
                 try {
-                    validateModelRepository(MODEL_REPOSITORY.get(context.settings()), context.environment().configFile());
+                    validateModelRepository(MODEL_REPOSITORY.get(context.settings()), context.environment().configDir());
                 } catch (Exception e) {
                     return BootstrapCheckResult.failure(
                         "Found an invalid configuration for xpack.ml.model_repository. "

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcessFactory.java
@@ -149,7 +149,7 @@ public class NativeAnalyticsProcessFactory implements AnalyticsProcessFactory<An
         ProcessPipes processPipes
     ) {
         AnalyticsBuilder analyticsBuilder = new AnalyticsBuilder(
-            env::tmpFile,
+            env::tmpDir,
             nativeController,
             processPipes,
             analyticsProcessConfig,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeMemoryUsageEstimationProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeMemoryUsageEstimationProcessFactory.java
@@ -116,7 +116,7 @@ public class NativeMemoryUsageEstimationProcessFactory implements AnalyticsProce
         ProcessPipes processPipes
     ) {
         AnalyticsBuilder analyticsBuilder = new AnalyticsBuilder(
-            env::tmpFile,
+            env::tmpDir,
             nativeController,
             processPipes,
             analyticsProcessConfig,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilder.java
@@ -209,9 +209,9 @@ public class AutodetectBuilder {
         // createTempFile has a race condition where it may return the same
         // temporary file name to different threads if called simultaneously
         // from multiple threads, hence add the thread ID to avoid this
-        FileUtils.recreateTempDirectoryIfNeeded(env.tmpFile());
+        FileUtils.recreateTempDirectoryIfNeeded(env.tmpDir());
         Path stateFile = Files.createTempFile(
-            env.tmpFile(),
+            env.tmpDir(),
             jobId + "_quantiles_" + Thread.currentThread().getId(),
             QUANTILES_FILE_EXTENSION
         );
@@ -227,8 +227,8 @@ public class AutodetectBuilder {
         if (scheduledEvents.isEmpty()) {
             return;
         }
-        FileUtils.recreateTempDirectoryIfNeeded(env.tmpFile());
-        Path eventsConfigFile = Files.createTempFile(env.tmpFile(), "eventsConfig", JSON_EXTENSION);
+        FileUtils.recreateTempDirectoryIfNeeded(env.tmpDir());
+        Path eventsConfigFile = Files.createTempFile(env.tmpDir(), "eventsConfig", JSON_EXTENSION);
         filesToDelete.add(eventsConfigFile);
 
         List<ScheduledEventToRuleWriter> scheduledEventToRuleWriters = scheduledEvents.stream()
@@ -252,8 +252,8 @@ public class AutodetectBuilder {
     }
 
     private void buildJobConfig(List<String> command) throws IOException {
-        FileUtils.recreateTempDirectoryIfNeeded(env.tmpFile());
-        Path configFile = Files.createTempFile(env.tmpFile(), "config", JSON_EXTENSION);
+        FileUtils.recreateTempDirectoryIfNeeded(env.tmpDir());
+        Path configFile = Files.createTempFile(env.tmpDir(), "config", JSON_EXTENSION);
         filesToDelete.add(configFile);
         try (
             OutputStreamWriter osw = new OutputStreamWriter(Files.newOutputStream(configFile), StandardCharsets.UTF_8);
@@ -271,8 +271,8 @@ public class AutodetectBuilder {
         if (referencedFilters.isEmpty()) {
             return;
         }
-        FileUtils.recreateTempDirectoryIfNeeded(env.tmpFile());
-        Path filtersConfigFile = Files.createTempFile(env.tmpFile(), "filtersConfig", JSON_EXTENSION);
+        FileUtils.recreateTempDirectoryIfNeeded(env.tmpDir());
+        Path filtersConfigFile = Files.createTempFile(env.tmpDir(), "filtersConfig", JSON_EXTENSION);
         filesToDelete.add(filtersConfigFile);
 
         try (

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/NativeStorageProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/NativeStorageProvider.java
@@ -52,7 +52,7 @@ public class NativeStorageProvider {
      */
     public void cleanupLocalTmpStorageInCaseOfUncleanShutdown() {
         try {
-            for (Path p : environment.dataFiles()) {
+            for (Path p : environment.dataDirs()) {
                 IOUtils.rm(p.resolve(LOCAL_STORAGE_SUBFOLDER).resolve(LOCAL_STORAGE_TMP_FOLDER));
             }
         } catch (Exception e) {
@@ -79,7 +79,7 @@ public class NativeStorageProvider {
     }
 
     private Path tryAllocateStorage(String uniqueIdentifier, ByteSizeValue requestedSize) {
-        for (Path path : environment.dataFiles()) {
+        for (Path path : environment.dataDirs()) {
             try {
                 if (getUsableSpace(path) >= requestedSize.getBytes() + minLocalStorageAvailable.getBytes()) {
                     Path tmpDirectory = path.resolve(LOCAL_STORAGE_SUBFOLDER).resolve(LOCAL_STORAGE_TMP_FOLDER).resolve(uniqueIdentifier);
@@ -97,7 +97,7 @@ public class NativeStorageProvider {
 
     public boolean localTmpStorageHasEnoughSpace(Path path, ByteSizeValue requestedSize) {
         Path realPath = path.toAbsolutePath();
-        for (Path p : environment.dataFiles()) {
+        for (Path p : environment.dataDirs()) {
             try {
                 if (realPath.startsWith(p.resolve(LOCAL_STORAGE_SUBFOLDER).resolve(LOCAL_STORAGE_TMP_FOLDER))) {
                     return getUsableSpace(p) >= requestedSize.getBytes() + minLocalStorageAvailable.getBytes();
@@ -122,7 +122,7 @@ public class NativeStorageProvider {
         if (path != null) {
             // do not allow to breakout from the tmp storage provided
             Path realPath = path.toAbsolutePath();
-            for (Path p : environment.dataFiles()) {
+            for (Path p : environment.dataDirs()) {
                 if (realPath.startsWith(p.resolve(LOCAL_STORAGE_SUBFOLDER).resolve(LOCAL_STORAGE_TMP_FOLDER))) {
                     IOUtils.rm(path);
                 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/ProcessPipes.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/ProcessPipes.java
@@ -94,7 +94,7 @@ public class ProcessPipes {
     ) {
         this.namedPipeHelper = namedPipeHelper;
         this.jobId = jobId;
-        this.tempDir = env.tmpFile();
+        this.tempDir = env.tmpDir();
         this.timeout = timeout;
 
         // The way the pipe names are formed MUST match what is done in the controller main()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelper.java
@@ -78,7 +78,7 @@ public class NamedPipeHelper {
         // All these factors need to align for everything to work in production. If any changes
         // are made here then CNamedPipeFactory::defaultPath() in the C++ code will probably
         // also need to be changed.
-        return env.tmpFile().toString() + PathUtils.getDefaultFileSystem().getSeparator();
+        return env.tmpDir().toString() + PathUtils.getDefaultFileSystem().getSeparator();
     }
 
     /**

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/NativeStorageProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/NativeStorageProviderTests.java
@@ -123,7 +123,7 @@ public class NativeStorageProviderTests extends ESTestCase {
     private NativeStorageProvider createNativeStorageProvider(Map<Path, Long> paths) throws IOException {
         Environment environment = mock(Environment.class);
 
-        when(environment.dataFiles()).thenReturn(paths.keySet().toArray(new Path[paths.size()]));
+        when(environment.dataDirs()).thenReturn(paths.keySet().toArray(new Path[paths.size()]));
         NativeStorageProvider storageProvider = spy(new NativeStorageProvider(environment, ByteSizeValue.ofGb(5)));
 
         doAnswer(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelperTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelperTests.java
@@ -67,7 +67,7 @@ public class NamedPipeHelperTests extends ESTestCase {
         Environment env = TestEnvironment.newEnvironment(
             Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build()
         );
-        Path tempFile = Files.createTempFile(env.tmpFile(), "not a named pipe", null);
+        Path tempFile = Files.createTempFile(env.tmpDir(), "not a named pipe", null);
 
         IOException ioe = ESTestCase.expectThrows(
             IOException.class,
@@ -83,7 +83,7 @@ public class NamedPipeHelperTests extends ESTestCase {
         Environment env = TestEnvironment.newEnvironment(
             Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build()
         );
-        Path tempFile = Files.createTempFile(env.tmpFile(), "not a named pipe", null);
+        Path tempFile = Files.createTempFile(env.tmpDir(), "not a named pipe", null);
 
         IOException ioe = ESTestCase.expectThrows(
             IOException.class,

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -820,7 +820,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             final String tmpRepositoryName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
             createRepositoryNoVerify(tmpRepositoryName, "fs");
             final Path repoPath = internalCluster().getCurrentMasterNodeInstance(Environment.class)
-                .resolveRepoFile(
+                .resolveRepoDir(
                     clusterAdmin().prepareGetRepositories(TEST_REQUEST_TIMEOUT, tmpRepositoryName)
                         .get()
                         .repositories()

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPrewarmingIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPrewarmingIntegTests.java
@@ -145,7 +145,7 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
             docsPerIndex.put(indexName, nbDocs);
         }
 
-        final Path repositoryPath = node().getEnvironment().resolveRepoFile(randomAlphaOfLength(10));
+        final Path repositoryPath = node().getEnvironment().resolveRepoDir(randomAlphaOfLength(10));
         final Settings.Builder repositorySettings = Settings.builder().put("location", repositoryPath);
         if (randomBoolean()) {
             repositorySettings.put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -98,7 +98,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
             .put("path.home", createTempDir())
             .build();
         final Environment environment = TestEnvironment.newEnvironment(settings);
-        for (Path path : environment.dataFiles()) {
+        for (Path path : environment.dataDirs()) {
             Files.createDirectories(path);
         }
         SnapshotId snapshotId = new SnapshotId("_name", "_uuid");

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
@@ -163,7 +163,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
         final boolean inEnrollmentMode = options.has(enrollmentTokenParam);
 
         // skipping security auto-configuration because node considered as restarting.
-        for (Path dataPath : env.dataFiles()) {
+        for (Path dataPath : env.dataDirs()) {
             if (Files.isDirectory(dataPath) && false == isDirEmpty(dataPath)) {
                 final String msg = "Skipping security auto configuration because it appears that the node is not starting up for the "
                     + "first time. The node might already be part of a cluster and this auto setup utility is designed to configure "
@@ -173,7 +173,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
         }
 
         // pre-flight checks for the files that are going to be changed
-        final Path ymlPath = env.configFile().resolve("elasticsearch.yml");
+        final Path ymlPath = env.configDir().resolve("elasticsearch.yml");
         // it is odd for the `elasticsearch.yml` file to be missing or not be a regular (the node won't start)
         // but auto configuration should not be concerned with fixing it (by creating the file) and let the node startup fail
         if (false == Files.exists(ymlPath) || false == Files.isRegularFile(ymlPath, LinkOption.NOFOLLOW_LINKS)) {
@@ -194,7 +194,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
             );
             notifyOfFailure(inEnrollmentMode, terminal, Terminal.Verbosity.NORMAL, ExitCodes.NOOP, msg);
         }
-        final Path keystorePath = KeyStoreWrapper.keystorePath(env.configFile());
+        final Path keystorePath = KeyStoreWrapper.keystorePath(env.configDir());
         // Inform that auto-configuration will not run if keystore cannot be read.
         if (Files.exists(keystorePath)
             && (false == Files.isRegularFile(keystorePath, LinkOption.NOFOLLOW_LINKS) || false == Files.isReadable(keystorePath))) {
@@ -218,7 +218,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
         checkExistingConfiguration(env.settings(), inEnrollmentMode, terminal);
 
         final ZonedDateTime autoConfigDate = ZonedDateTime.now(ZoneOffset.UTC);
-        final Path tempGeneratedTlsCertsDir = env.configFile()
+        final Path tempGeneratedTlsCertsDir = env.configDir()
             .resolve(String.format(Locale.ROOT, TLS_GENERATED_CERTS_DIR_NAME + ".%d.tmp", autoConfigDate.toInstant().getEpochSecond()));
         try {
             // it is useful to pre-create the sub-config dir in order to check that the config dir is writable and that file owners match
@@ -247,12 +247,12 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
         // If the node process works OK given the owner of the config dir, it should also tolerate the auto-created config dir,
         // provided that they both have the same owner and permissions.
         final UserPrincipal newFileOwner = Files.getOwner(tempGeneratedTlsCertsDir, LinkOption.NOFOLLOW_LINKS);
-        if (false == newFileOwner.equals(Files.getOwner(env.configFile(), LinkOption.NOFOLLOW_LINKS))) {
+        if (false == newFileOwner.equals(Files.getOwner(env.configDir(), LinkOption.NOFOLLOW_LINKS))) {
             // the following is only printed once, if the node starts successfully
             UserException userException = new UserException(
                 ExitCodes.CONFIG,
                 "Aborting auto configuration because of config dir ownership mismatch. Config dir is owned by "
-                    + Files.getOwner(env.configFile(), LinkOption.NOFOLLOW_LINKS).getName()
+                    + Files.getOwner(env.configDir(), LinkOption.NOFOLLOW_LINKS).getName()
                     + " but auto-configuration directory would be owned by "
                     + newFileOwner.getName()
             );
@@ -496,7 +496,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
         }
 
         // save the existing keystore before replacing
-        final Path keystoreBackupPath = env.configFile()
+        final Path keystoreBackupPath = env.configDir()
             .resolve(
                 String.format(Locale.ROOT, KeyStoreWrapper.KEYSTORE_FILENAME + ".%d.orig", autoConfigDate.toInstant().getEpochSecond())
             );
@@ -514,7 +514,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
         }
 
         final SetOnce<SecureString> nodeKeystorePassword = new SetOnce<>();
-        try (KeyStoreWrapper nodeKeystore = KeyStoreWrapper.bootstrap(env.configFile(), () -> {
+        try (KeyStoreWrapper nodeKeystore = KeyStoreWrapper.bootstrap(env.configDir(), () -> {
             nodeKeystorePassword.set(new SecureString(terminal.readSecret("")));
             return nodeKeystorePassword.get().clone();
         })) {
@@ -581,7 +581,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
                 nodeKeystore.setString("xpack.security.http.ssl.keystore.secure_password", httpKeystorePassword.getChars());
             }
             // finally overwrites the node keystore (if the keystores have been successfully written)
-            nodeKeystore.save(env.configFile(), nodeKeystorePassword.get() == null ? new char[0] : nodeKeystorePassword.get().getChars());
+            nodeKeystore.save(env.configDir(), nodeKeystorePassword.get() == null ? new char[0] : nodeKeystorePassword.get().getChars());
         } catch (Throwable t) {
             // restore keystore to revert possible keystore bootstrap
             try {
@@ -614,10 +614,10 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
         try {
             // all certs and keys have been generated in the temp certs dir, therefore:
             // 1. backup (move) any previously existing tls certs dir (this backup is NOT removed when auto-conf finishes)
-            if (Files.exists(env.configFile().resolve(TLS_GENERATED_CERTS_DIR_NAME))) {
+            if (Files.exists(env.configDir().resolve(TLS_GENERATED_CERTS_DIR_NAME))) {
                 moveDirectory(
-                    env.configFile().resolve(TLS_GENERATED_CERTS_DIR_NAME),
-                    env.configFile()
+                    env.configDir().resolve(TLS_GENERATED_CERTS_DIR_NAME),
+                    env.configDir()
                         .resolve(
                             String.format(
                                 Locale.ROOT,
@@ -628,7 +628,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
                 );
             }
             // 2. move the newly populated temp certs dir to its permanent static dir name
-            moveDirectory(tempGeneratedTlsCertsDir, env.configFile().resolve(TLS_GENERATED_CERTS_DIR_NAME));
+            moveDirectory(tempGeneratedTlsCertsDir, env.configDir().resolve(TLS_GENERATED_CERTS_DIR_NAME));
         } catch (Throwable t) {
             // restore keystore to revert possible keystore bootstrap
             try {
@@ -649,7 +649,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
             // revert any previously existing TLS certs
             try {
                 if (Files.exists(
-                    env.configFile()
+                    env.configDir()
                         .resolve(
                             String.format(
                                 Locale.ROOT,
@@ -659,7 +659,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
                         )
                 )) {
                     moveDirectory(
-                        env.configFile()
+                        env.configDir()
                             .resolve(
                                 String.format(
                                     Locale.ROOT,
@@ -667,7 +667,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
                                     autoConfigDate.toInstant().getEpochSecond()
                                 )
                             ),
-                        env.configFile().resolve(TLS_GENERATED_CERTS_DIR_NAME)
+                        env.configDir().resolve(TLS_GENERATED_CERTS_DIR_NAME)
                     );
                 }
             } catch (Exception ex) {
@@ -686,7 +686,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
             final Environment localFinalEnv = env;
             final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss", Locale.ROOT);
             List<String> existingConfigLines = Files.readAllLines(ymlPath, StandardCharsets.UTF_8);
-            fullyWriteFile(env.configFile(), "elasticsearch.yml", true, stream -> {
+            fullyWriteFile(env.configDir(), "elasticsearch.yml", true, stream -> {
                 try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(stream, StandardCharsets.UTF_8))) {
                     // start with the existing config lines
                     for (String line : existingConfigLines) {
@@ -827,16 +827,16 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
             }
             try {
                 // this removes a statically named directory, so it is potentially dangerous
-                deleteDirectory(env.configFile().resolve(TLS_GENERATED_CERTS_DIR_NAME));
+                deleteDirectory(env.configDir().resolve(TLS_GENERATED_CERTS_DIR_NAME));
             } catch (Exception ex) {
                 t.addSuppressed(ex);
             }
-            Path backupCertsDir = env.configFile()
+            Path backupCertsDir = env.configDir()
                 .resolve(
                     String.format(Locale.ROOT, TLS_GENERATED_CERTS_DIR_NAME + ".%d.orig", autoConfigDate.toInstant().getEpochSecond())
                 );
             if (Files.exists(backupCertsDir)) {
-                moveDirectory(backupCertsDir, env.configFile().resolve(TLS_GENERATED_CERTS_DIR_NAME));
+                moveDirectory(backupCertsDir, env.configDir().resolve(TLS_GENERATED_CERTS_DIR_NAME));
             }
             throw t;
         }
@@ -887,14 +887,14 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
         // with --enrolment-token token, in the first place.
         final List<String> existingConfigLines;
         try {
-            existingConfigLines = Files.readAllLines(env.configFile().resolve("elasticsearch.yml"), StandardCharsets.UTF_8);
+            existingConfigLines = Files.readAllLines(env.configDir().resolve("elasticsearch.yml"), StandardCharsets.UTF_8);
         } catch (IOException e) {
             // This shouldn't happen, we would have failed earlier but we need to catch the exception
             throw new UserException(ExitCodes.IO_ERROR, "Aborting enrolling to cluster. Unable to read elasticsearch.yml.", e);
         }
         final List<String> existingConfigWithoutAutoconfiguration = removePreviousAutoconfiguration(existingConfigLines);
         if (false == existingConfigLines.equals(existingConfigWithoutAutoconfiguration)
-            && Files.exists(env.configFile().resolve(TLS_GENERATED_CERTS_DIR_NAME))) {
+            && Files.exists(env.configDir().resolve(TLS_GENERATED_CERTS_DIR_NAME))) {
             terminal.println("");
             terminal.println("This node will be reconfigured to join an existing cluster, using the enrollment token that you provided.");
             terminal.println("This operation will overwrite the existing configuration. Specifically: ");
@@ -907,7 +907,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
             }
             removeAutoConfigurationFromKeystore(env, terminal);
             try {
-                fullyWriteFile(env.configFile(), "elasticsearch.yml", true, stream -> {
+                fullyWriteFile(env.configDir(), "elasticsearch.yml", true, stream -> {
                     try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(stream, StandardCharsets.UTF_8))) {
                         for (String l : existingConfigWithoutAutoconfiguration) {
                             bw.write(l);
@@ -915,7 +915,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
                         }
                     }
                 });
-                deleteDirectory(env.configFile().resolve(TLS_GENERATED_CERTS_DIR_NAME));
+                deleteDirectory(env.configDir().resolve(TLS_GENERATED_CERTS_DIR_NAME));
             } catch (Throwable t) {
                 throw new UserException(
                     ExitCodes.IO_ERROR,
@@ -1262,9 +1262,9 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
     }
 
     private static void removeAutoConfigurationFromKeystore(Environment env, Terminal terminal) throws UserException {
-        if (Files.exists(KeyStoreWrapper.keystorePath(env.configFile()))) {
+        if (Files.exists(KeyStoreWrapper.keystorePath(env.configDir()))) {
             try (
-                KeyStoreWrapper existingKeystore = KeyStoreWrapper.load(env.configFile());
+                KeyStoreWrapper existingKeystore = KeyStoreWrapper.load(env.configDir());
                 SecureString keystorePassword = existingKeystore.hasPassword()
                     ? new SecureString(terminal.readSecret("Enter password for the elasticsearch keystore: "))
                     : new SecureString(new char[0]);
@@ -1288,7 +1288,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
                     }
                     existingKeystore.remove(setting);
                 }
-                existingKeystore.save(env.configFile(), keystorePassword.getChars());
+                existingKeystore.save(env.configDir(), keystorePassword.getChars());
             } catch (Exception e) {
                 terminal.errorPrintln(Terminal.Verbosity.VERBOSE, "");
                 terminal.errorPrintln(Terminal.Verbosity.VERBOSE, ExceptionsHelper.stackTrace(e));

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
@@ -508,7 +508,7 @@ class HttpCertificateCommand extends EnvironmentAwareCommand {
         map.put("DATE", now.format(DateTimeFormatter.ISO_LOCAL_DATE));
         map.put("TIME", now.format(DateTimeFormatter.ISO_OFFSET_TIME));
         map.put("VERSION", Version.CURRENT.toString());
-        map.put("CONF_DIR", env.configFile().toAbsolutePath().toString());
+        map.put("CONF_DIR", env.configDir().toAbsolutePath().toString());
         map.putAll(entries);
         return map;
     }
@@ -1116,7 +1116,7 @@ class HttpCertificateCommand extends EnvironmentAwareCommand {
     private static Path requestPath(String prompt, Terminal terminal, Environment env, boolean requireExisting) {
         for (;;) {
             final String input = terminal.readText(prompt);
-            final Path path = env.configFile().resolve(input).toAbsolutePath();
+            final Path path = env.configDir().resolve(input).toAbsolutePath();
 
             if (path.getFileName() == null) {
                 terminal.println(Terminal.Verbosity.SILENT, input + " is not a valid file");

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/AutoConfigureNodeTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/AutoConfigureNodeTests.java
@@ -311,7 +311,7 @@ public class AutoConfigureNodeTests extends ESTestCase {
         SecureString httpKeystorePassword = nodeKeystore.getString("xpack.security.http.ssl.keystore.secure_password");
         SecureString transportKeystorePassword = nodeKeystore.getString("xpack.security.transport.ssl.keystore.secure_password");
 
-        final Settings newSettings = Settings.builder().loadFromPath(env.configFile().resolve("elasticsearch.yml")).build();
+        final Settings newSettings = Settings.builder().loadFromPath(env.configDir().resolve("elasticsearch.yml")).build();
         final String httpKeystorePath = newSettings.get("xpack.security.http.ssl.keystore.path");
         final String transportKeystorePath = newSettings.get("xpack.security.transport.ssl.keystore.path");
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/ssl/SSLReloadDuringStartupIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/ssl/SSLReloadDuringStartupIntegTests.java
@@ -55,7 +55,7 @@ public class SSLReloadDuringStartupIntegTests extends SecurityIntegTestCase {
         Environment tmpEnv = TestEnvironment.newEnvironment(settings);
 
         // For each node, copy the original testnode.jks into each node's config directory.
-        Path nodeKeystorePath = tmpEnv.configFile().resolve("testnode.jks");
+        Path nodeKeystorePath = tmpEnv.configDir().resolve("testnode.jks");
         try {
             Path goodKeystorePath = getDataPath(goodKeyStoreFilePath);
             Files.copy(goodKeystorePath, nodeKeystorePath, StandardCopyOption.REPLACE_EXISTING);
@@ -93,7 +93,7 @@ public class SSLReloadDuringStartupIntegTests extends SecurityIntegTestCase {
         final Environment env = internalCluster().getInstance(Environment.class, nodeName);
         final CountDownLatch beforeKeystoreFix = new CountDownLatch(2); // SYNC: Cert update & ES restart
         final CountDownLatch afterKeystoreFix = new CountDownLatch(1); // SYNC: Verify cluster after cert update
-        final Path nodeKeystorePath = env.configFile().resolve("testnode.jks"); // all nodes have good keystore
+        final Path nodeKeystorePath = env.configDir().resolve("testnode.jks"); // all nodes have good keystore
         final Path badKeystorePath = getDataPath(badKeyStoreFilePath); // stop a node, and apply this bad keystore
         final Path goodKeystorePath = getDataPath(goodKeyStoreFilePath); // start the node, and apply this good keystore
         assertTrue(Files.exists(nodeKeystorePath));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -725,9 +725,9 @@ public class Security extends Plugin
      * ES has already checked the file is actually in the config directory
      */
     public static Path resolveSecuredConfigFile(Environment env, String file) {
-        Path config = env.configFile().resolve(file);
+        Path config = env.configDir().resolve(file);
         if (doPrivileged((PrivilegedAction<Boolean>) () -> Files.exists(config)) == false) {
-            Path legacyConfig = env.configFile().resolve("x-pack").resolve(file);
+            Path legacyConfig = env.configDir().resolve("x-pack").resolve(file);
             if (doPrivileged((PrivilegedAction<Boolean>) () -> Files.exists(legacyConfig))) {
                 DeprecationLogger.getLogger(XPackPlugin.class)
                     .warn(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/tool/ResetPasswordTool.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/tool/ResetPasswordTool.java
@@ -43,7 +43,7 @@ class ResetPasswordTool extends BaseRunAsSuperuserCommand {
     private final OptionSpec<String> usernameOption;
 
     ResetPasswordTool() {
-        this(CommandLineHttpClient::new, environment -> KeyStoreWrapper.load(environment.configFile()));
+        this(CommandLineHttpClient::new, environment -> KeyStoreWrapper.load(environment.configDir()));
     }
 
     protected ResetPasswordTool(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordTool.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordTool.java
@@ -95,11 +95,11 @@ class SetupPasswordTool extends MultiCommand {
 
     SetupPasswordTool() {
         this(environment -> new CommandLineHttpClient(environment), environment -> {
-            KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.load(environment.configFile());
+            KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.load(environment.configDir());
             if (keyStoreWrapper == null) {
                 throw new UserException(
                     ExitCodes.CONFIG,
-                    "Elasticsearch keystore file is missing [" + KeyStoreWrapper.keystorePath(environment.configFile()) + "]"
+                    "Elasticsearch keystore file is missing [" + KeyStoreWrapper.keystorePath(environment.configDir()) + "]"
                 );
             }
             return keyStoreWrapper;
@@ -142,7 +142,7 @@ class SetupPasswordTool extends MultiCommand {
 
         @Override
         public void execute(Terminal terminal, OptionSet options, Environment env, ProcessInfo processInfo) throws Exception {
-            terminal.println(Verbosity.VERBOSE, "Running with configuration path: " + env.configFile());
+            terminal.println(Verbosity.VERBOSE, "Running with configuration path: " + env.configDir());
             setupOptions(terminal, options, env);
             checkElasticKeystorePasswordValid(terminal, env);
             checkClusterHealth(terminal);
@@ -198,7 +198,7 @@ class SetupPasswordTool extends MultiCommand {
 
         @Override
         public void execute(Terminal terminal, OptionSet options, Environment env, ProcessInfo processInfo) throws Exception {
-            terminal.println(Verbosity.VERBOSE, "Running with configuration path: " + env.configFile());
+            terminal.println(Verbosity.VERBOSE, "Running with configuration path: " + env.configDir());
             setupOptions(terminal, options, env);
             checkElasticKeystorePasswordValid(terminal, env);
             checkClusterHealth(terminal);
@@ -298,7 +298,7 @@ class SetupPasswordTool extends MultiCommand {
             Settings settings = settingsBuilder.build();
             elasticUserPassword = ReservedRealm.BOOTSTRAP_ELASTIC_PASSWORD.get(settings);
 
-            final Environment newEnv = new Environment(settings, env.configFile());
+            final Environment newEnv = new Environment(settings, env.configDir());
             Environment.assertEquivalent(newEnv, env);
 
             client = clientFunction.apply(newEnv);
@@ -354,7 +354,7 @@ class SetupPasswordTool extends MultiCommand {
                     terminal.errorPrintln("Possible causes include:");
                     terminal.errorPrintln(" * The password for the '" + elasticUser + "' user has already been changed on this cluster");
                     terminal.errorPrintln(" * Your elasticsearch node is running against a different keystore");
-                    terminal.errorPrintln("   This tool used the keystore at " + KeyStoreWrapper.keystorePath(env.configFile()));
+                    terminal.errorPrintln("   This tool used the keystore at " + KeyStoreWrapper.keystorePath(env.configDir()));
                     terminal.errorPrintln("");
                     terminal.errorPrintln(
                         "You can use the `elasticsearch-reset-password` CLI tool to reset the password of the '" + elasticUser + "' user"

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtUtil.java
@@ -338,7 +338,7 @@ public class JwtUtil {
     }
 
     public static Path resolvePath(final Environment environment, final String jwkSetPath) {
-        final Path directoryPath = environment.configFile();
+        final Path directoryPath = environment.configDir();
         return directoryPath.resolve(jwkSetPath);
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
@@ -101,7 +101,7 @@ public final class KerberosRealm extends Realm implements CachingRealm {
         }
         this.kerberosTicketValidator = kerberosTicketValidator;
         this.threadPool = threadPool;
-        this.keytabPath = config.env().configFile().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
+        this.keytabPath = config.env().configDir().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
 
         validateKeytab(this.keytabPath);
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
@@ -365,7 +365,7 @@ public class OpenIdConnectAuthenticator {
      * @throws IOException    if the file cannot be read
      */
     private JWKSet readJwkSetFromFile(String jwkSetPath) throws IOException, ParseException {
-        final Path path = realmConfig.env().configFile().resolve(jwkSetPath);
+        final Path path = realmConfig.env().configDir().resolve(jwkSetPath);
         // avoid using JWKSet.loadFile() as it does not close FileInputStream internally
         try {
             String jwkSet = AccessController.doPrivileged(
@@ -814,7 +814,7 @@ public class OpenIdConnectAuthenticator {
     }
 
     private void setMetadataFileWatcher(String jwkSetPath) throws IOException {
-        final Path path = realmConfig.env().configFile().resolve(jwkSetPath);
+        final Path path = realmConfig.env().configDir().resolve(jwkSetPath);
         FileWatcher watcher = new PrivilegedFileWatcher(path);
         watcher.addListener(new FileListener(LOGGER, () -> this.idTokenValidator.set(createIdTokenValidator(false))));
         watcherService.add(watcher, ResourceWatcherService.Frequency.MEDIUM);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataCommand.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataCommand.java
@@ -93,7 +93,7 @@ class SamlMetadataCommand extends KeyStoreAwareCommand {
 
     SamlMetadataCommand() {
         this((environment) -> {
-            KeyStoreWrapper ksWrapper = KeyStoreWrapper.load(environment.configFile());
+            KeyStoreWrapper ksWrapper = KeyStoreWrapper.load(environment.configDir());
             return ksWrapper;
         });
     }
@@ -458,7 +458,7 @@ class SamlMetadataCommand extends KeyStoreAwareCommand {
             final RealmConfig.RealmIdentifier identifier = new RealmConfig.RealmIdentifier(SamlRealmSettings.TYPE, name);
             final Settings realmSettings = realms.get(identifier);
             if (realmSettings == null) {
-                throw new UserException(ExitCodes.CONFIG, "No such realm '" + name + "' defined in " + env.configFile());
+                throw new UserException(ExitCodes.CONFIG, "No such realm '" + name + "' defined in " + env.configDir());
             }
             if (isSamlRealm(identifier)) {
                 return buildRealm(identifier, env, settings);
@@ -471,10 +471,10 @@ class SamlMetadataCommand extends KeyStoreAwareCommand {
                 .filter(entry -> isSamlRealm(entry.getKey()))
                 .toList();
             if (saml.isEmpty()) {
-                throw new UserException(ExitCodes.CONFIG, "There is no SAML realm configured in " + env.configFile());
+                throw new UserException(ExitCodes.CONFIG, "There is no SAML realm configured in " + env.configDir());
             }
             if (saml.size() > 1) {
-                terminal.errorPrintln("Using configuration in " + env.configFile());
+                terminal.errorPrintln("Using configuration in " + env.configDir());
                 terminal.errorPrintln(
                     "Found multiple SAML realms: "
                         + saml.stream().map(Map.Entry::getKey).map(Object::toString).collect(Collectors.joining(", "))

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
@@ -792,7 +792,7 @@ public final class SamlRealm extends Realm implements Releasable {
     ) throws ResolverException, ComponentInitializationException, IOException, PrivilegedActionException {
 
         final String entityId = require(config, IDP_ENTITY_ID);
-        final Path path = config.env().configFile().resolve(metadataPath);
+        final Path path = config.env().configDir().resolve(metadataPath);
         final FilesystemMetadataResolver resolver = new SamlFilesystemMetadataResolver(path.toFile());
 
         for (var httpSetting : List.of(IDP_METADATA_HTTP_REFRESH, IDP_METADATA_HTTP_MIN_REFRESH, IDP_METADATA_HTTP_FAIL_ON_ERROR)) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/tool/AutoConfigGenerateElasticPasswordHash.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/tool/AutoConfigGenerateElasticPasswordHash.java
@@ -48,10 +48,10 @@ class AutoConfigGenerateElasticPasswordHash extends KeyStoreAwareCommand {
         final Hasher hasher = Hasher.resolve(XPackSettings.PASSWORD_HASHING_ALGORITHM.get(env.settings()));
         try (
             SecureString elasticPassword = new SecureString(generatePassword(20));
-            KeyStoreWrapper nodeKeystore = KeyStoreWrapper.bootstrap(env.configFile(), () -> new SecureString(new char[0]))
+            KeyStoreWrapper nodeKeystore = KeyStoreWrapper.bootstrap(env.configDir(), () -> new SecureString(new char[0]))
         ) {
             nodeKeystore.setString(AUTOCONFIG_ELASTIC_PASSWORD_HASH.getKey(), hasher.hash(elasticPassword));
-            nodeKeystore.save(env.configFile(), new char[0]);
+            nodeKeystore.save(env.configDir(), new char[0]);
             terminal.print(Terminal.Verbosity.NORMAL, elasticPassword.toString());
         } catch (Exception e) {
             throw new UserException(ExitCodes.CANT_CREATE, "Failed to generate a password for the elastic user", e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/tool/CreateEnrollmentTokenTool.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/tool/CreateEnrollmentTokenTool.java
@@ -36,7 +36,7 @@ class CreateEnrollmentTokenTool extends BaseRunAsSuperuserCommand {
     CreateEnrollmentTokenTool() {
         this(
             environment -> new CommandLineHttpClient(environment),
-            environment -> KeyStoreWrapper.load(environment.configFile()),
+            environment -> KeyStoreWrapper.load(environment.configDir()),
             environment -> new ExternalEnrollmentTokenGenerator(environment)
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/tool/BaseRunAsSuperuserCommand.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/tool/BaseRunAsSuperuserCommand.java
@@ -93,7 +93,7 @@ public abstract class BaseRunAsSuperuserCommand extends KeyStoreAwareCommand {
                 settingsBuilder.setSecureSettings(keyStoreWrapper);
             }
             settings = settingsBuilder.build();
-            newEnv = new Environment(settings, env.configFile());
+            newEnv = new Environment(settings, env.configDir());
         } else {
             newEnv = env;
             settings = env.settings();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportKibanaEnrollmentActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportKibanaEnrollmentActionTests.java
@@ -69,7 +69,7 @@ public class TransportKibanaEnrollmentActionTests extends ESTestCase {
         final Path tempDir = createTempDir();
         final Path httpCaPath = tempDir.resolve("httpCa.p12");
         Files.copy(getDataPath("/org/elasticsearch/xpack/security/action/enrollment/httpCa.p12"), httpCaPath);
-        when(env.configFile()).thenReturn(tempDir);
+        when(env.configDir()).thenReturn(tempDir);
         final MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("keystore.secure_password", "password");
         final Settings settings = Settings.builder().put("keystore.path", httpCaPath).setSecureSettings(secureSettings).build();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
@@ -78,7 +78,7 @@ public class TransportNodeEnrollmentActionTests extends ESTestCase {
         Path transportPath = tempDir.resolve("transport.p12");
         Files.copy(getDataPath("/org/elasticsearch/xpack/security/action/enrollment/httpCa.p12"), httpCaPath);
         Files.copy(getDataPath("/org/elasticsearch/xpack/security/action/enrollment/transport.p12"), transportPath);
-        when(env.configFile()).thenReturn(tempDir);
+        when(env.configDir()).thenReturn(tempDir);
         final SSLService sslService = mock(SSLService.class);
         final MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("keystore.secure_password", "password");

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileUserPasswdStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileUserPasswdStoreTests.java
@@ -72,7 +72,7 @@ public class FileUserPasswdStoreTests extends ESTestCase {
     }
 
     public void testStore_ConfiguredWithUnreadableFile() throws Exception {
-        Path configDir = env.configFile();
+        Path configDir = env.configDir();
         Files.createDirectories(configDir);
         Path file = configDir.resolve("users");
 
@@ -88,7 +88,7 @@ public class FileUserPasswdStoreTests extends ESTestCase {
 
     public void testStore_AutoReload() throws Exception {
         Path users = getDataPath("users");
-        Path configDir = env.configFile();
+        Path configDir = env.configDir();
         Files.createDirectories(configDir);
         Path file = configDir.resolve("users");
         Files.copy(users, file, StandardCopyOption.REPLACE_EXISTING);
@@ -149,7 +149,7 @@ public class FileUserPasswdStoreTests extends ESTestCase {
 
     public void testStore_AutoReload_WithParseFailures() throws Exception {
         Path users = getDataPath("users");
-        Path confDir = env.configFile();
+        Path confDir = env.configDir();
         Files.createDirectories(confDir);
         Path testUsers = confDir.resolve("users");
         Files.copy(users, testUsers, StandardCopyOption.REPLACE_EXISTING);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileUserRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileUserRolesStoreTests.java
@@ -285,7 +285,7 @@ public class FileUserRolesStoreTests extends ESTestCase {
     }
 
     private Path getUsersRolesPath() throws IOException {
-        Path xpackConf = env.configFile();
+        Path xpackConf = env.configDir();
         Files.createDirectories(xpackConf);
         return xpackConf.resolve("users_roles");
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwkSetLoaderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwkSetLoaderTests.java
@@ -41,7 +41,7 @@ public class JwkSetLoaderTests extends ESTestCase {
         final RealmConfig realmConfig = mock(RealmConfig.class);
         when(realmConfig.getSetting(JwtRealmSettings.PKC_JWKSET_PATH)).thenReturn("jwkset.json");
         final Environment env = mock(Environment.class);
-        when(env.configFile()).thenReturn(tempDir);
+        when(env.configDir()).thenReturn(tempDir);
         when(realmConfig.env()).thenReturn(env);
 
         final JwkSetLoader jwkSetLoader = spy(new JwkSetLoader(realmConfig, List.of(), null));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtSignatureValidatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtSignatureValidatorTests.java
@@ -59,7 +59,7 @@ public class JwtSignatureValidatorTests extends ESTestCase {
         final RealmConfig realmConfig = mock(RealmConfig.class);
         when(realmConfig.getSetting(JwtRealmSettings.PKC_JWKSET_PATH)).thenReturn("jwkset.json");
         final Environment env = mock(Environment.class);
-        when(env.configFile()).thenReturn(tempDir);
+        when(env.configDir()).thenReturn(tempDir);
         when(realmConfig.env()).thenReturn(env);
 
         validateSignatureAttemptCounter = new AtomicInteger();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmAuthenticateFailedTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmAuthenticateFailedTests.java
@@ -63,7 +63,7 @@ public class KerberosRealmAuthenticateFailedTests extends KerberosRealmTestCase 
         final boolean throwExceptionForInvalidTicket = validTicket ? false : randomBoolean();
         final boolean throwLoginException = randomBoolean();
         final byte[] decodedTicket = randomByteArrayOfLength(5);
-        final Path keytabPath = config.env().configFile().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
+        final Path keytabPath = config.env().configDir().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
         final boolean krbDebug = config.getSetting(KerberosRealmSettings.SETTING_KRB_DEBUG_ENABLE);
         if (validTicket) {
             mockKerberosTicketValidator(decodedTicket, keytabPath, krbDebug, new Tuple<>(username, outToken), null);
@@ -144,7 +144,7 @@ public class KerberosRealmAuthenticateFailedTests extends KerberosRealmTestCase 
         settings = Settings.builder().put(settings).putList("authorization_realms", "other_realm").build();
         final KerberosRealm kerberosRealm = createKerberosRealm(Collections.singletonList(otherRealm), username);
         final byte[] decodedTicket = "base64encodedticket".getBytes(StandardCharsets.UTF_8);
-        final Path keytabPath = config.env().configFile().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
+        final Path keytabPath = config.env().configDir().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
         final boolean krbDebug = config.getSetting(KerberosRealmSettings.SETTING_KRB_DEBUG_ENABLE);
         mockKerberosTicketValidator(decodedTicket, keytabPath, krbDebug, new Tuple<>(username, "out-token"), null);
         final KerberosAuthenticationToken kerberosAuthenticationToken = new KerberosAuthenticationToken(decodedTicket);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmCacheTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmCacheTests.java
@@ -48,7 +48,7 @@ public class KerberosRealmCacheTests extends KerberosRealmTestCase {
         metadata.put(KerberosRealm.KRB_METADATA_UPN_KEY, username);
         final User expectedUser = new User(expectedUsername, roles.toArray(new String[0]), null, null, metadata, true);
         final byte[] decodedTicket = randomByteArrayOfLength(10);
-        final Path keytabPath = config.env().configFile().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
+        final Path keytabPath = config.env().configDir().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
         final boolean krbDebug = config.getSetting(KerberosRealmSettings.SETTING_KRB_DEBUG_ENABLE);
         mockKerberosTicketValidator(decodedTicket, keytabPath, krbDebug, new Tuple<>(username, outToken), null);
         final KerberosAuthenticationToken kerberosAuthenticationToken = new KerberosAuthenticationToken(decodedTicket);
@@ -78,7 +78,7 @@ public class KerberosRealmCacheTests extends KerberosRealmTestCase {
 
         final String authNUsername = randomFrom(userNames);
         final byte[] decodedTicket = randomByteArrayOfLength(10);
-        final Path keytabPath = config.env().configFile().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
+        final Path keytabPath = config.env().configDir().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
         final boolean krbDebug = config.getSetting(KerberosRealmSettings.SETTING_KRB_DEBUG_ENABLE);
         mockKerberosTicketValidator(decodedTicket, keytabPath, krbDebug, new Tuple<>(authNUsername, outToken), null);
         final String expectedUsername = maybeRemoveRealmName(authNUsername);
@@ -137,7 +137,7 @@ public class KerberosRealmCacheTests extends KerberosRealmTestCase {
         metadata.put(KerberosRealm.KRB_METADATA_UPN_KEY, username);
         final User expectedUser = new User(expectedUsername, roles.toArray(new String[0]), null, null, metadata, true);
         final byte[] decodedTicket = randomByteArrayOfLength(10);
-        final Path keytabPath = config.env().configFile().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
+        final Path keytabPath = config.env().configDir().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
         final boolean krbDebug = config.getSetting(KerberosRealmSettings.SETTING_KRB_DEBUG_ENABLE);
         mockKerberosTicketValidator(decodedTicket, keytabPath, krbDebug, new Tuple<>(username, outToken), null);
         final KerberosAuthenticationToken kerberosAuthenticationToken = new KerberosAuthenticationToken(decodedTicket);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmTests.java
@@ -82,7 +82,7 @@ public class KerberosRealmTests extends KerberosRealmTestCase {
         metadata.put(KerberosRealm.KRB_METADATA_UPN_KEY, username);
         final User expectedUser = new User(expectedUsername, roles.toArray(new String[roles.size()]), null, null, metadata, true);
         final byte[] decodedTicket = "base64encodedticket".getBytes(StandardCharsets.UTF_8);
-        final Path keytabPath = config.env().configFile().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
+        final Path keytabPath = config.env().configDir().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
         final boolean krbDebug = config.getSetting(KerberosRealmSettings.SETTING_KRB_DEBUG_ENABLE);
         mockKerberosTicketValidator(decodedTicket, keytabPath, krbDebug, new Tuple<>(username, "out-token"), null);
         final KerberosAuthenticationToken kerberosAuthenticationToken = new KerberosAuthenticationToken(decodedTicket);
@@ -106,7 +106,7 @@ public class KerberosRealmTests extends KerberosRealmTestCase {
         final String username = randomPrincipalName();
         final KerberosRealm kerberosRealm = createKerberosRealm(username);
         final byte[] decodedTicket = "base64encodedticket".getBytes(StandardCharsets.UTF_8);
-        final Path keytabPath = config.env().configFile().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
+        final Path keytabPath = config.env().configDir().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
         final boolean krbDebug = config.getSetting(KerberosRealmSettings.SETTING_KRB_DEBUG_ENABLE);
         mockKerberosTicketValidator(decodedTicket, keytabPath, krbDebug, new Tuple<>("does-not-exist@REALM", "out-token"), null);
 
@@ -236,7 +236,7 @@ public class KerberosRealmTests extends KerberosRealmTestCase {
         final KerberosRealm kerberosRealm = createKerberosRealm(Collections.singletonList(otherRealm), username);
         final User expectedUser = lookupUser;
         final byte[] decodedTicket = "base64encodedticket".getBytes(StandardCharsets.UTF_8);
-        final Path keytabPath = config.env().configFile().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
+        final Path keytabPath = config.env().configDir().resolve(config.getSetting(KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH));
         final boolean krbDebug = config.getSetting(KerberosRealmSettings.SETTING_KRB_DEBUG_ENABLE);
         mockKerberosTicketValidator(decodedTicket, keytabPath, krbDebug, new Tuple<>(username, "out-token"), null);
         final KerberosAuthenticationToken kerberosAuthenticationToken = new KerberosAuthenticationToken(decodedTicket);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/FileServiceAccountTokenStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/FileServiceAccountTokenStoreTests.java
@@ -128,7 +128,7 @@ public class FileServiceAccountTokenStoreTests extends ESTestCase {
 
     public void testAutoReload() throws Exception {
         Path serviceTokensSourceFile = getDataPath("service_tokens");
-        Path configDir = env.configFile();
+        Path configDir = env.configDir();
         Files.createDirectories(configDir);
         Path targetFile = configDir.resolve("service_tokens");
         Files.copy(serviceTokensSourceFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
@@ -225,7 +225,7 @@ public class FileServiceAccountTokenStoreTests extends ESTestCase {
 
     public void testFindTokensFor() throws IOException {
         Path serviceTokensSourceFile = getDataPath("service_tokens");
-        Path configDir = env.configFile();
+        Path configDir = env.configDir();
         Files.createDirectories(configDir);
         Path targetFile = configDir.resolve("service_tokens");
         Files.copy(serviceTokensSourceFile, targetFile, StandardCopyOption.REPLACE_EXISTING);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DnRoleMapperTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DnRoleMapperTests.java
@@ -76,8 +76,8 @@ public class DnRoleMapperTests extends ESTestCase {
     public void init() throws IOException {
         settings = Settings.builder().put("resource.reload.interval.high", "100ms").put("path.home", createTempDir()).build();
         env = TestEnvironment.newEnvironment(settings);
-        if (Files.exists(env.configFile()) == false) {
-            Files.createDirectory(env.configFile());
+        if (Files.exists(env.configDir()) == false) {
+            Files.createDirectory(env.configDir());
         }
         threadPool = new TestThreadPool("test");
     }
@@ -100,7 +100,7 @@ public class DnRoleMapperTests extends ESTestCase {
 
     public void testMapper_AutoReload() throws Exception {
         Path roleMappingFile = getDataPath("role_mapping.yml");
-        Path file = env.configFile().resolve("test_role_mapping.yml");
+        Path file = env.configDir().resolve("test_role_mapping.yml");
         Files.copy(roleMappingFile, file, StandardCopyOption.REPLACE_EXISTING);
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -144,7 +144,7 @@ public class DnRoleMapperTests extends ESTestCase {
 
     public void testMapper_AutoReload_WithParseFailures() throws Exception {
         Path roleMappingFile = getDataPath("role_mapping.yml");
-        Path file = env.configFile().resolve("test_role_mapping.yml");
+        Path file = env.configDir().resolve("test_role_mapping.yml");
         Files.copy(roleMappingFile, file, StandardCopyOption.REPLACE_EXISTING);
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -171,7 +171,7 @@ public class DnRoleMapperTests extends ESTestCase {
 
     public void testMapperAutoReloadWithoutListener() throws Exception {
         Path roleMappingFile = getDataPath("role_mapping.yml");
-        Path file = env.configFile().resolve("test_role_mapping.yml");
+        Path file = env.configDir().resolve("test_role_mapping.yml");
         Files.copy(roleMappingFile, file, StandardCopyOption.REPLACE_EXISTING);
 
         try (ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool)) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
@@ -484,7 +484,7 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
     }
 
     private Path getOperatorUsersPath() throws IOException {
-        Path xpackConf = env.configFile();
+        Path xpackConf = env.configDir();
         Files.createDirectories(xpackConf);
         return xpackConf.resolve("operator_users.yml");
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
@@ -375,7 +375,7 @@ public class SSLErrorMessageFileTests extends ESTestCase {
             + " ["
             + fileName
             + "] because access to read the file is blocked; SSL resources should be placed in the ["
-            + env.configFile().toAbsolutePath().toString()
+            + env.configDir().toAbsolutePath().toString()
             + "] directory";
 
         Throwable exception = expectFailure(settings);
@@ -477,7 +477,7 @@ public class SSLErrorMessageFileTests extends ESTestCase {
     private ElasticsearchException expectFailure(Settings.Builder settings) {
         return expectThrows(
             ElasticsearchException.class,
-            () -> new SSLService(new Environment(buildEnvSettings(settings.build()), env.configFile()))
+            () -> new SSLService(new Environment(buildEnvSettings(settings.build()), env.configDir()))
         );
     }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherScheduleEngineBenchmark.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherScheduleEngineBenchmark.java
@@ -112,8 +112,8 @@ public class WatcherScheduleEngineBenchmark {
             Node node = new Node(
                 internalNodeEnv,
                 PluginsLoader.createPluginsLoader(
-                    PluginsLoader.loadModulesBundles(internalNodeEnv.modulesFile()),
-                    PluginsLoader.loadPluginsBundles(internalNodeEnv.pluginsFile()),
+                    PluginsLoader.loadModulesBundles(internalNodeEnv.modulesDir()),
+                    PluginsLoader.loadPluginsBundles(internalNodeEnv.pluginsDir()),
                     Map.of()
                 )
             ).start()

--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
@@ -152,7 +152,7 @@ public abstract class KerberosTestCase extends ESTestCase {
 
     protected Path getKeytabPath(Environment env) {
         final Setting<String> setting = KerberosRealmSettings.HTTP_SERVICE_KEYTAB_PATH.getConcreteSettingForNamespace(REALM_NAME);
-        return env.configFile().resolve(setting.get(settings));
+        return env.configDir().resolve(setting.get(settings));
     }
 
     /**

--- a/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/enrollment/tool/AutoConfigGenerateElasticPasswordHashTests.java
+++ b/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/enrollment/tool/AutoConfigGenerateElasticPasswordHashTests.java
@@ -97,18 +97,18 @@ public class AutoConfigGenerateElasticPasswordHashTests extends CommandTestCase 
     public void testSuccessfullyGenerateAndStoreHash() throws Exception {
         execute();
         assertThat(terminal.getOutput(), hasLength(20));
-        KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.load(env.configFile());
+        KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.load(env.configDir());
         assertNotNull(keyStoreWrapper);
         keyStoreWrapper.decrypt(new char[0]);
         assertThat(keyStoreWrapper.getSettingNames(), containsInAnyOrder(AUTOCONFIG_ELASTIC_PASSWORD_HASH.getKey(), "keystore.seed"));
     }
 
     public void testExistingKeystoreWithWrongPassword() throws Exception {
-        KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.load(env.configFile());
+        KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.load(env.configDir());
         assertNotNull(keyStoreWrapper);
         keyStoreWrapper.decrypt(new char[0]);
         // set a random password so that we fail to decrypt it in GenerateElasticPasswordHash#execute
-        keyStoreWrapper.save(env.configFile(), randomAlphaOfLength(16).toCharArray());
+        keyStoreWrapper.save(env.configDir(), randomAlphaOfLength(16).toCharArray());
         UserException e = expectThrows(UserException.class, this::execute);
         assertThat(e.getMessage(), equalTo("Failed to generate a password for the elastic user"));
         assertThat(terminal.getOutput(), is(emptyString()));


### PR DESCRIPTION
The node environment has many paths. The accessors for these currently use a "file" suffix, but they are always directories. This commit renames the accessors to make it clear these paths are directories.