### PR TITLE
Stop retaining transport messages after serialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -12,13 +12,13 @@ package org.elasticsearch.transport;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.common.network.HandlingTimeTracker;
@@ -113,24 +113,12 @@ final class OutboundHandler {
             isHandshake,
             compressionScheme
         );
-        final Releasable onAfter;
-        if (request instanceof BytesTransportRequest) {
-            request.mustIncRef();
-            onAfter = () -> {
-                try {
-                    messageListener.onRequestSent(node, requestId, action, request, options);
-                } finally {
-                    request.decRef();
-                }
-            };
-        } else {
-            if (request.hasReferences() == false) {
-                assert false : "request [" + request + "] has been released already";
-                throw new AlreadyClosedException("request [" + request + "] has been released already");
-            }
-            onAfter = () -> messageListener.onRequestSent(node, requestId, action, request, options);
-        }
-        sendMessage(channel, message, ResponseStatsConsumer.NONE, onAfter);
+        sendMessage(
+            channel,
+            message,
+            ResponseStatsConsumer.NONE,
+            () -> messageListener.onRequestSent(node, requestId, action, request, options)
+        );
     }
 
     /**
@@ -223,7 +211,6 @@ final class OutboundHandler {
                 Releasables.closeExpectNoException(onAfter);
             }
         }
-        final Releasable release = Releasables.wrap(byteStreamOutput, onAfter);
         final BytesReference message;
         boolean serializeSuccess = false;
         try {
@@ -234,11 +221,20 @@ final class OutboundHandler {
             throw e;
         } finally {
             if (serializeSuccess == false) {
-                release.close();
+                Releasables.close(byteStreamOutput, onAfter);
             }
         }
         responseStatsConsumer.addResponseStats(message.length());
-        internalSend(channel, message, networkMessage, ActionListener.running(release::close));
+        internalSend(
+            channel,
+            message,
+            networkMessage,
+            ActionListener.releasing(
+                message instanceof ReleasableBytesReference r
+                    ? Releasables.wrap(byteStreamOutput, onAfter, r)
+                    : Releasables.wrap(byteStreamOutput, onAfter)
+            )
+        );
     }
 
     private void internalSend(


### PR DESCRIPTION
We should not retain messages after serialization. We currently, have no 0-copy logic in place outside of some special cases that are handled separately. As a result of not doing zero-copy logic, there is no need to retain messages until they have been flushed to the wire in full. This change reduces the lifetime of things like `SearchHit` significantly, reducing the data-node side impact of fetching large documents/large aggregations/top-hits to name a few. The fact that this change technically passes released request + response instances to the `messageListener` seems irrelevant since the listeners are only used in tests anyway. If anything, we should look to refactor this logic to avoid holding on to the request/response objects needlessly.