### PR TITLE
[8.x] Add a parameter to describe the lambda in a transformedMatch matcher (#122013)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/LambdaMatchers.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/LambdaMatchers.java
@@ -24,10 +24,12 @@ import java.util.function.Predicate;
 public class LambdaMatchers {
 
     private static class TransformMatcher<T, U> extends BaseMatcher<T> {
+        private final String transformDescription;
         private final Matcher<U> matcher;
         private final Function<T, U> transform;
 
-        private TransformMatcher(Matcher<U> matcher, Function<T, U> transform) {
+        private TransformMatcher(String transformDescription, Matcher<U> matcher, Function<T, U> transform) {
+            this.transformDescription = transformDescription;
             this.matcher = matcher;
             this.transform = transform;
         }
@@ -56,25 +58,31 @@ public class LambdaMatchers {
                 return;
             }
 
-            description.appendText("transformed value ");
+            description.appendText(transformDescription).appendText(" ");
             matcher.describeMismatch(u, description);
         }
 
         @Override
         public void describeTo(Description description) {
-            description.appendText("transformed to match ").appendDescriptionOf(matcher);
+            description.appendText(transformDescription).appendText(" matches ").appendDescriptionOf(matcher);
         }
     }
 
     public static <T, U> Matcher<T> transformedMatch(Function<T, U> function, Matcher<U> matcher) {
-        return new TransformMatcher<>(matcher, function);
+        return new TransformMatcher<>("transformed value", matcher, function);
+    }
+
+    public static <T, U> Matcher<T> transformedMatch(String description, Function<T, U> function, Matcher<U> matcher) {
+        return new TransformMatcher<>(description, matcher, function);
     }
 
     private static class ListTransformMatcher<T, U> extends TypeSafeMatcher<Iterable<T>> {
+        private final String transformDescription;
         private final Matcher<Iterable<? extends U>> matcher;
         private final Function<T, U> transform;
 
-        private ListTransformMatcher(Matcher<Iterable<? extends U>> matcher, Function<T, U> transform) {
+        private ListTransformMatcher(String transformDescription, Matcher<Iterable<? extends U>> matcher, Function<T, U> transform) {
+            this.transformDescription = transformDescription;
             this.matcher = matcher;
             this.transform = transform;
         }
@@ -110,25 +118,35 @@ public class LambdaMatchers {
                 }
             }
 
-            description.appendText("transformed item ");
+            description.appendText(transformDescription).appendText(" ");
             matcher.describeMismatch(us, description);
         }
 
         @Override
         public void describeTo(Description description) {
-            description.appendText("iterable with transformed items to match ").appendDescriptionOf(matcher);
+            description.appendText("iterable with ").appendText(transformDescription).appendText(" matching ").appendDescriptionOf(matcher);
         }
     }
 
     public static <T, U> Matcher<Iterable<T>> transformedItemsMatch(Function<T, U> function, Matcher<Iterable<? extends U>> matcher) {
-        return new ListTransformMatcher<>(matcher, function);
+        return new ListTransformMatcher<>("transformed items", matcher, function);
+    }
+
+    public static <T, U> Matcher<Iterable<T>> transformedItemsMatch(
+        String transformDescription,
+        Function<T, U> function,
+        Matcher<Iterable<? extends U>> matcher
+    ) {
+        return new ListTransformMatcher<>(transformDescription, matcher, function);
     }
 
     private static class ArrayTransformMatcher<T, U> extends TypeSafeMatcher<T[]> {
+        private final String transformDescription;
         private final Matcher<U[]> matcher;
         private final Function<T, U> transform;
 
-        private ArrayTransformMatcher(Matcher<U[]> matcher, Function<T, U> transform) {
+        private ArrayTransformMatcher(String transformDescription, Matcher<U[]> matcher, Function<T, U> transform) {
+            this.transformDescription = transformDescription;
             this.matcher = matcher;
             this.transform = transform;
         }
@@ -177,18 +195,26 @@ public class LambdaMatchers {
                 us[i] = u;
             }
 
-            description.appendText("transformed item ");
+            description.appendText(transformDescription).appendText(" ");
             matcher.describeMismatch(us, description);
         }
 
         @Override
         public void describeTo(Description description) {
-            description.appendText("array with transformed items to match ").appendDescriptionOf(matcher);
+            description.appendText("array with ").appendText(transformDescription).appendText(" matching ").appendDescriptionOf(matcher);
         }
     }
 
     public static <T, U> Matcher<T[]> transformedArrayItemsMatch(Function<T, U> function, Matcher<U[]> matcher) {
-        return new ArrayTransformMatcher<>(matcher, function);
+        return new ArrayTransformMatcher<>("transformed items", matcher, function);
+    }
+
+    public static <T, U> Matcher<T[]> transformedArrayItemsMatch(
+        String transformDescription,
+        Function<T, U> function,
+        Matcher<U[]> matcher
+    ) {
+        return new ArrayTransformMatcher<>(transformDescription, matcher, function);
     }
 
     private static class PredicateMatcher<T> extends BaseMatcher<Predicate<? super T>> {

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -255,7 +255,7 @@ public class ElasticsearchAssertions {
             assertThat(
                 "Request should have been blocked by [" + expectedBlockId + "] instead of " + e.blocks(),
                 e.blocks(),
-                hasItem(transformedMatch(ClusterBlock::id, equalTo(expectedBlockId)))
+                hasItem(transformedMatch("ClusterBlock id", ClusterBlock::id, equalTo(expectedBlockId)))
             );
         }
     }
@@ -762,33 +762,39 @@ public class ElasticsearchAssertions {
      * Assert that an index template is missing
      */
     public static void assertIndexTemplateMissing(GetIndexTemplatesResponse templatesResponse, String name) {
-        assertThat(templatesResponse.getIndexTemplates(), not(hasItem(transformedMatch(IndexTemplateMetadata::name, equalTo(name)))));
+        assertThat(
+            templatesResponse.getIndexTemplates(),
+            not(hasItem(transformedMatch("IndexTemplateMetadata name", IndexTemplateMetadata::name, equalTo(name))))
+        );
     }
 
     /**
      * Assert that an index template exists
      */
     public static void assertIndexTemplateExists(GetIndexTemplatesResponse templatesResponse, String name) {
-        assertThat(templatesResponse.getIndexTemplates(), hasItem(transformedMatch(IndexTemplateMetadata::name, equalTo(name))));
+        assertThat(
+            templatesResponse.getIndexTemplates(),
+            hasItem(transformedMatch("IndexTemplateMetadata name", IndexTemplateMetadata::name, equalTo(name)))
+        );
     }
 
     /*
      * matchers
      */
     public static Matcher<SearchHit> hasId(final String id) {
-        return transformedMatch(SearchHit::getId, equalTo(id));
+        return transformedMatch("SearchHit id", SearchHit::getId, equalTo(id));
     }
 
     public static Matcher<SearchHit> hasIndex(final String index) {
-        return transformedMatch(SearchHit::getIndex, equalTo(index));
+        return transformedMatch("SearchHit index", SearchHit::getIndex, equalTo(index));
     }
 
     public static Matcher<SearchHit> hasScore(final float score) {
-        return transformedMatch(SearchHit::getScore, equalTo(score));
+        return transformedMatch("SearchHit score", SearchHit::getScore, equalTo(score));
     }
 
     public static Matcher<SearchHit> hasRank(final int rank) {
-        return transformedMatch(SearchHit::getRank, equalTo(rank));
+        return transformedMatch("SearchHit rank", SearchHit::getRank, equalTo(rank));
     }
 
     public static <T extends Query> T assertBooleanSubQuery(Query query, Class<T> subqueryType, int i) {

--- a/test/framework/src/test/java/org/elasticsearch/test/LambdaMatchersTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/LambdaMatchersTests.java
@@ -60,7 +60,8 @@ public class LambdaMatchersTests extends ESTestCase {
     }
 
     public void testTransformDescription() {
-        assertDescribeTo(transformedMatch((A a) -> a.str, emptyString()), equalTo("transformed to match an empty string"));
+        assertDescribeTo(transformedMatch((A a) -> a.str, emptyString()), equalTo("transformed value matches an empty string"));
+        assertDescribeTo(transformedMatch("str field", (A a) -> a.str, emptyString()), equalTo("str field matches an empty string"));
     }
 
     public void testListTransformMatcher() {
@@ -71,14 +72,23 @@ public class LambdaMatchersTests extends ESTestCase {
         assertMismatch(
             as,
             transformedItemsMatch(a -> a.str, containsInAnyOrder("1", "2", "4")),
-            equalTo("transformed item not matched: \"3\"")
+            equalTo("transformed items not matched: \"3\"")
+        );
+        assertMismatch(
+            as,
+            transformedItemsMatch("str field", a -> a.str, containsInAnyOrder("1", "2", "4")),
+            equalTo("str field not matched: \"3\"")
         );
     }
 
     public void testListTransformDescription() {
         assertDescribeTo(
             transformedItemsMatch((A a) -> a.str, containsInAnyOrder("1")),
-            equalTo("iterable with transformed items to match iterable with items [\"1\"] in any order")
+            equalTo("iterable with transformed items matching iterable with items [\"1\"] in any order")
+        );
+        assertDescribeTo(
+            transformedItemsMatch("str field", (A a) -> a.str, containsInAnyOrder("1")),
+            equalTo("iterable with str field matching iterable with items [\"1\"] in any order")
         );
     }
 
@@ -89,14 +99,23 @@ public class LambdaMatchersTests extends ESTestCase {
         assertMismatch(
             as,
             transformedArrayItemsMatch(a -> a.str, arrayContainingInAnyOrder("1", "2", "4")),
-            equalTo("transformed item not matched: \"3\"")
+            equalTo("transformed items not matched: \"3\"")
+        );
+        assertMismatch(
+            as,
+            transformedArrayItemsMatch("str field", a -> a.str, arrayContainingInAnyOrder("1", "2", "4")),
+            equalTo("str field not matched: \"3\"")
         );
     }
 
     public void testArrayTransformDescription() {
         assertDescribeTo(
             transformedArrayItemsMatch((A a) -> a.str, arrayContainingInAnyOrder("1")),
-            equalTo("array with transformed items to match [\"1\"] in any order")
+            equalTo("array with transformed items matching [\"1\"] in any order")
+        );
+        assertDescribeTo(
+            transformedArrayItemsMatch("str field", (A a) -> a.str, arrayContainingInAnyOrder("1")),
+            equalTo("array with str field matching [\"1\"] in any order")
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add a parameter to describe the lambda in a transformedMatch matcher (#122013)