### PR TITLE
[8.18] [Entitlements] Add ability to set path relative to a special directory for Files policies (#122370)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -18,6 +18,7 @@ import org.elasticsearch.entitlement.instrumentation.Instrumenter;
 import org.elasticsearch.entitlement.instrumentation.MethodKey;
 import org.elasticsearch.entitlement.instrumentation.Transformer;
 import org.elasticsearch.entitlement.runtime.api.ElasticsearchEntitlementChecker;
+import org.elasticsearch.entitlement.runtime.policy.PathLookup;
 import org.elasticsearch.entitlement.runtime.policy.Policy;
 import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
 import org.elasticsearch.entitlement.runtime.policy.Scope;
@@ -48,7 +49,6 @@ import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -126,9 +126,9 @@ public class EntitlementInitialization {
     }
 
     private static PolicyManager createPolicyManager() {
-        Map<String, Policy> pluginPolicies = EntitlementBootstrap.bootstrapArgs().pluginPolicies();
-        Path[] dataDirs = EntitlementBootstrap.bootstrapArgs().dataDirs();
-        Path tempDir = EntitlementBootstrap.bootstrapArgs().tempDir();
+        EntitlementBootstrap.BootstrapArgs bootstrapArgs = EntitlementBootstrap.bootstrapArgs();
+        Map<String, Policy> pluginPolicies = bootstrapArgs.pluginPolicies();
+        var pathLookup = new PathLookup(bootstrapArgs.configDir(), bootstrapArgs.dataDirs(), bootstrapArgs.tempDir());
 
         // TODO(ES-10031): Decide what goes in the elasticsearch default policy and extend it
         var serverPolicy = new Policy(
@@ -147,7 +147,7 @@ public class EntitlementInitialization {
                         new LoadNativeLibrariesEntitlement(),
                         new ManageThreadsEntitlement(),
                         new FilesEntitlement(
-                            List.of(new FilesEntitlement.FileData(EntitlementBootstrap.bootstrapArgs().tempDir().toString(), READ_WRITE))
+                            List.of(FilesEntitlement.FileData.ofPath(EntitlementBootstrap.bootstrapArgs().tempDir(), READ_WRITE))
                         )
                     )
                 ),
@@ -159,7 +159,7 @@ public class EntitlementInitialization {
                     "org.elasticsearch.nativeaccess",
                     List.of(
                         new LoadNativeLibrariesEntitlement(),
-                        new FilesEntitlement(Arrays.stream(dataDirs).map(d -> new FileData(d.toString(), READ_WRITE)).toList())
+                        new FilesEntitlement(List.of(FileData.ofRelativePath(Path.of(""), FilesEntitlement.BaseDir.DATA, READ_WRITE)))
                     )
                 )
             )
@@ -175,7 +175,7 @@ public class EntitlementInitialization {
             resolver,
             AGENTS_PACKAGE_NAME,
             ENTITLEMENTS_MODULE,
-            tempDir
+            pathLookup
         );
     }
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
@@ -20,26 +20,30 @@ import java.util.Objects;
 import static org.elasticsearch.core.PathUtils.getDefaultFileSystem;
 
 public final class FileAccessTree {
+
     private static final String FILE_SEPARATOR = getDefaultFileSystem().getSeparator();
 
     private final String[] readPaths;
     private final String[] writePaths;
 
-    private FileAccessTree(FilesEntitlement filesEntitlement, Path tempDir) {
+    private FileAccessTree(FilesEntitlement filesEntitlement, PathLookup pathLookup) {
         List<String> readPaths = new ArrayList<>();
         List<String> writePaths = new ArrayList<>();
         for (FilesEntitlement.FileData fileData : filesEntitlement.filesData()) {
-            var path = normalizePath(Path.of(fileData.path()));
             var mode = fileData.mode();
-            if (mode == FilesEntitlement.Mode.READ_WRITE) {
-                writePaths.add(path);
-            }
-            readPaths.add(path);
+            var paths = fileData.resolvePaths(pathLookup);
+            paths.forEach(path -> {
+                var normalized = normalizePath(path);
+                if (mode == FilesEntitlement.Mode.READ_WRITE) {
+                    writePaths.add(normalized);
+                }
+                readPaths.add(normalized);
+            });
         }
 
         // everything has access to the temp dir
-        readPaths.add(tempDir.toString());
-        writePaths.add(tempDir.toString());
+        readPaths.add(pathLookup.tempDir().toString());
+        writePaths.add(pathLookup.tempDir().toString());
 
         readPaths.sort(String::compareTo);
         writePaths.sort(String::compareTo);
@@ -48,8 +52,8 @@ public final class FileAccessTree {
         this.writePaths = writePaths.toArray(new String[0]);
     }
 
-    public static FileAccessTree of(FilesEntitlement filesEntitlement, Path tempDir) {
-        return new FileAccessTree(filesEntitlement, tempDir);
+    public static FileAccessTree of(FilesEntitlement filesEntitlement, PathLookup pathLookup) {
+        return new FileAccessTree(filesEntitlement, pathLookup);
     }
 
     boolean canRead(Path path) {

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PathLookup.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PathLookup.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy;
+
+import java.nio.file.Path;
+
+public record PathLookup(Path configDir, Path[] dataDirs, Path tempDir) {}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -99,7 +99,7 @@ public class PolicyManager {
         return new ModuleEntitlements(
             componentName,
             entitlements.stream().collect(groupingBy(Entitlement::getClass)),
-            FileAccessTree.of(filesEntitlement, tempDir)
+            FileAccessTree.of(filesEntitlement, pathLookup)
         );
     }
 
@@ -109,7 +109,7 @@ public class PolicyManager {
     private final List<Entitlement> apmAgentEntitlements;
     private final Map<String, Map<String, List<Entitlement>>> pluginsEntitlements;
     private final Function<Class<?>, String> pluginResolver;
-    private final Path tempDir;
+    private final PathLookup pathLookup;
     private final FileAccessTree defaultFileAccess;
 
     public static final String ALL_UNNAMED = "ALL-UNNAMED";
@@ -146,7 +146,7 @@ public class PolicyManager {
         Function<Class<?>, String> pluginResolver,
         String apmAgentPackageName,
         Module entitlementsModule,
-        Path tempDir
+        PathLookup pathLookup
     ) {
         this.serverEntitlements = buildScopeEntitlementsMap(requireNonNull(serverPolicy));
         this.apmAgentEntitlements = apmAgentEntitlements;
@@ -156,9 +156,8 @@ public class PolicyManager {
         this.pluginResolver = pluginResolver;
         this.apmAgentPackageName = apmAgentPackageName;
         this.entitlementsModule = entitlementsModule;
-        this.defaultFileAccess = FileAccessTree.of(FilesEntitlement.EMPTY, tempDir);
-
-        this.tempDir = tempDir;
+        this.pathLookup = requireNonNull(pathLookup);
+        this.defaultFileAccess = FileAccessTree.of(FilesEntitlement.EMPTY, pathLookup);
 
         for (var e : serverEntitlements.entrySet()) {
             validateEntitlementsPerModule(SERVER_COMPONENT_NAME, e.getKey(), e.getValue());

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
@@ -10,12 +10,17 @@
 package org.elasticsearch.entitlement.runtime.policy.entitlements;
 
 import org.elasticsearch.entitlement.runtime.policy.ExternalEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.PathLookup;
 import org.elasticsearch.entitlement.runtime.policy.PolicyValidationException;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  * Describes a file entitlement with a path and mode.
@@ -29,8 +34,104 @@ public record FilesEntitlement(List<FileData> filesData) implements Entitlement 
         READ_WRITE
     }
 
-    public record FileData(String path, Mode mode) {
+    public enum BaseDir {
+        CONFIG,
+        DATA
+    }
 
+    public sealed interface FileData {
+
+        final class AbsolutePathFileData implements FileData {
+            private final Path path;
+            private final Mode mode;
+
+            private AbsolutePathFileData(Path path, Mode mode) {
+                this.path = path;
+                this.mode = mode;
+            }
+
+            @Override
+            public Stream<Path> resolvePaths(PathLookup pathLookup) {
+                return Stream.of(path);
+            }
+
+            @Override
+            public Mode mode() {
+                return mode;
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                if (obj == this) return true;
+                if (obj == null || obj.getClass() != this.getClass()) return false;
+                var that = (AbsolutePathFileData) obj;
+                return Objects.equals(this.path, that.path) && Objects.equals(this.mode, that.mode);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(path, mode);
+            }
+        }
+
+        final class RelativePathFileData implements FileData {
+            private final Path relativePath;
+            private final BaseDir baseDir;
+            private final Mode mode;
+
+            private RelativePathFileData(Path relativePath, BaseDir baseDir, Mode mode) {
+                this.relativePath = relativePath;
+                this.baseDir = baseDir;
+                this.mode = mode;
+            }
+
+            @Override
+            public Stream<Path> resolvePaths(PathLookup pathLookup) {
+                Objects.requireNonNull(pathLookup);
+                switch (baseDir) {
+                    case CONFIG:
+                        return Stream.of(pathLookup.configDir().resolve(relativePath));
+                    case DATA:
+                        return Arrays.stream(pathLookup.dataDirs()).map(d -> d.resolve(relativePath));
+                    default:
+                        throw new IllegalArgumentException();
+                }
+            }
+
+            @Override
+            public Mode mode() {
+                return mode;
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                if (obj == this) return true;
+                if (obj == null || obj.getClass() != this.getClass()) return false;
+                var that = (RelativePathFileData) obj;
+                return Objects.equals(this.mode, that.mode)
+                    && Objects.equals(this.relativePath, that.relativePath)
+                    && Objects.equals(this.baseDir, that.baseDir);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(relativePath, baseDir, mode);
+            }
+        }
+
+        static FileData ofPath(Path path, Mode mode) {
+            assert path.isAbsolute();
+            return new AbsolutePathFileData(path, mode);
+        }
+
+        static FileData ofRelativePath(Path relativePath, BaseDir baseDir, Mode mode) {
+            assert relativePath.isAbsolute() == false;
+            return new RelativePathFileData(relativePath, baseDir, mode);
+        }
+
+        Stream<Path> resolvePaths(PathLookup pathLookup);
+
+        Mode mode();
     }
 
     private static Mode parseMode(String mode) {
@@ -43,6 +144,15 @@ public record FilesEntitlement(List<FileData> filesData) implements Entitlement 
         }
     }
 
+    private static BaseDir parseBaseDir(String baseDir) {
+        if (baseDir.equals("config")) {
+            return BaseDir.CONFIG;
+        } else if (baseDir.equals("data")) {
+            return BaseDir.DATA;
+        }
+        throw new PolicyValidationException("invalid relative directory: " + baseDir + ", valid values: [config, data]");
+    }
+
     @ExternalEntitlement(parameterNames = { "paths" }, esModulesOnly = false)
     @SuppressWarnings("unchecked")
     public static FilesEntitlement build(List<Object> paths) {
@@ -52,18 +162,41 @@ public record FilesEntitlement(List<FileData> filesData) implements Entitlement 
         List<FileData> filesData = new ArrayList<>();
         for (Object object : paths) {
             Map<String, String> file = new HashMap<>((Map<String, String>) object);
-            String path = file.remove("path");
-            if (path == null) {
-                throw new PolicyValidationException("files entitlement must contain path for every listed file");
-            }
+            String pathAsString = file.remove("path");
+            String relativePathAsString = file.remove("relative_path");
+            String relativeTo = file.remove("relative_to");
             String mode = file.remove("mode");
-            if (mode == null) {
-                throw new PolicyValidationException("files entitlement must contain mode for every listed file");
-            }
+
             if (file.isEmpty() == false) {
-                throw new PolicyValidationException("unknown key(s) " + file + " in a listed file for files entitlement");
+                throw new PolicyValidationException("unknown key(s) [" + file + "] in a listed file for files entitlement");
             }
-            filesData.add(new FileData(path, parseMode(mode)));
+            if (mode == null) {
+                throw new PolicyValidationException("files entitlement must contain 'mode' for every listed file");
+            }
+            if (pathAsString != null && relativePathAsString != null) {
+                throw new PolicyValidationException("a files entitlement entry cannot contain both 'path' and 'relative_path'");
+            }
+
+            if (relativePathAsString != null) {
+                if (relativeTo == null) {
+                    throw new PolicyValidationException("files entitlement with a 'relative_path' must specify 'relative_to'");
+                }
+                final BaseDir baseDir = parseBaseDir(relativeTo);
+
+                Path relativePath = Path.of(relativePathAsString);
+                if (relativePath.isAbsolute()) {
+                    throw new PolicyValidationException("'relative_path' [" + relativePathAsString + "] must be relative");
+                }
+                filesData.add(FileData.ofRelativePath(relativePath, baseDir, parseMode(mode)));
+            } else if (pathAsString != null) {
+                Path path = Path.of(pathAsString);
+                if (path.isAbsolute() == false) {
+                    throw new PolicyValidationException("'path' [" + pathAsString + "] must be absolute");
+                }
+                filesData.add(FileData.ofPath(path, parseMode(mode)));
+            } else {
+                throw new PolicyValidationException("files entitlement must contain either 'path' or 'relative_path' for every entry");
+            }
         }
         return new FilesEntitlement(filesData);
     }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
@@ -35,6 +35,12 @@ public class FileAccessTreeTests extends ESTestCase {
         return root.resolve(s);
     }
 
+    private static final PathLookup TEST_PATH_LOOKUP = new PathLookup(
+        Path.of("/config"),
+        new Path[] { Path.of("/data1"), Path.of("/data2") },
+        Path.of("/tmp")
+    );
+
     public void testEmpty() {
         var tree = accessTree(FilesEntitlement.EMPTY);
         assertThat(tree.canRead(path("path")), is(false));
@@ -84,6 +90,53 @@ public class FileAccessTreeTests extends ESTestCase {
         assertThat(tree.canWrite(path("foo/bar")), is(true));
     }
 
+    public void testReadWithRelativePath() {
+        var tree = accessTree(entitlement(Map.of("relative_path", "foo", "mode", "read", "relative_to", "config")));
+        assertThat(tree.canRead(path("foo")), is(false));
+
+        assertThat(tree.canRead(path("/config/foo")), is(true));
+
+        assertThat(tree.canRead(path("/config/foo/subdir")), is(true));
+        assertThat(tree.canRead(path("/config/food")), is(false));
+        assertThat(tree.canWrite(path("/config/foo")), is(false));
+
+        assertThat(tree.canRead(path("/config")), is(false));
+        assertThat(tree.canRead(path("/config/before")), is(false));
+        assertThat(tree.canRead(path("/config/later")), is(false));
+    }
+
+    public void testWriteWithRelativePath() {
+        var tree = accessTree(entitlement(Map.of("relative_path", "foo", "mode", "read_write", "relative_to", "config")));
+        assertThat(tree.canWrite(path("/config/foo")), is(true));
+        assertThat(tree.canWrite(path("/config/foo/subdir")), is(true));
+        assertThat(tree.canWrite(path("foo")), is(false));
+        assertThat(tree.canWrite(path("/config/food")), is(false));
+        assertThat(tree.canRead(path("/config/foo")), is(true));
+        assertThat(tree.canRead(path("foo")), is(false));
+
+        assertThat(tree.canWrite(path("/config")), is(false));
+        assertThat(tree.canWrite(path("/config/before")), is(false));
+        assertThat(tree.canWrite(path("/config/later")), is(false));
+    }
+
+    public void testMultipleDataDirs() {
+        var tree = accessTree(entitlement(Map.of("relative_path", "foo", "mode", "read_write", "relative_to", "data")));
+        assertThat(tree.canWrite(path("/data1/foo")), is(true));
+        assertThat(tree.canWrite(path("/data2/foo")), is(true));
+        assertThat(tree.canWrite(path("/data3/foo")), is(false));
+        assertThat(tree.canWrite(path("/data1/foo/subdir")), is(true));
+        assertThat(tree.canWrite(path("foo")), is(false));
+        assertThat(tree.canWrite(path("/data1/food")), is(false));
+        assertThat(tree.canRead(path("/data1/foo")), is(true));
+        assertThat(tree.canRead(path("/data2/foo")), is(true));
+        assertThat(tree.canRead(path("foo")), is(false));
+
+        assertThat(tree.canWrite(path("/data1")), is(false));
+        assertThat(tree.canWrite(path("/data2")), is(false));
+        assertThat(tree.canWrite(path("/config/before")), is(false));
+        assertThat(tree.canWrite(path("/config/later")), is(false));
+    }
+
     public void testNormalizePath() {
         var tree = accessTree(entitlement("foo/../bar", "read"));
         assertThat(tree.canRead(path("foo/../bar")), is(true));
@@ -106,17 +159,19 @@ public class FileAccessTreeTests extends ESTestCase {
 
     public void testTempDirAccess() {
         Path tempDir = createTempDir();
-        var tree = FileAccessTree.of(FilesEntitlement.EMPTY, tempDir);
-
+        var tree = FileAccessTree.of(
+            FilesEntitlement.EMPTY,
+            new PathLookup(Path.of("/config"), new Path[] { Path.of("/data1"), Path.of("/data2") }, tempDir)
+        );
         assertThat(tree.canRead(tempDir), is(true));
         assertThat(tree.canWrite(tempDir), is(true));
     }
 
     FileAccessTree accessTree(FilesEntitlement entitlement) {
-        return FileAccessTree.of(entitlement, createTempDir());
+        return FileAccessTree.of(entitlement, TEST_PATH_LOOKUP);
     }
 
-    FilesEntitlement entitlement(String... values) {
+    static FilesEntitlement entitlement(String... values) {
         List<Object> filesData = new ArrayList<>();
         for (int i = 0; i < values.length; i += 2) {
             Map<String, String> fileData = new HashMap<>();
@@ -125,5 +180,9 @@ public class FileAccessTreeTests extends ESTestCase {
             filesData.add(fileData);
         }
         return FilesEntitlement.build(filesData);
+    }
+
+    static FilesEntitlement entitlement(Map<String, String> value) {
+        return FilesEntitlement.build(List.of(value));
     }
 }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
@@ -53,6 +53,12 @@ public class PolicyManagerTests extends ESTestCase {
      */
     private static Module NO_ENTITLEMENTS_MODULE;
 
+    private static final PathLookup TEST_PATH_LOOKUP = new PathLookup(
+        Path.of("/config"),
+        new Path[] { Path.of("/data1/"), Path.of("/data2") },
+        Path.of("/temp")
+    );
+
     @BeforeClass
     public static void beforeClass() {
         try {
@@ -61,7 +67,6 @@ public class PolicyManagerTests extends ESTestCase {
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
-
     }
 
     public void testGetEntitlementsThrowsOnMissingPluginUnnamedModule() {
@@ -72,7 +77,7 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "plugin1",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            createTempDir()
+            TEST_PATH_LOOKUP
         );
 
         // Any class from the current module (unnamed) will do
@@ -96,7 +101,7 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "plugin1",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            createTempDir()
+            TEST_PATH_LOOKUP
         );
 
         // Any class from the current module (unnamed) will do
@@ -116,7 +121,7 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "plugin1",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            createTempDir()
+            TEST_PATH_LOOKUP
         );
 
         // Any class from the current module (unnamed) will do
@@ -141,7 +146,7 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "plugin2",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            createTempDir()
+            TEST_PATH_LOOKUP
         );
 
         // Any class from the current module (unnamed) will do
@@ -159,7 +164,7 @@ public class PolicyManagerTests extends ESTestCase {
             c -> null,
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            createTempDir()
+            TEST_PATH_LOOKUP
         );
 
         // Tests do not run modular, so we cannot use a server class.
@@ -189,7 +194,7 @@ public class PolicyManagerTests extends ESTestCase {
             c -> null,
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            createTempDir()
+            TEST_PATH_LOOKUP
         );
 
         // Tests do not run modular, so we cannot use a server class.
@@ -215,7 +220,7 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "mock-plugin",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            createTempDir()
+            TEST_PATH_LOOKUP
         );
 
         var layer = createLayerForJar(jar, "org.example.plugin");
@@ -235,7 +240,7 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "plugin2",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            createTempDir()
+            TEST_PATH_LOOKUP
         );
 
         // Any class from the current module (unnamed) will do
@@ -294,7 +299,7 @@ public class PolicyManagerTests extends ESTestCase {
             c -> c.getPackageName().startsWith(TEST_AGENTS_PACKAGE_NAME) ? null : "test",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            createTempDir()
+            TEST_PATH_LOOKUP
         );
         ModuleEntitlements agentsEntitlements = policyManager.getEntitlements(TestAgent.class);
         assertThat(agentsEntitlements.hasEntitlement(CreateClassLoaderEntitlement.class), is(true));
@@ -322,7 +327,7 @@ public class PolicyManagerTests extends ESTestCase {
                 c -> "test",
                 TEST_AGENTS_PACKAGE_NAME,
                 NO_ENTITLEMENTS_MODULE,
-                createTempDir()
+                TEST_PATH_LOOKUP
             )
         );
         assertEquals(
@@ -339,7 +344,7 @@ public class PolicyManagerTests extends ESTestCase {
                 c -> "test",
                 TEST_AGENTS_PACKAGE_NAME,
                 NO_ENTITLEMENTS_MODULE,
-                createTempDir()
+                TEST_PATH_LOOKUP
             )
         );
         assertEquals(
@@ -362,7 +367,9 @@ public class PolicyManagerTests extends ESTestCase {
                                 List.of(
                                     FilesEntitlement.EMPTY,
                                     new CreateClassLoaderEntitlement(),
-                                    new FilesEntitlement(List.of(new FilesEntitlement.FileData("test", FilesEntitlement.Mode.READ)))
+                                    new FilesEntitlement(
+                                        List.of(FilesEntitlement.FileData.ofPath(Path.of("/tmp/test"), FilesEntitlement.Mode.READ))
+                                    )
                                 )
                             )
                         )
@@ -371,7 +378,7 @@ public class PolicyManagerTests extends ESTestCase {
                 c -> "plugin1",
                 TEST_AGENTS_PACKAGE_NAME,
                 NO_ENTITLEMENTS_MODULE,
-                createTempDir()
+                TEST_PATH_LOOKUP
             )
         );
         assertEquals(
@@ -391,7 +398,7 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "test", // Insist that the class is in a plugin
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            createTempDir()
+            TEST_PATH_LOOKUP
         );
         ModuleEntitlements notAgentsEntitlements = policyManager.getEntitlements(TestAgent.class);
         assertThat(notAgentsEntitlements.hasEntitlement(CreateClassLoaderEntitlement.class), is(false));
@@ -412,7 +419,7 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "test",
             agentsPackageName,
             entitlementsModule,
-            createTempDir()
+            TEST_PATH_LOOKUP
         );
     }
 
@@ -432,7 +439,9 @@ public class PolicyManagerTests extends ESTestCase {
                     name -> new Scope(
                         name,
                         List.of(
-                            new FilesEntitlement(List.of(new FilesEntitlement.FileData("/test/path", FilesEntitlement.Mode.READ))),
+                            new FilesEntitlement(
+                                List.of(FilesEntitlement.FileData.ofPath(Path.of("/test/path"), FilesEntitlement.Mode.READ))
+                            ),
                             new CreateClassLoaderEntitlement()
                         )
                     )

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlementTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlementTests.java
@@ -9,17 +9,40 @@
 
 package org.elasticsearch.entitlement.runtime.policy.entitlements;
 
+import org.elasticsearch.entitlement.runtime.policy.PathLookup;
 import org.elasticsearch.entitlement.runtime.policy.PolicyValidationException;
 import org.elasticsearch.test.ESTestCase;
 
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement.Mode.READ_WRITE;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 
 public class FilesEntitlementTests extends ESTestCase {
 
     public void testEmptyBuild() {
         PolicyValidationException pve = expectThrows(PolicyValidationException.class, () -> FilesEntitlement.build(List.of()));
-        assertEquals(pve.getMessage(), "must specify at least one path");
+        assertEquals("must specify at least one path", pve.getMessage());
         pve = expectThrows(PolicyValidationException.class, () -> FilesEntitlement.build(null));
-        assertEquals(pve.getMessage(), "must specify at least one path");
+        assertEquals("must specify at least one path", pve.getMessage());
+    }
+
+    public void testInvalidRelativeDirectory() {
+        var ex = expectThrows(
+            PolicyValidationException.class,
+            () -> FilesEntitlement.build(List.of((Map.of("relative_path", "foo", "mode", "read", "relative_to", "bar"))))
+        );
+        assertThat(ex.getMessage(), is("invalid relative directory: bar, valid values: [config, data]"));
+    }
+
+    public void testFileDataRelativeWithEmptyDirectory() {
+        var fileData = FilesEntitlement.FileData.ofRelativePath(Path.of(""), FilesEntitlement.BaseDir.DATA, READ_WRITE);
+        var dataDirs = fileData.resolvePaths(
+            new PathLookup(Path.of("/config"), new Path[] { Path.of("/data1/"), Path.of("/data2") }, Path.of("/temp"))
+        );
+        assertThat(dataDirs.toList(), contains(Path.of("/data1/"), Path.of("/data2")));
     }
 }

--- a/libs/entitlement/src/test/resources/org/elasticsearch/entitlement/runtime/policy/test-policy.yaml
+++ b/libs/entitlement/src/test/resources/org/elasticsearch/entitlement/runtime/policy/test-policy.yaml
@@ -1,4 +1,4 @@
 entitlement-module-name:
   - files:
-      - path: "test/path/to/file"
+      - path: "/test/path/to/file"
         mode: "read_write"


### PR DESCRIPTION
Backports the following commits to 8.18:
 - [Entitlements] Add ability to set path relative to a special directory for Files policies (#122370)