### PR TITLE
[9.0] ESQL: Clean index when retrying test (#121954)

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -684,6 +684,7 @@ public class HeapAttackIT extends ESRestTestCase {
             return responseAsMap(query(query.toString(), null));
         } finally {
             deleteIndex("sensor_data");
+            deleteIndex("sensor_lookup");
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - ESQL: Clean index when retrying test (#121954)