### PR TITLE
Speedup SearchResponse serialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -382,23 +382,23 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         assert hasReferences();
-        return Iterators.concat(
-            ChunkedToXContentHelper.startObject(),
-            this.innerToXContentChunked(params),
-            ChunkedToXContentHelper.endObject()
-        );
+        return getToXContentIterator(true, params);
     }
 
     public Iterator<? extends ToXContent> innerToXContentChunked(ToXContent.Params params) {
+        return getToXContentIterator(false, params);
+    }
+
+    private Iterator<ToXContent> getToXContentIterator(boolean wrapInObject, ToXContent.Params params) {
         return Iterators.concat(
+            wrapInObject ? ChunkedToXContentHelper.startObject() : Collections.emptyIterator(),
             ChunkedToXContentHelper.chunk(SearchResponse.this::headerToXContent),
             Iterators.single(clusters),
-            Iterators.concat(
-                hits.toXContentChunked(params),
-                aggregations == null ? Collections.emptyIterator() : ChunkedToXContentHelper.chunk(aggregations),
-                suggest == null ? Collections.emptyIterator() : ChunkedToXContentHelper.chunk(suggest),
-                profileResults == null ? Collections.emptyIterator() : ChunkedToXContentHelper.chunk(profileResults)
-            )
+            hits.toXContentChunked(params),
+            aggregations == null ? Collections.emptyIterator() : ChunkedToXContentHelper.chunk(aggregations),
+            suggest == null ? Collections.emptyIterator() : ChunkedToXContentHelper.chunk(suggest),
+            profileResults == null ? Collections.emptyIterator() : ChunkedToXContentHelper.chunk(profileResults),
+            wrapInObject ? ChunkedToXContentHelper.endObject() : Collections.emptyIterator()
         );
     }
 


### PR DESCRIPTION
No need to have two nested concat iterators here (each of which adding a layer of megamorphic calls + pointer indirection on every `next` and `hasNext()`!!!). There's obviously still lots and lots of room for optimization on this one, but just flattening out two obvious steps here enormously reduces the number of method calls required when serializing a search response. Given that method calls can consume up to half the serialization cost this change might massively speed up some use cases.