### PR TITLE
[BUILD] Rework build cache authentication on CI

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -44,6 +44,9 @@ export GRADLE_BUILD_CACHE_USERNAME
 GRADLE_BUILD_CACHE_PASSWORD=$(vault read -field=password secret/ci/elastic-elasticsearch/migrated/gradle-build-cache)
 export GRADLE_BUILD_CACHE_PASSWORD
 
+DEVELOCITY_ACCESS_KEY="gradle-enterprise.elastic.co=$(vault read -field=accesskey secret/ci/elastic-elasticsearch/migrated/gradle-build-cache)"
+export DEVELOCITY_ACCESS_KEY
+
 BUILDKITE_API_TOKEN=$(vault read -field=token secret/ci/elastic-elasticsearch/buildkite-api-token)
 export BUILDKITE_API_TOKEN
 

--- a/.ci/init.gradle
+++ b/.ci/init.gradle
@@ -1,29 +1,24 @@
-gradle.settingsEvaluated { settings ->
-  settings.pluginManager.withPlugin("com.gradle.develocity") {
-    settings.develocity {
-      server = 'https://gradle-enterprise.elastic.co'
-    }
-  }
-}
-
 final String buildCacheUrl = System.getProperty('org.elasticsearch.build.cache.url')
 final boolean buildCachePush = Boolean.valueOf(System.getProperty('org.elasticsearch.build.cache.push', 'false'))
 
-if (buildCacheUrl) {
-  gradle.settingsEvaluated { settings ->
-    settings.buildCache {
-      local {
-        // Disable the local build cache in CI since we use ephemeral workers and it incurs an IO penalty
-        enabled = false
-      }
-      remote(HttpBuildCache) {
-        url = buildCacheUrl
-        push = buildCachePush
-        credentials {
-          username = System.getenv("GRADLE_BUILD_CACHE_USERNAME")
-          password = System.getenv("GRADLE_BUILD_CACHE_PASSWORD")
+gradle.settingsEvaluated { settings ->
+  settings.pluginManager.withPlugin("com.gradle.develocity") {
+    settings.develocity {
+      server = "https://gradle-enterprise.elastic.co"
+    }
+    if (buildCacheUrl) {
+      settings.buildCache {
+        local {
+          // Disable the local build cache in CI since we use ephemeral workers and it incurs an IO penalty
+          enabled = false
+        }
+        remote(settings.develocity.buildCache) {
+          enabled = true
+          push = buildCachePush
         }
       }
     }
   }
 }
+
+

--- a/build-conventions/settings.gradle
+++ b/build-conventions/settings.gradle
@@ -6,6 +6,11 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
+
+plugins {
+  id "com.gradle.develocity" version "3.18.1"
+}
+
 rootProject.name = 'build-conventions'
 
 dependencyResolutionManagement {

--- a/build-tools-internal/settings.gradle
+++ b/build-tools-internal/settings.gradle
@@ -8,6 +8,10 @@ pluginManagement {
     includeBuild "../build-tools"
 }
 
+plugins {
+  id "com.gradle.develocity" version "3.18.1"
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         buildLibs {

--- a/build-tools/settings.gradle
+++ b/build-tools/settings.gradle
@@ -9,7 +9,9 @@
 pluginManagement {
     includeBuild "../build-conventions"
 }
-
+plugins {
+  id "com.gradle.develocity" version "3.18.1"
+}
 include 'reaper'
 
 dependencyResolutionManagement {


### PR DESCRIPTION
This is required to update to newer version of gradle enterprise and the gradle enterprise plugin.