### PR TITLE
Unmute search IT tests that are unmuted in main

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -208,12 +208,6 @@ tests:
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/10_apm/Test template reinstallation}
   issue: https://github.com/elastic/elasticsearch/issues/116445
-- class: org.elasticsearch.action.admin.HotThreadsIT
-  method: testHotThreadsDontFail
-  issue: https://github.com/elastic/elasticsearch/issues/115754
-- class: org.elasticsearch.action.search.PointInTimeIT
-  method: testPITTiebreak
-  issue: https://github.com/elastic/elasticsearch/issues/115810
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/61_enrich_ip/IP strings}
   issue: https://github.com/elastic/elasticsearch/issues/116529
@@ -226,15 +220,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/60_enrich/Enrich on keyword with fields}
   issue: https://github.com/elastic/elasticsearch/issues/116593
-- class: org.elasticsearch.xpack.spatial.search.GeoGridAggAndQueryConsistencyIT
-  method: testGeoShapeGeoTile
-  issue: https://github.com/elastic/elasticsearch/issues/115717
 - class: org.elasticsearch.search.StressSearchServiceReaperIT
   method: testStressReaper
   issue: https://github.com/elastic/elasticsearch/issues/115816
-- class: org.elasticsearch.xpack.spatial.search.GeoGridAggAndQueryConsistencyIT
-  method: testGeoShapeGeoHex
-  issue: https://github.com/elastic/elasticsearch/issues/115705
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {spatial.CentroidFromAirportsAfterIntersectsCompoundPredicateNoDocValues SYNC}
   issue: https://github.com/elastic/elasticsearch/issues/116945


### PR DESCRIPTION
Certain search IT tests were unmuted in main a long while ago and were left muted in 8.x. There are no specific reasons behind this discrepancy. This commit unmutes them in 8.x.

Closes #115754
Closes #115705
Closes #115717
Closes #115810
