### PR TITLE
[8.18] [Entitlements] Add missing entitlements for trust store (#122797)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -53,6 +53,7 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,76 +138,84 @@ public class EntitlementInitialization {
         var pathLookup = new PathLookup(getUserHome(), bootstrapArgs.configDir(), bootstrapArgs.dataDirs(), bootstrapArgs.tempDir());
         Path logsDir = EntitlementBootstrap.bootstrapArgs().logsDir();
 
-        // TODO(ES-10031): Decide what goes in the elasticsearch default policy and extend it
-        var serverPolicy = new Policy(
-            "server",
-            List.of(
-                new Scope("org.elasticsearch.base", List.of(new CreateClassLoaderEntitlement())),
-                new Scope("org.elasticsearch.xcontent", List.of(new CreateClassLoaderEntitlement())),
-                new Scope(
-                    "org.elasticsearch.server",
-                    List.of(
-                        new ExitVMEntitlement(),
-                        new ReadStoreAttributesEntitlement(),
-                        new CreateClassLoaderEntitlement(),
-                        new InboundNetworkEntitlement(),
-                        new OutboundNetworkEntitlement(),
-                        new LoadNativeLibrariesEntitlement(),
-                        new ManageThreadsEntitlement(),
-                        new FilesEntitlement(
-                            Stream.concat(
-                                Stream.of(
-                                    FileData.ofPath(bootstrapArgs.tempDir(), READ_WRITE),
-                                    FileData.ofPath(bootstrapArgs.configDir(), READ),
-                                    FileData.ofPath(bootstrapArgs.logsDir(), READ_WRITE),
-                                    // OS release on Linux
-                                    FileData.ofPath(Path.of("/etc/os-release"), READ),
-                                    FileData.ofPath(Path.of("/etc/system-release"), READ),
-                                    FileData.ofPath(Path.of("/usr/lib/os-release"), READ),
-                                    // read max virtual memory areas
-                                    FileData.ofPath(Path.of("/proc/sys/vm/max_map_count"), READ),
-                                    FileData.ofPath(Path.of("/proc/meminfo"), READ),
-                                    // load averages on Linux
-                                    FileData.ofPath(Path.of("/proc/loadavg"), READ),
-                                    // control group stats on Linux. cgroup v2 stats are in an unpredicable
-                                    // location under `/sys/fs/cgroup`, so unfortunately we have to allow
-                                    // read access to the entire directory hierarchy.
-                                    FileData.ofPath(Path.of("/proc/self/cgroup"), READ),
-                                    FileData.ofPath(Path.of("/sys/fs/cgroup/"), READ),
-                                    // // io stats on Linux
-                                    FileData.ofPath(Path.of("/proc/self/mountinfo"), READ),
-                                    FileData.ofPath(Path.of("/proc/diskstats"), READ)
-                                ),
-                                Arrays.stream(bootstrapArgs.dataDirs()).map(d -> FileData.ofPath(d, READ))
-                            ).toList()
-                        )
+        List<Scope> serverScopes = new ArrayList<>();
+        Collections.addAll(
+            serverScopes,
+            new Scope("org.elasticsearch.base", List.of(new CreateClassLoaderEntitlement())),
+            new Scope("org.elasticsearch.xcontent", List.of(new CreateClassLoaderEntitlement())),
+            new Scope(
+                "org.elasticsearch.server",
+                List.of(
+                    new ExitVMEntitlement(),
+                    new ReadStoreAttributesEntitlement(),
+                    new CreateClassLoaderEntitlement(),
+                    new InboundNetworkEntitlement(),
+                    new OutboundNetworkEntitlement(),
+                    new LoadNativeLibrariesEntitlement(),
+                    new ManageThreadsEntitlement(),
+                    new FilesEntitlement(
+                        Stream.concat(
+                            Stream.of(
+                                FileData.ofPath(bootstrapArgs.tempDir(), READ_WRITE),
+                                FileData.ofPath(bootstrapArgs.configDir(), READ),
+                                FileData.ofPath(bootstrapArgs.logsDir(), READ_WRITE),
+                                // OS release on Linux
+                                FileData.ofPath(Path.of("/etc/os-release"), READ),
+                                FileData.ofPath(Path.of("/etc/system-release"), READ),
+                                FileData.ofPath(Path.of("/usr/lib/os-release"), READ),
+                                // read max virtual memory areas
+                                FileData.ofPath(Path.of("/proc/sys/vm/max_map_count"), READ),
+                                FileData.ofPath(Path.of("/proc/meminfo"), READ),
+                                // load averages on Linux
+                                FileData.ofPath(Path.of("/proc/loadavg"), READ),
+                                // control group stats on Linux. cgroup v2 stats are in an unpredicable
+                                // location under `/sys/fs/cgroup`, so unfortunately we have to allow
+                                // read access to the entire directory hierarchy.
+                                FileData.ofPath(Path.of("/proc/self/cgroup"), READ),
+                                FileData.ofPath(Path.of("/sys/fs/cgroup/"), READ),
+                                // // io stats on Linux
+                                FileData.ofPath(Path.of("/proc/self/mountinfo"), READ),
+                                FileData.ofPath(Path.of("/proc/diskstats"), READ)
+                            ),
+                            Arrays.stream(bootstrapArgs.dataDirs()).map(d -> FileData.ofPath(d, READ))
+                        ).toList()
                     )
-                ),
-                new Scope("org.apache.httpcomponents.httpclient", List.of(new OutboundNetworkEntitlement())),
-                new Scope("io.netty.transport", List.of(new InboundNetworkEntitlement(), new OutboundNetworkEntitlement())),
-                new Scope(
-                    "org.apache.lucene.core",
-                    List.of(
-                        new LoadNativeLibrariesEntitlement(),
-                        new ManageThreadsEntitlement(),
-                        new FilesEntitlement(
-                            Stream.concat(
-                                Stream.of(FileData.ofPath(bootstrapArgs.configDir(), READ)),
-                                Arrays.stream(bootstrapArgs.dataDirs()).map(d -> FileData.ofPath(d, READ_WRITE))
-                            ).toList()
-                        )
+                )
+            ),
+            new Scope("org.apache.httpcomponents.httpclient", List.of(new OutboundNetworkEntitlement())),
+            new Scope("io.netty.transport", List.of(new InboundNetworkEntitlement(), new OutboundNetworkEntitlement())),
+            new Scope(
+                "org.apache.lucene.core",
+                List.of(
+                    new LoadNativeLibrariesEntitlement(),
+                    new ManageThreadsEntitlement(),
+                    new FilesEntitlement(
+                        Stream.concat(
+                            Stream.of(FileData.ofPath(bootstrapArgs.configDir(), READ)),
+                            Arrays.stream(bootstrapArgs.dataDirs()).map(d -> FileData.ofPath(d, READ_WRITE))
+                        ).toList()
                     )
-                ),
-                new Scope("org.apache.logging.log4j.core", List.of(new ManageThreadsEntitlement())),
-                new Scope(
-                    "org.elasticsearch.nativeaccess",
-                    List.of(
-                        new LoadNativeLibrariesEntitlement(),
-                        new FilesEntitlement(List.of(FileData.ofRelativePath(Path.of(""), FilesEntitlement.BaseDir.DATA, READ_WRITE)))
-                    )
+                )
+            ),
+            new Scope("org.apache.logging.log4j.core", List.of(new ManageThreadsEntitlement())),
+            new Scope(
+                "org.elasticsearch.nativeaccess",
+                List.of(
+                    new LoadNativeLibrariesEntitlement(),
+                    new FilesEntitlement(List.of(FileData.ofRelativePath(Path.of(""), FilesEntitlement.BaseDir.DATA, READ_WRITE)))
                 )
             )
         );
+
+        Path trustStorePath = trustStorePath();
+        if (trustStorePath != null) {
+            serverScopes.add(
+                new Scope("org.bouncycastle.fips.tls", List.of(new FilesEntitlement(List.of(FileData.ofPath(trustStorePath, READ)))))
+            );
+        }
+
+        // TODO(ES-10031): Decide what goes in the elasticsearch default policy and extend it
+        var serverPolicy = new Policy("server", serverScopes);
         // agents run without a module, so this is a special hack for the apm agent
         // this should be removed once https://github.com/elastic/elasticsearch/issues/109335 is completed
         List<Entitlement> agentEntitlements = List.of(new CreateClassLoaderEntitlement(), new ManageThreadsEntitlement());
@@ -228,6 +237,11 @@ public class EntitlementInitialization {
             throw new IllegalStateException("user.home system property is required");
         }
         return PathUtils.get(userHome);
+    }
+
+    private static Path trustStorePath() {
+        String trustStore = System.getProperty("javax.net.ssl.trustStore");
+        return trustStore != null ? Path.of(trustStore) : null;
     }
 
     private static Stream<InstrumentationService.InstrumentationInfo> fileSystemProviderChecks() throws ClassNotFoundException,

--- a/x-pack/plugin/security/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/security/src/main/plugin-metadata/entitlement-policy.yaml
@@ -12,3 +12,17 @@ org.opensaml.xmlsec.impl:
   - write_system_properties:
       properties:
         - org.apache.xml.security.ignoreLineBreaks
+org.opensaml.saml.impl:
+  - files:
+    - relative_path: idp-docs-metadata.xml
+      relative_to: config
+      mode: read
+    - relative_path: idp-metadata.xml
+      relative_to: config
+      mode: read
+    - relative_path: saml-metadata.xml
+      relative_to: config
+      mode: read
+    - relative_path: metadata.xml
+      relative_to: config
+      mode: read


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Entitlements] Add missing entitlements for trust store (#122797)](https://github.com/elastic/elasticsearch/pull/122797)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)