### PR TITLE
[8.18] Fix policy manager/parser absolute path checks (#122736)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
@@ -47,12 +47,10 @@ public record FilesEntitlement(List<FileData> filesData) implements Entitlement 
         Mode mode();
 
         static FileData ofPath(Path path, Mode mode) {
-            assert path.isAbsolute();
             return new AbsolutePathFileData(path, mode);
         }
 
         static FileData ofRelativePath(Path relativePath, BaseDir baseDir, Mode mode) {
-            assert relativePath.isAbsolute() == false;
             return new RelativePathFileData(relativePath, baseDir, mode);
         }
     }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
@@ -53,18 +53,23 @@ public class PolicyManagerTests extends ESTestCase {
      */
     private static Module NO_ENTITLEMENTS_MODULE;
 
-    private static final PathLookup TEST_PATH_LOOKUP = new PathLookup(
-        Path.of("/user/home"),
-        Path.of("/config"),
-        new Path[] { Path.of("/data1/"), Path.of("/data2") },
-        Path.of("/temp")
-    );
+    private static Path TEST_BASE_DIR;
+
+    private static PathLookup TEST_PATH_LOOKUP;
 
     @BeforeClass
     public static void beforeClass() {
         try {
             // Any old module will do for tests using NO_ENTITLEMENTS_MODULE
             NO_ENTITLEMENTS_MODULE = makeClassInItsOwnModule().getModule();
+
+            TEST_BASE_DIR = createTempDir().toAbsolutePath();
+            TEST_PATH_LOOKUP = new PathLookup(
+                TEST_BASE_DIR.resolve("/user/home"),
+                TEST_BASE_DIR.resolve("/config"),
+                new Path[] { TEST_BASE_DIR.resolve("/data1/"), TEST_BASE_DIR.resolve("/data2") },
+                TEST_BASE_DIR.resolve("/temp")
+            );
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
@@ -229,8 +234,7 @@ public class PolicyManagerTests extends ESTestCase {
 
         var entitlements = policyManager.getEntitlements(mockPluginClass);
         assertThat(entitlements.hasEntitlement(CreateClassLoaderEntitlement.class), is(true));
-        // TODO: this can't work on Windows, we need to have the root be unknown
-        // assertThat(entitlements.fileAccess().canRead("/test/path"), is(true));
+        assertThat(entitlements.fileAccess().canRead(TEST_BASE_DIR), is(true));
     }
 
     public void testGetEntitlementsResultIsCached() {
@@ -440,9 +444,7 @@ public class PolicyManagerTests extends ESTestCase {
                     name -> new Scope(
                         name,
                         List.of(
-                            new FilesEntitlement(
-                                List.of(FilesEntitlement.FileData.ofPath(Path.of("/test/path"), FilesEntitlement.Mode.READ))
-                            ),
+                            new FilesEntitlement(List.of(FilesEntitlement.FileData.ofPath(TEST_BASE_DIR, FilesEntitlement.Mode.READ))),
                             new CreateClassLoaderEntitlement()
                         )
                     )

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserFailureTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserFailureTests.java
@@ -64,35 +64,6 @@ public class PolicyParserFailureTests extends ESTestCase {
         );
     }
 
-    public void testEntitlementRelativePathWhenAbsolute() {
-        PolicyParserException ppe = expectThrows(PolicyParserException.class, () -> new PolicyParser(new ByteArrayInputStream("""
-            entitlement-module-name:
-              - files:
-                  - path: test-path
-                    mode: read
-            """.getBytes(StandardCharsets.UTF_8)), "test-failure-policy.yaml", false).parsePolicy());
-        assertEquals(
-            "[2:5] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
-                + "for entitlement type [files]: 'path' [test-path] must be absolute",
-            ppe.getMessage()
-        );
-    }
-
-    public void testEntitlementAbsolutePathWhenRelative() {
-        PolicyParserException ppe = expectThrows(PolicyParserException.class, () -> new PolicyParser(new ByteArrayInputStream("""
-            entitlement-module-name:
-              - files:
-                  - relative_path: /test-path
-                    relative_to: data
-                    mode: read
-            """.getBytes(StandardCharsets.UTF_8)), "test-failure-policy.yaml", false).parsePolicy());
-        assertEquals(
-            "[2:5] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
-                + "for entitlement type [files]: 'relative_path' [/test-path] must be relative",
-            ppe.getMessage()
-        );
-    }
-
     public void testEntitlementMutuallyExclusiveParameters() {
         PolicyParserException ppe = expectThrows(PolicyParserException.class, () -> new PolicyParser(new ByteArrayInputStream("""
             entitlement-module-name:

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.entitlement.runtime.policy;
 
+import org.elasticsearch.core.Strings;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.CreateClassLoaderEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.Entitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement;
@@ -18,17 +19,28 @@ import org.elasticsearch.entitlement.runtime.policy.entitlements.OutboundNetwork
 import org.elasticsearch.entitlement.runtime.policy.entitlements.SetHttpsConnectionPropertiesEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.WriteSystemPropertiesEntitlement;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.BeforeClass;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 
+@ESTestCase.WithoutSecurityManager
 public class PolicyParserTests extends ESTestCase {
+
+    public static String TEST_ABSOLUTE_PATH_TO_FILE;
+
+    @BeforeClass
+    public static void beforeClass() throws IOException {
+        TEST_ABSOLUTE_PATH_TO_FILE = createTempFile().toAbsolutePath().toString();
+    }
 
     private static class TestWrongEntitlementName implements Entitlement {}
 
@@ -79,15 +91,23 @@ public class PolicyParserTests extends ESTestCase {
         );
     }
 
+    private static InputStream createFilesTestPolicy() {
+        return new ByteArrayInputStream(Strings.format("""
+            entitlement-module-name:
+              - files:
+                - path: '%s'
+                  mode: "read_write"
+            """, TEST_ABSOLUTE_PATH_TO_FILE).getBytes(StandardCharsets.UTF_8));
+    }
+
     public void testPolicyBuilder() throws IOException {
-        Policy parsedPolicy = new PolicyParser(PolicyParserTests.class.getResourceAsStream("test-policy.yaml"), "test-policy.yaml", false)
-            .parsePolicy();
+        Policy parsedPolicy = new PolicyParser(createFilesTestPolicy(), "test-policy.yaml", false).parsePolicy();
         Policy expected = new Policy(
             "test-policy.yaml",
             List.of(
                 new Scope(
                     "entitlement-module-name",
-                    List.of(FilesEntitlement.build(List.of(Map.of("path", "/test/path/to/file", "mode", "read_write"))))
+                    List.of(FilesEntitlement.build(List.of(Map.of("path", TEST_ABSOLUTE_PATH_TO_FILE, "mode", "read_write"))))
                 )
             )
         );
@@ -95,14 +115,13 @@ public class PolicyParserTests extends ESTestCase {
     }
 
     public void testPolicyBuilderOnExternalPlugin() throws IOException {
-        Policy parsedPolicy = new PolicyParser(PolicyParserTests.class.getResourceAsStream("test-policy.yaml"), "test-policy.yaml", true)
-            .parsePolicy();
+        Policy parsedPolicy = new PolicyParser(createFilesTestPolicy(), "test-policy.yaml", true).parsePolicy();
         Policy expected = new Policy(
             "test-policy.yaml",
             List.of(
                 new Scope(
                     "entitlement-module-name",
-                    List.of(FilesEntitlement.build(List.of(Map.of("path", "/test/path/to/file", "mode", "read_write"))))
+                    List.of(FilesEntitlement.build(List.of(Map.of("path", TEST_ABSOLUTE_PATH_TO_FILE, "mode", "read_write"))))
                 )
             )
         );
@@ -110,31 +129,27 @@ public class PolicyParserTests extends ESTestCase {
     }
 
     public void testParseFiles() throws IOException {
-        Policy policyWithOnePath = new PolicyParser(new ByteArrayInputStream("""
-            entitlement-module-name:
-              - files:
-                - path: "/test/path/to/file"
-                  mode: "read_write"
-            """.getBytes(StandardCharsets.UTF_8)), "test-policy.yaml", false).parsePolicy();
+        Policy policyWithOnePath = new PolicyParser(createFilesTestPolicy(), "test-policy.yaml", false).parsePolicy();
         Policy expected = new Policy(
             "test-policy.yaml",
             List.of(
                 new Scope(
                     "entitlement-module-name",
-                    List.of(FilesEntitlement.build(List.of(Map.of("path", "/test/path/to/file", "mode", "read_write"))))
+                    List.of(FilesEntitlement.build(List.of(Map.of("path", TEST_ABSOLUTE_PATH_TO_FILE, "mode", "read_write"))))
                 )
             )
         );
         assertEquals(expected, policyWithOnePath);
 
-        Policy policyWithTwoPaths = new PolicyParser(new ByteArrayInputStream("""
+        String testPathToReadDir = createTempDir().toAbsolutePath().toString();
+        Policy policyWithTwoPaths = new PolicyParser(new ByteArrayInputStream(Strings.format("""
             entitlement-module-name:
               - files:
-                - path: "/test/path/to/file"
+                - path: '%s'
                   mode: "read_write"
-                - path: "/test/path/to/read-dir/"
+                - path: '%s'
                   mode: "read"
-            """.getBytes(StandardCharsets.UTF_8)), "test-policy.yaml", false).parsePolicy();
+            """, TEST_ABSOLUTE_PATH_TO_FILE, testPathToReadDir).getBytes(StandardCharsets.UTF_8)), "test-policy.yaml", false).parsePolicy();
         expected = new Policy(
             "test-policy.yaml",
             List.of(
@@ -143,8 +158,8 @@ public class PolicyParserTests extends ESTestCase {
                     List.of(
                         FilesEntitlement.build(
                             List.of(
-                                Map.of("path", "/test/path/to/file", "mode", "read_write"),
-                                Map.of("path", "/test/path/to/read-dir/", "mode", "read")
+                                Map.of("path", TEST_ABSOLUTE_PATH_TO_FILE, "mode", "read_write"),
+                                Map.of("path", testPathToReadDir, "mode", "read")
                             )
                         )
                     )
@@ -153,18 +168,24 @@ public class PolicyParserTests extends ESTestCase {
         );
         assertEquals(expected, policyWithTwoPaths);
 
-        Policy policyWithMultiplePathsAndBaseDir = new PolicyParser(new ByteArrayInputStream("""
-            entitlement-module-name:
-              - files:
-                - relative_path: "test/path/to/file"
-                  relative_to: "data"
-                  mode: "read_write"
-                - relative_path: "test/path/to/read-dir/"
-                  relative_to: "config"
-                  mode: "read"
-                - path: "/path/to/file"
-                  mode: "read_write"
-            """.getBytes(StandardCharsets.UTF_8)), "test-policy.yaml", false).parsePolicy();
+        String relativePathToFile = Path.of("test/path/to/file").normalize().toString();
+        String relativePathToDir = Path.of("test/path/to/read-dir/").normalize().toString();
+        Policy policyWithMultiplePathsAndBaseDir = new PolicyParser(
+            new ByteArrayInputStream(Strings.format("""
+                entitlement-module-name:
+                  - files:
+                    - relative_path: '%s'
+                      relative_to: "data"
+                      mode: "read_write"
+                    - relative_path: '%s'
+                      relative_to: "config"
+                      mode: "read"
+                    - path: '%s'
+                      mode: "read_write"
+                """, relativePathToFile, relativePathToDir, TEST_ABSOLUTE_PATH_TO_FILE).getBytes(StandardCharsets.UTF_8)),
+            "test-policy.yaml",
+            false
+        ).parsePolicy();
         expected = new Policy(
             "test-policy.yaml",
             List.of(
@@ -173,9 +194,9 @@ public class PolicyParserTests extends ESTestCase {
                     List.of(
                         FilesEntitlement.build(
                             List.of(
-                                Map.of("relative_path", "test/path/to/file", "mode", "read_write", "relative_to", "data"),
-                                Map.of("relative_path", "test/path/to/read-dir/", "mode", "read", "relative_to", "config"),
-                                Map.of("path", "/path/to/file", "mode", "read_write")
+                                Map.of("relative_path", relativePathToFile, "mode", "read_write", "relative_to", "data"),
+                                Map.of("relative_path", relativePathToDir, "mode", "read", "relative_to", "config"),
+                                Map.of("path", TEST_ABSOLUTE_PATH_TO_FILE, "mode", "read_write")
                             )
                         )
                     )

--- a/libs/entitlement/src/test/resources/org/elasticsearch/entitlement/runtime/policy/test-policy.yaml
+++ b/libs/entitlement/src/test/resources/org/elasticsearch/entitlement/runtime/policy/test-policy.yaml
@@ -1,4 +1,0 @@
-entitlement-module-name:
-  - files:
-      - path: "/test/path/to/file"
-        mode: "read_write"


### PR DESCRIPTION
Backport of #122736