### PR TITLE
Unmute DateProcessorTests::testJavaPatternDefaultYear

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -207,10 +207,11 @@ public class DateProcessorTests extends ESTestCase {
 
     public void testJavaPatternDefaultYear() {
         String format = randomFrom("dd/MM", "8dd/MM");
+        ZoneId zoneId = ZoneId.of("Europe/Amsterdam");
         DateProcessor dateProcessor = new DateProcessor(
             randomAlphaOfLength(10),
             null,
-            templatize(ZoneId.of("Europe/Amsterdam")),
+            templatize(zoneId),
             templatize(Locale.ENGLISH),
             "date_as_string",
             List.of(format),
@@ -222,7 +223,7 @@ public class DateProcessorTests extends ESTestCase {
         dateProcessor.execute(ingestDocument);
         assertThat(
             ingestDocument.getFieldValue("date_as_date", String.class),
-            equalTo(ZonedDateTime.now(ZoneId.of("Europe/Amsterdam")).getYear() + "-06-12T00:00:00.000+02:00")
+            equalTo(ZonedDateTime.now(zoneId).getYear() + "-06-12T00:00:00.000+02:00")
         );
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -222,7 +222,7 @@ public class DateProcessorTests extends ESTestCase {
         dateProcessor.execute(ingestDocument);
         assertThat(
             ingestDocument.getFieldValue("date_as_date", String.class),
-            equalTo(ZonedDateTime.now().getYear() + "-06-12T00:00:00.000+02:00")
+            equalTo(ZonedDateTime.now(ZoneId.of("Europe/Amsterdam")).getYear() + "-06-12T00:00:00.000+02:00")
         );
     }
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -275,9 +275,6 @@ tests:
 - class: org.elasticsearch.gradle.internal.info.BuildParameterExtensionSpec
   method: getJavaToolChainSpec is cached anc concurrently accessible
   issue: https://github.com/elastic/elasticsearch/issues/119173
-- class: org.elasticsearch.ingest.common.DateProcessorTests
-  method: testJavaPatternDefaultYear
-  issue: https://github.com/elastic/elasticsearch/issues/119391
 - class: org.elasticsearch.gradle.LoggedExecFuncTest
   method: failed tasks output logged to console when spooling true
   issue: https://github.com/elastic/elasticsearch/issues/119509


### PR DESCRIPTION
Failed due to the `2024-2025` year leap and timezone when this test was run. Attempting to fix by matching the timezone, but I can't reproduce the failure, should be safe to unmute. 

```
1> [2024-12-31T23:46:46,905][INFO ][o.e.i.c.DateProcessorTests] [testJavaPatternDefaultYear] after test |  
-- | --
  | 2> REPRODUCE WITH: ./gradlew ":modules:ingest-common:test" --tests "org.elasticsearch.ingest.common.DateProcessorTests.testJavaPatternDefaultYear" -Dtests.seed=BC4829F6371A460A -Dtests.locale=ga-GB -Dtests.timezone=America/North_Dakota/Center -Druntime.java=23 |  
  | 2> java.lang.AssertionError: |  
  | Expected: "2024-06-12T00:00:00.000+02:00" |  
  | but: was "2025-06-12T00:00:00.000+02:00"
```

Closes https://github.com/elastic/elasticsearch/issues/119391