### PR TITLE
[9.0] Increase timeout in `DataStreamLifecycleDownsampleDisruptionIT` (#122151)

### DIFF
--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleDisruptionIT.java
@@ -119,7 +119,7 @@ public class DataStreamLifecycleDownsampleDisruptionIT extends ESIntegTestCase {
             } catch (Exception e) {
                 throw new AssertionError(e);
             }
-        }, 60, TimeUnit.SECONDS);
+        }, 120, TimeUnit.SECONDS);
         ensureGreen(targetIndex);
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Increase timeout in &#x60;DataStreamLifecycleDownsampleDisruptionIT&#x60; (#122151)](https://github.com/elastic/elasticsearch/pull/122151)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)