### PR TITLE
[8.x] Updates the deprecation info API to not warn about system indices and data streams (#122951)

### DIFF
--- a/docs/changelog/122951.yaml
+++ b/docs/changelog/122951.yaml
@@ -1,0 +1,6 @@
+pr: 122951
+summary: Updates the deprecation info API to not warn about system indices and data
+  streams
+area: Indices APIs
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecatedIndexPredicate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecatedIndexPredicate.java
@@ -49,8 +49,13 @@ public class DeprecatedIndexPredicate {
      */
     public static boolean reindexRequired(IndexMetadata indexMetadata, boolean filterToBlockedStatus) {
         return creationVersionBeforeMinimumWritableVersion(indexMetadata)
+            && isNotSystem(indexMetadata)
             && isNotSearchableSnapshot(indexMetadata)
             && matchBlockedStatus(indexMetadata, filterToBlockedStatus);
+    }
+
+    private static boolean isNotSystem(IndexMetadata indexMetadata) {
+        return indexMetadata.isSystem() == false;
     }
 
     private static boolean isNotSearchableSnapshot(IndexMetadata indexMetadata) {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationChecker.java
@@ -72,12 +72,14 @@ public class DataStreamDeprecationChecker implements ResourceDeprecationChecker 
         Map<String, List<DeprecationIssue>> dataStreamIssues = new HashMap<>();
         for (String dataStreamName : dataStreamNames) {
             DataStream dataStream = clusterState.metadata().dataStreams().get(dataStreamName);
-            List<DeprecationIssue> issuesForSingleDataStream = DATA_STREAM_CHECKS.stream()
-                .map(c -> c.apply(dataStream, clusterState))
-                .filter(Objects::nonNull)
-                .toList();
-            if (issuesForSingleDataStream.isEmpty() == false) {
-                dataStreamIssues.put(dataStreamName, issuesForSingleDataStream);
+            if (dataStream.isSystem() == false) {
+                List<DeprecationIssue> issuesForSingleDataStream = DATA_STREAM_CHECKS.stream()
+                    .map(c -> c.apply(dataStream, clusterState))
+                    .filter(Objects::nonNull)
+                    .toList();
+                if (issuesForSingleDataStream.isEmpty() == false) {
+                    dataStreamIssues.put(dataStreamName, issuesForSingleDataStream);
+                }
             }
         }
         return dataStreamIssues.isEmpty() ? Map.of() : dataStreamIssues;

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationCheckerTests.java
@@ -329,7 +329,7 @@ public class DataStreamDeprecationCheckerTests extends ESTestCase {
         DataStream dataStream = new DataStream(
             randomAlphaOfLength(10),
             allIndices,
-            randomNegativeLong(),
+            randomNonNegativeLong(),
             Map.of(),
             true,
             false,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
@@ -299,6 +299,28 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
         assertEquals(List.of(expected), issuesByIndex.get("test"));
     }
 
+    public void testOldSystemIndicesIgnored() {
+        // We do not want system indices coming back in the deprecation info API
+        Settings.Builder settings = settings(OLD_VERSION).put(MetadataIndexStateService.VERIFIED_READ_ONLY_SETTING.getKey(), true);
+        IndexMetadata indexMetadata = IndexMetadata.builder("test")
+            .system(true)
+            .settings(settings)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .state(indexMetdataState)
+            .build();
+        ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(Metadata.builder().put(indexMetadata, true))
+            .blocks(clusterBlocksForIndices(indexMetadata))
+            .build();
+        Map<String, List<DeprecationIssue>> issuesByIndex = checker.check(
+            clusterState,
+            new DeprecationInfoAction.Request(TimeValue.THIRTY_SECONDS),
+            emptyPrecomputedData
+        );
+        assertThat(issuesByIndex, equalTo(Map.of()));
+    }
+
     private IndexMetadata readonlyIndexMetadata(String indexName, IndexVersion indexVersion) {
         Settings.Builder settings = settings(indexVersion).put(MetadataIndexStateService.VERIFIED_READ_ONLY_SETTING.getKey(), true);
         return IndexMetadata.builder(indexName).settings(settings).numberOfShards(1).numberOfReplicas(0).state(indexMetdataState).build();


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Updates the deprecation info API to not warn about system indices and data streams (#122951)