### PR TITLE
ESQL: Clean index when retrying test

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -684,6 +684,7 @@ public class HeapAttackIT extends ESRestTestCase {
             return responseAsMap(query(query.toString(), null));
         } finally {
             deleteIndex("sensor_data");
+            deleteIndex("sensor_lookup");
         }
     }
 


### PR DESCRIPTION
This modifies the `HeapAttackIT` test to clean an index created by the test if we have to retry it.

Closes #121873
