### PR TITLE
[8.x][Failure store] Remove ::* selector (#121900)

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -179,7 +179,7 @@ public class TransportVersions {
     public static final TransportVersion INFERENCE_REQUEST_ADAPTIVE_RATE_LIMITING = def(8_839_0_00);
     public static final TransportVersion ML_INFERENCE_IBM_WATSONX_RERANK_ADDED = def(8_840_0_00);
     public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED_BACKPORT_8_X = def(8_840_0_01);
-    public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR = def(8_841_0_00);
+    public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR_BACKPORT_8_X = def(8_840_0_02);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -179,6 +179,7 @@ public class TransportVersions {
     public static final TransportVersion INFERENCE_REQUEST_ADAPTIVE_RATE_LIMITING = def(8_839_0_00);
     public static final TransportVersion ML_INFERENCE_IBM_WATSONX_RERANK_ADDED = def(8_840_0_00);
     public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED_BACKPORT_8_X = def(8_840_0_01);
+    public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR = def(8_841_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -646,10 +646,6 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                             : switch (resolvedExpression.selector()) {
                                 case DATA -> dataStream.getDataComponent().getIndices().stream();
                                 case FAILURES -> dataStream.getFailureIndices().stream();
-                                case ALL_APPLICABLE -> Stream.concat(
-                                    dataStream.getIndices().stream(),
-                                    dataStream.getFailureIndices().stream()
-                                );
                             };
                         String[] backingIndices = dataStreamIndices.map(Index::getName).toArray(String[]::new);
                         dataStreams.add(new ResolvedDataStream(dataStream.getName(), backingIndices, DataStream.TIMESTAMP_FIELD_NAME));
@@ -669,13 +665,6 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                     case FAILURES -> {
                         assert ia.isDataStreamRelated() : "Illegal selector [failures] used on non data stream alias";
                         yield ia.getFailureIndices(metadata).stream();
-                    }
-                    case ALL_APPLICABLE -> {
-                        if (ia.isDataStreamRelated()) {
-                            yield Stream.concat(ia.getIndices().stream(), ia.getFailureIndices(metadata).stream());
-                        } else {
-                            yield ia.getIndices().stream();
-                        }
                     }
                 };
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
@@ -13,15 +13,14 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
-import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.SelectorResolver;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
@@ -149,14 +148,12 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
             );
         }
 
+        // Ensure we have a valid selector in the request
         if (rolloverTarget != null) {
-            ResolvedExpression resolvedExpression = SelectorResolver.parseExpression(rolloverTarget, indicesOptions);
-            IndexComponentSelector selector = resolvedExpression.selector();
-            if (IndexComponentSelector.ALL_APPLICABLE.equals(selector)) {
-                validationException = addValidationError(
-                    "rollover cannot be applied to both regular and failure indices at the same time",
-                    validationException
-                );
+            try {
+                SelectorResolver.parseExpression(rolloverTarget, indicesOptions);
+            } catch (InvalidIndexNameException exception) {
+                validationException = addValidationError(exception.getMessage(), validationException);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.action.support;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -23,14 +24,11 @@ import java.util.Map;
  * We define as index components the two different sets of indices a data stream could consist of:
  * - DATA: represents the backing indices
  * - FAILURES: represent the failing indices
- * - ALL: represents all available in this expression components, meaning if it's a data stream both backing and failure indices and if it's
- * an index only the index itself.
  * Note: An index is its own DATA component, but it cannot have a FAILURE component.
  */
 public enum IndexComponentSelector implements Writeable {
     DATA("data", (byte) 0),
-    FAILURES("failures", (byte) 1),
-    ALL_APPLICABLE("*", (byte) 2);
+    FAILURES("failures", (byte) 1);
 
     private final String key;
     private final byte id;
@@ -75,7 +73,13 @@ public enum IndexComponentSelector implements Writeable {
     }
 
     public static IndexComponentSelector read(StreamInput in) throws IOException {
-        return getById(in.readByte());
+        byte id = in.readByte();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR)) {
+            return getById(id);
+        } else {
+            // Legacy value ::*, converted to ::data
+            return id == 2 ? DATA : getById(id);
+        }
     }
 
     // Visible for testing
@@ -95,10 +99,10 @@ public enum IndexComponentSelector implements Writeable {
     }
 
     public boolean shouldIncludeData() {
-        return this == ALL_APPLICABLE || this == DATA;
+        return this == DATA;
     }
 
     public boolean shouldIncludeFailures() {
-        return this == ALL_APPLICABLE || this == FAILURES;
+        return this == FAILURES;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
@@ -74,7 +74,7 @@ public enum IndexComponentSelector implements Writeable {
 
     public static IndexComponentSelector read(StreamInput in) throws IOException {
         byte id = in.readByte();
-        if (in.getTransportVersion().onOrAfter(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR_BACKPORT_8_X)) {
             return getById(id);
         } else {
             // Legacy value ::*, converted to ::data

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -364,21 +364,9 @@ public class IndexNameExpressionResolver {
                 }
             } else {
                 if (isExclusion) {
-                    if (IndexComponentSelector.ALL_APPLICABLE.equals(selector)) {
-                        resources.remove(new ResolvedExpression(baseExpression, IndexComponentSelector.DATA));
-                        resources.remove(new ResolvedExpression(baseExpression, IndexComponentSelector.FAILURES));
-                    } else {
-                        resources.remove(new ResolvedExpression(baseExpression, selector));
-                    }
+                    resources.remove(new ResolvedExpression(baseExpression, selector));
                 } else if (ensureAliasOrIndexExists(context, baseExpression, selector)) {
-                    if (IndexComponentSelector.ALL_APPLICABLE.equals(selector)) {
-                        resources.add(new ResolvedExpression(baseExpression, IndexComponentSelector.DATA));
-                        if (context.getState().getMetadata().getIndicesLookup().get(baseExpression).isDataStreamRelated()) {
-                            resources.add(new ResolvedExpression(baseExpression, IndexComponentSelector.FAILURES));
-                        }
-                    } else {
-                        resources.add(new ResolvedExpression(baseExpression, selector));
-                    }
+                    resources.add(new ResolvedExpression(baseExpression, selector));
                 }
             }
         }
@@ -1046,8 +1034,7 @@ public class IndexNameExpressionResolver {
 
     private static boolean resolvedExpressionsContainsAbstraction(Set<ResolvedExpression> resolvedExpressions, String abstractionName) {
         return resolvedExpressions.contains(new ResolvedExpression(abstractionName))
-            || resolvedExpressions.contains(new ResolvedExpression(abstractionName, IndexComponentSelector.DATA))
-            || resolvedExpressions.contains(new ResolvedExpression(abstractionName, IndexComponentSelector.ALL_APPLICABLE));
+            || resolvedExpressions.contains(new ResolvedExpression(abstractionName, IndexComponentSelector.DATA));
     }
 
     /**
@@ -1342,8 +1329,7 @@ public class IndexNameExpressionResolver {
         if (context.options.allowSelectors()) {
             // Ensure that the selectors are present and that they are compatible with the abstractions they are used with
             assert selector != null : "Earlier logic should have parsed selectors or added the default selectors already";
-            // Check if ::failures has been explicitly requested, since requesting ::* for non-data-stream abstractions would just
-            // return their data components.
+            // Check if ::failures has been explicitly requested
             if (IndexComponentSelector.FAILURES.equals(selector) && indexAbstraction.isDataStreamRelated() == false) {
                 // If requested abstraction is not data stream related, then you cannot use ::failures
                 if (ignoreUnavailable) {
@@ -1700,9 +1686,9 @@ public class IndexNameExpressionResolver {
             final IndexMetadata.State excludeState = excludeState(context.getOptions());
             Set<ResolvedExpression> resources = new HashSet<>();
             if (context.isPreserveAliases() && indexAbstraction.getType() == Type.ALIAS) {
-                expandToApplicableSelectors(indexAbstraction, selector, resources);
+                resources.add(new ResolvedExpression(indexAbstraction.getName(), selector));
             } else if (context.isPreserveDataStreams() && indexAbstraction.getType() == Type.DATA_STREAM) {
-                expandToApplicableSelectors(indexAbstraction, selector, resources);
+                resources.add(new ResolvedExpression(indexAbstraction.getName(), selector));
             } else {
                 if (shouldIncludeRegularIndices(context.getOptions(), selector)) {
                     for (int i = 0, n = indexAbstraction.getIndices().size(); i < n; i++) {
@@ -1727,31 +1713,6 @@ public class IndexNameExpressionResolver {
                 }
             }
             return resources;
-        }
-
-        /**
-         * Adds the abstraction and selector to the results when preserving data streams and aliases at wildcard resolution. If a selector
-         * is provided, the result is only added if the selector is applicable to the abstraction provided. If
-         * {@link IndexComponentSelector#ALL_APPLICABLE} is given, the selectors are expanded only to those which are applicable to the
-         * provided abstraction.
-         * @param indexAbstraction abstraction to add
-         * @param selector The selector to add
-         * @param resources Result collector which is updated with all applicable resolved expressions for a given abstraction and selector
-         *                  pair.
-         */
-        private static void expandToApplicableSelectors(
-            IndexAbstraction indexAbstraction,
-            IndexComponentSelector selector,
-            Set<ResolvedExpression> resources
-        ) {
-            if (IndexComponentSelector.ALL_APPLICABLE.equals(selector)) {
-                resources.add(new ResolvedExpression(indexAbstraction.getName(), IndexComponentSelector.DATA));
-                if (indexAbstraction.isDataStreamRelated()) {
-                    resources.add(new ResolvedExpression(indexAbstraction.getName(), IndexComponentSelector.FAILURES));
-                }
-            } else if (selector == null || indexAbstraction.isDataStreamRelated() || selector.shouldIncludeFailures() == false) {
-                resources.add(new ResolvedExpression(indexAbstraction.getName(), selector));
-            }
         }
 
         private static List<ResolvedExpression> resolveEmptyOrTrivialWildcard(Context context, IndexComponentSelector selector) {
@@ -2150,20 +2111,10 @@ public class IndexNameExpressionResolver {
                 String suffix = expression.substring(lastDoubleColon + SELECTOR_SEPARATOR.length());
                 IndexComponentSelector selector = IndexComponentSelector.getByKey(suffix);
                 if (selector == null) {
-                    // Do some work to surface a helpful error message for likely errors
-                    if (Regex.isSimpleMatchPattern(suffix)) {
-                        throw new InvalidIndexNameException(
-                            expression,
-                            "Invalid usage of :: separator, ["
-                                + suffix
-                                + "] contains a wildcard, but only the match all wildcard [*] is supported in a selector"
-                        );
-                    } else {
-                        throw new InvalidIndexNameException(
-                            expression,
-                            "Invalid usage of :: separator, [" + suffix + "] is not a recognized selector"
-                        );
-                    }
+                    throw new InvalidIndexNameException(
+                        expression,
+                        "invalid usage of :: separator, [" + suffix + "] is not a recognized selector"
+                    );
                 }
                 String expressionBase = expression.substring(0, lastDoubleColon);
                 ensureNoMoreSelectorSeparators(expressionBase, expression);

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
@@ -157,15 +157,15 @@ public abstract class RemoteClusterAware {
                     if (indexName.equals("*") == false) {
                         throw new IllegalArgumentException(
                             Strings.format(
-                                "To exclude a cluster you must specify the '*' wildcard for " + "the index expression, but found: [%s]",
+                                "To exclude a cluster you must specify the '*' wildcard for the index expression, but found: [%s]",
                                 indexName
                             )
                         );
                     }
-                    if (selectorString != null && selectorString.equals("*") == false) {
+                    if (selectorString != null) {
                         throw new IllegalArgumentException(
                             Strings.format(
-                                "To exclude a cluster you must specify the '::*' selector or leave it off, but found: [%s]",
+                                "To exclude a cluster you must not specify the a selector, but found selector: [%s]",
                                 selectorString
                             )
                         );

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
@@ -256,7 +256,7 @@ public class RolloverRequestTests extends ESTestCase {
             assertNotNull(validationException);
             assertEquals(1, validationException.validationErrors().size());
             assertEquals(
-                "rollover cannot be applied to both regular and failure indices at the same time",
+                "Invalid index name [alias-index::*], invalid usage of :: separator, [*] is not a recognized selector",
                 validationException.validationErrors().get(0)
             );
         }

--- a/server/src/test/java/org/elasticsearch/action/support/IndexComponentSelectorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/IndexComponentSelectorTests.java
@@ -20,7 +20,7 @@ public class IndexComponentSelectorTests extends ESTestCase {
     public void testIndexComponentSelectorFromKey() {
         assertThat(IndexComponentSelector.getByKey("data"), equalTo(IndexComponentSelector.DATA));
         assertThat(IndexComponentSelector.getByKey("failures"), equalTo(IndexComponentSelector.FAILURES));
-        assertThat(IndexComponentSelector.getByKey("*"), equalTo(IndexComponentSelector.ALL_APPLICABLE));
+        assertThat(IndexComponentSelector.getByKey("*"), nullValue());
         assertThat(IndexComponentSelector.getByKey("d*ta"), nullValue());
         assertThat(IndexComponentSelector.getByKey("_all"), nullValue());
         assertThat(IndexComponentSelector.getByKey("**"), nullValue());
@@ -30,11 +30,10 @@ public class IndexComponentSelectorTests extends ESTestCase {
     public void testIndexComponentSelectorFromId() {
         assertThat(IndexComponentSelector.getById((byte) 0), equalTo(IndexComponentSelector.DATA));
         assertThat(IndexComponentSelector.getById((byte) 1), equalTo(IndexComponentSelector.FAILURES));
-        assertThat(IndexComponentSelector.getById((byte) 2), equalTo(IndexComponentSelector.ALL_APPLICABLE));
-        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> IndexComponentSelector.getById((byte) 3));
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> IndexComponentSelector.getById((byte) 2));
         assertThat(
             exception.getMessage(),
-            containsString("Unknown id of index component selector [3], available options are: {0=DATA, 1=FAILURES, 2=ALL_APPLICABLE}")
+            containsString("Unknown id of index component selector [2], available options are: {0=DATA, 1=FAILURES}")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolverTests.java
@@ -81,11 +81,8 @@ public class IndexAbstractionResolverTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> resolveAbstractionsSelectorNotAllowed(List.of("index1::data")));
         // Selectors allowed, valid selector given, data selector stripped off in result since it is the default
         assertThat(resolveAbstractionsSelectorAllowed(List.of("index1::data")), contains("index1"));
-        // Selectors allowed, wildcard selector provided, data selector stripped off in result since it is the default
-        // ** only returns ::data since expression is an index
-        assertThat(resolveAbstractionsSelectorAllowed(List.of("index1::*")), contains("index1"));
         // Selectors allowed, invalid selector given
-        expectThrows(InvalidIndexNameException.class, () -> resolveAbstractionsSelectorAllowed(List.of("index1::custom")));
+        expectThrows(InvalidIndexNameException.class, () -> resolveAbstractionsSelectorAllowed(List.of("index1::*")));
 
         // == Single Date Math Expressions ==
 
@@ -125,7 +122,7 @@ public class IndexAbstractionResolverTests extends ESTestCase {
         assertThat(resolveAbstractionsSelectorAllowed(List.of("index*::data")), containsInAnyOrder("index1", "index2"));
         // Selectors allowed, wildcard selector provided, data selector stripped off in result since it is the default
         // ** only returns ::data since expression is an index
-        assertThat(resolveAbstractionsSelectorAllowed(List.of("index*::*")), containsInAnyOrder("index1", "index2"));
+        assertThat(resolveAbstractionsSelectorAllowed(List.of("index*")), containsInAnyOrder("index1", "index2"));
         // Selectors allowed, invalid selector given
         expectThrows(InvalidIndexNameException.class, () -> resolveAbstractionsSelectorAllowed(List.of("index*::custom")));
 
@@ -137,11 +134,9 @@ public class IndexAbstractionResolverTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> resolveAbstractionsSelectorNotAllowed(List.of("data-stream1::data")));
         // Selectors allowed, valid selector given
         assertThat(resolveAbstractionsSelectorAllowed(List.of("data-stream1::failures")), contains("data-stream1::failures"));
-        // Selectors allowed, wildcard selector provided
-        // ** returns both ::data and ::failures since expression is a data stream
-        // ** data selector stripped off in result since it is the default
+        // Selectors allowed, data selector is not added in result since it is the default
         assertThat(
-            resolveAbstractionsSelectorAllowed(List.of("data-stream1::*")),
+            resolveAbstractionsSelectorAllowed(List.of("data-stream1", "data-stream1::failures")),
             containsInAnyOrder("data-stream1", "data-stream1::failures")
         );
         // Selectors allowed, invalid selector given
@@ -155,10 +150,9 @@ public class IndexAbstractionResolverTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> resolveAbstractionsSelectorNotAllowed(List.of("data-stream*::data")));
         // Selectors allowed, valid selector given
         assertThat(resolveAbstractionsSelectorAllowed(List.of("data-stream*::failures")), contains("data-stream1::failures"));
-        // Selectors allowed, wildcard selector provided
-        // ** returns both ::data and ::failures since expression is a data stream
+        // Selectors allowed, both ::data and ::failures are returned
         assertThat(
-            resolveAbstractionsSelectorAllowed(List.of("data-stream*::*")),
+            resolveAbstractionsSelectorAllowed(List.of("data-stream*", "data-stream*::failures")),
             containsInAnyOrder("data-stream1", "data-stream1::failures")
         );
         // Selectors allowed, invalid selector given
@@ -179,7 +173,7 @@ public class IndexAbstractionResolverTests extends ESTestCase {
         // Selectors allowed, wildcard selector provided
         // ** returns both ::data and ::failures for applicable abstractions
         assertThat(
-            resolveAbstractionsSelectorAllowed(List.of("*::*")),
+            resolveAbstractionsSelectorAllowed(List.of("*", "*::failures")),
             containsInAnyOrder("index1", "index2", "data-stream1", "data-stream1::failures")
         );
         // Selectors allowed, invalid selector given
@@ -194,11 +188,11 @@ public class IndexAbstractionResolverTests extends ESTestCase {
         // Selectors allowed, wildcard selector provided
         // ** returns both ::data and ::failures for applicable abstractions
         // ** limits the returned values based on selectors
-        assertThat(resolveAbstractionsSelectorAllowed(List.of("*::*", "-*::data")), contains("data-stream1::failures"));
+        assertThat(resolveAbstractionsSelectorAllowed(List.of("*", "*::failures", "-*::data")), contains("data-stream1::failures"));
         // Selectors allowed, wildcard selector provided
         // ** limits the returned values based on selectors
         assertThat(
-            resolveAbstractionsSelectorAllowed(List.of("*::*", "-*::failures")),
+            resolveAbstractionsSelectorAllowed(List.of("*", "*::failures", "-*::failures")),
             containsInAnyOrder("index1", "index2", "data-stream1")
         );
         // Selectors allowed, none given, default to both selectors

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/SelectorResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/SelectorResolverTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.test.ESTestCase;
 
-import static org.elasticsearch.action.support.IndexComponentSelector.ALL_APPLICABLE;
 import static org.elasticsearch.action.support.IndexComponentSelector.DATA;
 import static org.elasticsearch.action.support.IndexComponentSelector.FAILURES;
 import static org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.Context;
@@ -38,7 +37,6 @@ public class SelectorResolverTests extends ESTestCase {
         assertThat(resolve(selectorsAllowed, "testXXX"), equalTo(new ResolvedExpression("testXXX", DATA)));
         assertThat(resolve(selectorsAllowed, "testXXX::data"), equalTo(new ResolvedExpression("testXXX", DATA)));
         assertThat(resolve(selectorsAllowed, "testXXX::failures"), equalTo(new ResolvedExpression("testXXX", FAILURES)));
-        assertThat(resolve(selectorsAllowed, "testXXX::*"), equalTo(new ResolvedExpression("testXXX", ALL_APPLICABLE)));
 
         // Disallow selectors (example: creating, modifying, or deleting indices/data streams/aliases).
         // Accepts standard expressions but throws when selectors are specified.
@@ -47,7 +45,6 @@ public class SelectorResolverTests extends ESTestCase {
         assertThat(resolve(noSelectors, "testXXX"), equalTo(new ResolvedExpression("testXXX")));
         expectThrows(IllegalArgumentException.class, () -> resolve(noSelectors, "testXXX::data"));
         expectThrows(IllegalArgumentException.class, () -> resolve(noSelectors, "testXXX::failures"));
-        expectThrows(IllegalArgumentException.class, () -> resolve(noSelectors, "testXXX::*"));
 
         // === Errors
         // Only recognized components can be selected
@@ -116,9 +113,7 @@ public class SelectorResolverTests extends ESTestCase {
         assertThat(IndexNameExpressionResolver.combineSelectorExpression("a", null), is(equalTo("a")));
         assertThat(IndexNameExpressionResolver.combineSelectorExpression("a", ""), is(equalTo("a::")));
         assertThat(IndexNameExpressionResolver.combineSelectorExpression("a", "b"), is(equalTo("a::b")));
-        assertThat(IndexNameExpressionResolver.combineSelectorExpression("a", "*"), is(equalTo("a::*")));
         assertThat(IndexNameExpressionResolver.combineSelectorExpression("*", "b"), is(equalTo("*::b")));
-        assertThat(IndexNameExpressionResolver.combineSelectorExpression("*", "*"), is(equalTo("*::*")));
     }
 
     public void testHasSelectorSuffix() {
@@ -151,14 +146,14 @@ public class SelectorResolverTests extends ESTestCase {
 
         assertThat(IndexNameExpressionResolver.splitSelectorExpression("a::data"), is(equalTo(new Tuple<>("a", "data"))));
         assertThat(IndexNameExpressionResolver.splitSelectorExpression("a::failures"), is(equalTo(new Tuple<>("a", "failures"))));
-        assertThat(IndexNameExpressionResolver.splitSelectorExpression("a::*"), is(equalTo(new Tuple<>("a", "*"))));
+        expectThrows(InvalidIndexNameException.class, () -> IndexNameExpressionResolver.splitSelectorExpression("a::*"));
         expectThrows(InvalidIndexNameException.class, () -> IndexNameExpressionResolver.splitSelectorExpression("a::random"));
         expectThrows(InvalidIndexNameException.class, () -> IndexNameExpressionResolver.splitSelectorExpression("a::d*ta"));
         expectThrows(InvalidIndexNameException.class, () -> IndexNameExpressionResolver.splitSelectorExpression("a::*ailures"));
         expectThrows(InvalidIndexNameException.class, () -> IndexNameExpressionResolver.splitSelectorExpression("a::"));
         expectThrows(InvalidIndexNameException.class, () -> IndexNameExpressionResolver.splitSelectorExpression("a::**"));
         expectThrows(InvalidIndexNameException.class, () -> IndexNameExpressionResolver.splitSelectorExpression("index::data::*"));
-        assertThat(IndexNameExpressionResolver.splitSelectorExpression("::*"), is(equalTo(new Tuple<>("", "*"))));
+        expectThrows(InvalidIndexNameException.class, () -> IndexNameExpressionResolver.splitSelectorExpression("::*"));
     }
 
     private static IndicesOptions getOptionsForSelectors() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.action.support.IndexComponentSelector.ALL_APPLICABLE;
 import static org.elasticsearch.action.support.IndexComponentSelector.DATA;
 import static org.elasticsearch.action.support.IndexComponentSelector.FAILURES;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createBackingIndex;
@@ -54,19 +53,19 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             SystemIndexAccessLevel.NONE
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "ku*", ALL_APPLICABLE)),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "ku*", DATA)),
             equalTo(resolvedExpressionsSet("kuku"))
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "test*", ALL_APPLICABLE)),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "test*", DATA)),
             equalTo(resolvedExpressionsSet("testXXX", "testXYY", "testYYY"))
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "testX*", ALL_APPLICABLE)),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "testX*", DATA)),
             equalTo(resolvedExpressionsSet("testXXX", "testXYY"))
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "*", ALL_APPLICABLE)),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "*", DATA)),
             equalTo(resolvedExpressionsSet("testXXX", "testXYY", "testYYY", "kuku"))
         );
     }
