### PR TITLE
[8.18] Skip SM policy tests for JDK 24 when Security Manager is not available anymore (#122828)

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/ESPolicyUnitTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/ESPolicyUnitTests.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.bootstrap;
 
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.jdk.RuntimeVersionFeature;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.BeforeClass;
 
@@ -42,6 +43,7 @@ public class ESPolicyUnitTests extends ESTestCase {
 
     @BeforeClass
     public static void setupPolicy() {
+        assumeTrue("test requires security manager to be supported", RuntimeVersionFeature.isSecurityManagerAvailable());
         assumeTrue("test cannot run with security manager", System.getSecurityManager() == null);
         DEFAULT_POLICY = PolicyUtil.readPolicy(ESPolicy.class.getResource(POLICY_RESOURCE), TEST_CODEBASES);
     }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.bootstrap;
 
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.jdk.RuntimeVersionFeature;
 import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
@@ -40,6 +41,7 @@ public class PolicyUtilTests extends ESTestCase {
 
     @Before
     public void assumeSecurityManagerDisabled() {
+        assumeTrue("test requires security manager to be supported", RuntimeVersionFeature.isSecurityManagerAvailable());
         assumeTrue("test cannot run with security manager enabled", System.getSecurityManager() == null);
     }
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/cli/PluginSecurityTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/cli/PluginSecurityTests.java
@@ -11,8 +11,10 @@ package org.elasticsearch.plugins.cli;
 
 import org.elasticsearch.bootstrap.PluginPolicyInfo;
 import org.elasticsearch.bootstrap.PolicyUtil;
+import org.elasticsearch.jdk.RuntimeVersionFeature;
 import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -25,6 +27,11 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 
 /** Tests plugin manager security check */
 public class PluginSecurityTests extends ESTestCase {
+
+    @Before
+    public void assumeSecurityManagerSupported() {
+        assumeTrue("test requires security manager to be supported", RuntimeVersionFeature.isSecurityManagerAvailable());
+    }
 
     PluginPolicyInfo makeDummyPlugin(String policy, String... files) throws IOException {
         Path plugin = createTempDir();


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Skip SM policy tests for JDK 24 when Security Manager is not available anymore (#122828)