### PR TITLE
[8.18] Fix errors in the resolve-cluster asciidoc (#122078)

### DIFF
--- a/docs/reference/indices/resolve-cluster.asciidoc
+++ b/docs/reference/indices/resolve-cluster.asciidoc
@@ -101,6 +101,10 @@ about whether it has any indices, aliases or data streams that match `my-index-*
 [[resolve-cluster-api-request]]
 ==== {api-request-title}
 
+`GET /_resolve/cluster`
+
+or
+
 `GET /_resolve/cluster/<index_expression>`
 
 [[resolve-cluster-api-prereqs]]
@@ -116,7 +120,7 @@ privilege>> for the target data stream, index, or alias.
 `<index_expression>`::
 +
 --
-(Required, string) Comma-separated name(s) or index pattern(s) of the
+(Optional, string) Comma-separated name(s) or index pattern(s) of the
 indices, aliases, and data streams to resolve, using <<api-multi-index>>.
 Resources on <<remote-clusters,remote clusters>> can be specified using the
 `<cluster>:<name>` syntax.


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix errors in the resolve-cluster asciidoc (#122078)