@@ -87,7 +86,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             SystemIndexAccessLevel.NONE
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "testX*", ALL_APPLICABLE)),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "testX*", DATA)),
             equalTo(resolvedExpressionsSet("testXXX", "testXXY", "testXYY"))
         );
         context = new IndexNameExpressionResolver.Context(
@@ -96,7 +95,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             SystemIndexAccessLevel.NONE
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "testX*", ALL_APPLICABLE)),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "testX*", DATA)),
             equalTo(resolvedExpressionsSet("testXYY"))
         );
         context = new IndexNameExpressionResolver.Context(
@@ -105,7 +104,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             SystemIndexAccessLevel.NONE
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "testX*", ALL_APPLICABLE)),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "testX*", DATA)),
             equalTo(resolvedExpressionsSet("testXXX", "testXXY"))
         );
     }
@@ -128,31 +127,27 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             SystemIndexAccessLevel.NONE
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "test*X*", ALL_APPLICABLE)),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "test*X*", DATA)),
             equalTo(resolvedExpressionsSet("testXXX", "testXXY", "testXYY"))
         );
         assertThat(
-            newHashSet(
-                IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "test*X*Y", ALL_APPLICABLE)
-            ),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "test*X*Y", DATA)),
             equalTo(resolvedExpressionsSet("testXXY", "testXYY"))
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "kuku*Y*", ALL_APPLICABLE)),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "kuku*Y*", DATA)),
             equalTo(resolvedExpressionsSet("kukuYYY"))
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "*Y*", ALL_APPLICABLE)),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "*Y*", DATA)),
             equalTo(resolvedExpressionsSet("testXXY", "testXYY", "testYYY", "kukuYYY"))
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "test*Y*X", ALL_APPLICABLE))
-                .size(),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "test*Y*X", DATA)).size(),
             equalTo(0)
         );
         assertThat(
-            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "*Y*X", ALL_APPLICABLE))
-                .size(),
+            newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(context, "*Y*X", DATA)).size(),
             equalTo(0)
         );
     }
