### PR TITLE
Improve size limiting string message

### DIFF
--- a/docs/changelog/122427.yaml
+++ b/docs/changelog/122427.yaml
@@ -1,0 +1,5 @@
+pr: 122427
+summary: Improve size limiting string message
+area: Infra/Core
+type: enhancement
+issues: []

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
@@ -423,7 +423,7 @@ public class MustacheScriptEngineTests extends ESTestCase {
             ex.getCause().getCause(),
             allOf(
                 instanceOf(SizeLimitingStringWriter.SizeLimitExceededException.class),
-                transformedMatch(Throwable::getMessage, endsWith("has exceeded the size limit [1024]"))
+                transformedMatch(Throwable::getMessage, endsWith("has size [1030] which exceeds the size limit [1024]"))
             )
         );
     }

--- a/server/src/test/java/org/elasticsearch/common/text/SizeLimitingStringWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/text/SizeLimitingStringWriterTests.java
@@ -11,6 +11,8 @@ package org.elasticsearch.common.text;
 
 import org.elasticsearch.test.ESTestCase;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class SizeLimitingStringWriterTests extends ESTestCase {
     public void testSizeIsLimited() {
         SizeLimitingStringWriter writer = new SizeLimitingStringWriter(10);
@@ -25,5 +27,12 @@ public class SizeLimitingStringWriterTests extends ESTestCase {
         expectThrows(SizeLimitingStringWriter.SizeLimitExceededException.class, () -> writer.append('a'));
         expectThrows(SizeLimitingStringWriter.SizeLimitExceededException.class, () -> writer.append("a"));
         expectThrows(SizeLimitingStringWriter.SizeLimitExceededException.class, () -> writer.append("a", 0, 1));
+    }
+
+    public void testLimitMessage() {
+        SizeLimitingStringWriter writer = new SizeLimitingStringWriter(3);
+
+        var e = expectThrows(SizeLimitingStringWriter.SizeLimitExceededException.class, () -> writer.write("abcdefgh"));
+        assertThat(e.getMessage(), equalTo("String [abc...] has size [8] which exceeds the size limit [3]"));
     }
 }


### PR DESCRIPTION
SizeLimitingStringWriter is used to limit the output size of mustache scripts. When the size is limited, the resulting exception lacks detail needed to identify the problem. In particular, the actual size that would result is not given. Additionally, the excerpt lacks any of the new string being added. This commit tweaks the exception to include both of these details.