### PR TITLE
Improve Iterators.single

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/collect/Iterators.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/Iterators.java
@@ -34,22 +34,27 @@ public class Iterators {
      * Returns a single element iterator over the supplied value.
      */
     public static <T> Iterator<T> single(T element) {
-        return new Iterator<>() {
+        return new SingleIterator<>(element);
+    }
 
-            private T value = Objects.requireNonNull(element);
+    private static final class SingleIterator<T> implements Iterator<T> {
+        private T value;
 
-            @Override
-            public boolean hasNext() {
-                return value != null;
-            }
+        SingleIterator(T element) {
+            value = Objects.requireNonNull(element);
+        }
 
-            @Override
-            public T next() {
-                final T res = value;
-                value = null;
-                return res;
-            }
-        };
+        @Override
+        public boolean hasNext() {
+            return value != null;
+        }
+
+        @Override
+        public T next() {
+            final T res = value;
+            value = null;
+            return res;
+        }
     }
 
     @SafeVarargs
@@ -496,5 +501,4 @@ public class Iterators {
         }
         return result;
     }
-
 }


### PR DESCRIPTION
Random find from debugging: using an anonymous class here doesn't compile as expected. The resulting class comes out as:

```java
class Iterators$1 implements java.util.Iterator<T> {
  private T value;

  final java.lang.Object val$element;

  Iterators$1(java.lang.Object);
```

which seemingly also does not get fixed by the JIT compiler, judging by heap dumps. Lets just use a named class to clean this up and make things a bit more compact and save some heap as well here and there potentially.
