### PR TITLE
[8.x] Fix redact processor arraycopy bug (#122640)

### DIFF
--- a/docs/changelog/122640.yaml
+++ b/docs/changelog/122640.yaml
@@ -1,0 +1,5 @@
+pr: 122640
+summary: Fix redact processor arraycopy bug
+area: Ingest Node
+type: bug
+issues: []

--- a/x-pack/plugin/redact/src/main/java/org/elasticsearch/xpack/redact/RedactProcessor.java
+++ b/x-pack/plugin/redact/src/main/java/org/elasticsearch/xpack/redact/RedactProcessor.java
@@ -294,9 +294,13 @@ public class RedactProcessor extends AbstractProcessor {
          */
         String redactMatches(byte[] utf8Bytes, String redactStartToken, String redactEndToken) {
             var merged = mergeOverlappingReplacements(replacementPositions);
-            int longestPatternName = merged.stream().mapToInt(r -> r.patternName.getBytes(StandardCharsets.UTF_8).length).max().getAsInt();
+            int maxPatternNameLength = merged.stream()
+                .mapToInt(r -> r.patternName.getBytes(StandardCharsets.UTF_8).length)
+                .max()
+                .getAsInt();
 
-            int maxPossibleLength = longestPatternName * merged.size() + utf8Bytes.length;
+            int maxPossibleLength = (redactStartToken.length() + maxPatternNameLength + redactEndToken.length()) * merged.size()
+                + utf8Bytes.length;
             byte[] redact = new byte[maxPossibleLength];
 
             int readOffset = 0;

--- a/x-pack/plugin/redact/src/test/java/org/elasticsearch/xpack/redact/RedactProcessorTests.java
+++ b/x-pack/plugin/redact/src/test/java/org/elasticsearch/xpack/redact/RedactProcessorTests.java
@@ -108,6 +108,18 @@ public class RedactProcessorTests extends ESTestCase {
             var redacted = RedactProcessor.matchRedact(input, List.of(grok));
             assertEquals("<CREDIT_CARD> <CREDIT_CARD> <CREDIT_CARD> <CREDIT_CARD>", redacted);
         }
+        {
+            var config = new HashMap<String, Object>();
+            config.put("field", "to_redact");
+            config.put("patterns", List.of("%{NUMBER:NUMBER}"));
+            config.put("pattern_definitions", Map.of("NUMBER", "\\d{4}"));
+            var processor = new RedactProcessor.Factory(mockLicenseState(), MatcherWatchdog.noop()).create(null, "t", "d", config);
+            var grok = processor.getGroks().get(0);
+
+            String input = "1001";
+            var redacted = RedactProcessor.matchRedact(input, List.of(grok), "_prefix_", "_suffix_");
+            assertEquals("_prefix_NUMBER_suffix_", redacted);
+        }
     }
 
     public void testMatchRedactMultipleGroks() throws Exception {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix redact processor arraycopy bug (#122640)