### PR TITLE
Make sure index is healthy before calling _frozen in ReindexDatastreamIndexTransportActionIT

### DIFF
--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
@@ -611,7 +611,7 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     public void testIndexUnfrozen() {
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         safeGet(indicesAdmin().create(new CreateIndexRequest(sourceIndex)));
-
+        ensureHealth(sourceIndex);
         // add doc with timestamp
         String time = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(System.currentTimeMillis());
         var doc = String.format(Locale.ROOT, "{\"%s\":\"%s\"}", DEFAULT_TIMESTAMP_FIELD, time);


### PR DESCRIPTION
The _freeze API closes the index. In very rare cases, the close API calls. The reason is this:
```
[2025-02-14T09:26:05,631][DEBUG ][o.e.c.m.MetadataIndexStateService] [node_s1] verification of shards before closing [nrpzczbneasotbxjerkt/TJ5ynsgiQQyGDsNOcXknhQ] failed [[nrpzczbneasotbxjerkt/TJ5ynsgiQQyGDsNOcXknhQ]={"nrpzczbneasotbxjerkt":{"closed":false,"failedShards":{"0":{"failures":[{"node":"7uccCWfYQ3qLqZEtcqMI2A","shard":0,"index":"nrpzczbneasotbxjerkt","status":"INTERNAL_SERVER_ERROR","reason":{"type":"illegal_state_exception","reason":"Global checkpoint [-1] mismatches maximum sequence number [0] on index shard [nrpzczbneasotbxjerkt][0]"}}]}}}}]
```
This results in testIndexUnfrozen to fail with this:
```
java.lang.AssertionError: FreezeResponse failed - not acked
Expected: <true>
     but: was <false>
	at __randomizedtesting.SeedInfo.seed([1E91FABD6C795211:DA7716CD9CD99471]:0)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
	at org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked(ElasticsearchAssertions.java:160)
	at org.elasticsearch.xpack.migrate.action.ReindexDatastreamIndexTransportActionIT.testIndexUnfrozen(ReindexDatastreamIndexTransportActionIT.java:623)
```
This PR fixes it by making sure that the index is healthy before calling _frozen.
Closes #122604