### PR TITLE
Reduce number of `get` method variants in ShardGetService

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -312,7 +312,7 @@ public class TransportShardMultiGetAction extends TransportSingleShardAction<Mul
         MultiGetRequest.Item item = request.items.get(location);
         try {
             GetResult getResult = indexShard.getService()
-                .get(
+                .mget(
                     item.id(),
                     item.storedFields(),
                     request.realtime(),

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.metrics.MeanMetric;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.Engine;


### PR DESCRIPTION
ShardGetService contains multiple get*() methods
with different visibility.

One `getForUpdate` is only used in a test so it
can be moved there.

An `innerGet` private method is only called by
the private get() method so it can be folded in
there to remove one more undocumented `get`
variant.

A public `get` method is only used in
TransportShardMultiGetAction so we can rename
it to `mget` to avoid confusion with other `get`.

Finally the private `get` is renamed to `doGet`
to indicate it's an "inner" private method.
