### PR TITLE
[8.17] [Build] Fix the manifest target and source information for jdbc projects (#121888)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -58,7 +58,6 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getRootProject().getPlugins().apply(GlobalBuildInfoPlugin.class);
         // make sure the global build info plugin is applied to the root project
         project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
         buildParams = project.getRootProject().getExtensions().getByType(BuildParameterExtension.class);

--- a/x-pack/plugin/sql/jdbc/build.gradle
+++ b/x-pack/plugin/sql/jdbc/build.gradle
@@ -20,11 +20,20 @@ dependencies {
   testImplementation project(':modules:rest-root')
 }
 
-tasks.named("compileJava").configure {
+java {
   targetCompatibility = JavaVersion.VERSION_1_8
   sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
+tasks.named("compileTestJava").configure {
+  targetCompatibility = buildParams.getMinimumRuntimeVersion()
+  sourceCompatibility = buildParams.getMinimumRuntimeVersion()
+}
+
+tasks.named("test").configure {
+  // reset the unit test classpath as using the shadow jar won't work due to relocated packages
+  classpath = sourceSets.test.runtimeClasspath
+}
 
 tasks.named("shadowJar").configure {
   relocate 'com.fasterxml', 'shadow.fasterxml'
@@ -34,7 +43,3 @@ tasks.named("shadowJar").configure {
   }
 }
 
-tasks.named("test").configure {
-  // reset the unit test classpath as using the shadow jar won't work due to relocated packages
-  classpath = sourceSets.test.runtimeClasspath
-}

--- a/x-pack/plugin/sql/sql-client/build.gradle
+++ b/x-pack/plugin/sql/sql-client/build.gradle
@@ -12,9 +12,14 @@ dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
 }
 
-tasks.named("compileJava").configure {
+java {
   targetCompatibility = JavaVersion.VERSION_1_8
   sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.named("compileTestJava").configure {
+  targetCompatibility = buildParams.getMinimumRuntimeVersion()
+  sourceCompatibility = buildParams.getMinimumRuntimeVersion()
 }
 
 tasks.named('forbiddenApisMain').configure {

--- a/x-pack/plugin/sql/sql-proto/build.gradle
+++ b/x-pack/plugin/sql/sql-proto/build.gradle
@@ -16,9 +16,14 @@ dependencies {
   }
 }
 
-tasks.named("compileJava").configure {
+java {
   targetCompatibility = JavaVersion.VERSION_1_8
   sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.named("compileTestJava").configure {
+  targetCompatibility = buildParams.getMinimumRuntimeVersion()
+  sourceCompatibility = buildParams.getMinimumRuntimeVersion()
 }
 
 tasks.named('forbiddenApisMain').configure {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Build] Fix the manifest target and source information for jdbc projects (#121888)](https://github.com/elastic/elasticsearch/pull/121888)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)