### PR TITLE
[8.18] Fix early termination in LuceneSourceOperator (#123197)

### DIFF
--- a/docs/changelog/123197.yaml
+++ b/docs/changelog/123197.yaml
@@ -1,0 +1,5 @@
+pr: 123197
+summary: Fix early termination in `LuceneSourceOperator`
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
@@ -140,7 +140,7 @@ public class LuceneSourceOperator extends LuceneOperator {
 
     @Override
     public boolean isFinished() {
-        return doneCollecting;
+        return doneCollecting || remainingDocs <= 0;
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix early termination in LuceneSourceOperator (#123197)