### PR TITLE
[9.0] Copy metrics and default_metric properties when downsampling aggregate_metric_double (#121727)

### DIFF
--- a/docs/changelog/121727.yaml
+++ b/docs/changelog/121727.yaml
@@ -1,0 +1,7 @@
+pr: 121727
+summary: Copy metrics and `default_metric` properties when downsampling `aggregate_metric_double`
+area: Downsampling
+type: bug
+issues:
+ - 119696
+ - 96076

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamFeatures.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamFeatures.java
@@ -21,6 +21,10 @@ public class DataStreamFeatures implements FeatureSpecification {
 
     public static final NodeFeature DATA_STREAM_FAILURE_STORE_TSDB_FIX = new NodeFeature("data_stream.failure_store.tsdb_fix");
 
+    public static final NodeFeature DOWNSAMPLE_AGGREGATE_DEFAULT_METRIC_FIX = new NodeFeature(
+        "data_stream.downsample.default_aggregate_metric_fix"
+    );
+
     @Override
     public Set<NodeFeature> getFeatures() {
         return Set.of();
@@ -28,6 +32,6 @@ public class DataStreamFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
-        return Set.of(DATA_STREAM_FAILURE_STORE_TSDB_FIX);
+        return Set.of(DATA_STREAM_FAILURE_STORE_TSDB_FIX, DOWNSAMPLE_AGGREGATE_DEFAULT_METRIC_FIX);
     }
 }

--- a/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/80_downsample_aggregate.yml
+++ b/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/80_downsample_aggregate.yml
@@ -1,0 +1,79 @@
+"downsample aggregate field":
+  - requires:
+      cluster_features: ["data_stream.downsample.default_aggregate_metric_fix"]
+      reason: "#119696 fixed"
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 1
+            index:
+              mode: time_series
+              routing_path: [sensor_id]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              sensor_id:
+                type: keyword
+                time_series_dimension: true
+              temperature:
+                type: aggregate_metric_double
+                metrics: [min, sum, value_count]
+                default_metric: sum
+                time_series_metric: gauge
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:00:00Z", "sensor_id": "1", "temperature": {"min": 24.7, "sum": 50.2, "value_count": 2}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:30:00Z", "sensor_id": "1", "temperature": {"min": 24.2, "sum": 73.8, "value_count": 3}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T19:00:00Z", "sensor_id": "1", "temperature": {"min": 25.1, "sum": 51.0, "value_count": 2}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T19:30:00Z", "sensor_id": "1", "temperature": {"min": 24.8, "sum": 24.8, "value_count": 1}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T20:00:00Z", "sensor_id": "1", "temperature": {"min": 24.6, "sum": 49.1, "value_count": 2}}'
+
+  - do:
+      indices.put_settings:
+        index: test
+        body:
+          index.blocks.write: true
+
+  - do:
+      indices.downsample:
+        index: test
+        target_index: test-downsample
+        body:  >
+          {
+            "fixed_interval": "1h"
+          }
+  - is_true: acknowledged
+
+  - do:
+      search:
+        index: test-downsample
+        body:
+          size: 0
+
+  - match:
+      hits.total.value: 3
+
+  - do:
+      indices.get_mapping:
+        index: test-downsample
+  - match:
+      test-downsample.mappings.properties.temperature:
+        type: aggregate_metric_double
+        metrics: [min, sum, value_count]
+        default_metric: sum
+        time_series_metric: gauge


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Copy metrics and default_metric properties when downsampling aggregate_metric_double (#121727)