### PR TITLE
Increase timeout in indexRandom to 30s

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -201,8 +201,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
   issue: https://github.com/elastic/elasticsearch/issues/120810
-- class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
-  issue: https://github.com/elastic/elasticsearch/issues/116126
 - class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
   method: testAuthenticateShouldNotFallThroughInCaseOfFailure
   issue: https://github.com/elastic/elasticsearch/issues/120902

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1783,7 +1783,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
             }
         }
         for (CountDownLatch operation : inFlightAsyncOperations) {
-            safeAwait(operation);
+            safeAwait(operation, TEST_REQUEST_TIMEOUT);
         }
         if (bogusIds.isEmpty() == false) {
             // delete the bogus types again - it might trigger merges or at least holes in the segments and enforces deleted docs!


### PR DESCRIPTION
We have at least this one test where the combination of running in the single CPU environment and a relatively large document count + dynamic mapping updates exceeds the 10s threshold in very rare cases. Lets try moving this to 30s to hopefully turn "rare" into practically impossible. I could see this being an issue in other tests or becoming one, so I think it's fine to raise the timeout for all tests.

closes #116126
closes #115815
