### PR TITLE
[9.0] Instrument methods on File that require read permissions (#122544)

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.entitlement.bridge;
 
 import java.io.File;
+import java.io.FileFilter;
+import java.io.FilenameFilter;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -512,6 +514,12 @@ public interface EntitlementChecker {
     //
 
     // old io (ie File)
+    void check$java_io_File$canExecute(Class<?> callerClass, File file);
+
+    void check$java_io_File$canRead(Class<?> callerClass, File file);
+
+    void check$java_io_File$canWrite(Class<?> callerClass, File file);
+
     void check$java_io_File$createNewFile(Class<?> callerClass, File file);
 
     void check$java_io_File$$createTempFile(Class<?> callerClass, String prefix, String suffix, File directory);
@@ -519,6 +527,28 @@ public interface EntitlementChecker {
     void check$java_io_File$delete(Class<?> callerClass, File file);
 
     void check$java_io_File$deleteOnExit(Class<?> callerClass, File file);
+
+    void check$java_io_File$exists(Class<?> callerClass, File file);
+
+    void check$java_io_File$isDirectory(Class<?> callerClass, File file);
+
+    void check$java_io_File$isFile(Class<?> callerClass, File file);
+
+    void check$java_io_File$isHidden(Class<?> callerClass, File file);
+
+    void check$java_io_File$lastModified(Class<?> callerClass, File file);
+
+    void check$java_io_File$length(Class<?> callerClass, File file);
+
+    void check$java_io_File$list(Class<?> callerClass, File file);
+
+    void check$java_io_File$list(Class<?> callerClass, File file, FilenameFilter filter);
+
+    void check$java_io_File$listFiles(Class<?> callerClass, File file);
+
+    void check$java_io_File$listFiles(Class<?> callerClass, File file, FileFilter filter);
+
+    void check$java_io_File$listFiles(Class<?> callerClass, File file, FilenameFilter filter);
 
     void check$java_io_File$mkdir(Class<?> callerClass, File file);
 

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
@@ -47,6 +47,21 @@ class FileCheckActions {
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileCanExecute() throws IOException {
+        readFile().toFile().canExecute();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileCanRead() throws IOException {
+        readFile().toFile().canRead();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileCanWrite() throws IOException {
+        readFile().toFile().canWrite();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
     static void fileCreateNewFile() throws IOException {
         readWriteDir().resolve("new_file").toFile().createNewFile();
     }
@@ -68,6 +83,61 @@ class FileCheckActions {
         Path toDelete = readWriteDir().resolve("to_delete_on_exit");
         EntitledActions.createFile(toDelete);
         toDelete.toFile().deleteOnExit();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileExists() throws IOException {
+        readFile().toFile().exists();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileIsDirectory() throws IOException {
+        readFile().toFile().isDirectory();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileIsFile() throws IOException {
+        readFile().toFile().isFile();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileIsHidden() throws IOException {
+        readFile().toFile().isHidden();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileLastModified() throws IOException {
+        readFile().toFile().lastModified();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileLength() throws IOException {
+        readFile().toFile().length();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileList() throws IOException {
+        readDir().toFile().list();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileListWithFilter() throws IOException {
+        readDir().toFile().list((dir, name) -> true);
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileListFiles() throws IOException {
+        readDir().toFile().listFiles();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileListFilesWithFileFilter() throws IOException {
+        readDir().toFile().listFiles(pathname -> true);
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void fileListFilesWithFilenameFilter() throws IOException {
+        readDir().toFile().listFiles((dir, name) -> true);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -14,6 +14,8 @@ import org.elasticsearch.entitlement.bridge.EntitlementChecker;
 import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
 
 import java.io.File;
+import java.io.FileFilter;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -956,6 +958,21 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     // old io (ie File)
 
     @Override
+    public void check$java_io_File$canExecute(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$canRead(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$canWrite(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
     public void check$java_io_File$createNewFile(Class<?> callerClass, File file) {
         policyManager.checkFileWrite(callerClass, file);
     }
@@ -973,6 +990,61 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     @Override
     public void check$java_io_File$deleteOnExit(Class<?> callerClass, File file) {
         policyManager.checkFileWrite(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$exists(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$isDirectory(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$isFile(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$isHidden(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$lastModified(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$length(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$list(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$list(Class<?> callerClass, File file, FilenameFilter filter) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$listFiles(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$listFiles(Class<?> callerClass, File file, FileFilter filter) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_File$listFiles(Class<?> callerClass, File file, FilenameFilter filter) {
+        policyManager.checkFileRead(callerClass, file);
     }
 
     @Override

--- a/modules/repository-azure/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/repository-azure/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,3 +1,8 @@
 io.netty.common:
   - outbound_network
   - manage_threads
+  - files:
+    - path: "/etc/os-release"
+      mode: "read"
+    - path: "/usr/lib/os-release"
+      mode: "read"

--- a/modules/transport-netty4/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/transport-netty4/src/main/plugin-metadata/entitlement-policy.yaml
@@ -6,3 +6,8 @@ io.netty.common:
   - inbound_network
   - outbound_network
   - manage_threads
+  - files:
+    - path: "/etc/os-release"
+      mode: "read"
+    - path: "/usr/lib/os-release"
+      mode: "read"

--- a/x-pack/plugin/security/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/security/src/main/plugin-metadata/entitlement-policy.yaml
@@ -8,7 +8,23 @@ io.netty.common:
   - manage_threads
   - inbound_network
   - outbound_network
+  - files:
+    - path: "/etc/os-release"
+      mode: "read"
+    - path: "/usr/lib/os-release"
+      mode: "read"
 org.opensaml.xmlsec.impl:
   - write_system_properties:
       properties:
         - org.apache.xml.security.ignoreLineBreaks
+org.opensaml.saml.impl:
+  - files:
+    - relative_path: idp-docs-metadata.xml
+      relative_to: config
+      mode: read
+    - relative_path: idp-metadata.xml
+      relative_to: config
+      mode: read
+    - relative_path: saml-metadata.xml
+      relative_to: config
+      mode: read


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Instrument methods on File that require read permissions (#122544)