### PR TITLE
[8.18] Add metadata checking to RequestIndexFilteringIT (#122322)

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
@@ -38,7 +38,10 @@ import java.util.stream.Stream;
 
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.xpack.esql.ccq.Clusters.REMOTE_CLUSTER_NAME;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasKey;
 
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class MultiClustersIT extends ESRestTestCase {

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/RequestIndexFilteringIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/RequestIndexFilteringIT.java
@@ -15,9 +15,12 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.test.MapMatcher;
 import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.qa.rest.RequestIndexFilteringTestCase;
+import org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase;
+import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -27,6 +30,12 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.io.IOException;
+import java.util.Map;
+
+import static org.elasticsearch.test.MapMatcher.assertMap;
+import static org.elasticsearch.test.MapMatcher.matchesMap;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class RequestIndexFilteringIT extends RequestIndexFilteringTestCase {
@@ -51,6 +60,8 @@ public class RequestIndexFilteringIT extends RequestIndexFilteringTestCase {
         }
     }
 
+    private boolean isCCSRequest;
+
     @BeforeClass
     public static void checkVersion() {
         assumeTrue("skip if version before 8.18", Clusters.localClusterVersion().onOrAfter(Version.V_8_18_0));
@@ -73,11 +84,18 @@ public class RequestIndexFilteringIT extends RequestIndexFilteringTestCase {
 
     @Override
     protected String from(String... indexName) {
-        if (randomBoolean()) {
+        isCCSRequest = randomBoolean();
+        if (isCCSRequest) {
             return "FROM *:" + String.join(",*:", indexName);
         } else {
             return "FROM " + String.join(",", indexName);
         }
+    }
+
+    @Override
+    public Map<String, Object> runEsql(RestEsqlTestCase.RequestObjectBuilder requestObject) throws IOException {
+        requestObject.includeCCSMetadata(true);
+        return super.runEsql(requestObject);
     }
 
     @After
@@ -89,4 +107,35 @@ public class RequestIndexFilteringIT extends RequestIndexFilteringTestCase {
             assertEquals(404, re.getResponse().getStatusLine().getStatusCode());
         }
     }
+
+    private MapMatcher getClustersMetadataMatcher() {
+        MapMatcher mapMatcher = matchesMap();
+        mapMatcher = mapMatcher.entry("running", 0);
+        mapMatcher = mapMatcher.entry("total", 1);
+        mapMatcher = mapMatcher.entry("failed", 0);
+        mapMatcher = mapMatcher.entry("partial", 0);
+        mapMatcher = mapMatcher.entry("successful", 1);
+        mapMatcher = mapMatcher.entry("skipped", 0);
+        mapMatcher = mapMatcher.entry(
+            "details",
+            matchesMap().entry(
+                Clusters.REMOTE_CLUSTER_NAME,
+                matchesMap().entry("_shards", matchesMap().extraOk())
+                    .entry("took", greaterThanOrEqualTo(0))
+                    .entry("indices", instanceOf(String.class))
+                    .entry("status", "successful")
+            )
+        );
+        return mapMatcher;
+    }
+
+    @Override
+    protected void assertQueryResult(Map<String, Object> result, Matcher<?> columnMatcher, Matcher<?> valuesMatcher) {
+        var matcher = getResultMatcher(result).entry("columns", columnMatcher).entry("values", valuesMatcher);
+        if (isCCSRequest) {
+            matcher = matcher.entry("_clusters", getClustersMetadataMatcher());
+        }
+        assertMap(result, matcher);
+    }
+
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Add metadata checking to RequestIndexFilteringIT (#122322)](https://github.com/elastic/elasticsearch/pull/122322)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)