### PR TITLE
Add missing transport versions

### DIFF
--- a/docs/changelog/122506.yaml
+++ b/docs/changelog/122506.yaml
@@ -1,0 +1,5 @@
+pr: 122506
+summary: Add missing transport versions
+area: Data streams
+type: bug
+issues: []

--- a/docs/changelog/122506.yaml
+++ b/docs/changelog/122506.yaml
@@ -1,5 +1,0 @@
-pr: 122506
-summary: Add missing transport versions
-area: Data streams
-type: bug
-issues: []

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -389,51 +389,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/122377
 - class: org.elasticsearch.repositories.blobstore.testkit.analyze.HdfsRepositoryAnalysisRestIT
   issue: https://github.com/elastic/elasticsearch/issues/122378
-- class: org.elasticsearch.lucene.RollingUpgradeLuceneIndexCompatibilityTestCase
-  method: testClosedIndexUpgrade {p0=[9.1.0, 8.19.0, 8.19.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122481
-- class: org.elasticsearch.lucene.RollingUpgradeLuceneIndexCompatibilityTestCase
-  method: testRestoreIndex {p0=[9.1.0, 9.1.0, 8.19.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122482
-- class: org.elasticsearch.lucene.RollingUpgradeLuceneIndexCompatibilityTestCase
-  method: testRestoreIndex {p0=[9.1.0, 8.19.0, 8.19.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122483
-- class: org.elasticsearch.lucene.RollingUpgradeLuceneIndexCompatibilityTestCase
-  method: testIndexUpgrade {p0=[9.1.0, 8.19.0, 8.19.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122484
-- class: org.elasticsearch.lucene.RollingUpgradeLuceneIndexCompatibilityTestCase
-  method: testIndexUpgrade {p0=[9.1.0, 9.1.0, 9.1.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122487
-- class: org.elasticsearch.lucene.RollingUpgradeLuceneIndexCompatibilityTestCase
-  method: testClosedIndexUpgrade {p0=[9.1.0, 9.1.0, 8.19.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122488
-- class: org.elasticsearch.lucene.RollingUpgradeLuceneIndexCompatibilityTestCase
-  method: testIndexUpgrade {p0=[9.1.0, 9.1.0, 8.19.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122489
-- class: org.elasticsearch.lucene.RollingUpgradeLuceneIndexCompatibilityTestCase
-  method: testRestoreIndex {p0=[9.1.0, 9.1.0, 9.1.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122490
-- class: org.elasticsearch.lucene.RollingUpgradeLuceneIndexCompatibilityTestCase
-  method: testClosedIndexUpgrade {p0=[9.1.0, 9.1.0, 9.1.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122495
-- class: org.elasticsearch.lucene.RollingUpgradeSearchableSnapshotIndexCompatibilityIT
-  method: testSearchableSnapshotUpgrade {p0=[9.1.0, 8.19.0, 8.19.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122500
-- class: org.elasticsearch.lucene.RollingUpgradeSearchableSnapshotIndexCompatibilityIT
-  method: testMountSearchableSnapshot {p0=[9.1.0, 9.1.0, 8.19.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122501
-- class: org.elasticsearch.lucene.RollingUpgradeSearchableSnapshotIndexCompatibilityIT
-  method: testMountSearchableSnapshot {p0=[9.1.0, 8.19.0, 8.19.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122502
-- class: org.elasticsearch.lucene.RollingUpgradeSearchableSnapshotIndexCompatibilityIT
-  method: testSearchableSnapshotUpgrade {p0=[9.1.0, 9.1.0, 8.19.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122503
-- class: org.elasticsearch.lucene.RollingUpgradeSearchableSnapshotIndexCompatibilityIT
-  method: testMountSearchableSnapshot {p0=[9.1.0, 9.1.0, 9.1.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122504
-- class: org.elasticsearch.lucene.RollingUpgradeSearchableSnapshotIndexCompatibilityIT
-  method: testSearchableSnapshotUpgrade {p0=[9.1.0, 9.1.0, 9.1.0]}
-  issue: https://github.com/elastic/elasticsearch/issues/122505
 
 # Examples:
 #

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -173,11 +173,13 @@ public class TransportVersions {
     public static final TransportVersion INFERENCE_REQUEST_ADAPTIVE_RATE_LIMITING = def(8_839_0_00);
     public static final TransportVersion ML_INFERENCE_IBM_WATSONX_RERANK_ADDED = def(8_840_0_00);
     public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED_BACKPORT_8_X = def(8_840_0_01);
+    public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR_BACKPORT_8_X = def(8_840_0_02);
     public static final TransportVersion ELASTICSEARCH_9_0 = def(9_000_0_00);
     public static final TransportVersion REMOVE_SNAPSHOT_FAILURES_90 = def(9_000_0_01);
     public static final TransportVersion TRANSPORT_STATS_HANDLING_TIME_REQUIRED_90 = def(9_000_0_02);
     public static final TransportVersion REMOVE_DESIRED_NODE_VERSION_90 = def(9_000_0_03);
     public static final TransportVersion ESQL_DRIVER_TASK_DESCRIPTION_90 = def(9_000_0_04);
+    public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR_9_0 = def(9_000_0_05);
     public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED = def(9_001_0_00);
     public static final TransportVersion REMOVE_SNAPSHOT_FAILURES = def(9_002_0_00);
     public static final TransportVersion TRANSPORT_STATS_HANDLING_TIME_REQUIRED = def(9_003_0_00);

--- a/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
@@ -74,7 +74,9 @@ public enum IndexComponentSelector implements Writeable {
 
     public static IndexComponentSelector read(StreamInput in) throws IOException {
         byte id = in.readByte();
-        if (in.getTransportVersion().onOrAfter(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR)
+            || in.getTransportVersion().isPatchFrom(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR_9_0)
+            || in.getTransportVersion().isPatchFrom(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR_BACKPORT_8_X)) {
             return getById(id);
         } else {
             // Legacy value ::*, converted to ::data


### PR DESCRIPTION
With https://github.com/elastic/elasticsearch/pull/121900 & https://github.com/elastic/elasticsearch/pull/122433 we created gaps in the transport versions which is causing issues for clusters with mixed versions to form a cluster.

For reference the CI failures caused by this:
Fixes: https://github.com/elastic/elasticsearch/issues/122481
Fixes: https://github.com/elastic/elasticsearch/issues/122482
Fixes: https://github.com/elastic/elasticsearch/issues/122483
Fixes: https://github.com/elastic/elasticsearch/issues/122484
Fixes: https://github.com/elastic/elasticsearch/issues/122487
Fixes: https://github.com/elastic/elasticsearch/issues/122488
Fixes: https://github.com/elastic/elasticsearch/issues/122489
Fixes: https://github.com/elastic/elasticsearch/issues/122490
Fixes: https://github.com/elastic/elasticsearch/issues/122495
Fixes: https://github.com/elastic/elasticsearch/issues/122500
Fixes: https://github.com/elastic/elasticsearch/issues/122501
Fixes: https://github.com/elastic/elasticsearch/issues/122502
Fixes: https://github.com/elastic/elasticsearch/issues/122503
Fixes: https://github.com/elastic/elasticsearch/issues/122504
Fixes: https://github.com/elastic/elasticsearch/issues/122505