### PR TITLE
Fix failing SearchQueryThenFetchAsyncActionTests::testMinimumVersionBetweenNewAndOldVersion

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -247,9 +247,6 @@ tests:
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/116175
-- class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
-  method: testMinimumVersionBetweenNewAndOldVersion
-  issue: https://github.com/elastic/elasticsearch/issues/117485
 - class: org.elasticsearch.discovery.ClusterDisruptionIT
   method: testAckedIndexing
   issue: https://github.com/elastic/elasticsearch/issues/117024

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -272,16 +272,20 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
     }
 
     public void testMinimumVersionBetweenNewAndOldVersion() {
-        var oldVersion = new VersionInformation(
-            VersionUtils.getFirstVersion(),
-            IndexVersions.MINIMUM_COMPATIBLE,
-            IndexVersionUtils.randomCompatibleVersion(random())
-        );
-
         var newVersion = new VersionInformation(
             VersionUtils.maxCompatibleVersion(VersionUtils.getFirstVersion()),
             IndexVersions.MINIMUM_COMPATIBLE,
             IndexVersion.current()
+        );
+
+        var oldVersion = new VersionInformation(
+            VersionUtils.randomVersionBetween(
+                random(),
+                Version.CURRENT.minimumCompatibilityVersion(),
+                VersionUtils.getPreviousVersion(newVersion.nodeVersion())
+            ),
+            IndexVersions.MINIMUM_COMPATIBLE,
+            IndexVersionUtils.randomCompatibleVersion(random())
         );
 
         var minVersion = VersionUtils.randomVersionBetween(


### PR DESCRIPTION
This is similar to this #114630. 
Closes #117485
