### PR TITLE
[8.x] Increase await timeout for testCancelFailedSearchWhenPartialResultDisallowed (#123084)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -459,6 +459,3 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=data_stream/80_resolve_index_data_streams/Resolve index with hidden and closed indices}
   issue: https://github.com/elastic/elasticsearch/issues/123081
-- class: org.elasticsearch.search.SearchCancellationIT
-  method: testCancelFailedSearchWhenPartialResultDisallowed
-  issue: https://github.com/elastic/elasticsearch/issues/121719

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -267,7 +267,7 @@ public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
                 if (letOneShardProceed.compareAndSet(false, true)) {
                     // Let one shard continue.
                 } else {
-                    safeAwait(shardTaskLatch); // Block the other shards.
+                    safeAwait(shardTaskLatch, TimeValue.timeValueSeconds(30)); // Block the other shards.
                 }
             });
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Increase await timeout for testCancelFailedSearchWhenPartialResultDisallowed (#123084)](https://github.com/elastic/elasticsearch/pull/123084)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)