### PR TITLE
[9.0] Clarify breaking change note for #112903 (#122998)

### DIFF
--- a/docs/changelog/112903.yaml
+++ b/docs/changelog/112903.yaml
@@ -13,5 +13,5 @@ breaking:
     `single-node`.
   impact: >-
     Remove any value for `discovery.type` from your `elasticsearch.yml`
-    configuration file.
+    configuration file except for `multi-node` and `single-node`.
   notable: false

--- a/docs/reference/migration/migrate_9_0.asciidoc
+++ b/docs/reference/migration/migrate_9_0.asciidoc
@@ -184,7 +184,7 @@ Remove `xpack.searchable.snapshot.allocate_on_rolling_restart` from your setting
 Earlier versions of {es} had a `discovery.type` setting which permitted values that referred to legacy discovery types. From v9.0.0 onwards, the only supported values for this setting are `multi-node` (the default) and `single-node`.
 
 *Impact* +
-Remove any value for `discovery.type` from your `elasticsearch.yml` configuration file.
+Remove any value for `discovery.type` from your `elasticsearch.yml` configuration file except for `multi-node` and `single-node`.
 ====
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Clarify breaking change note for #112903 (#122998)