### PR TITLE
[8.18] Fixing the document count in reindex data stream status in-progress indices (#122976)

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/GetMigrationReindexStatusTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/GetMigrationReindexStatusTransportAction.java
@@ -173,7 +173,7 @@ public class GetMigrationReindexStatusTransportAction extends HandledTransportAc
                     if (sourceIndexStats == null) {
                         totalDocsInIndex = 0;
                     } else {
-                        DocsStats totalDocsStats = sourceIndexStats.getTotal().getDocs();
+                        DocsStats totalDocsStats = sourceIndexStats.getPrimaries().getDocs();
                         totalDocsInIndex = totalDocsStats == null ? 0 : totalDocsStats.getCount();
                     }
                     IndexStats migratedIndexStats = indicesStatsResponse.getIndex(
@@ -183,7 +183,7 @@ public class GetMigrationReindexStatusTransportAction extends HandledTransportAc
                     if (migratedIndexStats == null) {
                         reindexedDocsInIndex = 0;
                     } else {
-                        DocsStats reindexedDocsStats = migratedIndexStats.getTotal().getDocs();
+                        DocsStats reindexedDocsStats = migratedIndexStats.getPrimaries().getDocs();
                         reindexedDocsInIndex = reindexedDocsStats == null ? 0 : reindexedDocsStats.getCount();
                     }
                     inProgressMap.put(index, Tuple.tuple(totalDocsInIndex, reindexedDocsInIndex));


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fixing the document count in reindex data stream status in-progress indices (#122976)