### PR TITLE
Fix ShuffleForcedMergePolicyTests#testDiagnostics

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -291,9 +291,6 @@ tests:
 - class: org.elasticsearch.env.NodeEnvironmentTests
   method: testGetBestDowngradeVersion
   issue: https://github.com/elastic/elasticsearch/issues/121316
-- class: org.elasticsearch.index.engine.ShuffleForcedMergePolicyTests
-  method: testDiagnostics
-  issue: https://github.com/elastic/elasticsearch/issues/121336
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/rest-api/security/invalidate-tokens/line_194}
   issue: https://github.com/elastic/elasticsearch/issues/121337

--- a/server/src/test/java/org/elasticsearch/index/engine/ShuffleForcedMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ShuffleForcedMergePolicyTests.java
@@ -20,6 +20,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.Directory;
@@ -37,7 +38,14 @@ public class ShuffleForcedMergePolicyTests extends BaseMergePolicyTestCase {
             IndexWriterConfig iwc = newIndexWriterConfig();
             // Disable merging on flush.
             iwc.setMaxFullFlushMergeWaitMillis(0L);
-            MergePolicy mp = new ShuffleForcedMergePolicy(newTieredMergePolicy());
+            // Even though we set setMaxFullFlushMergeWaitMillis=0, opening the DirectoryReader
+            // might trigger a merge after flushing the in-memory documents. Therefore, we set
+            // a high enough number of maxSegmentsPerTier (we index at most 300 documents, and we flush
+            // a new segment per 10 documents) that would prevent merging all the segments into one and
+            // making the force merge a no-op.
+            var tieredMergePolicy = new TieredMergePolicy();
+            tieredMergePolicy.setSegmentsPerTier(100);
+            MergePolicy mp = new ShuffleForcedMergePolicy(tieredMergePolicy);
             iwc.setMergePolicy(mp);
             boolean sorted = random().nextBoolean();
             if (sorted) {


### PR DESCRIPTION
This commit ensures that opening the DirectoryReader won't merge all the segments into one, making the tested force merge a no-op.

Closes #121336
