### PR TITLE
[8.x] Add ignore_malformed and null_values to test data generation (#121983)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldDataGenerator.java
@@ -9,11 +9,13 @@
 
 package org.elasticsearch.logsdb.datageneration;
 
+import java.util.Map;
+
 /**
  * Entity responsible for generating a valid value for a field.
  *
  * Generator is expected to produce a different value on every call.
  */
 public interface FieldDataGenerator {
-    Object generateValue();
+    Object generateValue(Map<String, Object> fieldMapping);
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceHandler.java
@@ -58,6 +58,10 @@ public interface DataSourceHandler {
         return null;
     }
 
+    default DataSourceResponse.MalformedWrapper handle(DataSourceRequest.MalformedWrapper request) {
+        return null;
+    }
+
     default DataSourceResponse.ChildFieldGenerator handle(DataSourceRequest.ChildFieldGenerator request) {
         return null;
     }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceRequest.java
@@ -15,6 +15,7 @@ import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.fields.DynamicMapping;
 
 import java.util.Set;
+import java.util.function.Supplier;
 
 public interface DataSourceRequest<TResponse extends DataSourceResponse> {
     TResponse accept(DataSourceHandler handler);
@@ -87,6 +88,12 @@ public interface DataSourceRequest<TResponse extends DataSourceResponse> {
 
     record RepeatingWrapper() implements DataSourceRequest<DataSourceResponse.RepeatingWrapper> {
         public DataSourceResponse.RepeatingWrapper accept(DataSourceHandler handler) {
+            return handler.handle(this);
+        }
+    }
+
+    record MalformedWrapper(Supplier<Object> malformedValues) implements DataSourceRequest<DataSourceResponse.MalformedWrapper> {
+        public DataSourceResponse.MalformedWrapper accept(DataSourceHandler handler) {
             return handler.handle(this);
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceResponse.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceResponse.java
@@ -41,6 +41,8 @@ public interface DataSourceResponse {
 
     record RepeatingWrapper(Function<Supplier<Object>, Supplier<Object>> wrapper) implements DataSourceResponse {}
 
+    record MalformedWrapper(Function<Supplier<Object>, Supplier<Object>> wrapper) implements DataSourceResponse {}
+
     interface ChildFieldGenerator extends DataSourceResponse {
         int generateChildFieldCount();
 

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultWrappersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultWrappersHandler.java
@@ -32,6 +32,11 @@ public class DefaultWrappersHandler implements DataSourceHandler {
         return new DataSourceResponse.RepeatingWrapper(repeatValues());
     }
 
+    @Override
+    public DataSourceResponse.MalformedWrapper handle(DataSourceRequest.MalformedWrapper request) {
+        return new DataSourceResponse.MalformedWrapper(injectMalformed(request.malformedValues()));
+    }
+
     private static Function<Supplier<Object>, Supplier<Object>> injectNulls() {
         // Inject some nulls but majority of data should be non-null (as it likely is in reality).
         return (values) -> () -> ESTestCase.randomDouble() <= 0.05 ? null : values.get();
@@ -61,5 +66,9 @@ public class DefaultWrappersHandler implements DataSourceHandler {
                 }
             };
         };
+    }
+
+    private static Function<Supplier<Object>, Supplier<Object>> injectMalformed(Supplier<Object> malformedValues) {
+        return (values) -> () -> ESTestCase.randomDouble() <= 0.1 ? malformedValues.get() : values.get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ByteFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ByteFieldDataGenerator.java
@@ -13,21 +13,28 @@ import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class ByteFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Supplier<Object> valueGeneratorWithMalformed;
 
     public ByteFieldDataGenerator(String fieldName, DataSource dataSource) {
-        var bytes = dataSource.get(new DataSourceRequest.ByteGenerator());
-        var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
-        var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
+        var bytes = dataSource.get(new DataSourceRequest.ByteGenerator()).generator();
 
-        this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> bytes.generator().get());
+        this.valueGenerator = Wrappers.defaults(bytes::get, dataSource);
+
+        var strings = dataSource.get(new DataSourceRequest.StringGenerator()).generator();
+        this.valueGeneratorWithMalformed = Wrappers.defaultsWithMalformed(bytes::get, strings::get, dataSource);
     }
 
     @Override
-    public Object generateValue() {
+    public Object generateValue(Map<String, Object> fieldMapping) {
+        if (fieldMapping != null && (Boolean) fieldMapping.getOrDefault("ignore_malformed", false)) {
+            return valueGeneratorWithMalformed.get();
+        }
+
         return valueGenerator.get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/CountedKeywordFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/CountedKeywordFieldDataGenerator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -31,7 +32,7 @@ public class CountedKeywordFieldDataGenerator implements FieldDataGenerator {
     }
 
     @Override
-    public Object generateValue() {
+    public Object generateValue(Map<String, Object> fieldMapping) {
         return valueGenerator.get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/DoubleFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/DoubleFieldDataGenerator.java
@@ -13,21 +13,28 @@ import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class DoubleFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Supplier<Object> valueGeneratorWithMalformed;
 
     public DoubleFieldDataGenerator(String fieldName, DataSource dataSource) {
-        var doubles = dataSource.get(new DataSourceRequest.DoubleGenerator());
-        var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
-        var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
+        var doubles = dataSource.get(new DataSourceRequest.DoubleGenerator()).generator();
 
-        this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> doubles.generator().get());
+        this.valueGenerator = Wrappers.defaults(doubles::get, dataSource);
+
+        var strings = dataSource.get(new DataSourceRequest.StringGenerator()).generator();
+        this.valueGeneratorWithMalformed = Wrappers.defaultsWithMalformed(doubles::get, strings::get, dataSource);
     }
 
     @Override
-    public Object generateValue() {
+    public Object generateValue(Map<String, Object> fieldMapping) {
+        if (fieldMapping != null && (Boolean) fieldMapping.getOrDefault("ignore_malformed", false)) {
+            return valueGeneratorWithMalformed.get();
+        }
+
         return valueGenerator.get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/FloatFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/FloatFieldDataGenerator.java
@@ -13,21 +13,28 @@ import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class FloatFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Supplier<Object> valueGeneratorWithMalformed;
 
     public FloatFieldDataGenerator(String fieldName, DataSource dataSource) {
-        var floats = dataSource.get(new DataSourceRequest.FloatGenerator());
-        var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
-        var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
+        var floats = dataSource.get(new DataSourceRequest.FloatGenerator()).generator();
 
-        this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> floats.generator().get());
+        this.valueGenerator = Wrappers.defaults(floats::get, dataSource);
+
+        var strings = dataSource.get(new DataSourceRequest.StringGenerator()).generator();
+        this.valueGeneratorWithMalformed = Wrappers.defaultsWithMalformed(floats::get, strings::get, dataSource);
     }
 
     @Override
-    public Object generateValue() {
+    public Object generateValue(Map<String, Object> fieldMapping) {
+        if (fieldMapping != null && (Boolean) fieldMapping.getOrDefault("ignore_malformed", false)) {
+            return valueGeneratorWithMalformed.get();
+        }
+
         return valueGenerator.get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/HalfFloatFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/HalfFloatFieldDataGenerator.java
@@ -13,21 +13,28 @@ import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class HalfFloatFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Supplier<Object> valueGeneratorWithMalformed;
 
     public HalfFloatFieldDataGenerator(String fieldName, DataSource dataSource) {
-        var halfFloats = dataSource.get(new DataSourceRequest.HalfFloatGenerator());
-        var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
-        var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
+        var halfFloats = dataSource.get(new DataSourceRequest.HalfFloatGenerator()).generator();
 
-        this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> halfFloats.generator().get());
+        this.valueGenerator = Wrappers.defaults(halfFloats::get, dataSource);
+
+        var strings = dataSource.get(new DataSourceRequest.StringGenerator()).generator();
+        this.valueGeneratorWithMalformed = Wrappers.defaultsWithMalformed(halfFloats::get, strings::get, dataSource);
     }
 
     @Override
-    public Object generateValue() {
+    public Object generateValue(Map<String, Object> fieldMapping) {
+        if (fieldMapping != null && (Boolean) fieldMapping.getOrDefault("ignore_malformed", false)) {
+            return valueGeneratorWithMalformed.get();
+        }
+
         return valueGenerator.get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/IntegerFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/IntegerFieldDataGenerator.java
@@ -13,21 +13,28 @@ import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class IntegerFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Supplier<Object> valueGeneratorWithMalformed;
 
     public IntegerFieldDataGenerator(String fieldName, DataSource dataSource) {
-        var ints = dataSource.get(new DataSourceRequest.IntegerGenerator());
-        var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
-        var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
+        var ints = dataSource.get(new DataSourceRequest.IntegerGenerator()).generator();
 
-        this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> ints.generator().get());
+        this.valueGenerator = Wrappers.defaults(ints::get, dataSource);
+
+        var strings = dataSource.get(new DataSourceRequest.StringGenerator()).generator();
+        this.valueGeneratorWithMalformed = Wrappers.defaultsWithMalformed(ints::get, strings::get, dataSource);
     }
 
     @Override
-    public Object generateValue() {
+    public Object generateValue(Map<String, Object> fieldMapping) {
+        if (fieldMapping != null && (Boolean) fieldMapping.getOrDefault("ignore_malformed", false)) {
+            return valueGeneratorWithMalformed.get();
+        }
+
         return valueGenerator.get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/KeywordFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/KeywordFieldDataGenerator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class KeywordFieldDataGenerator implements FieldDataGenerator {
@@ -27,7 +28,7 @@ public class KeywordFieldDataGenerator implements FieldDataGenerator {
     }
 
     @Override
-    public Object generateValue() {
+    public Object generateValue(Map<String, Object> fieldMapping) {
         return valueGenerator.get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/LongFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/LongFieldDataGenerator.java
@@ -13,21 +13,28 @@ import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class LongFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Supplier<Object> valueGeneratorWithMalformed;
 
     public LongFieldDataGenerator(String fieldName, DataSource dataSource) {
-        var longs = dataSource.get(new DataSourceRequest.LongGenerator());
-        var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
-        var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
+        var longs = dataSource.get(new DataSourceRequest.LongGenerator()).generator();
 
-        this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> longs.generator().get());
+        this.valueGenerator = Wrappers.defaults(longs::get, dataSource);
+
+        var strings = dataSource.get(new DataSourceRequest.StringGenerator()).generator();
+        this.valueGeneratorWithMalformed = Wrappers.defaultsWithMalformed(longs::get, strings::get, dataSource);
     }
 
     @Override
-    public Object generateValue() {
+    public Object generateValue(Map<String, Object> fieldMapping) {
+        if (fieldMapping != null && (Boolean) fieldMapping.getOrDefault("ignore_malformed", false)) {
+            return valueGeneratorWithMalformed.get();
+        }
+
         return valueGenerator.get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ScaledFloatFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ScaledFloatFieldDataGenerator.java
@@ -13,21 +13,28 @@ import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class ScaledFloatFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Supplier<Object> valueGeneratorWithMalformed;
 
     public ScaledFloatFieldDataGenerator(String fieldName, DataSource dataSource) {
-        var doubles = dataSource.get(new DataSourceRequest.DoubleGenerator());
-        var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
-        var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
+        var doubles = dataSource.get(new DataSourceRequest.DoubleGenerator()).generator();
 
-        this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> doubles.generator().get());
+        this.valueGenerator = Wrappers.defaults(doubles::get, dataSource);
+
+        var strings = dataSource.get(new DataSourceRequest.StringGenerator()).generator();
+        this.valueGeneratorWithMalformed = Wrappers.defaultsWithMalformed(doubles::get, strings::get, dataSource);
     }
 
     @Override
-    public Object generateValue() {
+    public Object generateValue(Map<String, Object> fieldMapping) {
+        if (fieldMapping != null && (Boolean) fieldMapping.getOrDefault("ignore_malformed", false)) {
+            return valueGeneratorWithMalformed.get();
+        }
+
         return valueGenerator.get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/Wrappers.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/Wrappers.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.logsdb.datageneration.fields.leaf;
+
+import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+
+import java.util.function.Supplier;
+
+public class Wrappers {
+    /**
+     * Applies default wrappers for raw values - adds nulls and wraps values in arrays.
+     * @return
+     */
+    static Supplier<Object> defaults(Supplier<Object> rawValues, DataSource dataSource) {
+        var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
+        var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
+
+        return arrays.wrapper().compose(nulls.wrapper()).apply(rawValues::get);
+    }
+
+    /**
+     * Applies default wrappers for raw values and also adds malformed values.
+     * @return
+     */
+    static Supplier<Object> defaultsWithMalformed(Supplier<Object> rawValues, Supplier<Object> malformedValues, DataSource dataSource) {
+        var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
+        var malformed = dataSource.get(new DataSourceRequest.MalformedWrapper(malformedValues));
+        var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
+
+        return arrays.wrapper().compose(nulls.wrapper()).compose(malformed.wrapper()).apply(rawValues::get);
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/FieldSpecificMatcher.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/matchers/source/FieldSpecificMatcher.java
@@ -111,25 +111,27 @@ interface FieldSpecificMatcher {
         Object convert(Object value, Object nullValue) {
             var nullValueShort = nullValue != null ? HalfFloatPoint.halfFloatToSortableShort(((Number) nullValue).floatValue()) : null;
 
-            return switch (value) {
-                case null -> nullValueShort;
-                case Number n -> HalfFloatPoint.halfFloatToSortableShort(n.floatValue());
-                case String s -> {
-                    // Special case for number coercion from strings
-                    if (s.isEmpty()) {
-                        yield nullValueShort;
-                    }
-
-                    try {
-                        var f = Float.parseFloat(s);
-                        yield HalfFloatPoint.halfFloatToSortableShort(f);
-                    } catch (NumberFormatException e) {
-                        // Malformed, leave it be and match as is
-                        yield s;
-                    }
+            if (value == null) {
+                return nullValueShort;
+            }
+            if (value instanceof String s) {
+                // Special case for number coercion from strings
+                if (s.isEmpty()) {
+                    return nullValueShort;
                 }
-                default -> value;
-            };
+
+                try {
+                    var f = Float.parseFloat(s);
+                    return HalfFloatPoint.halfFloatToSortableShort(f);
+                } catch (NumberFormatException e) {
+                    // Malformed, leave it be and match as is
+                    return s;
+                }
+            }
+            if (value instanceof Number n) {
+                return HalfFloatPoint.halfFloatToSortableShort(n.floatValue());
+            }
+            return value;
         }
     }
 
@@ -272,20 +274,21 @@ interface FieldSpecificMatcher {
         Object convert(Object value, Object nullValue) {
             var nullValueBigInt = nullValue != null ? BigInteger.valueOf(((Number) nullValue).longValue()) : null;
 
-            return switch (value) {
-                case null -> nullValueBigInt;
-                case String s -> {
-                    // Special case for number coercion from strings
-                    if (s.isEmpty()) {
-                        yield nullValueBigInt;
-                    }
-
-                    yield s;
+            if (value == null) {
+                return nullValueBigInt;
+            }
+            if (value instanceof String s) {
+                // Special case for number coercion from strings
+                if (s.isEmpty()) {
+                    return nullValueBigInt;
                 }
-                case Long l -> BigInteger.valueOf(l);
-                default -> value;
-            };
 
+                return s;
+            }
+            if (value instanceof Long l) {
+                return BigInteger.valueOf(l);
+            }
+            return value;
         }
     }
 

--- a/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/SourceMatcherTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/SourceMatcherTests.java
@@ -62,8 +62,8 @@ public class SourceMatcherTests extends ESTestCase {
 
     public void testMappedMatch() throws IOException {
         List<Map<String, Object>> values = List.of(
-            Map.of("aaa", 124, "bbb", false, "ccc", 12.34),
-            Map.of("aaa", 124, "bbb", false, "ccc", 12.34)
+            Map.of("aaa", 124, "bbb", "hey", "ccc", 12.34),
+            Map.of("aaa", 124, "bbb", "yeh", "ccc", 12.34)
         );
 
         var mapping = XContentBuilder.builder(XContentType.JSON.xContent());
@@ -71,7 +71,7 @@ public class SourceMatcherTests extends ESTestCase {
         mapping.startObject("_doc");
         {
             mapping.startObject("aaa").field("type", "long").endObject();
-            mapping.startObject("bbb").field("type", "boolean").endObject();
+            mapping.startObject("bbb").field("type", "keyword").endObject();
             mapping.startObject("ccc").field("type", "half_float").endObject();
         }
         mapping.endObject();
@@ -83,12 +83,12 @@ public class SourceMatcherTests extends ESTestCase {
 
     public void testMappedMismatch() throws IOException {
         List<Map<String, Object>> actual = List.of(
-            Map.of("aaa", 124, "bbb", false, "ccc", 12.34),
-            Map.of("aaa", 124, "bbb", false, "ccc", 12.34)
+            Map.of("aaa", 124, "bbb", "hey", "ccc", 12.34),
+            Map.of("aaa", 124, "bbb", "yeh", "ccc", 12.34)
         );
         List<Map<String, Object>> expected = List.of(
-            Map.of("aaa", 124, "bbb", false, "ccc", 12.34),
-            Map.of("aaa", 124, "bbb", false, "ccc", 12.35)
+            Map.of("aaa", 124, "bbb", "hey", "ccc", 12.34),
+            Map.of("aaa", 124, "bbb", "yeh", "ccc", 12.35)
         );
 
         var mapping = XContentBuilder.builder(XContentType.JSON.xContent());
@@ -96,7 +96,7 @@ public class SourceMatcherTests extends ESTestCase {
         mapping.startObject("_doc");
         {
             mapping.startObject("aaa").field("type", "long").endObject();
-            mapping.startObject("bbb").field("type", "boolean").endObject();
+            mapping.startObject("bbb").field("type", "keyword").endObject();
             mapping.startObject("ccc").field("type", "half_float").endObject();
         }
         mapping.endObject();

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/DataGenerationHelper.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/DataGenerationHelper.java
@@ -49,14 +49,14 @@ public class DataGenerationHelper {
                         "host.name",
                         FieldType.KEYWORD,
                         Map.of("type", "keyword"),
-                        () -> ESTestCase.randomAlphaOfLength(5)
+                        (ignored) -> ESTestCase.randomAlphaOfLength(5)
                     ),
                     // Needed for terms query
                     new PredefinedField.WithGenerator(
                         "method",
                         FieldType.KEYWORD,
                         Map.of("type", "keyword"),
-                        () -> ESTestCase.randomFrom("put", "post", "get")
+                        (ignored) -> ESTestCase.randomFrom("put", "post", "get")
                     ),
 
                     // Needed for histogram aggregation
@@ -64,7 +64,7 @@ public class DataGenerationHelper {
                         "memory_usage_bytes",
                         FieldType.LONG,
                         Map.of("type", "long"),
-                        () -> ESTestCase.randomLongBetween(1000, 2000)
+                        (ignored) -> ESTestCase.randomLongBetween(1000, 2000)
                     )
                 )
             );


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add ignore_malformed and null_values to test data generation (#121983)