### PR TITLE
[8.x] ES|QL: Improve random query generation tests (#121750)

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/GenerativeIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/GenerativeIT.java
@@ -15,7 +15,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.qa.rest.generative.GenerativeRestTest;
 import org.junit.ClassRule;
 
-@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102084")
+@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/121754")
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class GenerativeIT extends GenerativeRestTest {
     @ClassRule


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ES|QL: Improve random query generation tests (#121750)