### PR TITLE
Log hot threads after cluster cleanup timeout

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1014,14 +1014,21 @@ public abstract class ESRestTestCase extends ESTestCase {
 
     private void waitForClusterUpdates() throws Exception {
         logger.info("Waiting for all cluster updates up to this moment to be processed");
+
         try {
             assertOK(adminClient().performRequest(new Request("GET", "_cluster/health?wait_for_events=languid")));
         } catch (ResponseException e) {
             if (e.getResponse().getStatusLine().getStatusCode() == HttpStatus.SC_REQUEST_TIMEOUT) {
+                StringBuilder logMessage = new StringBuilder("Timed out waiting for cluster updates to be processed.");
                 final var pendingTasks = getPendingClusterStateTasks();
                 if (pendingTasks != null) {
-                    logger.error("Timed out waiting for cluster updates to be processed, {}", pendingTasks);
+                    logMessage.append('\n').append(pendingTasks);
                 }
+                final var hotThreads = getHotThreads();
+                if (hotThreads != null) {
+                    logMessage.append("\nHot threads: ").append(hotThreads);
+                }
+                logger.error(logMessage.toString());
             }
             throw e;
         }
@@ -1031,8 +1038,8 @@ public abstract class ESRestTestCase extends ESTestCase {
         try {
             Response response = adminClient().performRequest(new Request("GET", "/_cluster/pending_tasks"));
             List<?> tasks = (List<?>) entityAsMap(response).get("tasks");
-            if (false == tasks.isEmpty()) {
-                StringBuilder message = new StringBuilder("there are still running tasks:");
+            if (tasks.isEmpty() == false) {
+                StringBuilder message = new StringBuilder("There are still running tasks:");
                 for (Object task : tasks) {
                     message.append('\n').append(task.toString());
                 }
@@ -1040,6 +1047,16 @@ public abstract class ESRestTestCase extends ESTestCase {
             }
         } catch (IOException e) {
             fail(e, "Failed to retrieve pending tasks in the cluster during cleanup");
+        }
+        return null;
+    }
+
+    private static String getHotThreads() {
+        try {
+            Response response = adminClient().performRequest(new Request("GET", "/_nodes/hot_threads"));
+            return EntityUtils.toString(response.getEntity());
+        } catch (IOException e) {
+            fail(e, "Failed to retrieve hot threads in the cluster during cleanup");
         }
         return null;
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1051,12 +1051,14 @@ public abstract class ESRestTestCase extends ESTestCase {
         return null;
     }
 
-    private static String getHotThreads() {
+    private String getHotThreads() {
         try {
-            Response response = adminClient().performRequest(new Request("GET", "/_nodes/hot_threads"));
+            Response response = adminClient().performRequest(
+                new Request("GET", "/_nodes/hot_threads?ignore_idle_threads=false&threads=9999")
+            );
             return EntityUtils.toString(response.getEntity());
         } catch (IOException e) {
-            fail(e, "Failed to retrieve hot threads in the cluster during cleanup");
+            logger.error("Failed to retrieve hot threads in the cluster during cleanup", e);
         }
         return null;
     }


### PR DESCRIPTION
In addition to logging the pending cluster tasks after the cluster health request times out during cluster cleanup in REST tests, we should log the hot threads to help identify any issues that could cause tasks to get stuck.

Follow-up of #119186

Relates #111632
Relates #111431
Relates #111662