### PR TITLE
Unmute org.elasticsearch.search.CrossClusterSearchUnavailableClusterIT.testSearchSkipUnavailable

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -332,9 +332,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/42_knn_search_int4_flat/Vector similarity with filter only}
   issue: https://github.com/elastic/elasticsearch/issues/121412
-- class: org.elasticsearch.search.CrossClusterSearchUnavailableClusterIT
-  method: testSearchSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/121497
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/cat/health/cat-health-no-timestamp-example}
   issue: https://github.com/elastic/elasticsearch/issues/121867


### PR DESCRIPTION
Long fixed, forgot to unmute.

closes #121497
