### PR TITLE
[8.x] Fix listener usage in remote clusters (#122629)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
@@ -85,7 +85,6 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
             var resp = finalResponse.get();
             return Objects.requireNonNullElseGet(resp, () -> new ComputeResponse(profiles));
         }))) {
-            var openExchangeListener = computeListener.acquireAvoid();
             ExchangeService.openExchange(
                 transportService,
                 cluster.connection,
@@ -93,7 +92,7 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                 queryPragmas.exchangeBufferSize(),
                 esqlExecutor,
                 EsqlCCSUtils.skipUnavailableListener(
-                    openExchangeListener,
+                    computeListener.acquireAvoid(),
                     executionInfo,
                     clusterAlias,
                     EsqlExecutionInfo.Cluster.Status.SKIPPED
@@ -104,7 +103,7 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                         computeListener,
                         clusterAlias,
                         executionInfo,
-                        openExchangeListener
+                        l
                     );
 
                     var remoteSink = exchangeService.newRemoteSink(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteListenerGroup.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteListenerGroup.java
@@ -74,7 +74,7 @@ class RemoteListenerGroup {
     private <T> ActionListener<T> createCancellingListener(String reason, ActionListener<T> delegate, Runnable finishGroup) {
         return ActionListener.runAfter(delegate.delegateResponse((inner, e) -> {
             taskManager.cancelTaskAndDescendants(groupTask, reason, true, ActionListener.running(() -> {
-                EsqlCCSUtils.skipUnavailableListener(delegate, executionInfo, clusterAlias, EsqlExecutionInfo.Cluster.Status.PARTIAL)
+                EsqlCCSUtils.skipUnavailableListener(inner, executionInfo, clusterAlias, EsqlExecutionInfo.Cluster.Status.PARTIAL)
                     .onFailure(e);
             }));
         }), finishGroup);


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix listener usage in remote clusters (#122629)