### PR TITLE
[9.0] Remove index setting when override value is null (#122267)

### DIFF
--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceActionIT.java
@@ -208,7 +208,7 @@ public class CreateIndexFromSourceActionIT extends ESIntegTestCase {
         assertTrue(destSettings.getAsBoolean(IndexMetadata.SETTING_BLOCKS_READ, false));
 
         // override null removed
-        assertNull(destSettings.get(IndexMetadata.SETTING_BLOCKS_WRITE));
+        assertThat(destSettings.keySet(), not(hasItem(IndexMetadata.SETTING_BLOCKS_WRITE)));
     }
 
     public void testRemoveIndexBlocksByDefault() throws Exception {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Remove index setting when override value is null (#122267)](https://github.com/elastic/elasticsearch/pull/122267)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)