### PR TITLE
[8.16] Improve jwt logging on failed auth (#122247)

### DIFF
--- a/docs/changelog/122247.yaml
+++ b/docs/changelog/122247.yaml
@@ -1,0 +1,5 @@
+pr: 122247
+summary: Improve jwt logging on failed auth
+area: Authentication
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealm.java
@@ -263,12 +263,10 @@ public class JwtRealm extends Realm implements CachingRealm, ReloadableSecurityC
                     + tokenPrincipal
                     + "] with header ["
                     + jwtAuthenticationToken.getSignedJWT().getHeader()
-                    + "] and claimSet ["
-                    + jwtAuthenticationToken.getJWTClaimsSet()
                     + "]";
 
                 if (logger.isTraceEnabled()) {
-                    logger.trace(msg, ex);
+                    logger.trace(msg + " and claimSet [" + jwtAuthenticationToken.getJWTClaimsSet() + "]", ex);
                 } else {
                     logger.debug(msg + " Cause: " + ex.getMessage()); // only log the stack trace at trace level
                 }


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Improve jwt logging on failed auth (#122247)