### PR TITLE
[8.x] Add read-block to source index during data stream reindex (#122887)

### DIFF
--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.migrate.action;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -18,7 +17,6 @@ import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
-import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.delete.TransportDeleteIndexTemplateAction;
@@ -36,11 +34,9 @@ import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.action.ingest.PutPipelineTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.cluster.metadata.MetadataIndexStateService;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -97,7 +93,6 @@ import static org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.DE
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
-import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
@@ -304,8 +299,7 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
         assertEquals(expectedDestIndexName, response.getDestIndex());
     }
 
-    public void testDestIndexNameSet_withDotPrefix() throws Exception {
-
+    public void testDestIndexNameSet_withDotPrefix() {
         var sourceIndex = "." + randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         safeGet(indicesAdmin().create(new CreateIndexRequest(sourceIndex)));
 
@@ -318,12 +312,18 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
         assertEquals(expectedDestIndexName, response.getDestIndex());
     }
 
-    public void testDestIndexContainsDocs() throws Exception {
+    public void testDestIndexContainsDocs() {
         // source index with docs
         var numDocs = randomIntBetween(1, 100);
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         safeGet(indicesAdmin().create(new CreateIndexRequest(sourceIndex)));
         indexDocs(sourceIndex, numDocs);
+
+        var settings = Settings.builder()
+            .put(IndexMetadata.SETTING_BLOCKS_METADATA, randomBoolean())
+            .put(IndexMetadata.SETTING_READ_ONLY, randomBoolean())
+            .build();
+        safeGet(indicesAdmin().updateSettings(new UpdateSettingsRequest(settings, sourceIndex)));
 
         // call reindex
         var response = safeGet(
@@ -333,29 +333,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
 
         // verify that dest contains docs
         assertHitCount(prepareSearch(response.getDestIndex()).setSize(0), numDocs);
-    }
-
-    public void testSetSourceToBlockWrites() throws Exception {
-        var settings = randomBoolean() ? Settings.builder().put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build() : Settings.EMPTY;
-
-        // empty source index
-        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
-        safeGet(indicesAdmin().create(new CreateIndexRequest(sourceIndex, settings)));
-
-        // call reindex
-        safeGet(client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex)));
-
-        // Assert that source index is now read-only but not verified read-only
-        GetSettingsResponse getSettingsResponse = safeGet(admin().indices().getSettings(new GetSettingsRequest().indices(sourceIndex)));
-        assertTrue(parseBoolean(getSettingsResponse.getSetting(sourceIndex, IndexMetadata.SETTING_BLOCKS_WRITE)));
-        assertFalse(
-            parseBoolean(getSettingsResponse.getSetting(sourceIndex, MetadataIndexStateService.VERIFIED_READ_ONLY_SETTING.getKey()))
-        );
-
-        // assert that write to source fails
-        var indexReq = new IndexRequest(sourceIndex).source(jsonBuilder().startObject().field("field", "1").endObject());
-        expectThrows(ClusterBlockException.class, client().index(indexReq));
-        assertHitCount(prepareSearch(sourceIndex).setSize(0), 0);
     }
 
     public void testMissingSourceIndex() {
@@ -413,34 +390,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
         assertEquals("text", XContentMapValues.extractValue("properties.foo1.type", destMappings));
     }
 
-    public void testFailIfMetadataBlockSet() {
-        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
-        var settings = Settings.builder().put(IndexMetadata.SETTING_BLOCKS_METADATA, true).build();
-        safeGet(indicesAdmin().create(new CreateIndexRequest(sourceIndex, settings)));
-
-        ElasticsearchException e = expectThrows(
-            ElasticsearchException.class,
-            client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex))
-        );
-        assertTrue(e.getMessage().contains("Cannot reindex index") || e.getCause().getMessage().equals("Cannot reindex index"));
-
-        cleanupMetadataBlocks(sourceIndex);
-    }
-
-    public void testFailIfReadBlockSet() {
-        var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
-        var settings = Settings.builder().put(IndexMetadata.SETTING_BLOCKS_READ, true).build();
-        safeGet(indicesAdmin().create(new CreateIndexRequest(sourceIndex, settings)));
-
-        ElasticsearchException e = expectThrows(
-            ElasticsearchException.class,
-            client().execute(ReindexDataStreamIndexAction.INSTANCE, new ReindexDataStreamIndexAction.Request(sourceIndex))
-        );
-        assertTrue(e.getMessage().contains("Cannot reindex index") || e.getCause().getMessage().equals("Cannot reindex index"));
-
-        cleanupMetadataBlocks(sourceIndex);
-    }
-
     public void testReadOnlyBlocksNotAddedBack() {
         var sourceIndex = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
         var settings = Settings.builder()
@@ -460,7 +409,6 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
         assertFalse(parseBoolean(settingsResponse.getSetting(destIndex, IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE)));
         assertFalse(parseBoolean(settingsResponse.getSetting(destIndex, IndexMetadata.SETTING_BLOCKS_WRITE)));
 
-        cleanupMetadataBlocks(sourceIndex);
         cleanupMetadataBlocks(destIndex);
     }
 
