### PR TITLE
[8.x] apm-data: use representative count as event.success_count if available (#119995)

### DIFF
--- a/docs/changelog/119995.yaml
+++ b/docs/changelog/119995.yaml
@@ -1,0 +1,5 @@
+pr: 119995
+summary: "apm-data: Use representative count as event.success_count if available"
+area: Ingest Node
+type: bug
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/ingest-pipelines/traces-apm@pipeline.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/ingest-pipelines/traces-apm@pipeline.yaml
@@ -31,12 +31,15 @@ processors:
     ignore_failure: true
     ignore_missing: true
 - set:
-    if: ctx.event?.outcome == 'success'
-    field: event.success_count
-    value: 1
-- set:
     if: ctx.event?.outcome == 'failure'
     field: event.success_count
     value: 0
+- set:
+    if: ctx.event?.outcome == 'success'
+    field: event.success_count
+    value: 1
+- script:
+    if: ctx.event?.outcome == 'success' && ctx[ctx.processor?.event]?.representative_count != null
+    source: ctx.event.success_count = ctx[ctx.processor?.event]?.representative_count;
 - pipeline:
     name: apm@pipeline

--- a/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/20_traces_ingest.yml
+++ b/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/20_traces_ingest.yml
@@ -80,7 +80,35 @@ setup:
           - '{"@timestamp": "2017-06-22", "event": {"outcome": "unknown"}}'
 
           - create: {}
-          - '{"@timestamp": "2017-06-22", "event": {"outcome": "success"}}'
+          - '{
+            "@timestamp": "2017-06-22",
+            "processor": {"event": "transaction"},
+            "event": {"outcome": "success"},
+            "transaction": {"representative_count": 2}
+          }'
+
+          - create: {}
+          - '{
+            "@timestamp": "2017-06-22",
+            "processor": {"event": "span"},
+            "event": {"outcome": "success"},
+            "span": {"representative_count": 3}
+          }'
+
+          - create: {}
+          - '{
+            "@timestamp": "2017-06-22",
+            "processor": {"event": "span"},
+            "event": {"outcome": "success"},
+            "span": {"representative_count": null}
+          }'
+
+          - create: {}
+          - '{
+            "@timestamp": "2017-06-22",
+            "processor": {"event": "transaction"},
+            "event": {"outcome": "success"}
+          }'
 
           - create: {}
           - '{"@timestamp": "2017-06-22", "event": {"outcome": "failure"}}'
@@ -92,11 +120,15 @@ setup:
         index: traces-apm-testing
         body:
           fields: ["event.success_count"]
-  - length: { hits.hits: 4 }
+  - length: { hits.hits: 7 }
   - match: { hits.hits.0.fields: null }
   - match: { hits.hits.1.fields: null }
-  - match: { hits.hits.2.fields: {"event.success_count": [1]} }
-  - match: { hits.hits.3.fields: {"event.success_count": [0]} }
+  - match: { hits.hits.2.fields: {"event.success_count": [2]} }
+  - match: { hits.hits.3.fields: {"event.success_count": [3]} }
+  - match: { hits.hits.4.fields: {"event.success_count": [1]} }
+  - match: { hits.hits.5.fields: {"event.success_count": [1]} }
+  - match: { hits.hits.6.fields: {"event.success_count": [0]} }
+
 ---
 "Test traces-apm-* setting event.ingested via ingest pipeline":
   - requires:
@@ -123,4 +155,4 @@ setup:
           fields: ["event.ingested"]
   - length: { hits.hits: 2 }
   - is_after: { hits.hits.1.fields.event\.ingested.0: "2017-06-22T00:00:00.000Z" }
-  
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [apm-data: use representative count as event.success_count if available (#119995)](https://github.com/elastic/elasticsearch/pull/119995)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)