### PR TITLE
Don't serialize `backwardCompatibleMessage` field from `RepositoryConflictException` in V9

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -195,6 +195,7 @@ public class TransportVersions {
     public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR = def(9_009_0_00);
     public static final TransportVersion SLM_UNHEALTHY_IF_NO_SNAPSHOT_WITHIN = def(9_010_0_00);
     public static final TransportVersion ESQL_SUPPORT_PARTIAL_RESULTS = def(9_011_0_00);
+    public static final TransportVersion REMOVE_REPOSITORY_CONFLICT_MESSAGE = def(9_012_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryConflictException.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryConflictException.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.repositories;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -29,16 +29,20 @@ public class RepositoryConflictException extends RepositoryException {
         return RestStatus.CONFLICT;
     }
 
-    @UpdateForV9(owner = UpdateForV9.Owner.DISTRIBUTED_COORDINATION) // drop unneeded string from wire format
     public RepositoryConflictException(StreamInput in) throws IOException {
         super(in);
-        in.readString();
+        if (in.getTransportVersion().before(TransportVersions.REMOVE_REPOSITORY_CONFLICT_MESSAGE)) {
+            // Deprecated `backwardCompatibleMessage` field
+            in.readString();
+        }
     }
 
     @Override
-    @UpdateForV9(owner = UpdateForV9.Owner.DISTRIBUTED_COORDINATION) // drop unneeded string from wire format
     protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
         super.writeTo(out, nestedExceptionsWriter);
-        out.writeString("");
+        if (out.getTransportVersion().before(TransportVersions.REMOVE_REPOSITORY_CONFLICT_MESSAGE)) {
+            // Deprecated `backwardCompatibleMessage` field
+            out.writeString("");
+        }
     }
 }


### PR DESCRIPTION
This field was deprecated in V8 and removed in #114726. We don't need to serialize it in V9

