### PR TITLE
Move isOperator to x-pack-core

### DIFF
--- a/x-pack/plugin/core/src/main/java/module-info.java
+++ b/x-pack/plugin/core/src/main/java/module-info.java
@@ -172,6 +172,7 @@ module org.elasticsearch.xcore {
     exports org.elasticsearch.xpack.core.security.authz.store;
     exports org.elasticsearch.xpack.core.security.authz.support;
     exports org.elasticsearch.xpack.core.security.authz;
+    exports org.elasticsearch.xpack.core.security.operator;
     exports org.elasticsearch.xpack.core.security.support;
     exports org.elasticsearch.xpack.core.security.user;
     exports org.elasticsearch.xpack.core.security.xcontent;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
@@ -14,7 +14,8 @@ import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.action.support.MappedActionFilter;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
+
+import static org.elasticsearch.xpack.core.security.operator.OperatorPrivilegesUtil.isOperator;
 
 public abstract class ApiFilteringActionFilter<Res extends ActionResponse> implements MappedActionFilter {
 
@@ -45,7 +46,7 @@ public abstract class ApiFilteringActionFilter<Res extends ActionResponse> imple
         ActionFilterChain<Request, Response> chain
     ) {
         final ActionListener<Response> responseFilteringListener;
-        if (isOperator() == false && actionName.equals(action)) {
+        if (isOperator(threadContext) == false && actionName.equals(action)) {
             responseFilteringListener = listener.map(this::filter);
         } else {
             responseFilteringListener = listener;
@@ -60,12 +61,6 @@ public abstract class ApiFilteringActionFilter<Res extends ActionResponse> imple
         } else {
             return response;
         }
-    }
-
-    private boolean isOperator() {
-        return AuthenticationField.PRIVILEGE_CATEGORY_VALUE_OPERATOR.equals(
-            threadContext.getHeader(AuthenticationField.PRIVILEGE_CATEGORY_KEY)
-        );
     }
 
     protected abstract Res filterResponse(Res response) throws Exception;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/operator/OperatorPrivilegesUtil.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/operator/OperatorPrivilegesUtil.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.operator;
+
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
+
+public class OperatorPrivilegesUtil {
+    public static boolean isOperator(ThreadContext threadContext) {
+        return AuthenticationField.PRIVILEGE_CATEGORY_VALUE_OPERATOR.equals(
+            threadContext.getHeader(AuthenticationField.PRIVILEGE_CATEGORY_KEY)
+        );
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportAuthenticateAction.java
@@ -19,10 +19,10 @@ import org.elasticsearch.xpack.core.security.action.user.AuthenticateAction;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateRequest;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateResponse;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.operator.OperatorPrivilegesUtil;
 import org.elasticsearch.xpack.core.security.user.AnonymousUser;
 import org.elasticsearch.xpack.core.security.user.InternalUser;
 import org.elasticsearch.xpack.core.security.user.User;
-import org.elasticsearch.xpack.security.operator.OperatorPrivileges;
 
 public class TransportAuthenticateAction extends HandledTransportAction<AuthenticateRequest, AuthenticateResponse> {
 
@@ -61,7 +61,7 @@ public class TransportAuthenticateAction extends HandledTransportAction<Authenti
             listener.onResponse(
                 new AuthenticateResponse(
                     authentication.maybeAddAnonymousRoles(anonymousUser),
-                    OperatorPrivileges.isOperator(securityContext.getThreadContext())
+                    OperatorPrivilegesUtil.isOperator(securityContext.getThreadContext())
                 )
             );
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/OperatorPrivileges.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/OperatorPrivileges.java
@@ -25,6 +25,8 @@ import org.elasticsearch.xpack.core.security.user.InternalUser;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.Security;
 
+import static org.elasticsearch.xpack.core.security.operator.OperatorPrivilegesUtil.isOperator;
+
 public class OperatorPrivileges {
 
     private static final Logger logger = LogManager.getLogger(OperatorPrivileges.class);
@@ -34,12 +36,6 @@ public class OperatorPrivileges {
         false,
         Setting.Property.NodeScope
     );
-
-    public static boolean isOperator(ThreadContext threadContext) {
-        return AuthenticationField.PRIVILEGE_CATEGORY_VALUE_OPERATOR.equals(
-            threadContext.getHeader(AuthenticationField.PRIVILEGE_CATEGORY_KEY)
-        );
-    }
 
     public interface OperatorPrivilegesService {
         /**


### PR DESCRIPTION
This moves from `isOperator(ThreadContext`) method from

    org.elasticsearch.xpack.security.operator.OperatorPrivileges

to

    org.elasticsearch.xpack.core.security.operator.OperatorPrivilegesUtil

so that it can be used by modules that depend on x-pack-core (without needing to depend on x-pack-security)
