### PR TITLE
ES|QL: disable mixed cluster CSV tests that require source field mapping

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.esql.CsvTestUtils.isEnabled;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.JOIN_LOOKUP_V12;
-import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.SOURCE_FIELD_MAPPING;
 
 public class MixedClusterEsqlSpecIT extends EsqlSpecTestCase {
     @ClassRule
@@ -93,7 +92,7 @@ public class MixedClusterEsqlSpecIT extends EsqlSpecTestCase {
 
     @Override
     protected boolean supportsSourceFieldMapping() throws IOException {
-        return hasCapabilities(List.of(SOURCE_FIELD_MAPPING.capabilityName()));
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Mixed cluster tests fail in serverless, as source mapping is not allowed.
All the other multi-node CSV tests have these tests disabled already, see [single_node](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlSpecIT.java#L53) and [multi_node](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlSpecIT.java#L45) EsqlSpecIT.
We are doing the same for Mixed cluster