### PR TITLE
[8.18] Adjust details in the SourceFieldMapper deprecation warning (#122083)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -71,6 +71,8 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     public static final String LOSSY_PARAMETERS_ALLOWED_SETTING_NAME = "index.lossy.source-mapping-parameters";
 
+    public static final String DEPRECATION_WARNING_TITLE = "Configuring source mode in mappings is deprecated.";
+
     public static final String DEPRECATION_WARNING = "Configuring source mode in mappings is deprecated and will be removed "
         + "in future versions. Use [index.mapping.source.mode] index setting instead.";
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationChecker.java
@@ -122,9 +122,9 @@ public class TemplateDeprecationChecker implements ResourceDeprecationChecker {
                     if (sourceMap.containsKey("mode")) {
                         return new DeprecationIssue(
                             DeprecationIssue.Level.CRITICAL,
+                            SourceFieldMapper.DEPRECATION_WARNING_TITLE,
+                            "https://ela.st/migrate-source-mode",
                             SourceFieldMapper.DEPRECATION_WARNING,
-                            "https://github.com/elastic/elasticsearch/pull/117172",
-                            null,
                             false,
                             null
                         );

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TemplateDeprecationCheckerTests.java
@@ -51,9 +51,9 @@ public class TemplateDeprecationCheckerTests extends ESTestCase {
         Map<String, List<DeprecationIssue>> issuesByComponentTemplate = checker.check(clusterState);
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
+            SourceFieldMapper.DEPRECATION_WARNING_TITLE,
+            "https://ela.st/migrate-source-mode",
             SourceFieldMapper.DEPRECATION_WARNING,
-            "https://github.com/elastic/elasticsearch/pull/117172",
-            null,
             false,
             null
         );

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsIndexModeCustomSettingsIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsIndexModeCustomSettingsIT.java
@@ -520,6 +520,7 @@ public class LogsIndexModeCustomSettingsIT extends LogsIndexModeRestTestIT {
         Map<?, ?> issuesByTemplate = (Map<?, ?>) response.get("templates");
         assertThat(issuesByTemplate.containsKey(templateName), equalTo(true));
         var templateIssues = (List<?>) issuesByTemplate.get(templateName);
-        assertThat(((Map<?, ?>) templateIssues.get(0)).get("message"), equalTo(SourceFieldMapper.DEPRECATION_WARNING));
+        assertThat(((Map<?, ?>) templateIssues.get(0)).get("message"), equalTo(SourceFieldMapper.DEPRECATION_WARNING_TITLE));
+        assertThat(((Map<?, ?>) templateIssues.get(0)).get("details"), equalTo(SourceFieldMapper.DEPRECATION_WARNING));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.18:
 - [8.x] Adjust details in the SourceFieldMapper deprecation warning (#122083)