### PR TITLE
Make persistent task name and ID available in update source

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/persistent/PersistentTaskCreationFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/persistent/PersistentTaskCreationFailureIT.java
@@ -77,7 +77,9 @@ public class PersistentTaskCreationFailureIT extends ESIntegTestCase {
                                 .pendingTasks()
                                 .stream()
                                 .filter(
-                                    pendingClusterTask -> pendingClusterTask.getSource().string().equals("finish persistent task (failed)")
+                                    pendingClusterTask -> pendingClusterTask.getSource()
+                                        .string()
+                                        .matches("finish persistent task \\[.*] \\(failed\\)")
                                 )
                                 .count();
                             assertThat(completePersistentTaskPendingTasksCount, lessThanOrEqualTo(1L));

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
@@ -113,7 +113,7 @@ public final class PersistentTasksClusterService implements ClusterStateListener
         Params taskParams,
         ActionListener<PersistentTask<?>> listener
     ) {
-        submitUnbatchedTask("create persistent task", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("create persistent task [name=" + taskName + ", id=" + taskId + "]", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 PersistentTasksCustomMetadata.Builder builder = builder(currentState);
@@ -166,9 +166,9 @@ public final class PersistentTasksClusterService implements ClusterStateListener
         final String source;
         if (failure != null) {
             logger.warn("persistent task " + id + " failed", failure);
-            source = "finish persistent task (failed)";
+            source = "finish persistent task [id=" + id + "] (failed)";
         } else {
-            source = "finish persistent task (success)";
+            source = "finish persistent task [id=" + id + "] (success)";
         }
         submitUnbatchedTask(source, new ClusterStateUpdateTask() {
             @Override
@@ -212,7 +212,7 @@ public final class PersistentTasksClusterService implements ClusterStateListener
      * @param listener the listener that will be called when task is removed
      */
     public void removePersistentTask(String id, ActionListener<PersistentTask<?>> listener) {
-        submitUnbatchedTask("remove persistent task", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("remove persistent task [id=" + id + "]", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 PersistentTasksCustomMetadata.Builder tasksInProgress = builder(currentState);
@@ -250,7 +250,7 @@ public final class PersistentTasksClusterService implements ClusterStateListener
         final PersistentTaskState taskState,
         final ActionListener<PersistentTask<?>> listener
     ) {
-        submitUnbatchedTask("update task state [" + taskId + "]", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("update task state [id=" + taskId + "]", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 PersistentTasksCustomMetadata.Builder tasksInProgress = builder(currentState);
@@ -295,7 +295,7 @@ public final class PersistentTasksClusterService implements ClusterStateListener
         final String reason,
         final ActionListener<PersistentTask<?>> listener
     ) {
-        submitUnbatchedTask("unassign persistent task from any node", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("unassign persistent task [id=" + taskId + "] from any node", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
                 PersistentTasksCustomMetadata.Builder tasksInProgress = builder(currentState);

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
@@ -113,7 +113,7 @@ public final class PersistentTasksClusterService implements ClusterStateListener
         Params taskParams,
         ActionListener<PersistentTask<?>> listener
     ) {
-        submitUnbatchedTask("create persistent task [name=" + taskName + ", id=" + taskId + "]", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("create persistent task " + taskName + " [" + taskId + "]", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 PersistentTasksCustomMetadata.Builder builder = builder(currentState);
@@ -166,9 +166,9 @@ public final class PersistentTasksClusterService implements ClusterStateListener
         final String source;
         if (failure != null) {
             logger.warn("persistent task " + id + " failed", failure);
-            source = "finish persistent task [id=" + id + "] (failed)";
+            source = "finish persistent task [" + id + "] (failed)";
         } else {
-            source = "finish persistent task [id=" + id + "] (success)";
+            source = "finish persistent task [" + id + "] (success)";
         }
         submitUnbatchedTask(source, new ClusterStateUpdateTask() {
             @Override
@@ -212,7 +212,7 @@ public final class PersistentTasksClusterService implements ClusterStateListener
      * @param listener the listener that will be called when task is removed
      */
     public void removePersistentTask(String id, ActionListener<PersistentTask<?>> listener) {
-        submitUnbatchedTask("remove persistent task [id=" + id + "]", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("remove persistent task [" + id + "]", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 PersistentTasksCustomMetadata.Builder tasksInProgress = builder(currentState);
@@ -250,7 +250,7 @@ public final class PersistentTasksClusterService implements ClusterStateListener
         final PersistentTaskState taskState,
         final ActionListener<PersistentTask<?>> listener
     ) {
-        submitUnbatchedTask("update task state [id=" + taskId + "]", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("update task state [" + taskId + "]", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 PersistentTasksCustomMetadata.Builder tasksInProgress = builder(currentState);
@@ -295,7 +295,7 @@ public final class PersistentTasksClusterService implements ClusterStateListener
         final String reason,
         final ActionListener<PersistentTask<?>> listener
     ) {
-        submitUnbatchedTask("unassign persistent task [id=" + taskId + "] from any node", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("unassign persistent task [" + taskId + "] from any node", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
                 PersistentTasksCustomMetadata.Builder tasksInProgress = builder(currentState);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportSetTransformUpgradeModeActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportSetTransformUpgradeModeActionTests.java
@@ -38,6 +38,7 @@ import static org.elasticsearch.xpack.core.action.AbstractTransportSetUpgradeMod
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -176,7 +177,7 @@ public class TransportSetTransformUpgradeModeActionTests extends ESTestCase {
 
         upgradeModeSuccessfullyChanged(stateWithTransformTask(), assertNoFailureListener(r -> {
             assertThat(r, is(AcknowledgedResponse.TRUE));
-            verify(clusterService).submitUnbatchedStateUpdateTask(eq("unassign persistent task from any node"), any());
+            verify(clusterService).submitUnbatchedStateUpdateTask(matches("unassign persistent task \\[.*\\] from any node"), any());
         }));
     }
 


### PR DESCRIPTION
Add the task name and ID (when possible) as part of the source string for updating cluster state. This helps better identifying the source of a task. The updatePersistentTaskState method already does it. This PR ensures it is the case in other places.

