### PR TITLE
[9.0] If reindex data streams fails on one index, try the next (#122294)

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
@@ -226,6 +226,7 @@ public class ReindexDataStreamPersistentTaskExecutor extends PersistentTasksExec
             }, e -> {
                 reindexDataStreamTask.reindexFailed(index.getName(), e);
                 listener.onResponse(null);
+                maybeProcessNextIndex(indicesRemaining, reindexDataStreamTask, sourceDataStream, listener, parentTaskId);
             }));
     }
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - If reindex data streams fails on one index, try the next (#122294)