### PR TITLE
[9.0] Ensure removal of index blocks does not leave key with null value (#122246)

### DIFF
--- a/docs/changelog/122246.yaml
+++ b/docs/changelog/122246.yaml
@@ -1,0 +1,5 @@
+pr: 122246
+summary: Ensure removal of index blocks does not leave key with null value
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
@@ -32,6 +32,8 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 
 public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
 
@@ -236,9 +238,9 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
         var destSettings = settingsResponse.getIndexToSettings().get(destIndex);
 
         // remove block settings override both source settings and override settings
-        assertNull(destSettings.get(IndexMetadata.SETTING_BLOCKS_WRITE));
-        assertNull(destSettings.get(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE));
-        assertNull(destSettings.get(IndexMetadata.SETTING_BLOCKS_READ));
+        assertThat(destSettings.keySet(), not(hasItem(IndexMetadata.SETTING_BLOCKS_WRITE)));
+        assertThat(destSettings.keySet(), not(hasItem(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE)));
+        assertThat(destSettings.keySet(), not(hasItem(IndexMetadata.SETTING_BLOCKS_READ)));
     }
 
     public void testMappingsOverridden() {

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
@@ -46,13 +46,13 @@ public class CreateIndexFromSourceTransportAction extends HandledTransportAction
     private final ClusterService clusterService;
     private final Client client;
     private final IndexScopedSettings indexScopedSettings;
-    private static final Settings REMOVE_INDEX_BLOCKS_SETTING_OVERRIDE = Settings.builder()
-        .putNull(IndexMetadata.SETTING_READ_ONLY)
-        .putNull(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE)
-        .putNull(IndexMetadata.SETTING_BLOCKS_WRITE)
-        .putNull(IndexMetadata.SETTING_BLOCKS_METADATA)
-        .putNull(IndexMetadata.SETTING_BLOCKS_READ)
-        .build();
+    private static final Set<String> INDEX_BLOCK_SETTINGS = Set.of(
+        IndexMetadata.SETTING_READ_ONLY,
+        IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE,
+        IndexMetadata.SETTING_BLOCKS_WRITE,
+        IndexMetadata.SETTING_BLOCKS_METADATA,
+        IndexMetadata.SETTING_BLOCKS_READ
+    );
 
     @Inject
     public CreateIndexFromSourceTransportAction(
@@ -94,7 +94,7 @@ public class CreateIndexFromSourceTransportAction extends HandledTransportAction
             .put(request.settingsOverride());
         if (request.removeIndexBlocks()) {
             // lastly, override with settings to remove index blocks if requested
-            settings.put(REMOVE_INDEX_BLOCKS_SETTING_OVERRIDE);
+            INDEX_BLOCK_SETTINGS.forEach(settings::remove);
         }
 
         Map<String, Object> mergeMappings;


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Ensure removal of index blocks does not leave key with null value (#122246)