### PR TITLE
[TEST] Remove assert on non scored doc from SearchTimeoutIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchTimeoutIT.java
@@ -240,13 +240,14 @@ public class SearchTimeoutIT extends ESIntegTestCase {
                                             for (int doc = min; doc < max; ++doc) {
                                                 if (acceptDocs == null || acceptDocs.get(doc)) {
                                                     collector.collect(doc);
-                                                    // collect one doc, then throw a timeout, this ensures partial results will be returned
+                                                    // collect one doc per segment, only then throw a timeout: this ensures partial
+                                                    // results are returned
                                                     ((ContextIndexSearcher) searcher).throwTimeExceededException();
                                                 }
                                             }
-                                            throw new AssertionError(
-                                                "Should have thrown a time exceeded exception: [min: " + min + " - max: " + max + "]"
-                                            );
+                                            //there is a slight chance that no docs are scored for a specific segment.
+                                            //other shards / slices will throw the timeout anyway, one is enough.
+                                            return max == maxDoc ? DocIdSetIterator.NO_MORE_DOCS : max;
                                         }
 
                                         @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchTimeoutIT.java
@@ -245,8 +245,8 @@ public class SearchTimeoutIT extends ESIntegTestCase {
                                                     ((ContextIndexSearcher) searcher).throwTimeExceededException();
                                                 }
                                             }
-                                            //there is a slight chance that no docs are scored for a specific segment.
-                                            //other shards / slices will throw the timeout anyway, one is enough.
+                                            // there is a slight chance that no docs are scored for a specific segment.
+                                            // other shards / slices will throw the timeout anyway, one is enough.
                                             return max == maxDoc ? DocIdSetIterator.NO_MORE_DOCS : max;
                                         }
 


### PR DESCRIPTION
In the recent rewrite of SearchTimeoutIT (#120390), an edge case was not considered for the situation where a specific segment may not score any document. In that case, other shards and their segments will raise a timeout anyway.