### PR TITLE
[Entitlements] Add logsDir to entitlement bootstrap parameters

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
@@ -38,7 +38,8 @@ public class EntitlementBootstrap {
         Function<Class<?>, String> pluginResolver,
         Path[] dataDirs,
         Path configDir,
-        Path tempDir
+        Path tempDir,
+        Path logsDir
     ) {
         public BootstrapArgs {
             requireNonNull(pluginPolicies);
@@ -64,22 +65,24 @@ public class EntitlementBootstrap {
      *
      * @param pluginPolicies a map holding policies for plugins (and modules), by plugin (or module) name.
      * @param pluginResolver a functor to map a Java Class to the plugin it belongs to (the plugin name).
-     * @param dataDirs data directories for Elasticsearch
-     * @param configDir the config directory for Elasticsearch
-     * @param tempDir the temp directory for Elasticsearch
+     * @param dataDirs       data directories for Elasticsearch
+     * @param configDir      the config directory for Elasticsearch
+     * @param tempDir        the temp directory for Elasticsearch
+     * @param logsDir        the log directory for Elasticsearch
      */
     public static void bootstrap(
         Map<String, Policy> pluginPolicies,
         Function<Class<?>, String> pluginResolver,
         Path[] dataDirs,
         Path configDir,
-        Path tempDir
+        Path tempDir,
+        Path logsDir
     ) {
         logger.debug("Loading entitlement agent");
         if (EntitlementBootstrap.bootstrapArgs != null) {
             throw new IllegalStateException("plugin data is already set");
         }
-        EntitlementBootstrap.bootstrapArgs = new BootstrapArgs(pluginPolicies, pluginResolver, dataDirs, configDir, tempDir);
+        EntitlementBootstrap.bootstrapArgs = new BootstrapArgs(pluginPolicies, pluginResolver, dataDirs, configDir, tempDir, logsDir);
         exportInitializationToAgent();
         loadAgent(findAgentJar());
         selfTest();

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -129,6 +129,7 @@ public class EntitlementInitialization {
         Map<String, Policy> pluginPolicies = EntitlementBootstrap.bootstrapArgs().pluginPolicies();
         Path[] dataDirs = EntitlementBootstrap.bootstrapArgs().dataDirs();
         Path tempDir = EntitlementBootstrap.bootstrapArgs().tempDir();
+        Path logsDir = EntitlementBootstrap.bootstrapArgs().logsDir();
 
         // TODO(ES-10031): Decide what goes in the elasticsearch default policy and extend it
         var serverPolicy = new Policy(
@@ -147,7 +148,10 @@ public class EntitlementInitialization {
                         new LoadNativeLibrariesEntitlement(),
                         new ManageThreadsEntitlement(),
                         new FilesEntitlement(
-                            List.of(new FilesEntitlement.FileData(EntitlementBootstrap.bootstrapArgs().tempDir().toString(), READ_WRITE))
+                            List.of(
+                                new FilesEntitlement.FileData(tempDir.toString(), READ_WRITE),
+                                new FilesEntitlement.FileData(logsDir.toString(), READ_WRITE)
+                            )
                         )
                     )
                 ),

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -388,14 +388,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.mapper.SemanticInferenceMetadataFieldsRecoveryTests
   method: testSnapshotRecovery {p0=false p1=true}
   issue: https://github.com/elastic/elasticsearch/issues/122551
-- class: org.elasticsearch.entitlement.qa.EntitlementsDeniedIT
-  issue: https://github.com/elastic/elasticsearch/issues/122566
-- class: org.elasticsearch.entitlement.qa.EntitlementsAllowedIT
-  issue: https://github.com/elastic/elasticsearch/issues/122567
-- class: org.elasticsearch.entitlement.qa.EntitlementsAllowedNonModularIT
-  issue: https://github.com/elastic/elasticsearch/issues/122568
-- class: org.elasticsearch.entitlement.qa.EntitlementsDeniedNonModularIT
-  issue: https://github.com/elastic/elasticsearch/issues/122569
 
 # Examples:
 #

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -247,7 +247,8 @@ class Elasticsearch {
                 pluginsResolver::resolveClassToPluginName,
                 nodeEnv.dataDirs(),
                 nodeEnv.configDir(),
-                nodeEnv.tmpDir()
+                nodeEnv.tmpDir(),
+                nodeEnv.logsDir()
             );
         } else {
             assert RuntimeVersionFeature.isSecurityManagerAvailable();


### PR DESCRIPTION
While testing https://github.com/elastic/elasticsearch/pull/122591, I realized we need to grand read/write permission to the logs dir to server.

This PR adds the `logsDir` to the bootstrap parameters, and uses it in the `server` policy.