@@ -171,7 +166,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 SystemIndexAccessLevel.NONE
             );
             assertThat(
-                newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, ALL_APPLICABLE)),
+                newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, DATA)),
                 equalTo(resolvedExpressionsSet("testXXX", "testXYY", "testYYY"))
             );
         }
@@ -189,7 +184,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 SystemIndexAccessLevel.NONE
             );
             assertThat(
-                newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, null)),
+                newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, DATA)),
                 equalTo(resolvedExpressionsNoSelectorSet("testXXX", "testXYY", "testYYY"))
             );
         }
@@ -212,10 +207,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 IndicesOptions.lenientExpandOpen(), // don't include hidden
                 SystemIndexAccessLevel.NONE
             );
-            assertThat(
-                newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, ALL_APPLICABLE)),
-                equalTo(newHashSet())
-            );
+            assertThat(newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, DATA)), equalTo(newHashSet()));
         }
 
         {
@@ -235,7 +227,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 SystemIndexAccessLevel.NONE
             );
             assertThat(
-                newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, ALL_APPLICABLE)),
+                newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, DATA)),
                 equalTo(resolvedExpressionsSet("index-visible-alias"))
             );
         }
@@ -290,13 +282,8 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 equalTo(resolvedExpressionsSet(DataStream.getDefaultBackingIndexName("foo_logs", 1, epochMillis)))
             );
             assertThat(
-                newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, ALL_APPLICABLE)),
-                equalTo(
-                    resolvedExpressionsSet(
-                        DataStream.getDefaultBackingIndexName("foo_logs", 1, epochMillis),
-                        DataStream.getDefaultFailureStoreName("foo_logs", 1, epochMillis)
-                    )
-                )
+                newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, FAILURES)),
+                equalTo(resolvedExpressionsSet(DataStream.getDefaultFailureStoreName("foo_logs", 1, epochMillis)))
             );
         }
 
