### PR TITLE
[9.0] Don't attempt to install modules into test cluster more than once (#121833)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -765,7 +765,12 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
 
                 });
 
-                IOUtils.syncMaybeWithLinks(modulePath, destination);
+                // If we aren't overriding anything we can use links here, otherwise do a full copy
+                if (installSpec.entitlementsOverride == null && installSpec.propertiesOverride == null) {
+                    IOUtils.syncMaybeWithLinks(modulePath, destination);
+                } else {
+                    IOUtils.syncWithCopy(modulePath, destination);
+                }
 
                 try {
                     if (installSpec.entitlementsOverride != null) {
@@ -794,7 +799,9 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                     if (extendedProperty != null) {
                         String[] extendedModules = extendedProperty.split(",");
                         for (String module : extendedModules) {
-                            installModule(module, new DefaultPluginInstallSpec(), modulePaths);
+                            if (spec.getModules().containsKey(module) == false) {
+                                installModule(module, new DefaultPluginInstallSpec(), modulePaths);
+                            }
                         }
                     }
                 } catch (IOException e) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Don&#x27;t attempt to install modules into test cluster more than once (#121833)](https://github.com/elastic/elasticsearch/pull/121833)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)