### PR TITLE
Unmute `20_reindex_status/Test Reindex With Existing Data Stream`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -308,9 +308,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
   method: testSettingsApplied
   issue: https://github.com/elastic/elasticsearch/issues/116694
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=migrate/20_reindex_status/Test Reindex With Existing Data Stream}
-  issue: https://github.com/elastic/elasticsearch/issues/118576
 - class: org.elasticsearch.discovery.ec2.DiscoveryEc2AvailabilityZoneAttributeNoImdsIT
   method: testAvailabilityZoneAttribute
   issue: https://github.com/elastic/elasticsearch/issues/118564


### PR DESCRIPTION
Unmute test that was muted in https://github.com/elastic/elasticsearch/issues/118576 but was already fixed in https://github.com/elastic/elasticsearch/pull/119245