### PR TITLE
Remove assertion for escapes in FileAccessTreeTests

### DIFF
--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
@@ -102,9 +102,6 @@ public class FileAccessTreeTests extends ESTestCase {
         // Forward slashes also work
         assertThat(tree.canRead(path("a/b")), is(true));
         assertThat(tree.canRead(path("m/n")), is(true));
-
-        // In case the native separator is a backslash, don't treat that as an escape
-        assertThat(tree.canRead(path("m\n")), is(false));
     }
 
     FilesEntitlement entitlement(String... values) {


### PR DESCRIPTION
FileAccessTrees operate on string paths, but use the FileSystem to normalize the path. This test assertion is trying to check backslash's aren't interpreted as an escape, but escapes happen before the path is sent to FileSystem, so here we end up passing a newline as part of a path, which fails on windows. This commit removes the assertion.

closes #121872