### PR TITLE
Index-time scripted fields to be fetched from doc values

### DIFF
--- a/docs/changelog/122376.yaml
+++ b/docs/changelog/122376.yaml
@@ -1,0 +1,6 @@
+pr: 122376
+summary: Index-time scripted fields to be fetched from doc values
+area: Search
+type: bug
+issues:
+ - 119939

--- a/modules/runtime-fields-common/build.gradle
+++ b/modules/runtime-fields-common/build.gradle
@@ -22,3 +22,10 @@ dependencies {
   api project(':libs:grok')
   api project(':libs:dissect')
 }
+
+tasks.named("yamlRestCompatTestTransform").configure ({ task ->
+  task.skipTest("runtime_fields/13_keyword_calculated_at_index/fetch fields", "Script no longer executed at fetch time")
+  task.skipTest("runtime_fields/23_long_calculated_at_index/fetch fields", "Script no longer executed at fetch time")
+  task.skipTest("runtime_fields/33_double_calculated_at_index/fetch fields", "Script no longer executed at fetch time")
+  task.skipTest("runtime_fields/103_geo_point_calculated_at_index/fetch fields from source", "Script no longer executed at fetch time")
+})

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/103_geo_point_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/103_geo_point_calculated_at_index.yml
@@ -64,12 +64,24 @@ setup:
   - match: {hits.total.value: 6}
   - match: {hits.hits.0.fields.location.0.type: "Point" }
   - match: {hits.hits.0.fields.location.0.coordinates: [34.89, 13.5] }
-  # calculated from scripts adds annoying extra precision
-  - match: { hits.hits.0.fields.location_from_doc_value.0.type: "Point" }
-  - match: { hits.hits.0.fields.location_from_doc_value.0.coordinates: [ 34.889999935403466, 13.499999991618097 ] }
-  - match: { hits.hits.0.fields.location_from_source.0.type: "Point" }
-  - match: { hits.hits.0.fields.location_from_source.0.coordinates: [ 34.89, 13.5 ] }
+  - match: { hits.hits.0.fields.location_from_doc_value.0: "13.499999991618097, 34.889999935403466" }
+  - match: { hits.hits.0.fields.location_from_source.0: "13.499999991618097, 34.889999935403466" }
 
+---
+"docvalue_fields":
+  - do:
+      search:
+        index: locations
+        body:
+          sort: timestamp
+          docvalue_fields:
+            - location
+            - location_from_doc_value
+            - location_from_source
+  - match: {hits.total.value: 6}
+  - match: { hits.hits.0.fields.location.0: "13.499999991618097, 34.889999935403466" }
+  - match: { hits.hits.0.fields.location_from_doc_value.0: "13.499999991618097, 34.889999935403466" }
+  - match: { hits.hits.0.fields.location_from_source.0: "13.499999991618097, 34.889999935403466" }
 ---
 "exists query":
   - do:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/13_keyword_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/13_keyword_calculated_at_index.yml
@@ -88,7 +88,7 @@ setup:
   - match: {hits.total.value: 6}
   - match: {hits.hits.0.fields.day_of_week: [Thursday] }
   - match: {hits.hits.0.fields.day_of_week_from_source: [Thursday] }
-  - match: {hits.hits.0.fields.day_of_week_letters: [T, h, u, r, s, d, a, y] }
+  - match: {hits.hits.0.fields.day_of_week_letters: [T, a, d, h, r, s, u, y] }
   - match: {hits.hits.0.fields.prefixed_node: [node_c] }
 
 ---

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/23_long_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/23_long_calculated_at_index.yml
@@ -17,6 +17,11 @@ setup:
                 type: double
               node:
                 type: keyword
+              random_long:
+                type: long
+                script:
+                  source: |
+                    emit(new Random().nextLong());
               voltage_times_ten:
                 type: long
                 script:
@@ -90,18 +95,53 @@ setup:
           sort: timestamp
           fields:
             - voltage_times_ten
-            - voltage_times_ten_no_dv
             - temperature_digits
   - match: {hits.total.value: 6}
   - match: {hits.hits.0.fields.voltage_times_ten: [40] }
