### PR TITLE
Release latches at the end of the test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -373,9 +373,6 @@ tests:
 - class: org.elasticsearch.search.CrossClusterSearchUnavailableClusterIT
   method: testSearchSkipUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/121497
-- class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
-  method: testStopQueryLocal
-  issue: https://github.com/elastic/elasticsearch/issues/121672
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   issue: https://github.com/elastic/elasticsearch/issues/121411
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractCrossClusterTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractCrossClusterTestCase.java
@@ -23,6 +23,7 @@ import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -105,6 +106,13 @@ public abstract class AbstractCrossClusterTestCase extends AbstractMultiClusters
         SimplePauseFieldPlugin.resetPlugin();
         FailingPauseFieldPlugin.resetPlugin();
         CrossClusterAsyncQueryIT.CountingPauseFieldPlugin.resetPlugin();
+    }
+
+    @After
+    public void releaseLatches() {
+        SimplePauseFieldPlugin.release();
+        FailingPauseFieldPlugin.release();
+        CrossClusterAsyncQueryIT.CountingPauseFieldPlugin.release();
     }
 
     protected void assertClusterInfoSuccess(EsqlExecutionInfo.Cluster cluster, int numShards) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersCancellationIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersCancellationIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.plugin.ComputeService;
+import org.junit.After;
 import org.junit.Before;
 
 import java.util.ArrayList;
@@ -74,6 +75,11 @@ public class CrossClustersCancellationIT extends AbstractMultiClustersTestCase {
     @Before
     public void resetPlugin() {
         SimplePauseFieldPlugin.resetPlugin();
+    }
+
+    @After
+    public void releasePlugin() {
+        SimplePauseFieldPlugin.release();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FailingPauseFieldPlugin.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FailingPauseFieldPlugin.java
@@ -29,6 +29,10 @@ public class FailingPauseFieldPlugin extends AbstractPauseFieldPlugin {
         startEmitting = new CountDownLatch(1);
     }
 
+    public static void release() {
+        allowEmitting.countDown();
+    }
+
     @Override
     public void onStartExecute() {
         startEmitting.countDown();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/SimplePauseFieldPlugin.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/SimplePauseFieldPlugin.java
@@ -24,6 +24,10 @@ public class SimplePauseFieldPlugin extends AbstractPauseFieldPlugin {
         startEmitting = new CountDownLatch(1);
     }
 
+    public static void release() {
+        allowEmitting.countDown();
+    }
+
     @Override
     public void onStartExecute() {
         startEmitting.countDown();


### PR DESCRIPTION
This may prevent failure contamination to other tests
