### PR TITLE
[8.18] Unmuting fixed int4 flakiness (#122545)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -450,9 +450,6 @@ tests:
 - class: org.elasticsearch.xpack.security.profile.ProfileIntegTests
   method: testSuggestProfileWithData
   issue: https://github.com/elastic/elasticsearch/issues/121258
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search.vectors/42_knn_search_int4_flat/Vector similarity with filter only}
-  issue: https://github.com/elastic/elasticsearch/issues/121412
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/*}
   issue: https://github.com/elastic/elasticsearch/issues/120816


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Unmuting fixed int4 flakiness (#122545)](https://github.com/elastic/elasticsearch/pull/122545)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)