### PR TITLE
Don't run FieldExtractorIT#testScaledFloat using JDK17

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
@@ -223,7 +223,7 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
     public void testScaledFloat() throws IOException {
         double value = randomBoolean() ? randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true) : randomFloat();
         // Scale factors less than about 5.6e-309 will result in NaN (due to 1/scaleFactor being infinity)
-        double scalingFactor = randomDoubleBetween(1e-308, Double.MAX_VALUE, false);
+        double scalingFactor = randomDoubleBetween(1e-308, Float.MAX_VALUE, false);
         new Test("scaled_float").expectedType("double")
             .randomIgnoreMalformedUnlessSynthetic()
             .randomDocValuesUnlessSynthetic()

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
@@ -221,9 +221,14 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
     }
 
     public void testScaledFloat() throws IOException {
+        // Running this on 17 when nodes in cluster run JDK >17 triggers an assert due to a mismatch
+        // of results produced by Double#toString for some specific numbers.
+        // See https://github.com/elastic/elasticsearch/issues/122984.
+        assumeTrue("JDK version greater than 17", Runtime.version().feature() > 17);
+
         double value = randomBoolean() ? randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true) : randomFloat();
         // Scale factors less than about 5.6e-309 will result in NaN (due to 1/scaleFactor being infinity)
-        double scalingFactor = randomDoubleBetween(1e-308, Float.MAX_VALUE, false);
+        double scalingFactor = randomDoubleBetween(1e-308, Double.MAX_VALUE, false);
         new Test("scaled_float").expectedType("double")
             .randomIgnoreMalformedUnlessSynthetic()
             .randomDocValuesUnlessSynthetic()


### PR DESCRIPTION
Closes #122984.