### PR TITLE
[8.x] Some missing entitlements preventing serverless to start (#123271)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -251,7 +251,9 @@ public class EntitlementInitialization {
             new FilesEntitlement(
                 List.of(
                     FileData.ofPath(Path.of("/co/elastic/apm/agent/"), READ),
-                    FileData.ofPath(Path.of("/agent/co/elastic/apm/agent/"), READ)
+                    FileData.ofPath(Path.of("/agent/co/elastic/apm/agent/"), READ),
+                    FileData.ofPath(Path.of("/proc/meminfo"), READ),
+                    FileData.ofPath(Path.of("/sys/fs/cgroup/"), READ)
                 )
             )
         );

--- a/x-pack/plugin/security/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/security/src/main/plugin-metadata/entitlement-policy.yaml
@@ -37,3 +37,6 @@ org.opensaml.saml.impl:
     - relative_path: metadata.xml
       relative_to: config
       mode: read
+    - relative_path: "saml/"
+      relative_to: config
+      mode: read


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Some missing entitlements preventing serverless to start (#123271)