### PR TITLE
[Entitlements] Make `lookupImplementationMethod` inheritance-aware

### DIFF
--- a/libs/entitlement/asm-provider/src/test/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests.java
+++ b/libs/entitlement/asm-provider/src/test/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests.java
@@ -89,6 +89,8 @@ public class InstrumentationServiceImplTests extends ESTestCase {
         void checkInstanceMethodManual(Class<?> clazz, TestTargetBaseClass that, int x, String y);
     }
 
+    interface TestCheckerDerived3 extends TestCheckerMixed {}
+
     public void testInstrumentationTargetLookup() throws ClassNotFoundException {
         Map<MethodKey, CheckMethod> checkMethods = instrumentationService.lookupMethods(TestChecker.class);
 
@@ -370,12 +372,50 @@ public class InstrumentationServiceImplTests extends ESTestCase {
         );
     }
 
-    public void testLookupImplementationMethodWithInheritance() throws ClassNotFoundException, NoSuchMethodException {
+    public void testLookupImplementationMethodWithInheritanceOnTarget() throws ClassNotFoundException, NoSuchMethodException {
         var info = instrumentationService.lookupImplementationMethod(
             TestTargetBaseClass.class,
             "instanceMethod2",
             TestTargetImplementationClass.class,
             TestCheckerMixed.class,
+            "checkInstanceMethodManual",
+            int.class,
+            String.class
+        );
+
+        assertThat(
+            info.targetMethod(),
+            equalTo(
+                new MethodKey(
+                    "org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestTargetIntermediateClass",
+                    "instanceMethod2",
+                    List.of("I", "java/lang/String")
+                )
+            )
+        );
+        assertThat(
+            info.checkMethod(),
+            equalTo(
+                new CheckMethod(
+                    "org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestCheckerMixed",
+                    "checkInstanceMethodManual",
+                    List.of(
+                        "Ljava/lang/Class;",
+                        "Lorg/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestTargetBaseClass;",
+                        "I",
+                        "Ljava/lang/String;"
+                    )
+                )
+            )
+        );
+    }
+
+    public void testLookupImplementationMethodWithInheritanceOnChecker() throws ClassNotFoundException, NoSuchMethodException {
+        var info = instrumentationService.lookupImplementationMethod(
+            TestTargetBaseClass.class,
+            "instanceMethod2",
+            TestTargetImplementationClass.class,
+            TestCheckerDerived3.class,
             "checkInstanceMethodManual",
             int.class,
             String.class

--- a/libs/entitlement/asm-provider/src/test/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests.java
+++ b/libs/entitlement/asm-provider/src/test/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.entitlement.instrumentation.MethodKey;
 import org.elasticsearch.test.ESTestCase;
 import org.objectweb.asm.Type;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -90,7 +89,7 @@ public class InstrumentationServiceImplTests extends ESTestCase {
         void checkInstanceMethodManual(Class<?> clazz, TestTargetBaseClass that, int x, String y);
     }
 
-    public void testInstrumentationTargetLookup() throws IOException {
+    public void testInstrumentationTargetLookup() throws ClassNotFoundException {
         Map<MethodKey, CheckMethod> checkMethods = instrumentationService.lookupMethods(TestChecker.class);
 
         assertThat(checkMethods, aMapWithSize(3));
@@ -143,7 +142,7 @@ public class InstrumentationServiceImplTests extends ESTestCase {
         );
     }
 
-    public void testInstrumentationTargetLookupWithOverloads() throws IOException {
+    public void testInstrumentationTargetLookupWithOverloads() throws ClassNotFoundException {
         Map<MethodKey, CheckMethod> checkMethods = instrumentationService.lookupMethods(TestCheckerOverloads.class);
 
         assertThat(checkMethods, aMapWithSize(2));
@@ -175,7 +174,7 @@ public class InstrumentationServiceImplTests extends ESTestCase {
         );
     }
 
-    public void testInstrumentationTargetLookupWithDerivedClass() throws IOException {
+    public void testInstrumentationTargetLookupWithDerivedClass() throws ClassNotFoundException {
         Map<MethodKey, CheckMethod> checkMethods = instrumentationService.lookupMethods(TestCheckerDerived2.class);
 
         assertThat(checkMethods, aMapWithSize(4));
@@ -244,7 +243,7 @@ public class InstrumentationServiceImplTests extends ESTestCase {
         );
     }
 
-    public void testInstrumentationTargetLookupWithCtors() throws IOException {
+    public void testInstrumentationTargetLookupWithCtors() throws ClassNotFoundException {
         Map<MethodKey, CheckMethod> checkMethods = instrumentationService.lookupMethods(TestCheckerCtors.class);
 
         assertThat(checkMethods, aMapWithSize(2));
@@ -276,7 +275,7 @@ public class InstrumentationServiceImplTests extends ESTestCase {
         );
     }
 
-    public void testInstrumentationTargetLookupWithExtraMethods() throws IOException {
+    public void testInstrumentationTargetLookupWithExtraMethods() throws ClassNotFoundException {
         Map<MethodKey, CheckMethod> checkMethods = instrumentationService.lookupMethods(TestCheckerMixed.class);
 
         assertThat(checkMethods, aMapWithSize(1));

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/InstrumentationService.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/InstrumentationService.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.entitlement.instrumentation;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -23,7 +22,7 @@ public interface InstrumentationService {
 
     Instrumenter newInstrumenter(Class<?> clazz, Map<MethodKey, CheckMethod> methods);
 
-    Map<MethodKey, CheckMethod> lookupMethods(Class<?> clazz) throws IOException;
+    Map<MethodKey, CheckMethod> lookupMethods(Class<?> clazz) throws ClassNotFoundException;
 
     InstrumentationInfo lookupImplementationMethod(
         Class<?> targetSuperclass,


### PR DESCRIPTION
Forward-port of https://github.com/elastic/elasticsearch/pull/122471/commits/9166b5db9296aeccbb4941816ad8a61f5009b97c

While backporting https://github.com/elastic/elasticsearch/pull/122232, I found that it is convenient to change `lookupImplementationMethod` to have the same behaviour of `lookupMethods`; this way the lookup will always find the correct interface, without the need to specify it manually.

Since the 2 functions now share the same basic structure, I refactored them to share a common helper and a consistent signature (exception thrown).