### PR TITLE
Fix listener leak in exchange service

### DIFF
--- a/docs/changelog/122417.yaml
+++ b/docs/changelog/122417.yaml
@@ -2,4 +2,5 @@ pr: 122417
 summary: Fix listener leak in exchange service
 area: ES|QL
 type: bug
-issues: []
+issues:
+ - 122271

--- a/docs/changelog/122417.yaml
+++ b/docs/changelog/122417.yaml
@@ -1,0 +1,5 @@
+pr: 122417
+summary: Fix listener leak in exchange service
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/EsqlRefCountingListener.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/EsqlRefCountingListener.java
@@ -34,7 +34,8 @@ public final class EsqlRefCountingListener implements Releasable {
     }
 
     public ActionListener<Void> acquire() {
-        return refs.acquireListener().delegateResponse((l, e) -> {
+        var listener = ActionListener.assertAtLeastOnce(refs.acquireListener());
+        return listener.delegateResponse((l, e) -> {
             failureCollector.unwrapAndCollect(e);
             l.onFailure(e);
         });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
@@ -47,7 +47,8 @@ final class ComputeListener implements Releasable {
      * Acquires a new listener that doesn't collect result
      */
     ActionListener<Void> acquireAvoid() {
-        return refs.acquire().delegateResponse((l, e) -> {
+        var listener = ActionListener.assertAtLeastOnce(refs.acquire());
+        return listener.delegateResponse((l, e) -> {
             try {
                 runOnFailure.run();
             } finally {


### PR DESCRIPTION
If we hit the circuit breaker exception before fetching pages, we fail to notify the listener.

Closes #122271