### PR TITLE
Add deprecation warning to TransportHandshaker 

### DIFF
--- a/docs/changelog/123168.yaml
+++ b/docs/changelog/123168.yaml
@@ -1,0 +1,11 @@
+pr: 123168
+summary: Add deprecation warning to `TransportHandshaker`
+area: Infra/Core
+type: deprecation
+issues: []
+deprecation:
+  title: Add deprecation warning to `TransportHandshaker`
+  area: Infra/Core
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users

--- a/docs/changelog/123168.yaml
+++ b/docs/changelog/123168.yaml
@@ -6,6 +6,5 @@ issues: []
 deprecation:
   title: Add deprecation warning to `TransportHandshaker`
   area: Infra/Core
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  details: This PR adds a deprecation log to versions < v8.18.
+  impact: Users will now see deprecation logs during CCS/CCR requests for clusters with nodes < v8.18, warning them that they will need to upgrade remote nodes to maintain compatability.

--- a/docs/changelog/123168.yaml
+++ b/docs/changelog/123168.yaml
@@ -5,6 +5,6 @@ type: deprecation
 issues: []
 deprecation:
   title: Add deprecation warning to `TransportHandshaker`
-  area: Infra/Core
+  area: REST API
   details: This PR adds a deprecation log to versions < v8.18.
   impact: Users will now see deprecation logs during CCS/CCR requests for clusters with nodes < v8.18, warning them that they will need to upgrade remote nodes to maintain compatability.


### PR DESCRIPTION
Jira: ES-10547

This PR adds a deprecation warning to the `TransportHandshaker` when connecting with nodes < v8.18.

This PR is in a draft state to get feedback prior to fixing the tests in `TransportHandshakerRawMessageTests`, as this looks to be somewhat non-trivial. 