### PR TITLE
Update 101 and 912 CompletionPostingFormats to use off-heap FST load mode

### DIFF
--- a/docs/changelog/123011.yaml
+++ b/docs/changelog/123011.yaml
@@ -1,0 +1,5 @@
+pr: 123011
+summary: Update 101 and 912 `CompletionPostingFormats` to use off-heap FST load mode
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -443,8 +443,12 @@ module org.elasticsearch.server {
         with
             org.elasticsearch.index.codec.bloomfilter.ES85BloomFilterPostingsFormat,
             org.elasticsearch.index.codec.bloomfilter.ES87BloomFilterPostingsFormat,
-            org.elasticsearch.index.codec.postings.ES812PostingsFormat;
+            org.elasticsearch.index.codec.postings.ES812PostingsFormat,
+            org.elasticsearch.index.codec.postings.ESCompletion912PostingsFormat,
+            org.elasticsearch.index.codec.postings.ESCompletion101PostingsFormat;
+
     provides org.apache.lucene.codecs.DocValuesFormat with org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormat;
+
     provides org.apache.lucene.codecs.KnnVectorsFormat
         with
             org.elasticsearch.index.codec.vectors.ES813FlatVectorFormat,

--- a/server/src/main/java/org/elasticsearch/index/codec/postings/ESCompletion101PostingsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/postings/ESCompletion101PostingsFormat.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.postings;
+
+import org.apache.lucene.search.suggest.document.Completion101PostingsFormat;
+
+/** Identical to that of Lucene's Completion101PostingsFormat, except that we flip the default to FSTLoadMode.OFF_HEAP. */
+public class ESCompletion101PostingsFormat extends Completion101PostingsFormat {
+
+    public ESCompletion101PostingsFormat() {
+        super(FSTLoadMode.OFF_HEAP);  // we flip the default there, from that of Lucene's impl
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/postings/ESCompletion912PostingsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/postings/ESCompletion912PostingsFormat.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.postings;
+
+import org.apache.lucene.search.suggest.document.Completion912PostingsFormat;
+
+/** Identical to that of Lucene's Completion101PostingsFormat, except that we flip the default to FSTLoadMode.OFF_HEAP. */
+public class ESCompletion912PostingsFormat extends Completion912PostingsFormat {
+
+    public ESCompletion912PostingsFormat() {
+        super(FSTLoadMode.OFF_HEAP);  // we flip the default there, from that of Lucene's impl
+    }
+}

--- a/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.PostingsFormat
+++ b/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.PostingsFormat
@@ -1,3 +1,5 @@
 org.elasticsearch.index.codec.bloomfilter.ES85BloomFilterPostingsFormat
 org.elasticsearch.index.codec.bloomfilter.ES87BloomFilterPostingsFormat
 org.elasticsearch.index.codec.postings.ES812PostingsFormat
+org.elasticsearch.index.codec.postings.ESCompletion912PostingsFormat
+org.elasticsearch.index.codec.postings.ESCompletion101PostingsFormat


### PR DESCRIPTION
Identical to that of Lucene's Completion101PostingsFormat, except that we flip the default to FSTLoadMode.OFF_HEAP.

These implementations reuse the exact same format name as that of the formats provided by the `org.apache.lucene.suggest` module. In effect they "override" the formats provided by that module, since Lucene's NamedSPILoader only uses the first service for each name found, later services will be ignored. So once we find the ES versions first, then they will be used rather than the Lucene ones.