### PR TITLE
Unmute ingest YAML tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -199,12 +199,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search/380_sort_segments_on_timestamp/Test that index segments are NOT sorted on timestamp field when @timestamp field is dynamically added}
   issue: https://github.com/elastic/elasticsearch/issues/116221
-- class: org.elasticsearch.ingest.common.IngestCommonClientYamlTestSuiteIT
-  method: test {yaml=ingest/310_reroute_processor/Test remove then add reroute processor with and without lazy rollover}
-  issue: https://github.com/elastic/elasticsearch/issues/116158
-- class: org.elasticsearch.ingest.common.IngestCommonClientYamlTestSuiteIT
-  method: test {yaml=ingest/310_reroute_processor/Test data stream with lazy rollover obtains pipeline from template}
-  issue: https://github.com/elastic/elasticsearch/issues/116157
 - class: org.elasticsearch.ingest.geoip.EnterpriseGeoIpDownloaderIT
   method: testEnterpriseDownloaderTask
   issue: https://github.com/elastic/elasticsearch/issues/115163


### PR DESCRIPTION
These tests were already fixed by #116200. The failing builds that the bot linked when it muted the test all didn't contain the fixing commit of that PR -- so it was just unfortunate timing.

Closes #116157
Closes #116158