### PR TITLE
[9.0] Remove TLSv1.1 from default protocols (#121731)

### DIFF
--- a/docs/changelog/121731.yaml
+++ b/docs/changelog/121731.yaml
@@ -1,0 +1,21 @@
+pr: 121731
+summary: Remove TLSv1.1 from default protocols
+area: TLS
+type: breaking
+issues: []
+breaking:
+  title: Remove TLSv1.1 from default protocols
+  area: Cluster and node setting
+  details: "TLSv1.1 is no longer enabled by default. Prior to version 9.0, Elasticsearch\
+    \ would attempt to enable TLSv1.1 if the JDK supported it. In most cases, including\
+    \ all cases where Elasticsearch 8 was running with the bundled JDK, the JDK would\
+    \ not support TLSv1.1, so that protocol would not be available in Elasticsearch.\
+    \ However, if Elasticsearch was running on an old JDK or a JDK that have been\
+    \ reconfigured to support TLSv1.1, then the protocol would automatically be available\
+    \ within Elasticsearch. As of Elasticsearch 9.0, this is no longer true. If you\
+    \ wish to enable TLSv1.1 then you must enable it within the JDK and also enable\
+    \ it within Elasticsearch by using the `ssl.supported_protocols` setting."
+  impact: "Most users will not be impacted. If your Elastisearch 8 cluster was using\
+    \ a custom JDK and you relied on TLSv1.1, then you will need to explicitly enable\
+    \ TLSv1.1 within Elasticsearch (as well as enabling it within your JDK)"
+  notable: false

--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfigurationLoader.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfigurationLoader.java
@@ -13,8 +13,6 @@ import org.elasticsearch.core.Nullable;
 
 import java.nio.file.Path;
 import java.security.KeyStore;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -25,7 +23,6 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
 
 import static org.elasticsearch.common.ssl.KeyStoreUtil.inferKeyStoreType;
-import static org.elasticsearch.common.ssl.SslConfiguration.ORDERED_PROTOCOL_ALGORITHM_MAP;
 import static org.elasticsearch.common.ssl.SslConfigurationKeys.CERTIFICATE;
 import static org.elasticsearch.common.ssl.SslConfigurationKeys.CERTIFICATE_AUTHORITIES;
 import static org.elasticsearch.common.ssl.SslConfigurationKeys.CIPHERS;
@@ -63,11 +60,7 @@ import static org.elasticsearch.common.ssl.SslConfigurationKeys.VERIFICATION_MOD
  */
 public abstract class SslConfigurationLoader {
 
-    static final List<String> DEFAULT_PROTOCOLS = Collections.unmodifiableList(
-        ORDERED_PROTOCOL_ALGORITHM_MAP.containsKey("TLSv1.3")
-            ? Arrays.asList("TLSv1.3", "TLSv1.2", "TLSv1.1")
-            : Arrays.asList("TLSv1.2", "TLSv1.1")
-    );
+    static final List<String> DEFAULT_PROTOCOLS = List.of("TLSv1.3", "TLSv1.2");
 
     private static final List<String> JDK12_CIPHERS = List.of(
         // TLSv1.3 cipher has PFS, AEAD, hardware support

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -317,7 +317,7 @@ public class XPackSettings {
         }, Property.NodeScope);
     }
 
-    public static final List<String> DEFAULT_SUPPORTED_PROTOCOLS = Arrays.asList("TLSv1.3", "TLSv1.2", "TLSv1.1");
+    public static final List<String> DEFAULT_SUPPORTED_PROTOCOLS = Arrays.asList("TLSv1.3", "TLSv1.2");
 
     public static final SslClientAuthenticationMode CLIENT_AUTH_DEFAULT = SslClientAuthenticationMode.REQUIRED;
     public static final SslClientAuthenticationMode HTTP_CLIENT_AUTH_DEFAULT = SslClientAuthenticationMode.NONE;


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Remove TLSv1.1 from default protocols (#121731)