### PR TITLE
Cleanup duplication and dead code around ChunkedToXContentHelper

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpMetadata.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpMetadata.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
@@ -92,7 +91,7 @@ public final class IngestGeoIpMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params ignored) {
-        return Iterators.concat(ChunkedToXContentHelper.xContentObjectFields(DATABASES_FIELD.getPreferredName(), databases));
+        return ChunkedToXContentHelper.xContentObjectFields(DATABASES_FIELD.getPreferredName(), databases);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
@@ -196,11 +196,7 @@ public final class ClusterAllocationExplanation implements ChunkedToXContentObje
             return builder;
         }),
             this.clusterInfo != null
-                ? Iterators.concat(
-                    ChunkedToXContentHelper.startObject("cluster_info"),
-                    this.clusterInfo.toXContentChunked(params),
-                    ChunkedToXContentHelper.endObject()
-                )
+                ? ChunkedToXContentHelper.object("cluster_info", this.clusterInfo.toXContentChunked(params))
                 : Collections.emptyIterator(),
             getShardAllocationDecisionChunked(params),
             Iterators.single((builder, p) -> builder.endObject())

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ToXContent;
@@ -34,8 +35,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.chunk;
-import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.endObject;
-import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.startObject;
 
 public class DesiredBalanceResponse extends ActionResponse implements ChunkedToXContentObject {
 
@@ -96,16 +95,15 @@ public class DesiredBalanceResponse extends ActionResponse implements ChunkedToX
             ),
             Iterators.flatMap(
                 routingTable.entrySet().iterator(),
-                indexEntry -> Iterators.concat(
-                    startObject(indexEntry.getKey()),
+                indexEntry -> ChunkedToXContentHelper.object(
+                    indexEntry.getKey(),
                     Iterators.flatMap(
                         indexEntry.getValue().entrySet().iterator(),
                         shardEntry -> Iterators.concat(
                             chunk((builder, p) -> builder.field(String.valueOf(shardEntry.getKey()))),
                             shardEntry.getValue().toXContentChunked(params)
                         )
-                    ),
-                    endObject()
+                    )
                 )
             ),
             chunk((builder, p) -> builder.endObject().startObject("cluster_info")),

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
@@ -42,14 +42,13 @@ public class NodesStatsResponse extends BaseNodesXContentResponse<NodeStats> {
 
     @Override
     protected Iterator<? extends ToXContent> xContentChunks(ToXContent.Params outerParams) {
-        return Iterators.concat(
-            ChunkedToXContentHelper.startObject("nodes"),
+        return ChunkedToXContentHelper.object(
+            "nodes",
             Iterators.flatMap(getNodes().iterator(), nodeStats -> Iterators.concat(Iterators.single((builder, params) -> {
                 builder.startObject(nodeStats.getNode().getId());
                 builder.field("timestamp", nodeStats.getTimestamp());
                 return builder;
-            }), nodeStats.toXContentChunked(outerParams), ChunkedToXContentHelper.endObject())),
-            ChunkedToXContentHelper.endObject()
+            }), nodeStats.toXContentChunked(outerParams), ChunkedToXContentHelper.endObject()))
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -71,9 +71,8 @@ public class IndicesSegmentResponse extends ChunkedBroadcastResponse {
 
     @Override
     protected Iterator<ToXContent> customXContentChunks(ToXContent.Params params) {
-        return Iterators.concat(
-
-            ChunkedToXContentHelper.startObject(Fields.INDICES),
+        return ChunkedToXContentHelper.object(
+            Fields.INDICES,
             Iterators.flatMap(
                 getIndices().values().iterator(),
                 indexSegments -> Iterators.concat(
@@ -81,9 +80,8 @@ public class IndicesSegmentResponse extends ChunkedBroadcastResponse {
                     ChunkedToXContentHelper.chunk((builder, p) -> builder.startObject(indexSegments.getIndex()).startObject(Fields.SHARDS)),
                     Iterators.flatMap(
                         indexSegments.iterator(),
-                        indexSegment -> Iterators.concat(
-
-                            ChunkedToXContentHelper.startArray(Integer.toString(indexSegment.shardId().id())),
+                        indexSegment -> ChunkedToXContentHelper.array(
+                            Integer.toString(indexSegment.shardId().id()),
                             Iterators.flatMap(
                                 indexSegment.iterator(),
                                 shardSegments -> Iterators.concat(
@@ -141,14 +139,12 @@ public class IndicesSegmentResponse extends ChunkedBroadcastResponse {
                                     ),
                                     ChunkedToXContentHelper.chunk((builder, p) -> builder.endObject().endObject())
                                 )
-                            ),
-                            ChunkedToXContentHelper.endArray()
+                            )
                         )
                     ),
                     ChunkedToXContentHelper.chunk((builder, p) -> builder.endObject().endObject())
                 )
-            ),
-            ChunkedToXContentHelper.endObject()
+            )
         );
     }
 
@@ -157,25 +153,21 @@ public class IndicesSegmentResponse extends ChunkedBroadcastResponse {
             return Collections.emptyIterator();
         }
 
-        return Iterators.concat(
-            ChunkedToXContentHelper.startArray("sort"),
-            Iterators.map(Iterators.forArray(segmentSort.getSort()), field -> (builder, p) -> {
-                builder.startObject();
-                builder.field("field", field.getField());
-                if (field instanceof SortedNumericSortField sortedNumericSortField) {
-                    builder.field("mode", sortedNumericSortField.getSelector().toString().toLowerCase(Locale.ROOT));
-                } else if (field instanceof SortedSetSortField sortedSetSortField) {
-                    builder.field("mode", sortedSetSortField.getSelector().toString().toLowerCase(Locale.ROOT));
-                }
-                if (field.getMissingValue() != null) {
-                    builder.field("missing", field.getMissingValue().toString());
-                }
-                builder.field("reverse", field.getReverse());
-                builder.endObject();
-                return builder;
-            }),
-            ChunkedToXContentHelper.endArray()
-        );
+        return ChunkedToXContentHelper.array("sort", Iterators.map(Iterators.forArray(segmentSort.getSort()), field -> (builder, p) -> {
+            builder.startObject();
+            builder.field("field", field.getField());
+            if (field instanceof SortedNumericSortField sortedNumericSortField) {
+                builder.field("mode", sortedNumericSortField.getSelector().toString().toLowerCase(Locale.ROOT));
+            } else if (field instanceof SortedSetSortField sortedSetSortField) {
+                builder.field("mode", sortedSetSortField.getSelector().toString().toLowerCase(Locale.ROOT));
+            }
+            if (field.getMissingValue() != null) {
+                builder.field("missing", field.getMissingValue().toString());
+            }
+            builder.field("reverse", field.getReverse());
+            builder.endObject();
+            return builder;
+        }));
     }
 
     static final class Fields {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
@@ -279,13 +279,7 @@ public class IndicesShardStoresResponse extends ActionResponse implements Chunke
         return Iterators.concat(
             ChunkedToXContentHelper.startObject(),
 
-            failures.isEmpty()
-                ? Collections.emptyIterator()
-                : Iterators.concat(
-                    ChunkedToXContentHelper.startArray(Fields.FAILURES),
-                    failures.iterator(),
-                    ChunkedToXContentHelper.endArray()
-                ),
+            failures.isEmpty() ? Collections.emptyIterator() : ChunkedToXContentHelper.array(Fields.FAILURES, failures.iterator()),
 
             ChunkedToXContentHelper.startObject(Fields.INDICES),
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -232,22 +232,20 @@ public class IndicesStatsResponse extends ChunkedBroadcastResponse {
                         }),
 
                         level == ClusterStatsLevel.SHARDS
-                            ? Iterators.concat(
-                                ChunkedToXContentHelper.startObject(Fields.SHARDS),
+                            ? ChunkedToXContentHelper.object(
+                                Fields.SHARDS,
                                 Iterators.flatMap(
                                     indexStats.iterator(),
-                                    indexShardStats -> Iterators.concat(
-                                        ChunkedToXContentHelper.startArray(Integer.toString(indexShardStats.getShardId().id())),
-                                        Iterators.<ShardStats, ToXContent>map(indexShardStats.iterator(), shardStats -> (builder, p) -> {
+                                    indexShardStats -> ChunkedToXContentHelper.array(
+                                        Integer.toString(indexShardStats.getShardId().id()),
+                                        Iterators.map(indexShardStats.iterator(), shardStats -> (builder, p) -> {
                                             builder.startObject();
                                             shardStats.toXContent(builder, p);
                                             builder.endObject();
                                             return builder;
-                                        }),
-                                        ChunkedToXContentHelper.endArray()
+                                        })
                                     )
-                                ),
-                                ChunkedToXContentHelper.endObject()
+                                )
                             )
                             : Collections.emptyIterator(),
 

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -747,10 +747,9 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
                 metrics.contains(Metric.ROUTING_NODES),
                 (builder, params) -> builder.startObject("nodes"),
                 getRoutingNodes().iterator(),
-                routingNode -> Iterators.concat(
-                    ChunkedToXContentHelper.startArray(routingNode.nodeId() == null ? "null" : routingNode.nodeId()),
-                    routingNode.iterator(),
-                    ChunkedToXContentHelper.endArray()
+                routingNode -> ChunkedToXContentHelper.array(
+                    routingNode.nodeId() == null ? "null" : routingNode.nodeId(),
+                    routingNode.iterator()
                 ),
                 (builder, params) -> builder.endObject().endObject()
             ),

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ShutdownShardMigrationStatus.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ShutdownShardMigrationStatus.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ToXContent;
@@ -170,7 +171,7 @@ public class ShutdownShardMigrationStatus implements Writeable, ChunkedToXConten
             startObject(),
             chunk((builder, p) -> buildHeader(builder)),
             Objects.nonNull(allocationDecision)
-                ? Iterators.concat(startObject(NODE_ALLOCATION_DECISION_KEY), allocationDecision.toXContentChunked(params), endObject())
+                ? ChunkedToXContentHelper.object(NODE_ALLOCATION_DECISION_KEY, allocationDecision.toXContentChunked(params))
                 : Collections.emptyIterator(),
             endObject()
         );

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentHelper.java
@@ -83,20 +83,12 @@ public enum ChunkedToXContentHelper {
         return Iterators.concat(Iterators.single((builder, innerParam) -> builder.field(name)), value.toXContentChunked(params));
     }
 
-    public static Iterator<ToXContent> array(Iterator<? extends ToXContent> contents) {
-        return Iterators.concat(startArray(), contents, endArray());
-    }
-
     public static Iterator<ToXContent> array(String name, Iterator<? extends ToXContent> contents) {
         return Iterators.concat(startArray(name), contents, endArray());
     }
 
     public static <T> Iterator<ToXContent> array(Iterator<T> items, Function<T, ToXContent> toXContent) {
         return Iterators.concat(startArray(), Iterators.map(items, toXContent), endArray());
-    }
-
-    public static <T> Iterator<ToXContent> array(String name, Iterator<T> items, Function<T, ToXContent> toXContent) {
-        return Iterators.concat(startArray(name), Iterators.map(items, toXContent), endArray());
     }
 
     /**
@@ -108,7 +100,7 @@ public enum ChunkedToXContentHelper {
      * @return Iterator composing field name and value serialization
      */
     public static Iterator<ToXContent> array(String name, Iterator<? extends ChunkedToXContentObject> contents, ToXContent.Params params) {
-        return Iterators.concat(startArray(name), Iterators.flatMap(contents, c -> c.toXContentChunked(params)), endArray());
+        return array(name, Iterators.flatMap(contents, c -> c.toXContentChunked(params)));
     }
 
     /**
@@ -129,14 +121,4 @@ public enum ChunkedToXContentHelper {
         return Iterators.single(item);
     }
 
-    /**
-     * Creates an Iterator of a single ToXContent object that serializes the given object as a single chunk. Just wraps {@link
-     * Iterators#single}, but still useful because it avoids any type ambiguity.
-     *
-     * @param item Item to wrap
-     * @return Singleton iterator for the given item.
-     */
-    public static Iterator<ToXContent> singleChunk(ToXContent item) {
-        return Iterators.single(item);
-    }
 }

--- a/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -257,22 +257,21 @@ public class NodeIndicesStats implements Writeable, ChunkedToXContent {
 
                 case NODE -> Collections.<ToXContent>emptyIterator();
 
-                case INDICES -> Iterators.concat(
-                    ChunkedToXContentHelper.startObject(Fields.INDICES),
+                case INDICES -> ChunkedToXContentHelper.object(
+                    Fields.INDICES,
                     Iterators.map(createCommonStatsByIndex().entrySet().iterator(), entry -> (builder, params) -> {
                         builder.startObject(entry.getKey().getName());
                         entry.getValue().toXContent(builder, params);
                         return builder.endObject();
-                    }),
-                    ChunkedToXContentHelper.endObject()
+                    })
                 );
 
-                case SHARDS -> Iterators.concat(
-                    ChunkedToXContentHelper.startObject(Fields.SHARDS),
+                case SHARDS -> ChunkedToXContentHelper.object(
+                    Fields.SHARDS,
                     Iterators.flatMap(
                         statsByShard.entrySet().iterator(),
-                        entry -> Iterators.concat(
-                            ChunkedToXContentHelper.startArray(entry.getKey().getName()),
+                        entry -> ChunkedToXContentHelper.array(
+                            entry.getKey().getName(),
                             Iterators.flatMap(
                                 entry.getValue().iterator(),
                                 indexShardStats -> Iterators.concat(
@@ -282,11 +281,9 @@ public class NodeIndicesStats implements Writeable, ChunkedToXContent {
                                     Iterators.flatMap(Iterators.forArray(indexShardStats.getShards()), Iterators::<ToXContent>single),
                                     Iterators.single((b, p) -> b.endObject().endObject())
                                 )
-                            ),
-                            ChunkedToXContentHelper.endArray()
+                            )
                         )
-                    ),
-                    ChunkedToXContentHelper.endObject()
+                    )
                 );
             },
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RegisteredPolicySnapshots.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RegisteredPolicySnapshots.java
@@ -111,10 +111,7 @@ public class RegisteredPolicySnapshots implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params ignored) {
-        return Iterators.concat(Iterators.single((builder, params) -> {
-            builder.field(SNAPSHOTS.getPreferredName(), snapshots);
-            return builder;
-        }));
+        return Iterators.single((builder, params) -> builder.field(SNAPSHOTS.getPreferredName(), snapshots));
     }
 
     public static RegisteredPolicySnapshots parse(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
@@ -162,10 +162,6 @@ public record ThreadPoolStats(Collection<Stats> stats) implements Writeable, Chu
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return Iterators.concat(
-            ChunkedToXContentHelper.startObject(Fields.THREAD_POOL),
-            Iterators.flatMap(stats.iterator(), s -> s.toXContentChunked(params)),
-            ChunkedToXContentHelper.endObject()
-        );
+        return ChunkedToXContentHelper.object(Fields.THREAD_POOL, Iterators.flatMap(stats.iterator(), s -> s.toXContentChunked(params)));
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/StreamingUnifiedChatCompletionResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/StreamingUnifiedChatCompletionResults.java
@@ -76,7 +76,7 @@ public record StreamingUnifiedChatCompletionResults(Flow.Publisher<? extends Inf
 
         @Override
         public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-            return Iterators.concat(Iterators.flatMap(chunks.iterator(), c -> c.toXContentChunked(params)));
+            return Iterators.flatMap(chunks.iterator(), c -> c.toXContentChunked(params));
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.AbstractNamedDiffable;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
@@ -97,7 +96,7 @@ public final class RoleMappingMetadata extends AbstractNamedDiffable<Metadata.Cu
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         // role mappings are serialized without their names
-        return Iterators.concat(ChunkedToXContentHelper.startArray(TYPE), roleMappings.iterator(), ChunkedToXContentHelper.endArray());
+        return ChunkedToXContentHelper.array(TYPE, roleMappings.iterator());
     }
 
     public static RoleMappingMetadata fromXContent(XContentParser parser) throws IOException {


### PR DESCRIPTION
Cleans up a couple things that are obviously broken:

* duplicate array and object constructs where the helper utility generates the exact same iterator
* unused helper methods
* single iterator concatenations
