### PR TITLE
Validate mrjar plugin versions (#120823) (#120942)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/MrjarPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/MrjarPlugin.java
@@ -72,12 +72,13 @@ public class MrjarPlugin implements Plugin<Project> {
         var javaExtension = project.getExtensions().getByType(JavaPluginExtension.class);
         var isIdeaSync = System.getProperty("idea.sync.active", "false").equals("true");
         var ideaSourceSetsEnabled = project.hasProperty(MRJAR_IDEA_ENABLED) && project.property(MRJAR_IDEA_ENABLED).equals("true");
+        int minJavaVersion = Integer.parseInt(buildParams.getMinimumCompilerVersion().getMajorVersion());
 
         // Ignore version-specific source sets if we are importing into IntelliJ and have not explicitly enabled this.
         // Avoids an IntelliJ bug:
         // https://youtrack.jetbrains.com/issue/IDEA-285640/Compiler-Options-Settings-language-level-is-set-incorrectly-with-JDK-19ea
         if (isIdeaSync == false || ideaSourceSetsEnabled) {
-            List<Integer> mainVersions = findSourceVersions(project);
+            List<Integer> mainVersions = findSourceVersions(project, minJavaVersion);
             List<String> mainSourceSets = new ArrayList<>();
             mainSourceSets.add(SourceSet.MAIN_SOURCE_SET_NAME);
             List<String> testSourceSets = new ArrayList<>(mainSourceSets);
@@ -101,6 +102,7 @@ public class MrjarPlugin implements Plugin<Project> {
     }
 
     private void configureMrjar(Project project) {
+
         var jarTask = project.getTasks().withType(Jar.class).named(JavaPlugin.JAR_TASK_NAME);
         jarTask.configure(task -> { task.manifest(manifest -> { manifest.attributes(Map.of("Multi-Release", "true")); }); });
 
@@ -216,7 +218,7 @@ public class MrjarPlugin implements Plugin<Project> {
         project.getTasks().named("check").configure(checkTask -> checkTask.dependsOn(testTaskProvider));
     }
 
-    private static List<Integer> findSourceVersions(Project project) {
+    private static List<Integer> findSourceVersions(Project project, int minJavaVersion) {
         var srcDir = project.getProjectDir().toPath().resolve("src");
         List<Integer> versions = new ArrayList<>();
         try (var subdirStream = Files.list(srcDir)) {
@@ -225,7 +227,23 @@ public class MrjarPlugin implements Plugin<Project> {
                 String sourcesetName = sourceSetPath.getFileName().toString();
                 Matcher sourcesetMatcher = MRJAR_SOURCESET_PATTERN.matcher(sourcesetName);
                 if (sourcesetMatcher.matches()) {
-                    versions.add(Integer.parseInt(sourcesetMatcher.group(1)));
+                    int version = Integer.parseInt(sourcesetMatcher.group(1));
+                    if (version < minJavaVersion) {
+                        // NOTE: We allow mainNN for the min java version so that incubating modules can be used without warnings.
+                        // It is a workaround for https://bugs.openjdk.org/browse/JDK-8187591. Once min java is 22, we
+                        // can use the SuppressWarnings("preview") in the code using incubating modules and this check
+                        // can change to <=
+                        throw new IllegalArgumentException(
+                            "Found src dir '"
+                                + sourcesetName
+                                + "' for Java "
+                                + version
+                                + " but multi-release jar sourceset should have version "
+                                + minJavaVersion
+                                + " or greater"
+                        );
+                    }
+                    versions.add(version);
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
The mrjar plugin adds support for sourcesets named in the form mainNN, which adds the appropriate compiler and other settings for that version of Java, and produces a multi-release jar. Having multi-release jars only makes sense for versions of java newer than the minimum compile version. This commit adds validation that the version is not too old.

Note that the check is slightly relaxed; it allows mainNN where NN is equal to the min java version. This is due to the desire to keep code using incubating modules separate because warnings must be disabled.
