### PR TITLE
[9.0] Licensing controls for logsdb routing on sort fields  (#120276)

### DIFF
--- a/x-pack/plugin/logsdb/qa/with-basic/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbWithBasicRestIT.java
+++ b/x-pack/plugin/logsdb/qa/with-basic/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbWithBasicRestIT.java
@@ -235,7 +235,7 @@ public class LogsdbWithBasicRestIT extends ESRestTestCase {
         var settings = (Map<?, ?>) ((Map<?, ?>) getIndexSettings(index).get(index)).get("settings");
         assertEquals("logsdb", settings.get("index.mode"));
         assertEquals(SourceFieldMapper.Mode.STORED.toString(), settings.get("index.mapping.source.mode"));
-        assertEquals("true", settings.get(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.getKey()));
-        assertEquals(List.of("host.name", "message"), settings.get(IndexMetadata.INDEX_ROUTING_PATH.getKey()));
+        assertEquals("false", settings.get(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.getKey()));
+        assertNull(settings.get(IndexMetadata.INDEX_ROUTING_PATH.getKey()));
     }
 }

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 
 public class LogsdbRestIT extends ESRestTestCase {
@@ -66,9 +67,15 @@ public class LogsdbRestIT extends ESRestTestCase {
             List<Map<?, ?>> features = (List<Map<?, ?>>) response.get("features");
             logger.info("response's features: {}", features);
             assertThat(features, Matchers.not(Matchers.empty()));
-            Map<?, ?> feature = features.stream().filter(map -> "mappings".equals(map.get("family"))).findFirst().get();
-            assertThat(feature.get("name"), equalTo("synthetic-source"));
-            assertThat(feature.get("license_level"), equalTo("enterprise"));
+            boolean found = false;
+            for (var feature : features) {
+                if (feature.get("family") != null) {
+                    assertThat(feature.get("name"), anyOf(equalTo("synthetic-source"), equalTo("logsdb-routing-on-sort-fields")));
+                    assertThat(feature.get("license_level"), equalTo("enterprise"));
+                    found = true;
+                }
+            }
+            assertTrue(found);
 
             var indexResponse = (Map<?, ?>) getIndexSettings("test-index", true).get("test-index");
             logger.info("indexResponse: {}", indexResponse);

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
@@ -40,12 +40,12 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseService.FALLBACK_SETTING;
+import static org.elasticsearch.xpack.logsdb.LogsdbLicenseService.FALLBACK_SETTING;
 
 public class LogsDBPlugin extends Plugin implements ActionPlugin {
 
     private final Settings settings;
-    private final SyntheticSourceLicenseService licenseService;
+    private final LogsdbLicenseService licenseService;
     private static final Setting<Boolean> LOGSDB_PRIOR_LOGS_USAGE = Setting.boolSetting(
         "logsdb.prior_logs_usage",
         false,
@@ -63,7 +63,7 @@ public class LogsDBPlugin extends Plugin implements ActionPlugin {
 
     public LogsDBPlugin(Settings settings) {
         this.settings = settings;
-        this.licenseService = new SyntheticSourceLicenseService(settings);
+        this.licenseService = new LogsdbLicenseService(settings);
         this.logsdbIndexModeSettingsProvider = new LogsdbIndexModeSettingsProvider(licenseService, settings);
     }
 
@@ -82,7 +82,6 @@ public class LogsDBPlugin extends Plugin implements ActionPlugin {
             CLUSTER_LOGSDB_ENABLED,
             logsdbIndexModeSettingsProvider::updateClusterIndexModeLogsdbEnabled
         );
-
         // Nothing to share here:
         return super.createComponents(services);
     }
@@ -95,6 +94,7 @@ public class LogsDBPlugin extends Plugin implements ActionPlugin {
                 IndexVersion.current(),
                 parameters.clusterService().state().nodes().getMaxDataNodeCompatibleIndexVersion()
             ),
+            DiscoveryNode.isStateless(settings) == false,
             DiscoveryNode.isStateless(settings) == false
         );
         return List.of(logsdbIndexModeSettingsProvider);

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBUsageTransportAction.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBUsageTransportAction.java
@@ -64,7 +64,7 @@ public class LogsDBUsageTransportAction extends XPackUsageFeatureTransportAction
             }
         }
         final boolean enabled = LogsDBPlugin.CLUSTER_LOGSDB_ENABLED.get(clusterService.getSettings());
-        final boolean hasCustomCutoffDate = System.getProperty(SyntheticSourceLicenseService.CUTOFF_DATE_SYS_PROP_NAME) != null;
+        final boolean hasCustomCutoffDate = System.getProperty(LogsdbLicenseService.CUTOFF_DATE_SYS_PROP_NAME) != null;
         final DiscoveryNode[] nodes = state.nodes().getDataNodes().values().toArray(DiscoveryNode[]::new);
         final var statsRequest = new IndexModeStatsActionType.StatsRequest(nodes);
         final int finalNumIndices = numIndices;

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LegacyLicenceIntegrationTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LegacyLicenceIntegrationTests.java
@@ -31,8 +31,8 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.test.ESIntegTestCase.Scope.TEST;
-import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseServiceTests.createEnterpriseLicense;
-import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseServiceTests.createGoldOrPlatinumLicense;
+import static org.elasticsearch.xpack.logsdb.LogsdbLicenseServiceTests.createEnterpriseLicense;
+import static org.elasticsearch.xpack.logsdb.LogsdbLicenseServiceTests.createGoldOrPlatinumLicense;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -57,15 +57,15 @@ public class LegacyLicenceIntegrationTests extends AbstractLicensesIntegrationTe
     public void testSyntheticSourceUsageDisallowed() {
         createIndexWithSyntheticSourceAndAssertExpectedType("test", "STORED");
 
-        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, nullValue());
-        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE, nullValue());
+        assertFeatureUsage(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, nullValue());
+        assertFeatureUsage(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE, nullValue());
     }
 
     public void testSyntheticSourceUsageWithLegacyLicense() {
         createIndexWithSyntheticSourceAndAssertExpectedType(".profiling-stacktraces", "synthetic");
 
-        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, not(nullValue()));
-        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE, nullValue());
+        assertFeatureUsage(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, not(nullValue()));
+        assertFeatureUsage(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE, nullValue());
     }
 
     public void testSyntheticSourceUsageWithLegacyLicensePastCutoff() throws Exception {
@@ -75,8 +75,8 @@ public class LegacyLicenceIntegrationTests extends AbstractLicensesIntegrationTe
         ensureGreen();
 
         createIndexWithSyntheticSourceAndAssertExpectedType(".profiling-stacktraces", "STORED");
-        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, nullValue());
-        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE, nullValue());
+        assertFeatureUsage(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, nullValue());
+        assertFeatureUsage(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE, nullValue());
     }
 
     public void testSyntheticSourceUsageWithEnterpriseLicensePastCutoff() throws Exception {
@@ -87,8 +87,8 @@ public class LegacyLicenceIntegrationTests extends AbstractLicensesIntegrationTe
         createIndexWithSyntheticSourceAndAssertExpectedType(".profiling-traces", "synthetic");
         // also supports non-exceptional indices
         createIndexWithSyntheticSourceAndAssertExpectedType("test", "synthetic");
-        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, nullValue());
-        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE, not(nullValue()));
+        assertFeatureUsage(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, nullValue());
+        assertFeatureUsage(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE, not(nullValue()));
     }
 
     public void testSyntheticSourceUsageTracksBothLegacyAndRegularFeature() throws Exception {
@@ -99,8 +99,8 @@ public class LegacyLicenceIntegrationTests extends AbstractLicensesIntegrationTe
 
         createIndexWithSyntheticSourceAndAssertExpectedType(".profiling-traces-v2", "synthetic");
 
-        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, not(nullValue()));
-        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE, not(nullValue()));
+        assertFeatureUsage(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, not(nullValue()));
+        assertFeatureUsage(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE, not(nullValue()));
     }
 
     private void createIndexWithSyntheticSourceAndAssertExpectedType(String indexName, String expectedType) {
@@ -119,7 +119,7 @@ public class LegacyLicenceIntegrationTests extends AbstractLicensesIntegrationTe
 
     private void assertFeatureUsage(LicensedFeature.Momentary syntheticSourceFeature, Matcher<Object> matcher) {
         GetFeatureUsageResponse.FeatureUsageInfo featureUsage = getFeatureUsageInfo().stream()
-            .filter(f -> f.getFamily().equals(SyntheticSourceLicenseService.MAPPINGS_FEATURE_FAMILY))
+            .filter(f -> f.getFamily().equals(LogsdbLicenseService.MAPPINGS_FEATURE_FAMILY))
             .filter(f -> f.getName().equals(syntheticSourceFeature.getName()))
             .findAny()
             .orElse(null);

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProviderTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProviderTests.java
@@ -37,10 +37,12 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.common.settings.Settings.builder;
-import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseServiceTests.createEnterpriseLicense;
+import static org.elasticsearch.xpack.logsdb.LogsdbLicenseServiceTests.createEnterpriseLicense;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,33 +67,31 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         }
         """;
 
-    private SyntheticSourceLicenseService syntheticSourceLicenseService;
+    private LogsdbLicenseService logsdbLicenseService;
     private final AtomicInteger newMapperServiceCounter = new AtomicInteger();
 
     @Before
     public void setup() throws Exception {
         MockLicenseState licenseState = MockLicenseState.createMock();
         when(licenseState.isAllowed(any())).thenReturn(true);
-        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
-        licenseService.setLicenseState(licenseState);
         var mockLicenseService = mock(LicenseService.class);
         License license = createEnterpriseLicense();
         when(mockLicenseService.getLicense()).thenReturn(license);
-        syntheticSourceLicenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
-        syntheticSourceLicenseService.setLicenseState(licenseState);
-        syntheticSourceLicenseService.setLicenseService(mockLicenseService);
+        logsdbLicenseService = new LogsdbLicenseService(Settings.EMPTY);
+        logsdbLicenseService.setLicenseState(licenseState);
+        logsdbLicenseService.setLicenseService(mockLicenseService);
     }
 
     private LogsdbIndexModeSettingsProvider withSyntheticSourceDemotionSupport(boolean enabled) {
         newMapperServiceCounter.set(0);
         var provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", enabled).build()
         );
         provider.init(im -> {
             newMapperServiceCounter.incrementAndGet();
             return MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName());
-        }, IndexVersion::current, true);
+        }, IndexVersion::current, true, true);
         return provider;
     }
 
@@ -102,13 +102,13 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
     private Settings generateLogsdbSettings(Settings settings, String mapping) throws IOException {
         Metadata metadata = Metadata.EMPTY_METADATA;
         var provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
         provider.init(im -> {
             newMapperServiceCounter.incrementAndGet();
             return MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName());
-        }, IndexVersion::current, true);
+        }, IndexVersion::current, true, true);
         var result = provider.getAdditionalIndexSettings(
             DataStream.getDefaultBackingIndexName(DATA_STREAM_NAME, 0),
             DATA_STREAM_NAME,
@@ -123,7 +123,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testDisabled() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", false).build()
         );
 
@@ -142,7 +142,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testOnIndexCreation() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
 
@@ -161,7 +161,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testOnExplicitStandardIndex() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
 
@@ -180,7 +180,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testOnExplicitTimeSeriesIndex() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
 
@@ -199,7 +199,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testNonLogsDataStream() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
 
@@ -218,7 +218,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testWithoutLogsComponentTemplate() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
 
@@ -237,7 +237,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testWithLogsComponentTemplate() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
 
@@ -256,7 +256,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testWithMultipleComponentTemplates() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
 
@@ -275,7 +275,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testWithCustomComponentTemplatesOnly() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
 
@@ -294,7 +294,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testNonMatchingTemplateIndexPattern() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
 
@@ -313,7 +313,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testCaseSensitivity() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
 
@@ -332,7 +332,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testMultipleHyphensInDataStreamName() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", true).build()
         );
 
@@ -351,7 +351,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
 
     public void testBeforeAndAFterSettingUpdate() throws IOException {
         final LogsdbIndexModeSettingsProvider provider = new LogsdbIndexModeSettingsProvider(
-            syntheticSourceLicenseService,
+            logsdbLicenseService,
             Settings.builder().put("cluster.logsdb.enabled", false).build()
         );
 
@@ -583,7 +583,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         }
     }
 
-    public void testNewIndexHasSyntheticSourceUsage_invalidSettings() throws IOException {
+    public void testNewIndexHasSyntheticSourceUsageInvalidSettings() throws IOException {
         String dataStreamName = DATA_STREAM_NAME;
         String indexName = DataStream.getDefaultBackingIndexName(dataStreamName, 0);
         Settings settings = Settings.builder().put("index.soft_deletes.enabled", false).build();
@@ -655,7 +655,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         assertThat(result.size(), equalTo(0));
         assertThat(newMapperServiceCounter.get(), equalTo(1));
 
-        syntheticSourceLicenseService.setSyntheticSourceFallback(true);
+        logsdbLicenseService.setSyntheticSourceFallback(true);
         result = provider.getAdditionalIndexSettings(
             DataStream.getDefaultBackingIndexName(dataStreamName, 2),
             dataStreamName,
@@ -699,7 +699,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
     }
 
     public void testGetAdditionalIndexSettingsDowngradeFromSyntheticSourceFileMatch() throws IOException {
-        syntheticSourceLicenseService.setSyntheticSourceFallback(true);
+        logsdbLicenseService.setSyntheticSourceFallback(true);
         LogsdbIndexModeSettingsProvider provider = withSyntheticSourceDemotionSupport(true);
         final Settings settings = Settings.EMPTY;
 
@@ -810,7 +810,7 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
         assertTrue(result.isEmpty());
     }
 
-    public void testExplicitRoutingPathDoesNotMatchSortFields() throws Exception {
+    public void testExplicitRoutingPathDoesNotMatchSortFields() {
         var settings = Settings.builder()
             .put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "host,message,@timestamp")
             .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "host,message,foo")
@@ -827,6 +827,22 @@ public class LogsdbIndexModeSettingsProviderTests extends ESTestCase {
                     + "and routing fields, [index.routing_path:[host, message, foo]], [index.sort.fields:[host, message]]"
             )
         );
+    }
+
+    public void testExplicitRoutingPathNotAllowedByLicense() throws Exception {
+        MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.LOGSDB_ROUTING_ON_SORT_FIELDS_FEATURE))).thenReturn(false);
+        logsdbLicenseService = new LogsdbLicenseService(Settings.EMPTY);
+        logsdbLicenseService.setLicenseState(licenseState);
+
+        var settings = Settings.builder()
+            .put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "host,message")
+            .put(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.getKey(), true)
+            .build();
+        Settings result = generateLogsdbSettings(settings);
+        assertFalse(IndexSettings.LOGSDB_ROUTE_ON_SORT_FIELDS.get(result));
+        assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), empty());
     }
 
     public void testSortAndHostNamePropagateValue() throws Exception {

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LogsdbIndexSettingsProviderLegacyLicenseTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LogsdbIndexSettingsProviderLegacyLicenseTests.java
@@ -25,7 +25,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 
-import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseServiceTests.createGoldOrPlatinumLicense;
+import static org.elasticsearch.xpack.logsdb.LogsdbLicenseServiceTests.createGoldOrPlatinumLicense;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -40,12 +40,12 @@ public class LogsdbIndexSettingsProviderLegacyLicenseTests extends ESTestCase {
         License license = createGoldOrPlatinumLicense();
         var licenseState = new XPackLicenseState(() -> time, new XPackLicenseStatus(license.operationMode(), true, null));
 
-        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        var licenseService = new LogsdbLicenseService(Settings.EMPTY);
         licenseService.setLicenseState(licenseState);
         var mockLicenseService = mock(LicenseService.class);
         when(mockLicenseService.getLicense()).thenReturn(license);
 
-        SyntheticSourceLicenseService syntheticSourceLicenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        LogsdbLicenseService syntheticSourceLicenseService = new LogsdbLicenseService(Settings.EMPTY);
         syntheticSourceLicenseService.setLicenseState(licenseState);
         syntheticSourceLicenseService.setLicenseService(mockLicenseService);
 
@@ -53,6 +53,7 @@ public class LogsdbIndexSettingsProviderLegacyLicenseTests extends ESTestCase {
         provider.init(
             im -> MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName()),
             IndexVersion::current,
+            true,
             true
         );
     }
@@ -102,12 +103,12 @@ public class LogsdbIndexSettingsProviderLegacyLicenseTests extends ESTestCase {
         long time = LocalDateTime.of(2024, 12, 31, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
         var licenseState = new XPackLicenseState(() -> time, new XPackLicenseStatus(license.operationMode(), true, null));
 
-        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        var licenseService = new LogsdbLicenseService(Settings.EMPTY);
         licenseService.setLicenseState(licenseState);
         var mockLicenseService = mock(LicenseService.class);
         when(mockLicenseService.getLicense()).thenReturn(license);
 
-        SyntheticSourceLicenseService syntheticSourceLicenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        LogsdbLicenseService syntheticSourceLicenseService = new LogsdbLicenseService(Settings.EMPTY);
         syntheticSourceLicenseService.setLicenseState(licenseState);
         syntheticSourceLicenseService.setLicenseService(mockLicenseService);
 
@@ -115,6 +116,7 @@ public class LogsdbIndexSettingsProviderLegacyLicenseTests extends ESTestCase {
         provider.init(
             im -> MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName()),
             IndexVersion::current,
+            true,
             true
         );
 

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LogsdbLicenseServiceTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LogsdbLicenseServiceTests.java
@@ -26,23 +26,43 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SyntheticSourceLicenseServiceTests extends ESTestCase {
+public class LogsdbLicenseServiceTests extends ESTestCase {
 
     private LicenseService mockLicenseService;
-    private SyntheticSourceLicenseService licenseService;
+    private LogsdbLicenseService licenseService;
 
     @Before
     public void setup() throws Exception {
         mockLicenseService = mock(LicenseService.class);
         License license = createEnterpriseLicense();
         when(mockLicenseService.getLicense()).thenReturn(license);
-        licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        licenseService = new LogsdbLicenseService(Settings.EMPTY);
+    }
+
+    public void testAllowRoutingOnSortFields() {
+        MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.LOGSDB_ROUTING_ON_SORT_FIELDS_FEATURE))).thenReturn(true);
+        licenseService.setLicenseState(licenseState);
+        licenseService.setLicenseService(mockLicenseService);
+        assertTrue(licenseService.allowLogsdbRoutingOnSortField(false));
+        Mockito.verify(licenseState, Mockito.times(1)).featureUsed(any());
+    }
+
+    public void testAllowRoutingOnSortFieldsTemplateValidation() {
+        MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.LOGSDB_ROUTING_ON_SORT_FIELDS_FEATURE))).thenReturn(true);
+        licenseService.setLicenseState(licenseState);
+        licenseService.setLicenseService(mockLicenseService);
+        assertTrue(licenseService.allowLogsdbRoutingOnSortField(true));
+        Mockito.verify(licenseState, Mockito.never()).featureUsed(any());
     }
 
     public void testLicenseAllowsSyntheticSource() {
         MockLicenseState licenseState = MockLicenseState.createMock();
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
-        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(true);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(true);
         licenseService.setLicenseState(licenseState);
         licenseService.setLicenseService(mockLicenseService);
         assertFalse(
@@ -55,7 +75,7 @@ public class SyntheticSourceLicenseServiceTests extends ESTestCase {
     public void testLicenseAllowsSyntheticSourceTemplateValidation() {
         MockLicenseState licenseState = MockLicenseState.createMock();
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
-        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(true);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(true);
         licenseService.setLicenseState(licenseState);
         licenseService.setLicenseService(mockLicenseService);
         assertFalse(
@@ -65,10 +85,10 @@ public class SyntheticSourceLicenseServiceTests extends ESTestCase {
         Mockito.verify(licenseState, Mockito.never()).featureUsed(any());
     }
 
-    public void testDefaultDisallow() {
+    public void testDefaultDisallowSyntheticSource() {
         MockLicenseState licenseState = MockLicenseState.createMock();
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
-        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(false);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(false);
         licenseService.setLicenseState(licenseState);
         licenseService.setLicenseService(mockLicenseService);
         assertTrue(
@@ -78,10 +98,10 @@ public class SyntheticSourceLicenseServiceTests extends ESTestCase {
         Mockito.verify(licenseState, Mockito.never()).featureUsed(any());
     }
 
-    public void testFallback() {
+    public void testFallbackSyntheticSource() {
         MockLicenseState licenseState = MockLicenseState.createMock();
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
-        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(true);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(true);
         licenseService.setLicenseState(licenseState);
         licenseService.setLicenseService(mockLicenseService);
         licenseService.setSyntheticSourceFallback(true);
@@ -101,15 +121,15 @@ public class SyntheticSourceLicenseServiceTests extends ESTestCase {
         MockLicenseState licenseState = MockLicenseState.createMock();
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.getOperationMode()).thenReturn(license.operationMode());
-        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY))).thenReturn(true);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY))).thenReturn(true);
         licenseService.setLicenseState(licenseState);
         licenseService.setLicenseService(mockLicenseService);
         assertFalse(
             "legacy licensed usage is allowed, so not fallback to stored source",
             licenseService.fallbackToStoredSource(false, true)
         );
-        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE));
-        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY));
+        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE));
+        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY));
         Mockito.verify(licenseState, Mockito.times(1)).featureUsed(any());
     }
 
@@ -121,7 +141,7 @@ public class SyntheticSourceLicenseServiceTests extends ESTestCase {
         MockLicenseState licenseState = MockLicenseState.createMock();
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.getOperationMode()).thenReturn(license.operationMode());
-        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(false);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(false);
         licenseService.setLicenseState(licenseState);
         licenseService.setLicenseService(mockLicenseService);
         assertTrue(
@@ -129,7 +149,7 @@ public class SyntheticSourceLicenseServiceTests extends ESTestCase {
             licenseService.fallbackToStoredSource(false, false)
         );
         Mockito.verify(licenseState, Mockito.never()).featureUsed(any());
-        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE));
+        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE));
     }
 
     public void testGoldOrPlatinumLicenseBeyondCutoffDate() throws Exception {
@@ -141,17 +161,17 @@ public class SyntheticSourceLicenseServiceTests extends ESTestCase {
         MockLicenseState licenseState = MockLicenseState.createMock();
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.getOperationMode()).thenReturn(license.operationMode());
-        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(false);
-        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY))).thenReturn(true);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(false);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY))).thenReturn(true);
         licenseService.setLicenseState(licenseState);
         licenseService.setLicenseService(mockLicenseService);
         assertTrue("beyond cutoff date, so fallback to stored source", licenseService.fallbackToStoredSource(false, true));
         Mockito.verify(licenseState, Mockito.never()).featureUsed(any());
-        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE));
+        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE));
     }
 
     public void testGoldOrPlatinumLicenseCustomCutoffDate() throws Exception {
-        licenseService = new SyntheticSourceLicenseService(Settings.EMPTY, "2025-01-02T00:00");
+        licenseService = new LogsdbLicenseService(Settings.EMPTY, "2025-01-02T00:00");
 
         long start = LocalDateTime.of(2025, 1, 3, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
         License license = createGoldOrPlatinumLicense(start);
@@ -161,12 +181,12 @@ public class SyntheticSourceLicenseServiceTests extends ESTestCase {
         MockLicenseState licenseState = MockLicenseState.createMock();
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.getOperationMode()).thenReturn(license.operationMode());
-        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(false);
-        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY))).thenReturn(true);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(false);
+        when(licenseState.isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY))).thenReturn(true);
         licenseService.setLicenseState(licenseState);
         licenseService.setLicenseService(mockLicenseService);
         assertTrue("custom cutoff date, so fallback to stored source", licenseService.fallbackToStoredSource(false, true));
-        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE));
+        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(LogsdbLicenseService.SYNTHETIC_SOURCE_FEATURE));
         Mockito.verify(licenseState, Mockito.never()).featureUsed(any());
     }
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Licensing controls for logsdb routing on sort fields  (#120276)