### PR TITLE
Fix `testLogsSlowInboundProcessing`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -387,9 +387,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/121672
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   issue: https://github.com/elastic/elasticsearch/issues/121411
-- class: org.elasticsearch.transport.InboundHandlerTests
-  method: testLogsSlowInboundProcessing
-  issue: https://github.com/elastic/elasticsearch/issues/121816
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/cat/health/cat-health-no-timestamp-example}
   issue: https://github.com/elastic/elasticsearch/issues/121867

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -291,8 +291,11 @@ public class InboundHandlerTests extends ESTestCase {
             BytesStreamOutput byteData = new BytesStreamOutput();
             TaskId.EMPTY_TASK_ID.writeTo(byteData);
             // simulate bytes of a transport handshake: vInt transport version then release version string
-            TransportVersion.writeVersion(remoteVersion, byteData);
-            byteData.writeString(randomIdentifier());
+            try (var payloadByteData = new BytesStreamOutput()) {
+                TransportVersion.writeVersion(remoteVersion, payloadByteData);
+                payloadByteData.writeString(randomIdentifier());
+                byteData.writeBytesReference(payloadByteData.bytes());
+            }
             final InboundMessage requestMessage = new InboundMessage(
                 requestHeader,
                 ReleasableBytesReference.wrap(byteData.bytes()),


### PR DESCRIPTION
This test creates an incorrectly-serialized handshake which cannot be
validated, and #121747 made that validation compulsory. This test
corrects the serialization.

Closes #121816