### PR TITLE
[8.18] Fix cat APIs query parameters (#123020)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
@@ -18,17 +18,6 @@
           ]
         }
       ]
-    },
-    "params":{
-      "help":{
-        "type":"boolean",
-        "description":"Return help information",
-        "default":false
-      },
-      "s":{
-        "type":"list",
-        "description":"Comma-separated list of column names or column aliases to sort by"
-      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -36,6 +36,14 @@
         "type":"string",
         "description":"a short version of the Accept header, e.g. json, yaml"
       },
+      "local":{
+        "type":"boolean",
+        "description":"Return local information, do not retrieve the state from master node (default: false)"
+      },
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
       "bytes":{
         "type":"enum",
         "description":"The unit in which to display byte values",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
@@ -70,6 +70,16 @@
         "type":"boolean",
         "description":"Verbose mode. Display column headers",
         "default":false
+      },
+      "timeout":{
+        "type":"time",
+        "default":"30s",
+        "description":"Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error."
+      },
+      "wait_for_completion":{
+        "type":"boolean",
+        "default":false,
+        "description":"If `true`, the request blocks until the task has completed."
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix cat APIs query parameters (#123020)