### PR TITLE
[9.0] backport various aggs code gen improvements

### DIFF
--- a/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Aggregator.java
+++ b/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Aggregator.java
@@ -37,11 +37,6 @@ import java.lang.annotation.Target;
  *     are ever collected.
  * </p>
  * <p>
- *     The generation code will also look for a method called {@code combineValueCount}
- *     which is called once per received block with a count of values. NOTE: We may
- *     not need this after we convert AVG into a composite operation.
- * </p>
- * <p>
  *     The generation code also looks for the optional methods {@code combineIntermediate}
  *     and {@code evaluateFinal} which are used to combine intermediate states and
  *     produce the final output. If the first is missing then the generated code will

--- a/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Aggregator.java
+++ b/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Aggregator.java
@@ -58,4 +58,8 @@ public @interface Aggregator {
      */
     Class<? extends Exception>[] warnExceptions() default {};
 
+    /**
+     * If {@code true} then the @timestamp LongVector will be appended to the input blocks of the aggregation function.
+     */
+    boolean includeTimestamps() default false;
 }

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
@@ -95,8 +95,7 @@ public class AggregatorImplementer {
 
         this.init = requireStaticMethod(
             declarationType,
-            // This should be more restrictive and require org.elasticsearch.compute.aggregation.AggregatorState
-            requirePrimitiveOrImplements(elements, Types.RELEASABLE),
+            requirePrimitiveOrImplements(elements, Types.AGGREGATOR_STATE),
             requireName("init", "initSingle"),
             requireAnyArgs("<arbitrary init arguments>")
         );

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
@@ -17,6 +17,7 @@ import com.squareup.javapoet.TypeSpec;
 
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.gen.Methods.TypeMatcher;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,8 +34,14 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 
 import static java.util.stream.Collectors.joining;
-import static org.elasticsearch.compute.gen.Methods.findMethod;
-import static org.elasticsearch.compute.gen.Methods.findRequiredMethod;
+import static org.elasticsearch.compute.gen.Methods.requireAnyArgs;
+import static org.elasticsearch.compute.gen.Methods.requireAnyType;
+import static org.elasticsearch.compute.gen.Methods.requireArgs;
+import static org.elasticsearch.compute.gen.Methods.requireName;
+import static org.elasticsearch.compute.gen.Methods.requirePrimitiveOrImplements;
+import static org.elasticsearch.compute.gen.Methods.requireStaticMethod;
+import static org.elasticsearch.compute.gen.Methods.requireType;
+import static org.elasticsearch.compute.gen.Methods.requireVoidType;
 import static org.elasticsearch.compute.gen.Methods.vectorAccessorName;
 import static org.elasticsearch.compute.gen.Types.AGGREGATOR_FUNCTION;
 import static org.elasticsearch.compute.gen.Types.BIG_ARRAYS;
@@ -66,8 +73,6 @@ public class AggregatorImplementer {
     private final List<TypeMirror> warnExceptions;
     private final ExecutableElement init;
     private final ExecutableElement combine;
-    private final ExecutableElement combineIntermediate;
-    private final ExecutableElement evaluateFinal;
     private final ClassName implementation;
     private final List<IntermediateStateDesc> intermediateState;
     private final List<Parameter> createParameters;
@@ -84,21 +89,24 @@ public class AggregatorImplementer {
         this.declarationType = declarationType;
         this.warnExceptions = warnExceptions;
 
-        this.init = findRequiredMethod(declarationType, new String[] { "init", "initSingle" }, e -> true);
+        this.init = requireStaticMethod(
+            declarationType,
+            // This should be more restrictive and require org.elasticsearch.compute.aggregation.AggregatorState
+            requirePrimitiveOrImplements(elements, Types.RELEASABLE),
+            requireName("init", "initSingle"),
+            requireAnyArgs("<arbitrary init arguments>")
+        );
         this.aggState = AggregationState.create(elements, init.getReturnType(), warnExceptions.isEmpty() == false, false);
 
-        this.combine = findRequiredMethod(declarationType, new String[] { "combine" }, e -> {
-            if (e.getParameters().size() == 0) {
-                return false;
-            }
-            TypeName firstParamType = TypeName.get(e.getParameters().get(0).asType());
-            return Objects.equals(firstParamType.toString(), aggState.declaredType().toString());
-        });
+        this.combine = requireStaticMethod(
+            declarationType,
+            aggState.declaredType().isPrimitive() ? requireType(aggState.declaredType()) : requireVoidType(),
+            requireName("combine"),
+            requireArgs(requireType(aggState.declaredType()), requireAnyType("<aggregation input column type>"))
+        );
         // TODO support multiple parameters
         this.aggParam = AggregationParameter.create(combine.getParameters().get(1).asType());
 
-        this.combineIntermediate = findMethod(declarationType, "combineIntermediate");
-        this.evaluateFinal = findMethod(declarationType, "evaluateFinal");
         this.createParameters = init.getParameters()
             .stream()
             .map(Parameter::from)
@@ -447,12 +455,7 @@ public class AggregatorImplementer {
             interState.assignToVariable(builder, i);
             builder.addStatement("assert $L.getPositionCount() == 1", interState.name());
         }
-        if (combineIntermediate != null) {
-            if (intermediateState.stream().map(IntermediateStateDesc::elementType).anyMatch(n -> n.equals("BYTES_REF"))) {
-                builder.addStatement("$T scratch = new $T()", BYTES_REF, BYTES_REF);
-            }
-            builder.addStatement("$T.combineIntermediate(state, " + intermediateStateRowAccess() + ")", declarationType);
-        } else if (aggState.declaredType().isPrimitive()) {
+        if (aggState.declaredType().isPrimitive()) {
             if (warnExceptions.isEmpty()) {
                 assert intermediateState.size() == 2;
                 assert intermediateState.get(1).name().equals("seen");
@@ -485,7 +488,21 @@ public class AggregatorImplementer {
             });
             builder.endControlFlow();
         } else {
-            throw new IllegalArgumentException("Don't know how to combine intermediate input. Define combineIntermediate");
+            requireStaticMethod(
+                declarationType,
+                requireVoidType(),
+                requireName("combineIntermediate"),
+                requireArgs(
+                    Stream.concat(
+                        Stream.of(aggState.declaredType()), // aggState
+                        intermediateState.stream().map(IntermediateStateDesc::combineArgType) // intermediate state
+                    ).map(Methods::requireType).toArray(TypeMatcher[]::new)
+                )
+            );
+            if (intermediateState.stream().map(IntermediateStateDesc::elementType).anyMatch(n -> n.equals("BYTES_REF"))) {
+                builder.addStatement("$T scratch = new $T()", BYTES_REF, BYTES_REF);
+            }
+            builder.addStatement("$T.combineIntermediate(state, " + intermediateStateRowAccess() + ")", declarationType);
         }
         return builder.build();
     }
@@ -524,7 +541,7 @@ public class AggregatorImplementer {
             builder.addStatement("return");
             builder.endControlFlow();
         }
-        if (evaluateFinal == null) {
+        if (aggState.declaredType().isPrimitive()) {
             builder.addStatement(switch (aggState.declaredType().toString()) {
                 case "boolean" -> "blocks[offset] = driverContext.blockFactory().newConstantBooleanBlockWith(state.booleanValue(), 1)";
                 case "int" -> "blocks[offset] = driverContext.blockFactory().newConstantIntBlockWith(state.intValue(), 1)";
@@ -534,6 +551,12 @@ public class AggregatorImplementer {
                 default -> throw new IllegalArgumentException("Unexpected primitive type: [" + aggState.declaredType() + "]");
             });
         } else {
+            requireStaticMethod(
+                declarationType,
+                requireType(BLOCK),
+                requireName("evaluateFinal"),
+                requireArgs(requireType(aggState.declaredType()), requireType(DRIVER_CONTEXT))
+            );
             builder.addStatement("blocks[offset] = $T.evaluateFinal(state, driverContext)", declarationType);
         }
         return builder.build();
@@ -592,6 +615,11 @@ public class AggregatorImplementer {
             } else {
                 builder.addStatement("$T $L = (($T) $L).asVector()", vectorType(elementType), name, blockType, name + "Uncast");
             }
+        }
+
+        public TypeName combineArgType() {
+            var type = Types.fromString(elementType);
+            return block ? blockType(type) : type;
         }
     }
 

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
@@ -78,7 +78,6 @@ public class AggregatorImplementer {
     private final List<TypeMirror> warnExceptions;
     private final ExecutableElement init;
     private final ExecutableElement combine;
-    private final ExecutableElement combineValueCount;
     private final ExecutableElement combineIntermediate;
     private final ExecutableElement evaluateFinal;
     private final ClassName implementation;
@@ -115,7 +114,6 @@ public class AggregatorImplementer {
             TypeName firstParamType = TypeName.get(e.getParameters().get(0).asType());
             return firstParamType.isPrimitive() || firstParamType.toString().equals(stateType.toString());
         });
-        this.combineValueCount = findMethod(declarationType, "combineValueCount");
         this.combineIntermediate = findMethod(declarationType, "combineIntermediate");
         this.evaluateFinal = findMethod(declarationType, "evaluateFinal");
         this.createParameters = init.getParameters()
@@ -415,9 +413,6 @@ public class AggregatorImplementer {
             combineRawInput(builder, "vector");
         }
         builder.endControlFlow();
-        if (combineValueCount != null) {
-            builder.addStatement("$T.combineValueCount(state, vector.getPositionCount())", declarationType);
-        }
         return builder.build();
     }
 
@@ -459,9 +454,6 @@ public class AggregatorImplementer {
             }
         }
         builder.endControlFlow();
-        if (combineValueCount != null) {
-            builder.addStatement("$T.combineValueCount(state, block.getTotalValueCount())", declarationType);
-        }
         return builder.build();
     }
 

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,24 +40,13 @@ import static org.elasticsearch.compute.gen.Types.AGGREGATOR_FUNCTION;
 import static org.elasticsearch.compute.gen.Types.BIG_ARRAYS;
 import static org.elasticsearch.compute.gen.Types.BLOCK;
 import static org.elasticsearch.compute.gen.Types.BLOCK_ARRAY;
-import static org.elasticsearch.compute.gen.Types.BOOLEAN_BLOCK;
 import static org.elasticsearch.compute.gen.Types.BOOLEAN_VECTOR;
 import static org.elasticsearch.compute.gen.Types.BYTES_REF;
-import static org.elasticsearch.compute.gen.Types.BYTES_REF_BLOCK;
-import static org.elasticsearch.compute.gen.Types.BYTES_REF_VECTOR;
-import static org.elasticsearch.compute.gen.Types.DOUBLE_BLOCK;
-import static org.elasticsearch.compute.gen.Types.DOUBLE_VECTOR;
 import static org.elasticsearch.compute.gen.Types.DRIVER_CONTEXT;
 import static org.elasticsearch.compute.gen.Types.ELEMENT_TYPE;
