### PR TITLE
[8.17] [CI] Remove Windows 2016 testing (#121941)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -40,7 +40,6 @@ steps:
         matrix:
           setup:
             image:
-              - windows-2016
               - windows-2019
               - windows-2022
         agents:

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -617,7 +617,6 @@ steps:
         matrix:
           setup:
             image:
-              - windows-2016
               - windows-2019
               - windows-2022
         agents:

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -39,7 +39,6 @@ steps:
         matrix:
           setup:
             image:
-              - windows-2016
               - windows-2019
               - windows-2022
             GRADLE_TASK:

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
@@ -10,7 +10,6 @@ steps:
         matrix:
           setup:
             image:
-              - windows-2016
               - windows-2019
               - windows-2022
             PACKAGING_TASK:


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.17`:
 - [[CI] Remove Windows 2016 testing (#121941)](https://github.com/elastic/elasticsearch/pull/121941)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)