### PR TITLE
Fix bug in testDataStreamUpgrade caused by setting old write index to read-only verified

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -335,9 +335,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
   method: testStopQueryLocal
   issue: https://github.com/elastic/elasticsearch/issues/121672
-- class: org.elasticsearch.upgrades.DataStreamsUpgradeIT
-  method: testUpgradeDataStream
-  issue: https://github.com/elastic/elasticsearch/issues/123189
 
 # Examples:
 #

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -548,9 +548,6 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             if (randomBoolean()) {
                 closeIndex(oldIndexName);
             }
-            if (randomBoolean()) {
-                assertOK(client().performRequest(new Request("PUT", oldIndexName + "/_block/read_only")));
-            }
         }
         Request reindexRequest = new Request("POST", "/_migration/reindex");
         reindexRequest.setJsonEntity(Strings.format("""


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/122887 set read-only on the source indices of a data stream reindex. To test behavior when the source index was already read-only, testDataStreamUpgrade sometimes set the old write index to read-only. But the rest end point for adding a read-only block always sets verifed-read-only. This caused the old write index to not need to be upgraded, resulting in an incorrect value for `total_indices_requiring_upgrade`