### PR TITLE
Fix SO-Error in SearchWithRandomDisconnectsIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -72,9 +72,6 @@ tests:
 - class: org.elasticsearch.action.search.SearchPhaseControllerTests
   method: testProgressListener
   issue: https://github.com/elastic/elasticsearch/issues/116149
-- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-  method: testSearchWithRandomDisconnects
-  issue: https://github.com/elastic/elasticsearch/issues/116175
 - class: org.elasticsearch.xpack.deprecation.DeprecationHttpIT
   method: testDeprecatedSettingsReturnWarnings
   issue: https://github.com/elastic/elasticsearch/issues/108628


### PR DESCRIPTION
Obvious SO exception possibility if we encounter exceptions back to back in the callback. Use promise style pattern instead of callback in the individual loops to limit stack-depth (this should be good enough for a fix, technically you could still run into very deep stacks if the search completes between the `isDone` check and adding the listener back-to-back a couple times but practically this should be good enough since all the instant-done situations are from the search fully failing outright.

closes #116175
