### PR TITLE
[8.x] bump apm-data plugin version (#123166)

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 12
+version: 13
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
Backports the following commits to 8.x:
 - bump apm-data plugin version (#123166)