### PR TITLE
[Deprecation API] Adjust details in the SourceFieldMapper deprecation warning

### DIFF
--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SourceModeRollingUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SourceModeRollingUpgradeIT.java
@@ -85,8 +85,13 @@ public class SourceModeRollingUpgradeIT extends AbstractRollingUpgradeTestCase {
         assertThat(response.containsKey("templates"), equalTo(true));
         Map<?, ?> issuesByTemplate = (Map<?, ?>) response.get("templates");
         assertThat(issuesByTemplate.containsKey(templateName), equalTo(true));
-        var templateIssues = (List<?>) issuesByTemplate.get(templateName);
-        assertThat(((Map<?, ?>) templateIssues.getFirst()).get("message"), equalTo(SourceFieldMapper.DEPRECATION_WARNING_TITLE));
-        assertThat(((Map<?, ?>) templateIssues.getFirst()).get("details"), equalTo(SourceFieldMapper.DEPRECATION_WARNING));
+        var templateIssue = (Map<?, ?>) ((List<?>) issuesByTemplate.get(templateName)).getFirst();
+        // Bwc compatible logic until backports are complete.
+        if (templateIssue.containsKey("details")) {
+            assertThat(templateIssue.get("message"), equalTo(SourceFieldMapper.DEPRECATION_WARNING_TITLE));
+            assertThat(templateIssue.get("details"), equalTo(SourceFieldMapper.DEPRECATION_WARNING));
+        } else {
+            assertThat(templateIssue.get("message"), equalTo(SourceFieldMapper.DEPRECATION_WARNING));
+        }
     }
 }

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SourceModeRollingUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SourceModeRollingUpgradeIT.java
@@ -46,7 +46,7 @@ public class SourceModeRollingUpgradeIT extends AbstractRollingUpgradeTestCase {
                   }
                 }""";
             var putComponentTemplateRequest = new Request("PUT", "/_component_template/" + templateName);
-            putComponentTemplateRequest.setOptions(expectWarnings(SourceFieldMapper.DEPRECATION_WARNING_TITLE));
+            putComponentTemplateRequest.setOptions(expectWarnings(SourceFieldMapper.DEPRECATION_WARNING));
             putComponentTemplateRequest.setJsonEntity(storedSourceMapping);
             assertOK(client().performRequest(putComponentTemplateRequest));
             assertDeprecationWarningForTemplate(templateName);
@@ -70,7 +70,7 @@ public class SourceModeRollingUpgradeIT extends AbstractRollingUpgradeTestCase {
                   }
                 }""";
             var putComponentTemplateRequest = new Request("PUT", "/_component_template/" + templateName);
-            putComponentTemplateRequest.setOptions(expectWarnings(SourceFieldMapper.DEPRECATION_WARNING_TITLE));
+            putComponentTemplateRequest.setOptions(expectWarnings(SourceFieldMapper.DEPRECATION_WARNING));
             putComponentTemplateRequest.setJsonEntity(storedSourceMapping);
             assertOK(client().performRequest(putComponentTemplateRequest));
             assertDeprecationWarningForTemplate(templateName);

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SourceModeRollingUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SourceModeRollingUpgradeIT.java
@@ -46,7 +46,7 @@ public class SourceModeRollingUpgradeIT extends AbstractRollingUpgradeTestCase {
                   }
                 }""";
             var putComponentTemplateRequest = new Request("PUT", "/_component_template/" + templateName);
-            putComponentTemplateRequest.setOptions(expectWarnings(SourceFieldMapper.DEPRECATION_WARNING));
+            putComponentTemplateRequest.setOptions(expectWarnings(SourceFieldMapper.DEPRECATION_WARNING_TITLE));
             putComponentTemplateRequest.setJsonEntity(storedSourceMapping);
             assertOK(client().performRequest(putComponentTemplateRequest));
             assertDeprecationWarningForTemplate(templateName);
@@ -70,7 +70,7 @@ public class SourceModeRollingUpgradeIT extends AbstractRollingUpgradeTestCase {
                   }
                 }""";
             var putComponentTemplateRequest = new Request("PUT", "/_component_template/" + templateName);
-            putComponentTemplateRequest.setOptions(expectWarnings(SourceFieldMapper.DEPRECATION_WARNING));
+            putComponentTemplateRequest.setOptions(expectWarnings(SourceFieldMapper.DEPRECATION_WARNING_TITLE));
             putComponentTemplateRequest.setJsonEntity(storedSourceMapping);
             assertOK(client().performRequest(putComponentTemplateRequest));
             assertDeprecationWarningForTemplate(templateName);