@@ -328,10 +315,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             );
 
             assertThat(newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, DATA)), equalTo(Set.of()));
-            assertThat(
-                newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, ALL_APPLICABLE)),
-                equalTo(Set.of())
-            );
+            assertThat(newHashSet(IndexNameExpressionResolver.WildcardExpressionResolver.resolveAll(context, FAILURES)), equalTo(Set.of()));
         }
     }
 
@@ -455,7 +439,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             Collection<ResolvedExpression> indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
                 indicesAndAliasesContext,
                 "foo_a*",
-                ALL_APPLICABLE
+                DATA
             );
             assertThat(indices, containsInAnyOrder(new ResolvedExpression("foo_index", DATA), new ResolvedExpression("bar_index", DATA)));
         }
@@ -463,7 +447,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             Collection<ResolvedExpression> indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
                 skipAliasesLenientContext,
                 "foo_a*",
-                ALL_APPLICABLE
+                DATA
             );
             assertEquals(0, indices.size());
         }
@@ -471,7 +455,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             Set<ResolvedExpression> indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
                 skipAliasesStrictContext,
                 "foo_a*",
-                ALL_APPLICABLE
+                DATA
             );
             assertThat(indices, empty());
         }
@@ -479,7 +463,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             Collection<ResolvedExpression> indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
                 indicesAndAliasesContext,
                 "foo*",