-  - match: {hits.hits.0.fields.temperature_digits: [2, 0, 2] }
+  - match: {hits.hits.0.fields.temperature_digits: [0, 2, 2] }
   - match: {hits.hits.0.fields.voltage_times_ten: [40] }
-  - match: {hits.hits.0.fields.voltage_times_ten_no_dv: [40] }
   - match: {hits.hits.1.fields.voltage_times_ten: [42] }
   - match: {hits.hits.2.fields.voltage_times_ten: [56] }
   - match: {hits.hits.3.fields.voltage_times_ten: [51] }
   - match: {hits.hits.4.fields.voltage_times_ten: [58] }
   - match: {hits.hits.5.fields.voltage_times_ten: [52] }
+
+---
+"script runs at index time":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          fields:
+            - random_long
+  - match: {hits.total.value: 6}
+  - set: { hits.hits.0.fields.random_long.0: random_value }
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            match:
+              random_long: $random_value
+          aggs:
+            random_value:
+              terms:
+                field: random_long
+  - match: {hits.total.value: 1}
+  - match: {aggregations.random_value.buckets.0.key: $random_value}
+
+---
+"fetch fields no doc_values":
+  - do:
+      catch: bad_request
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          fields:
+            - voltage_times_ten_no_dv
 
 ---
 "docvalue_fields":

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/23_long_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/23_long_calculated_at_index.yml
@@ -131,6 +131,7 @@ setup:
                 field: random_long
   - match: {hits.total.value: 1}
   - match: {aggregations.random_value.buckets.0.key: $random_value}
+  - match: {aggregations.random_value.buckets.0.doc_count: 1}
 
 ---
 "fetch fields no doc_values":

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/33_double_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/33_double_calculated_at_index.yml
@@ -17,6 +17,11 @@ setup:
                 type: double
               node:
                 type: keyword
+              random_double:
+                type: double
+                script:
+                  source: |
+                    emit(new Random().nextDouble());
               voltage_percent:
                 type: double
                 script:
@@ -88,17 +93,53 @@ setup:
         index: sensor
         body:
           sort: timestamp
-          fields: [voltage_percent, voltage_percent_no_dv, voltage_sqrts]
+          fields: [voltage_percent, voltage_sqrts]
   - match: {hits.total.value: 6}
   - match: {hits.hits.0.fields.voltage_percent: [0.6896551724137931] }
-  # Scripts that scripts that emit multiple values are supported
-  - match: {hits.hits.0.fields.voltage_sqrts: [4.0, 2.0, 1.4142135623730951] }
+  # Test that scripts that emit multiple values are supported and their results are sorted
+  - match: {hits.hits.0.fields.voltage_sqrts: [1.4142135623730951, 2.0, 4.0] }
   - match: {hits.hits.1.fields.voltage_percent: [0.7241379310344828] }
-  - match: {hits.hits.1.fields.voltage_percent_no_dv: [0.7241379310344828] }
   - match: {hits.hits.2.fields.voltage_percent: [0.9655172413793103] }
   - match: {hits.hits.3.fields.voltage_percent: [0.8793103448275862] }
   - match: {hits.hits.4.fields.voltage_percent: [1.0] }
   - match: {hits.hits.5.fields.voltage_percent: [0.896551724137931] }
+
+---
+"script runs at index time":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          fields:
+            - random_double
+  - match: {hits.total.value: 6}
+  - set: { hits.hits.0.fields.random_double.0: random_value }
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            match:
+              random_double: $random_value
+          aggs:
+            random_value:
+              terms:
+                field: random_double
+  - match: {hits.total.value: 1}
+  - match: {aggregations.random_value.buckets.0.key: $random_value}
+
+---
+"fetch fields no doc values":
+  - do:
+      catch: bad_request
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          fields:
+            - voltage_percent_no_dv
 
 ---
 "docvalue_fields":
@@ -110,7 +151,7 @@ setup:
           docvalue_fields: [voltage_percent, voltage_sqrts]
   - match: {hits.total.value: 6}
   - match: {hits.hits.0.fields.voltage_percent: [0.6896551724137931] }
