### PR TITLE
[7.17] [BUILD] Rework build cache authentication on CI (#122296)

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -44,6 +44,9 @@ export GRADLE_BUILD_CACHE_USERNAME
 GRADLE_BUILD_CACHE_PASSWORD=$(vault read -field=password secret/ci/elastic-elasticsearch/migrated/gradle-build-cache)
 export GRADLE_BUILD_CACHE_PASSWORD
 
+DEVELOCITY_ACCESS_KEY="gradle-enterprise.elastic.co=$(vault read -field=accesskey secret/ci/elastic-elasticsearch/migrated/gradle-build-cache)"
+export DEVELOCITY_ACCESS_KEY
+
 BUILDKITE_API_TOKEN=$(vault read -field=token secret/ci/elastic-elasticsearch/buildkite-api-token)
 export BUILDKITE_API_TOKEN
 

--- a/.ci/init.gradle
+++ b/.ci/init.gradle
@@ -1,126 +1,22 @@
-import com.bettercloud.vault.VaultConfig;
-import com.bettercloud.vault.Vault;
-
-initscript {
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    classpath 'com.bettercloud:vault-java-driver:4.1.0'
-  }
-}
-
-boolean USE_ARTIFACTORY = false
-
-if (System.getenv('VAULT_ADDR') == null) {
-  // When trying to reproduce errors outside of CI, it can be useful to allow this to just return rather than blowing up
-  if (System.getenv('CI') == null) {
-    return
-  }
-
-  throw new GradleException("You must set the VAULT_ADDR environment variable to use this init script.")
-}
-
-if (System.getenv('VAULT_ROLE_ID') == null && System.getenv('VAULT_SECRET_ID') == null && System.getenv('VAULT_TOKEN') == null) {
-    // When trying to reproduce errors outside of CI, it can be useful to allow this to just return rather than blowing up
-  if (System.getenv('CI') == null) {
-    return
-  }
-
-  throw new GradleException("You must set either the VAULT_ROLE_ID and VAULT_SECRET_ID environment variables, " +
-    "or the VAULT_TOKEN environment variable to use this init script.")
-}
-
-final String vaultPathPrefix = System.getenv('VAULT_ADDR') ==~ /.+vault-ci.+\.dev.*/ ? "secret/ci/elastic-elasticsearch/migrated" : "secret/elasticsearch-ci"
-
-final String vaultToken = System.getenv('VAULT_TOKEN') ?: new Vault(
-  new VaultConfig()
-    .address(System.env.VAULT_ADDR)
-    .engineVersion(1)
-    .build()
-)
-  .withRetries(5, 1000)
-  .auth()
-  .loginByAppRole("approle", System.env.VAULT_ROLE_ID, System.env.VAULT_SECRET_ID)
-  .getAuthClientToken();
-
-final Vault vault = new Vault(
-  new VaultConfig()
-    .address(System.env.VAULT_ADDR)
-    .engineVersion(1)
-    .token(vaultToken)
-    .build()
-)
-  .withRetries(5, 1000)
-
-
-if (USE_ARTIFACTORY) {
-  final Map<String, String> artifactoryCredentials = vault.logical()
-    .read("${vaultPathPrefix}/artifactory.elstc.co")
-    .getData()
-  logger.info("Using elastic artifactory repos")
-  Closure configCache = {
-    return {
-      name "artifactory-gradle-release"
-      url "https://artifactory.elstc.co/artifactory/gradle-release"
-      credentials {
-        username artifactoryCredentials.get("username")
-        password artifactoryCredentials.get("token")
-      }
-    }
-  }
-  settingsEvaluated { settings ->
-    settings.pluginManagement {
-      repositories {
-        maven configCache()
-      }
-    }
-  }
-  projectsLoaded {
-    allprojects {
-      buildscript {
-        repositories {
-          maven configCache()
-        }
-      }
-      repositories {
-        maven configCache()
-      }
-    }
-  }
-}
-
-gradle.settingsEvaluated { settings ->
-  settings.pluginManager.withPlugin("com.gradle.enterprise") {
-    settings.gradleEnterprise {
-      server = 'https://gradle-enterprise.elastic.co'
-    }
-  }
-}
-
-
 final String buildCacheUrl = System.getProperty('org.elasticsearch.build.cache.url')
 final boolean buildCachePush = Boolean.valueOf(System.getProperty('org.elasticsearch.build.cache.push', 'false'))
 
-if (buildCacheUrl) {
-  final Map<String, String> buildCacheCredentials = System.getenv("GRADLE_BUILD_CACHE_USERNAME") ? [:] : vault.logical()
-    .read("${vaultPathPrefix}/gradle-build-cache")
-    .getData()
-  gradle.settingsEvaluated { settings ->
-    settings.buildCache {
-      local {
-        // Disable the local build cache in CI since we use ephemeral workers and it incurs an IO penalty
-        enabled = false
-      }
-      remote(HttpBuildCache) {
-        url = buildCacheUrl
-        push = buildCachePush
-        credentials {
-          username = System.getenv("GRADLE_BUILD_CACHE_USERNAME") ?: buildCacheCredentials.get("username")
-          password = System.getenv("GRADLE_BUILD_CACHE_PASSWORD") ?: buildCacheCredentials.get("password")
+gradle.settingsEvaluated { settings ->
+  settings.pluginManager.withPlugin("com.gradle.develocity") {
+    settings.develocity {
+      server = "https://gradle-enterprise.elastic.co"
+    }
+    if (buildCacheUrl) {
+      settings.buildCache {
+        local {
+          // Disable the local build cache in CI since we use ephemeral workers and it incurs an IO penalty
+          enabled = false
+        }
+        remote(settings.develocity.buildCache) {
+          enabled = true
+          push = buildCachePush
         }
       }
     }
   }
 }
-

--- a/build-conventions/settings.gradle
+++ b/build-conventions/settings.gradle
@@ -5,6 +5,11 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
+plugins {
+  id "com.gradle.develocity" version "3.18.1"
+}
+
 rootProject.name = 'build-conventions'
 
 dependencyResolutionManagement {

--- a/build-tools-internal/settings.gradle
+++ b/build-tools-internal/settings.gradle
@@ -8,6 +8,10 @@ pluginManagement {
     includeBuild "../build-tools"
 }
 
+plugins {
+  id "com.gradle.develocity" version "3.18.1"
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         buildLibs {

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -32,7 +32,9 @@ develocity {
     // Automatically publish scans from Elasticsearch CI
     if (onCI) {
       publishing.onlyIf { true }
-      server = 'https://gradle-enterprise.elastic.co'
+      if(server.isPresent() == false) {
+        server = 'https://gradle-enterprise.elastic.co'
+      }
     } else if( server.isPresent() == false) {
       publishing.onlyIf { false }
     }

--- a/build-tools/settings.gradle
+++ b/build-tools/settings.gradle
@@ -8,7 +8,9 @@
 pluginManagement {
     includeBuild "../build-conventions"
 }
-
+plugins {
+  id "com.gradle.develocity" version "3.18.1"
+}
 include 'reaper'
 
 dependencyResolutionManagement {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[BUILD] Rework build cache authentication on CI (#122296)](https://github.com/elastic/elasticsearch/pull/122296)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)