### PR TITLE
[8.x] Improve cancellation test (#122085)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -522,12 +522,6 @@ tests:
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testUpdateProfileData
   issue: https://github.com/elastic/elasticsearch/issues/121108
-- class: org.elasticsearch.xpack.esql.action.CrossClustersCancellationIT
-  method: testCloseSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/121627
-- class: org.elasticsearch.xpack.esql.action.CrossClustersCancellationIT
-  method: testCancelSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/121631
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/rest-api/common-options/line_102}
   issue: https://github.com/elastic/elasticsearch/issues/121748


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Improve cancellation test (#122085)](https://github.com/elastic/elasticsearch/pull/122085)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)