-                ALL_APPLICABLE
+                DATA
             );
             assertThat(
                 indices,
@@ -494,7 +478,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             Collection<ResolvedExpression> indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
                 skipAliasesLenientContext,
                 "foo*",
-                ALL_APPLICABLE
+                DATA
             );
             assertThat(indices, containsInAnyOrder(new ResolvedExpression("foo_foo", DATA), new ResolvedExpression("foo_index", DATA)));
         }
@@ -502,7 +486,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             Collection<ResolvedExpression> indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
                 skipAliasesStrictContext,
                 "foo*",
-                ALL_APPLICABLE
+                DATA
             );
             assertThat(indices, containsInAnyOrder(new ResolvedExpression("foo_foo", DATA), new ResolvedExpression("foo_index", DATA)));
         }
@@ -556,7 +540,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             Collection<ResolvedExpression> indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
                 indicesAndAliasesContext,
                 "foo_*",
-                ALL_APPLICABLE
+                DATA
             );
             assertThat(
                 indices,
@@ -571,7 +555,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
                 indicesAndAliasesContext,
                 "bar_*",
-                ALL_APPLICABLE
+                DATA
             );
             assertThat(indices, containsInAnyOrder(new ResolvedExpression("bar_bar", DATA), new ResolvedExpression("bar_index", DATA)));
         }
