### PR TITLE
Have ASM recompute frames on HDFS patched classes

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/dependencies/patches/hdfs/HdfsClassPatcher.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/dependencies/patches/hdfs/HdfsClassPatcher.java
@@ -40,6 +40,8 @@ import java.util.jar.JarOutputStream;
 import java.util.regex.Pattern;
 
 import static java.util.Map.entry;
+import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
+import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
 
 @CacheableTransform
 public abstract class HdfsClassPatcher implements TransformAction<HdfsClassPatcher.Parameters> {
@@ -128,7 +130,7 @@ public abstract class HdfsClassPatcher implements TransformAction<HdfsClassPatch
                     byte[] classToPatch = jarFile.getInputStream(entry).readAllBytes();
 
                     ClassReader classReader = new ClassReader(classToPatch);
-                    ClassWriter classWriter = new ClassWriter(classReader, 0);
+                    ClassWriter classWriter = new ClassWriter(classReader, COMPUTE_FRAMES | COMPUTE_MAXS);
                     classReader.accept(classPatcher.apply(classWriter), 0);
 
                     jos.write(classWriter.toByteArray());


### PR DESCRIPTION
While backporting I realized we sometimes need to compute frames, or Java will bail with a verify exception on our patched code. Better be safe and ask ASM do it.
This is already fixed in the backports.