### PR TITLE
Summarize cause when replacing no shard available exception in search

### DIFF
--- a/docs/changelog/123070.yaml
+++ b/docs/changelog/123070.yaml
@@ -1,0 +1,5 @@
+pr: 123070
+summary: Summarize cause when replacing no shard available exception in search
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/NoShardAvailableActionException.java
+++ b/server/src/main/java/org/elasticsearch/action/NoShardAvailableActionException.java
@@ -23,8 +23,8 @@ public final class NoShardAvailableActionException extends ElasticsearchExceptio
     // It isn't necessary to serialize this field over the wire as the empty stack trace is serialized instead.
     private final boolean onShardFailureWrapper;
 
-    public static NoShardAvailableActionException forOnShardFailureWrapper(String msg) {
-        return new NoShardAvailableActionException(null, msg, null, true);
+    public static NoShardAvailableActionException forOnShardFailureWrapper(Exception e, Throwable cause) {
+        return new NoShardAvailableActionException(null, e + ", cause: " + cause, null, true);
     }
 
     public NoShardAvailableActionException(ShardId shardId) {

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -442,10 +442,11 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
      * @param e the failure reason
      */
     void onShardFailure(final int shardIndex, SearchShardTarget shardTarget, Exception e) {
-        if (TransportActions.isShardNotAvailableException(e)) {
+        Throwable cause = ExceptionsHelper.unwrapCause(e);
+        if (TransportActions.isShardNotAvailableException(cause)) {
             // Groups shard not available exceptions under a generic exception that returns a SERVICE_UNAVAILABLE(503)
             // temporary error.
-            e = NoShardAvailableActionException.forOnShardFailureWrapper(e.getMessage());
+            e = NoShardAvailableActionException.forOnShardFailureWrapper(e, cause);
         }
         // we don't aggregate shard on failures due to the internal cancellation,
         // but do keep the header counts right

--- a/server/src/test/java/org/elasticsearch/action/search/ShardSearchFailureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/ShardSearchFailureTests.java
@@ -123,13 +123,16 @@ public class ShardSearchFailureTests extends ESTestCase {
         BytesReference xContent = toXContent(failure, XContentType.JSON, randomBoolean());
         assertEquals(
             XContentHelper.stripWhitespace(
-                """
-                    {
-                      "shard": 123,
-                      "index": "indexName",
-                      "node": "nodeId",
-                      "reason":{"type":"no_shard_available_action_exception","reason":"org.apache.lucene.store.AlreadyClosedException: shard unassigned, cause: null"}
-                    }"""
+            """
+                {
+                  "shard": 123,
+                  "index": "indexName",
+                  "node": "nodeId",
+                  "reason": {
+                    "type": "no_shard_available_action_exception",
+                    "reason": "org.apache.lucene.store.AlreadyClosedException: shard unassigned, cause: null"
+                  }
+                }"""
             ),
             xContent.utf8ToString()
         );

--- a/server/src/test/java/org/elasticsearch/action/search/ShardSearchFailureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/ShardSearchFailureTests.java
@@ -121,21 +121,16 @@ public class ShardSearchFailureTests extends ESTestCase {
             new SearchShardTarget("nodeId", shardId, null)
         );
         BytesReference xContent = toXContent(failure, XContentType.JSON, randomBoolean());
-        assertEquals(
-            XContentHelper.stripWhitespace(
-            """
-                {
-                  "shard": 123,
-                  "index": "indexName",
-                  "node": "nodeId",
-                  "reason": {
-                    "type": "no_shard_available_action_exception",
-                    "reason": "org.apache.lucene.store.AlreadyClosedException: shard unassigned, cause: null"
-                  }
-                }"""
-            ),
-            xContent.utf8ToString()
-        );
+        assertEquals(XContentHelper.stripWhitespace("""
+            {
+              "shard": 123,
+              "index": "indexName",
+              "node": "nodeId",
+              "reason": {
+                "type": "no_shard_available_action_exception",
+                "reason": "org.apache.lucene.store.AlreadyClosedException: shard unassigned, cause: null"
+              }
+            }"""), xContent.utf8ToString());
     }
 
     public void testToXContentWithClusterAlias() throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
@@ -202,8 +202,9 @@ abstract class DataNodeRequestSender {
 
     private static Exception unwrapFailure(Exception e) {
         e = e instanceof TransportException te ? FailureCollector.unwrapTransportException(te) : e;
-        if (TransportActions.isShardNotAvailableException(e)) {
-            return NoShardAvailableActionException.forOnShardFailureWrapper(e.getMessage());
+        Throwable cause = ExceptionsHelper.unwrapCause(e);
+        if (TransportActions.isShardNotAvailableException(cause)) {
+            return NoShardAvailableActionException.forOnShardFailureWrapper(e, cause);
         } else {
             return e;
         }


### PR DESCRIPTION
When a shard fails during search, the error handling logic looks at the root cause and in case it is in the availability bucket, the exception is replaced with a more generic NoShardAvailableException without a shard_id and cause, to prevent spamming the coord node with many of the same errors. See #91365 .

This is quite lossy, and makes it very hard to track actual problems if they arise, especially as the message used for the new exception does not include the cause in any way. This commit reuses the toString of both the exception and its cause, which is going to concatenate their class name and message in a single reason field.

In a very specific scenario, I was tracking a bug, and I was getting a super generic exception, same was logged on the server logs, which would not give me any clue about where the problem was:

```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "no_shard_available_action_exception",
        "reason" : "[runTask-0][127.0.0.1:9300][indices:data/read/search[phase/query]]"
      }
    ],
    "type" : "search_phase_execution_exception",
    "reason" : "all shards failed",
    "phase" : "query",
    "grouped" : true,
    "failed_shards" : [
      {
        "shard" : 0,
        "index" : "music",
        "node" : "rqycsd9cSpCxKhIY4Zz9kQ",
        "reason" : {
          "type" : "no_shard_available_action_exception",
          "reason" : "[runTask-0][127.0.0.1:9300][indices:data/read/search[phase/query]]"
        }
      }
    ]
  },
  "status" : 503
}
```

After my change, we would instead output the following:

```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "no_shard_available_action_exception",
        "reason" : "org.elasticsearch.transport.RemoteTransportException: [runTask-0][127.0.0.1:9300][indices:data/read/search[phase/query]], cause: org.apache.lucene.store.AlreadyClosedException: Already closed: MemorySegmentIndexInput(path=\"/home/javanna/elastic/elasticsearch/build/testclusters/runTask-0/data/indices/vnpmpZXlRlekAEPkFxbmDA/0/index/_0.cfs\") [slice=_0_ESCompletion101_0.lkp]"
      }
    ],
    "type" : "search_phase_execution_exception",
    "reason" : "all shards failed",
    "phase" : "query",
    "grouped" : true,
    "failed_shards" : [
      {
        "shard" : 0,
        "index" : "music",
        "node" : "EV0WS4zEQoeEcN7ilHyEFg",
        "reason" : {
          "type" : "no_shard_available_action_exception",
          "reason" : "org.elasticsearch.transport.RemoteTransportException: [runTask-0][127.0.0.1:9300][indices:data/read/search[phase/query]], cause: org.apache.lucene.store.AlreadyClosedException: Already closed: MemorySegmentIndexInput(path=\"/home/javanna/elastic/elasticsearch/build/testclusters/runTask-0/data/indices/vnpmpZXlRlekAEPkFxbmDA/0/index/_0.cfs\") [slice=_0_ESCompletion101_0.lkp]"
        }
      }
    ]
  },
  "status" : 503
}
```

Given that there are different exception types that would be subject to this treatment, and replaced by the generic no shard available exception, I believe that adding the cause to the message may affect deduplication a bit, yet I think it is worth it.