### PR TITLE
[ML] Unmute inference service upgrade tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -566,10 +566,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/121483
 - class: org.elasticsearch.xpack.application.FullClusterRestartIT
   issue: https://github.com/elastic/elasticsearch/issues/121935
-- class: org.elasticsearch.xpack.inference.qa.mixed.CohereServiceMixedIT
-  issue: https://github.com/elastic/elasticsearch/issues/122110
-- class: org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT
-  issue: https://github.com/elastic/elasticsearch/issues/122111
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncEnrichStopIT
   method: testEnrichAfterStop
   issue: https://github.com/elastic/elasticsearch/issues/121994


### PR DESCRIPTION
The logs don't show any errors the problem appears to be a transient error forming a cluster. Unmuting to see if the tests fail again

Closes #122110
Closes #122111