-  # Scripts that scripts that emit multiple values are supported and their results are sorted
+  # Test that scripts that emit multiple values are supported and their results are sorted
   - match: {hits.hits.0.fields.voltage_sqrts: [1.4142135623730951, 2.0, 4.0] }
   - match: {hits.hits.1.fields.voltage_percent: [0.7241379310344828] }
   - match: {hits.hits.2.fields.voltage_percent: [0.9655172413793103] }

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/33_double_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/33_double_calculated_at_index.yml
@@ -129,6 +129,7 @@ setup:
                 field: random_double
   - match: {hits.total.value: 1}
   - match: {aggregations.random_value.buckets.0.key: $random_value}
+  - match: {aggregations.random_value.buckets.0.doc_count: 1}
 
 ---
 "fetch fields no doc values":

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/43_date_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/43_date_calculated_at_index.yml
@@ -60,6 +60,11 @@ setup:
                 type: double
               node:
                 type: keyword
+              ingest_time:
+                type: date
+                script:
+                  source: |
+                    emit(new Date().getTime());
 
   - do:
       bulk:
@@ -124,6 +129,27 @@ setup:
         - 2018-01-23T17:41:34.000Z
         - 2018-01-24T17:41:34.000Z
   - match: {hits.hits.0.fields.formatted_tomorrow: [2018-01-19] }