@@ -807,9 +755,8 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
         var settings = Settings.builder()
             .putNull(IndexMetadata.SETTING_READ_ONLY)
             .putNull(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE)
-            .putNull(IndexMetadata.SETTING_BLOCKS_METADATA)
-            .build();
-        safeGet(indicesAdmin().updateSettings(new UpdateSettingsRequest(settings, index)));
+            .putNull(IndexMetadata.SETTING_BLOCKS_METADATA);
+        updateIndexSettings(settings, index);
     }
 
     private static void indexDocs(String index, int numDocs) {

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.admin.indices.readonly.AddIndexBlockResponse;
 import org.elasticsearch.action.admin.indices.readonly.TransportAddIndexBlockAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.settings.put.TransportUpdateSettingsAction;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.search.SearchRequest;
@@ -59,11 +60,13 @@ import org.elasticsearch.xpack.core.deprecation.DeprecatedIndexPredicate;
 import org.elasticsearch.xpack.core.frozen.action.FreezeIndexAction;
 import org.elasticsearch.xpack.migrate.MigrateTemplateRegistry;
 
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.cluster.metadata.IndexMetadata.APIBlock.WRITE;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.APIBlock.METADATA;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.APIBlock.READ_ONLY;
 
 public class ReindexDataStreamIndexTransportAction extends HandledTransportAction<
     ReindexDataStreamIndexAction.Request,
@@ -149,20 +152,12 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
             );
         }
 
-        if (settingsBefore.getAsBoolean(IndexMetadata.SETTING_BLOCKS_READ, false)) {
-            var errorMessage = String.format(Locale.ROOT, "Cannot reindex index [%s] which has a read block.", destIndexName);
-            listener.onFailure(new ElasticsearchException(errorMessage));
-            return;
-        }
-        if (settingsBefore.getAsBoolean(IndexMetadata.SETTING_BLOCKS_METADATA, false)) {
-            var errorMessage = String.format(Locale.ROOT, "Cannot reindex index [%s] which has a metadata block.", destIndexName);
-            listener.onFailure(new ElasticsearchException(errorMessage));
-            return;
-        }
         final boolean wasClosed = isClosed(sourceIndex);
-        SubscribableListener.<FreezeResponse>newForked(l -> unfreezeIfFrozen(sourceIndexName, sourceIndex, l, taskId))
-            .<AcknowledgedResponse>andThen(l -> setBlockWrites(sourceIndexName, l, taskId))
+
+        SubscribableListener.<AcknowledgedResponse>newForked(l -> removeMetadataBlocks(sourceIndexName, taskId, l))
+            .<FreezeResponse>andThen(l -> unfreezeIfFrozen(sourceIndexName, sourceIndex, l, taskId))
             .<OpenIndexResponse>andThen(l -> openIndexIfClosed(sourceIndexName, wasClosed, l, taskId))
+            .<AcknowledgedResponse>andThen(l -> setReadOnly(sourceIndexName, l, taskId))
             .<BroadcastResponse>andThen(l -> refresh(sourceIndexName, l, taskId))
             .<AcknowledgedResponse>andThen(l -> deleteDestIfExists(destIndexName, l, taskId))
             .<AcknowledgedResponse>andThen(l -> createIndex(sourceIndex, destIndexName, l, taskId))
