### PR TITLE
[8.18] Fix example plugin using config dir (#122212)

### DIFF
--- a/plugins/examples/custom-settings/src/main/java/org/elasticsearch/example/customsettings/ExampleCustomSettingsConfig.java
+++ b/plugins/examples/custom-settings/src/main/java/org/elasticsearch/example/customsettings/ExampleCustomSettingsConfig.java
@@ -70,7 +70,7 @@ public class ExampleCustomSettingsConfig {
 
     public ExampleCustomSettingsConfig(final Environment environment) {
         // Elasticsearch config directory
-        final Path configDir = environment.configFile();
+        final Path configDir = environment.configDir();
 
         // Resolve the plugin's custom settings file
         final Path customSettingsYamlFile = configDir.resolve("custom-settings/custom.yml");


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix example plugin using config dir (#122212)