### PR TITLE
MixedClusterClientYamlTestSuiteIT unmute 380_sort_segments_on_timestamp test 8.x

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -196,9 +196,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.CoreFullClusterRestartIT
   method: testSnapshotRestore {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/111799
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search/380_sort_segments_on_timestamp/Test that index segments are NOT sorted on timestamp field when @timestamp field is dynamically added}
-  issue: https://github.com/elastic/elasticsearch/issues/116221
 - class: org.elasticsearch.ingest.geoip.EnterpriseGeoIpDownloaderIT
   method: testEnterpriseDownloaderTask
   issue: https://github.com/elastic/elasticsearch/issues/115163


### PR DESCRIPTION
I couldn't reproduce the failure. Please check @cbuescher's https://github.com/elastic/elasticsearch/issues/116221#issuecomment-2626821901 for details.
I unmute the failing tests to verify if they are still failing and, if so, to have a fresher failure to analyze.t.
