### PR TITLE
[8.18] Deduplicate IngestStats and IngestStats.Stats identity records when deserializing (#122496)

### DIFF
--- a/docs/changelog/122496.yaml
+++ b/docs/changelog/122496.yaml
@@ -1,0 +1,5 @@
+pr: 122496
+summary: Deduplicate `IngestStats` and `IngestStats.Stats` identity records when deserializing
+area: Ingest Node
+type: bug
+issues: []

--- a/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class IngestStatsTests extends ESTestCase {
 
@@ -29,6 +30,11 @@ public class IngestStatsTests extends ESTestCase {
         IngestStats ingestStats = new IngestStats(totalStats, pipelineStats, processorStats);
         IngestStats serializedStats = serialize(ingestStats);
         assertIngestStats(ingestStats, serializedStats);
+    }
+
+    public void testIdentitySerialization() throws IOException {
+        IngestStats serializedStats = serialize(IngestStats.IDENTITY);
+        assertThat(serializedStats, sameInstance(IngestStats.IDENTITY));
     }
 
     public void testStatsMerge() {


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Deduplicate IngestStats and IngestStats.Stats identity records when deserializing (#122496)