-import static org.elasticsearch.compute.gen.Types.FLOAT_BLOCK;
-import static org.elasticsearch.compute.gen.Types.FLOAT_VECTOR;
 import static org.elasticsearch.compute.gen.Types.INTERMEDIATE_STATE_DESC;
-import static org.elasticsearch.compute.gen.Types.INT_BLOCK;
-import static org.elasticsearch.compute.gen.Types.INT_VECTOR;
 import static org.elasticsearch.compute.gen.Types.LIST_AGG_FUNC_DESC;
 import static org.elasticsearch.compute.gen.Types.LIST_INTEGER;
-import static org.elasticsearch.compute.gen.Types.LONG_BLOCK;
-import static org.elasticsearch.compute.gen.Types.LONG_VECTOR;
 import static org.elasticsearch.compute.gen.Types.PAGE;
 import static org.elasticsearch.compute.gen.Types.WARNINGS;
 import static org.elasticsearch.compute.gen.Types.blockType;
@@ -81,13 +69,11 @@ public class AggregatorImplementer {
     private final ExecutableElement combineIntermediate;
     private final ExecutableElement evaluateFinal;
     private final ClassName implementation;
-    private final TypeName stateType;
-    private final boolean stateTypeHasSeen;
-    private final boolean stateTypeHasFailed;
-    private final boolean valuesIsBytesRef;
-    private final boolean valuesIsArray;
     private final List<IntermediateStateDesc> intermediateState;
     private final List<Parameter> createParameters;
+
+    private final AggregationState aggState;
+    private final AggregationParameter aggParam;
 
     public AggregatorImplementer(
         Elements elements,
@@ -99,21 +85,18 @@ public class AggregatorImplementer {
         this.warnExceptions = warnExceptions;
 
         this.init = findRequiredMethod(declarationType, new String[] { "init", "initSingle" }, e -> true);
-        this.stateType = choseStateType();
-        this.stateTypeHasSeen = elements.getAllMembers(elements.getTypeElement(stateType.toString()))
-            .stream()
-            .anyMatch(e -> e.toString().equals("seen()"));
-        this.stateTypeHasFailed = elements.getAllMembers(elements.getTypeElement(stateType.toString()))
-            .stream()
-            .anyMatch(e -> e.toString().equals("failed()"));
+        this.aggState = AggregationState.create(elements, init.getReturnType(), warnExceptions.isEmpty() == false, false);
 
         this.combine = findRequiredMethod(declarationType, new String[] { "combine" }, e -> {
             if (e.getParameters().size() == 0) {
                 return false;
             }
             TypeName firstParamType = TypeName.get(e.getParameters().get(0).asType());
-            return firstParamType.isPrimitive() || firstParamType.toString().equals(stateType.toString());
+            return Objects.equals(firstParamType.toString(), aggState.declaredType().toString());
         });
+        // TODO support multiple parameters
+        this.aggParam = AggregationParameter.create(combine.getParameters().get(1).asType());
+
         this.combineIntermediate = findMethod(declarationType, "combineIntermediate");
         this.evaluateFinal = findMethod(declarationType, "evaluateFinal");
         this.createParameters = init.getParameters()
@@ -126,8 +109,6 @@ public class AggregatorImplementer {
             elements.getPackageOf(declarationType).toString(),
             (declarationType.getSimpleName() + "AggregatorFunction").replace("AggregatorAggregator", "Aggregator")
         );
-        this.valuesIsBytesRef = BYTES_REF.equals(valueTypeName());
-        this.valuesIsArray = TypeKind.ARRAY.equals(valueTypeKind());
         intermediateState = Arrays.stream(interStateAnno).map(IntermediateStateDesc::newIntermediateStateDesc).toList();
     }
 
@@ -139,68 +120,8 @@ public class AggregatorImplementer {
         return createParameters;
     }
 
-    private TypeName choseStateType() {
-        TypeName initReturn = TypeName.get(init.getReturnType());
-        if (false == initReturn.isPrimitive()) {
-            return initReturn;
-        }
-        String simpleName = firstUpper(initReturn.toString());
-        if (warnExceptions.isEmpty()) {
-            return ClassName.get("org.elasticsearch.compute.aggregation", simpleName + "State");
-        }
-        return ClassName.get("org.elasticsearch.compute.aggregation", simpleName + "FallibleState");
-    }
-
-    static String valueType(ExecutableElement init, ExecutableElement combine) {
-        if (combine != null) {
-            // If there's an explicit combine function it's final parameter is the type of the value.
-            return combine.getParameters().get(combine.getParameters().size() - 1).asType().toString();
-        }
-        String initReturn = init.getReturnType().toString();
-        switch (initReturn) {
-            case "double":
-                return "double";
-            case "float":
-                return "float";
-            case "long":
-                return "long";
-            case "int":
-                return "int";
-            case "boolean":
-                return "boolean";
-            default:
-                throw new IllegalArgumentException("unknown primitive type for " + initReturn);
-        }
-    }
-
-    static ClassName valueBlockType(ExecutableElement init, ExecutableElement combine) {
-        return switch (valueType(init, combine)) {
-            case "boolean" -> BOOLEAN_BLOCK;
-            case "double" -> DOUBLE_BLOCK;
-            case "float" -> FLOAT_BLOCK;
-            case "long" -> LONG_BLOCK;
-            case "int", "int[]" -> INT_BLOCK;
-            case "org.apache.lucene.util.BytesRef" -> BYTES_REF_BLOCK;
-            default -> throw new IllegalArgumentException("unknown block type for " + valueType(init, combine));
-        };
-    }
-
-    static ClassName valueVectorType(ExecutableElement init, ExecutableElement combine) {
-        return switch (valueType(init, combine)) {
-            case "boolean" -> BOOLEAN_VECTOR;
-            case "double" -> DOUBLE_VECTOR;
-            case "float" -> FLOAT_VECTOR;
-            case "long" -> LONG_VECTOR;
-            case "int", "int[]" -> INT_VECTOR;
-            case "org.apache.lucene.util.BytesRef" -> BYTES_REF_VECTOR;
-            default -> throw new IllegalArgumentException("unknown vector type for " + valueType(init, combine));
-        };
-    }
-
-    public static String firstUpper(String s) {
-        String head = s.toString().substring(0, 1).toUpperCase(Locale.ROOT);
-        String tail = s.toString().substring(1);
-        return head + tail;
+    public static String capitalize(String s) {
+        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
     }
 
     public JavaFile sourceFile() {
@@ -230,7 +151,7 @@ public class AggregatorImplementer {
         }
 
         builder.addField(DRIVER_CONTEXT, "driverContext", Modifier.PRIVATE, Modifier.FINAL);
-        builder.addField(stateType, "state", Modifier.PRIVATE, Modifier.FINAL);
+        builder.addField(aggState.type, "state", Modifier.PRIVATE, Modifier.FINAL);
         builder.addField(LIST_INTEGER, "channels", Modifier.PRIVATE, Modifier.FINAL);
 
         for (Parameter p : createParameters) {
@@ -290,10 +211,10 @@ public class AggregatorImplementer {
             .map(p -> TypeName.get(p.asType()).equals(BIG_ARRAYS) ? "driverContext.bigArrays()" : p.getSimpleName().toString())
             .collect(joining(", "));
         CodeBlock.Builder builder = CodeBlock.builder();
-        if (init.getReturnType().toString().equals(stateType.toString())) {
-            builder.add("$T.$L($L)", declarationType, init.getSimpleName(), initParametersCall);
+        if (aggState.declaredType().isPrimitive()) {
+            builder.add("new $T($T.$L($L))", aggState.type(), declarationType, init.getSimpleName(), initParametersCall);
         } else {
-            builder.add("new $T($T.$L($L))", stateType, declarationType, init.getSimpleName(), initParametersCall);
+            builder.add("$T.$L($L)", declarationType, init.getSimpleName(), initParametersCall);
         }
         return builder.build();
     }
@@ -318,7 +239,7 @@ public class AggregatorImplementer {
         }
         builder.addParameter(DRIVER_CONTEXT, "driverContext");
         builder.addParameter(LIST_INTEGER, "channels");
-        builder.addParameter(stateType, "state");
+        builder.addParameter(aggState.type, "state");
 
         if (warnExceptions.isEmpty() == false) {
             builder.addStatement("this.warnings = warnings");
@@ -350,7 +271,7 @@ public class AggregatorImplementer {
     private MethodSpec addRawInput() {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("addRawInput");
         builder.addAnnotation(Override.class).addModifiers(Modifier.PUBLIC).addParameter(PAGE, "page").addParameter(BOOLEAN_VECTOR, "mask");
-        if (stateTypeHasFailed) {
+        if (aggState.hasFailed()) {
             builder.beginControlFlow("if (state.failed())");
             builder.addStatement("return");
             builder.endControlFlow();
@@ -364,8 +285,8 @@ public class AggregatorImplementer {
         builder.beginControlFlow("if (mask.allTrue())");
         {
             builder.addComment("No masking");
-            builder.addStatement("$T block = page.getBlock(channels.get(0))", valueBlockType(init, combine));
-            builder.addStatement("$T vector = block.asVector()", valueVectorType(init, combine));
+            builder.addStatement("$T block = page.getBlock(channels.get(0))", blockType(aggParam.type()));
+            builder.addStatement("$T vector = block.asVector()", vectorType(aggParam.type()));
             builder.beginControlFlow("if (vector != null)");
             builder.addStatement("addRawVector(vector)");
             builder.nextControlFlow("else");
@@ -376,8 +297,8 @@ public class AggregatorImplementer {
         builder.endControlFlow();
 
         builder.addComment("Some positions masked away, others kept");
-        builder.addStatement("$T block = page.getBlock(channels.get(0))", valueBlockType(init, combine));
-        builder.addStatement("$T vector = block.asVector()", valueVectorType(init, combine));
+        builder.addStatement("$T block = page.getBlock(channels.get(0))", blockType(aggParam.type()));
+        builder.addStatement("$T vector = block.asVector()", vectorType(aggParam.type()));
         builder.beginControlFlow("if (vector != null)");
         builder.addStatement("addRawVector(vector, mask)");
         builder.nextControlFlow("else");
@@ -388,19 +309,19 @@ public class AggregatorImplementer {
 
     private MethodSpec addRawVector(boolean masked) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("addRawVector");
-        builder.addModifiers(Modifier.PRIVATE).addParameter(valueVectorType(init, combine), "vector");
+        builder.addModifiers(Modifier.PRIVATE).addParameter(vectorType(aggParam.type()), "vector");
         if (masked) {
             builder.addParameter(BOOLEAN_VECTOR, "mask");
         }
-        if (valuesIsArray) {
+        if (aggParam.isArray()) {
             builder.addComment("This type does not support vectors because all values are multi-valued");
             return builder.build();
         }
 
-        if (stateTypeHasSeen) {
+        if (aggState.hasSeen()) {
             builder.addStatement("state.seen(true)");
         }
-        if (valuesIsBytesRef) {
+        if (aggParam.isBytesRef()) {
             // Add bytes_ref scratch var that will be used for bytes_ref blocks/vectors
             builder.addStatement("$T scratch = new $T()", BYTES_REF, BYTES_REF);
         }
@@ -418,12 +339,12 @@ public class AggregatorImplementer {
 
     private MethodSpec addRawBlock(boolean masked) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("addRawBlock");
-        builder.addModifiers(Modifier.PRIVATE).addParameter(valueBlockType(init, combine), "block");
+        builder.addModifiers(Modifier.PRIVATE).addParameter(blockType(aggParam.type()), "block");
         if (masked) {
             builder.addParameter(BOOLEAN_VECTOR, "mask");
         }
 
-        if (valuesIsBytesRef) {
+        if (aggParam.isBytesRef()) {
             // Add bytes_ref scratch var that will only be used for bytes_ref blocks/vectors
             builder.addStatement("$T scratch = new $T()", BYTES_REF, BYTES_REF);
         }
@@ -435,16 +356,16 @@ public class AggregatorImplementer {
             builder.beginControlFlow("if (block.isNull(p))");
             builder.addStatement("continue");
             builder.endControlFlow();
-            if (stateTypeHasSeen) {
+            if (aggState.hasSeen()) {
                 builder.addStatement("state.seen(true)");
             }
             builder.addStatement("int start = block.getFirstValueIndex(p)");
             builder.addStatement("int end = start + block.getValueCount(p)");
-            if (valuesIsArray) {
-                String arrayType = valueTypeString();
+            if (aggParam.isArray()) {
+                String arrayType = aggParam.type().toString().replace("[]", "");
                 builder.addStatement("$L[] valuesArray = new $L[end - start]", arrayType, arrayType);
                 builder.beginControlFlow("for (int i = start; i < end; i++)");
-                builder.addStatement("valuesArray[i-start] = $L.get$L(i)", "block", firstUpper(arrayType));
+                builder.addStatement("valuesArray[i-start] = $L.get$L(i)", "block", capitalize(arrayType));
                 builder.endControlFlow();
                 combineRawInputForArray(builder, "valuesArray");
             } else {
@@ -460,7 +381,7 @@ public class AggregatorImplementer {
     private void combineRawInput(MethodSpec.Builder builder, String blockVariable) {
         TypeName returnType = TypeName.get(combine.getReturnType());
         warningsBlock(builder, () -> {
-            if (valuesIsBytesRef) {
+            if (aggParam.isBytesRef()) {
                 combineRawInputForBytesRef(builder, blockVariable);
             } else if (returnType.isPrimitive()) {
                 combineRawInputForPrimitive(returnType, builder, blockVariable);
@@ -479,7 +400,7 @@ public class AggregatorImplementer {
             declarationType,
             returnType,
             blockVariable,
-            firstUpper(combine.getParameters().get(1).asType().toString())
+            capitalize(combine.getParameters().get(1).asType().toString())
         );
     }
 
@@ -492,7 +413,7 @@ public class AggregatorImplementer {
             "$T.combine(state, $L.get$L(i))",
             declarationType,
             blockVariable,
-            firstUpper(combine.getParameters().get(1).asType().toString())
+            capitalize(combine.getParameters().get(1).asType().toString())
         );
     }
 
@@ -531,7 +452,7 @@ public class AggregatorImplementer {
                 builder.addStatement("$T scratch = new $T()", BYTES_REF, BYTES_REF);
             }
             builder.addStatement("$T.combineIntermediate(state, " + intermediateStateRowAccess() + ")", declarationType);
-        } else if (hasPrimitiveState()) {
+        } else if (aggState.declaredType().isPrimitive()) {
             if (warnExceptions.isEmpty()) {
                 assert intermediateState.size() == 2;
                 assert intermediateState.get(1).name().equals("seen");
@@ -549,9 +470,17 @@ public class AggregatorImplementer {
             }
 
             warningsBlock(builder, () -> {
+                var primitiveStateMethod = switch (aggState.declaredType().toString()) {
+                    case "boolean" -> "booleanValue";
+                    case "int" -> "intValue";
+                    case "long" -> "longValue";
+                    case "double" -> "doubleValue";
+                    case "float" -> "floatValue";
+                    default -> throw new IllegalArgumentException("Unexpected primitive type: [" + aggState.declaredType() + "]");
+                };
                 var state = intermediateState.get(0);
                 var s = "state.$L($T.combine(state.$L(), " + state.name() + "." + vectorAccessorName(state.elementType()) + "(0)))";
-                builder.addStatement(s, primitiveStateMethod(), declarationType, primitiveStateMethod());
+                builder.addStatement(s, primitiveStateMethod, declarationType, primitiveStateMethod);
                 builder.addStatement("state.seen(true)");
             });
             builder.endControlFlow();
@@ -563,25 +492,6 @@ public class AggregatorImplementer {
 
     String intermediateStateRowAccess() {
         return intermediateState.stream().map(desc -> desc.access("0")).collect(joining(", "));
-    }
-
-    private String primitiveStateMethod() {
-        switch (stateType.toString()) {
-            case "org.elasticsearch.compute.aggregation.BooleanState", "org.elasticsearch.compute.aggregation.BooleanFallibleState":
-                return "booleanValue";
-            case "org.elasticsearch.compute.aggregation.IntState", "org.elasticsearch.compute.aggregation.IntFallibleState":
-                return "intValue";
-            case "org.elasticsearch.compute.aggregation.LongState", "org.elasticsearch.compute.aggregation.LongFallibleState":
-                return "longValue";
-            case "org.elasticsearch.compute.aggregation.DoubleState", "org.elasticsearch.compute.aggregation.DoubleFallibleState":
-                return "doubleValue";
-            case "org.elasticsearch.compute.aggregation.FloatState", "org.elasticsearch.compute.aggregation.FloatFallibleState":
-                return "floatValue";
-            default:
-                throw new IllegalArgumentException(
-                    "don't know how to fetch primitive values from " + stateType + ". define combineIntermediate."
-                );
-        }
     }
 
     private MethodSpec evaluateIntermediate() {
@@ -602,43 +512,31 @@ public class AggregatorImplementer {
             .addParameter(BLOCK_ARRAY, "blocks")
             .addParameter(TypeName.INT, "offset")
             .addParameter(DRIVER_CONTEXT, "driverContext");
-        if (stateTypeHasSeen || stateTypeHasFailed) {
-            var condition = Stream.of(stateTypeHasSeen ? "state.seen() == false" : null, stateTypeHasFailed ? "state.failed()" : null)
-                .filter(Objects::nonNull)
-                .collect(joining(" || "));
-            builder.beginControlFlow("if ($L)", condition);
+        if (aggState.hasSeen() || aggState.hasFailed()) {
+            builder.beginControlFlow(
+                "if ($L)",
+                Stream.concat(
+                    Stream.of("state.seen() == false").filter(c -> aggState.hasSeen()),
+                    Stream.of("state.failed()").filter(c -> aggState.hasFailed())
+                ).collect(joining(" || "))
+            );
             builder.addStatement("blocks[offset] = driverContext.blockFactory().newConstantNullBlock(1)", BLOCK);
             builder.addStatement("return");
             builder.endControlFlow();
         }
         if (evaluateFinal == null) {
-            primitiveStateToResult(builder);
+            builder.addStatement(switch (aggState.declaredType().toString()) {
+                case "boolean" -> "blocks[offset] = driverContext.blockFactory().newConstantBooleanBlockWith(state.booleanValue(), 1)";
+                case "int" -> "blocks[offset] = driverContext.blockFactory().newConstantIntBlockWith(state.intValue(), 1)";
+                case "long" -> "blocks[offset] = driverContext.blockFactory().newConstantLongBlockWith(state.longValue(), 1)";
+                case "double" -> "blocks[offset] = driverContext.blockFactory().newConstantDoubleBlockWith(state.doubleValue(), 1)";
+                case "float" -> "blocks[offset] = driverContext.blockFactory().newConstantFloatBlockWith(state.floatValue(), 1)";
+                default -> throw new IllegalArgumentException("Unexpected primitive type: [" + aggState.declaredType() + "]");
+            });
         } else {
             builder.addStatement("blocks[offset] = $T.evaluateFinal(state, driverContext)", declarationType);
         }
         return builder.build();
-    }
-
-    private void primitiveStateToResult(MethodSpec.Builder builder) {
-        switch (stateType.toString()) {
-            case "org.elasticsearch.compute.aggregation.BooleanState", "org.elasticsearch.compute.aggregation.BooleanFallibleState":
-                builder.addStatement("blocks[offset] = driverContext.blockFactory().newConstantBooleanBlockWith(state.booleanValue(), 1)");
-                return;
-            case "org.elasticsearch.compute.aggregation.IntState", "org.elasticsearch.compute.aggregation.IntFallibleState":
-                builder.addStatement("blocks[offset] = driverContext.blockFactory().newConstantIntBlockWith(state.intValue(), 1)");
-                return;
-            case "org.elasticsearch.compute.aggregation.LongState", "org.elasticsearch.compute.aggregation.LongFallibleState":
-                builder.addStatement("blocks[offset] = driverContext.blockFactory().newConstantLongBlockWith(state.longValue(), 1)");
-                return;
-            case "org.elasticsearch.compute.aggregation.DoubleState", "org.elasticsearch.compute.aggregation.DoubleFallibleState":
-                builder.addStatement("blocks[offset] = driverContext.blockFactory().newConstantDoubleBlockWith(state.doubleValue(), 1)");
-                return;
-            case "org.elasticsearch.compute.aggregation.FloatState", "org.elasticsearch.compute.aggregation.FloatFallibleState":
-                builder.addStatement("blocks[offset] = driverContext.blockFactory().newConstantFloatBlockWith(state.floatValue(), 1)");
-                return;
-            default:
-                throw new IllegalArgumentException("don't know how to convert state to result: " + stateType);
-        }
     }
 
     private MethodSpec toStringMethod() {
@@ -657,14 +555,6 @@ public class AggregatorImplementer {
         builder.addAnnotation(Override.class).addModifiers(Modifier.PUBLIC);
         builder.addStatement("state.close()");
         return builder.build();
-    }
-
-    private static final Pattern PRIMITIVE_STATE_PATTERN = Pattern.compile(
-        "org.elasticsearch.compute.aggregation.(Boolean|Int|Long|Double|Float)(Fallible)?State"
-    );
-
-    private boolean hasPrimitiveState() {
-        return PRIMITIVE_STATE_PATTERN.matcher(stateType.toString()).matches();
     }
 
     record IntermediateStateDesc(String name, String elementType, boolean block) {
@@ -705,20 +595,50 @@ public class AggregatorImplementer {
         }
     }
 
-    private TypeMirror valueTypeMirror() {
-        return combine.getParameters().get(combine.getParameters().size() - 1).asType();
+    /**
+     * This represents the type returned by init method used to keep aggregation state
+     * @param declaredType declared state type as returned by init method
+     * @param type actual type used (we have some predefined state types for primitive values)
+     */
+    public record AggregationState(TypeName declaredType, TypeName type, boolean hasSeen, boolean hasFailed) {
+
+        public static AggregationState create(Elements elements, TypeMirror mirror, boolean hasFailures, boolean isArray) {
+            var declaredType = TypeName.get(mirror);
+            var stateType = declaredType.isPrimitive()
+                ? ClassName.get("org.elasticsearch.compute.aggregation", primitiveStateStoreClassname(declaredType, hasFailures, isArray))
+                : declaredType;
+            return new AggregationState(
+                declaredType,
+                stateType,
+                hasMethod(elements, stateType, "seen()"),
+                hasMethod(elements, stateType, "failed()")
+            );
+        }
+
+        private static String primitiveStateStoreClassname(TypeName declaredType, boolean hasFailures, boolean isArray) {
+            var name = capitalize(declaredType.toString());
+            if (hasFailures) {
+                name += "Fallible";
+            }
+            if (isArray) {
+                name += "Array";
+            }
+            return name + "State";
+        }
     }
 
-    private TypeName valueTypeName() {
-        return TypeName.get(valueTypeMirror());
+    public record AggregationParameter(TypeName type, boolean isArray) {
+
+        public static AggregationParameter create(TypeMirror mirror) {
+            return new AggregationParameter(TypeName.get(mirror), Objects.equals(mirror.getKind(), TypeKind.ARRAY));
+        }
+
+        public boolean isBytesRef() {
+            return Objects.equals(type, BYTES_REF);
+        }
     }
 
-    private TypeKind valueTypeKind() {
-        return valueTypeMirror().getKind();
-    }
-
-    private String valueTypeString() {
-        String valueTypeString = TypeName.get(valueTypeMirror()).toString();
-        return valuesIsArray ? valueTypeString.substring(0, valueTypeString.length() - 2) : valueTypeString;
+    private static boolean hasMethod(Elements elements, TypeName type, String name) {
+        return elements.getAllMembers(elements.getTypeElement(type.toString())).stream().anyMatch(e -> e.toString().equals(name));
     }
 }

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
@@ -54,6 +54,8 @@ import static org.elasticsearch.compute.gen.Types.ELEMENT_TYPE;
 import static org.elasticsearch.compute.gen.Types.INTERMEDIATE_STATE_DESC;
 import static org.elasticsearch.compute.gen.Types.LIST_AGG_FUNC_DESC;
 import static org.elasticsearch.compute.gen.Types.LIST_INTEGER;
+import static org.elasticsearch.compute.gen.Types.LONG_BLOCK;
+import static org.elasticsearch.compute.gen.Types.LONG_VECTOR;
 import static org.elasticsearch.compute.gen.Types.PAGE;
 import static org.elasticsearch.compute.gen.Types.WARNINGS;
 import static org.elasticsearch.compute.gen.Types.blockType;
@@ -73,9 +75,10 @@ public class AggregatorImplementer {
     private final List<TypeMirror> warnExceptions;
     private final ExecutableElement init;
     private final ExecutableElement combine;
+    private final List<Parameter> createParameters;
     private final ClassName implementation;
     private final List<IntermediateStateDesc> intermediateState;
-    private final List<Parameter> createParameters;
+    private final boolean includeTimestampVector;
 
     private final AggregationState aggState;
     private final AggregationParameter aggParam;
@@ -84,7 +87,8 @@ public class AggregatorImplementer {
         Elements elements,
         TypeElement declarationType,
         IntermediateState[] interStateAnno,
-        List<TypeMirror> warnExceptions
+        List<TypeMirror> warnExceptions,
+        boolean includeTimestampVector
     ) {
         this.declarationType = declarationType;
         this.warnExceptions = warnExceptions;
@@ -102,10 +106,10 @@ public class AggregatorImplementer {
             declarationType,
             aggState.declaredType().isPrimitive() ? requireType(aggState.declaredType()) : requireVoidType(),
             requireName("combine"),
-            requireArgs(requireType(aggState.declaredType()), requireAnyType("<aggregation input column type>"))
+            combineArgs(aggState, includeTimestampVector)
         );
         // TODO support multiple parameters
-        this.aggParam = AggregationParameter.create(combine.getParameters().get(1).asType());
+        this.aggParam = AggregationParameter.create(combine.getParameters().getLast().asType());
 
         this.createParameters = init.getParameters()
             .stream()
@@ -117,7 +121,20 @@ public class AggregatorImplementer {
             elements.getPackageOf(declarationType).toString(),
             (declarationType.getSimpleName() + "AggregatorFunction").replace("AggregatorAggregator", "Aggregator")
         );
-        intermediateState = Arrays.stream(interStateAnno).map(IntermediateStateDesc::newIntermediateStateDesc).toList();
+        this.intermediateState = Arrays.stream(interStateAnno).map(IntermediateStateDesc::newIntermediateStateDesc).toList();
+        this.includeTimestampVector = includeTimestampVector;
+    }
+
+    private static Methods.ArgumentMatcher combineArgs(AggregationState aggState, boolean includeTimestampVector) {
+        if (includeTimestampVector) {
+            return requireArgs(
+                requireType(aggState.declaredType()),
+                requireType(TypeName.LONG), // @timestamp
+                requireAnyType("<aggregation input column type>")
+            );
+        } else {
+            return requireArgs(requireType(aggState.declaredType()), requireAnyType("<aggregation input column type>"));
+        }
     }
 
     ClassName implementation() {
@@ -295,10 +312,18 @@ public class AggregatorImplementer {
             builder.addComment("No masking");
             builder.addStatement("$T block = page.getBlock(channels.get(0))", blockType(aggParam.type()));
             builder.addStatement("$T vector = block.asVector()", vectorType(aggParam.type()));
+            if (includeTimestampVector) {
+                builder.addStatement("$T timestampsBlock = page.getBlock(channels.get(1))", LONG_BLOCK);
+                builder.addStatement("$T timestampsVector = timestampsBlock.asVector()", LONG_VECTOR);
+
+                builder.beginControlFlow("if (timestampsVector == null) ");
+                builder.addStatement("throw new IllegalStateException($S)", "expected @timestamp vector; but got a block");
+                builder.endControlFlow();
+            }
             builder.beginControlFlow("if (vector != null)");
-            builder.addStatement("addRawVector(vector)");
+            builder.addStatement(includeTimestampVector ? "addRawVector(vector, timestampsVector)" : "addRawVector(vector)");
             builder.nextControlFlow("else");
-            builder.addStatement("addRawBlock(block)");
+            builder.addStatement(includeTimestampVector ? "addRawBlock(block, timestampsVector)" : "addRawBlock(block)");
             builder.endControlFlow();
             builder.addStatement("return");
         }
@@ -307,10 +332,18 @@ public class AggregatorImplementer {
         builder.addComment("Some positions masked away, others kept");
         builder.addStatement("$T block = page.getBlock(channels.get(0))", blockType(aggParam.type()));
         builder.addStatement("$T vector = block.asVector()", vectorType(aggParam.type()));
+        if (includeTimestampVector) {
+            builder.addStatement("$T timestampsBlock = page.getBlock(channels.get(1))", LONG_BLOCK);
+            builder.addStatement("$T timestampsVector = timestampsBlock.asVector()", LONG_VECTOR);
+
+            builder.beginControlFlow("if (timestampsVector == null) ");
+            builder.addStatement("throw new IllegalStateException($S)", "expected @timestamp vector; but got a block");
+            builder.endControlFlow();
+        }
         builder.beginControlFlow("if (vector != null)");
-        builder.addStatement("addRawVector(vector, mask)");
+        builder.addStatement(includeTimestampVector ? "addRawVector(vector, timestampsVector, mask)" : "addRawVector(vector, mask)");
         builder.nextControlFlow("else");
-        builder.addStatement("addRawBlock(block, mask)");
+        builder.addStatement(includeTimestampVector ? "addRawBlock(block, timestampsVector, mask)" : "addRawBlock(block, mask)");
         builder.endControlFlow();
         return builder.build();
     }
@@ -318,6 +351,9 @@ public class AggregatorImplementer {
     private MethodSpec addRawVector(boolean masked) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("addRawVector");
         builder.addModifiers(Modifier.PRIVATE).addParameter(vectorType(aggParam.type()), "vector");
+        if (includeTimestampVector) {
+            builder.addParameter(LONG_VECTOR, "timestamps");
+        }
         if (masked) {
             builder.addParameter(BOOLEAN_VECTOR, "mask");
         }
@@ -348,6 +384,9 @@ public class AggregatorImplementer {
     private MethodSpec addRawBlock(boolean masked) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("addRawBlock");
         builder.addModifiers(Modifier.PRIVATE).addParameter(blockType(aggParam.type()), "block");
+        if (includeTimestampVector) {
+            builder.addParameter(LONG_VECTOR, "timestamps");
+        }
         if (masked) {
             builder.addParameter(BOOLEAN_VECTOR, "mask");
         }
@@ -401,33 +440,57 @@ public class AggregatorImplementer {
         });
     }
 
+    private void combineRawInputForBytesRef(MethodSpec.Builder builder, String blockVariable) {
+        // scratch is a BytesRef var that must have been defined before the iteration starts
+        if (includeTimestampVector) {
+            builder.addStatement("$T.combine(state, timestamps.getLong(i), $L.getBytesRef(i, scratch))", declarationType, blockVariable);
+        } else {
+            builder.addStatement("$T.combine(state, $L.getBytesRef(i, scratch))", declarationType, blockVariable);
+        }
+    }
+
     private void combineRawInputForPrimitive(TypeName returnType, MethodSpec.Builder builder, String blockVariable) {
-        builder.addStatement(
-            "state.$TValue($T.combine(state.$TValue(), $L.get$L(i)))",
-            returnType,
-            declarationType,
-            returnType,
-            blockVariable,
-            capitalize(combine.getParameters().get(1).asType().toString())
-        );
+        if (includeTimestampVector) {
+            builder.addStatement(
+                "state.$TValue($T.combine(state.$TValue(), timestamps.getLong(i), $L.get$L(i)))",
+                returnType,
+                declarationType,
+                returnType,
+                blockVariable,
+                capitalize(combine.getParameters().get(1).asType().toString())
+            );
+        } else {
+            builder.addStatement(
+                "state.$TValue($T.combine(state.$TValue(), $L.get$L(i)))",
+                returnType,
+                declarationType,
+                returnType,
+                blockVariable,
+                capitalize(combine.getParameters().get(1).asType().toString())
+            );
+        }
+    }
+
+    private void combineRawInputForVoid(MethodSpec.Builder builder, String blockVariable) {
+        if (includeTimestampVector) {
+            builder.addStatement(
+                "$T.combine(state, timestamps.getLong(i), $L.get$L(i))",
+                declarationType,
+                blockVariable,
+                capitalize(combine.getParameters().get(1).asType().toString())
+            );
+        } else {
+            builder.addStatement(
+                "$T.combine(state, $L.get$L(i))",
+                declarationType,
+                blockVariable,
+                capitalize(combine.getParameters().get(1).asType().toString())
+            );
+        }
     }
 
     private void combineRawInputForArray(MethodSpec.Builder builder, String arrayVariable) {
         warningsBlock(builder, () -> builder.addStatement("$T.combine(state, $L)", declarationType, arrayVariable));
-    }
-
-    private void combineRawInputForVoid(MethodSpec.Builder builder, String blockVariable) {
-        builder.addStatement(
-            "$T.combine(state, $L.get$L(i))",
-            declarationType,
-            blockVariable,
-            capitalize(combine.getParameters().get(1).asType().toString())
-        );
-    }
-
-    private void combineRawInputForBytesRef(MethodSpec.Builder builder, String blockVariable) {
-        // scratch is a BytesRef var that must have been defined before the iteration starts
-        builder.addStatement("$T.combine(state, $L.getBytesRef(i, scratch))", declarationType, blockVariable);
     }
 
     private void warningsBlock(MethodSpec.Builder builder, Runnable block) {

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorProcessor.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorProcessor.java
@@ -87,7 +87,13 @@ public class AggregatorProcessor implements Processor {
             );
             if (aggClass.getAnnotation(Aggregator.class) != null) {
                 IntermediateState[] intermediateState = aggClass.getAnnotation(Aggregator.class).value();
-                implementer = new AggregatorImplementer(env.getElementUtils(), aggClass, intermediateState, warnExceptionsTypes);
+                implementer = new AggregatorImplementer(
+                    env.getElementUtils(),
+                    aggClass,
+                    intermediateState,
+                    warnExceptionsTypes,
+                    aggClass.getAnnotation(Aggregator.class).includeTimestamps()
+                );
                 write(aggClass, "aggregator", implementer.sourceFile(), env);
             }
             GroupingAggregatorImplementer groupingAggregatorImplementer = null;
@@ -96,13 +102,12 @@ public class AggregatorProcessor implements Processor {
                 if (intermediateState.length == 0 && aggClass.getAnnotation(Aggregator.class) != null) {
                     intermediateState = aggClass.getAnnotation(Aggregator.class).value();
                 }
-                boolean includeTimestamps = aggClass.getAnnotation(GroupingAggregator.class).includeTimestamps();
                 groupingAggregatorImplementer = new GroupingAggregatorImplementer(
                     env.getElementUtils(),
                     aggClass,
                     intermediateState,
                     warnExceptionsTypes,
-                    includeTimestamps
+                    aggClass.getAnnotation(GroupingAggregator.class).includeTimestamps()
                 );
                 write(aggClass, "grouping aggregator", groupingAggregatorImplementer.sourceFile(), env);
             }

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
@@ -99,8 +99,7 @@ public class GroupingAggregatorImplementer {
 
         this.init = requireStaticMethod(
             declarationType,
-            // This should be more restrictive and require org.elasticsearch.compute.aggregation.GroupingAggregatorState
-            requirePrimitiveOrImplements(elements, Types.RELEASABLE),
+            requirePrimitiveOrImplements(elements, Types.GROUPING_AGGREGATOR_STATE),
             requireName("init", "initGrouping"),
             requireAnyArgs("<arbitrary init arguments>")
         );

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
@@ -22,9 +22,10 @@ import org.elasticsearch.compute.gen.AggregatorImplementer.AggregationState;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -34,10 +35,17 @@ import javax.lang.model.util.Elements;
 
 import static java.util.stream.Collectors.joining;
 import static org.elasticsearch.compute.gen.AggregatorImplementer.capitalize;
-import static org.elasticsearch.compute.gen.Methods.findMethod;
-import static org.elasticsearch.compute.gen.Methods.findRequiredMethod;
+import static org.elasticsearch.compute.gen.Methods.requireAnyArgs;
+import static org.elasticsearch.compute.gen.Methods.requireAnyType;
+import static org.elasticsearch.compute.gen.Methods.requireArgs;
+import static org.elasticsearch.compute.gen.Methods.requireName;
+import static org.elasticsearch.compute.gen.Methods.requirePrimitiveOrImplements;
+import static org.elasticsearch.compute.gen.Methods.requireStaticMethod;
+import static org.elasticsearch.compute.gen.Methods.requireType;
+import static org.elasticsearch.compute.gen.Methods.requireVoidType;
 import static org.elasticsearch.compute.gen.Methods.vectorAccessorName;
 import static org.elasticsearch.compute.gen.Types.BIG_ARRAYS;
+import static org.elasticsearch.compute.gen.Types.BLOCK;
 import static org.elasticsearch.compute.gen.Types.BLOCK_ARRAY;
 import static org.elasticsearch.compute.gen.Types.BYTES_REF;
 import static org.elasticsearch.compute.gen.Types.DRIVER_CONTEXT;
@@ -71,9 +79,6 @@ public class GroupingAggregatorImplementer {
     private final List<TypeMirror> warnExceptions;
     private final ExecutableElement init;
     private final ExecutableElement combine;
-    private final ExecutableElement combineStates;
-    private final ExecutableElement evaluateFinal;
-    private final ExecutableElement combineIntermediate;
     private final List<Parameter> createParameters;
     private final ClassName implementation;
     private final List<AggregatorImplementer.IntermediateStateDesc> intermediateState;
@@ -92,22 +97,23 @@ public class GroupingAggregatorImplementer {
         this.declarationType = declarationType;
         this.warnExceptions = warnExceptions;
 
-        this.init = findRequiredMethod(declarationType, new String[] { "init", "initGrouping" }, e -> true);
+        this.init = requireStaticMethod(
+            declarationType,
+            // This should be more restrictive and require org.elasticsearch.compute.aggregation.GroupingAggregatorState
+            requirePrimitiveOrImplements(elements, Types.RELEASABLE),
+            requireName("init", "initGrouping"),
+            requireAnyArgs("<arbitrary init arguments>")
+        );
         this.aggState = AggregationState.create(elements, init.getReturnType(), warnExceptions.isEmpty() == false, true);
 
-        this.combine = findRequiredMethod(declarationType, new String[] { "combine" }, e -> {
-            if (e.getParameters().size() == 0) {
-                return false;
-            }
-            TypeName firstParamType = TypeName.get(e.getParameters().get(0).asType());
-            return Objects.equals(firstParamType.toString(), aggState.declaredType().toString());
-        });
-        // TODO support multiple parameters
+        this.combine = requireStaticMethod(
+            declarationType,
+            aggState.declaredType().isPrimitive() ? requireType(aggState.declaredType()) : requireVoidType(),
+            requireName("combine"),
+            combineArgs(aggState, includeTimestampVector)
+        );
         this.aggParam = AggregationParameter.create(combine.getParameters().get(combine.getParameters().size() - 1).asType());
 
-        this.combineStates = findMethod(declarationType, "combineStates");
-        this.combineIntermediate = findMethod(declarationType, "combineIntermediate");
-        this.evaluateFinal = findMethod(declarationType, "evaluateFinal");
         this.createParameters = init.getParameters()
             .stream()
             .map(Parameter::from)
@@ -123,6 +129,25 @@ public class GroupingAggregatorImplementer {
             .map(AggregatorImplementer.IntermediateStateDesc::newIntermediateStateDesc)
             .toList();
         this.includeTimestampVector = includeTimestampVector;
+    }
+
+    private static Methods.ArgumentMatcher combineArgs(AggregationState aggState, boolean includeTimestampVector) {
+        if (aggState.declaredType().isPrimitive()) {
+            return requireArgs(requireType(aggState.declaredType()), requireAnyType("<aggregation input column type>"));
+        } else if (includeTimestampVector) {
+            return requireArgs(
+                requireType(aggState.declaredType()),
+                requireType(TypeName.INT),
+                requireType(TypeName.LONG), // @timestamp
+                requireAnyType("<aggregation input column type>")
+            );
+        } else {
+            return requireArgs(
+                requireType(aggState.declaredType()),
+                requireType(TypeName.INT),
+                requireAnyType("<aggregation input column type>")
+            );
+        }
     }
 
     public ClassName implementation() {
@@ -557,29 +582,31 @@ public class GroupingAggregatorImplementer {
                 });
                 builder.endControlFlow();
             } else {
-                builder.addStatement("$T.combineIntermediate(state, groupId, " + intermediateStateRowAccess() + ")", declarationType);
+                var stateHasBlock = intermediateState.stream().anyMatch(AggregatorImplementer.IntermediateStateDesc::block);
+                requireStaticMethod(
+                    declarationType,
+                    requireVoidType(),
+                    requireName("combineIntermediate"),
+                    requireArgs(
+                        Stream.of(
+                            Stream.of(aggState.declaredType(), TypeName.INT), // aggState and groupId
+                            intermediateState.stream().map(AggregatorImplementer.IntermediateStateDesc::combineArgType),
+                            Stream.of(TypeName.INT).filter(p -> stateHasBlock) // position
+                        ).flatMap(Function.identity()).map(Methods::requireType).toArray(Methods.TypeMatcher[]::new)
+                    )
+                );
+
+                builder.addStatement(
+                    "$T.combineIntermediate(state, groupId, "
+                        + intermediateState.stream().map(desc -> desc.access("groupPosition + positionOffset")).collect(joining(", "))
+                        + (stateHasBlock ? ", groupPosition + positionOffset" : "")
+                        + ")",
+                    declarationType
+                );
             }
             builder.endControlFlow();
         }
         return builder.build();
-    }
-
-    String intermediateStateRowAccess() {
-        String rowAccess = intermediateState.stream().map(desc -> desc.access("groupPosition + positionOffset")).collect(joining(", "));
-        if (intermediateState.stream().anyMatch(AggregatorImplementer.IntermediateStateDesc::block)) {
-            rowAccess += ", groupPosition + positionOffset";
-        }
-        return rowAccess;
-    }
-
-    private void combineStates(MethodSpec.Builder builder) {
-        if (combineStates == null) {
-            builder.beginControlFlow("if (inState.hasValue(position))");
-            builder.addStatement("state.set(groupId, $T.combine(state.getOrDefault(groupId), inState.get(position)))", declarationType);
-            builder.endControlFlow();
-            return;
-        }
-        builder.addStatement("$T.combineStates(state, groupId, inState, position)", declarationType);
     }
 
     private MethodSpec addIntermediateRowInput() {
@@ -593,7 +620,24 @@ public class GroupingAggregatorImplementer {
         builder.endControlFlow();
         builder.addStatement("$T inState = (($T) input).state", aggState.type(), implementation);
         builder.addStatement("state.enableGroupIdTracking(new $T.Empty())", SEEN_GROUP_IDS);
-        combineStates(builder);
+        if (aggState.declaredType().isPrimitive()) {
+            builder.beginControlFlow("if (inState.hasValue(position))");
+            builder.addStatement("state.set(groupId, $T.combine(state.getOrDefault(groupId), inState.get(position)))", declarationType);
+            builder.endControlFlow();
+        } else {
+            requireStaticMethod(
+                declarationType,
+                requireVoidType(),
+                requireName("combineStates"),
+                requireArgs(
+                    requireType(aggState.declaredType()),
+                    requireType(TypeName.INT),
+                    requireType(aggState.declaredType()),
+                    requireType(TypeName.INT)
+                )
+            );
+            builder.addStatement("$T.combineStates(state, groupId, inState, position)", declarationType);
+        }
         return builder.build();
     }
 
@@ -617,9 +661,15 @@ public class GroupingAggregatorImplementer {
             .addParameter(INT_VECTOR, "selected")
             .addParameter(DRIVER_CONTEXT, "driverContext");
 
-        if (evaluateFinal == null) {
+        if (aggState.declaredType().isPrimitive()) {
             builder.addStatement("blocks[offset] = state.toValuesBlock(selected, driverContext)");
         } else {
+            requireStaticMethod(
+                declarationType,
+                requireType(BLOCK),
+                requireName("evaluateFinal"),
+                requireArgs(requireType(aggState.declaredType()), requireType(INT_VECTOR), requireType(DRIVER_CONTEXT))
+            );
             builder.addStatement("blocks[offset] = $T.evaluateFinal(state, selected, driverContext)", declarationType);
         }
         return builder.build();

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
@@ -112,7 +112,8 @@ public class GroupingAggregatorImplementer {
             requireName("combine"),
             combineArgs(aggState, includeTimestampVector)
         );
-        this.aggParam = AggregationParameter.create(combine.getParameters().get(combine.getParameters().size() - 1).asType());
+        // TODO support multiple parameters
+        this.aggParam = AggregationParameter.create(combine.getParameters().getLast().asType());
 
         this.createParameters = init.getParameters()
             .stream()
@@ -125,7 +126,7 @@ public class GroupingAggregatorImplementer {
             (declarationType.getSimpleName() + "GroupingAggregatorFunction").replace("AggregatorGroupingAggregator", "GroupingAggregator")
         );
 
-        intermediateState = Arrays.stream(interStateAnno)
+        this.intermediateState = Arrays.stream(interStateAnno)
             .map(AggregatorImplementer.IntermediateStateDesc::newIntermediateStateDesc)
             .toList();
         this.includeTimestampVector = includeTimestampVector;
@@ -370,8 +371,7 @@ public class GroupingAggregatorImplementer {
     private MethodSpec addRawInputLoop(TypeName groupsType, TypeName valuesType) {
         boolean groupsIsBlock = groupsType.toString().endsWith("Block");
         boolean valuesIsBlock = valuesType.toString().endsWith("Block");
-        String methodName = "addRawInput";
-        MethodSpec.Builder builder = MethodSpec.methodBuilder(methodName);
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("addRawInput");
         builder.addModifiers(Modifier.PRIVATE);
         builder.addParameter(TypeName.INT, "positionOffset").addParameter(groupsType, "groups").addParameter(valuesType, "values");
         if (includeTimestampVector) {
@@ -443,8 +443,6 @@ public class GroupingAggregatorImplementer {
         warningsBlock(builder, () -> {
             if (aggParam.isBytesRef()) {
                 combineRawInputForBytesRef(builder, blockVariable, offsetVariable);
-            } else if (includeTimestampVector) {
-                combineRawInputWithTimestamp(builder, offsetVariable);
             } else if (valueType.isPrimitive() == false) {
                 throw new IllegalArgumentException("second parameter to combine must be a primitive, array or BytesRef: " + valueType);
             } else if (returnType.isPrimitive()) {
@@ -457,48 +455,75 @@ public class GroupingAggregatorImplementer {
         });
     }
 
+    private void combineRawInputForBytesRef(MethodSpec.Builder builder, String blockVariable, String offsetVariable) {
+        // scratch is a BytesRef var that must have been defined before the iteration starts
+        if (includeTimestampVector) {
+            if (offsetVariable.contains(" + ")) {
+                builder.addStatement("var valuePosition = $L", offsetVariable);
+                offsetVariable = "valuePosition";
+            }
+            builder.addStatement(
+                "$T.combine(state, groupId, timestamps.getLong($L), $L.getBytesRef($L, scratch))",
+                declarationType,
+                offsetVariable,
+                blockVariable,
+                offsetVariable
+            );
+        } else {
+            builder.addStatement("$T.combine(state, groupId, $L.getBytesRef($L, scratch))", declarationType, blockVariable, offsetVariable);
+        }
+    }
+
     private void combineRawInputForPrimitive(MethodSpec.Builder builder, String blockVariable, String offsetVariable) {
-        builder.addStatement(
-            "state.set(groupId, $T.combine(state.getOrDefault(groupId), $L.get$L($L)))",
-            declarationType,
-            blockVariable,
-            capitalize(aggParam.type().toString()),
-            offsetVariable
-        );
+        if (includeTimestampVector) {
+            if (offsetVariable.contains(" + ")) {
+                builder.addStatement("var valuePosition = $L", offsetVariable);
+                offsetVariable = "valuePosition";
+            }
+            builder.addStatement(
+                "$T.combine(state, groupId, timestamps.getLong($L), values.get$L($L))",
+                declarationType,
+                offsetVariable,
+                capitalize(aggParam.type().toString()),
+                offsetVariable
+            );
+        } else {
+            builder.addStatement(
+                "state.set(groupId, $T.combine(state.getOrDefault(groupId), $L.get$L($L)))",
+                declarationType,
+                blockVariable,
+                capitalize(aggParam.type().toString()),
+                offsetVariable
+            );
+        }
+    }
+
+    private void combineRawInputForVoid(MethodSpec.Builder builder, String blockVariable, String offsetVariable) {
+        if (includeTimestampVector) {
+            if (offsetVariable.contains(" + ")) {
+                builder.addStatement("var valuePosition = $L", offsetVariable);
+                offsetVariable = "valuePosition";
+            }
+            builder.addStatement(
+                "$T.combine(state, groupId, timestamps.getLong($L), values.get$L($L))",
+                declarationType,
+                offsetVariable,
+                capitalize(aggParam.type().toString()),
+                offsetVariable
+            );
+        } else {
+            builder.addStatement(
+                "$T.combine(state, groupId, $L.get$L($L))",
+                declarationType,
+                blockVariable,
+                capitalize(aggParam.type().toString()),
+                offsetVariable
+            );
+        }
     }
 
     private void combineRawInputForArray(MethodSpec.Builder builder, String arrayVariable) {
         warningsBlock(builder, () -> builder.addStatement("$T.combine(state, groupId, $L)", declarationType, arrayVariable));
-    }
-
-    private void combineRawInputForVoid(MethodSpec.Builder builder, String blockVariable, String offsetVariable) {
-        builder.addStatement(
-            "$T.combine(state, groupId, $L.get$L($L))",
-            declarationType,
-            blockVariable,
-            capitalize(aggParam.type().toString()),
-            offsetVariable
-        );
-    }
-
-    private void combineRawInputWithTimestamp(MethodSpec.Builder builder, String offsetVariable) {
-        String blockType = capitalize(aggParam.type().toString());
-        if (offsetVariable.contains(" + ")) {
-            builder.addStatement("var valuePosition = $L", offsetVariable);
-            offsetVariable = "valuePosition";
-        }
-        builder.addStatement(
-            "$T.combine(state, groupId, timestamps.getLong($L), values.get$L($L))",
-            declarationType,
-            offsetVariable,
-            blockType,
-            offsetVariable
-        );
-    }
-
-    private void combineRawInputForBytesRef(MethodSpec.Builder builder, String blockVariable, String offsetVariable) {
-        // scratch is a BytesRef var that must have been defined before the iteration starts
-        builder.addStatement("$T.combine(state, groupId, $L.getBytesRef($L, scratch))", declarationType, blockVariable, offsetVariable);
     }
 
     private void warningsBlock(MethodSpec.Builder builder, Runnable block) {

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Methods.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Methods.java
@@ -9,18 +9,22 @@ package org.elasticsearch.compute.gen;
 
 import com.squareup.javapoet.TypeName;
 
-import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
-import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
 
+import static java.util.stream.Collectors.joining;
 import static org.elasticsearch.compute.gen.Types.BOOLEAN_BLOCK;
 import static org.elasticsearch.compute.gen.Types.BOOLEAN_BLOCK_BUILDER;
 import static org.elasticsearch.compute.gen.Types.BOOLEAN_VECTOR;
@@ -49,30 +53,116 @@ import static org.elasticsearch.compute.gen.Types.LONG_VECTOR_FIXED_BUILDER;
  * Finds declared methods for the code generator.
  */
 public class Methods {
-    static ExecutableElement findRequiredMethod(TypeElement declarationType, String[] names, Predicate<ExecutableElement> filter) {
-        ExecutableElement result = findMethod(names, filter, declarationType, superClassOf(declarationType));
-        if (result == null) {
-            if (names.length == 1) {
-                throw new IllegalArgumentException(declarationType + "#" + names[0] + " is required");
-            }
-            throw new IllegalArgumentException("one of " + declarationType + "#" + Arrays.toString(names) + " is required");
-        }
-        return result;
+
+    static ExecutableElement requireStaticMethod(
+        TypeElement declarationType,
+        TypeMatcher returnTypeMatcher,
+        NameMatcher nameMatcher,
+        ArgumentMatcher argumentMatcher
+    ) {
+        return typeAndSuperType(declarationType).flatMap(type -> ElementFilter.methodsIn(type.getEnclosedElements()).stream())
+            .filter(method -> method.getModifiers().contains(Modifier.STATIC))
+            .filter(method -> nameMatcher.test(method.getSimpleName().toString()))
+            .filter(method -> returnTypeMatcher.test(TypeName.get(method.getReturnType())))
+            .filter(method -> argumentMatcher.test(method.getParameters().stream().map(it -> TypeName.get(it.asType())).toList()))
+            .findFirst()
+            .orElseThrow(() -> {
+                var message = nameMatcher.names.size() == 1 ? "Requires method: " : "Requires one of methods: ";
+                var signatures = nameMatcher.names.stream()
+                    .map(name -> "public static " + returnTypeMatcher + " " + declarationType + "#" + name + "(" + argumentMatcher + ")")
+                    .collect(joining(" or "));
+                return new IllegalArgumentException(message + signatures);
+            });
     }
 
-    static ExecutableElement findMethod(TypeElement declarationType, String name) {
-        return findMethod(new String[] { name }, e -> true, declarationType, superClassOf(declarationType));
+    static NameMatcher requireName(String... names) {
+        return new NameMatcher(Set.of(names));
     }
 
-    private static TypeElement superClassOf(TypeElement declarationType) {
-        TypeMirror superclass = declarationType.getSuperclass();
-        if (superclass instanceof DeclaredType declaredType) {
-            Element superclassElement = declaredType.asElement();
-            if (superclassElement instanceof TypeElement) {
-                return (TypeElement) superclassElement;
-            }
+    static TypeMatcher requireVoidType() {
+        return new TypeMatcher(type -> Objects.equals(TypeName.VOID, type), "void");
+    }
+
+    static TypeMatcher requireAnyType(String description) {
+        return new TypeMatcher(type -> true, description);
+    }
+
+    static TypeMatcher requirePrimitiveOrImplements(Elements elements, TypeName requiredInterface) {
+        return new TypeMatcher(
+            type -> type.isPrimitive() || isImplementing(elements, type, requiredInterface),
+            "[boolean|int|long|float|double|" + requiredInterface + "]"
+        );
+    }
+
+    static TypeMatcher requireType(TypeName requiredType) {
+        return new TypeMatcher(type -> Objects.equals(requiredType, type), requiredType.toString());
+    }
+
+    static ArgumentMatcher requireAnyArgs(String description) {
+        return new ArgumentMatcher(args -> true, description);
+    }
+
+    static ArgumentMatcher requireArgs(TypeMatcher... argTypes) {
+        return new ArgumentMatcher(
+            args -> args.size() == argTypes.length && IntStream.range(0, argTypes.length).allMatch(i -> argTypes[i].test(args.get(i))),
+            Stream.of(argTypes).map(TypeMatcher::toString).collect(joining(", "))
+        );
+    }
+
+    record NameMatcher(Set<String> names) implements Predicate<String> {
+        @Override
+        public boolean test(String name) {
+            return names.contains(name);
         }
-        return null;
+    }
+
+    record TypeMatcher(Predicate<TypeName> matcher, String description) implements Predicate<TypeName> {
+        @Override
+        public boolean test(TypeName typeName) {
+            return matcher.test(typeName);
+        }
+
+        @Override
+        public String toString() {
+            return description;
+        }
+    }
+
+    record ArgumentMatcher(Predicate<List<TypeName>> matcher, String description) implements Predicate<List<TypeName>> {
+        @Override
+        public boolean test(List<TypeName> typeName) {
+            return matcher.test(typeName);
+        }
+
+        @Override
+        public String toString() {
+            return description;
+        }
+    }
+
+    private static boolean isImplementing(Elements elements, TypeName type, TypeName requiredInterface) {
+        return allInterfacesOf(elements, type).anyMatch(
+            anInterface -> Objects.equals(anInterface.toString(), requiredInterface.toString())
+        );
+    }
+
+    private static Stream<TypeName> allInterfacesOf(Elements elements, TypeName type) {
+        var typeElement = elements.getTypeElement(type.toString());
+        var superType = Stream.of(typeElement.getSuperclass()).filter(sType -> sType.getKind() != TypeKind.NONE).map(TypeName::get);
+        var interfaces = typeElement.getInterfaces().stream().map(TypeName::get);
+        return Stream.concat(
+            superType.flatMap(sType -> allInterfacesOf(elements, sType)),
+            interfaces.flatMap(anInterface -> Stream.concat(Stream.of(anInterface), allInterfacesOf(elements, anInterface)))
+        );
+    }
+
+    private static Stream<TypeElement> typeAndSuperType(TypeElement declarationType) {
+        if (declarationType.getSuperclass() instanceof DeclaredType declaredType
+            && declaredType.asElement() instanceof TypeElement superType) {
+            return Stream.of(declarationType, superType);
+        } else {
+            return Stream.of(declarationType);
+        }
     }
 
     static ExecutableElement findMethod(TypeElement declarationType, String[] names, Predicate<ExecutableElement> filter) {
@@ -93,16 +183,6 @@ public class Methods {
             }
         }
         return null;
-    }
-
-    /**
-     * Returns the arguments of a method after applying a filter.
-     */
-    static VariableElement[] findMethodArguments(ExecutableElement method, Predicate<VariableElement> filter) {
-        if (method.getParameters().isEmpty()) {
-            return new VariableElement[0];
-        }
-        return method.getParameters().stream().filter(filter).toArray(VariableElement[]::new);
     }
 
     /**

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Types.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Types.java
@@ -79,6 +79,9 @@ public class Types {
     static final ClassName DOUBLE_VECTOR_FIXED_BUILDER = ClassName.get(DATA_PACKAGE, "DoubleVector", "FixedBuilder");
     static final ClassName FLOAT_VECTOR_FIXED_BUILDER = ClassName.get(DATA_PACKAGE, "FloatVector", "FixedBuilder");
 
+    static final ClassName AGGREGATOR_STATE = ClassName.get(AGGREGATION_PACKAGE, "AggregatorState");
+    static final ClassName GROUPING_AGGREGATOR_STATE = ClassName.get(AGGREGATION_PACKAGE, "GroupingAggregatorState");
+
     static final ClassName AGGREGATOR_FUNCTION = ClassName.get(AGGREGATION_PACKAGE, "AggregatorFunction");
     static final ClassName AGGREGATOR_FUNCTION_SUPPLIER = ClassName.get(AGGREGATION_PACKAGE, "AggregatorFunctionSupplier");
     static final ClassName GROUPING_AGGREGATOR_FUNCTION = ClassName.get(AGGREGATION_PACKAGE, "GroupingAggregatorFunction");

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleAggregator.java
@@ -333,7 +333,8 @@ public class RateDoubleAggregator {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
             // noop - we handle the null states inside `toIntermediate` and `evaluateFinal`
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateFloatAggregator.java
@@ -334,7 +334,8 @@ public class RateFloatAggregator {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
             // noop - we handle the null states inside `toIntermediate` and `evaluateFinal`
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntAggregator.java
@@ -334,7 +334,8 @@ public class RateIntAggregator {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
             // noop - we handle the null states inside `toIntermediate` and `evaluateFinal`
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongAggregator.java
@@ -333,7 +333,8 @@ public class RateLongAggregator {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
             // noop - we handle the null states inside `toIntermediate` and `evaluateFinal`
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBooleanAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopBooleanAggregator.java
@@ -17,7 +17,6 @@ import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.sort.BooleanBucketedSort;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.sort.SortOrder;
 
@@ -74,7 +73,7 @@ class TopBooleanAggregator {
         return state.toBlock(driverContext.blockFactory(), selected);
     }
 
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final BooleanBucketedSort sort;
 
         private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
@@ -89,7 +88,8 @@ class TopBooleanAggregator {
             sort.merge(groupId, other.sort, otherGroupId);
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory(), selected);
         }
 
@@ -97,7 +97,8 @@ class TopBooleanAggregator {
             return sort.toBlock(blockFactory, selected);
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             // we figure out seen values from nulls on the values block
         }
 
@@ -107,7 +108,7 @@ class TopBooleanAggregator {
         }
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private final GroupingState internalState;
 
         private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
@@ -122,7 +123,8 @@ class TopBooleanAggregator {
             internalState.merge(0, other, 0);
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory());
         }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopFloatAggregator.java
@@ -17,7 +17,6 @@ import org.elasticsearch.compute.data.FloatBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.sort.FloatBucketedSort;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.sort.SortOrder;
 
@@ -74,7 +73,7 @@ class TopFloatAggregator {
         return state.toBlock(driverContext.blockFactory(), selected);
     }
 
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final FloatBucketedSort sort;
 
         private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
@@ -89,7 +88,8 @@ class TopFloatAggregator {
             sort.merge(groupId, other.sort, otherGroupId);
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory(), selected);
         }
 
@@ -97,7 +97,8 @@ class TopFloatAggregator {
             return sort.toBlock(blockFactory, selected);
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             // we figure out seen values from nulls on the values block
         }
 
@@ -107,7 +108,7 @@ class TopFloatAggregator {
         }
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private final GroupingState internalState;
 
         private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
@@ -122,7 +123,8 @@ class TopFloatAggregator {
             internalState.merge(0, other, 0);
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory());
         }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopIntAggregator.java
@@ -17,7 +17,6 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.sort.IntBucketedSort;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.sort.SortOrder;
 
@@ -74,7 +73,7 @@ class TopIntAggregator {
         return state.toBlock(driverContext.blockFactory(), selected);
     }
 
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final IntBucketedSort sort;
 
         private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
@@ -89,7 +88,8 @@ class TopIntAggregator {
             sort.merge(groupId, other.sort, otherGroupId);
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory(), selected);
         }
 
@@ -97,7 +97,8 @@ class TopIntAggregator {
             return sort.toBlock(blockFactory, selected);
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             // we figure out seen values from nulls on the values block
         }
 
@@ -107,7 +108,7 @@ class TopIntAggregator {
         }
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private final GroupingState internalState;
 
         private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
@@ -122,7 +123,8 @@ class TopIntAggregator {
             internalState.merge(0, other, 0);
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory());
         }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/TopLongAggregator.java
@@ -17,7 +17,6 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.sort.LongBucketedSort;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.sort.SortOrder;
 
@@ -74,7 +73,7 @@ class TopLongAggregator {
         return state.toBlock(driverContext.blockFactory(), selected);
     }
 
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final LongBucketedSort sort;
 
         private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
@@ -89,7 +88,8 @@ class TopLongAggregator {
             sort.merge(groupId, other.sort, otherGroupId);
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory(), selected);
         }
 
@@ -97,7 +97,8 @@ class TopLongAggregator {
             return sort.toBlock(blockFactory, selected);
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             // we figure out seen values from nulls on the values block
         }
 
@@ -107,7 +108,7 @@ class TopLongAggregator {
         }
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private final GroupingState internalState;
 
         private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
@@ -122,7 +123,8 @@ class TopLongAggregator {
             internalState.merge(0, other, 0);
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory());
         }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesDoubleAggregator.java
@@ -18,7 +18,6 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 
 /**
  * Aggregates field values for double.
@@ -77,14 +76,15 @@ class ValuesDoubleAggregator {
         return state.toBlock(driverContext.blockFactory(), selected);
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private final LongHash values;
 
         private SingleState(BigArrays bigArrays) {
             values = new LongHash(1, bigArrays);
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory());
         }
 
@@ -118,14 +118,15 @@ class ValuesDoubleAggregator {
      * an {@code O(n^2)} operation for collection to support a {@code O(1)}
      * collector operation. But at least it's fairly simple.
      */
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final LongLongHash values;
 
         private GroupingState(BigArrays bigArrays) {
             values = new LongLongHash(1, bigArrays);
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory(), selected);
         }
 
@@ -168,7 +169,8 @@ class ValuesDoubleAggregator {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             // we figure out seen values from nulls on the values block
         }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesFloatAggregator.java
@@ -17,7 +17,6 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.FloatBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 
 /**
  * Aggregates field values for float.
@@ -82,14 +81,15 @@ class ValuesFloatAggregator {
         return state.toBlock(driverContext.blockFactory(), selected);
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private final LongHash values;
 
         private SingleState(BigArrays bigArrays) {
             values = new LongHash(1, bigArrays);
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory());
         }
 
@@ -123,14 +123,15 @@ class ValuesFloatAggregator {
      * an {@code O(n^2)} operation for collection to support a {@code O(1)}
      * collector operation. But at least it's fairly simple.
      */
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final LongHash values;
 
         private GroupingState(BigArrays bigArrays) {
             values = new LongHash(1, bigArrays);
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory(), selected);
         }
 
@@ -175,7 +176,8 @@ class ValuesFloatAggregator {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             // we figure out seen values from nulls on the values block
         }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesIntAggregator.java
@@ -17,7 +17,6 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 
 /**
  * Aggregates field values for int.
@@ -82,14 +81,15 @@ class ValuesIntAggregator {
         return state.toBlock(driverContext.blockFactory(), selected);
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private final LongHash values;
 
         private SingleState(BigArrays bigArrays) {
             values = new LongHash(1, bigArrays);
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory());
         }
 
@@ -123,14 +123,15 @@ class ValuesIntAggregator {
      * an {@code O(n^2)} operation for collection to support a {@code O(1)}
      * collector operation. But at least it's fairly simple.
      */
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final LongHash values;
 
         private GroupingState(BigArrays bigArrays) {
             values = new LongHash(1, bigArrays);
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory(), selected);
         }
 
@@ -175,7 +176,8 @@ class ValuesIntAggregator {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             // we figure out seen values from nulls on the values block
         }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesLongAggregator.java
@@ -18,7 +18,6 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 
 /**
  * Aggregates field values for long.
@@ -77,14 +76,15 @@ class ValuesLongAggregator {
         return state.toBlock(driverContext.blockFactory(), selected);
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private final LongHash values;
 
         private SingleState(BigArrays bigArrays) {
             values = new LongHash(1, bigArrays);
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory());
         }
 
@@ -118,14 +118,15 @@ class ValuesLongAggregator {
      * an {@code O(n^2)} operation for collection to support a {@code O(1)}
      * collector operation. But at least it's fairly simple.
      */
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final LongLongHash values;
 
         private GroupingState(BigArrays bigArrays) {
             values = new LongLongHash(1, bigArrays);
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory(), selected);
         }
 
@@ -168,7 +169,8 @@ class ValuesLongAggregator {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             // we figure out seen values from nulls on the values block
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractArrayState.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractArrayState.java
@@ -37,6 +37,7 @@ public abstract class AbstractArrayState implements Releasable, GroupingAggregat
      * idempotent and fast if already tracking so it's safe to, say, call it once
      * for every block of values that arrives containing {@code null}.
      */
+    @Override
     public final void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
         if (seen == null) {
             seen = seenGroupIds.seenGroupIds(bigArrays);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/BytesRefArrayState.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/BytesRefArrayState.java
@@ -138,7 +138,8 @@ public final class BytesRefArrayState implements GroupingAggregatorState, Releas
      *     stores a flag to know if optimizations can be made.
      * </p>
      */
-    void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
+    @Override
+    public void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
         this.groupIdTrackingEnabled = true;
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorState.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorState.java
@@ -17,4 +17,5 @@ public interface GroupingAggregatorState extends Releasable {
     /** Extracts an intermediate view of the contents of this state.  */
     void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext);
 
+    void enableGroupIdTracking(SeenGroupIds seenGroupIds);
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/HllStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/HllStates.java
@@ -138,7 +138,8 @@ final class HllStates {
             this.hll = new HyperLogLogPlusPlus(HyperLogLogPlusPlus.precisionFromThreshold(precision), bigArrays, 1);
         }
 
-        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
             // Nothing to do
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxBytesRefAggregator.java
@@ -17,7 +17,6 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
 /**
@@ -71,7 +70,7 @@ class MaxBytesRefAggregator {
         return state.toBlock(selected, driverContext);
     }
 
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final BytesRefArrayState internalState;
 
         private GroupingState(BigArrays bigArrays, CircuitBreaker breaker) {
@@ -90,7 +89,8 @@ class MaxBytesRefAggregator {
             }
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             internalState.toIntermediate(blocks, offset, selected, driverContext);
         }
 
@@ -98,7 +98,8 @@ class MaxBytesRefAggregator {
             return internalState.toValuesBlock(selected, driverContext);
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             internalState.enableGroupIdTracking(seen);
         }
 
@@ -108,7 +109,7 @@ class MaxBytesRefAggregator {
         }
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private final BreakingBytesRefBuilder internalState;
         private boolean seen;
 
@@ -128,7 +129,8 @@ class MaxBytesRefAggregator {
             }
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = driverContext.blockFactory().newConstantBytesRefBlockWith(internalState.bytesRefView(), 1);
             blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(seen, 1);
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinIpAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MinIpAggregator.java
@@ -15,7 +15,6 @@ import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
 @Aggregator({ @IntermediateState(name = "max", type = "BYTES_REF"), @IntermediateState(name = "seen", type = "BOOLEAN") })
@@ -67,7 +66,7 @@ class MinIpAggregator {
         return state.toBlock(selected, driverContext);
     }
 
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final BytesRef scratch = new BytesRef();
         private final IpArrayState internalState;
 
@@ -87,7 +86,8 @@ class MinIpAggregator {
             }
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             internalState.toIntermediate(blocks, offset, selected, driverContext);
         }
 
@@ -95,7 +95,8 @@ class MinIpAggregator {
             return internalState.toValuesBlock(selected, driverContext);
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             internalState.enableGroupIdTracking(seen);
         }
 
@@ -105,7 +106,7 @@ class MinIpAggregator {
         }
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private final BytesRef internalState;
         private boolean seen;
 
@@ -121,7 +122,8 @@ class MinIpAggregator {
             }
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = driverContext.blockFactory().newConstantBytesRefBlockWith(internalState, 1);
             blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(seen, 1);
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/QuantileStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/QuantileStates.java
@@ -146,7 +146,8 @@ public final class QuantileStates {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
             // We always enable.
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/StdDevStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/StdDevStates.java
@@ -204,7 +204,8 @@ public final class StdDevStates {
             Releasables.close(states);
         }
 
-        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
             // noop - we handle the null states inside `toIntermediate` and `evaluateFinal`
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesBooleanAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesBooleanAggregator.java
@@ -17,7 +17,6 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
 /**
@@ -84,11 +83,12 @@ class ValuesBooleanAggregator {
         return state.toBlock(driverContext.blockFactory(), selected);
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private boolean seenFalse;
         private boolean seenTrue;
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory());
         }
 
@@ -113,14 +113,15 @@ class ValuesBooleanAggregator {
         public void close() {}
     }
 
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final BitArray values;
 
         private GroupingState(BigArrays bigArrays) {
             values = new BitArray(1, bigArrays);
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory(), selected);
         }
 
@@ -155,7 +156,8 @@ class ValuesBooleanAggregator {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             // we don't need to track which values have been seen because we don't do anything special for groups without values
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateAggregator.java.st
@@ -338,7 +338,8 @@ public class Rate$Type$Aggregator {
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
             // noop - we handle the null states inside `toIntermediate` and `evaluateFinal`
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-TopAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-TopAggregator.java.st
@@ -28,7 +28,6 @@ import org.elasticsearch.compute.data.$Type$Block;
 $endif$
 import org.elasticsearch.compute.data.sort.$Name$BucketedSort;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.sort.SortOrder;
 
@@ -99,7 +98,7 @@ $endif$
         return state.toBlock(driverContext.blockFactory(), selected);
     }
 
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
         private final $Name$BucketedSort sort;
 
         private GroupingState(BigArrays bigArrays, int limit, boolean ascending) {
@@ -120,7 +119,8 @@ $endif$
             sort.merge(groupId, other.sort, otherGroupId);
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory(), selected);
         }
 
@@ -128,7 +128,8 @@ $endif$
             return sort.toBlock(blockFactory, selected);
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             // we figure out seen values from nulls on the values block
         }
 
@@ -138,7 +139,7 @@ $endif$
         }
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
         private final GroupingState internalState;
 
         private SingleState(BigArrays bigArrays, int limit, boolean ascending) {
@@ -153,7 +154,8 @@ $endif$
             internalState.merge(0, other, 0);
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory());
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ValuesAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ValuesAggregator.java.st
@@ -35,7 +35,6 @@ $if(long)$
 import org.elasticsearch.compute.data.LongBlock;
 $endif$
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasable;
 $if(BytesRef)$
 import org.elasticsearch.core.Releasables;
 
@@ -155,7 +154,7 @@ $endif$
         return state.toBlock(driverContext.blockFactory(), selected);
     }
 
-    public static class SingleState implements Releasable {
+    public static class SingleState implements AggregatorState {
 $if(BytesRef)$
         private final BytesRefHash values;
 
@@ -171,7 +170,8 @@ $else$
 $endif$
         }
 
-        void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory());
         }
 
@@ -228,7 +228,7 @@ $endif$
      * an {@code O(n^2)} operation for collection to support a {@code O(1)}
      * collector operation. But at least it's fairly simple.
      */
-    public static class GroupingState implements Releasable {
+    public static class GroupingState implements GroupingAggregatorState {
 $if(long||double)$
         private final LongLongHash values;
 
@@ -263,7 +263,8 @@ $elseif(int||float)$
 $endif$
         }
 
-        void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             blocks[offset] = toBlock(driverContext.blockFactory(), selected);
         }
 
@@ -324,7 +325,8 @@ $endif$
             }
         }
 
-        void enableGroupIdTracking(SeenGroupIds seen) {
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seen) {
             // we figure out seen values from nulls on the values block
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidPointAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidPointAggregator.java
@@ -260,7 +260,8 @@ abstract class CentroidPointAggregator {
         }
 
         /** Needed for generated code that does null tracking, which we do not need because we use count */
-        final void enableGroupIdTracking(SeenGroupIds ignore) {}
+        @Override
+        public final void enableGroupIdTracking(SeenGroupIds ignore) {}
 
         private void ensureCapacity(int groupId) {
             if (groupId >= xValues.size()) {


### PR DESCRIPTION
This backports following changes to 9.0 branch:

* https://github.com/elastic/elasticsearch/pull/121637
* https://github.com/elastic/elasticsearch/pull/121818
* https://github.com/elastic/elasticsearch/pull/121749
* https://github.com/elastic/elasticsearch/pull/122174
* https://github.com/elastic/elasticsearch/pull/121898

I believe it will be faster to backport them all in one change rather than do it per PR.
I would like to have review/approval to confirm we want to backport all of it.