### PR TITLE
Remove `local` param from field mapping API spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -65,10 +65,6 @@
         ],
         "default":"open",
         "description":"Whether to expand wildcard expression to concrete indices that are open, closed or both."
-      },
-      "local":{
-        "type":"boolean",
-        "description":"Return local information, do not retrieve the state from master node (default: false)"
       }
     }
   }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yml
@@ -50,17 +50,3 @@ setup:
 
   - match: {test_index.mappings.text.mapping.text.type:     text}
   - match: {test_index.mappings.text.mapping.text.analyzer: default}
-
----
-"Get field mapping with local parameter should fail":
-
-  - requires:
-      test_runner_features: ["warnings"]
-      cluster_features: ["gte_v8.0.0"]
-      reason: "local parameter for get field mapping API was allowed before v8"
-
-  - do:
-      catch: bad_request
-      indices.get_field_mapping:
-        fields: text
-        local: true


### PR DESCRIPTION
The `local` param for the `GetFieldMapping` API was deprecated in #55014 and I think #57265 aimed to propogate that deprecation to the REST API spec, but it changed `get_mapping.json` instead of `get_field_mapping.json`. #55100 removed the `local` param for the _field_ mapping API so we can safely remove the field from the spec and remove the YAML test.