### PR TITLE
[9.0] [ML] Fix serialising the Inference API update request (#122278)

### DIFF
--- a/docs/changelog/122278.yaml
+++ b/docs/changelog/122278.yaml
@@ -1,0 +1,5 @@
+pr: 122278
+summary: Fix serialising the inference update request
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/UpdateInferenceModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/UpdateInferenceModelAction.java
@@ -70,8 +70,8 @@ public class UpdateInferenceModelAction extends ActionType<UpdateInferenceModelA
         public Request(StreamInput in) throws IOException {
             super(in);
             this.inferenceEntityId = in.readString();
-            this.content = in.readBytesReference();
             this.taskType = TaskType.fromStream(in);
+            this.content = in.readBytesReference();
             this.contentType = in.readEnum(XContentType.class);
         }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/UpdateInferenceModelActionRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/UpdateInferenceModelActionRequestTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.inference.action.UpdateInferenceModelAction;
+import org.elasticsearch.xpack.inference.InferenceNamedWriteablesProvider;
+
+import java.io.IOException;
+
+public class UpdateInferenceModelActionRequestTests extends AbstractWireSerializingTestCase<UpdateInferenceModelAction.Request> {
+
+    @Override
+    protected Writeable.Reader<UpdateInferenceModelAction.Request> instanceReader() {
+        return UpdateInferenceModelAction.Request::new;
+    }
+
+    @Override
+    protected UpdateInferenceModelAction.Request createTestInstance() {
+        return new UpdateInferenceModelAction.Request(
+            randomAlphaOfLength(5),
+            randomBytesReference(50),
+            randomFrom(XContentType.values()),
+            randomFrom(TaskType.values()),
+            randomTimeValue()
+        );
+    }
+
+    @Override
+    protected UpdateInferenceModelAction.Request mutateInstance(UpdateInferenceModelAction.Request instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(InferenceNamedWriteablesProvider.getNamedWriteables());
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/UpdateInferenceModelActionResponseTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/UpdateInferenceModelActionResponseTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.inference.action.UpdateInferenceModelAction;
+import org.elasticsearch.xpack.inference.InferenceNamedWriteablesProvider;
+import org.elasticsearch.xpack.inference.ModelConfigurationsTests;
+
+import java.io.IOException;
+
+public class UpdateInferenceModelActionResponseTests extends AbstractWireSerializingTestCase<UpdateInferenceModelAction.Response> {
+    @Override
+    protected Writeable.Reader<UpdateInferenceModelAction.Response> instanceReader() {
+        return UpdateInferenceModelAction.Response::new;
+    }
+
+    @Override
+    protected UpdateInferenceModelAction.Response createTestInstance() {
+        return new UpdateInferenceModelAction.Response(ModelConfigurationsTests.createRandomInstance());
+    }
+
+    @Override
+    protected UpdateInferenceModelAction.Response mutateInstance(UpdateInferenceModelAction.Response instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(InferenceNamedWriteablesProvider.getNamedWriteables());
+    }
+}


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [ML] Fix serialising the Inference API update request (#122278)