### PR TITLE
[8.x] Converting an Existing Data Stream to a System DataStream is Broken (#121392)

### DIFF
--- a/docs/changelog/121392.yaml
+++ b/docs/changelog/121392.yaml
@@ -1,0 +1,5 @@
+pr: 121392
+summary: Include data streams when converting an existing resource to a system resource
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
@@ -14,18 +14,28 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
-import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.SystemIndexMappingUpdateService;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A service responsible for updating the metadata used by system indices.
@@ -38,47 +48,61 @@ public class SystemIndexMetadataUpgradeService implements ClusterStateListener {
 
     private final SystemIndices systemIndices;
     private final ClusterService clusterService;
-
-    private volatile boolean updateTaskPending = false;
-
-    private volatile long triggeredVersion = -1L;
+    private final MasterServiceTaskQueue<SystemIndexMetadataUpgradeTask> taskQueue;
 
     public SystemIndexMetadataUpgradeService(SystemIndices systemIndices, ClusterService clusterService) {
         this.systemIndices = systemIndices;
         this.clusterService = clusterService;
+        this.taskQueue = clusterService.createTaskQueue(
+            "system-indices-metadata-upgrade",
+            Priority.NORMAL,
+            new SystemIndexMetadataUpgradeExecutor()
+        );
     }
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        if (updateTaskPending == false
-            && event.localNodeMaster()
+        Metadata currentMetadata = event.state().metadata();
+        Metadata previousMetadata = event.previousState().metadata();
+        if (event.localNodeMaster()
             && (event.previousState().nodes().isLocalNodeElectedMaster() == false
-                || event.state().metadata().indices() != event.previousState().metadata().indices())) {
-            final Map<String, IndexMetadata> indexMetadataMap = event.state().metadata().indices();
-            final var previousIndices = event.previousState().metadata().indices();
-            final long triggerV = event.state().version();
-            triggeredVersion = triggerV;
+                || currentMetadata.indices() != previousMetadata.indices()
+                || currentMetadata.dataStreams() != previousMetadata.dataStreams())) {
+            final Map<String, IndexMetadata> indexMetadataMap = currentMetadata.indices();
+            final var previousIndices = previousMetadata.indices();
+            Map<String, DataStream> dataStreams = currentMetadata.dataStreams();
+            Map<String, DataStream> previousDataStreams = previousMetadata.dataStreams();
             // Fork to the management pool to avoid blocking the cluster applier thread unnecessarily for very large index counts
             // TODO: we should have a more efficient way of getting just the changed indices so that we don't have to fork here
             clusterService.threadPool().executor(ThreadPool.Names.MANAGEMENT).execute(new AbstractRunnable() {
                 @Override
                 protected void doRun() {
-                    if (triggeredVersion != triggerV) {
-                        // don't run if another newer check task was triggered already
-                        return;
-                    }
-                    for (Map.Entry<String, IndexMetadata> cursor : indexMetadataMap.entrySet()) {
-                        if (cursor.getValue() != previousIndices.get(cursor.getKey())) {
-                            IndexMetadata indexMetadata = cursor.getValue();
-                            if (requiresUpdate(indexMetadata)) {
-                                updateTaskPending = true;
-                                submitUnbatchedTask(
-                                    "system_index_metadata_upgrade_service {system metadata change}",
-                                    new SystemIndexMetadataUpdateTask()
-                                );
-                                break;
+                    Collection<DataStream> changedDataStreams = new ArrayList<>();
+                    Set<Index> dataStreamIndices = new HashSet<>();
+                    for (Map.Entry<String, DataStream> cursor : dataStreams.entrySet()) {
+                        DataStream dataStream = cursor.getValue();
+                        if (dataStream != previousDataStreams.get(cursor.getKey())) {
+                            if (requiresUpdate(dataStream)) {
+                                changedDataStreams.add(dataStream);
                             }
                         }
+
+                        getIndicesBackingDataStream(dataStream).forEach(dataStreamIndices::add);
+                    }
+
+                    Collection<Index> changedIndices = new ArrayList<>();
+                    for (Map.Entry<String, IndexMetadata> cursor : indexMetadataMap.entrySet()) {
+                        IndexMetadata indexMetadata = cursor.getValue();
+                        Index index = indexMetadata.getIndex();
+                        if (cursor.getValue() != previousIndices.get(cursor.getKey()) && dataStreamIndices.contains(index) == false) {
+                            if (requiresUpdate(indexMetadata)) {
+                                changedIndices.add(index);
+                            }
+                        }
+                    }
+
+                    if (changedIndices.isEmpty() == false || changedDataStreams.isEmpty() == false) {
+                        submitUpdateTask(changedIndices, changedDataStreams);
                     }
                 }
 
@@ -89,6 +113,12 @@ public class SystemIndexMetadataUpgradeService implements ClusterStateListener {
                 }
             });
         }
+    }
+
+    // visible for testing
+    void submitUpdateTask(Collection<Index> changedIndices, Collection<DataStream> changedDataStreams) {
+        SystemIndexMetadataUpgradeTask task = new SystemIndexMetadataUpgradeTask(changedIndices, changedDataStreams);
+        taskQueue.submitTask("system-index-metadata-upgrade-service", task, null);
     }
 
     // package-private for testing
@@ -108,14 +138,37 @@ public class SystemIndexMetadataUpgradeService implements ClusterStateListener {
     }
 
     // package-private for testing
+    boolean requiresUpdate(DataStream dataStream) {
+        final boolean shouldBeSystem = shouldBeSystem(dataStream);
+
+        // should toggle system index status
+        if (shouldBeSystem != dataStream.isSystem()) {
+            return true;
+        }
+
+        if (shouldBeSystem) {
+            return dataStream.isHidden() == false;
+        }
+
+        return false;
+    }
+
+    private boolean shouldBeSystem(DataStream dataStream) {
+        return systemIndices.isSystemDataStream(dataStream.getName());
+    }
+
+    private static Stream<Index> getIndicesBackingDataStream(DataStream dataStream) {
+        return Stream.concat(dataStream.getIndices().stream(), dataStream.getFailureIndices().stream());
+    }
+
+    // package-private for testing
     static boolean isVisible(IndexMetadata indexMetadata) {
         return indexMetadata.getSettings().getAsBoolean(IndexMetadata.SETTING_INDEX_HIDDEN, false) == false;
     }
 
     // package-private for testing
     boolean shouldBeSystem(IndexMetadata indexMetadata) {
-        return systemIndices.isSystemIndex(indexMetadata.getIndex())
-            || systemIndices.isSystemIndexBackingDataStream(indexMetadata.getIndex().getName());
+        return systemIndices.isSystemIndex(indexMetadata.getIndex());
     }
 
     // package-private for testing
@@ -123,73 +176,148 @@ public class SystemIndexMetadataUpgradeService implements ClusterStateListener {
         return indexMetadata.getAliases().values().stream().anyMatch(a -> Boolean.FALSE.equals(a.isHidden()));
     }
 
-    @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
-        clusterService.submitUnbatchedStateUpdateTask(source, task);
-    }
-
-    // visible for testing
-    SystemIndexMetadataUpdateTask getTask() {
-        return new SystemIndexMetadataUpdateTask();
-    }
-
-    public class SystemIndexMetadataUpdateTask extends ClusterStateUpdateTask {
-
-        @Override
-        public ClusterState execute(ClusterState currentState) throws Exception {
-            final Map<String, IndexMetadata> indexMetadataMap = currentState.metadata().indices();
-            final List<IndexMetadata> updatedMetadata = new ArrayList<>();
-            for (Map.Entry<String, IndexMetadata> entry : indexMetadataMap.entrySet()) {
-                final IndexMetadata indexMetadata = entry.getValue();
-                final boolean shouldBeSystem = shouldBeSystem(indexMetadata);
-                IndexMetadata.Builder builder = IndexMetadata.builder(indexMetadata);
-                boolean updated = false;
-                if (shouldBeSystem != indexMetadata.isSystem()) {
-                    builder.system(indexMetadata.isSystem() == false);
-                    updated = true;
-                }
-                if (shouldBeSystem && isVisible(indexMetadata)) {
-                    builder.settings(Settings.builder().put(indexMetadata.getSettings()).put(IndexMetadata.SETTING_INDEX_HIDDEN, true));
-                    builder.settingsVersion(builder.settingsVersion() + 1);
-                    updated = true;
-                }
-                if (shouldBeSystem && hasVisibleAlias(indexMetadata)) {
-                    for (AliasMetadata aliasMetadata : indexMetadata.getAliases().values()) {
-                        if (Boolean.FALSE.equals(aliasMetadata.isHidden())) {
-                            builder.removeAlias(aliasMetadata.alias());
-                            builder.putAlias(
-                                AliasMetadata.builder(aliasMetadata.alias())
-                                    .filter(aliasMetadata.filter())
-                                    .indexRouting(aliasMetadata.indexRouting())
-                                    .isHidden(true)
-                                    .searchRouting(aliasMetadata.searchRouting())
-                                    .writeIndex(aliasMetadata.writeIndex())
-                            );
-                        }
-                    }
-                }
-                if (updated) {
-                    updatedMetadata.add(builder.build());
-                }
-            }
-
-            if (updatedMetadata.isEmpty() == false) {
-                final Metadata.Builder builder = Metadata.builder(currentState.metadata());
-                updatedMetadata.forEach(idxMeta -> builder.put(idxMeta, true));
-                return ClusterState.builder(currentState).metadata(builder).build();
-            }
-            return currentState;
-        }
+    private record SystemIndexMetadataUpgradeTask(Collection<Index> changedIndices, Collection<DataStream> changedDataStreams)
+        implements
+            ClusterStateTaskListener {
 
         @Override
         public void onFailure(Exception e) {
-            updateTaskPending = false;
-            logger.error("failed to update system index metadata", e);
+            logger.error("System index metadata upgrade failed", e);
         }
 
         @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            updateTaskPending = false;
+        public String toString() {
+            return "SystemIndexMetadataUpgradeTask[changedIndices="
+                + changedIndices.stream().map(Index::getName).collect(Collectors.joining(","))
+                + ";changedDataStreams="
+                + changedDataStreams.stream().map(DataStream::getName).collect(Collectors.joining(","))
+                + "]";
+        }
+    }
+
+    private class SystemIndexMetadataUpgradeExecutor implements ClusterStateTaskExecutor<SystemIndexMetadataUpgradeTask> {
+        @Override
+        public ClusterState execute(BatchExecutionContext<SystemIndexMetadataUpgradeTask> batchExecutionContext) {
+            ClusterState initialState = batchExecutionContext.initialState();
+
+            List<? extends TaskContext<SystemIndexMetadataUpgradeTask>> taskContexts = batchExecutionContext.taskContexts();
+            List<Index> indices = taskContexts.stream()
+                .map(TaskContext::getTask)
+                .map(SystemIndexMetadataUpgradeTask::changedIndices)
+                .flatMap(Collection::stream)
+                .toList();
+            List<IndexMetadata> updatedMetadata = updateIndices(initialState, indices);
+
+            List<DataStream> dataStreams = taskContexts.stream()
+                .map(TaskContext::getTask)
+                .map(SystemIndexMetadataUpgradeTask::changedDataStreams)
+                .flatMap(Collection::stream)
+                .toList();
+            List<DataStream> updatedDataStreams = updateDataStreams(dataStreams);
+            List<IndexMetadata> updatedBackingIndices = updateIndicesBackingDataStreams(initialState, updatedDataStreams);
+
+            for (TaskContext<SystemIndexMetadataUpgradeTask> taskContext : taskContexts) {
+                taskContext.success(() -> {});
+            }
+
+            if (updatedMetadata.isEmpty() == false || updatedDataStreams.isEmpty() == false) {
+                Metadata.Builder builder = Metadata.builder(initialState.metadata());
+                updatedMetadata.forEach(idxMeta -> builder.put(idxMeta, true));
+                updatedDataStreams.forEach(builder::put);
+                updatedBackingIndices.forEach(idxMeta -> builder.put(idxMeta, true));
+
+                return ClusterState.builder(initialState).metadata(builder).build();
+            }
+            return initialState;
+        }
+
+        private List<IndexMetadata> updateIndices(ClusterState currentState, List<Index> indices) {
+            if (indices.isEmpty()) {
+                return Collections.emptyList();
+            }
+            Metadata metadata = currentState.metadata();
+            final List<IndexMetadata> updatedMetadata = new ArrayList<>();
+            for (Index index : indices) {
+                IndexMetadata indexMetadata = metadata.index(index);
+                final boolean shouldBeSystem = shouldBeSystem(indexMetadata);
+                IndexMetadata updatedIndexMetadata = updateIndexIfNecessary(indexMetadata, shouldBeSystem);
+                if (updatedIndexMetadata != null) {
+                    updatedMetadata.add(updatedIndexMetadata);
+                }
+            }
+            return updatedMetadata;
+        }
+
+        private IndexMetadata updateIndexIfNecessary(IndexMetadata indexMetadata, boolean shouldBeSystem) {
+            IndexMetadata.Builder builder = IndexMetadata.builder(indexMetadata);
+            boolean updated = false;
+            if (shouldBeSystem != indexMetadata.isSystem()) {
+                builder.system(indexMetadata.isSystem() == false);
+                updated = true;
+            }
+            if (shouldBeSystem && isVisible(indexMetadata)) {
+                builder.settings(Settings.builder().put(indexMetadata.getSettings()).put(IndexMetadata.SETTING_INDEX_HIDDEN, true));
+                builder.settingsVersion(builder.settingsVersion() + 1);
+                updated = true;
+            }
+            if (shouldBeSystem && hasVisibleAlias(indexMetadata)) {
+                for (AliasMetadata aliasMetadata : indexMetadata.getAliases().values()) {
+                    if (Boolean.FALSE.equals(aliasMetadata.isHidden())) {
+                        builder.removeAlias(aliasMetadata.alias());
+                        builder.putAlias(
+                            AliasMetadata.builder(aliasMetadata.alias())
+                                .filter(aliasMetadata.filter())
+                                .indexRouting(aliasMetadata.indexRouting())
+                                .isHidden(true)
+                                .searchRouting(aliasMetadata.searchRouting())
+                                .writeIndex(aliasMetadata.writeIndex())
+                        );
+                        updated = true;
+                    }
+                }
+            }
+            return updated ? builder.build() : null;
+        }
+
+        private List<DataStream> updateDataStreams(List<DataStream> dataStreams) {
+            if (dataStreams.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<DataStream> updatedDataStreams = new ArrayList<>();
+            for (DataStream dataStream : dataStreams) {
+                boolean shouldBeSystem = shouldBeSystem(dataStream);
+                if (dataStream.isSystem() != shouldBeSystem) {
+                    DataStream.Builder dataStreamBuilder = dataStream.copy().setSystem(shouldBeSystem);
+                    if (shouldBeSystem) {
+                        dataStreamBuilder.setHidden(true);
+                    }
+
+                    updatedDataStreams.add(dataStreamBuilder.build());
+                }
+            }
+            return updatedDataStreams;
+        }
+
+        private List<IndexMetadata> updateIndicesBackingDataStreams(ClusterState currentState, List<DataStream> updatedDataStreams) {
+            if (updatedDataStreams.isEmpty()) {
+                return Collections.emptyList();
+            }
+            Metadata metadata = currentState.metadata();
+            final List<IndexMetadata> updatedMetadata = new ArrayList<>();
+
+            for (DataStream updatedDataStream : updatedDataStreams) {
+                boolean shouldBeSystem = updatedDataStream.isSystem();
+                List<IndexMetadata> updatedIndicesMetadata = getIndicesBackingDataStreamMetadata(metadata, updatedDataStream).map(
+                    idx -> updateIndexIfNecessary(idx, shouldBeSystem)
+                ).filter(Objects::nonNull).toList();
+
+                updatedMetadata.addAll(updatedIndicesMetadata);
+            }
+            return updatedMetadata;
+        }
+
+        private Stream<IndexMetadata> getIndicesBackingDataStreamMetadata(Metadata metadata, DataStream dataStream) {
+            return getIndicesBackingDataStream(dataStream).map(metadata::index);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeServiceTests.java
@@ -11,20 +11,32 @@ package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
+import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.indices.ExecutorNames;
+import org.elasticsearch.indices.SystemDataStreamDescriptor;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SystemIndexMetadataUpgradeServiceTests extends ESTestCase {
 
@@ -50,15 +62,60 @@ public class SystemIndexMetadataUpgradeServiceTests extends ESTestCase {
         .setOrigin("FAKE_ORIGIN")
         .build();
 
-    private SystemIndexMetadataUpgradeService service;
+    private static final String SYSTEM_DATA_STREAM_NAME = ".my-ds";
+    private static final String SYSTEM_DATA_STREAM_INDEX_NAME = DataStream.BACKING_INDEX_PREFIX + SYSTEM_DATA_STREAM_NAME + "-1";
+    private static final String SYSTEM_DATA_STREAM_FAILSTORE_NAME = DataStream.FAILURE_STORE_PREFIX + SYSTEM_DATA_STREAM_NAME;
+    private static final SystemDataStreamDescriptor SYSTEM_DATA_STREAM_DESCRIPTOR = new SystemDataStreamDescriptor(
+        SYSTEM_DATA_STREAM_NAME,
+        "System datastream for test",
+        SystemDataStreamDescriptor.Type.INTERNAL,
+        ComposableIndexTemplate.builder().build(),
+        Collections.emptyMap(),
+        Collections.singletonList("FAKE_ORIGIN"),
+        ExecutorNames.DEFAULT_SYSTEM_DATA_STREAM_THREAD_POOLS
+    );
 
+    private SystemIndexMetadataUpgradeService service;
+    private ClusterStateTaskListener task;
+    private ClusterStateTaskExecutor<ClusterStateTaskListener> executor;
+
+    @SuppressWarnings("unchecked")
     @Before
     public void setUpTest() {
         // set up a system index upgrade service
+        ClusterService clusterService = mock(ClusterService.class);
+        MasterServiceTaskQueue<ClusterStateTaskListener> queue = mock(MasterServiceTaskQueue.class);
+        when(clusterService.createTaskQueue(eq("system-indices-metadata-upgrade"), eq(Priority.NORMAL), any())).thenAnswer(invocation -> {
+            executor = invocation.getArgument(2, ClusterStateTaskExecutor.class);
+            return queue;
+        });
+        doAnswer(invocation -> {
+            task = invocation.getArgument(1, ClusterStateTaskListener.class);
+            return null;
+        }).when(queue).submitTask(any(), any(), any());
+
         this.service = new SystemIndexMetadataUpgradeService(
-            new SystemIndices(List.of(new SystemIndices.Feature("foo", "a test feature", List.of(DESCRIPTOR)))),
-            mock(ClusterService.class)
+            new SystemIndices(
+                List.of(
+                    new SystemIndices.Feature("foo", "a test feature", List.of(DESCRIPTOR)),
+                    new SystemIndices.Feature(
+                        "sds",
+                        "system data stream feature",
+                        Collections.emptyList(),
+                        Collections.singletonList(SYSTEM_DATA_STREAM_DESCRIPTOR)
+                    )
+                )
+            ),
+            clusterService
         );
+    }
+
+    private ClusterState executeTask(ClusterState clusterState) {
+        try {
+            return ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(clusterState, executor, Collections.singletonList(task));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
@@ -74,6 +131,54 @@ public class SystemIndexMetadataUpgradeServiceTests extends ESTestCase {
             .build();
 
         assertSystemUpgradeAppliesHiddenSetting(hiddenIndexMetadata);
+    }
+
+    public void testUpgradeDataStreamToSystemDataStream() {
+        IndexMetadata dsIndexMetadata = IndexMetadata.builder(SYSTEM_DATA_STREAM_INDEX_NAME)
+            .system(false)
+            .settings(getSettingsBuilder().put(IndexMetadata.SETTING_INDEX_HIDDEN, true))
+            .build();
+        IndexMetadata fsIndexMetadata = IndexMetadata.builder(SYSTEM_DATA_STREAM_FAILSTORE_NAME)
+            .system(false)
+            .settings(getSettingsBuilder().put(IndexMetadata.SETTING_INDEX_HIDDEN, true))
+            .build();
+        DataStream.DataStreamIndices failureIndices = DataStream.DataStreamIndices.failureIndicesBuilder(
+            Collections.singletonList(fsIndexMetadata.getIndex())
+        ).build();
+        DataStream dataStream = DataStream.builder(SYSTEM_DATA_STREAM_NAME, Collections.singletonList(dsIndexMetadata.getIndex()))
+            .setFailureIndices(failureIndices)
+            .setHidden(false)
+            .setSystem(false)
+            .build();
+
+        assertTrue(dataStream.containsIndex(dsIndexMetadata.getIndex().getName()));
+        assertTrue(dataStream.containsIndex(fsIndexMetadata.getIndex().getName()));
+
+        Metadata.Builder clusterMetadata = new Metadata.Builder();
+        clusterMetadata.put(dataStream);
+        clusterMetadata.put(dsIndexMetadata, true);
+        clusterMetadata.put(fsIndexMetadata, true);
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("system-index-metadata-upgrade-service-tests"))
+            .metadata(clusterMetadata.build())
+            .customs(Map.of())
+            .build();
+
+        service.submitUpdateTask(Collections.emptyList(), Collections.singletonList(dataStream));
+        // Execute a metadata upgrade task on the initial cluster state
+        ClusterState newState = executeTask(clusterState);
+
+        DataStream updatedDataStream = newState.metadata().dataStreams().get(dataStream.getName());
+        assertThat(updatedDataStream.isSystem(), equalTo(true));
+        assertThat(updatedDataStream.isHidden(), equalTo(true));
+
+        IndexMetadata updatedIndexMetadata = newState.metadata().index(dsIndexMetadata.getIndex().getName());
+        assertThat(updatedIndexMetadata.isSystem(), equalTo(true));
+        assertThat(updatedIndexMetadata.isHidden(), equalTo(true));
+
+        IndexMetadata updatedFailstoreMetadata = newState.metadata().index(fsIndexMetadata.getIndex().getName());
+        assertThat(updatedFailstoreMetadata.isSystem(), equalTo(true));
+        assertThat(updatedFailstoreMetadata.isHidden(), equalTo(true));
     }
 
     /**
@@ -210,7 +315,7 @@ public class SystemIndexMetadataUpgradeServiceTests extends ESTestCase {
         assertThat(service.requiresUpdate(systemVisibleIndex), equalTo(true));
     }
 
-    private void assertSystemUpgradeAppliesHiddenSetting(IndexMetadata hiddenIndexMetadata) throws Exception {
+    private void assertSystemUpgradeAppliesHiddenSetting(IndexMetadata hiddenIndexMetadata) {
         assertTrue("Metadata should require update but does not", service.requiresUpdate(hiddenIndexMetadata));
         Metadata.Builder clusterMetadata = new Metadata.Builder();
         clusterMetadata.put(IndexMetadata.builder(hiddenIndexMetadata));
@@ -220,8 +325,9 @@ public class SystemIndexMetadataUpgradeServiceTests extends ESTestCase {
             .customs(Map.of())
             .build();
 
+        service.submitUpdateTask(Collections.singletonList(hiddenIndexMetadata.getIndex()), Collections.emptyList());
         // Get a metadata upgrade task and execute it on the initial cluster state
-        ClusterState newState = service.getTask().execute(clusterState);
+        ClusterState newState = executeTask(clusterState);
 
         IndexMetadata result = newState.metadata().index(SYSTEM_INDEX_NAME);
         assertThat(result.isSystem(), equalTo(true));
@@ -238,8 +344,9 @@ public class SystemIndexMetadataUpgradeServiceTests extends ESTestCase {
             .customs(Map.of())
             .build();
 
+        service.submitUpdateTask(Collections.singletonList(visibleAliasMetadata.getIndex()), Collections.emptyList());
         // Get a metadata upgrade task and execute it on the initial cluster state
-        ClusterState newState = service.getTask().execute(clusterState);
+        ClusterState newState = executeTask(clusterState);
 
         IndexMetadata result = newState.metadata().index(SYSTEM_INDEX_NAME);
         assertThat(result.isSystem(), equalTo(true));


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Converting an Existing Data Stream to a System DataStream is Broken (#121392)