### PR TITLE
[8.18] If reindex data streams fails on one index, try the next (#122294)

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
@@ -225,6 +225,7 @@ public class ReindexDataStreamPersistentTaskExecutor extends PersistentTasksExec
             }, e -> {
                 reindexDataStreamTask.reindexFailed(index.getName(), e);
                 listener.onResponse(null);
+                maybeProcessNextIndex(indicesRemaining, reindexDataStreamTask, sourceDataStream, listener, parentTaskId);
             }));
     }
 


### PR DESCRIPTION
Backports the following commits to 8.18:
 - If reindex data streams fails on one index, try the next (#122294)