### PR TITLE
[8.x] Fix CrossClusterAsyncQueryStopIT testStopQueryLocal test (#123050)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
@@ -156,6 +156,7 @@ public class CrossClusterAsyncQueryStopIT extends AbstractCrossClusterTestCase {
                 try (EsqlQueryResponse asyncResponse = getAsyncResponse(client(), asyncExecutionId)) {
                     EsqlExecutionInfo executionInfo = asyncResponse.getExecutionInfo();
                     assertNotNull(executionInfo);
+                    assertThat(executionInfo.isStopped(), is(true));
                 }
             });
             // allow local query to proceed


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix CrossClusterAsyncQueryStopIT testStopQueryLocal test (#123050)](https://github.com/elastic/elasticsearch/pull/123050)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)