### PR TITLE
[DOCS] Clarify support for doc_values

### DIFF
--- a/docs/reference/mapping/params/doc-values.asciidoc
+++ b/docs/reference/mapping/params/doc-values.asciidoc
@@ -11,11 +11,13 @@ different data access pattern. Instead of looking up the term and finding
 documents, we need to be able to look up the document and find the terms that
 it has in a field.
 
-Doc values are the on-disk data structure, built at document index time, which
-makes this data access pattern possible. They store the same values as the
-`_source` but in a column-oriented fashion that is way more efficient for
-sorting and aggregations. Doc values are supported on almost all field types,
-with the __notable exception of `text` and `annotated_text` fields__.
+The `doc_values` field is an on-disk data structure that is built at index time and
+enables efficient data access. It stores the same values as 
+`_source`, but in a column-oriented format that is more efficient for
+sorting and aggregations. 
+
+Doc values are supported on most field types,
+excluding `text` and `annotated_text` fields. See also <<doc-values-disable>>.
 
 [[doc-value-only-fields]]
 ==== Doc-value-only fields
@@ -55,11 +57,17 @@ PUT my-index-000001
 <2> The `session_id` field has `index` disabled, and is therefore a
     doc-value-only long field as doc values are enabled by default.
 
+[[doc-values-disable]]
 ==== Disabling doc values
 
-All fields which support doc values have them enabled by default. If you are
-sure that you don't need to sort or aggregate on a field, or access the field
-value from a script, you can disable doc values in order to save disk space:
+For all fields that support them, `doc_values` are enabled by default. In 
+some field types, such as <<search-as-you-type,`search_as_you_type`>>, 
+`doc_values` appear in API responses but can't be configured. Setting 
+`doc_values` for these fields might result in an error or have no effect.
+
+If you're
+certain you don't need to sort or aggregate on a field or access its
+value from a script, you can disable `doc_values` in order to save disk space:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
[Preview](https://elasticsearch_bk_123309.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/8.18/doc-values.html)

- Note that sometimes doc_values is returned but can't be set
- Make small edits elsewhere

@l-trotta thanks for pointing this out!

corresponding 9.x PR: #124047

