### PR TITLE
[9.0] Add entitlements lib to core/infra codeowners (#122611)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,6 +49,7 @@ distribution/docker/src @elastic/es-delivery
 # Core/Infra
 distribution/tools @elastic/es-core-infra
 libs/core @elastic/es-core-infra
+libs/entitlement @elastic/es-core-infra
 libs/logging @elastic/es-core-infra
 libs/native @elastic/es-core-infra
 libs/plugin-analysis-api @elastic/es-core-infra


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Add entitlements lib to core/infra codeowners (#122611)