### PR TITLE
Improve cancellation test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -358,18 +358,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
   method: testDependentVariableIsAliasToKeyword
   issue: https://github.com/elastic/elasticsearch/issues/121492
-- class: org.elasticsearch.xpack.esql.action.CrossClustersCancellationIT
-  method: testTasks
-  issue: https://github.com/elastic/elasticsearch/issues/121626
-- class: org.elasticsearch.xpack.esql.action.CrossClustersCancellationIT
-  method: testCloseSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/121627
-- class: org.elasticsearch.xpack.esql.action.CrossClustersCancellationIT
-  method: testCancel
-  issue: https://github.com/elastic/elasticsearch/issues/121632
-- class: org.elasticsearch.xpack.esql.action.CrossClustersCancellationIT
-  method: testCancelSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/121631
 - class: org.elasticsearch.search.CrossClusterSearchUnavailableClusterIT
   method: testSearchSkipUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/121497


### PR DESCRIPTION
- Don't require specific message since cancel can take several forms
- Stop both branches for close test to avoid race

Note this does not fully fix the test yet, since there's another problem there, but I am unmuting it anyway to get better visibility into it. 