### PR TITLE
Adding more tests for rank_vectors for hex string case

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rank_vectors/rank_vectors_max_sim.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rank_vectors/rank_vectors_max_sim.yml
@@ -14,12 +14,12 @@ setup:
           mappings:
             properties:
               vector:
-                 type: rank_vectors
-                 dims: 5
+                type: rank_vectors
+                dims: 5
               byte_vector:
-                 type: rank_vectors
-                 dims: 5
-                 element_type: byte
+                type: rank_vectors
+                dims: 5
+                element_type: byte
               bit_vector:
                 type: rank_vectors
                 dims: 40
@@ -39,8 +39,8 @@ setup:
         id: "3"
         body:
           vector: [[0.5, 111.3, -13.0, 14.8, -156.0]]
-          byte_vector: [[2, 18, -5, 0, -124]]
-          bit_vector: [[2, 18, -5, 0, -124]]
+          byte_vector: ["0212fb0084"]
+          bit_vector: ["0212fb0084"]
 
   - do:
       indices.refresh: {}
@@ -115,7 +115,7 @@ setup:
   - match: {hits.hits.1._id: "3"}
   - close_to: {hits.hits.1._score: {value: 2, error: 0.01}}
 
-# doing max-sim dot product with a vector where the stored bit vectors are used as masks
+  # doing max-sim dot product with a vector where the stored bit vectors are used as masks
   - do:
       headers:
         Content-Type: application/json
@@ -189,9 +189,53 @@ setup:
             script_score:
               query: {match_all: {} }
               script:
+                source: "maxSimInvHamming(params.query_vector, 'byte_vector')"
+                params:
+                  query_vector: ["0102010101"]
+
+  - match: {hits.total: 2}
+
+  - match: {hits.hits.0._id: "3"}
+  - close_to: {hits.hits.0._score: {value: 0.675, error: 0.01}}
+
+  - match: {hits.hits.1._id: "1"}
+  - close_to: {hits.hits.1._score: {value: 0.65, error: 0.01}}
+
+  - do:
+      headers:
+        Content-Type: application/json
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            script_score:
+              query: {match_all: {} }
+              script:
                 source: "maxSimInvHamming(params.query_vector, 'bit_vector')"
                 params:
                   query_vector: [[1, 2, 1, 1, 1]]
+
+  - match: {hits.total: 2}
+
+  - match: {hits.hits.0._id: "3"}
+  - close_to: {hits.hits.0._score: {value: 0.675, error: 0.01}}
+
+  - match: {hits.hits.1._id: "1"}
+  - close_to: {hits.hits.1._score: {value: 0.65, error: 0.01}}
+
+  - do:
+      headers:
+        Content-Type: application/json
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            script_score:
+              query: {match_all: {} }
+              script:
+                source: "maxSimInvHamming(params.query_vector, 'bit_vector')"
+                params:
+                  query_vector: ["0102010101"]
 
   - match: {hits.total: 2}
 


### PR DESCRIPTION
Noticed we were missing some coverage here for a valid case.

Added coverage.