### PR TITLE
[8.x] Add missing body to ML rest-api-spec API (#123235)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
@@ -75,6 +75,10 @@
         "options": ["starting", "started", "fully_allocated"],
         "default": "started"
       }
+    },
+    "body":{
+      "description": "The settings for the trained model deployment",
+      "required": false
     }
   }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add missing body to ML rest-api-spec API (#123235)