### PR TITLE
Test-fix testAcceptsMismatchedServerlessBuildHash #121869

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -83,7 +83,7 @@ public class TransportService extends AbstractLifecycleComponent
     /**
      * A feature flag enabling transport upgrades for serverless.
      */
-    private static final String SERVERLESS_TRANSPORT_SYSTEM_PROPERTY = "es.serverless_transport";
+    static final String SERVERLESS_TRANSPORT_SYSTEM_PROPERTY = "es.serverless_transport";
     private static final boolean SERVERLESS_TRANSPORT_FEATURE_FLAG = Booleans.parseBoolean(
         System.getProperty(SERVERLESS_TRANSPORT_SYSTEM_PROPERTY),
         false

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -377,7 +377,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
     public void testAcceptsMismatchedServerlessBuildHash() {
         assumeTrue("Current build needs to be a snapshot", Build.current().isSnapshot());
         assumeTrue("Security manager needs to be disabled", System.getSecurityManager() == null);
-        System.setProperty("es.serverless", Boolean.TRUE.toString());   // security manager blocks this
+        System.setProperty(TransportService.SERVERLESS_TRANSPORT_SYSTEM_PROPERTY, Boolean.TRUE.toString());   // security manager blocks this
         try {
             final DisruptingTransportInterceptor transportInterceptorA = new DisruptingTransportInterceptor();
             final DisruptingTransportInterceptor transportInterceptorB = new DisruptingTransportInterceptor();
@@ -404,7 +404,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             AbstractSimpleTransportTestCase.connectToNode(transportServiceA, transportServiceB.getLocalNode(), TestProfiles.LIGHT_PROFILE);
             assertTrue(transportServiceA.nodeConnected(transportServiceB.getLocalNode()));
         } finally {
-            System.clearProperty("es.serverless");
+            System.clearProperty(TransportService.SERVERLESS_TRANSPORT_SYSTEM_PROPERTY);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -377,7 +377,8 @@ public class TransportServiceHandshakeTests extends ESTestCase {
     public void testAcceptsMismatchedServerlessBuildHash() {
         assumeTrue("Current build needs to be a snapshot", Build.current().isSnapshot());
         assumeTrue("Security manager needs to be disabled", System.getSecurityManager() == null);
-        System.setProperty(TransportService.SERVERLESS_TRANSPORT_SYSTEM_PROPERTY, Boolean.TRUE.toString());   // security manager blocks this
+        System.setProperty(TransportService.SERVERLESS_TRANSPORT_SYSTEM_PROPERTY, Boolean.TRUE.toString());   // security manager blocks
+                                                                                                              // this
         try {
             final DisruptingTransportInterceptor transportInterceptorA = new DisruptingTransportInterceptor();
             final DisruptingTransportInterceptor transportInterceptorB = new DisruptingTransportInterceptor();


### PR DESCRIPTION
Fixes #121869

`testAcceptsMismatchedServerlessBuildHash` uses wrong system property name `"es.serverless"` but should be `"es.serverless_transport"`.