### PR TITLE
Only fork TransportGetAllocationStatsAction if heavy allocation stats are requested

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsActionTests.java
@@ -68,7 +68,6 @@ public class TransportGetAllocationStatsActionTests extends ESTestCase {
             clusterService,
             threadPool,
             new ActionFilters(Set.of()),
-            null,
             allocationStatsService
         );
     }


### PR DESCRIPTION
Don't fork unless the heavy stats calculation is requested. Also, this is superior to forking via the transport action as it avoids capturing the clusterstate in the forked task which can become a problem when these tasks take a long time to run.
