### PR TITLE
[9.0] Improve resolve/cluster yaml test (#121315)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
@@ -1,55 +1,56 @@
 {
-  "indices.resolve_cluster":{
-    "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-cluster-api.html",
-      "description":"Resolves the specified index expressions to return information about each cluster, including the local cluster, if included."
+  "indices.resolve_cluster": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-cluster-api.html",
+      "description": "Resolves the specified index expressions to return information about each cluster. If no index expression is provided, this endpoint will return information about all the remote clusters that are configured on the local cluster."
     },
-    "stability":"stable",
-    "visibility":"public",
-    "headers":{
-      "accept": [ "application/json"]
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
     },
-    "url":{
-      "paths":[
+    "url": {
+      "paths": [
         {
-          "path":"/_resolve/cluster/{name}",
-          "methods":[
-            "GET"
-          ],
-          "parts":{
-            "name":{
-              "type":"list",
-              "description":"A comma-separated list of cluster:index names or wildcard expressions"
+          "path": "/_resolve/cluster",
+          "methods": ["GET"]
+        },
+        {
+          "path": "/_resolve/cluster/{name}",
+          "methods": ["GET"],
+          "parts": {
+            "name": {
+              "type": "list",
+              "description": "A comma-separated list of cluster:index names or wildcard expressions"
             }
           }
         }
       ]
     },
-    "params":{
-      "ignore_unavailable":{
-        "type":"boolean",
-        "description":"Whether specified concrete indices should be ignored when unavailable (missing or closed)"
+    "params": {
+      "ignore_unavailable": {
+        "type": "boolean",
+        "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed). Only allowed when providing an index expression."
       },
-      "ignore_throttled":{
-        "type":"boolean",
-        "description":"Whether specified concrete, expanded or aliased indices should be ignored when throttled"
+      "ignore_throttled": {
+        "type": "boolean",
+        "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled. Only allowed when providing an index expression."
       },
-      "allow_no_indices":{
-        "type":"boolean",
-        "description":"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+      "allow_no_indices": {
+        "type": "boolean",
+        "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified). Only allowed when providing an index expression."
       },
-      "expand_wildcards":{
-        "type":"enum",
-        "options":[
-          "open",
-          "closed",
-          "hidden",
-          "none",
-          "all"
-        ],
-        "default":"open",
-        "description":"Whether wildcard expressions should get expanded to open or closed indices (default: open)"
+      "expand_wildcards": {
+        "type": "enum",
+        "options": ["open", "closed", "hidden", "none", "all"],
+        "default": "open",
+        "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open). Only allowed when providing an index expression."
+      },
+      "timeout": {
+        "type": "time",
+        "description": "The maximum time to wait for remote clusters to respond"
       }
     }
   }
 }
+

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.resolve_cluster/10_basic_resolve_cluster.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.resolve_cluster/10_basic_resolve_cluster.yml
@@ -39,7 +39,7 @@ setup:
   - do:
       indices.resolve_cluster:
         name: '*'
-        expand_wildcards: [closed]
+        expand_wildcards: closed
 
   - match: {(local).connected: true}
   - match: {(local).skip_unavailable: false}
@@ -65,7 +65,7 @@ setup:
   - do:
       indices.resolve_cluster:
         name: 'index2*'
-        expand_wildcards: [open,closed]
+        expand_wildcards: open,closed
 
   - match: {(local).connected: true}
   - match: {(local).skip_unavailable: false}
@@ -75,7 +75,7 @@ setup:
   - do:
       indices.resolve_cluster:
         name: 'index2*'
-        expand_wildcards: [closed]
+        expand_wildcards: closed
 
   - match: {(local).connected: true}
   - match: {(local).skip_unavailable: false}
@@ -115,7 +115,7 @@ setup:
   - do:
       indices.resolve_cluster:
         name: 'my_alias2,doesnotexist*'
-        expand_wildcards: [all]
+        expand_wildcards: all
 
   - match: {(local).connected: true}
   - match: {(local).skip_unavailable: false}
@@ -141,10 +141,10 @@ setup:
   - do:
       indices.resolve_cluster:
         name: '*'
-        expand_wildcards: [all]
-        ignore_unavailable: [true]
-        ignore_throttled: [true]
-        allow_no_indices: [true]
+        expand_wildcards: all
+        ignore_unavailable: true
+        ignore_throttled: true
+        allow_no_indices: true
       allowed_warnings:
         - "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
 
@@ -157,10 +157,10 @@ setup:
   - do:
       indices.resolve_cluster:
         name: '*'
-        expand_wildcards: [open]
-        ignore_unavailable: [false]
-        ignore_throttled: [false]
-        allow_no_indices: [false]
+        expand_wildcards: open
+        ignore_unavailable: false
+        ignore_throttled: false
+        allow_no_indices: false
       allowed_warnings:
         - "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
 
@@ -170,3 +170,14 @@ setup:
   - is_false: (local).error # should not be present
   - exists: (local).version.number
 
+---
+"Resolve cluster with no index expression":
+  - requires:
+      cluster_features: ["gte_v8.18.0"]
+      reason: "resolve cluster with no index expression introduced in 8.18"
+
+  - do:
+      indices.resolve_cluster:
+        timeout: 400s
+
+  - is_false: (local).error # should not be present - body should be empty since no remotes configured


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Improve resolve/cluster yaml test (#121315)](https://github.com/elastic/elasticsearch/pull/121315)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)