### PR TITLE
Reduce warnings in entitlement REST tests

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/DummyImplementations.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/DummyImplementations.java
@@ -13,7 +13,6 @@ import jdk.nio.Channels;
 
 import org.elasticsearch.core.SuppressForbidden;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.DatagramPacket;
@@ -459,71 +458,71 @@ class DummyImplementations {
     }
 
     static class DummyDatagramSocket extends DatagramSocket {
-        DummyDatagramSocket() throws SocketException {
+        DummyDatagramSocket() {
             super(new DatagramSocketImpl() {
                 @Override
-                protected void create() throws SocketException {}
+                protected void create() {}
 
                 @Override
-                protected void bind(int lport, InetAddress laddr) throws SocketException {}
+                protected void bind(int lport, InetAddress laddr) {}
 
                 @Override
-                protected void send(DatagramPacket p) throws IOException {}
+                protected void send(DatagramPacket p) {}
 
                 @Override
-                protected int peek(InetAddress i) throws IOException {
+                protected int peek(InetAddress i) {
                     return 0;
                 }
 
                 @Override
-                protected int peekData(DatagramPacket p) throws IOException {
+                protected int peekData(DatagramPacket p) {
                     return 0;
                 }
 
                 @Override
-                protected void receive(DatagramPacket p) throws IOException {}
+                protected void receive(DatagramPacket p) {}
 
                 @Override
-                protected void setTTL(byte ttl) throws IOException {}
+                protected void setTTL(byte ttl) {}
 
                 @Override
-                protected byte getTTL() throws IOException {
+                protected byte getTTL() {
                     return 0;
                 }
 
                 @Override
-                protected void setTimeToLive(int ttl) throws IOException {}
+                protected void setTimeToLive(int ttl) {}
 
                 @Override
-                protected int getTimeToLive() throws IOException {
+                protected int getTimeToLive() {
                     return 0;
                 }
 
                 @Override
-                protected void join(InetAddress inetaddr) throws IOException {}
+                protected void join(InetAddress inetaddr) {}
 
                 @Override
-                protected void leave(InetAddress inetaddr) throws IOException {}
+                protected void leave(InetAddress inetaddr) {}
 
                 @Override
-                protected void joinGroup(SocketAddress mcastaddr, NetworkInterface netIf) throws IOException {}
+                protected void joinGroup(SocketAddress mcastaddr, NetworkInterface netIf) {}
 
                 @Override
-                protected void leaveGroup(SocketAddress mcastaddr, NetworkInterface netIf) throws IOException {}
+                protected void leaveGroup(SocketAddress mcastaddr, NetworkInterface netIf) {}
 
                 @Override
                 protected void close() {}
 
                 @Override
-                public void setOption(int optID, Object value) throws SocketException {}
+                public void setOption(int optID, Object value) {}
 
                 @Override
-                public Object getOption(int optID) throws SocketException {
+                public Object getOption(int optID) {
                     return null;
                 }
 
                 @Override
-                protected void connect(InetAddress address, int port) throws SocketException {}
+                protected void connect(InetAddress address, int port) {}
             });
         }
     }
@@ -534,54 +533,54 @@ class DummyImplementations {
 
     static class DummySelectorProvider extends SelectorProvider {
         @Override
-        public DatagramChannel openDatagramChannel() throws IOException {
+        public DatagramChannel openDatagramChannel() {
             return null;
         }
 
         @Override
-        public DatagramChannel openDatagramChannel(ProtocolFamily family) throws IOException {
+        public DatagramChannel openDatagramChannel(ProtocolFamily family) {
             return null;
         }
 
         @Override
-        public Pipe openPipe() throws IOException {
+        public Pipe openPipe() {
             return null;
         }
 
         @Override
-        public AbstractSelector openSelector() throws IOException {
+        public AbstractSelector openSelector() {
             return null;
         }
 
         @Override
-        public ServerSocketChannel openServerSocketChannel() throws IOException {
+        public ServerSocketChannel openServerSocketChannel() {
             return null;
         }
 
         @Override
-        public SocketChannel openSocketChannel() throws IOException {
+        public SocketChannel openSocketChannel() {
             return null;
         }
     }
 
     static class DummyAsynchronousChannelProvider extends AsynchronousChannelProvider {
         @Override
-        public AsynchronousChannelGroup openAsynchronousChannelGroup(int nThreads, ThreadFactory threadFactory) throws IOException {
+        public AsynchronousChannelGroup openAsynchronousChannelGroup(int nThreads, ThreadFactory threadFactory) {
             return null;
         }
 
         @Override
-        public AsynchronousChannelGroup openAsynchronousChannelGroup(ExecutorService executor, int initialSize) throws IOException {
+        public AsynchronousChannelGroup openAsynchronousChannelGroup(ExecutorService executor, int initialSize) {
             return null;
         }
 
         @Override
-        public AsynchronousServerSocketChannel openAsynchronousServerSocketChannel(AsynchronousChannelGroup group) throws IOException {
+        public AsynchronousServerSocketChannel openAsynchronousServerSocketChannel(AsynchronousChannelGroup group) {
             return null;
         }
 
         @Override
-        public AsynchronousSocketChannel openAsynchronousSocketChannel(AsynchronousChannelGroup group) throws IOException {
+        public AsynchronousSocketChannel openAsynchronousSocketChannel(AsynchronousChannelGroup group) {
             return null;
         }
     }
@@ -605,7 +604,7 @@ class DummyImplementations {
         }
 
         @Override
-        public FileSystem newFileSystem(URI uri, Map<String, ?> env) throws IOException {
+        public FileSystem newFileSystem(URI uri, Map<String, ?> env) {
             return null;
         }
 
@@ -620,53 +619,52 @@ class DummyImplementations {
         }
 
         @Override
-        public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs)
-            throws IOException {
+        public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) {
             return null;
         }
 
         @Override
-        public DirectoryStream<Path> newDirectoryStream(Path dir, DirectoryStream.Filter<? super Path> filter) throws IOException {
+        public DirectoryStream<Path> newDirectoryStream(Path dir, DirectoryStream.Filter<? super Path> filter) {
             return null;
         }
 
         @Override
-        public void createDirectory(Path dir, FileAttribute<?>... attrs) throws IOException {
+        public void createDirectory(Path dir, FileAttribute<?>... attrs) {
 
         }
 
         @Override
-        public void delete(Path path) throws IOException {
+        public void delete(Path path) {
 
         }
 
         @Override
-        public void copy(Path source, Path target, CopyOption... options) throws IOException {
+        public void copy(Path source, Path target, CopyOption... options) {
 
         }
 
         @Override
-        public void move(Path source, Path target, CopyOption... options) throws IOException {
+        public void move(Path source, Path target, CopyOption... options) {
 
         }
 
         @Override
-        public boolean isSameFile(Path path, Path path2) throws IOException {
+        public boolean isSameFile(Path path, Path path2) {
             return false;
         }
 
         @Override
-        public boolean isHidden(Path path) throws IOException {
+        public boolean isHidden(Path path) {
             return false;
         }
 
         @Override
-        public FileStore getFileStore(Path path) throws IOException {
+        public FileStore getFileStore(Path path) {
             return null;
         }
 
         @Override
-        public void checkAccess(Path path, AccessMode... modes) throws IOException {
+        public void checkAccess(Path path, AccessMode... modes) {
 
         }
 
@@ -676,104 +674,104 @@ class DummyImplementations {
         }
 
         @Override
-        public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type, LinkOption... options) throws IOException {
+        public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type, LinkOption... options) {
             return null;
         }
 
         @Override
-        public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options) throws IOException {
+        public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options) {
             return Map.of();
         }
 
         @Override
-        public void setAttribute(Path path, String attribute, Object value, LinkOption... options) throws IOException {
+        public void setAttribute(Path path, String attribute, Object value, LinkOption... options) {
 
         }
     }
 
     static class DummyFileChannel extends FileChannel {
         @Override
-        protected void implCloseChannel() throws IOException {
+        protected void implCloseChannel() {
 
         }
 
         @Override
-        public int read(ByteBuffer dst) throws IOException {
+        public int read(ByteBuffer dst) {
             return 0;
         }
 
         @Override
-        public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+        public long read(ByteBuffer[] dsts, int offset, int length) {
             return 0;
         }
 
         @Override
-        public int write(ByteBuffer src) throws IOException {
+        public int write(ByteBuffer src) {
             return 0;
         }
 
         @Override
-        public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        public long write(ByteBuffer[] srcs, int offset, int length) {
             return 0;
         }
 
         @Override
-        public long position() throws IOException {
+        public long position() {
             return 0;
         }
 
         @Override
-        public FileChannel position(long newPosition) throws IOException {
+        public FileChannel position(long newPosition) {
             return null;
         }
 
         @Override
-        public long size() throws IOException {
+        public long size() {
             return 0;
         }
 
         @Override
-        public FileChannel truncate(long size) throws IOException {
+        public FileChannel truncate(long size) {
             return null;
         }
 
         @Override
-        public void force(boolean metaData) throws IOException {
+        public void force(boolean metaData) {
 
         }
 
         @Override
-        public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
+        public long transferTo(long position, long count, WritableByteChannel target) {
             return 0;
         }
 
         @Override
-        public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
+        public long transferFrom(ReadableByteChannel src, long position, long count) {
             return 0;
         }
 
         @Override
-        public int read(ByteBuffer dst, long position) throws IOException {
+        public int read(ByteBuffer dst, long position) {
             return 0;
         }
 
         @Override
-        public int write(ByteBuffer src, long position) throws IOException {
+        public int write(ByteBuffer src, long position) {
             return 0;
         }
 
         @Override
-        public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
+        public MappedByteBuffer map(MapMode mode, long position, long size) {
             return null;
         }
 
         @Override
-        public FileLock lock(long position, long size, boolean shared) throws IOException {
+        public FileLock lock(long position, long size, boolean shared) {
             return null;
         }
 
         @Override
-        public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+        public FileLock tryLock(long position, long size, boolean shared) {
             return null;
         }
     }
@@ -785,22 +783,22 @@ class DummyImplementations {
         }
 
         @Override
-        public void close() throws IOException {
+        public void close() {
 
         }
 
         @Override
-        public long size() throws IOException {
+        public long size() {
             return 0;
         }
 
         @Override
-        public AsynchronousFileChannel truncate(long size) throws IOException {
+        public AsynchronousFileChannel truncate(long size) {
             return null;
         }
 
         @Override
-        public void force(boolean metaData) throws IOException {
+        public void force(boolean metaData) {
 
         }
 
@@ -815,7 +813,7 @@ class DummyImplementations {
         }
 
         @Override
-        public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+        public FileLock tryLock(long position, long size, boolean shared) {
             return null;
         }
 
@@ -843,9 +841,9 @@ class DummyImplementations {
     @SuppressForbidden(reason = "specifically testing readWriteSelectableChannel")
     static class DummySelectableChannelCloser implements Channels.SelectableChannelCloser {
         @Override
-        public void implCloseChannel(SelectableChannel sc) throws IOException {}
+        public void implCloseChannel(SelectableChannel sc) {}
 
         @Override
-        public void implReleaseChannel(SelectableChannel sc) throws IOException {}
+        public void implReleaseChannel(SelectableChannel sc) {}
     }
 }

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAcce
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 
 @SuppressForbidden(reason = "Explicitly checking APIs that are forbidden")
-@SuppressWarnings("unused") // Called via reflection
+@SuppressWarnings({ "unused" /* called via reflection */, "ResultOfMethodCallIgnored" })
 class FileCheckActions {
 
     static Path testRootDir = Paths.get(System.getProperty("es.entitlements.testdir"));
@@ -62,17 +62,17 @@ class FileCheckActions {
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileCanExecute() throws IOException {
+    static void fileCanExecute() {
         readFile().toFile().canExecute();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileCanRead() throws IOException {
+    static void fileCanRead() {
         readFile().toFile().canRead();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileCanWrite() throws IOException {
+    static void fileCanWrite() {
         readFile().toFile().canWrite();
     }
 
@@ -101,68 +101,68 @@ class FileCheckActions {
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileExists() throws IOException {
+    static void fileExists() {
         readFile().toFile().exists();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileIsDirectory() throws IOException {
+    static void fileIsDirectory() {
         readFile().toFile().isDirectory();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileIsFile() throws IOException {
+    static void fileIsFile() {
         readFile().toFile().isFile();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileIsHidden() throws IOException {
+    static void fileIsHidden() {
         readFile().toFile().isHidden();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileLastModified() throws IOException {
+    static void fileLastModified() {
         readFile().toFile().lastModified();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileLength() throws IOException {
+    static void fileLength() {
         readFile().toFile().length();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileList() throws IOException {
+    static void fileList() {
         readDir().toFile().list();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileListWithFilter() throws IOException {
+    static void fileListWithFilter() {
         readDir().toFile().list((dir, name) -> true);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileListFiles() throws IOException {
+    static void fileListFiles() {
         readDir().toFile().listFiles();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileListFilesWithFileFilter() throws IOException {
+    static void fileListFilesWithFileFilter() {
         readDir().toFile().listFiles(pathname -> true);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileListFilesWithFilenameFilter() throws IOException {
+    static void fileListFilesWithFilenameFilter() {
         readDir().toFile().listFiles((dir, name) -> true);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileMkdir() throws IOException {
+    static void fileMkdir() {
         Path mkdir = readWriteDir().resolve("mkdir");
         mkdir.toFile().mkdir();
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileMkdirs() throws IOException {
+    static void fileMkdirs() {
         Path mkdir = readWriteDir().resolve("mkdirs");
         mkdir.toFile().mkdirs();
     }
@@ -175,27 +175,27 @@ class FileCheckActions {
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileSetExecutable() throws IOException {
+    static void fileSetExecutable() {
         readWriteFile().toFile().setExecutable(false);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileSetExecutableOwner() throws IOException {
+    static void fileSetExecutableOwner() {
         readWriteFile().toFile().setExecutable(false, false);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileSetLastModified() throws IOException {
+    static void fileSetLastModified() {
         readWriteFile().toFile().setLastModified(System.currentTimeMillis());
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileSetReadable() throws IOException {
+    static void fileSetReadable() {
         readWriteFile().toFile().setReadable(true);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileSetReadableOwner() throws IOException {
+    static void fileSetReadableOwner() {
         readWriteFile().toFile().setReadable(true, false);
     }
 
@@ -207,12 +207,12 @@ class FileCheckActions {
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileSetWritable() throws IOException {
+    static void fileSetWritable() {
         readWriteFile().toFile().setWritable(true);
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
-    static void fileSetWritableOwner() throws IOException {
+    static void fileSetWritableOwner() {
         readWriteFile().toFile().setWritable(true, false);
     }
 
@@ -363,6 +363,7 @@ class FileCheckActions {
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
+    @SuppressWarnings("DataFlowIssue") // Passing null to a @NotNull parameter
     static void keystoreBuilderNewInstance() {
         try {
             KeyStore.Builder.newInstance("", null, readFile().toFile(), null);

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileStoreActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileStoreActions.java
@@ -16,6 +16,7 @@ import java.nio.file.attribute.FileStoreAttributeView;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_DENIED;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.SERVER_ONLY;
 
+@SuppressWarnings({ "unused" /* called via reflection */ })
 class FileStoreActions {
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/ManageThreadsActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/ManageThreadsActions.java
@@ -18,7 +18,7 @@ import static java.lang.Thread.currentThread;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 
 @SuppressForbidden(reason = "testing entitlements")
-@SuppressWarnings("unused") // used via reflection
+@SuppressWarnings({ "unused" /* called via reflaction */, "removal" })
 class ManageThreadsActions {
     private ManageThreadsActions() {}
 

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NativeActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NativeActions.java
@@ -33,6 +33,7 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.SERVER_ONLY;
 
+@SuppressWarnings({ "unused" /* called via reflection */ })
 class NativeActions {
 
     @EntitlementTest(expectedAccess = SERVER_ONLY)

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NetworkAccessCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NetworkAccessCheckActions.java
@@ -81,7 +81,7 @@ class NetworkAccessCheckActions {
         assert urlConnection != null;
     }
 
-    static void createLDAPCertStore() throws NoSuchAlgorithmException {
+    static void createLDAPCertStore() {
         try {
             // We pass down null params to provoke a InvalidAlgorithmParameterException
             CertStore.getInstance("LDAP", null);

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioChannelsActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioChannelsActions.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_DENIED;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 
+@SuppressWarnings({ "unused" /* called via reflection */ })
 class NioChannelsActions {
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
@@ -51,7 +52,7 @@ class NioChannelsActions {
     }
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
-    static void createAsynchronousFileChannel() throws IOException {
+    static void createAsynchronousFileChannel() {
         new DummyImplementations.DummyAsynchronousFileChannel().close();
     }
 

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioFileSystemActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioFileSystemActions.java
@@ -27,6 +27,7 @@ import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAcce
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.SERVER_ONLY;
 
+@SuppressWarnings({ "unused" /* called via reflection */ })
 class NioFileSystemActions {
 
     @EntitlementTest(expectedAccess = SERVER_ONLY)

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioFilesActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/NioFilesActions.java
@@ -39,6 +39,7 @@ import static org.elasticsearch.entitlement.qa.test.FileCheckActions.readFile;
 import static org.elasticsearch.entitlement.qa.test.FileCheckActions.readWriteDir;
 import static org.elasticsearch.entitlement.qa.test.FileCheckActions.readWriteFile;
 
+@SuppressWarnings({ "unused" /* called via reflection */ })
 class NioFilesActions {
 
     @EntitlementTest(expectedAccess = PLUGINS)
@@ -313,52 +314,36 @@ class NioFilesActions {
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void checkFilesWalkFileTree() throws IOException {
-        Files.walkFileTree(readDir(), new FileVisitor<>() {
-            @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                return FileVisitResult.SKIP_SUBTREE;
-            }
-
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                return FileVisitResult.SKIP_SUBTREE;
-            }
-
-            @Override
-            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-                return FileVisitResult.SKIP_SUBTREE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                return FileVisitResult.SKIP_SUBTREE;
-            }
-        });
+        Files.walkFileTree(readDir(), dummyVisitor());
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)
     static void checkFilesWalkFileTreeWithOptions() throws IOException {
-        Files.walkFileTree(readDir(), Set.of(FileVisitOption.FOLLOW_LINKS), 2, new FileVisitor<>() {
+        Files.walkFileTree(readDir(), Set.of(FileVisitOption.FOLLOW_LINKS), 2, dummyVisitor());
+    }
+
+    private static FileVisitor<Path> dummyVisitor() {
+        return new FileVisitor<>() {
             @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
                 return FileVisitResult.SKIP_SUBTREE;
             }
 
             @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 return FileVisitResult.SKIP_SUBTREE;
             }
 
             @Override
-            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
                 return FileVisitResult.SKIP_SUBTREE;
             }
 
             @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
                 return FileVisitResult.SKIP_SUBTREE;
             }
-        });
+        };
     }
 
     @EntitlementTest(expectedAccess = PLUGINS)

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/PathActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/PathActions.java
@@ -16,7 +16,7 @@ import java.nio.file.WatchEvent;
 
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 
-@SuppressWarnings({ "unused" /* called via reflection */ })
+@SuppressWarnings({ "unused" /* called via reflection */, "rawtypes" })
 class PathActions {
 
     @EntitlementTest(expectedAccess = PLUGINS)

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/PathActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/PathActions.java
@@ -16,6 +16,7 @@ import java.nio.file.WatchEvent;
 
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 
+@SuppressWarnings({ "unused" /* called via reflection */ })
 class PathActions {
 
     @EntitlementTest(expectedAccess = PLUGINS)
@@ -28,7 +29,6 @@ class PathActions {
         FileCheckActions.readFile().toRealPath(LinkOption.NOFOLLOW_LINKS);
     }
 
-    @SuppressWarnings("rawtypes")
     @EntitlementTest(expectedAccess = PLUGINS)
     static void checkRegister() throws IOException {
         try (var watchService = FileSystems.getDefault().newWatchService()) {
@@ -38,7 +38,6 @@ class PathActions {
         }
     }
 
-    @SuppressWarnings("rawtypes")
     @EntitlementTest(expectedAccess = PLUGINS)
     static void checkRegisterWithModifiers() throws IOException {
         try (var watchService = FileSystems.getDefault().newWatchService()) {

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/SpiActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/SpiActions.java
@@ -15,6 +15,7 @@ import java.nio.channels.spi.SelectorProvider;
 
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_DENIED;
 
+@SuppressWarnings({ "unused" /* called via reflection */ })
 class SpiActions {
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
     static void createBreakIteratorProvider() {
@@ -78,14 +79,7 @@ class SpiActions {
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
     static void getInheritedChannel() throws IOException {
-        Channel channel = null;
-        try {
-            channel = SelectorProvider.provider().inheritedChannel();
-        } finally {
-            if (channel != null) {
-                channel.close();
-            }
-        }
+        try (Channel channel = SelectorProvider.provider().inheritedChannel()) {}
     }
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/SystemActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/SystemActions.java
@@ -14,6 +14,7 @@ import org.elasticsearch.core.SuppressForbidden;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_DENIED;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.SERVER_ONLY;
 
+@SuppressWarnings({ "unused" /* called via reflection */ })
 class SystemActions {
 
     @SuppressForbidden(reason = "Specifically testing Runtime.exit")

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/VersionSpecificNetworkChecks.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/VersionSpecificNetworkChecks.java
@@ -19,7 +19,7 @@ import java.net.spi.InetAddressResolverProvider;
 
 class VersionSpecificNetworkChecks {
     static void createInetAddressResolverProvider() {
-        var x = new InetAddressResolverProvider() {
+        new InetAddressResolverProvider() {
             @Override
             public InetAddressResolver get(Configuration configuration) {
                 return null;


### PR DESCRIPTION
Cosmetic changes to the REST test code to reduce warnings.
- Remove `throws` declarations for exceptions not thrown
- Suppress warnings for unused methods called via reflection
- Eliminate a 20-line section of duplicated code
- A couple of other miscellaneous tweaks