@@ -602,7 +586,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             Collection<ResolvedExpression> indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
                 indicesAliasesAndDataStreamsContext,
                 "foo_*",
-                ALL_APPLICABLE
+                DATA
             );
             assertThat(
                 indices,
@@ -611,9 +595,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                     new ResolvedExpression("bar_index", DATA),
                     new ResolvedExpression("foo_foo", DATA),
                     new ResolvedExpression(DataStream.getDefaultBackingIndexName("foo_logs", 1, epochMillis), DATA),
-                    new ResolvedExpression(DataStream.getDefaultBackingIndexName("foo_logs", 2, epochMillis), DATA),
-                    new ResolvedExpression(DataStream.getDefaultFailureStoreName("foo_logs", 1, epochMillis), DATA),
-                    new ResolvedExpression(DataStream.getDefaultFailureStoreName("foo_logs", 2, epochMillis), DATA)
+                    new ResolvedExpression(DataStream.getDefaultBackingIndexName("foo_logs", 2, epochMillis), DATA)
                 )
             );
 
@@ -630,26 +612,6 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                         DataStream.getDefaultFailureStoreName("foo_logs", 1, epochMillis),
                         DataStream.getDefaultFailureStoreName("foo_logs", 2, epochMillis)
                     )
-                )
-            );
-
-            // include all wildcard adds the data stream's backing indices
-            indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
-                indicesAliasesAndDataStreamsContext,
-                "*",
-                ALL_APPLICABLE
-            );
-            assertThat(
-                indices,
-                containsInAnyOrder(
-                    new ResolvedExpression("foo_index", DATA),
-                    new ResolvedExpression("bar_index", DATA),
-                    new ResolvedExpression("foo_foo", DATA),
-                    new ResolvedExpression("bar_bar", DATA),
-                    new ResolvedExpression(DataStream.getDefaultBackingIndexName("foo_logs", 1, epochMillis), DATA),
-                    new ResolvedExpression(DataStream.getDefaultBackingIndexName("foo_logs", 2, epochMillis), DATA),
-                    new ResolvedExpression(DataStream.getDefaultFailureStoreName("foo_logs", 1, epochMillis), DATA),
-                    new ResolvedExpression(DataStream.getDefaultFailureStoreName("foo_logs", 2, epochMillis), DATA)
                 )
             );
         }
