### PR TITLE
[TEST] Unmute TSDBPassthroughIndexingIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -400,8 +400,6 @@ tests:
 - class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
   method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
   issue: https://github.com/elastic/elasticsearch/issues/122104
-- class: org.elasticsearch.datastreams.TSDBPassthroughIndexingIT
-  issue: https://github.com/elastic/elasticsearch/issues/121716
 - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
   method: testWithOnlyTrainingRowsAndTrainingPercentIsFifty_DependentVariableIsBoolean
   issue: https://github.com/elastic/elasticsearch/issues/121680


### PR DESCRIPTION
Yet another unmute, the failures are due to a platform issue in Windows.

Related to #121716