### PR TITLE
[8.x] Missing providers from nio (#122004)

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -41,6 +41,7 @@ import java.nio.channels.CompletionHandler;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.SelectorProvider;
 import java.nio.charset.Charset;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -205,6 +206,8 @@ public interface EntitlementChecker {
     void check$jdk_vm_ci_services_Services$$load(Class<?> callerClass, Class<?> service);
 
     void check$jdk_vm_ci_services_Services$$loadSingle(Class<?> callerClass, Class<?> service, boolean required);
+
+    void check$java_nio_charset_spi_CharsetProvider$(Class<?> callerClass);
 
     /// /////////////////
     //
@@ -402,6 +405,16 @@ public interface EntitlementChecker {
     void check$sun_nio_ch_DatagramChannelImpl$send(Class<?> callerClass, DatagramChannel that, ByteBuffer src, SocketAddress target);
 
     void check$sun_nio_ch_DatagramChannelImpl$receive(Class<?> callerClass, DatagramChannel that, ByteBuffer dst);
+
+    // providers (SPI)
+
+    // protected constructors
+    void check$java_nio_channels_spi_SelectorProvider$(Class<?> callerClass);
+
+    void check$java_nio_channels_spi_AsynchronousChannelProvider$(Class<?> callerClass);
+
+    // provider methods (dynamic)
+    void checkSelectorProviderInheritedChannel(Class<?> callerClass, SelectorProvider that);
 
     /// /////////////////
     //

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/DummyImplementations.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/DummyImplementations.java
@@ -17,11 +17,24 @@ import java.net.DatagramSocket;
 import java.net.DatagramSocketImpl;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.net.ProtocolFamily;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.SocketImpl;
+import java.nio.channels.AsynchronousChannelGroup;
+import java.nio.channels.AsynchronousServerSocketChannel;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.Pipe;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.AbstractSelector;
+import java.nio.channels.spi.AsynchronousChannelProvider;
+import java.nio.channels.spi.SelectorProvider;
+import java.nio.charset.Charset;
+import java.nio.charset.spi.CharsetProvider;
 import java.security.cert.Certificate;
 import java.text.BreakIterator;
 import java.text.Collator;
@@ -35,8 +48,11 @@ import java.text.spi.DateFormatProvider;
 import java.text.spi.DateFormatSymbolsProvider;
 import java.text.spi.DecimalFormatSymbolsProvider;
 import java.text.spi.NumberFormatProvider;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.spi.CalendarDataProvider;
 import java.util.spi.CalendarNameProvider;
 import java.util.spi.CurrencyNameProvider;
@@ -485,5 +501,71 @@ class DummyImplementations {
 
     private static RuntimeException unexpected() {
         return new IllegalStateException("This method isn't supposed to be called");
+    }
+
+    static class DummySelectorProvider extends SelectorProvider {
+        @Override
+        public DatagramChannel openDatagramChannel() throws IOException {
+            return null;
+        }
+
+        @Override
+        public DatagramChannel openDatagramChannel(ProtocolFamily family) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Pipe openPipe() throws IOException {
+            return null;
+        }
+
+        @Override
+        public AbstractSelector openSelector() throws IOException {
+            return null;
+        }
+
+        @Override
+        public ServerSocketChannel openServerSocketChannel() throws IOException {
+            return null;
+        }
+
+        @Override
+        public SocketChannel openSocketChannel() throws IOException {
+            return null;
+        }
+    }
+
+    static class DummyAsynchronousChannelProvider extends AsynchronousChannelProvider {
+        @Override
+        public AsynchronousChannelGroup openAsynchronousChannelGroup(int nThreads, ThreadFactory threadFactory) throws IOException {
+            return null;
+        }
+
+        @Override
+        public AsynchronousChannelGroup openAsynchronousChannelGroup(ExecutorService executor, int initialSize) throws IOException {
+            return null;
+        }
+
+        @Override
+        public AsynchronousServerSocketChannel openAsynchronousServerSocketChannel(AsynchronousChannelGroup group) throws IOException {
+            return null;
+        }
+
+        @Override
+        public AsynchronousSocketChannel openAsynchronousSocketChannel(AsynchronousChannelGroup group) throws IOException {
+            return null;
+        }
+    }
+
+    static class DummyCharsetProvider extends CharsetProvider {
+        @Override
+        public Iterator<Charset> charsets() {
+            return null;
+        }
+
+        @Override
+        public Charset charsetForName(String charsetName) {
+            return null;
+        }
     }
 }

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/SpiActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/SpiActions.java
@@ -9,6 +9,10 @@
 
 package org.elasticsearch.entitlement.qa.test;
 
+import java.io.IOException;
+import java.nio.channels.Channel;
+import java.nio.channels.spi.SelectorProvider;
+
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_DENIED;
 
 class SpiActions {
@@ -70,6 +74,33 @@ class SpiActions {
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
     static void createLocaleServiceProvider() {
         new DummyImplementations.DummyLocaleServiceProvider();
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void getInheritedChannel() throws IOException {
+        Channel channel = null;
+        try {
+            channel = SelectorProvider.provider().inheritedChannel();
+        } finally {
+            if (channel != null) {
+                channel.close();
+            }
+        }
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void createSelectorProvider() {
+        new DummyImplementations.DummySelectorProvider();
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void createAsynchronousChannelProvider() {
+        new DummyImplementations.DummyAsynchronousChannelProvider();
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void createCharsetProvider() {
+        new DummyImplementations.DummyCharsetProvider();
     }
 
     private SpiActions() {}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -31,6 +31,7 @@ import org.elasticsearch.entitlement.runtime.policy.entitlements.OutboundNetwork
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.channels.spi.SelectorProvider;
 import java.nio.file.FileSystems;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -79,6 +80,13 @@ public class EntitlementInitialization {
                 "checkNewInputStream",
                 Path.class,
                 OpenOption[].class
+            ),
+            INSTRUMENTATION_SERVICE.lookupImplementationMethod(
+                SelectorProvider.class,
+                "inheritedChannel",
+                SelectorProvider.provider().getClass(),
+                EntitlementChecker.class,
+                "checkSelectorProviderInheritedChannel"
             )
         ).forEach(instrumentation -> checkMethods.put(instrumentation.targetMethod(), instrumentation.checkMethod()));
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -46,6 +46,7 @@ import java.nio.channels.CompletionHandler;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.SelectorProvider;
 import java.nio.charset.Charset;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -278,6 +279,11 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     @Override
     public void check$jdk_vm_ci_services_Services$$loadSingle(Class<?> callerClass, Class<?> service, boolean required) {
+        policyManager.checkChangeJVMGlobalState(callerClass);
+    }
+
+    @Override
+    public void check$java_nio_charset_spi_CharsetProvider$(Class<?> callerClass) {
         policyManager.checkChangeJVMGlobalState(callerClass);
     }
 
@@ -791,6 +797,21 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     @Override
     public void check$sun_nio_ch_DatagramChannelImpl$receive(Class<?> callerClass, DatagramChannel that, ByteBuffer dst) {
         policyManager.checkInboundNetworkAccess(callerClass);
+    }
+
+    @Override
+    public void check$java_nio_channels_spi_SelectorProvider$(Class<?> callerClass) {
+        policyManager.checkChangeNetworkHandling(callerClass);
+    }
+
+    @Override
+    public void check$java_nio_channels_spi_AsynchronousChannelProvider$(Class<?> callerClass) {
+        policyManager.checkChangeNetworkHandling(callerClass);
+    }
+
+    @Override
+    public void checkSelectorProviderInheritedChannel(Class<?> callerClass, SelectorProvider that) {
+        policyManager.checkChangeNetworkHandling(callerClass);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Missing providers from nio (#122004)