### PR TITLE
[9.0] Remove `@UpdateForV9` annotation from `ReindexRequest#failOnSizeSpecified` (#122729)

### DIFF
--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -167,3 +167,7 @@ if (OS.current() == OS.WINDOWS) {
     }
   }
 }
+
+tasks.named("yamlRestCompatTestTransform").configure { task ->
+  task.skipTest("reindex/20_validation/specifying size fails", "size is rejected in 9.0")
+}

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/20_validation.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/20_validation.yml
@@ -107,7 +107,7 @@
         body:   { "text": "test" }
 
   - do:
-      catch: /invalid parameter \[size\], use \[max_docs\] instead/
+      catch: /(invalid parameter \[size\], use \[max_docs\] instead|unknown field \[size\])/
       reindex:
         body:
           source:

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -355,10 +354,6 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
         );
 
         PARSER.declareInt(ReindexRequest::setMaxDocsValidateIdentical, new ParseField("max_docs"));
-
-        // avoid silently accepting an ignored size.
-        PARSER.declareInt((r, s) -> failOnSizeSpecified(), new ParseField("size"));
-
         PARSER.declareField((p, v, c) -> v.setScript(Script.parse(p)), new ParseField("script"), ObjectParser.ValueType.OBJECT);
         PARSER.declareString(ReindexRequest::setConflicts, new ParseField("conflicts"));
     }
@@ -497,11 +492,5 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
         } else {
             request.setMaxDocs(maxDocs);
         }
-    }
-
-    @UpdateForV9(owner = UpdateForV9.Owner.DISTRIBUTED_INDEXING)
-    // do we still need this ref to [max_docs] or can we remove the field entirely so it's rejected with the default message?
-    private static void failOnSizeSpecified() {
-        throw new IllegalArgumentException("invalid parameter [size], use [max_docs] instead");
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Remove `@UpdateForV9` annotation from `ReindexRequest#failOnSizeSpecified` (#122729)