### PR TITLE
[9.0] Add missing entitlements discovered in IT tests (#123015)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
@@ -42,6 +42,7 @@ public class EntitlementBootstrap {
         Function<String, Path> repoDirResolver,
         Path[] dataDirs,
         Path configDir,
+        Path libDir,
         Path logsDir,
         Path tempDir
     ) {
@@ -56,6 +57,7 @@ public class EntitlementBootstrap {
                 throw new IllegalArgumentException("must provide at least one data directory");
             }
             requireNonNull(configDir);
+            requireNonNull(libDir);
             requireNonNull(logsDir);
             requireNonNull(tempDir);
         }
@@ -78,6 +80,7 @@ public class EntitlementBootstrap {
      * @param repoDirResolver a functor to map a repository location to its Elasticsearch path.
      * @param dataDirs       data directories for Elasticsearch
      * @param configDir      the config directory for Elasticsearch
+     * @param libDir         the lib directory for Elasticsearch
      * @param tempDir        the temp directory for Elasticsearch
      * @param logsDir        the log directory for Elasticsearch
      */
@@ -89,6 +92,7 @@ public class EntitlementBootstrap {
         Function<String, Path> repoDirResolver,
         Path[] dataDirs,
         Path configDir,
+        Path libDir,
         Path logsDir,
         Path tempDir
     ) {
@@ -104,6 +108,7 @@ public class EntitlementBootstrap {
             repoDirResolver,
             dataDirs,
             configDir,
+            libDir,
             logsDir,
             tempDir
         );

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -234,7 +234,11 @@ public class EntitlementInitialization {
             Collections.addAll(
                 serverScopes,
                 new Scope("org.bouncycastle.fips.tls", List.of(new FilesEntitlement(List.of(FileData.ofPath(trustStorePath, READ))))),
-                new Scope("org.bouncycastle.fips.core", List.of(new ManageThreadsEntitlement()))
+                new Scope(
+                    "org.bouncycastle.fips.core",
+                    // read to lib dir is required for checksum validation
+                    List.of(new FilesEntitlement(List.of(FileData.ofPath(bootstrapArgs.libDir(), READ))), new ManageThreadsEntitlement())
+                )
             );
         }
 

--- a/modules/repository-s3/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/repository-s3/src/main/plugin-metadata/entitlement-policy.yaml
@@ -5,3 +5,6 @@ ALL-UNNAMED:
     - relative_path: "repository-s3/aws-web-identity-token-file"
       relative_to: "config"
       mode: "read"
+    - relative_path: ".aws/"
+      relative_to: "home"
+      mode: "read"

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -250,6 +250,7 @@ class Elasticsearch {
                 nodeEnv::resolveRepoDir,
                 nodeEnv.dataDirs(),
                 nodeEnv.configDir(),
+                nodeEnv.libDir(),
                 nodeEnv.logsDir(),
                 nodeEnv.tmpDir()
             );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Add missing entitlements discovered in IT tests (#123015)](https://github.com/elastic/elasticsearch/pull/123015)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)