### PR TITLE
Clean up exchanges in EsqlNodeFailureIT (#121633)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlNodeFailureIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlNodeFailureIT.java
@@ -10,7 +10,8 @@ package org.elasticsearch.xpack.esql.action;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.compute.operator.exchange.ExchangeService;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.OnScriptError;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
@@ -38,7 +39,20 @@ import static org.hamcrest.Matchers.equalTo;
 public class EsqlNodeFailureIT extends AbstractEsqlIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return CollectionUtils.appendToCopy(super.nodePlugins(), FailingFieldPlugin.class);
+        var plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(FailingFieldPlugin.class);
+        plugins.add(InternalExchangePlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        Settings settings = Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(ExchangeService.INACTIVE_SINKS_INTERVAL_SETTING, TimeValue.timeValueMillis(between(3000, 4000)))
+            .build();
+        logger.info("settings {}", settings);
+        return settings;
     }
 
     /**
@@ -58,7 +72,7 @@ public class EsqlNodeFailureIT extends AbstractEsqlIntegTestCase {
         mapping.endObject();
         client().admin().indices().prepareCreate("fail").setSettings(indexSettings(1, 0)).setMapping(mapping.endObject()).get();
 
-        int docCount = 100;
+        int docCount = 50;
         List<IndexRequestBuilder> docs = new ArrayList<>(docCount);
         for (int d = 0; d < docCount; d++) {
             docs.add(client().prepareIndex("ok").setSource("foo", d));


### PR DESCRIPTION
If the query hits the failing index first, we will cancel the request, preventing exchange-sink requests and data-node requests from reaching another data node. As a result, exchange sinks could stay for 30 seconds.
