### PR TITLE
[8.18] Fix broken test caused by setting old write index to read-only verified (#123190)

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -566,9 +566,6 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             if (randomBoolean()) {
                 closeIndex(oldIndexName);
             }
-            if (randomBoolean()) {
-                assertOK(client().performRequest(new Request("PUT", oldIndexName + "/_block/read_only")));
-            }
         }
         Request reindexRequest = new Request("POST", "/_migration/reindex");
         reindexRequest.setJsonEntity(Strings.format("""


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Fix broken test caused by setting old write index to read-only verified (#123190)](https://github.com/elastic/elasticsearch/pull/123190)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)