### PR TITLE
Strip out seed from reproduce method name

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -61,7 +61,6 @@ public class SettingsTests extends ESTestCase {
             .replacePropertyPlaceholders()
             .build();
         assertThat(settings.get("setting1"), equalTo(value));
-        fail("foo");
     }
 
     public void testReplacePropertiesPlaceholderSystemVariablesHaveNoEffect() {

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -61,6 +61,7 @@ public class SettingsTests extends ESTestCase {
             .replacePropertyPlaceholders()
             .build();
         assertThat(settings.get("setting1"), equalTo(value));
+        fail("foo");
     }
 
     public void testReplacePropertiesPlaceholderSystemVariablesHaveNoEffect() {

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -77,8 +77,11 @@ public class ReproduceInfoPrinter extends RunListener {
         }
         b.append(failure.getDescription().getClassName());
 
-        final String methodName = failure.getDescription().getMethodName();
+        String methodName = failure.getDescription().getMethodName();
         if (methodName != null) {
+            // Method names only have spaces if used with -Dtests.iters where the seed is appended.
+            // Here we strip out anything from the first space, leaving the real method name intact.
+            methodName = methodName.split(" ")[0];
             // fallback to system property filter when tests contain "."
             if (methodName.contains(".") || isBwcTest) {
                 b.append("\" -Dtests.method=\"");


### PR DESCRIPTION
When -Dtests.iters is used the test seed is appended to the method name by randomized runner. That in turn causes the reproduce line to contain the seed as part of the method name, which makes the reproduce line unuseable. This commit strips off any additional part of the method name before printing.