### PR TITLE
[8.17] Canonicalize processor names and types in IngestStats (#122610)

### DIFF
--- a/docs/changelog/122610.yaml
+++ b/docs/changelog/122610.yaml
@@ -1,0 +1,5 @@
+pr: 122610
+summary: Canonicalize processor names and types in `IngestStats`
+area: Ingest Node
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1159,20 +1159,35 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         if (processor instanceof ConditionalProcessor conditionalProcessor) {
             processor = conditionalProcessor.getInnerProcessor();
         }
-        StringBuilder sb = new StringBuilder(5);
-        sb.append(processor.getType());
 
-        if (processor instanceof PipelineProcessor pipelineProcessor) {
-            String pipelineName = pipelineProcessor.getPipelineTemplate().newInstance(Map.of()).execute();
-            sb.append(":");
-            sb.append(pipelineName);
-        }
         String tag = processor.getTag();
-        if (tag != null && tag.isEmpty() == false) {
-            sb.append(":");
-            sb.append(tag);
+        if (tag != null && tag.isEmpty()) {
+            tag = null; // it simplifies the rest of the logic slightly to coalesce to null
         }
-        return sb.toString();
+
+        String pipelineName = null;
+        if (processor instanceof PipelineProcessor pipelineProcessor) {
+            pipelineName = pipelineProcessor.getPipelineTemplate().newInstance(Map.of()).execute();
+        }
+
+        // if there's a tag, OR if it's a pipeline processor, then the processor name is a compound thing,
+        // BUT if neither of those apply, then it's just the type -- so we can return the type itself without
+        // allocating a new String object
+        if (tag == null && pipelineName == null) {
+            return processor.getType();
+        } else {
+            StringBuilder sb = new StringBuilder(5);
+            sb.append(processor.getType());
+            if (pipelineName != null) {
+                sb.append(":");
+                sb.append(pipelineName);
+            }
+            if (tag != null) {
+                sb.append(":");
+                sb.append(tag);
+            }
+            return sb.toString();
+        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -2146,7 +2146,7 @@ public class IngestServiceTests extends ESTestCase {
         Processor processor = mock(Processor.class);
         String name = randomAlphaOfLength(10);
         when(processor.getType()).thenReturn(name);
-        assertThat(IngestService.getProcessorName(processor), equalTo(name));
+        assertThat(IngestService.getProcessorName(processor), sameInstance(name));
         String tag = randomAlphaOfLength(10);
         when(processor.getTag()).thenReturn(tag);
         assertThat(IngestService.getProcessorName(processor), equalTo(name + ":" + tag));

--- a/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class IngestStatsTests extends ESTestCase {
@@ -35,6 +36,33 @@ public class IngestStatsTests extends ESTestCase {
     public void testIdentitySerialization() throws IOException {
         IngestStats serializedStats = serialize(IngestStats.IDENTITY);
         assertThat(serializedStats, sameInstance(IngestStats.IDENTITY));
+    }
+
+    public void testProcessorNameAndTypeIdentitySerialization() throws IOException {
+        IngestStats.Builder builder = new IngestStats.Builder();
+        builder.addPipelineMetrics("pipeline_id", new IngestPipelineMetric());
+        builder.addProcessorMetrics("pipeline_id", "set", "set", new IngestMetric());
+        builder.addProcessorMetrics("pipeline_id", "set:foo", "set", new IngestMetric());
+        builder.addProcessorMetrics("pipeline_id", "set:bar", "set", new IngestMetric());
+        builder.addTotalMetrics(new IngestMetric());
+
+        IngestStats serializedStats = serialize(builder.build());
+        List<IngestStats.ProcessorStat> processorStats = serializedStats.processorStats().get("pipeline_id");
+
+        // these are just table stakes
+        assertThat(processorStats.get(0).name(), is("set"));
+        assertThat(processorStats.get(0).type(), is("set"));
+        assertThat(processorStats.get(1).name(), is("set:foo"));
+        assertThat(processorStats.get(1).type(), is("set"));
+        assertThat(processorStats.get(2).name(), is("set:bar"));
+        assertThat(processorStats.get(2).type(), is("set"));
+
+        // this is actually interesting, though -- we're canonical-izing these strings to keep our heap usage under control
+        final String set = processorStats.get(0).name();
+        assertThat(processorStats.get(0).name(), sameInstance(set));
+        assertThat(processorStats.get(0).type(), sameInstance(set));
+        assertThat(processorStats.get(1).type(), sameInstance(set));
+        assertThat(processorStats.get(2).type(), sameInstance(set));
     }
 
     public void testStatsMerge() {


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Canonicalize processor names and types in IngestStats (#122610)