### PR TITLE
Fix example plugin using config dir

### DIFF
--- a/plugins/examples/custom-settings/src/main/java/org/elasticsearch/example/customsettings/ExampleCustomSettingsConfig.java
+++ b/plugins/examples/custom-settings/src/main/java/org/elasticsearch/example/customsettings/ExampleCustomSettingsConfig.java
@@ -70,7 +70,7 @@ public class ExampleCustomSettingsConfig {
 
     public ExampleCustomSettingsConfig(final Environment environment) {
         // Elasticsearch config directory
-        final Path configDir = environment.configFile();
+        final Path configDir = environment.configDir();
 
         // Resolve the plugin's custom settings file
         final Path customSettingsYamlFile = configDir.resolve("custom-settings/custom.yml");


### PR DESCRIPTION
This commit fixes a use of accessing the config dir from the environment.