### PR TITLE
[8.x] Fix KeywordSyntheticSourceNativeArrayIntegrationTests for release builds (#123008)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordSyntheticSourceNativeArrayIntegrationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordSyntheticSourceNativeArrayIntegrationTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.IdsQueryBuilder;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -33,6 +34,7 @@ import java.util.Set;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
@@ -183,7 +185,14 @@ public class KeywordSyntheticSourceNativeArrayIntegrationTests extends ESSingleN
                 var document = reader.storedFields().document(i);
                 // Verify that there is no ignored source:
                 Set<String> storedFieldNames = new LinkedHashSet<>(document.getFields().stream().map(IndexableField::name).toList());
-                assertThat(storedFieldNames, contains(expectedStoredFields));
+                if (IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE.isEnabled()) {
+                    assertThat(storedFieldNames, contains(expectedStoredFields));
+                } else {
+                    String[] copyExpectedStoredFields = new String[expectedStoredFields.length + 1];
+                    System.arraycopy(expectedStoredFields, 0, copyExpectedStoredFields, 0, expectedStoredFields.length);
+                    copyExpectedStoredFields[copyExpectedStoredFields.length - 1] = "_recovery_source";
+                    assertThat(storedFieldNames, containsInAnyOrder(copyExpectedStoredFields));
+                }
             }
             var fieldInfo = FieldInfos.getMergedFieldInfos(reader).fieldInfo("field.offsets");
             assertThat(fieldInfo.getDocValuesType(), equalTo(DocValuesType.SORTED));
@@ -248,7 +257,11 @@ public class KeywordSyntheticSourceNativeArrayIntegrationTests extends ESSingleN
                 var document = reader.storedFields().document(i);
                 // Verify that there is ignored source because of leaf array being wrapped by object array:
                 List<String> storedFieldNames = document.getFields().stream().map(IndexableField::name).toList();
-                assertThat(storedFieldNames, contains("_id", "_ignored_source"));
+                if (IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE.isEnabled()) {
+                    assertThat(storedFieldNames, contains("_id", "_ignored_source"));
+                } else {
+                    assertThat(storedFieldNames, containsInAnyOrder("_id", "_ignored_source", "_recovery_source"));
+                }
 
                 // Verify that there is no offset field:
                 LeafReader leafReader = reader.leaves().get(0).reader();
@@ -321,7 +334,11 @@ public class KeywordSyntheticSourceNativeArrayIntegrationTests extends ESSingleN
                 var document = reader.storedFields().document(i);
                 // Verify that there is no ignored source:
                 Set<String> storedFieldNames = new LinkedHashSet<>(document.getFields().stream().map(IndexableField::name).toList());
-                assertThat(storedFieldNames, contains("_id"));
+                if (IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE.isEnabled()) {
+                    assertThat(storedFieldNames, contains("_id"));
+                } else {
+                    assertThat(storedFieldNames, containsInAnyOrder("_id", "_recovery_source"));
+                }
             }
             var fieldInfo = FieldInfos.getMergedFieldInfos(reader).fieldInfo("object.field.offsets");
             assertThat(fieldInfo.getDocValuesType(), equalTo(DocValuesType.SORTED));


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix KeywordSyntheticSourceNativeArrayIntegrationTests for release builds (#123008)