### PR TITLE
Clean up `RepositoryConflictException` wire protocol

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -196,6 +196,7 @@ public class TransportVersions {
     public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR = def(9_009_0_00);
     public static final TransportVersion SLM_UNHEALTHY_IF_NO_SNAPSHOT_WITHIN = def(9_010_0_00);
     public static final TransportVersion ESQL_SUPPORT_PARTIAL_RESULTS = def(9_011_0_00);
+    public static final TransportVersion REPO_CONFLICT_EXCEPTION_UNUSED_STRING = def(9_012_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryConflictException.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryConflictException.java
@@ -11,10 +11,11 @@ package org.elasticsearch.repositories;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
+
+import static org.elasticsearch.TransportVersions.REPO_CONFLICT_EXCEPTION_UNUSED_STRING;
 
 /**
  * Repository conflict exception
@@ -29,16 +30,18 @@ public class RepositoryConflictException extends RepositoryException {
         return RestStatus.CONFLICT;
     }
 
-    @UpdateForV9(owner = UpdateForV9.Owner.DISTRIBUTED_COORDINATION) // drop unneeded string from wire format
     public RepositoryConflictException(StreamInput in) throws IOException {
         super(in);
-        in.readString();
+        if (in.getTransportVersion().before(REPO_CONFLICT_EXCEPTION_UNUSED_STRING)) {
+            in.readString();
+        }
     }
 
     @Override
-    @UpdateForV9(owner = UpdateForV9.Owner.DISTRIBUTED_COORDINATION) // drop unneeded string from wire format
     protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
         super.writeTo(out, nestedExceptionsWriter);
-        out.writeString("");
+        if (out.getTransportVersion().before(REPO_CONFLICT_EXCEPTION_UNUSED_STRING)) {
+            out.writeString("");
+        }
     }
 }


### PR DESCRIPTION
Removes string that became unused in #114726.