### PR TITLE
Block running ES 8.17 with JDK 24+.

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
@@ -79,8 +79,10 @@ class ServerCli extends EnvironmentAwareCommand {
         }
 
         if (Runtime.version().feature() >= 24) {
-            throw new UserException(ExitCodes.USAGE,
-                "Elasticsearch 8.17.x cannot run with JDK 24+, but you are running JDK " + Runtime.version());
+            throw new UserException(
+                ExitCodes.USAGE,
+                "Elasticsearch 8.17.x cannot run with JDK 24+, but you are running JDK " + Runtime.version()
+            );
         }
 
         validateConfig(options, env);

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
@@ -78,6 +78,11 @@ class ServerCli extends EnvironmentAwareCommand {
             return;
         }
 
+        if (Runtime.version().feature() >= 24) {
+            throw new UserException(ExitCodes.USAGE,
+                "Elasticsearch 8.17.x cannot run with JDK 24+, but you are running JDK " + Runtime.version());
+        }
+
         validateConfig(options, env);
 
         var secureSettingsLoader = secureSettingsLoader(env);

--- a/docs/changelog/122517.yaml
+++ b/docs/changelog/122517.yaml
@@ -1,0 +1,5 @@
+pr: 122517
+summary: Block running ES 8.17 with JDK 24+
+area: Infra/Node Lifecycle
+type: bug
+issues: []


### PR DESCRIPTION
JDK 24+ will not work due to SecurityManager being disabled. This commit makes the error explicit instead of runtime errors in SecurityManager code.