### PR TITLE
[Test] Unmute MinioSearchableSnapshotsIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -378,8 +378,6 @@ tests:
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/cat/health/cat-health-no-timestamp-example}
   issue: https://github.com/elastic/elasticsearch/issues/121867
-- class: org.elasticsearch.xpack.searchablesnapshots.minio.MinioSearchableSnapshotsIT
-  issue: https://github.com/elastic/elasticsearch/issues/121882
 - class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
   method: testCreateAndRestorePartialSearchableSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/121927


### PR DESCRIPTION
Tests failures were caused by transient
download failure of the Minion Docker
image.

Closes #121882
