### PR TITLE
[9.0] StressSearchServiceReaperIT_unmute_test (#122793)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -61,9 +61,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
   issue: https://github.com/elastic/elasticsearch/issues/115808
-- class: org.elasticsearch.search.StressSearchServiceReaperIT
-  method: testStressReaper
-  issue: https://github.com/elastic/elasticsearch/issues/115816
 - class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
   issue: https://github.com/elastic/elasticsearch/issues/116087
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT


### PR DESCRIPTION
Backports the following commits to 9.0:
 - StressSearchServiceReaperIT_unmute_test (#122793)