### PR TITLE
[DOCS] clarify usage of proxy_address

### DIFF
--- a/docs/reference/modules/cluster/remote-clusters-settings.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-settings.asciidoc
@@ -131,7 +131,7 @@ settings.
 
 `cluster.remote.<cluster_alias>.proxy_address`::
 
-  The address used for all remote connections.
+  The address used for all remote connections. A single address value, either an ip address or a fully qualified domain name (FQDN).
 
 `cluster.remote.<cluster_alias>.proxy_socket_connections`::
 


### PR DESCRIPTION
Clarify proxy_address must be a single ip or fqdn value.
Until https://github.com/elastic/elasticsearch/issues/82366 is completed, only single values are acceptable.
