### PR TITLE
Disable field name canonicalization

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/cbor/CborXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/cbor/CborXContentImpl.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.xcontent.provider.cbor;
 
 import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.dataformat.cbor.CBORConstants;
@@ -53,6 +54,8 @@ public final class CborXContentImpl implements XContent {
         cborFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
         cborFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
         cborFactory.configure(JsonParser.Feature.USE_FAST_DOUBLE_PARSER, true);
+        // Speeds up deserialization a lot.
+        cborFactory.configure(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES, false);
         cborXContent = new CborXContentImpl();
     }
 

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentImpl.java
@@ -57,6 +57,8 @@ public class JsonXContentImpl implements XContent {
         jsonFactory.configure(JsonParser.Feature.USE_FAST_DOUBLE_PARSER, true);
         // keeping existing behavior of including source, for now
         jsonFactory.configure(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION, true);
+        // Speeds up deserialization a lot.
+        jsonFactory.configure(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES, false);
         jsonXContent = new JsonXContentImpl();
     }
 

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/smile/SmileXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/smile/SmileXContentImpl.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.xcontent.provider.smile;
 
 import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.dataformat.smile.SmileConstants;
@@ -55,6 +56,8 @@ public final class SmileXContentImpl implements XContent {
         smileFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
         smileFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
         smileFactory.configure(JsonParser.Feature.USE_FAST_DOUBLE_PARSER, true);
+        // Speeds up deserialization a lot.
+        smileFactory.configure(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES, false);
         smileXContent = new SmileXContentImpl();
     }
 

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/yaml/YamlXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/yaml/YamlXContentImpl.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.xcontent.provider.yaml;
 
 import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
@@ -51,6 +52,8 @@ public final class YamlXContentImpl implements XContent {
         yamlFactory.configure(YAMLParser.Feature.EMPTY_STRING_AS_NULL, true);
         yamlFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
         yamlFactory.configure(JsonParser.Feature.USE_FAST_DOUBLE_PARSER, true);
+        // Speeds up deserialization a lot.
+        yamlFactory.configure(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES, false);
         yamlXContent = new YamlXContentImpl();
     }
 


### PR DESCRIPTION
Disable jackson's field name canonicalization to speed up parsing. We don't use `==` to test for string equality from field names so we don't *need* it. It can save memory for sure, but out field names usually don't live very long.
