### PR TITLE
Skip SecurityManager policy parsing and validation for JDK 24+

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
@@ -38,6 +38,7 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.jdk.JarHell;
+import org.elasticsearch.jdk.RuntimeVersionFeature;
 import org.elasticsearch.plugin.scanner.ClassReaders;
 import org.elasticsearch.plugin.scanner.NamedComponentScanner;
 import org.elasticsearch.plugins.Platforms;
@@ -922,10 +923,12 @@ public class InstallPluginAction implements Closeable {
      */
     private PluginDescriptor installPlugin(InstallablePlugin descriptor, Path tmpRoot, List<Path> deleteOnFailure) throws Exception {
         final PluginDescriptor info = loadPluginInfo(tmpRoot);
-        PluginPolicyInfo pluginPolicy = PolicyUtil.getPluginPolicyInfo(tmpRoot, env.tmpDir());
-        if (pluginPolicy != null) {
-            Set<String> permissions = PluginSecurity.getPermissionDescriptions(pluginPolicy, env.tmpDir());
-            PluginSecurity.confirmPolicyExceptions(terminal, permissions, batch);
+        if (RuntimeVersionFeature.isSecurityManagerAvailable()) {
+            PluginPolicyInfo pluginPolicy = PolicyUtil.getPluginPolicyInfo(tmpRoot, env.tmpDir());
+            if (pluginPolicy != null) {
+                Set<String> permissions = PluginSecurity.getPermissionDescriptions(pluginPolicy, env.tmpDir());
+                PluginSecurity.confirmPolicyExceptions(terminal, permissions, batch);
+            }
         }
 
         // Validate that the downloaded plugin's ID matches what we expect from the descriptor. The


### PR DESCRIPTION
During plugin install, we validate the plugin's policy file against a set of allowed/disallowed permissions. However, methods for anything related to SecurityManager (including policy parsing) have been removed from JDK 24+.

We will eventually completely remove this code once Entitlements (SecurityManager replacement) is complete; this PR provisionally disable policy parsing and validation if the SecurityManager is not available (has been removed).

closes #121989