### PR TITLE
Remove `@UpdateForV9` from `RepositoryConflictException`

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryConflictException.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryConflictException.java
@@ -11,7 +11,6 @@ package org.elasticsearch.repositories;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryConflictException.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryConflictException.java
@@ -29,14 +29,12 @@ public class RepositoryConflictException extends RepositoryException {
         return RestStatus.CONFLICT;
     }
 
-    @UpdateForV9(owner = UpdateForV9.Owner.DISTRIBUTED_COORDINATION) // drop unneeded string from wire format
     public RepositoryConflictException(StreamInput in) throws IOException {
         super(in);
         in.readString();
     }
 
     @Override
-    @UpdateForV9(owner = UpdateForV9.Owner.DISTRIBUTED_COORDINATION) // drop unneeded string from wire format
     protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
         super.writeTo(out, nestedExceptionsWriter);
         out.writeString("");


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/122730 added checks in 9.1.0 that `backwardCompatibleMessage` won't be serialized

