### PR TITLE
[9.0] ESQL: Benchmark TO_LOWER and TO_UPPER (#123268)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
@@ -267,8 +267,7 @@ public class EvalBenchmark {
             null,
             false,
             Map.of(),
-            0,
-            false
+            0
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - ESQL: Benchmark TO_LOWER and TO_UPPER (#123268)