### PR TITLE
[9.0] Remove call to super.cleanupCluster in cleanup methods which does not override parent method (#122209)

### DIFF
--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
@@ -24,8 +24,6 @@ import org.elasticsearch.action.admin.indices.template.put.TransportPutComposabl
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.ingest.DeletePipelineRequest;
-import org.elasticsearch.action.ingest.DeletePipelineTransportAction;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.action.ingest.PutPipelineTransportAction;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -70,18 +68,8 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     @After
-    private void cleanupCluster() throws Exception {
-        safeGet(
-            clusterAdmin().execute(
-                DeletePipelineTransportAction.TYPE,
-                new DeletePipelineRequest(
-                    TEST_REQUEST_TIMEOUT,
-                    TEST_REQUEST_TIMEOUT,
-                    MigrateTemplateRegistry.REINDEX_DATA_STREAM_PIPELINE_NAME
-                )
-            )
-        );
-        super.cleanUpCluster();
+    private void cleanup() {
+        deletePipeline(MigrateTemplateRegistry.REINDEX_DATA_STREAM_PIPELINE_NAME);
     }
 
     private static final String MAPPING = """


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Remove call to super.cleanupCluster in cleanup methods which does not override parent method (#122209)](https://github.com/elastic/elasticsearch/pull/122209)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)