@@ -681,7 +643,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
             Collection<ResolvedExpression> indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
                 indicesAliasesDataStreamsAndHiddenIndices,
                 "foo_*",
-                ALL_APPLICABLE
+                DATA
             );
             assertThat(
                 indices,
@@ -690,9 +652,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                     new ResolvedExpression("bar_index", DATA),
                     new ResolvedExpression("foo_foo", DATA),
                     new ResolvedExpression(DataStream.getDefaultBackingIndexName("foo_logs", 1, epochMillis), DATA),
-                    new ResolvedExpression(DataStream.getDefaultBackingIndexName("foo_logs", 2, epochMillis), DATA),
-                    new ResolvedExpression(DataStream.getDefaultFailureStoreName("foo_logs", 1, epochMillis), DATA),
-                    new ResolvedExpression(DataStream.getDefaultFailureStoreName("foo_logs", 2, epochMillis), DATA)
+                    new ResolvedExpression(DataStream.getDefaultBackingIndexName("foo_logs", 2, epochMillis), DATA)
                 )
             );
 
@@ -712,32 +672,11 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 )
             );
 
-            // Resolve both backing and failure indices
-            indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
-                indicesAliasesDataStreamsAndHiddenIndices,
-                "foo_*",
-                ALL_APPLICABLE
-            );
-            assertThat(
-                newHashSet(indices),
-                equalTo(
-                    resolvedExpressionsSet(
-                        "foo_index",
-                        "bar_index",
-                        "foo_foo",
-                        DataStream.getDefaultBackingIndexName("foo_logs", 1, epochMillis),
-                        DataStream.getDefaultBackingIndexName("foo_logs", 2, epochMillis),
-                        DataStream.getDefaultFailureStoreName("foo_logs", 1, epochMillis),
-                        DataStream.getDefaultFailureStoreName("foo_logs", 2, epochMillis)
-                    )
-                )
-            );
-
             // include all wildcard adds the data stream's backing indices
             indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
                 indicesAliasesDataStreamsAndHiddenIndices,
                 "*",
