### PR TITLE
[8.x] [ML] Support delaying EIS authorization revocation until after the node has finished booting (#122644)

### DIFF
--- a/server/src/main/java/org/elasticsearch/inference/InferenceService.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceService.java
@@ -241,4 +241,10 @@ public interface InferenceService extends Closeable {
     default void updateModelsWithDynamicFields(List<Model> model, ActionListener<List<Model>> listener) {
         listener.onResponse(model);
     }
+
+    /**
+     * Called after the Elasticsearch node has completed its start up. This allows the service to perform initialization
+     * after ensuring the node's internals are set up (for example if this ensures the internal ES client is ready for use).
+     */
+    default void onNodeStarted() {}
 }

--- a/server/src/main/java/org/elasticsearch/inference/InferenceServiceRegistry.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceServiceRegistry.java
@@ -41,6 +41,10 @@ public class InferenceServiceRegistry implements Closeable {
         services.values().forEach(s -> s.init(client));
     }
 
+    public void onNodeStarted() {
+        services.values().forEach(InferenceService::onNodeStarted);
+    }
+
     public Map<String, InferenceService> getServices() {
         return services;
     }

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/InferenceRevokeDefaultEndpointsIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/InferenceRevokeDefaultEndpointsIT.java
@@ -91,8 +91,9 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
         try (var service = createElasticInferenceService()) {
-            service.waitForAuthorizationToComplete(TIMEOUT);
+            ensureAuthorizationCallFinished(service);
             assertThat(service.supportedStreamingTasks(), is(EnumSet.of(TaskType.CHAT_COMPLETION, TaskType.ANY)));
+
             assertThat(
                 service.defaultConfigIds(),
                 is(
@@ -125,7 +126,8 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
             try (var service = createElasticInferenceService()) {
-                service.waitForAuthorizationToComplete(TIMEOUT);
+                ensureAuthorizationCallFinished(service);
+
                 assertThat(service.supportedStreamingTasks(), is(EnumSet.of(TaskType.CHAT_COMPLETION, TaskType.ANY)));
                 assertThat(
                     service.defaultConfigIds(),
@@ -164,7 +166,8 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(noAuthorizationResponseJson));
 
             try (var service = createElasticInferenceService()) {
-                service.waitForAuthorizationToComplete(TIMEOUT);
+                ensureAuthorizationCallFinished(service);
+
                 assertThat(service.supportedStreamingTasks(), is(EnumSet.noneOf(TaskType.class)));
                 assertTrue(service.defaultConfigIds().isEmpty());
                 assertThat(service.supportedTaskTypes(), is(EnumSet.noneOf(TaskType.class)));
@@ -198,7 +201,8 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
             try (var service = createElasticInferenceService()) {
-                service.waitForAuthorizationToComplete(TIMEOUT);
+                ensureAuthorizationCallFinished(service);
+
                 assertThat(service.supportedStreamingTasks(), is(EnumSet.of(TaskType.CHAT_COMPLETION, TaskType.ANY)));
                 assertThat(
                     service.defaultConfigIds(),
@@ -244,7 +248,8 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(noAuthorizationResponseJson));
 
             try (var service = createElasticInferenceService()) {
-                service.waitForAuthorizationToComplete(TIMEOUT);
+                ensureAuthorizationCallFinished(service);
+
                 assertThat(service.supportedStreamingTasks(), is(EnumSet.noneOf(TaskType.class)));
                 assertThat(
                     service.defaultConfigIds(),
@@ -264,6 +269,11 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
         }
     }
 
+    private void ensureAuthorizationCallFinished(ElasticInferenceService service) {
+        service.onNodeStarted();
+        service.waitForAuthorizationToComplete(TIMEOUT);
+    }
+
     private ElasticInferenceService createElasticInferenceService() {
         var httpManager = HttpClientManager.create(Settings.EMPTY, threadPool, mockClusterServiceEmpty(), mock(ThrottlerManager.class));
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, httpManager);
@@ -271,7 +281,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
         return new ElasticInferenceService(
             senderFactory,
             createWithEmptySettings(threadPool),
-            new ElasticInferenceServiceComponents(gatewayUrl),
+            ElasticInferenceServiceComponents.withNoRevokeDelay(gatewayUrl),
             modelRegistry,
             new ElasticInferenceServiceAuthorizationHandler(gatewayUrl, threadPool)
         );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -34,6 +34,7 @@ import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -146,7 +147,8 @@ public class InferencePlugin extends Plugin
         SystemIndexPlugin,
         MapperPlugin,
         SearchPlugin,
-        InternalSearchPlugin {
+        InternalSearchPlugin,
+        ClusterPlugin {
 
     /**
      * When this setting is true the verification check that
@@ -274,7 +276,7 @@ public class InferencePlugin extends Plugin
         ElasticInferenceServiceSettings inferenceServiceSettings = new ElasticInferenceServiceSettings(settings);
         String elasticInferenceUrl = inferenceServiceSettings.getElasticInferenceServiceUrl();
 
-        var elasticInferenceServiceComponentsInstance = new ElasticInferenceServiceComponents(elasticInferenceUrl);
+        var elasticInferenceServiceComponentsInstance = ElasticInferenceServiceComponents.withDefaultRevokeDelay(elasticInferenceUrl);
         elasticInferenceServiceComponents.set(elasticInferenceServiceComponentsInstance);
 
         var authorizationHandler = new ElasticInferenceServiceAuthorizationHandler(
@@ -514,6 +516,15 @@ public class InferencePlugin extends Plugin
     // to the new Elastic Inference Service URL.
     private String getElasticInferenceServiceUrl(ElasticInferenceServiceSettings settings) {
         return settings.getElasticInferenceServiceUrl();
+    }
+
+    @Override
+    public void onNodeStarted() {
+        var registry = inferenceServiceRegistry.get();
+
+        if (registry != null) {
+            registry.onNodeStarted();
+        }
     }
 
     protected SSLService getSslService() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -134,8 +134,6 @@ public class ElasticInferenceService extends SenderService {
 
         configuration = new Configuration(authRef.get().taskTypesAndModels.getAuthorizedTaskTypes());
         defaultModelsConfigs = initDefaultEndpoints(elasticInferenceServiceComponents);
-
-        getAuthorization();
     }
 
     private static Map<String, DefaultModelConfig> initDefaultEndpoints(
@@ -282,9 +280,24 @@ public class ElasticInferenceService extends SenderService {
             authorizationCompletedLatch.countDown();
         });
 
-        getServiceComponents().threadPool()
-            .executor(UTILITY_THREAD_POOL_NAME)
-            .execute(() -> modelRegistry.removeDefaultConfigs(unauthorizedDefaultInferenceEndpointIds, deleteInferenceEndpointsListener));
+        Runnable removeFromRegistry = () -> {
+            logger.debug("Synchronizing default inference endpoints");
+            modelRegistry.removeDefaultConfigs(unauthorizedDefaultInferenceEndpointIds, deleteInferenceEndpointsListener);
+        };
+
+        var delay = elasticInferenceServiceComponents.revokeAuthorizationDelay();
+        if (delay == null) {
+            getServiceComponents().threadPool().executor(UTILITY_THREAD_POOL_NAME).execute(removeFromRegistry);
+        } else {
+            getServiceComponents().threadPool()
+                .schedule(removeFromRegistry, delay, getServiceComponents().threadPool().executor(UTILITY_THREAD_POOL_NAME));
+        }
+
+    }
+
+    @Override
+    public void onNodeStarted() {
+        getServiceComponents().threadPool().executor(UTILITY_THREAD_POOL_NAME).execute(this::getAuthorization);
     }
 
     /**

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceComponents.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceComponents.java
@@ -8,5 +8,23 @@
 package org.elasticsearch.xpack.inference.services.elastic;
 
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 
-public record ElasticInferenceServiceComponents(@Nullable String elasticInferenceServiceUrl) {}
+/**
+ * @param elasticInferenceServiceUrl the upstream Elastic Inference Server's URL
+ * @param revokeAuthorizationDelay Amount of time to wait before attempting to revoke authorization to certain model ids.
+ *                                 null indicates that there should be no delay
+ */
+public record ElasticInferenceServiceComponents(@Nullable String elasticInferenceServiceUrl, @Nullable TimeValue revokeAuthorizationDelay) {
+    private static final TimeValue DEFAULT_REVOKE_AUTHORIZATION_DELAY = TimeValue.timeValueMinutes(10);
+
+    public static final ElasticInferenceServiceComponents EMPTY_INSTANCE = new ElasticInferenceServiceComponents(null, null);
+
+    public static ElasticInferenceServiceComponents withNoRevokeDelay(String elasticInferenceServiceUrl) {
+        return new ElasticInferenceServiceComponents(elasticInferenceServiceUrl, null);
+    }
+
+    public static ElasticInferenceServiceComponents withDefaultRevokeDelay(String elasticInferenceServiceUrl) {
+        return new ElasticInferenceServiceComponents(elasticInferenceServiceUrl, DEFAULT_REVOKE_AUTHORIZATION_DELAY);
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandler.java
@@ -76,7 +76,7 @@ public class ElasticInferenceServiceAuthorizationHandler {
             logger.debug("Retrieving authorization information from the Elastic Inference Service.");
 
             if (Strings.isNullOrEmpty(baseUrl)) {
-                logger.warn("The base URL for the authorization service is not valid, rejecting authorization.");
+                logger.debug("The base URL for the authorization service is not valid, rejecting authorization.");
                 listener.onResponse(ElasticInferenceServiceAuthorization.newDisabledService());
                 return;
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModelTests.java
@@ -26,7 +26,7 @@ public class ElasticInferenceServiceSparseEmbeddingsModelTests extends ESTestCas
             new ElasticInferenceServiceSparseEmbeddingsServiceSettings(modelId, maxInputTokens, null),
             EmptyTaskSettings.INSTANCE,
             EmptySecretSettings.INSTANCE,
-            new ElasticInferenceServiceComponents(url)
+            ElasticInferenceServiceComponents.withNoRevokeDelay(url)
         );
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -567,6 +567,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
 
     public void testHideFromConfigurationApi_ReturnsTrue_WithNoAvailableModels() throws Exception {
         try (var service = createServiceWithMockSender(ElasticInferenceServiceAuthorization.newDisabledService())) {
+            ensureAuthorizationCallFinished(service);
+
             assertTrue(service.hideFromConfigurationApi());
         }
     }
@@ -586,6 +588,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
                 )
             )
         ) {
+            ensureAuthorizationCallFinished(service);
+
             assertTrue(service.hideFromConfigurationApi());
         }
     }
@@ -605,6 +609,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
                 )
             )
         ) {
+            ensureAuthorizationCallFinished(service);
+
             assertFalse(service.hideFromConfigurationApi());
         }
     }
@@ -624,6 +630,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
                 )
             )
         ) {
+            ensureAuthorizationCallFinished(service);
+
             String content = XContentHelper.stripWhitespace("""
                 {
                        "service": "elastic",
@@ -677,6 +685,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
 
     public void testGetConfiguration_WithoutSupportedTaskTypes() throws Exception {
         try (var service = createServiceWithMockSender(ElasticInferenceServiceAuthorization.newDisabledService())) {
+            ensureAuthorizationCallFinished(service);
+
             String content = XContentHelper.stripWhitespace("""
                 {
                        "service": "elastic",
@@ -744,6 +754,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
                 )
             )
         ) {
+            ensureAuthorizationCallFinished(service);
+
             String content = XContentHelper.stripWhitespace("""
                 {
                        "service": "elastic",
@@ -811,7 +823,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
 
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
         try (var service = createServiceWithAuthHandler(senderFactory, getUrl(webServer))) {
-            service.waitForAuthorizationToComplete(TIMEOUT);
+            ensureAuthorizationCallFinished(service);
+
             assertThat(service.supportedStreamingTasks(), is(EnumSet.of(TaskType.CHAT_COMPLETION, TaskType.ANY)));
             assertTrue(service.defaultConfigIds().isEmpty());
 
@@ -841,7 +854,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
 
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
         try (var service = createServiceWithAuthHandler(senderFactory, getUrl(webServer))) {
-            service.waitForAuthorizationToComplete(TIMEOUT);
+            ensureAuthorizationCallFinished(service);
+
             assertThat(service.supportedTaskTypes(), is(EnumSet.of(TaskType.SPARSE_EMBEDDING)));
         }
     }
@@ -866,7 +880,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
 
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
         try (var service = createServiceWithAuthHandler(senderFactory, getUrl(webServer))) {
-            service.waitForAuthorizationToComplete(TIMEOUT);
+            ensureAuthorizationCallFinished(service);
+
             assertThat(service.supportedTaskTypes(), is(EnumSet.of(TaskType.SPARSE_EMBEDDING, TaskType.CHAT_COMPLETION)));
         }
     }
@@ -887,7 +902,8 @@ public class ElasticInferenceServiceTests extends ESTestCase {
 
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
         try (var service = createServiceWithAuthHandler(senderFactory, getUrl(webServer))) {
-            service.waitForAuthorizationToComplete(TIMEOUT);
+            ensureAuthorizationCallFinished(service);
+
             assertThat(service.supportedStreamingTasks(), is(EnumSet.noneOf(TaskType.class)));
             assertTrue(service.defaultConfigIds().isEmpty());
             assertThat(service.supportedTaskTypes(), is(EnumSet.of(TaskType.SPARSE_EMBEDDING)));
@@ -914,7 +930,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
 
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
         try (var service = createServiceWithAuthHandler(senderFactory, getUrl(webServer))) {
-            service.waitForAuthorizationToComplete(TIMEOUT);
+            ensureAuthorizationCallFinished(service);
             assertThat(service.supportedStreamingTasks(), is(EnumSet.noneOf(TaskType.class)));
             assertThat(
                 service.defaultConfigIds(),
@@ -952,7 +968,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
 
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
         try (var service = createServiceWithAuthHandler(senderFactory, getUrl(webServer))) {
-            service.waitForAuthorizationToComplete(TIMEOUT);
+            ensureAuthorizationCallFinished(service);
             assertThat(service.supportedStreamingTasks(), is(EnumSet.of(TaskType.CHAT_COMPLETION, TaskType.ANY)));
             assertThat(
                 service.defaultConfigIds(),
@@ -1027,7 +1043,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
                 new ElasticInferenceServiceCompletionServiceSettings("model_id", new RateLimitSettings(100)),
                 EmptyTaskSettings.INSTANCE,
                 EmptySecretSettings.INSTANCE,
-                new ElasticInferenceServiceComponents(eisGatewayUrl)
+                ElasticInferenceServiceComponents.withNoRevokeDelay(eisGatewayUrl)
             );
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
             service.unifiedCompletionInfer(
@@ -1060,6 +1076,11 @@ public class ElasticInferenceServiceTests extends ESTestCase {
         }
     }
 
+    private void ensureAuthorizationCallFinished(ElasticInferenceService service) {
+        service.onNodeStarted();
+        service.waitForAuthorizationToComplete(TIMEOUT);
+    }
+
     private ElasticInferenceService createServiceWithMockSender() {
         return createServiceWithMockSender(ElasticInferenceServiceAuthorizationTests.createEnabledAuth());
     }
@@ -1075,7 +1096,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
         return new ElasticInferenceService(
             mock(HttpRequestSender.Factory.class),
             createWithEmptySettings(threadPool),
-            new ElasticInferenceServiceComponents(null),
+            ElasticInferenceServiceComponents.EMPTY_INSTANCE,
             mockModelRegistry(),
             mockAuthHandler
         );
@@ -1104,7 +1125,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
         return new ElasticInferenceService(
             senderFactory,
             createWithEmptySettings(threadPool),
-            new ElasticInferenceServiceComponents(gatewayUrl),
+            ElasticInferenceServiceComponents.withNoRevokeDelay(gatewayUrl),
             mockModelRegistry(),
             mockAuthHandler
         );
@@ -1114,7 +1135,7 @@ public class ElasticInferenceServiceTests extends ESTestCase {
         return new ElasticInferenceService(
             senderFactory,
             createWithEmptySettings(threadPool),
-            new ElasticInferenceServiceComponents(eisGatewayUrl),
+            ElasticInferenceServiceComponents.withNoRevokeDelay(eisGatewayUrl),
             mockModelRegistry(),
             new ElasticInferenceServiceAuthorizationHandler(eisGatewayUrl, threadPool)
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandlerTests.java
@@ -83,9 +83,10 @@ public class ElasticInferenceServiceAuthorizationHandlerTests extends ESTestCase
             assertFalse(authResponse.isAuthorized());
 
             var loggerArgsCaptor = ArgumentCaptor.forClass(String.class);
-            verify(logger).warn(loggerArgsCaptor.capture());
-            var message = loggerArgsCaptor.getValue();
-            assertThat(message, is("The base URL for the authorization service is not valid, rejecting authorization."));
+            verify(logger, times(2)).debug(loggerArgsCaptor.capture());
+            var messages = loggerArgsCaptor.getAllValues();
+            assertThat(messages.getFirst(), is("Retrieving authorization information from the Elastic Inference Service."));
+            assertThat(messages.get(1), is("The base URL for the authorization service is not valid, rejecting authorization."));
         }
     }
 
@@ -104,9 +105,10 @@ public class ElasticInferenceServiceAuthorizationHandlerTests extends ESTestCase
             assertFalse(authResponse.isAuthorized());
 
             var loggerArgsCaptor = ArgumentCaptor.forClass(String.class);
-            verify(logger).warn(loggerArgsCaptor.capture());
-            var message = loggerArgsCaptor.getValue();
-            assertThat(message, is("The base URL for the authorization service is not valid, rejecting authorization."));
+            verify(logger, times(2)).debug(loggerArgsCaptor.capture());
+            var messages = loggerArgsCaptor.getAllValues();
+            assertThat(messages.getFirst(), is("Retrieving authorization information from the Elastic Inference Service."));
+            assertThat(messages.get(1), is("The base URL for the authorization service is not valid, rejecting authorization."));
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandlerTests.java
@@ -85,7 +85,7 @@ public class ElasticInferenceServiceAuthorizationHandlerTests extends ESTestCase
             var loggerArgsCaptor = ArgumentCaptor.forClass(String.class);
             verify(logger, times(2)).debug(loggerArgsCaptor.capture());
             var messages = loggerArgsCaptor.getAllValues();
-            assertThat(messages.getFirst(), is("Retrieving authorization information from the Elastic Inference Service."));
+            assertThat(messages.get(0), is("Retrieving authorization information from the Elastic Inference Service."));
             assertThat(messages.get(1), is("The base URL for the authorization service is not valid, rejecting authorization."));
         }
     }
@@ -107,7 +107,7 @@ public class ElasticInferenceServiceAuthorizationHandlerTests extends ESTestCase
             var loggerArgsCaptor = ArgumentCaptor.forClass(String.class);
             verify(logger, times(2)).debug(loggerArgsCaptor.capture());
             var messages = loggerArgsCaptor.getAllValues();
-            assertThat(messages.getFirst(), is("Retrieving authorization information from the Elastic Inference Service."));
+            assertThat(messages.get(0), is("Retrieving authorization information from the Elastic Inference Service."));
             assertThat(messages.get(1), is("The base URL for the authorization service is not valid, rejecting authorization."));
         }
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionModelTests.java
@@ -29,7 +29,7 @@ public class ElasticInferenceServiceCompletionModelTests extends ESTestCase {
             new ElasticInferenceServiceCompletionServiceSettings("model_id", new RateLimitSettings(100)),
             EmptyTaskSettings.INSTANCE,
             EmptySecretSettings.INSTANCE,
-            new ElasticInferenceServiceComponents("url")
+            ElasticInferenceServiceComponents.withNoRevokeDelay("url")
         );
 
         var request = new UnifiedCompletionRequest(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ML] Support delaying EIS authorization revocation until after the node has finished booting (#122644)](https://github.com/elastic/elasticsearch/pull/122644)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)