### PR TITLE
Optimize query plan using query progress

### DIFF
--- a/docs/changelog/123322.yaml
+++ b/docs/changelog/123322.yaml
@@ -1,0 +1,5 @@
+pr: 123322
+summary: Optimize query plan using query progress
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeBuffer.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeBuffer.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.operator.Operator;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 final class ExchangeBuffer {
 
@@ -31,6 +32,7 @@ final class ExchangeBuffer {
     private SubscribableListener<Void> notFullFuture = null;
 
     private final SubscribableListener<Void> completionFuture = new SubscribableListener<>();
+    private final AtomicLong addedRows = new AtomicLong();
 
     private volatile boolean noMoreInputs = false;
 
@@ -58,6 +60,8 @@ final class ExchangeBuffer {
                     completionFuture.onResponse(null);
                 }
             }
+        } else {
+            addedRows.addAndGet(page.getPositionCount());
         }
     }
 
@@ -153,6 +157,13 @@ final class ExchangeBuffer {
 
     int size() {
         return queueSize.get();
+    }
+
+    /**
+     * Returns number of rows has been added to this exchange buffer
+     */
+    long addedRows() {
+        return addedRows.get();
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkHandler.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkHandler.java
@@ -205,4 +205,11 @@ public final class ExchangeSinkHandler {
     public int bufferSize() {
         return buffer.size();
     }
+
+    /**
+     * Returns the number of rows (i.e. positions) has been added to this exchange sink
+     */
+    public long addedRows() {
+        return buffer.addedRows();
+    }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EarlyTerminationIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EarlyTerminationIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.compute.lucene.DataPartitioning;
+import org.elasticsearch.compute.lucene.LuceneSourceOperator;
+import org.elasticsearch.compute.operator.DriverProfile;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class EarlyTerminationIT extends AbstractEsqlIntegTestCase {
+
+    public void testAdjustLimitOnDataNodes() {
+        assumeTrue("control concurrency", canUseQueryPragmas());
+        String dataNode = internalCluster().startDataOnlyNode();
+        int numIndices = 10;
+        int value = 0;
+        for (int i = 0; i < numIndices; i++) {
+            String index = "test-" + i;
+            assertAcked(
+                admin().indices()
+                    .prepareCreate(index)
+                    .setSettings(indexSettings(1, 0).put("index.routing.allocation.require._name", dataNode))
+            );
+            List<IndexRequestBuilder> indexRequests = new ArrayList<>();
+            for (int d = 0; d < 20; d++) {
+                indexRequests.add(new IndexRequestBuilder(client()).setIndex(index).setSource("v", Integer.toString(value++)));
+            }
+            indexRandom(true, indexRequests);
+        }
+        EsqlQueryRequest request = new EsqlQueryRequest();
+        request.query("FROM test-* | LIMIT 95");
+        QueryPragmas pragmas = new QueryPragmas(
+            Settings.builder()
+                .put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 2)
+                .put(QueryPragmas.DATA_PARTITIONING.getKey(), DataPartitioning.SHARD)
+                .put(QueryPragmas.TASK_CONCURRENCY.getKey(), between(3, 5))
+                .build()
+        );
+        request.pragmas(pragmas);
+        request.profile(true);
+        try (EsqlQueryResponse resp = run(request)) {
+            List<List<Object>> values = EsqlTestUtils.getValuesList(resp);
+            assertThat(values, hasSize(95));
+            List<DriverProfile> drivers = resp.profile().drivers();
+            List<DriverProfile> queryProfiles = drivers.stream().filter(d -> d.taskDescription().equals("data")).toList();
+            assertThat(queryProfiles, hasSize(6));
+            var luceneOperators = queryProfiles.stream().map(d -> (LuceneSourceOperator.Status) d.operators().getFirst().status()).toList();
+            assertThat(luceneOperators, hasSize(6));
+            // first batch with LIMIT 100
+            assertThat(luceneOperators.get(0).rowsEmitted() + luceneOperators.get(1).rowsEmitted(), equalTo(40L));
+            // second batch with LIMIT 60
+            assertThat(luceneOperators.get(2).rowsEmitted() + luceneOperators.get(3).rowsEmitted(), equalTo(40L));
+            // third batch with LIMIT 15
+            assertThat(luceneOperators.get(4).rowsEmitted() + luceneOperators.get(5).rowsEmitted(), equalTo(15L));
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EarlyTerminationIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EarlyTerminationIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.compute.lucene.DataPartitioning;
+import org.elasticsearch.compute.lucene.LuceneSourceOperator;
+import org.elasticsearch.compute.operator.DriverProfile;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class EarlyTerminationIT extends AbstractEsqlIntegTestCase {
+
+    public void testAdjustLimit() {
+        assumeTrue("require pragmas", canUseQueryPragmas());
+        String dataNode = internalCluster().startDataOnlyNode();
+        int numIndices = 10;
+        int value = 0;
+        for (int i = 0; i < numIndices; i++) {
+            String index = "test-" + i;
+            assertAcked(
+                admin().indices()
+                    .prepareCreate(index)
+                    .setSettings(indexSettings(1, 0).put("index.routing.allocation.require._name", dataNode))
+            );
+            List<IndexRequestBuilder> indexRequests = new ArrayList<>();
+            for (int d = 0; d < 20; d++) {
+                indexRequests.add(new IndexRequestBuilder(client()).setIndex(index).setSource("v", Integer.toString(value++)));
+            }
+            indexRandom(true, indexRequests);
+        }
+        EsqlQueryRequest request = new EsqlQueryRequest();
+        request.query("FROM test-* | LIMIT 95");
+        QueryPragmas pragmas = new QueryPragmas(
+            Settings.builder()
+                .put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 2)
+                .put(QueryPragmas.DATA_PARTITIONING.getKey(), DataPartitioning.SHARD)
+                .put(QueryPragmas.TASK_CONCURRENCY.getKey(), between(3, 5))
+                .build()
+        );
+        request.pragmas(pragmas);
+        request.profile(true);
+        try (EsqlQueryResponse resp = run(request)) {
+            List<List<Object>> values = EsqlTestUtils.getValuesList(resp);
+            assertThat(values, hasSize(95));
+            List<DriverProfile> drivers = resp.profile().drivers();
+            List<DriverProfile> queryProfiles = drivers.stream().filter(d -> d.taskDescription().equals("data")).toList();
+            assertThat(queryProfiles, hasSize(6));
+            var luceneOperators = queryProfiles.stream().map(d -> (LuceneSourceOperator.Status) d.operators().getFirst().status()).toList();
+            assertThat(luceneOperators, hasSize(6));
+            assertThat(luceneOperators.get(0).rowsEmitted() + luceneOperators.get(1).rowsEmitted(), equalTo(40L));
+            assertThat(luceneOperators.get(2).rowsEmitted() + luceneOperators.get(3).rowsEmitted(), equalTo(40L));
+            assertThat(luceneOperators.get(4).rowsEmitted() + luceneOperators.get(5).rowsEmitted(), equalTo(15L));
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/QueryProgressFragmentOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/QueryProgressFragmentOptimizer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
+
+import java.util.function.IntSupplier;
+
+/**
+ * Attempts to rewrite the fragment enclosed in a data-node plan based on the progress of the query. For example:
+ * `FROM x | LIMIT 100` can be safely rewritten to `FROM x | LIMIT 40` if 60 rows have already been collected.
+ * TODO: Rewrite TopN to filters
+ */
+public final class QueryProgressFragmentOptimizer {
+    private final PhysicalVerifier verifier = PhysicalVerifier.INSTANCE;
+    private final IntSupplier alreadyCollectedLimit;
+
+    /**
+     * @param alreadyCollectedLimit the supplier to get the number of rows already collected
+     */
+    public QueryProgressFragmentOptimizer(@Nullable IntSupplier alreadyCollectedLimit) {
+        this.alreadyCollectedLimit = alreadyCollectedLimit;
+    }
+
+    /**
+     * Attempts to optimize the fragment enclosed in a data-node plan based on the progress of the query.
+     * @param plan the input plan
+     * @return the optimized plan. If this returns null, the query can be early terminated.
+     */
+    public PhysicalPlan optimizeFragment(PhysicalPlan plan) {
+        if (alreadyCollectedLimit == null) {
+            return plan;
+        }
+        final var fragments = plan.collectFirstChildren(p -> p instanceof FragmentExec);
+        if (fragments.size() != 1) {
+            return plan;
+        }
+        final FragmentExec fragment = (FragmentExec) fragments.getFirst();
+        final var pipelineBreakers = fragment.fragment().collectFirstChildren(Mapper::isPipelineBreaker);
+        if (pipelineBreakers.isEmpty()) {
+            return plan;
+        }
+        // Rewrite LIMIT
+        if (pipelineBreakers.getFirst() instanceof Limit firstLimit) {
+            final int collected = alreadyCollectedLimit.getAsInt();
+            if (collected == 0) {
+                return plan;
+            }
+            final int originalLimit = (int) firstLimit.limit().fold(FoldContext.small());
+            if (originalLimit <= collected) {
+                return null;
+            }
+            final var newFragment = fragment.fragment().transformUp(Limit.class, l -> {
+                if (l == firstLimit) {
+                    return l.withLimit(Literal.of(firstLimit.limit(), originalLimit - collected));
+                } else {
+                    return l;
+                }
+            });
+            var newPlan = plan.transformUp(FragmentExec.class, f -> {
+                if (f == fragment) {
+                    return new FragmentExec(newFragment);
+                } else {
+                    return f;
+                }
+            });
+            verifier.verify(newPlan);
+            return newPlan;
+        }
+
+        return plan;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -356,7 +356,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
 
         private void onBatchCompleted(int lastBatchIndex) {
             PhysicalPlan nextPlan = null;
-            if (lastBatchIndex < request.shardIds().size()) {
+            if (lastBatchIndex < request.shardIds().size() && exchangeSink.isFinished() == false) {
                 nextPlan = fragmentOptimizer.optimizeFragment(request.plan());
             }
             if (nextPlan != null) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -40,6 +40,7 @@ import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.optimizer.QueryProgressFragmentOptimizer;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
@@ -153,6 +154,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                                 computeListener.acquireAvoid()
                             );
                             final boolean sameNode = transportService.getLocalNode().getId().equals(connection.getNode().getId());
+                            // TODO: Rewrite the plan with the QueryProgressFragmentOptimizer
                             var dataNodeRequest = new DataNodeRequest(
                                 childSessionId,
                                 configuration,
@@ -199,6 +201,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         private final ExchangeSink blockingSink; // block until we have completed on all shards or the coordinator has enough data
         private final boolean failFastOnShardFailure;
         private final Map<ShardId, Exception> shardLevelFailures;
+        private final QueryProgressFragmentOptimizer fragmentOptimizer;
 
         DataNodeRequestExecutor(
             DataNodeRequest request,
@@ -217,16 +220,17 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             this.failFastOnShardFailure = failFastOnShardFailure;
             this.shardLevelFailures = shardLevelFailures;
             this.blockingSink = exchangeSink.createExchangeSink(() -> {});
+            this.fragmentOptimizer = new QueryProgressFragmentOptimizer(() -> (int) Math.min(Integer.MAX_VALUE, exchangeSink.addedRows()));
         }
 
         void start() {
             parentTask.addListener(
                 () -> exchangeService.finishSinkHandler(request.sessionId(), new TaskCancelledException(parentTask.getReasonCancelled()))
             );
-            runBatch(0);
+            runBatch(request.plan(), 0);
         }
 
-        private void runBatch(int startBatchIndex) {
+        private void runBatch(PhysicalPlan plan, int startBatchIndex) {
             final Configuration configuration = request.configuration();
             final String clusterAlias = request.clusterAlias();
             final var sessionId = request.sessionId();
@@ -278,7 +282,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                     null,
                     () -> exchangeSink.createExchangeSink(pagesProduced::incrementAndGet)
                 );
-                computeService.runCompute(parentTask, computeContext, request.plan(), batchListener);
+                computeService.runCompute(parentTask, computeContext, plan, batchListener);
             }, batchListener::onFailure));
         }
 
@@ -351,8 +355,12 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         }
 
         private void onBatchCompleted(int lastBatchIndex) {
-            if (lastBatchIndex < request.shardIds().size() && exchangeSink.isFinished() == false) {
-                runBatch(lastBatchIndex);
+            PhysicalPlan nextPlan = null;
+            if (lastBatchIndex < request.shardIds().size()) {
+                nextPlan = fragmentOptimizer.optimizeFragment(request.plan());
+            }
+            if (nextPlan != null) {
+                runBatch(nextPlan, lastBatchIndex);
             } else {
                 // don't return until all pages are fetched
                 var completionListener = computeListener.acquireAvoid();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
@@ -32,7 +32,7 @@ public final class QueryPragmas implements Writeable {
     public static final Setting<Integer> EXCHANGE_CONCURRENT_CLIENTS = Setting.intSetting("exchange_concurrent_clients", 3);
     public static final Setting<Integer> ENRICH_MAX_WORKERS = Setting.intSetting("enrich_max_workers", 1);
 
-    private static final Setting<Integer> TASK_CONCURRENCY = Setting.intSetting(
+    public static final Setting<Integer> TASK_CONCURRENCY = Setting.intSetting(
         "task_concurrency",
         ThreadPool.searchOrGetThreadPoolSize(EsExecutors.allocatedProcessors(Settings.EMPTY))
     );


### PR DESCRIPTION


Today, we execute shards on data nodes in batches of 10. For queries like `FROM some-indices | WHERE ... | LIMIT 100`, we might need to process multiple shards to find 100 matches. This change introduces an optimizer that rewrites the plan based on query progress. For example, if we’ve collected 60 hits, we rewrite it to `FROM some-indices | WHERE ... | LIMIT 40` since we only need 40 more. We can also apply this on the coordinator to rewrite plans before sending data-node requests.

This approach can extend to TopN queries too. For instance, with `FROM hot-indices, warm-indices, cold-indices | WHERE clause-1 | SORT @timestamp | LIMIT 100`, once we have the first 100 hits, we rewrite the plan using the bottom of the queue to `FROM hot-indices, warm-indices, cold-indices | WHERE clause-1 | WHERE @timestamp <= bottom_of_the_queue | SORT @timestamp DESC | LIMIT 100` to skip non-competitive hits. We could also write a custom collector to support non-indexed fields. For this PR, we’re only applying this optimization to LIMIT during data-node plan execution.