### PR TITLE
[8.16] EQL: fix JOIN command validation (not supported) (#122011)

### DIFF
--- a/docs/changelog/122011.yaml
+++ b/docs/changelog/122011.yaml
@@ -1,0 +1,5 @@
+pr: 122011
+summary: Fix JOIN command validation (not supported)
+area: EQL
+type: bug
+issues: []

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Verifier.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Verifier.java
@@ -71,6 +71,9 @@ public class Verifier {
 
         // start bottom-up
         plan.forEachUp(p -> {
+            if (p.getClass().equals(Join.class)) {
+                failures.add(fail(p, "JOIN command is not supported"));
+            }
             if (p.analyzed()) {
                 return;
             }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
@@ -368,6 +368,13 @@ public class VerifierTests extends ESTestCase {
         accept(idxr, "foo where serial_event_id == 0");
     }
 
+    public void testJoinCommand() {
+        final IndexResolution idxr = loadIndexResolution("mapping-ip.json");
+
+        assertEquals("1:1: JOIN command is not supported", error(idxr, "join [any where true] [any where true]"));
+        assertEquals("1:1: JOIN command is not supported", error(idxr, "join [any where true] [any where true] | tail 3"));
+    }
+
     public void testMultiField() {
         final IndexResolution idxr = loadIndexResolution("mapping-multi-field.json");
         accept(idxr, "foo where multi_field.raw == \"bar\"");


### PR DESCRIPTION
Backports the following commits to 8.16:
 - EQL: fix JOIN command validation (not supported) (#122011)