### PR TITLE
Unmute testSuggestTimeoutWithPartialResults

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -281,9 +281,6 @@ tests:
 - class: org.elasticsearch.repositories.blobstore.testkit.analyze.MinioRepositoryAnalysisRestIT
   method: testRepositoryAnalysis
   issue: https://github.com/elastic/elasticsearch/issues/122670
-- class: org.elasticsearch.search.SearchTimeoutIT
-  method: testSuggestTimeoutWithPartialResults
-  issue: https://github.com/elastic/elasticsearch/issues/122548
 
 # Examples:
 #


### PR DESCRIPTION
This test uncovered an issue in the suggest timeout handling logic. Addressed with #122675 in 9.0. The test can be unmuted. It got muted due to failures happened right before the merge was merged.