### PR TITLE
SQL: Comment that we're not removing deprecated

### DIFF
--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequest.java
@@ -70,6 +70,10 @@ public class SqlQueryRequest extends AbstractSqlQueryRequest {
         PARSER.declareBoolean(SqlQueryRequest::columnar, COLUMNAR);
         PARSER.declareBoolean(SqlQueryRequest::fieldMultiValueLeniency, FIELD_MULTI_VALUE_LENIENCY);
         PARSER.declareBoolean((r, v) -> {
+            /*
+             * We don't plan to remove this no matter how few folks use it to make sure
+             * we don't break anyone.
+             */
             DEPRECATION_LOGGER.warn(DeprecationCategory.API, "sql_index_include_frozen", INDEX_INCLUDE_FROZEN_DEPRECATION_MESSAGE);
             r.indexIncludeFrozen(v);
         }, INDEX_INCLUDE_FROZEN);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/LogicalPlanBuilder.java
@@ -78,6 +78,10 @@ abstract class LogicalPlanBuilder extends ExpressionBuilder {
 
     protected void maybeWarnDeprecatedFrozenSyntax(boolean includeFrozen, String syntax) {
         if (includeFrozen) {
+            /*
+             * We don't plan to remove this no matter how few folks use it to make sure
+             * we don't break anyone.
+             */
             DEPRECATION_LOGGER.warn(DeprecationCategory.PARSING, "include_frozen_syntax", format(null, FROZEN_DEPRECATION_WARNING, syntax));
         }
     }


### PR DESCRIPTION
This adds a comment that we're not removing `index_include_frozen` to make sure we don't break anyone.
