### PR TITLE
[9.0] Fix testValidFromPattern (#121996)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -363,9 +363,6 @@ tests:
 - class: org.elasticsearch.xpack.migrate.action.ReindexDatastreamIndexTransportActionIT
   method: testFailIfMetadataBlockSet
   issue: https://github.com/elastic/elasticsearch/issues/121978
-- class: org.elasticsearch.xpack.esql.parser.StatementParserTests
-  method: testValidFromPattern
-  issue: https://github.com/elastic/elasticsearch/issues/121990
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/IdentifierGenerator.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/IdentifierGenerator.java
@@ -78,14 +78,15 @@ public class IdentifierGenerator {
             index.insert(0, "-");
         }
 
-        var pattern = maybeQuote(index.toString());
+        var pattern = index.toString();
+        if (pattern.contains("|")) {
+            pattern = quote(pattern);
+        }
+        pattern = maybeQuote(pattern);
+
         if (canAdd(Features.CROSS_CLUSTER, features)) {
             var cluster = maybeQuote(randomIdentifier());
             pattern = maybeQuote(cluster + ":" + pattern);
-        }
-
-        if (pattern.contains("|") && pattern.contains("\"") == false) {
-            pattern = quote(pattern);
         }
 
         return pattern;


### PR DESCRIPTION
This backports following changes to 9.0:
* #121996 