### PR TITLE
Re-enable synthetic source recovery tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -134,12 +134,6 @@ tests:
 - class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
   method: test {p0=data_stream/120_data_streams_stats/Multiple data stream}
   issue: https://github.com/elastic/elasticsearch/issues/118217
-  # TODO: re-enable after backporting https://github.com/elastic/elasticsearch/pull/119110
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=update/100_synthetic_source/keyword}
-  # TODO: re-enable after backporting https://github.com/elastic/elasticsearch/pull/119110
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=update/100_synthetic_source/stored text}
 - class: org.elasticsearch.xpack.searchablesnapshots.RetrySearchIntegTests
   method: testSearcherId
   issue: https://github.com/elastic/elasticsearch/issues/118374

--- a/qa/smoke-test-multinode/build.gradle
+++ b/qa/smoke-test-multinode/build.gradle
@@ -28,7 +28,5 @@ tasks.named("yamlRestTest").configure {
     'cat.templates/10_basic/No templates',
     'cat.templates/10_basic/Sort templates',
     'cat.templates/10_basic/Multiple template',
-    'update/100_synthetic_source/keyword',
-    'update/100_synthetic_source/stored text'
   ].join(',')
 }

--- a/x-pack/plugin/logsdb/build.gradle
+++ b/x-pack/plugin/logsdb/build.gradle
@@ -42,13 +42,3 @@ tasks.named("javaRestTest").configure {
 tasks.named('yamlRestTest') {
   usesDefaultDistribution()
 }
-
-tasks.named("yamlRestTest") {
-  if (buildParams.isSnapshotBuild() == false) {
-    systemProperty 'tests.rest.blacklist', [
-      "60_synthetic_source_recovery/*"
-    ].join(',')
-  }
-}
-
-

--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -32,8 +32,6 @@ tasks.named("yamlRestTest").configure {
   ArrayList<String> blacklist = [
     'index/10_with_id/Index with ID',
     'indices.get_alias/10_basic/Get alias against closed indices',
-    'update/100_synthetic_source/keyword',
-    'update/100_synthetic_source/stored text'
   ];
   if (buildParams.isSnapshotBuild() == false) {
     blacklist += [


### PR DESCRIPTION
With this PR we re-enable synthetic source recovery tests which were disabled
in #119110, after back-porting the original PR in #121760 