### PR TITLE
Speedup FieldsVisitor.reset

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/CustomFieldsVisitor.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/CustomFieldsVisitor.java
@@ -9,7 +9,9 @@
 package org.elasticsearch.index.fieldvisitor;
 
 import org.apache.lucene.index.FieldInfo;
+import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
+import org.elasticsearch.index.mapper.RoutingFieldMapper;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,7 +29,8 @@ public class CustomFieldsVisitor extends FieldsVisitor {
         this.fields = new HashSet<>(fields);
         // metadata fields that are always retrieved are already handled by FieldsVisitor, so removing
         // them here means that if the only fields requested are those metadata fields then we can shortcut loading
-        FieldsVisitor.BASE_REQUIRED_FIELDS.forEach(this.fields::remove);
+        this.fields.remove(IdFieldMapper.NAME);
+        this.fields.remove(RoutingFieldMapper.NAME);
         this.fields.remove(this.sourceFieldName);
         this.fields.remove(IgnoredFieldMapper.NAME);
     }

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -35,7 +35,6 @@ import static java.util.Collections.emptyMap;
  * Base {@link StoredFieldVisitor} that retrieves all non-redundant metadata.
  */
 public class FieldsVisitor extends FieldNamesProvidingStoredFieldsVisitor {
-    static final Set<String> BASE_REQUIRED_FIELDS = Set.of(IdFieldMapper.NAME, RoutingFieldMapper.NAME);
 
     private final boolean loadSource;
     final String sourceFieldName;
@@ -179,7 +178,9 @@ public class FieldsVisitor extends FieldNamesProvidingStoredFieldsVisitor {
         source = null;
         id = null;
 
-        requiredFields.addAll(BASE_REQUIRED_FIELDS);
+        var requiredFields = this.requiredFields;
+        requiredFields.add(IdFieldMapper.NAME);
+        requiredFields.add(RoutingFieldMapper.NAME);
         if (loadSource) {
             requiredFields.add(sourceFieldName);
         }


### PR DESCRIPTION
Random find from profiling. `addAll` is needlessly costly here (see profile below, it's like 1/4 of advancing the stored fields loader), seems even though the method is quite hot the creation of the iterator over the constant set doesn't compile away.
-> just unroll to 2 `add`s and do the same in the only remaining use-site of the set

<img width="1619" alt="image" src="https://github.com/user-attachments/assets/32a7e779-2495-418a-8823-ccdfaf26a1f6" />

