### PR TITLE
System Index Migration Failure Results in a Non-Recoverable State

### DIFF
--- a/docs/changelog/122326.yaml
+++ b/docs/changelog/122326.yaml
@@ -1,0 +1,5 @@
+pr: 122326
+summary: System Index Migration Failure Results in a Non-Recoverable State
+area: Infra/Core
+type: bug
+issues: []

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -277,7 +277,6 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         });
     }
 
-    @AwaitsFix(bugUrl = "ES-10666") // This test uncovered an existing issue
     public void testIndexBlockIsRemovedWhenAliasRequestFails() throws Exception {
         createSystemIndexForDescriptor(INTERNAL_UNMANAGED);
         ensureGreen();

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -635,7 +635,6 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
         String indexName = Optional.ofNullable(migrationInfo).map(SystemIndexMigrationInfo::getCurrentIndexName).orElse("<unknown index>");
 
         MigrationResultsUpdateTask.upsert(
-            // this is for the Custom Metadata, not the Persistent Task
             featureName,
             SingleFeatureMigrationResult.failure(indexName, e),
             ActionListener.wrap(state -> super.markAsFailed(e), exception -> super.markAsFailed(e))

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -468,19 +468,6 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
         }
     }
 
-    // ActionListener<BulkByScrollResponse> innerListener = ActionListener.wrap(listener::accept, this::markAsFailed);
-    private <T> void retryAfterFailureHandler(
-        ActionListener<T> listener,
-        Consumer<ActionListener<T>> retryableAction,
-        Consumer<Exception> failureHandler
-    ) {
-        retryableAction.accept(ActionListener.wrap(listener::onResponse, e -> {
-            logger.error("error occurred while executing retryable action", e);
-            failureHandler.accept(e);
-            listener.onFailure(e);
-        }));
-    }
-
     private void createIndex(SystemIndexMigrationInfo migrationInfo, ActionListener<ShardsAcknowledgedResponse> listener) {
         logger.info("creating new system index [{}] from feature [{}]", migrationInfo.getNextIndexName(), migrationInfo.getFeatureName());
 

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -513,6 +513,8 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
             if (ackedResponse.isAcknowledged()) {
                 logger.info("successfully removed index [{}]", newIndexName);
                 listener.onResponse(ackedResponse);
+            } else {
+                listener.onFailure(new ElasticsearchException("Failed to acknowledge index deletion for [" + newIndexName + "]"));
             }
         }, listener::onFailure));
     }

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -501,13 +501,12 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
             logger.warn("createIndex failed, retrying after removing index [{}] from previous attempt", migrationInfo.getNextIndexName());
             deleteIndex(migrationInfo, ActionListener.wrap(cleanupResponse -> createIndex(migrationInfo, l.delegateResponse((l3, e3) -> {
                 logger.error(
-                    "createIndex failed after retrying, aborting; index [{}] will be left in an inconsistent state",
-                    migrationInfo.getNextIndexName(),
+                    "createIndex failed after retrying, aborting system index migration. index: " + migrationInfo.getNextIndexName(),
                     e3
                 );
                 l.onFailure(e3);
             })), e2 -> {
-                logger.error("deleteIndex failed after retrying, aborting", e2);
+                logger.error("deleteIndex failed, aborting system index migration. index: " + migrationInfo.getNextIndexName(), e2);
                 l.onFailure(e2);
             }));
         }));


### PR DESCRIPTION
Jira: ES-10666

In https://github.com/elastic/elasticsearch/pull/120566 I wrote a test that uncovered a pre-existing issue whereby the system indices could end up in a non-recoverable state if the migration failed.

Specifically, broken system indices from the previous migration attempts will not be cleaned-up (although there is code to do so) because persistent task state is missing on the subsequent runs.  When the system index migration logic tries to make a new index, and an existing broken new index already exists, an exception will occur.  This appears to be caused by the task state not being persisted correctly during the original failure. 

This PR changes the code to no-longer rely on the persistent task state for the cleanup logic of exisiting indices.