### PR TITLE
Re-enable shard rebalance in ES|QL rest tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -14,15 +14,22 @@ import org.elasticsearch.test.cluster.util.Version;
 public class Clusters {
     public static ElasticsearchCluster mixedVersionCluster() {
         Version oldVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
-        return ElasticsearchCluster.local()
+        var cluster = ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
             .withNode(node -> node.version(oldVersion))
             .withNode(node -> node.version(Version.CURRENT))
             .withNode(node -> node.version(oldVersion))
             .withNode(node -> node.version(Version.CURRENT))
             .setting("xpack.security.enabled", "false")
-            .setting("xpack.license.self_generated.type", "trial")
-            .setting("cluster.routing.rebalance.enable", "none") // disable relocation until we have retry in ESQL
-            .build();
+            .setting("xpack.license.self_generated.type", "trial");
+        if (supportRetryOnShardFailures(oldVersion) == false) {
+            cluster.setting("cluster.routing.rebalance.enable", "none");
+        }
+        return cluster.build();
+    }
+
+    private static boolean supportRetryOnShardFailures(Version version) {
+        return version.onOrAfter(Version.fromString("9.1.0"))
+            || (version.onOrAfter(Version.fromString("8.19.0")) && version.before(Version.fromString("9.0.0")));
     }
 }


### PR DESCRIPTION
Today, we disable shard rebalancing in ES|QL REST tests to avoid failures when shards are rebalanced while the query is being executed. This is no longer necessary if the clusters are on version 8.19 or 9.1.