### PR TITLE
Update ilm-downsample.asciidoc to remove `average` from downsampling statistics

### DIFF
--- a/docs/reference/ilm/actions/ilm-downsample.asciidoc
+++ b/docs/reference/ilm/actions/ilm-downsample.asciidoc
@@ -5,8 +5,8 @@
 Phases allowed: hot, warm, cold.
 
 Aggregates a time series (TSDS) index and stores
-pre-computed statistical summaries (`min`, `max`, `sum`, `value_count` and
-`avg`) for each metric field grouped by a configured time interval. For example,
+pre-computed statistical summaries (`min`, `max`, `sum`, and `value_count`)
+for each metric field grouped by a configured time interval. For example,
 a TSDS index that contains metrics sampled every 10 seconds can be downsampled
 to an hourly index. All documents within an hour interval are summarized and
 stored as a single document and stored in the downsample index.


### PR DESCRIPTION
Heya Team! 

I came across a support case where it was discovered "average" statistic has no longer been included in downsampling for a while now. It is possible for customers to calculate it or run the average aggregation against the data, but it will not be displayed as one of the other statistics. 

It was removed from the documentation for one specific page, but all the other references were leftover. Trying to clean those leftovers up to avoid customer confusion. 

See https://github.com/elastic/elasticsearch/pull/110189 for original removal.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
Yes
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
NA
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
NA
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
NA
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
NA
