### PR TITLE
Clarify analyze_wildcard param in queries

### DIFF
--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -94,6 +94,9 @@ as the first character of the query string. Defaults to `true`.
 `analyze_wildcard`::
 (Optional, Boolean) If `true`, the query attempts to analyze wildcard terms in
 the query string. Defaults to `false`.
+Note that, in case of  `true`, only queries that end with a `*`
+are fully analyzed. Queries that start with `*` or have it in the middle
+are only <<analysis-normalizers,normalized>>.
 
 `analyzer`::
 (Optional, string) <<analysis,Analyzer>> used to convert text in the

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -78,6 +78,9 @@ AND of AND Hungary`.
 `analyze_wildcard`::
 (Optional, Boolean) If `true`, the query attempts to analyze wildcard terms in
 the query string. Defaults to `false`.
+Note that, in case of  `true`, only queries that end with a `*`
+are fully analyzed. Queries that start with `*` or have it in the middle
+are only <<analysis-normalizers,normalized>>.
 
 `analyzer`::
 (Optional, string) <<analysis,Analyzer>> used to convert text in the


### PR DESCRIPTION
Clarify that analyze_wildcard param in query_string and simple_query_string queries 
behaves differently depending where "*" is.

Closes #121281