### PR TITLE
Fix NPE in `ReindexDataStreamTransportAction`

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamTransportAction.java
@@ -83,11 +83,7 @@ public class ReindexDataStreamTransportAction extends HandledTransportAction<Rei
             ClientHelper.getPersistableSafeSecurityHeaders(transportService.getThreadPool().getThreadContext(), clusterService.state())
         );
         String persistentTaskId = getPersistentTaskId(sourceDataStreamName);
-
-        PersistentTasksCustomMetadata persistentTasksCustomMetadata = clusterService.state()
-            .getMetadata()
-            .custom(PersistentTasksCustomMetadata.TYPE);
-        PersistentTasksCustomMetadata.PersistentTask<?> persistentTask = persistentTasksCustomMetadata.getTask(persistentTaskId);
+        final var persistentTask = PersistentTasksCustomMetadata.getTaskWithId(clusterService.state(), persistentTaskId);
 
         if (persistentTask == null) {
             startTask(listener, persistentTaskId, params);


### PR DESCRIPTION
In the multi-project branch, we're making some changes to persistent tasks and those changes can cause the persistent tasks custom to still be `null`. This resulted in an NPE here, so I'm fixing the check here.