### PR TITLE
Fix listener leak in exchange service (#122417) (#122454)

### DIFF
--- a/docs/changelog/122417.yaml
+++ b/docs/changelog/122417.yaml
@@ -1,0 +1,6 @@
+pr: 122417
+summary: Fix listener leak in exchange service
+area: ES|QL
+type: bug
+issues:
+ - 122271

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/EsqlRefCountingListener.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/EsqlRefCountingListener.java
@@ -34,7 +34,8 @@ public final class EsqlRefCountingListener implements Releasable {
     }
 
     public ActionListener<Void> acquire() {
-        return refs.acquireListener().delegateResponse((l, e) -> {
+        var listener = ActionListener.assertAtLeastOnce(refs.acquireListener());
+        return listener.delegateResponse((l, e) -> {
             failureCollector.unwrapAndCollect(e);
             l.onFailure(e);
         });

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeService.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeService.java
@@ -14,6 +14,7 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.ChannelActionListener;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -334,7 +335,13 @@ public final class ExchangeService extends AbstractLifecycleComponent {
             final long reservedBytes = allSourcesFinished ? 0 : estimatedPageSizeInBytes.get();
             if (reservedBytes > 0) {
                 // This doesn't fully protect ESQL from OOM, but reduces the likelihood.
-                blockFactory.breaker().addEstimateBytesAndMaybeBreak(reservedBytes, "fetch page");
+                try {
+                    blockFactory.breaker().addEstimateBytesAndMaybeBreak(reservedBytes, "fetch page");
+                } catch (Exception e) {
+                    assert e instanceof CircuitBreakingException : new AssertionError(e);
+                    listener.onFailure(e);
+                    return;
+                }
                 listener = ActionListener.runAfter(listener, () -> blockFactory.breaker().addWithoutBreaking(-reservedBytes));
             }
             transportService.sendChildRequest(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
@@ -174,7 +174,8 @@ final class ComputeListener implements Releasable {
      * Acquires a new listener that doesn't collect result
      */
     ActionListener<Void> acquireAvoid() {
-        return refs.acquire().delegateResponse((l, e) -> {
+        var listener = ActionListener.assertAtLeastOnce(refs.acquire());
+        return listener.delegateResponse((l, e) -> {
             try {
                 if (cancelled.compareAndSet(false, true)) {
                     LOGGER.debug("cancelling ESQL task {} on failure", task);


### PR DESCRIPTION
If we hit the circuit breaker exception before fetching pages, we fail to notify the listener.

Closes #122271