### PR TITLE
[8.x] Add entitlement checks for java.io stream classes (#122406)

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.entitlement.bridge;
 
 import java.io.File;
+import java.io.FileDescriptor;
 import java.io.FileFilter;
 import java.io.FilenameFilter;
 import java.io.InputStream;
@@ -510,13 +511,53 @@ public interface EntitlementChecker {
 
     void check$java_io_File$setWritable(Class<?> callerClass, File file, boolean writable, boolean ownerOnly);
 
+    void check$java_io_FileInputStream$(Class<?> callerClass, File file);
+
+    void check$java_io_FileInputStream$(Class<?> callerClass, FileDescriptor fd);
+
+    void check$java_io_FileInputStream$(Class<?> callerClass, String name);
+
     void check$java_io_FileOutputStream$(Class<?> callerClass, File file);
 
     void check$java_io_FileOutputStream$(Class<?> callerClass, File file, boolean append);
 
+    void check$java_io_FileOutputStream$(Class<?> callerClass, FileDescriptor fd);
+
     void check$java_io_FileOutputStream$(Class<?> callerClass, String name);
 
     void check$java_io_FileOutputStream$(Class<?> callerClass, String name, boolean append);
+
+    void check$java_io_FileReader$(Class<?> callerClass, File file);
+
+    void check$java_io_FileReader$(Class<?> callerClass, File file, Charset charset);
+
+    void check$java_io_FileReader$(Class<?> callerClass, FileDescriptor fd);
+
+    void check$java_io_FileReader$(Class<?> callerClass, String name);
+
+    void check$java_io_FileReader$(Class<?> callerClass, String name, Charset charset);
+
+    void check$java_io_FileWriter$(Class<?> callerClass, File file);
+
+    void check$java_io_FileWriter$(Class<?> callerClass, File file, boolean append);
+
+    void check$java_io_FileWriter$(Class<?> callerClass, File file, Charset charset);
+
+    void check$java_io_FileWriter$(Class<?> callerClass, File file, Charset charset, boolean append);
+
+    void check$java_io_FileWriter$(Class<?> callerClass, FileDescriptor fd);
+
+    void check$java_io_FileWriter$(Class<?> callerClass, String name);
+
+    void check$java_io_FileWriter$(Class<?> callerClass, String name, boolean append);
+
+    void check$java_io_FileWriter$(Class<?> callerClass, String name, Charset charset);
+
+    void check$java_io_FileWriter$(Class<?> callerClass, String name, Charset charset, boolean append);
+
+    void check$java_io_RandomAccessFile$(Class<?> callerClass, String name, String mode);
+
+    void check$java_io_RandomAccessFile$(Class<?> callerClass, File file, String mode);
 
     void check$java_util_Scanner$(Class<?> callerClass, File source);
 

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
@@ -13,9 +13,14 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.entitlement.qa.entitled.EntitledActions;
 
 import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,6 +28,7 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.Scanner;
 
+import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_DENIED;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 
 @SuppressForbidden(reason = "Explicitly checking APIs that are forbidden")
@@ -217,6 +223,21 @@ class FileCheckActions {
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileInputStreamFile() throws IOException {
+        new FileInputStream(readFile().toFile()).close();
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void createFileInputStreamFileDescriptor() throws IOException {
+        new FileInputStream(FileDescriptor.in).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileInputStreamString() throws IOException {
+        new FileInputStream(readFile().toString()).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
     static void createFileOutputStreamString() throws IOException {
         new FileOutputStream(readWriteFile().toString()).close();
     }
@@ -234,6 +255,96 @@ class FileCheckActions {
     @EntitlementTest(expectedAccess = PLUGINS)
     static void createFileOutputStreamFileWithAppend() throws IOException {
         new FileOutputStream(readWriteFile().toFile(), false).close();
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void createFileOutputStreamFileDescriptor() throws IOException {
+        new FileOutputStream(FileDescriptor.out).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileReaderFile() throws IOException {
+        new FileReader(readFile().toFile()).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileReaderFileCharset() throws IOException {
+        new FileReader(readFile().toFile(), StandardCharsets.UTF_8).close();
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void createFileReaderFileDescriptor() throws IOException {
+        new FileReader(FileDescriptor.in).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileReaderString() throws IOException {
+        new FileReader(readFile().toString()).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileReaderStringCharset() throws IOException {
+        new FileReader(readFile().toString(), StandardCharsets.UTF_8).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileWriterFile() throws IOException {
+        new FileWriter(readWriteFile().toFile()).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileWriterFileWithAppend() throws IOException {
+        new FileWriter(readWriteFile().toFile(), false).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileWriterFileCharsetWithAppend() throws IOException {
+        new FileWriter(readWriteFile().toFile(), StandardCharsets.UTF_8, false).close();
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void createFileWriterFileDescriptor() throws IOException {
+        new FileWriter(FileDescriptor.out).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileWriterString() throws IOException {
+        new FileWriter(readWriteFile().toString()).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileWriterStringWithAppend() throws IOException {
+        new FileWriter(readWriteFile().toString(), false).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileWriterStringCharset() throws IOException {
+        new FileWriter(readWriteFile().toString(), StandardCharsets.UTF_8).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createFileWriterStringCharsetWithAppend() throws IOException {
+        new FileWriter(readWriteFile().toString(), StandardCharsets.UTF_8, false).close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createRandomAccessFileStringRead() throws IOException {
+        new RandomAccessFile(readFile().toString(), "r").close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createRandomAccessFileStringReadWrite() throws IOException {
+        new RandomAccessFile(readWriteFile().toString(), "rw").close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createRandomAccessFileRead() throws IOException {
+        new RandomAccessFile(readFile().toFile(), "r").close();
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createRandomAccessFileReadWrite() throws IOException {
+        new RandomAccessFile(readWriteFile().toFile(), "rw").close();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -14,6 +14,7 @@ import org.elasticsearch.entitlement.bridge.EntitlementChecker;
 import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
 
 import java.io.File;
+import java.io.FileDescriptor;
 import java.io.FileFilter;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -1017,6 +1018,21 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     }
 
     @Override
+    public void check$java_io_FileInputStream$(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_FileInputStream$(Class<?> callerClass, FileDescriptor fd) {
+        policyManager.checkFileDescriptorRead(callerClass);
+    }
+
+    @Override
+    public void check$java_io_FileInputStream$(Class<?> callerClass, String name) {
+        policyManager.checkFileRead(callerClass, new File(name));
+    }
+
+    @Override
     public void check$java_io_FileOutputStream$(Class<?> callerClass, String name) {
         policyManager.checkFileWrite(callerClass, new File(name));
     }
@@ -1034,6 +1050,99 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     @Override
     public void check$java_io_FileOutputStream$(Class<?> callerClass, File file, boolean append) {
         policyManager.checkFileWrite(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_FileOutputStream$(Class<?> callerClass, FileDescriptor fd) {
+        policyManager.checkFileDescriptorWrite(callerClass);
+    }
+
+    @Override
+    public void check$java_io_FileReader$(Class<?> callerClass, File file) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_FileReader$(Class<?> callerClass, File file, Charset charset) {
+        policyManager.checkFileRead(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_FileReader$(Class<?> callerClass, FileDescriptor fd) {
+        policyManager.checkFileDescriptorRead(callerClass);
+    }
+
+    @Override
+    public void check$java_io_FileReader$(Class<?> callerClass, String name) {
+        policyManager.checkFileRead(callerClass, new File(name));
+    }
+
+    @Override
+    public void check$java_io_FileReader$(Class<?> callerClass, String name, Charset charset) {
+        policyManager.checkFileRead(callerClass, new File(name));
+    }
+
+    @Override
+    public void check$java_io_FileWriter$(Class<?> callerClass, File file) {
+        policyManager.checkFileWrite(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_FileWriter$(Class<?> callerClass, File file, boolean append) {
+        policyManager.checkFileWrite(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_FileWriter$(Class<?> callerClass, File file, Charset charset) {
+        policyManager.checkFileWrite(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_FileWriter$(Class<?> callerClass, File file, Charset charset, boolean append) {
+        policyManager.checkFileWrite(callerClass, file);
+    }
+
+    @Override
+    public void check$java_io_FileWriter$(Class<?> callerClass, FileDescriptor fd) {
+        policyManager.checkFileDescriptorWrite(callerClass);
+    }
+
+    @Override
+    public void check$java_io_FileWriter$(Class<?> callerClass, String name) {
+        policyManager.checkFileWrite(callerClass, new File(name));
+    }
+
+    @Override
+    public void check$java_io_FileWriter$(Class<?> callerClass, String name, boolean append) {
+        policyManager.checkFileWrite(callerClass, new File(name));
+    }
+
+    @Override
+    public void check$java_io_FileWriter$(Class<?> callerClass, String name, Charset charset) {
+        policyManager.checkFileWrite(callerClass, new File(name));
+    }
+
+    @Override
+    public void check$java_io_FileWriter$(Class<?> callerClass, String name, Charset charset, boolean append) {
+        policyManager.checkFileWrite(callerClass, new File(name));
+    }
+
+    @Override
+    public void check$java_io_RandomAccessFile$(Class<?> callerClass, String name, String mode) {
+        if (mode.equals("r")) {
+            policyManager.checkFileRead(callerClass, new File(name));
+        } else {
+            policyManager.checkFileWrite(callerClass, new File(name));
+        }
+    }
+
+    @Override
+    public void check$java_io_RandomAccessFile$(Class<?> callerClass, File file, String mode) {
+        if (mode.equals("r")) {
+            policyManager.checkFileRead(callerClass, file);
+        } else {
+            policyManager.checkFileWrite(callerClass, file);
+        }
     }
 
     @Override

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -304,6 +304,14 @@ public class PolicyManager {
         }
     }
 
+    public void checkFileDescriptorRead(Class<?> callerClass) {
+        neverEntitled(callerClass, () -> "read file descriptor");
+    }
+
+    public void checkFileDescriptorWrite(Class<?> callerClass) {
+        neverEntitled(callerClass, () -> "write file descriptor");
+    }
+
     /**
      * Invoked when we try to get an arbitrary {@code FileAttributeView} class. Such a class can modify attributes, like owner etc.;
      * we could think about introducing checks for each of the operations, but for now we over-approximate this and simply deny when it is

--- a/modules/ingest-geoip/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/ingest-geoip/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,0 +1,5 @@
+com.maxmind.db:
+  - files:
+    - relative_path: "ingest-geoip/"
+      relative_to: "config"
+      mode: "read_write"

--- a/modules/repository-s3/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/repository-s3/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,3 +1,7 @@
 ALL-UNNAMED:
   - manage_threads
   - outbound_network
+  - files:
+    - relative_path: "repository-s3/aws-web-identity-token-file"
+      relative_to: "config"
+      mode: "read"

--- a/x-pack/plugin/blob-cache/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/blob-cache/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,0 +1,5 @@
+org.elasticsearch.blobcache:
+  - files:
+    - relative_path: "shared_snapshot_cache"
+      relative_to: "data"
+      mode: "read_write"

--- a/x-pack/plugin/watcher/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/watcher/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,2 +1,10 @@
 ALL-UNNAMED:
   - manage_threads
+  - files:
+    - relative_path: ".mime.types"
+      relative_to: "home"
+      mode: "read"
+    - relative_path: ".mailcap"
+      relative_to: "home"
+      mode: "read"
+


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add entitlement checks for java.io stream classes (#122406)