+
+---
+"script runs at index time":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          fields:
+            - ingest_time
+  - match: {hits.total.value: 6}
+  - set: { hits.hits.0.fields.ingest_time.0: ingest_time }
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            match:
+              ingest_time: $ingest_time
+  - gt: {hits.total.value: 0}
 
 ---
 "docvalue_fields":

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -40,6 +40,7 @@ import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.script.field.BooleanDocValuesField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -238,7 +239,11 @@ public class BooleanFieldMapper extends FieldMapper {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
             if (this.scriptValues != null) {
-                return FieldValues.valueFetcher(this.scriptValues, context);
+                return new DocValueFetcher(
+                    docValueFormat(format, null),
+                    context.getForField(this, FielddataOperation.SEARCH),
+                    StoredFieldsSpec.NO_REQUIREMENTS
+                );
             }
             return sourceValueFetcher(context.isSourceEnabled() ? context.sourcePath(name()) : Collections.emptySet());
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -53,6 +53,7 @@ import org.elasticsearch.script.field.DateMillisDocValuesField;
 import org.elasticsearch.script.field.DateNanosDocValuesField;
 import org.elasticsearch.script.field.ToScriptFieldFactory;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.LongScriptFieldDistanceFeatureQuery;
@@ -548,7 +549,11 @@ public final class DateFieldMapper extends FieldMapper {
                 ? DateFormatter.forPattern(format).withLocale(defaultFormatter.locale())
                 : defaultFormatter;
             if (scriptValues != null) {
-                return FieldValues.valueFetcher(scriptValues, v -> format((long) v, formatter), context);
+                return new DocValueFetcher(
+                    docValueFormat(format, null),
+                    context.getForField(this, FielddataOperation.SEARCH),
+                    StoredFieldsSpec.NO_REQUIREMENTS
+                );
             }
             return new SourceValueFetcher(name(), context, nullValue) {
                 @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.GeoFormatterFactory;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
-import org.elasticsearch.common.geo.GeometryFormatterFactory;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.SimpleVectorTileFormatter;
 import org.elasticsearch.common.unit.DistanceUnit;

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -49,6 +49,7 @@ import org.elasticsearch.script.field.GeoPointDocValuesField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.TimeSeriesValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.GeoPointScriptFieldDistanceFeatureQuery;
@@ -419,8 +420,11 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             if (scriptValues == null) {
                 return super.valueFetcher(context, format);
             }
-            Function<List<GeoPoint>, List<Object>> formatter = getFormatter(format != null ? format : GeometryFormatterFactory.GEOJSON);
-            return FieldValues.valueListFetcher(scriptValues, formatter, context);
+            return new DocValueFetcher(
+                docValueFormat(format, null),
+                context.getForField(this, FielddataOperation.SEARCH),
+                StoredFieldsSpec.NO_REQUIREMENTS
+            );
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -41,6 +41,7 @@ import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.script.field.IpDocValuesField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -285,7 +286,11 @@ public class IpFieldMapper extends FieldMapper {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
             if (scriptValues != null) {
-                return FieldValues.valueFetcher(scriptValues, v -> InetAddresses.toAddrString((InetAddress) v), context);
+                return new DocValueFetcher(
+                    docValueFormat(format, null),
+                    context.getForField(this, FielddataOperation.SEARCH),
+                    StoredFieldsSpec.NO_REQUIREMENTS
+                );
             }
             return new SourceValueFetcher(name(), context, nullValue) {
                 @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -59,6 +59,7 @@ import org.elasticsearch.script.SortedSetDocValuesStringFieldScript;
 import org.elasticsearch.script.StringFieldScript;
 import org.elasticsearch.script.field.KeywordDocValuesField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.StringScriptFieldFuzzyQuery;
@@ -843,7 +844,11 @@ public final class KeywordFieldMapper extends FieldMapper {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
             if (this.scriptValues != null) {
-                return FieldValues.valueFetcher(this.scriptValues, context);
+                return new DocValueFetcher(
+                    docValueFormat(format, null),
+                    context.getForField(this, FielddataOperation.SEARCH),
+                    StoredFieldsSpec.NO_REQUIREMENTS
+                );
             }
             return sourceValueFetcher(context.isSourceEnabled() ? context.sourcePath(name()) : Collections.emptySet());
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1807,6 +1807,9 @@ public class NumberFieldMapper extends FieldMapper {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
             if (this.scriptValues != null) {
+
+
+
                 return new DocValueFetcher(
                     docValueFormat(format, null),
                     context.getForField(this, FielddataOperation.SEARCH),

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1808,8 +1808,6 @@ public class NumberFieldMapper extends FieldMapper {
             }
             if (this.scriptValues != null) {
 
-
-
                 return new DocValueFetcher(
                     docValueFormat(format, null),
                     context.getForField(this, FielddataOperation.SEARCH),

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -60,6 +60,7 @@ import org.elasticsearch.script.field.ShortDocValuesField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.TimeSeriesValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.SourceProvider;
@@ -1806,7 +1807,11 @@ public class NumberFieldMapper extends FieldMapper {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
             if (this.scriptValues != null) {
-                return FieldValues.valueFetcher(this.scriptValues, context);
+                return new DocValueFetcher(
+                    docValueFormat(format, null),
+                    context.getForField(this, FielddataOperation.SEARCH),
+                    StoredFieldsSpec.NO_REQUIREMENTS
+                );
             }
             return sourceValueFetcher(context.isSourceEnabled() ? context.sourcePath(name()) : Collections.emptySet());
         }

--- a/server/src/main/java/org/elasticsearch/search/lookup/FieldValues.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/FieldValues.java
@@ -10,14 +10,8 @@
 package org.elasticsearch.search.lookup;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.SearchExecutionContext;
-import org.elasticsearch.search.fetch.StoredFieldsSpec;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Represents values for a given document
@@ -32,86 +26,4 @@ public interface FieldValues<T> {
      * @param consumer  called with each document value
      */
     void valuesForDoc(SearchLookup lookup, LeafReaderContext ctx, int doc, Consumer<T> consumer);
-
-    /**
-     * Creates a {@link ValueFetcher} that fetches values from a {@link FieldValues} instance
-     * @param fieldValues the source of the values
-     * @param context the search execution context
-     * @return the value fetcher
-     */
-    static ValueFetcher valueFetcher(FieldValues<?> fieldValues, SearchExecutionContext context) {
-        return valueFetcher(fieldValues, v -> v, context);
-    }
-
-    /**
-     * Creates a {@link ValueFetcher} that fetches values from a {@link FieldValues} instance
-     * @param fieldValues the source of the values
-     * @param formatter   a function to format the values
-     * @param context the search execution context
-     * @return the value fetcher
-     */
-    static ValueFetcher valueFetcher(FieldValues<?> fieldValues, Function<Object, Object> formatter, SearchExecutionContext context) {
-        return new ValueFetcher() {
-            LeafReaderContext ctx;
-
-            @Override
-            public void setNextReader(LeafReaderContext context) {
-                this.ctx = context;
-            }
-
-            @Override
-            public List<Object> fetchValues(Source lookup, int doc, List<Object> ignoredValues) {
-                List<Object> values = new ArrayList<>();
-                try {
-                    fieldValues.valuesForDoc(context.lookup(), ctx, doc, v -> values.add(formatter.apply(v)));
-                } catch (Exception e) {
-                    ignoredValues.addAll(values);
-                }
-                return values;
-            }
-
-            @Override
-            public StoredFieldsSpec storedFieldsSpec() {
-                return StoredFieldsSpec.NEEDS_SOURCE;       // TODO can we get more information from the script
-            }
-        };
-    }
-
-    /**
-     * Creates a {@link ValueFetcher} that fetches values from a {@link FieldValues} instance
-     * @param fieldValues the source of the values
-     * @param formatter   a function to format the list values
-     * @param context the search execution context
-     * @return the value fetcher
-     */
-    static <T> ValueFetcher valueListFetcher(
-        FieldValues<T> fieldValues,
-        Function<List<T>, List<Object>> formatter,
-        SearchExecutionContext context
-    ) {
-        return new ValueFetcher() {
-            LeafReaderContext ctx;
-
-            @Override
-            public void setNextReader(LeafReaderContext context) {
-                this.ctx = context;
-            }
-
-            @Override
-            public List<Object> fetchValues(Source source, int doc, List<Object> ignoredValues) {
-                List<T> values = new ArrayList<>();
-                try {
-                    fieldValues.valuesForDoc(context.lookup(), ctx, doc, values::add);
-                } catch (Exception e) {
-                    ignoredValues.addAll(values);
-                }
-                return formatter.apply(values);
-            }
-
-            @Override
-            public StoredFieldsSpec storedFieldsSpec() {
-                return StoredFieldsSpec.NEEDS_SOURCE;   // TODO can we get more info from the script?
-            }
-        };
-    }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapper;
 import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
@@ -59,6 +60,7 @@ import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.script.field.AbstractScriptFieldFactory;
 import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
 import org.elasticsearch.script.field.Field;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
@@ -293,8 +295,11 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
                 };
             }
             if (scriptValues != null) {
-                Function<List<Geometry>, List<Object>> formatter = getFormatter(format != null ? format : GeometryFormatterFactory.GEOJSON);
-                return FieldValues.valueListFetcher(scriptValues, formatter, context);
+                return new DocValueFetcher(
+                    docValueFormat(format, null),
+                    context.getForField(this, FielddataOperation.SEARCH),
+                    StoredFieldsSpec.NO_REQUIREMENTS
+                );
             }
             return super.valueFetcher(context, format);
         }


### PR DESCRIPTION
Certain field types support index-time scripts. When a script is provided for them, values for such fields are not accepted in incoming documents. Instead, the script is executed at index time and the result of the script is indexed. There is no trace of the resulting value in `_source`, but such calculated fields can be queried, aggregated on etc.

The described calculated fields can also be retrieved as part of the fetch phase, using the fields API or docvalue_fields. The fetch fields api is though re-executing the script at fetch time as opposed to retrieving the value that is in the index. That causes discrepancy between indexing, querying and fetching. This PR addresses that by retrieving the value from doc values. There's a couple of limitations with this approach:
- values can no longer be fetched once doc_values are turned off for that field, as these are not stored in `_source` like ordinarily ingested fields
- fetching from doc values introduces format discrepancies as well sorting, same as docvalue_fields. That makes these calculated fields look different at fetch time compared to other fields

These limitations are not great, but I think that fixing the bug of not re-running the script at fetch time is valuable. Re-executing the script at fetch is unexpected: users may have indexed such scripted fields for better performance for instance, and reexecuting the script may lead to a different result, depending on the content of the script.

Closes #119939