### PR TITLE
[8.18][Inference API] Rename model_id prop to model in EIS sparse inference request body

### DIFF
--- a/docs/changelog/122398.yaml
+++ b/docs/changelog/122398.yaml
@@ -1,0 +1,6 @@
+pr: 122398
+summary: "[8.18][Inference API] Rename `model_id` prop to model in EIS sparse inference\
+  \ request body"
+area: Inference
+type: enhancement
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntity.java
@@ -23,9 +23,7 @@ public record ElasticInferenceServiceSparseEmbeddingsRequestEntity(
 ) implements ToXContentObject {
 
     private static final String INPUT_FIELD = "input";
-
-    private static final String MODEL_ID_FIELD = "model_id";
-
+    private static final String MODEL_FIELD = "model";
     private static final String USAGE_CONTEXT = "usage_context";
 
     public ElasticInferenceServiceSparseEmbeddingsRequestEntity {
@@ -44,7 +42,7 @@ public record ElasticInferenceServiceSparseEmbeddingsRequestEntity(
 
         builder.endArray();
 
-        builder.field(MODEL_ID_FIELD, modelId);
+        builder.field(MODEL_FIELD, modelId);
 
         // optional field
         if ((usageContext == ElasticInferenceServiceUsageContext.UNSPECIFIED) == false) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/elastic/ElasticInferenceServiceActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/elastic/ElasticInferenceServiceActionCreatorTests.java
@@ -124,7 +124,7 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
             assertThat(requestMap.get("input"), instanceOf(List.class));
             var inputList = (List<String>) requestMap.get("input");
             assertThat(inputList, contains("hello world"));
-            assertThat(requestMap.get("model_id"), is("my-model-id"));
+            assertThat(requestMap.get("model"), is("my-model-id"));
         }
     }
 
@@ -179,7 +179,7 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
             assertThat(requestMap.get("input"), instanceOf(List.class));
             var inputList = (List<String>) requestMap.get("input");
             assertThat(inputList, contains("hello world"));
-            assertThat(requestMap.get("model_id"), is("my-model-id"));
+            assertThat(requestMap.get("model"), is("my-model-id"));
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestEntityTests.java
@@ -31,7 +31,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestEntityTests extends E
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
             {
                 "input": ["abc"],
-                "model_id": "my-model-id"
+                "model": "my-model-id"
             }"""));
     }
 
@@ -48,7 +48,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestEntityTests extends E
                     "abc",
                     "def"
                 ],
-                "model_id": "my-model-id"
+                "model": "my-model-id"
             }
             """));
     }
@@ -63,7 +63,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestEntityTests extends E
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
             {
                 "input": ["abc"],
-                "model_id": "my-model-id",
+                "model": "my-model-id",
                 "usage_context": "search"
             }
             """));
@@ -79,7 +79,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestEntityTests extends E
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
             {
                 "input": ["abc"],
-                "model_id": "my-model-id",
+                "model": "my-model-id",
                 "usage_context": "ingest"
             }
             """));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
@@ -47,7 +47,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
 
         assertThat(requestMap.size(), equalTo(3));
         assertThat(requestMap.get("input"), is(List.of(input)));
-        assertThat(requestMap.get("model_id"), is(modelId));
+        assertThat(requestMap.get("model"), is(modelId));
         assertThat(requestMap.get("usage_context"), equalTo("search"));
     }
 
@@ -84,7 +84,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
         var requestMap = entityAsMap(httpPost.getEntity().getContent());
         assertThat(requestMap, aMapWithSize(2));
         assertThat(requestMap.get("input"), is(List.of("ab")));
-        assertThat(requestMap.get("model_id"), is(modelId));
+        assertThat(requestMap.get("model"), is(modelId));
     }
 
     public void testIsTruncated_ReturnsTrue() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -504,8 +504,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
             assertThat(request.getHeader(HttpHeaders.CONTENT_TYPE), Matchers.equalTo(XContentType.JSON.mediaType()));
 
             var requestMap = entityAsMap(request.getBody());
-
-            assertThat(requestMap, is(Map.of("input", List.of("input text"), "model_id", "my-model-id", "usage_context", "search")));
+            assertThat(requestMap, is(Map.of("input", List.of("input text"), "model", "my-model-id", "usage_context", "search")));
         }
     }
 
@@ -562,8 +561,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
             );
 
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
-
-            assertThat(requestMap, is(Map.of("input", List.of("input text"), "model_id", "my-model-id", "usage_context", "ingest")));
+            assertThat(requestMap, is(Map.of("input", List.of("input text"), "model", "my-model-id", "usage_context", "ingest")));
         }
     }
 


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/122272.

For consistency with other APIs we're renaming the `model_id` property to `model` in the outgoing sparse embedding inference request to Elastic Inference Service (EIS). EIS has already been updated (and deployed) to accept either notation.