### PR TITLE
[ML] Unmute fixed Classification IT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -382,9 +382,6 @@ tests:
 - class: org.elasticsearch.xpack.security.operator.OperatorPrivilegesIT
   method: testEveryActionIsEitherOperatorOnlyOrNonOperator
   issue: https://github.com/elastic/elasticsearch/issues/119911
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testWithOnlyTrainingRowsAndTrainingPercentIsFifty_DependentVariableIsKeyword
-  issue: https://github.com/elastic/elasticsearch/issues/120071
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldSourceOnlyRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/120080
@@ -483,18 +480,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/42_knn_search_int4_flat/Vector similarity with filter only}
   issue: https://github.com/elastic/elasticsearch/issues/121412
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testStopAndRestart
-  issue: https://github.com/elastic/elasticsearch/issues/121433
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testDependentVariableIsNested
-  issue: https://github.com/elastic/elasticsearch/issues/121458
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testWithDatastreams
-  issue: https://github.com/elastic/elasticsearch/issues/121236
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testWithOnlyTrainingRowsAndTrainingPercentIsFifty_DependentVariableIsBoolean
-  issue: https://github.com/elastic/elasticsearch/issues/121680
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/*}
   issue: https://github.com/elastic/elasticsearch/issues/120816
@@ -504,9 +489,6 @@ tests:
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testGetProfiles
   issue: https://github.com/elastic/elasticsearch/issues/121101
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testWithOnlyTrainingRowsAndTrainingPercentIsHundred
-  issue: https://github.com/elastic/elasticsearch/issues/121368
 - class: org.elasticsearch.xpack.ml.packageloader.action.ModelLoaderUtilsTests
   method: testSplitIntoRanges
   issue: https://github.com/elastic/elasticsearch/issues/121799
@@ -523,14 +505,8 @@ tests:
   method: testHasPrivileges
   issue: https://github.com/elastic/elasticsearch/issues/121346
 - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testDeleteExpiredData_RemovesUnusedState
-  issue: https://github.com/elastic/elasticsearch/issues/116234
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
   method: testWithOnlyTrainingRowsAndTrainingPercentIsFifty_DependentVariableIsTextAndKeyword
   issue: https://github.com/elastic/elasticsearch/issues/121502
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testSingleNumericFeatureAndMixedTrainingAndNonTrainingRows
-  issue: https://github.com/elastic/elasticsearch/issues/121479
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testSuggestProfilesWithName
   issue: https://github.com/elastic/elasticsearch/issues/121022


### PR DESCRIPTION
Unmute tests following https://github.com/elastic/elasticsearch/pull/122268

Closes #120071
Closes #121680
Closes #121479
Closes #121458
Closes #121433
Closes #121368
Closes #121236
Closes #116234
