### PR TITLE
Add missing body to ML rest-api-spec API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
@@ -75,6 +75,10 @@
         "options": ["starting", "started", "fully_allocated"],
         "default": "started"
       }
+    },
+    "body":{
+      "description": "The settings for the trained model deployment",
+      "required": false
     }
   }
 }


### PR DESCRIPTION
As added in https://github.com/elastic/elasticsearch-specification/pull/3779.