### PR TITLE
[9.0] Add _metric_names_hash field to OTel metric mappings (#120952)

### DIFF
--- a/docs/changelog/120952.yaml
+++ b/docs/changelog/120952.yaml
@@ -1,0 +1,5 @@
+pr: 120952
+summary: Add `_metric_names_hash` field to OTel metric mappings
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
@@ -14,6 +14,10 @@ template:
         type: passthrough
         dynamic: true
         priority: 10
+      # workaround for https://github.com/elastic/elasticsearch/issues/99123
+      _metric_names_hash:
+        type: keyword
+        time_series_dimension: true
       unit:
         type: keyword
         time_series_dimension: true

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_tests.yml
@@ -302,3 +302,26 @@ Metrics with different scope names are not duplicates:
             metrics:
               foo.bar: 42
   - is_false: errors
+
+---
+Metrics with different metric name hashes are not duplicates:
+  - do:
+      bulk:
+        index: metrics-generic.otel-default
+        refresh: true
+        body:
+          - create: {"dynamic_templates":{"metrics.foo":"counter_long"}}
+          - "@timestamp": 2024-07-18T14:00:00Z
+            attributes:
+              foo: bar
+            metrics:
+              foo: 42
+            _metric_names_hash: a9f37ed7
+          - create: {"dynamic_templates":{"metrics.bar":"counter_long"}}
+          - "@timestamp": 2024-07-18T14:00:00Z
+            attributes:
+              foo: bar
+            metrics:
+              bar: 42
+            _metric_names_hash: 76b77d1a
+  - is_false: errors


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Add _metric_names_hash field to OTel metric mappings (#120952)