### PR TITLE
Remove unnecessary temp dir access

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -175,7 +175,6 @@ public class EntitlementInitialization {
                     new FilesEntitlement(
                         List.of(
                             // Base ES directories
-                            FileData.ofPath(bootstrapArgs.tempDir(), READ_WRITE),
                             FileData.ofPath(bootstrapArgs.configDir(), READ),
                             FileData.ofPath(bootstrapArgs.logsDir(), READ_WRITE),
                             FileData.ofRelativePath(Path.of(""), DATA, READ_WRITE),
@@ -212,7 +211,6 @@ public class EntitlementInitialization {
                     new FilesEntitlement(
                         List.of(
                             FileData.ofPath(bootstrapArgs.configDir(), READ),
-                            FileData.ofPath(bootstrapArgs.tempDir(), READ),
                             FileData.ofRelativePath(Path.of(""), DATA, READ_WRITE)
                         )
                     )

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -209,10 +209,7 @@ public class EntitlementInitialization {
                     new LoadNativeLibrariesEntitlement(),
                     new ManageThreadsEntitlement(),
                     new FilesEntitlement(
-                        List.of(
-                            FileData.ofPath(bootstrapArgs.configDir(), READ),
-                            FileData.ofRelativePath(Path.of(""), DATA, READ_WRITE)
-                        )
+                        List.of(FileData.ofPath(bootstrapArgs.configDir(), READ), FileData.ofRelativePath(Path.of(""), DATA, READ_WRITE))
                     )
                 )
             ),


### PR DESCRIPTION
All modules have read/write access to the temp dir. This commit removes unnecessarily adding the temp dir explicitly to the server policy.