### PR TITLE
[8.17] Add missing ES|QL, data stream, inference, and PKI security specifications (#119472)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_delete.json
@@ -1,0 +1,27 @@
+{
+  "esql.async_query_delete": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-delete-api.html",
+      "description": "Delete an async query request given its ID."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_query/async/{id}",
+          "methods": ["DELETE"],
+          "parts": {
+            "id": {
+              "type": "string",
+              "description": "The async query ID"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle_stats.json
@@ -1,0 +1,21 @@
+{
+  "indices.get_data_lifecycle_stats": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle-stats.html",
+      "description": "Get data stream lifecycle statistics."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_lifecycle/stats",
+          "methods": ["GET"]
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.update.json
@@ -1,0 +1,45 @@
+{
+  "inference.update": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-inference-api.html",
+      "description": "Update inference"
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_inference/{inference_id}/_update",
+          "methods": ["POST"],
+          "parts": {
+            "inference_id": {
+              "type": "string",
+              "description": "The inference Id"
+            }
+          }
+        },
+        {
+          "path": "/_inference/{task_type}/{inference_id}/_update",
+          "methods": ["POST"],
+          "parts": {
+            "task_type": {
+              "type": "string",
+              "description": "The task type"
+            },
+            "inference_id": {
+              "type": "string",
+              "description": "The inference Id"
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "The inference endpoint's task and service settings"
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.delegate_pki.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.delegate_pki.json
@@ -1,0 +1,26 @@
+{
+  "security.delegate_pki": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-delegate-pki-authentication.html",
+      "description": "Delegate PKI authentication."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_security/delegate_pki",
+          "methods": ["POST"]
+        }
+      ]
+    },
+    "params": {},
+    "body": {
+      "description":"The X509Certificate chain.",
+      "required":true
+    }
+  }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Add missing ES|QL, data stream, inference, and PKI security specifications (#119472)](https://github.com/elastic/elasticsearch/pull/119472)

<!--- Backport version: 9.6.4 -->

This pull request was not backported to 8.17, but those APIs are in 8.17 (and earlier versions, but I'm interested in 8.17 here).

| API name | Elasticsearch PR | Introduced in | Specification PR | Backported to |
| - | - | - | - | - |
| esql.async_query_delete | https://github.com/elastic/elasticsearch/pull/103628 | 8.13 | https://github.com/elastic/elasticsearch-specification/pull/3398 | 8.17 |
| indices.get_data_lifecycle_stats | https://github.com/elastic/elasticsearch/pull/101845 | 8.12 | https://github.com/elastic/elasticsearch-specification/pull/3418 | 8.17 |
| inference.update | https://github.com/elastic/elasticsearch/pull/114457 | 8.16 | https://github.com/elastic/elasticsearch-specification/pull/3399 | 8.17 |
| security.delegate_pki | https://github.com/elastic/elasticsearch/pull/45906 | 7.4 (!) | https://github.com/elastic/elasticsearch-specification/pull/3402 | 8.17 |


### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)