### PR TITLE
bump apm-data plugin version

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 12
+version: 13
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/119995

Forgot to bump the version of apm-data plugin