### PR TITLE
[9.0] Hold store reference in InternalEngine#performActionWithDirectoryReader(...)

### DIFF
--- a/docs/changelog/123010.yaml
+++ b/docs/changelog/123010.yaml
@@ -1,0 +1,6 @@
+pr: 123010
+summary: Hold store reference in `InternalEngine#performActionWithDirectoryReader(...)`
+area: Engine
+type: bug
+issues:
+ - 122974


### PR DESCRIPTION
Backport #123010 to 9.0 branch.

This method gets called from `InternalEngine#resolveDocVersion(...)`, which gets during indexing (via `InternalEngine.index(...)`).

When `InternalEngine.index(...)` gets invoked, the InternalEngine only ensures that it holds a ref to the engine via Engine#acquireEnsureOpenRef(), but this doesn't ensure whether it holds a reference to the store.

Closes #122974