@@ -86,6 +86,7 @@ public class SourceModeRollingUpgradeIT extends AbstractRollingUpgradeTestCase {
         Map<?, ?> issuesByTemplate = (Map<?, ?>) response.get("templates");
         assertThat(issuesByTemplate.containsKey(templateName), equalTo(true));
         var templateIssues = (List<?>) issuesByTemplate.get(templateName);
-        assertThat(((Map<?, ?>) templateIssues.getFirst()).get("message"), equalTo(SourceFieldMapper.DEPRECATION_WARNING));
+        assertThat(((Map<?, ?>) templateIssues.getFirst()).get("message"), equalTo(SourceFieldMapper.DEPRECATION_WARNING_TITLE));
+        assertThat(((Map<?, ?>) templateIssues.getFirst()).get("details"), equalTo(SourceFieldMapper.DEPRECATION_WARNING));
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -58,9 +58,9 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     public static final String LOSSY_PARAMETERS_ALLOWED_SETTING_NAME = "index.lossy.source-mapping-parameters";
 
-    public static final String DEPRECATION_WARNING = "Configuring source mode in mappings is deprecated.";
+    public static final String DEPRECATION_WARNING_TITLE = "Configuring source mode in mappings is deprecated.";
 
-    public static final String DEPRECATION_DETAILS = "Configuring source mode in mappings is deprecated and will be removed "
+    public static final String DEPRECATION_WARNING = "Configuring source mode in mappings is deprecated and will be removed "
         + "in future versions. Use [index.mapping.source.mode] index setting instead.";
 
     /** The source mode */

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -58,7 +58,9 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     public static final String LOSSY_PARAMETERS_ALLOWED_SETTING_NAME = "index.lossy.source-mapping-parameters";
 
-    public static final String DEPRECATION_WARNING = "Configuring source mode in mappings is deprecated and will be removed "
+    public static final String DEPRECATION_WARNING = "Configuring source mode in mappings is deprecated.";
+
+    public static final String DEPRECATION_DETAILS = "Configuring source mode in mappings is deprecated and will be removed "
         + "in future versions. Use [index.mapping.source.mode] index setting instead.";
 
     /** The source mode */

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationChecker.java
@@ -124,7 +124,7 @@ public class TemplateDeprecationChecker implements ResourceDeprecationChecker {
                             DeprecationIssue.Level.CRITICAL,
                             SourceFieldMapper.DEPRECATION_WARNING,
                             "https://github.com/elastic/elasticsearch/pull/117172",
-                            null,
+                            SourceFieldMapper.DEPRECATION_DETAILS,
                             false,
                             null
                         );

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationChecker.java
@@ -122,9 +122,9 @@ public class TemplateDeprecationChecker implements ResourceDeprecationChecker {
                     if (sourceMap.containsKey("mode")) {
                         return new DeprecationIssue(
                             DeprecationIssue.Level.CRITICAL,
-                            SourceFieldMapper.DEPRECATION_WARNING,
+                            SourceFieldMapper.DEPRECATION_WARNING_TITLE,
                             "https://ela.st/migrate-source-mode",
-                            SourceFieldMapper.DEPRECATION_DETAILS,
+                            SourceFieldMapper.DEPRECATION_WARNING,
                             false,
                             null
                         );

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationChecker.java
@@ -123,7 +123,7 @@ public class TemplateDeprecationChecker implements ResourceDeprecationChecker {
                         return new DeprecationIssue(
                             DeprecationIssue.Level.CRITICAL,
                             SourceFieldMapper.DEPRECATION_WARNING,
-                            "https://github.com/elastic/elasticsearch/pull/117172",
+                            "https://ela.st/migrate-source-mode",
                             SourceFieldMapper.DEPRECATION_DETAILS,
                             false,
                             null

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationCheckerTests.java
@@ -51,9 +51,9 @@ public class TemplateDeprecationCheckerTests extends ESTestCase {
         Map<String, List<DeprecationIssue>> issuesByComponentTemplate = checker.check(clusterState);
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
-            SourceFieldMapper.DEPRECATION_WARNING,
+            SourceFieldMapper.DEPRECATION_WARNING_TITLE,
             "https://ela.st/migrate-source-mode",
-            SourceFieldMapper.DEPRECATION_DETAILS,
+            SourceFieldMapper.DEPRECATION_WARNING,
             false,
             null
         );

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationCheckerTests.java
@@ -53,7 +53,7 @@ public class TemplateDeprecationCheckerTests extends ESTestCase {
             DeprecationIssue.Level.CRITICAL,
             SourceFieldMapper.DEPRECATION_WARNING,
             "https://github.com/elastic/elasticsearch/pull/117172",
-            null,
+            SourceFieldMapper.DEPRECATION_DETAILS,
             false,
             null
         );

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationCheckerTests.java
@@ -52,7 +52,7 @@ public class TemplateDeprecationCheckerTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             SourceFieldMapper.DEPRECATION_WARNING,
-            "https://github.com/elastic/elasticsearch/pull/117172",
+            "https://ela.st/migrate-source-mode",
             SourceFieldMapper.DEPRECATION_DETAILS,
             false,
             null


### PR DESCRIPTION
In this PR we improve the deprecation warning about configuring source in the mapping.

- We reduce the size of the warning message so it looks better in kibana.
- We keep the original message in the details.
- We use an alias help url, so we can associate it with the guide when it's created.