### PR TITLE
[8.x] Rewire 8.19 backport constants to avoid conflicts with 8.18 backport constants

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -178,7 +178,7 @@ public class TransportVersions {
     public static final TransportVersion TIMEOUT_GET_PARAM_FOR_RESOLVE_CLUSTER = def(8_838_0_00);
     public static final TransportVersion INFERENCE_REQUEST_ADAPTIVE_RATE_LIMITING = def(8_839_0_00);
     public static final TransportVersion ML_INFERENCE_IBM_WATSONX_RERANK_ADDED = def(8_840_0_00);
-    public static final TransportVersion ELASTICSEARCH_8_19 = def(8_841_0_00);
+    public static final TransportVersion INITIAL_ELASTICSEARCH_8_19 = def(8_841_0_00);
     public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED_BACKPORT_8_X = def(8_841_0_01);
     public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR_BACKPORT_8_X = def(8_841_0_02);
 

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -178,8 +178,9 @@ public class TransportVersions {
     public static final TransportVersion TIMEOUT_GET_PARAM_FOR_RESOLVE_CLUSTER = def(8_838_0_00);
     public static final TransportVersion INFERENCE_REQUEST_ADAPTIVE_RATE_LIMITING = def(8_839_0_00);
     public static final TransportVersion ML_INFERENCE_IBM_WATSONX_RERANK_ADDED = def(8_840_0_00);
-    public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED_BACKPORT_8_X = def(8_840_0_01);
-    public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR_BACKPORT_8_X = def(8_840_0_02);
+    public static final TransportVersion ELASTICSEARCH_8_19 = def(8_841_0_00);
+    public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED_BACKPORT_8_X = def(8_841_0_01);
+    public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR_BACKPORT_8_X = def(8_841_0_02);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -32,11 +32,11 @@ public class TransportVersionTests extends ESTestCase {
 
     /**
      * This test is specific for 8.19, to ensure that transport versions are backported correctly. Do not forward or backport it,
-     * and do not adjust the TransportVersion to check (ELASTICSEARCH_8_19).
+     * and do not adjust the TransportVersion to check (INITIAL_ELASTICSEARCH_8_19).
      * If the test fails, there is something wrong with your backport PR.
      */
     public void testMaximumAllowedTransportVersion() {
-        assertThat(TransportVersions.LATEST_DEFINED.isPatchFrom(TransportVersions.ELASTICSEARCH_8_19), is(true));
+        assertThat(TransportVersions.LATEST_DEFINED.isPatchFrom(TransportVersions.INITIAL_ELASTICSEARCH_8_19), is(true));
     }
 
     public void testVersionComparison() {

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -31,10 +31,12 @@ import static org.hamcrest.Matchers.sameInstance;
 public class TransportVersionTests extends ESTestCase {
 
     /**
-     * This test is specific for 8.19, to ensure that transport versions are backported correctly. Do not forward or backport it.
+     * This test is specific for 8.19, to ensure that transport versions are backported correctly. Do not forward or backport it,
+     * and do not adjust the TransportVersion to check (ELASTICSEARCH_8_19).
+     * If the test fails, there is something wrong with your backport PR.
      */
     public void testMaximumAllowedTransportVersion() {
-        assertThat(TransportVersions.LATEST_DEFINED.isPatchFrom(TransportVersions.ML_INFERENCE_IBM_WATSONX_RERANK_ADDED), is(true));
+        assertThat(TransportVersions.LATEST_DEFINED.isPatchFrom(TransportVersions.ELASTICSEARCH_8_19), is(true));
     }
 
     public void testVersionComparison() {


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/122578 and https://github.com/elastic/elasticsearch/pull/122582 ready to propagate changes to newer barnches