### PR TITLE
Add upgrade note about release date constraint

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -26,6 +26,18 @@ proceeding with the upgrade. For instructions, refer to
 from 7.x].
 
 [discrete]
+[[upgrade-newer-releases]]
+=== Out-of-order releases
+
+Elastic maintains several minor versions of {es} at once, so releases do not
+always happen in order of their version numbers. You can only upgrade to
+{version} if the version you are currently running has an older version number
+than {version} _and_ has an earlier release date than {version}.
+
+If you are currently running a version with an older version number but a later
+release date than {version}, wait for a newer release before upgrading.
+
+[discrete]
 [[upgrade-index-compatibility]]
 === Index compatibility
 

--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -29,10 +29,13 @@ from 7.x].
 [[upgrade-newer-releases]]
 === Out-of-order releases
 
-Elastic maintains several minor versions of {es} at once, so releases do not
-always happen in order of their version numbers. You can only upgrade to
-{version} if the version you are currently running has an older version number
-than {version} _and_ has an earlier release date than {version}.
+Elastic maintains several minor versions of {es} at once. This means releases
+do not always happen in order of their version numbers. You can only upgrade to
+{version} if the version you are currently running meets both of these
+conditions:
+
+* Has an older version number than {version}.
+* Has an earlier release date than {version}.
 
 If you are currently running a version with an older version number but a later
 release date than {version}, wait for a newer release before upgrading.


### PR DESCRIPTION
We don't support (and will actively block) upgrades to
chronologically-older versions. This commit adds a note in the docs
about this.