### PR TITLE
[8.x] [Test] Fix IndexAliasesTests#testRemoveIndex (#122864)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -474,4 +474,3 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
   issue: https://github.com/elastic/elasticsearch/issues/122755
-

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/IndexAliasesTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/IndexAliasesTests.java
@@ -802,7 +802,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         assertAcked(client.admin().indices().prepareAliases().removeIndex("*").get());
         GetAliasesResponse getAliasesResponse = client.admin().indices().prepareGetAliases().setAliases("*").get();
         assertThat(getAliasesResponse.getAliases().size(), equalTo(0));
-        assertAliases(indicesAdmin().prepareGetAliases().setAliases("*"), "bogus_index_1", "bogus_alias_1", "bogus_alias_2");
+        assertAliases(indicesAdmin().prepareGetAliases().setAliases("*", "-.security*"), "bogus_index_1", "bogus_alias_1", "bogus_alias_2");
     }
 
     public void testAliasesForHiddenIndices() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Test] Fix IndexAliasesTests#testRemoveIndex (#122864)](https://github.com/elastic/elasticsearch/pull/122864)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)