### PR TITLE
Fix handling of auto expand replicas for stateless indices

### DIFF
--- a/docs/changelog/122365.yaml
+++ b/docs/changelog/122365.yaml
@@ -1,5 +1,5 @@
 pr: 122365
 summary: Fix handling of auto expand replicas for stateless indices
-area: "Distributed, Search"
+area: "Search"
 type: bug
 issues: []

--- a/docs/changelog/122365.yaml
+++ b/docs/changelog/122365.yaml
@@ -1,0 +1,5 @@
+pr: 122365
+summary: Fix handling of auto expand replicas for stateless indices
+area: "Distributed, Search"
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
@@ -156,9 +156,8 @@ public record AutoExpandReplicas(int minReplicas, int maxReplicas, boolean enabl
                 )) {
                     if (indexMetadata.getNumberOfReplicas() == 0) {
                         nrReplicasChanged.computeIfAbsent(1, ArrayList::new).add(indexMetadata.getIndex().getName());
-                    } else {
-                        continue;
                     }
+                    continue;
                 }
                 if (allocation == null) {
                     allocation = allocationSupplier.get();


### PR DESCRIPTION
Auto expand replicas is meant to be entirely disabled for stateless indices. The only scenario where a change needs to be applied is when the number of replicas is initialized to 0, in which case 0 needs to be turned into 1. Otherwise, no changes should be applied in stateless indices despite auto expand replicas is used.

The current handling for this was missing an early exit of the indices loop in the case where 0 shoudl be turned into 1, that leads to a potentially higher number of copies being allocated (effectively auto-expand gets applied by mistake).
