### PR TITLE
[8.x] Fix async stop sometimes not properly collecting result (#121843)

### DIFF
--- a/docs/changelog/121843.yaml
+++ b/docs/changelog/121843.yaml
@@ -1,0 +1,6 @@
+pr: 121843
+summary: Fix async stop sometimes not properly collecting result
+area: ES|QL
+type: bug
+issues:
+ - 121249

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -393,6 +393,22 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
         AsyncExecutionId asyncExecutionId,
         Class<T> tClass
     ) throws IOException {
+        return getTaskAndCheckAuthentication(taskManager, security, asyncExecutionId, tClass);
+    }
+
+    /**
+    * Returns the {@link AsyncTask} if the provided <code>asyncTaskId</code>
+    * is registered in the task manager, <code>null</code> otherwise.
+    *
+    * This method throws a {@link ResourceNotFoundException} if the authenticated user
+    * is not the creator of the original task.
+    */
+    public static <T extends AsyncTask> T getTaskAndCheckAuthentication(
+        TaskManager taskManager,
+        AsyncSearchSecurity security,
+        AsyncExecutionId asyncExecutionId,
+        Class<T> tClass
+    ) throws IOException {
         T asyncTask = getTask(taskManager, asyncExecutionId, tClass);
         if (asyncTask == null) {
             return null;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix async stop sometimes not properly collecting result (#121843)](https://github.com/elastic/elasticsearch/pull/121843)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)