### PR TITLE
[DOCS] [Inference API] Alibaba Cloud Inference Service adds support for deepseek models

### DIFF
--- a/docs/reference/inference/service-alibabacloud-ai-search.asciidoc
+++ b/docs/reference/inference/service-alibabacloud-ai-search.asciidoc
@@ -88,7 +88,10 @@ Available service_ids for the `completion` task:
 * `qwen-turbo`
 * `qwen-plus`
 * `qwen-max`
-÷ `qwen-max-longcontext`
+* `deepseek-r1`
+* `deepseek-v3`
+* `deepseek-r1-distill-qwen-7b`
+* `deepseek-r1-distill-qwen-14b`
 
 For the supported `completion` service_ids, refer to the https://help.aliyun.com/zh/open-search/search-platform/developer-reference/text-generation-api-details[documentation].
 


### PR DESCRIPTION
Alibaba Cloud Inference Service adds support for deepseek models,  Here is the chinese documents: https://help.aliyun.com/zh/open-search/search-platform/developer-reference/text-generation-api-details

I remove the qwen-max-longcontext(not support), and add the four deepseek models.