### PR TITLE
[8.x] Removing the type from the destination index when using CreateIndexFromSourceAction (#121982)

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
@@ -122,10 +122,14 @@ public class CreateIndexFromSourceTransportAction extends HandledTransportAction
             .orElse(Map.of());
     }
 
+    @SuppressWarnings("unchecked")
     private static Map<String, Object> mergeMappings(@Nullable MappingMetadata sourceMapping, Map<String, Object> mappingAddition)
         throws IOException {
         Map<String, Object> combinedMappingMap = new HashMap<>(toMap(sourceMapping));
         XContentHelper.update(combinedMappingMap, mappingAddition, true);
+        if (sourceMapping != null && combinedMappingMap.size() == 1 && combinedMappingMap.containsKey(sourceMapping.type())) {
+            combinedMappingMap = (Map<String, Object>) combinedMappingMap.get(sourceMapping.type());
+        }
         return combinedMappingMap;
     }
 

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -12,9 +12,11 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.common.settings.SecureString;
@@ -419,8 +421,27 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
         putIndexTemplateRequest.setJsonEntity(
             indexTemplate.replace("$TEMPLATE", templateWithNoTimestamp).replace("$PATTERN", dataStreamFromNonDataStreamIndices + "-*")
         );
-        assertOK(client().performRequest(putIndexTemplateRequest));
         String indexName = dataStreamFromNonDataStreamIndices + "-01";
+        if (minimumTransportVersion().before(TransportVersions.V_8_0_0)) {
+            /*
+             * It is not possible to create a 7.x index template with a type. And you can't create an empty index with a type. But you can
+             * create the index with a type by posting a document to an index with a type. We do that here so that we test that the type is
+             * removed when we reindex into 8.x.
+             */
+            String typeName = "test-type";
+            Request createIndexRequest = new Request("POST", indexName + "/" + typeName);
+            createIndexRequest.setJsonEntity("""
+                {
+                  "@timestamp": "2099-11-15T13:12:00",
+                  "message": "GET /search HTTP/1.1 200 1070000",
+                  "user": {
+                    "id": "kimchy"
+                  }
+                }""");
+            createIndexRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE).build());
+            assertOK(client().performRequest(createIndexRequest));
+        }
+        assertOK(client().performRequest(putIndexTemplateRequest));
         bulkLoadDataMissingTimestamp(indexName);
         /*
          * Next, we will change the index's mapping to include a @timestamp field since we are going to convert it to a data stream. But


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Removing the type from the destination index when using CreateIndexFromSourceAction (#121982)