### PR TITLE
Fix version confusion in `testHandshakeRequestFutureVersionsCompatibility`

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.Level;
 import org.elasticsearch.Build;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -235,7 +234,7 @@ public class TransportHandshakerTests extends ESTestCase {
         TaskId.EMPTY_TASK_ID.writeTo(futureHandshake);
         final var extraDataSize = between(0, 1024);
         try (BytesStreamOutput internalMessage = new BytesStreamOutput()) {
-            Version.writeVersion(Version.CURRENT, internalMessage);
+            internalMessage.writeVInt(TransportVersion.current().id() + between(0, 100));
             internalMessage.writeString(buildVersion);
             lengthCheckingHandshake.writeBytesReference(internalMessage.bytes());
             internalMessage.write(new byte[extraDataSize]);


### PR DESCRIPTION
Today we use the ID from `Version#CURRENT` in this test, which only
works if its ID is no less than that of `TranportVersion#current()`.
This commit fixes the test to ensure it always picks a transport version
ID that is not from the past.