@@ -171,6 +166,7 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
             .<AcknowledgedResponse>andThen(l -> copyIndexMetadataToDest(sourceIndexName, destIndexName, l, taskId))
             .<AcknowledgedResponse>andThen(l -> sanityCheck(sourceIndexName, destIndexName, l, taskId))
             .<CloseIndexResponse>andThen(l -> closeIndexIfWasClosed(destIndexName, wasClosed, l, taskId))
+            .<AcknowledgedResponse>andThen(l -> removeAPIBlocks(sourceIndexName, taskId, l, READ_ONLY))
             .andThenApply(ignored -> new ReindexDataStreamIndexAction.Response(destIndexName))
             .addListener(listener);
     }
@@ -222,9 +218,9 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
         }
     }
 
-    private void setBlockWrites(String sourceIndexName, ActionListener<AcknowledgedResponse> listener, TaskId parentTaskId) {
-        logger.debug("Setting write block on source index [{}]", sourceIndexName);
-        addBlockToIndex(WRITE, sourceIndexName, new ActionListener<>() {
+    private void setReadOnly(String sourceIndexName, ActionListener<AcknowledgedResponse> listener, TaskId parentTaskId) {
+        logger.debug("Setting read-only on source index [{}]", sourceIndexName);
+        addBlockToIndex(READ_ONLY, sourceIndexName, new ActionListener<>() {
             @Override
             public void onResponse(AddIndexBlockResponse response) {
                 if (response.isAcknowledged()) {
@@ -418,6 +414,29 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
         addIndexBlockRequest.markVerified(false);
         addIndexBlockRequest.setParentTask(parentTaskId);
         client.admin().indices().execute(TransportAddIndexBlockAction.TYPE, addIndexBlockRequest, listener);
+    }
+
+    /**
+     * All metadata blocks need to be removed at the start for the following reasons:
+     * 1) If the source index has a metadata only block, the read-only block can't be added.
+     * 2) If the source index is read-only and closed, it can't be opened.
+     */
+    private void removeMetadataBlocks(String indexName, TaskId parentTaskId, ActionListener<AcknowledgedResponse> listener) {
+        logger.debug("Removing metadata blocks from index [{}]", indexName);
+        removeAPIBlocks(indexName, parentTaskId, listener, METADATA, READ_ONLY);
+    }
+
+    private void removeAPIBlocks(
+        String indexName,
+        TaskId parentTaskId,
+        ActionListener<AcknowledgedResponse> listener,
+        IndexMetadata.APIBlock... blocks
+    ) {
+        Settings.Builder settings = Settings.builder();
+        Arrays.stream(blocks).forEach(b -> settings.putNull(b.settingName()));
+        var updateSettingsRequest = new UpdateSettingsRequest(settings.build(), indexName);
+        updateSettingsRequest.setParentTask(parentTaskId);
+        client.execute(TransportUpdateSettingsAction.TYPE, updateSettingsRequest, listener);
     }
 
     private void getIndexDocCount(String index, TaskId parentTaskId, ActionListener<Long> listener) {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -566,6 +566,9 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             if (randomBoolean()) {
                 closeIndex(oldIndexName);
             }
+            if (randomBoolean()) {
+                assertOK(client().performRequest(new Request("PUT", oldIndexName + "/_block/read_only")));
+            }
         }
         Request reindexRequest = new Request("POST", "/_migration/reindex");
         reindexRequest.setJsonEntity(Strings.format("""

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -566,9 +566,6 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             if (randomBoolean()) {
                 closeIndex(oldIndexName);
             }
-            if (randomBoolean()) {
-                assertOK(client().performRequest(new Request("PUT", oldIndexName + "/_block/read_only")));
-            }
         }
         Request reindexRequest = new Request("POST", "/_migration/reindex");
         reindexRequest.setJsonEntity(Strings.format("""


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add read-block to source index during data stream reindex (#122887)](https://github.com/elastic/elasticsearch/pull/122887)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)