### PR TITLE
Fix testValidFromPattern

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -397,9 +397,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/121966
 - class: org.elasticsearch.xpack.searchablesnapshots.hdfs.SecureHdfsSearchableSnapshotsIT
   issue: https://github.com/elastic/elasticsearch/issues/121967
-- class: org.elasticsearch.xpack.esql.parser.StatementParserTests
-  method: testInvalidJoinPatterns
-  issue: https://github.com/elastic/elasticsearch/issues/121968
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=update/100_synthetic_source/stored text}
   issue: https://github.com/elastic/elasticsearch/issues/121991

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/IdentifierGenerator.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/IdentifierGenerator.java
@@ -79,13 +79,13 @@ public class IdentifierGenerator {
         }
 
         var pattern = maybeQuote(index.toString());
+        if (pattern.contains("|")) {
+            pattern = quote(unquoteIndexPattern(pattern));
+        }
+
         if (canAdd(Features.CROSS_CLUSTER, features)) {
             var cluster = maybeQuote(randomIdentifier());
             pattern = maybeQuote(cluster + ":" + pattern);
-        }
-
-        if (pattern.contains("|") && pattern.endsWith("\"") == false) {
-            pattern = quote(unquoteIndexPattern(pattern));
         }
 
         return pattern;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/IdentifierGenerator.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/IdentifierGenerator.java
@@ -84,8 +84,8 @@ public class IdentifierGenerator {
             pattern = maybeQuote(cluster + ":" + pattern);
         }
 
-        if (pattern.contains("|") && pattern.contains("\"") == false) {
-            pattern = quote(pattern);
+        if (pattern.contains("|") && pattern.endsWith("\"") == false) {
+            pattern = quote(unquoteIndexPattern(pattern));
         }
 
         return pattern;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/IdentifierGenerator.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/IdentifierGenerator.java
@@ -78,10 +78,11 @@ public class IdentifierGenerator {
             index.insert(0, "-");
         }
 
-        var pattern = maybeQuote(index.toString());
+        var pattern = index.toString();
         if (pattern.contains("|")) {
-            pattern = quote(unquoteIndexPattern(pattern));
+            pattern = quote(pattern);
         }
+        pattern = maybeQuote(pattern);
 
         if (canAdd(Features.CROSS_CLUSTER, features)) {
             var cluster = maybeQuote(randomIdentifier());


### PR DESCRIPTION
Since https://github.com/elastic/elasticsearch/pull/120355 now it is possible to generate patterns with remote and data math that are quoted as following: `"remote":<index-{now/M{yyyy.MM.dd|+16:00}}>`. `|` require indexPattern to be quoted. Unfortunately, the branch that is doing so was erroneously detecting quotes on clasterPattern only, not on entire identifier. 

https://github.com/elastic/elasticsearch/blob/24bc9fa1ce870de87c6ef529716c045282d387f1/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/IdentifierGenerator.java#L87-L89

This change fixes that.

Closes: #121990
Closes: #121968
