### PR TITLE
[9.0] Remove unused `@UpdateForV9` owners (#122748)

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/UpdateForV9.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/UpdateForV9.java
@@ -24,14 +24,11 @@ public @interface UpdateForV9 {
     enum Owner {
         CORE_INFRA,
         DATA_MANAGEMENT,
-        DISTRIBUTED_COORDINATION,
         DISTRIBUTED_INDEXING,
         ENTERPRISE_SEARCH,
         MACHINE_LEARNING,
         PROFILING,
         SEARCH_ANALYTICS,
-        SEARCH_FOUNDATIONS,
-        SEARCH_RELEVANCE,
         SECURITY,
     }
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Remove unused `@UpdateForV9` owners (#122748)