### PR TITLE
Remove testCloseSkipUnavailable

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -277,9 +277,6 @@ tests:
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/cat/health/cat-health-example}
   issue: https://github.com/elastic/elasticsearch/issues/122335
-- class: org.elasticsearch.xpack.esql.action.CrossClusterCancellationIT
-  method: testCloseSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/122336
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/alias/line_260}
   issue: https://github.com/elastic/elasticsearch/issues/122343

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterCancellationIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterCancellationIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.action;
 
-import org.elasticsearch.Build;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.TransportCancelTasksAction;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterCancellationIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterCancellationIT.java
@@ -287,44 +287,4 @@ public class CrossClusterCancellationIT extends AbstractMultiClustersTestCase {
         Exception error = expectThrows(Exception.class, requestFuture::actionGet);
         assertThat(error, instanceOf(TaskCancelledException.class));
     }
-
-    // Check that closing remote node with skip_unavailable=true produces partial
-    public void testCloseSkipUnavailable() throws Exception {
-        // We are using delay() here because closing cluster while inside pause fields doesn't seem to produce clean closure
-        assumeTrue("Only snapshot builds have delay()", Build.current().isSnapshot());
-        createRemoteIndex(between(1000, 5000));
-        createLocalIndex(10);
-        EsqlQueryRequest request = EsqlQueryRequest.syncEsqlQueryRequest();
-        request.query("""
-            FROM test*,cluster-a:test* METADATA _index
-            | EVAL cluster=MV_FIRST(SPLIT(_index, ":"))
-            | WHERE CASE(cluster == "cluster-a", delay(1ms), true)
-            | STATS total = sum(const) | LIMIT 1
-            """);
-        request.pragmas(randomPragmas());
-        var requestFuture = client().execute(EsqlQueryAction.INSTANCE, request);
-        assertTrue(SimplePauseFieldPlugin.startEmitting.await(30, TimeUnit.SECONDS));
-        SimplePauseFieldPlugin.allowEmitting.countDown();
-        cluster(REMOTE_CLUSTER).close();
-        try (var resp = requestFuture.actionGet()) {
-            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
-            assertNotNull(executionInfo);
-            assertThat(executionInfo.isPartial(), equalTo(true));
-
-            List<List<Object>> values = getValuesList(resp);
-            assertThat(values.get(0).size(), equalTo(1));
-            // We can't be sure of the exact value here as we don't know if any data from remote came in, but all local data should be there
-            assertThat((long) values.get(0).get(0), greaterThanOrEqualTo(10L));
-
-            EsqlExecutionInfo.Cluster cluster = executionInfo.getCluster(REMOTE_CLUSTER);
-            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(1));
-
-            assertThat(cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.PARTIAL));
-            assertThat(cluster.getSuccessfulShards(), equalTo(0));
-            assertThat(cluster.getFailures().size(), equalTo(1));
-        }
-    }
 }


### PR DESCRIPTION
It duplicates CrossClusterQueryWithPartialResultsIT so there's no more need of it.

Fixes https://github.com/elastic/elasticsearch/issues/122336