### PR TITLE
[Inference] The semantic_text type index options parameters

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -279,6 +279,11 @@ public class DenseVectorFieldMapper extends FieldMapper {
             return this;
         }
 
+        public Builder indexOptions(IndexOptions indexOptions) {
+            this.indexOptions.setValue(indexOptions);
+            return this;
+        }
+
         @Override
         public DenseVectorFieldMapper build(MapperBuilderContext context) {
             // Validate again here because the dimensions or element type could have been set programmatically,
@@ -1177,7 +1182,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         public abstract VectorSimilarityFunction vectorSimilarityFunction(IndexVersion indexVersion, ElementType elementType);
     }
 
-    abstract static class IndexOptions implements ToXContent {
+    public abstract static class IndexOptions implements ToXContent {
         final VectorIndexType type;
 
         IndexOptions(VectorIndexType type) {
@@ -2319,7 +2324,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         return new Builder(leafName(), indexCreatedVersion).init(this);
     }
 
-    private static IndexOptions parseIndexOptions(String fieldName, Object propNode) {
+    public static IndexOptions parseIndexOptions(String fieldName, Object propNode) {
         @SuppressWarnings("unchecked")
         Map<String, ?> indexOptionsMap = (Map<String, ?>) propNode;
         Object typeNode = indexOptionsMap.remove("type");

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -1191,7 +1191,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
 
         abstract KnnVectorsFormat getVectorsFormat(ElementType elementType);
 
-        final void validateElementType(ElementType elementType) {
+        public final void validateElementType(ElementType elementType) {
             if (type.supportsElementType(elementType) == false) {
                 throw new IllegalArgumentException(
                     "[element_type] cannot be [" + elementType.toString() + "] when using index type [" + type + "]"
@@ -2322,6 +2322,10 @@ public class DenseVectorFieldMapper extends FieldMapper {
     @Override
     public FieldMapper.Builder getMergeBuilder() {
         return new Builder(leafName(), indexCreatedVersion).init(this);
+    }
+
+    public IndexOptions indexOptions() {
+        return indexOptions;
     }
 
     public static IndexOptions parseIndexOptions(String fieldName, Object propNode) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -997,7 +997,11 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
                 }
                 denseVectorMapperBuilder.dimensions(modelSettings.dimensions());
                 denseVectorMapperBuilder.elementType(modelSettings.elementType());
-                denseVectorMapperBuilder.indexOptions(indexOptions);
+                if (indexOptions != null) {
+                    indexOptions.validateDimension(modelSettings.dimensions());
+                    indexOptions.validateElementType(modelSettings.elementType());
+                    denseVectorMapperBuilder.indexOptions(indexOptions);
+                }
 
                 yield denseVectorMapperBuilder;
             }

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
@@ -245,7 +245,7 @@ setup:
   - match: { "test-index-options.mappings.properties.dense_field.index_options.type": "hnsw" }
   - match: { "test-index-options.mappings.properties.dense_field.index_options.m": 24 }
   - match: { "test-index-options.mappings.properties.dense_field.index_options.ef_construction": 200 }
-  - length: { "test-index.mappings.properties.dense_field": 4 }
+  - length: { "test-index-options.mappings.properties.dense_field": 4 }
 
 ---
 "Field caps with text embedding":

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
@@ -193,6 +193,61 @@ setup:
   - length: { "test-index.mappings.properties.dense_field": 3 }
 
 ---
+"Indexes dense vector document with index_options":
+
+  - do:
+      indices.create:
+        index: test-index-options
+        body:
+          mappings:
+            properties:
+              dense_field:
+                type: semantic_text
+                inference_id: dense-inference-id
+                index_options:
+                  type: "hnsw"
+                  m: 24
+                  ef_construction: 200
+
+  - do:
+      index:
+        index: test-index-options
+        id: doc_2
+        body:
+          dense_field:
+            text: "these are not the droids you're looking for. He's free to go around"
+            inference:
+              inference_id: "dense-inference-id"
+              model_settings:
+                task_type: "text_embedding"
+                dimensions: 4
+                similarity: "cosine"
+                element_type: "float"
+              index_options:
+                type: "int8_hnsw"
+                m: 24
+                ef_construction: 100
+                confidence_interval: 0.9
+              chunks:
+                - text: "these are not the droids you're looking for"
+                  embeddings: [0.04673296958208084, -0.03237321600317955, -0.02543032355606556, 0.056035321205854416]
+                - text: "He's free to go around"
+                  embeddings: [0.00641461368650198, -0.0016253676731139421, -0.05126338079571724, 0.053438711911439896]
+
+  # Checks mapping is updated when first doc arrives
+  - do:
+      indices.get_mapping:
+        index: test-index-options
+
+  - match: { "test-index-options.mappings.properties.dense_field.type": "semantic_text" }
+  - match: { "test-index-options.mappings.properties.dense_field.inference_id": "dense-inference-id" }
+  - match: { "test-index-options.mappings.properties.dense_field.model_settings.task_type": "text_embedding" }
+  - match: { "test-index-options.mappings.properties.dense_field.index_options.type": "hnsw" }
+  - match: { "test-index-options.mappings.properties.dense_field.index_options.m": 24 }
+  - match: { "test-index-options.mappings.properties.dense_field.index_options.ef_construction": 200 }
+  - length: { "test-index.mappings.properties.dense_field": 4 }
+
+---
 "Field caps with text embedding":
   - requires:
       cluster_features: "gte_v8.16.0"


### PR DESCRIPTION
The semantic_text type is very useful for the AI Search.
When inference_id is text_embedding, the semantic_text internal field is dense_vector type.
But now the semantic_text can't support index_options of the dense_vector type.
User can't set quantification type or m, ef parameters.
So I added the index_options in the semantic_text type.