### PR TITLE
[8.x] Remove unnecessary temp dir access (#123314)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -176,7 +176,6 @@ public class EntitlementInitialization {
                     new FilesEntitlement(
                         List.of(
                             // Base ES directories
-                            FileData.ofPath(bootstrapArgs.tempDir(), READ_WRITE),
                             FileData.ofPath(bootstrapArgs.configDir(), READ),
                             FileData.ofPath(bootstrapArgs.logsDir(), READ_WRITE),
                             FileData.ofRelativePath(Path.of(""), DATA, READ_WRITE),
@@ -211,11 +210,7 @@ public class EntitlementInitialization {
                     new LoadNativeLibrariesEntitlement(),
                     new ManageThreadsEntitlement(),
                     new FilesEntitlement(
-                        List.of(
-                            FileData.ofPath(bootstrapArgs.configDir(), READ),
-                            FileData.ofPath(bootstrapArgs.tempDir(), READ),
-                            FileData.ofRelativePath(Path.of(""), DATA, READ_WRITE)
-                        )
+                        List.of(FileData.ofPath(bootstrapArgs.configDir(), READ), FileData.ofRelativePath(Path.of(""), DATA, READ_WRITE))
                     )
                 )
             ),


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Remove unnecessary temp dir access (#123314)