### PR TITLE
Handle status code 200 for s3 CMU response

### DIFF
--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -902,8 +902,7 @@ class S3BlobContainer extends AbstractBlobContainer {
                     || amazonS3Exception.getStatusCode() == 200 && "NoSuchUpload".equals(amazonS3Exception.getErrorCode()))) {
                 // An uncaught 404 means that our multipart upload was aborted by a concurrent operation before we could complete it.
                 // Also (rarely) S3 can start processing the request during a concurrent abort and this can result in a 200 OK with an
-                // <Error><Code>NoSuchUpload</Code>... in the response, which the SDK translates to status code 200 since 1.12.691
-                // (0 for prior versions). Either way, this means that our write encountered contention:
+                // <Error><Code>NoSuchUpload</Code>... in the response. Either way, this means that our write encountered contention:
                 delegate.onResponse(OptionalBytesReference.MISSING);
             } else {
                 delegate.onFailure(e);

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -899,11 +899,11 @@ class S3BlobContainer extends AbstractBlobContainer {
             logger.trace(() -> Strings.format("[%s]: compareAndExchangeRegister failed", key), e);
             if (e instanceof AmazonS3Exception amazonS3Exception
                 && (amazonS3Exception.getStatusCode() == 404
-                    || amazonS3Exception.getStatusCode() == 0 && "NoSuchUpload".equals(amazonS3Exception.getErrorCode()))) {
+                    || amazonS3Exception.getStatusCode() == 200 && "NoSuchUpload".equals(amazonS3Exception.getErrorCode()))) {
                 // An uncaught 404 means that our multipart upload was aborted by a concurrent operation before we could complete it.
                 // Also (rarely) S3 can start processing the request during a concurrent abort and this can result in a 200 OK with an
-                // <Error><Code>NoSuchUpload</Code>... in the response, which the SDK translates to status code 0. Either way, this means
-                // that our write encountered contention:
+                // <Error><Code>NoSuchUpload</Code>... in the response, which the SDK translates to status code 200 since 1.12.691
+                // (0 for prior versions). Either way, this means that our write encountered contention:
                 delegate.onResponse(OptionalBytesReference.MISSING);
             } else {
                 delegate.onFailure(e);

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -394,9 +394,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/122680
 - class: org.elasticsearch.entitlement.qa.EntitlementsDeniedIT
   issue: https://github.com/elastic/elasticsearch/issues/122566
-- class: org.elasticsearch.repositories.blobstore.testkit.analyze.S3RepositoryAnalysisRestIT
-  method: testRepositoryAnalysis
-  issue: https://github.com/elastic/elasticsearch/issues/122799
 - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
   issue: https://github.com/elastic/elasticsearch/issues/122810
 


### PR DESCRIPTION
When a CopmleteMultipartUpload request fails after the initial 200 response, the status code of the failure response use to be not set and hence got translated to status code 0. With #116212, we handle this case accordingly. Since AWS SDK 1.12.691, the status code is now set to 200 instead of 0. This PR changes our error handling code accordingly.

Relates: #122431
Relates: #116212
Resolves: #122799

Relevant AWS SDK change
https://github.com/aws/aws-sdk-java/blame/430899c217f34fae63b35c77f4d9bfd361c9de77/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java#L3696-L3709
