### PR TITLE
[8.18] Fixing minimum data stream lifecycle version In DataStreamsUpgradeIT (#122207)

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -256,7 +256,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     private void createAndRolloverDataStream(String dataStreamName, int numRollovers) throws IOException {
-        boolean useIlm = minimumTransportVersion().before(TransportVersions.V_8_9_X) || randomBoolean();
+        boolean useIlm = minimumTransportVersion().before(TransportVersions.V_8_11_X) || randomBoolean();
         if (useIlm) {
             createIlmPolicy();
         }


### PR DESCRIPTION
DataStreamsUpgradeIT was incorrectly using 8.9 as the minimum version where it could create a data stream lifecycle. That is the version where data stream lifecycles were introduced, but they were behind a feature flag until 8.11.0. This fixes that.
Closes #122033