### PR TITLE
[8.x] Simplify comparators in InternalOrder (#122330)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -190,33 +191,22 @@ public abstract class InternalOrder extends BucketOrder {
 
         @Override
         public <T extends Bucket> Comparator<BucketAndOrd<T>> partiallyBuiltBucketComparator(Aggregator aggregator) {
-            List<Comparator<BucketAndOrd<T>>> comparators = new ArrayList<>(orderElements.size());
-            for (BucketOrder order : orderElements) {
-                comparators.add(order.partiallyBuiltBucketComparator(aggregator));
+            Iterator<BucketOrder> iterator = orderElements.iterator();
+            Comparator<BucketAndOrd<T>> comparator = iterator.next().partiallyBuiltBucketComparator(aggregator);
+            while (iterator.hasNext()) {
+                comparator = comparator.thenComparing(iterator.next().partiallyBuiltBucketComparator(aggregator));
             }
-            return (lhs, rhs) -> {
-                for (Comparator<BucketAndOrd<T>> c : comparators) {
-                    int result = c.compare(lhs, rhs);
-                    if (result != 0) {
-                        return result;
-                    }
-                }
-                return 0;
-            };
+            return comparator;
         }
 
         @Override
         public Comparator<Bucket> comparator() {
-            List<Comparator<Bucket>> comparators = orderElements.stream().map(BucketOrder::comparator).toList();
-            return (lhs, rhs) -> {
-                for (Comparator<Bucket> c : comparators) {
-                    int result = c.compare(lhs, rhs);
-                    if (result != 0) {
-                        return result;
-                    }
-                }
-                return 0;
-            };
+            Iterator<BucketOrder> iterator = orderElements.iterator();
+            Comparator<Bucket> comparator = iterator.next().comparator();
+            while (iterator.hasNext()) {
+                comparator = comparator.thenComparing(iterator.next().comparator());
+            }
+            return comparator;
         }
 
         @Override
@@ -224,18 +214,12 @@ public abstract class InternalOrder extends BucketOrder {
             BiFunction<List<B>, AggregationReduceContext, B> reduce,
             AggregationReduceContext reduceContext
         ) {
-            List<Comparator<DelayedBucket<B>>> comparators = orderElements.stream()
-                .map(b -> b.delayedBucketComparator(reduce, reduceContext))
-                .toList();
-            return (lhs, rhs) -> {
-                for (Comparator<DelayedBucket<B>> c : comparators) {
-                    int result = c.compare(lhs, rhs);
-                    if (result != 0) {
-                        return result;
-                    }
-                }
-                return 0;
-            };
+            Iterator<BucketOrder> iterator = orderElements.iterator();
+            Comparator<DelayedBucket<B>> comparator = iterator.next().delayedBucketComparator(reduce, reduceContext);
+            while (iterator.hasNext()) {
+                comparator = comparator.thenComparing(iterator.next().delayedBucketComparator(reduce, reduceContext));
+            }
+            return comparator;
         }
 
         @Override
@@ -287,12 +271,13 @@ public abstract class InternalOrder extends BucketOrder {
             return comparator;
         }
 
+        @SuppressWarnings({ "rawtypes", "unchecked" })
         @Override
         <B extends InternalMultiBucketAggregation.InternalBucket> Comparator<DelayedBucket<B>> delayedBucketComparator(
             BiFunction<List<B>, AggregationReduceContext, B> reduce,
             AggregationReduceContext reduceContext
         ) {
-            return delayedBucketCompator::compare;
+            return (Comparator) delayedBucketCompator;
         }
 
         @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Simplify comparators in InternalOrder (#122330)