### PR TITLE
[8.18] Handling frozen indices in reindex data streams (#122279)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.search.TransportSearchScrollAction;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.core.frozen.action.FreezeIndexAction;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.support.MetadataUtils;
 
@@ -215,6 +216,7 @@ public class InternalUsers {
                         TransportUpdateSettingsAction.TYPE.name(),
                         RefreshAction.NAME,
                         ReindexAction.NAME,
+                        FreezeIndexAction.NAME,
                         TransportSearchAction.NAME,
                         TransportBulkAction.NAME,
                         TransportIndexAction.NAME,

--- a/x-pack/plugin/migrate/build.gradle
+++ b/x-pack/plugin/migrate/build.gradle
@@ -17,6 +17,7 @@ dependencies {
   compileOnly project(path: xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation project(xpackModule('ccr'))
+  testImplementation project(xpackModule('frozen-indices'))
   testImplementation project(':modules:data-streams')
   testImplementation project(path: ':modules:reindex')
   testImplementation project(path: ':modules:ingest-common')

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.migrate.action;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
@@ -38,25 +40,34 @@ import org.elasticsearch.cluster.metadata.MetadataIndexStateService;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.engine.frozen.FrozenEngine;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.ingest.common.IngestCommonPlugin;
+import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.protocol.xpack.frozen.FreezeRequest;
+import org.elasticsearch.protocol.xpack.frozen.FreezeResponse;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.frozen.action.FreezeIndexAction;
+import org.elasticsearch.xpack.frozen.action.TransportFreezeIndexAction;
 import org.elasticsearch.xpack.migrate.MigratePlugin;
 import org.elasticsearch.xpack.migrate.MigrateTemplateRegistry;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -69,6 +80,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitC
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
 
@@ -112,7 +124,8 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
             ReindexPlugin.class,
             MockTransportService.TestPlugin.class,
             DataStreamsPlugin.class,
-            IngestCommonPlugin.class
+            IngestCommonPlugin.class,
+            TestFrozenIndicesPlugin.class
         );
     }
 
@@ -595,6 +608,43 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
         assertHitCount(prepareSearch(destIndex).setSize(0), 1);
     }
 
+    public void testIndexUnfrozen() {
+        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        safeGet(indicesAdmin().create(new CreateIndexRequest(sourceIndex)));
+
+        // add doc with timestamp
+        String time = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(System.currentTimeMillis());
+        var doc = String.format(Locale.ROOT, "{\"%s\":\"%s\"}", DEFAULT_TIMESTAMP_FIELD, time);
+        addDoc(sourceIndex, doc);
+        FreezeRequest freezeRequest = new FreezeRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, sourceIndex);
+        freezeRequest.setFreeze(true);
+        FreezeResponse freezeResponse = safeGet(client().execute(FreezeIndexAction.INSTANCE, freezeRequest));
+        assertAcked(freezeResponse);
+        assertThat(
+            safeGet(admin().indices().getSettings(new GetSettingsRequest().indices(sourceIndex))).getIndexToSettings()
+                .get(sourceIndex)
+                .get(FrozenEngine.INDEX_FROZEN.getKey()),
+            not(equalTo(null))
+        );
+
+        String destIndex = safeGet(
+            client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex))
+        ).getDestIndex();
+
+        assertThat(
+            safeGet(admin().indices().getSettings(new GetSettingsRequest().indices(sourceIndex))).getIndexToSettings()
+                .get(sourceIndex)
+                .get(FrozenEngine.INDEX_FROZEN.getKey()),
+            equalTo(null)
+        );
+        assertThat(
+            safeGet(admin().indices().getSettings(new GetSettingsRequest().indices(destIndex))).getIndexToSettings()
+                .get(destIndex)
+                .get(FrozenEngine.INDEX_FROZEN.getKey()),
+            equalTo(null)
+        );
+    }
+
     private static void cleanupMetadataBlocks(String index) {
         var settings = Settings.builder()
             .putNull(IndexMetadata.SETTING_READ_ONLY)
@@ -633,6 +683,24 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
             ensureGreen(index);
         } else {
             ensureYellow(index);
+        }
+    }
+
+    /*
+     * This takes the place of the real FrozenIndices plugin. We can't use that one because its EngineFactory conflicts with the one used
+     * by this test. We only need the settings and the mapping of the FreezeIndexAction though.
+     */
+    public static class TestFrozenIndicesPlugin extends Plugin implements ActionPlugin {
+        @Override
+        public List<Setting<?>> getSettings() {
+            return Arrays.asList(FrozenEngine.INDEX_FROZEN);
+        }
+
+        @Override
+        public List<ActionPlugin.ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+            List<ActionPlugin.ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>();
+            actions.add(new ActionPlugin.ActionHandler<>(FreezeIndexAction.INSTANCE, TransportFreezeIndexAction.class));
+            return actions;
         }
     }
 }


### PR DESCRIPTION
This handles the case where a data stream has a [frozen index](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/freeze-index-api.html). We unfreeze the source index as the first step in reindexing. Not doing this causes an assertion error:

```
[2025-02-10T17:11:23,246][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [mac.lan] fatal error in thread [elasticsearch[mac.lan][refresh][T#8]], exitingjava.lang.AssertionError: primary has not refreshed
	at org.elasticsearch.server@8.18.0-SNAPSHOT/org.elasticsearch.action.admin.indices.refresh.TransportShardRefreshAction$UnpromotableReplicasRefreshProxy.onPrimaryOperationComplete(TransportShardRefreshAction.java:121)
	at org.elasticsearch.server@8.18.0-SNAPSHOT/org.elasticsearch.action.admin.indices.refresh.TransportShardRefreshAction$UnpromotableReplicasRefreshProxy.onPrimaryOperationComplete(TransportShardRefreshAction.java:113)
	at org.elasticsearch.server@8.18.0-SNAPSHOT/org.elasticsearch.action.support.replication.ReplicationOperation.handlePrimaryResult(ReplicationOperation.java:140)
	at org.elasticsearch.server@8.18.0-SNAPSHOT/org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:257)
	at org.elasticsearch.server@8.18.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$MappedActionListener.onResponse(ActionListenerImplementations.java:97)
```