### PR TITLE
Unmute HdfsSearchableSnapshotsIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -274,8 +274,6 @@ tests:
 - class: org.elasticsearch.blocks.SimpleBlocksIT
   method: testConcurrentAddBlock
   issue: https://github.com/elastic/elasticsearch/issues/122324
-- class: org.elasticsearch.xpack.searchablesnapshots.hdfs.HdfsSearchableSnapshotsIT
-  issue: https://github.com/elastic/elasticsearch/issues/122024
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/cat/health/cat-health-example}
   issue: https://github.com/elastic/elasticsearch/issues/122335


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/122044 solved (temporarily) the issue with HDFS libraries not being compatible with JDK 24.
This PR unmutes a test with the same issues

Solves https://github.com/elastic/elasticsearch/issues/122024