-                ALL_APPLICABLE
+                DATA
             );
             assertThat(
                 newHashSet(indices),
@@ -765,28 +704,6 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 newHashSet(indices),
                 equalTo(
                     resolvedExpressionsSet(
-                        DataStream.getDefaultFailureStoreName("foo_logs", 1, epochMillis),
-                        DataStream.getDefaultFailureStoreName("foo_logs", 2, epochMillis)
-                    )
-                )
-            );
-
-            // include all wildcard adds the data stream's backing and failure indices
-            indices = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
-                indicesAliasesDataStreamsAndHiddenIndices,
-                "*",
-                ALL_APPLICABLE
-            );
-            assertThat(
-                newHashSet(indices),
-                equalTo(
-                    resolvedExpressionsSet(
-                        "foo_index",
-                        "bar_index",
-                        "foo_foo",
-                        "bar_bar",
-                        DataStream.getDefaultBackingIndexName("foo_logs", 1, epochMillis),
-                        DataStream.getDefaultBackingIndexName("foo_logs", 2, epochMillis),
                         DataStream.getDefaultFailureStoreName("foo_logs", 1, epochMillis),
                         DataStream.getDefaultFailureStoreName("foo_logs", 2, epochMillis)
                     )
@@ -824,7 +741,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
         Collection<ResolvedExpression> matches = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
             indicesAndAliasesContext,
             "*",
-            ALL_APPLICABLE
+            DATA
         );
         assertThat(
             matches,
@@ -835,7 +752,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 new ResolvedExpression("bar_index", DATA)
             )
         );
-        matches = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(onlyIndicesContext, "*", ALL_APPLICABLE);
+        matches = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(onlyIndicesContext, "*", DATA);
         assertThat(
             matches,
             containsInAnyOrder(
@@ -845,11 +762,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 new ResolvedExpression("bar_index", DATA)
             )
         );
-        matches = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
-            indicesAndAliasesContext,
-            "foo*",
-            ALL_APPLICABLE
-        );
+        matches = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(indicesAndAliasesContext, "foo*", DATA);
         assertThat(
             matches,
             containsInAnyOrder(
@@ -858,11 +771,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 new ResolvedExpression("bar_index", DATA)
             )
         );
-        matches = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(
-            onlyIndicesContext,
-            "foo*",
-            ALL_APPLICABLE
-        );
+        matches = IndexNameExpressionResolver.WildcardExpressionResolver.matchWildcardToResources(onlyIndicesContext, "foo*", DATA);
         assertThat(matches, containsInAnyOrder(new ResolvedExpression("foo_foo", DATA), new ResolvedExpression("foo_index", DATA)));
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -465,22 +465,6 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         );
     }
 
-    public void testWildcardSelectorsAreNotAllowedInShardLevelRequests() {
-        ShardSearchRequest request = mock(ShardSearchRequest.class);
-        when(request.indices()).thenReturn(new String[] { "index10::*" });
-        IllegalArgumentException exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> defaultIndicesResolver.resolveIndicesAndAliasesWithoutWildcards(TransportSearchAction.TYPE.name() + "[s]", request)
-        );
-        assertThat(
-            exception,
-            throwableWithMessage(
-                "the action indices:data/read/search[s] does not support wildcard selectors;"
-                    + " the provided index expression(s) [index10::*] are not allowed"
-            )
-        );
-    }
-
     public void testAllIsNotAllowedInShardLevelRequests() {
         ShardSearchRequest request = mock(ShardSearchRequest.class);
         final boolean literalAll = randomBoolean();


### PR DESCRIPTION
Backports the following commits to `8.x`:

 - [Failure store] Remove ::* selector (#121900)