### PR TITLE
Improve ESQL lookup join error message for missing fields

### DIFF
--- a/docs/changelog/122995.yaml
+++ b/docs/changelog/122995.yaml
@@ -1,0 +1,5 @@
+pr: 122995
+title: "Improve ESQL lookup join error message for missing fields"
+type: enhancement
+area: ESQL
+issue: 120189

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/LookupJoin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/LookupJoin.java
@@ -90,7 +90,7 @@ public class LookupJoin extends Join implements SurrogateLogicalPlan, PostAnalys
             var indexNameWithModes = esr.indexNameWithModes();
             if (indexNameWithModes.size() != 1) {
                 failures.add(
-                    fail(esr, "invalid [{}] resolution in lookup mode to [{}] indices", esr.indexPattern(), indexNameWithModes.size())
+                    fail(esr, "Unknown field for lookup join in index [{}]", esr.indexPattern())
                 );
             } else if (indexNameWithModes.values().iterator().next() != IndexMode.LOOKUP) {
                 failures.add(


### PR DESCRIPTION
When a field doesn't exist in a lookup join, the current error message is misleading:
`invalid [test1] resolution in lookup mode to [0] indices`

This incorrectly suggests there are no indices, when the actual problem is that a field is missing from an **existing** index.

Changed the error message to clearly indicate the actual problem:
`Unknown field for lookup join in index [whatever]`

[Original issue](https://github.com/elastic/elasticsearch/issues/120189#issue-2789491514)