### PR TITLE
Removed trailing comma on docs

### DIFF
--- a/docs/reference/search/search-your-data/semantic-text-hybrid-search
+++ b/docs/reference/search/search-your-data/semantic-text-hybrid-search
@@ -24,7 +24,7 @@ PUT semantic-embeddings
   "mappings": {
     "properties": {
       "semantic_text": { <1>
-        "type": "semantic_text", 
+        "type": "semantic_text"
       },
       "content": { <2>
         "type": "text",


### PR DESCRIPTION
When this example was copy/pasted onto the console it was throwing a 'Bad string' error on the editor