### PR TITLE
[9.0] Fix how we suppress logs for self-tests (#123361)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -42,7 +43,8 @@ public class EntitlementBootstrap {
         Path libDir,
         Path logsDir,
         Path tempDir,
-        Path pidFile
+        Path pidFile,
+        Set<Class<?>> suppressFailureLogClasses
     ) {
         public BootstrapArgs {
             requireNonNull(pluginPolicies);
@@ -58,6 +60,7 @@ public class EntitlementBootstrap {
             requireNonNull(libDir);
             requireNonNull(logsDir);
             requireNonNull(tempDir);
+            requireNonNull(suppressFailureLogClasses);
         }
     }
 
@@ -82,6 +85,7 @@ public class EntitlementBootstrap {
      * @param tempDir        the temp directory for Elasticsearch
      * @param logsDir        the log directory for Elasticsearch
      * @param pidFile        path to a pid file for Elasticsearch, or {@code null} if one was not specified
+     * @param suppressFailureLogClasses   classes for which we do not need or want to log Entitlements failures
      */
     public static void bootstrap(
         Map<String, Policy> pluginPolicies,
@@ -94,7 +98,8 @@ public class EntitlementBootstrap {
         Path libDir,
         Path logsDir,
         Path tempDir,
-        Path pidFile
+        Path pidFile,
+        Set<Class<?>> suppressFailureLogClasses
     ) {
         logger.debug("Loading entitlement agent");
         if (EntitlementBootstrap.bootstrapArgs != null) {
@@ -111,7 +116,8 @@ public class EntitlementBootstrap {
             libDir,
             logsDir,
             tempDir,
-            pidFile
+            pidFile,
+            suppressFailureLogClasses
         );
         exportInitializationToAgent();
         loadAgent(findAgentJar());

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -269,7 +269,8 @@ public class EntitlementInitialization {
             resolver,
             AGENTS_PACKAGE_NAME,
             ENTITLEMENTS_MODULE,
-            pathLookup
+            pathLookup,
+            bootstrapArgs.suppressFailureLogClasses()
         );
     }
 

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
@@ -87,7 +87,8 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "plugin1",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP
+            TEST_PATH_LOOKUP,
+            Set.of()
         );
 
         // Any class from the current module (unnamed) will do
@@ -111,7 +112,8 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "plugin1",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP
+            TEST_PATH_LOOKUP,
+            Set.of()
         );
 
         // Any class from the current module (unnamed) will do
@@ -131,7 +133,8 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "plugin1",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP
+            TEST_PATH_LOOKUP,
+            Set.of()
         );
 
         // Any class from the current module (unnamed) will do
@@ -156,7 +159,8 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "plugin2",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP
+            TEST_PATH_LOOKUP,
+            Set.of()
         );
 
         // Any class from the current module (unnamed) will do
@@ -174,7 +178,8 @@ public class PolicyManagerTests extends ESTestCase {
             c -> null,
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP
+            TEST_PATH_LOOKUP,
+            Set.of()
         );
 
         // Tests do not run modular, so we cannot use a server class.
@@ -204,7 +209,8 @@ public class PolicyManagerTests extends ESTestCase {
             c -> null,
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP
+            TEST_PATH_LOOKUP,
+            Set.of()
         );
 
         // Tests do not run modular, so we cannot use a server class.
@@ -230,7 +236,8 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "mock-plugin",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP
+            TEST_PATH_LOOKUP,
+            Set.of()
         );
 
         var layer = createLayerForJar(jar, "org.example.plugin");
@@ -249,7 +256,8 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "plugin2",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP
+            TEST_PATH_LOOKUP,
+            Set.of()
         );
 
         // Any class from the current module (unnamed) will do
@@ -308,7 +316,8 @@ public class PolicyManagerTests extends ESTestCase {
             c -> c.getPackageName().startsWith(TEST_AGENTS_PACKAGE_NAME) ? null : "test",
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP
+            TEST_PATH_LOOKUP,
+            Set.of()
         );
         ModuleEntitlements agentsEntitlements = policyManager.getEntitlements(TestAgent.class);
         assertThat(agentsEntitlements.hasEntitlement(CreateClassLoaderEntitlement.class), is(true));
@@ -336,7 +345,8 @@ public class PolicyManagerTests extends ESTestCase {
                 c -> "test",
                 TEST_AGENTS_PACKAGE_NAME,
                 NO_ENTITLEMENTS_MODULE,
-                TEST_PATH_LOOKUP
+                TEST_PATH_LOOKUP,
+                Set.of()
             )
         );
         assertEquals(
@@ -353,7 +363,8 @@ public class PolicyManagerTests extends ESTestCase {
                 c -> "test",
                 TEST_AGENTS_PACKAGE_NAME,
                 NO_ENTITLEMENTS_MODULE,
-                TEST_PATH_LOOKUP
+                TEST_PATH_LOOKUP,
+                Set.of()
             )
         );
         assertEquals(
@@ -387,7 +398,8 @@ public class PolicyManagerTests extends ESTestCase {
                 c -> "plugin1",
                 TEST_AGENTS_PACKAGE_NAME,
                 NO_ENTITLEMENTS_MODULE,
-                TEST_PATH_LOOKUP
+                TEST_PATH_LOOKUP,
+                Set.of()
             )
         );
         assertEquals(
@@ -407,7 +419,8 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "test", // Insist that the class is in a plugin
             TEST_AGENTS_PACKAGE_NAME,
             NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP
+            TEST_PATH_LOOKUP,
+            Set.of()
         );
         ModuleEntitlements notAgentsEntitlements = policyManager.getEntitlements(TestAgent.class);
         assertThat(notAgentsEntitlements.hasEntitlement(CreateClassLoaderEntitlement.class), is(false));
@@ -428,7 +441,8 @@ public class PolicyManagerTests extends ESTestCase {
             c -> "test",
             agentsPackageName,
             entitlementsModule,
-            TEST_PATH_LOOKUP
+            TEST_PATH_LOOKUP,
+            Set.of()
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Fix how we suppress logs for self-tests (#123361)