### PR TITLE
[8.18] Removed trailing comma (#122430)

### DIFF
--- a/docs/reference/search/search-your-data/semantic-text-hybrid-search
+++ b/docs/reference/search/search-your-data/semantic-text-hybrid-search
@@ -24,7 +24,7 @@ PUT semantic-embeddings
   "mappings": {
     "properties": {
       "semantic_text": { <1>
-        "type": "semantic_text", 
+        "type": "semantic_text"
       },
       "content": { <2>
         "type": "text",


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Removed trailing comma (#122430)