### PR TITLE
[9.0] Deprecate Behavioral Analytics CRUD apis (#122960)

### DIFF
--- a/docs/changelog/122960.yaml
+++ b/docs/changelog/122960.yaml
@@ -1,0 +1,10 @@
+pr: 122960
+summary: Deprecate Behavioral Analytics CRUD apis
+area: Search
+type: deprecation
+issues: [ ]
+deprecation:
+  title: Deprecate Behavioral Analytics CRUD apis
+  area: Search
+  details: Behavioral Analytics has been deprecated as of 9.0.0 and will be removed in a future release. The APIs will still work for now, but will emit warning headers that the API has been deprecated.
+  impact: Behavioral Analytics has been deprecated as of 9.0.0 and will be removed in a future release.

--- a/docs/reference/behavioral-analytics/apis/delete-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/delete-analytics-collection.asciidoc
@@ -2,6 +2,7 @@
 [[delete-analytics-collection]]
 === Delete Analytics Collection
 
+deprecated:[9.0.0]
 beta::[]
 
 ++++
@@ -13,15 +14,6 @@ beta::[]
 --
 For the most up-to-date API details, refer to {api-es}/group/endpoint-analytics[Behavioral analytics APIs].
 --
-
-////
-[source,console]
-----
-PUT _application/analytics/my_analytics_collection
-----
-// TESTSETUP
-
-////
 
 Removes a <<behavioral-analytics-overview,Behavioral Analytics>> Collection and its associated data stream.
 
@@ -59,3 +51,4 @@ The following example deletes the Analytics Collection named `my_analytics_colle
 ----
 DELETE _application/analytics/my_analytics_collection/
 ----
+// TEST[skip:Behavioral Analytics APIs emit deprecation warnings and will not be updated]

--- a/docs/reference/behavioral-analytics/apis/index.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/index.asciidoc
@@ -1,6 +1,7 @@
 [[behavioral-analytics-apis]]
 == Behavioral Analytics APIs
 
+deprecated:[9.0.0]
 beta::[]
 
 ++++

--- a/docs/reference/behavioral-analytics/apis/list-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/list-analytics-collection.asciidoc
@@ -2,6 +2,7 @@
 [[list-analytics-collection]]
 === List Analytics Collections
 
+deprecated:[9.0.0]
 beta::[]
 
 ++++
@@ -13,22 +14,6 @@ beta::[]
 --
 For the most up-to-date API details, refer to {api-es}/group/endpoint-analytics[Behavioral analytics APIs].
 --
-
-////
-[source,console]
-----
-PUT _application/analytics/my_analytics_collection
-PUT _application/analytics/my_analytics_collection2
-----
-// TESTSETUP
-
-[source,console]
-----
-DELETE _application/analytics/my_analytics_collection
-DELETE _application/analytics/my_analytics_collection2
-----
-// TEARDOWN
-////
 
 Returns information about <<behavioral-analytics-overview,Behavioral Analytics>> Collections.
 
@@ -46,8 +31,9 @@ Requires the `manage_behavioral_analytics` cluster privilege.
 ==== {api-path-parms-title}
 
 `<criteria>`::
-(optional, string)
-Criteria is used to find a matching analytics collection. This could be the name of the collection or a pattern to match multiple. If not specified, will return all analytics collections.
+(optional, string) Criteria is used to find a matching analytics collection.
+This could be the name of the collection or a pattern to match multiple.
+If not specified, will return all analytics collections.
 
 [[list-analytics-collection-response-codes]]
 ==== {api-response-codes-title}
@@ -66,6 +52,7 @@ The following example lists all configured Analytics Collections:
 ----
 GET _application/analytics/
 ----
+// TEST[skip:Behavioral Analytics APIs emit deprecation warnings and will not be updated]
 
 A sample response:
 
@@ -91,6 +78,7 @@ The following example returns the Analytics Collection that matches `my_analytic
 ----
 GET _application/analytics/my_analytics_collection
 ----
+// TEST[skip:Behavioral Analytics APIs emit deprecation warnings and will not be updated]
 
 A sample response:
 
@@ -111,6 +99,7 @@ The following example returns all Analytics Collections prefixed with `my`:
 ----
 GET _application/analytics/my*
 ----
+// TEST[skip:Behavioral Analytics APIs emit deprecation warnings and will not be updated]
 
 A sample response:
 

--- a/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
@@ -2,6 +2,7 @@
 [[post-analytics-collection-event]]
 === Post Event to an Analytics Collection
 
+deprecated:[9.0.0]
 beta::[]
 
 ++++
@@ -13,20 +14,6 @@ beta::[]
 --
 For the most up-to-date API details, refer to {api-es}/group/endpoint-analytics[Behavioral analytics APIs].
 --
-
-////
-[source,console]
-----
-PUT _application/analytics/my_analytics_collection
-----
-// TESTSETUP
-
-[source,console]
-----
-DELETE _application/analytics/my_analytics_collection
-----
-// TEARDOWN
-////
 
 Post an event to a <<behavioral-analytics-overview,Behavioral Analytics>> Collection.
 
@@ -105,3 +92,4 @@ POST _application/analytics/my_analytics_collection/event/search_click
   }
 }
 ----
+// TEST[skip:Behavioral Analytics APIs emit deprecation warnings and will not be updated]

--- a/docs/reference/behavioral-analytics/apis/put-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/put-analytics-collection.asciidoc
@@ -2,6 +2,7 @@
 [[put-analytics-collection]]
 === Put Analytics Collection
 
+deprecated:[9.0.0]
 beta::[]
 
 ++++
@@ -13,14 +14,6 @@ beta::[]
 --
 For the most up-to-date API details, refer to {api-es}/group/endpoint-analytics[Behavioral analytics APIs].
 --
-
-////
-[source,console]
-----
-DELETE _application/analytics/my_analytics_collection
-----
-// TEARDOWN
-////
 
 Creates a <<behavioral-analytics-overview,Behavioral Analytics>> Collection.
 
@@ -55,3 +48,4 @@ The following example creates a new Analytics Collection called `my_analytics_co
 ----
 PUT _application/analytics/my_analytics_collection
 ----
+// TEST[skip:Behavioral Analytics APIs emit deprecation warnings and will not be updated]

--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-api.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-api.asciidoc
@@ -1,8 +1,11 @@
 [[behavioral-analytics-api]]
 === Behavioral Analytics API overview
+
 ++++
 <titleabbrev>API overview</titleabbrev>
 ++++
+
+deprecated:[9.0.0]
 
 This page outlines all the APIs available for behavioral analytics and links to their documentation.
 

--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-cors.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-cors.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>Set up CORs</titleabbrev>
 ++++
 
+deprecated:[9.0.0]
+
 Behavioral Analytics sends events directly to the {es} API.
 This means that the browser makes requests to the {es} API directly.
 {es} supports https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[Cross-Origin Resource Sharing (CORS)^], but this feature is disabled by default.

--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-event-reference.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-event-reference.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>Events reference</titleabbrev>
 ++++
 
+deprecated:[9.0.0]
+
 Behavioral Analytics logs events using the {ecs-ref}/ecs-reference.html[Elastic Common Schema^], including a custom field set for analytics events.
 Refer to <<behavioral-analytics-event-reference-examples,examples>> of the full data objects that are logged.
 

--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-event.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-event.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>View events</titleabbrev>
 ++++
 
+deprecated:[9.0.0]
+
 [TIP]
 ====
 Refer to <<behavioral-analytics-event-reference>> for a complete list of the fields logged by events.

--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-overview.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-overview.asciidoc
@@ -1,6 +1,9 @@
 [[behavioral-analytics-overview]]
 == Search analytics
 
+deprecated:[9.0.0]
+
+
 Behavioral Analytics is an analytics event collection platform.
 Use these tools to analyze your users' searching and clicking behavior.
 Leverage this information to improve the relevance of your search results and identify gaps in your content.

--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-start.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-start.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>Get started</titleabbrev>
 ++++
 
+deprecated:[9.0.0]
+
 You can manage your analytics in the {kib} UI.
 Go to *Search > Behavioral Analytics* to get started.
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete_behavioral_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete_behavioral_analytics.json
@@ -6,6 +6,10 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "9.0.0",
+      "description": "Behavioral Analytics has been deprecated and will be removed in a future release."
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get_behavioral_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get_behavioral_analytics.json
@@ -6,6 +6,10 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "9.0.0",
+      "description": "Behavioral Analytics has been deprecated and will be removed in a future release."
+    },
     "headers": {
       "accept": [
         "application/json"
@@ -24,10 +28,10 @@
           "methods": [
             "GET"
           ],
-          "parts":{
-            "name":{
-              "type":"list",
-              "description":"A comma-separated list of analytics collections to limit the returned information"
+          "parts": {
+            "name": {
+              "type": "list",
+              "description": "A comma-separated list of analytics collections to limit the returned information"
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.post_behavioral_analytics_event.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.post_behavioral_analytics_event.json
@@ -6,6 +6,10 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "9.0.0",
+      "description": "Behavioral Analytics has been deprecated and will be removed in a future release."
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put_behavioral_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put_behavioral_analytics.json
@@ -5,6 +5,10 @@
       "description": "Creates a behavioral analytics collection."
     },
     "stability": "experimental",
+    "deprecated": {
+      "version": "9.0.0",
+      "description": "Behavioral Analytics has been deprecated and will be removed in a future release."
+    },
     "visibility": "public",
     "headers": {
       "accept": [

--- a/x-pack/plugin/ent-search/qa/rest/build.gradle
+++ b/x-pack/plugin/ent-search/qa/rest/build.gradle
@@ -37,3 +37,11 @@ testClusters.configureEach {
 artifacts {
   restXpackTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
 }
+
+
+tasks.named("yamlRestCompatTestTransform").configure(
+  { task ->
+    // Behavioral Analytics is deprecated with 9.0.0.
+    task.addAllowedWarning("Behavioral Analytics is deprecated and will be removed in a future release.")
+  }
+)

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_usage.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_usage.yml
@@ -27,6 +27,8 @@ teardown:
 
 ---
 "xpack usage includes Enterprise Search":
+  - requires:
+      test_runner_features: [ allowed_warnings ]
 
   - do:
       xpack.usage: { }
@@ -79,6 +81,8 @@ teardown:
                     query: "{{query_string}}"
 
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.put_behavioral_analytics:
         name: test-analytics-collection
 
@@ -113,6 +117,8 @@ teardown:
   }
 
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.delete_behavioral_analytics:
         name: test-analytics-collection
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/analytics/10_behavioral_analytics_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/analytics/10_behavioral_analytics_list.yml
@@ -1,39 +1,55 @@
 setup:
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.put_behavioral_analytics:
         name: my-test-analytics-collection
 
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.put_behavioral_analytics:
         name: my-test-analytics-collection2
 
 ---
 teardown:
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.delete_behavioral_analytics:
         name: my-test-analytics-collection
 
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.delete_behavioral_analytics:
         name: my-test-analytics-collection2
 
 ---
 "Get Analytics Collection for a particular collection":
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.get_behavioral_analytics:
         name: my-test-analytics-collection
 
   - match: {
-      "my-test-analytics-collection": {
-        event_data_stream: {
-          name: "behavioral_analytics-events-my-test-analytics-collection"
-        }
+    "my-test-analytics-collection": {
+      event_data_stream: {
+        name: "behavioral_analytics-events-my-test-analytics-collection"
       }
     }
+  }
 
 ---
 "Get Analytics Collection list":
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.get_behavioral_analytics:
         name:
 
@@ -56,6 +72,8 @@ teardown:
 "Get Analytics Collection - Resource does not exist":
   - do:
       catch: "missing"
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.get_behavioral_analytics:
         name: test-nonexistent-analytics-collection
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/analytics/20_behavioral_analytics_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/analytics/20_behavioral_analytics_put.yml
@@ -1,11 +1,19 @@
 teardown:
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.delete_behavioral_analytics:
         name: test-analytics-collection
 
 ---
 "Create Analytics Collection":
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.put_behavioral_analytics:
         name: test-analytics-collection
 
@@ -14,7 +22,11 @@ teardown:
 
 ---
 "Create Analytics Collection - analytics collection already exists":
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.put_behavioral_analytics:
         name: test-analytics-collection
 
@@ -22,6 +34,8 @@ teardown:
 
   - do:
       catch: bad_request
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.put_behavioral_analytics:
         name: test-analytics-collection
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/analytics/30_behavioral_analytics_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/analytics/30_behavioral_analytics_delete.yml
@@ -1,18 +1,30 @@
 setup:
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.put_behavioral_analytics:
         name: my-test-analytics-collection
 
 ---
 teardown:
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.delete_behavioral_analytics:
         name: my-test-analytics-collection
         ignore: 404
 
 ---
 "Delete Analytics Collection":
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.delete_behavioral_analytics:
         name: my-test-analytics-collection
 
@@ -20,13 +32,19 @@ teardown:
 
   - do:
       catch: "missing"
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.get_behavioral_analytics:
         name: my-test-analytics-collection
 
 ---
 "Delete Analytics Collection - Analytics Collection does not exist":
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
       catch: "missing"
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.delete_behavioral_analytics:
         name: test-nonexistent-analytics-collection
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/analytics/40_behavioral_analytics_event_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/analytics/40_behavioral_analytics_event_post.yml
@@ -1,11 +1,19 @@
 setup:
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.put_behavioral_analytics:
         name: my-test-analytics-collection
 
 ---
 teardown:
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.delete_behavioral_analytics:
         name: my-test-analytics-collection
 
@@ -13,30 +21,34 @@ teardown:
 # Page view event tests #########################################
 ---
 "Post page_view analytics event":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
         body:
-            session:
-              id: "123"
-            user:
-              id: "456"
-            page:
-              url: "https://www.elastic.co"
+          session:
+            id: "123"
+          user:
+            id: "456"
+          page:
+            url: "https://www.elastic.co"
 
 ---
 "Post page_view analytics event - Missing page.url":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -49,11 +61,13 @@ teardown:
 
 ---
 "Post page_view analytics event - With document":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -70,11 +84,13 @@ teardown:
 
 ---
 "Post page_view analytics event - With page title":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -89,11 +105,13 @@ teardown:
 
 ---
 "Post page_view analytics event - With referrer":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -108,14 +126,16 @@ teardown:
 
 ---
 "Post page_view analytics event - debug and session information":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers:
         X-Forwarded-For: 192.23.12.12
         User-Agent: Mozilla/5.0
         Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ="  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -152,11 +172,13 @@ teardown:
 # Search event tests ############################################
 ---
 "Post search analytics event":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -170,12 +192,14 @@ teardown:
 
 ---
 "Post search analytics event – Missing search query":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -188,11 +212,13 @@ teardown:
 
 ---
 "Post search analytics event - With sort order":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -208,11 +234,13 @@ teardown:
 
 ---
 "Post search analytics event - With sort name and direction":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -229,11 +257,13 @@ teardown:
 
 ---
 "Post search analytics event - With pagination":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -250,11 +280,13 @@ teardown:
 
 ---
 "Post search analytics event - With search application":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -269,10 +301,12 @@ teardown:
 
 ---
 "Post search analytics event - With search results":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
@@ -287,7 +321,7 @@ teardown:
             results:
               total_results: 150
               items:
-                - document :
+                - document:
                     id: doc-1
                 - document:
                     id: doc-2
@@ -302,11 +336,13 @@ teardown:
 
 ---
 "Post search analytics event - With filters":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -324,14 +360,16 @@ teardown:
 
 ---
 "Post search analytics event - debug and session information":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers:
         X-Forwarded-For: 192.23.12.12
         User-Agent: Mozilla/5.0
         Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ="  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -393,11 +431,13 @@ teardown:
 # Search click event tests #######################################
 ---
 "Post search_click analytics event":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -415,14 +455,16 @@ teardown:
 
 ---
 "Post search_click analytics event - debug and session information":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers:
         X-Forwarded-For: 192.23.12.12
         User-Agent: Mozilla/5.0
         Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ="  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -455,11 +497,13 @@ teardown:
 
 ---
 "Post search_click analytics event - Page Only":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -475,11 +519,13 @@ teardown:
 
 ---
 "Post search_click analytics event - Document Only":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -496,12 +542,14 @@ teardown:
 
 ---
 "Post search_click analytics event – Missing search query":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -516,12 +564,14 @@ teardown:
 
 ---
 "Post search_click analytics event – Missing page url and document":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -537,12 +587,14 @@ teardown:
 # Generic errors tests ###############################################
 ---
 "Post analytics event - Analytics collection does not exist":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       catch: "missing"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: test-nonexistent-analytics-collection
         event_type: "page_view"
@@ -556,12 +608,14 @@ teardown:
 
 ---
 "Post analytics event - Event type does not exist":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "nonexistent-event-type"
@@ -577,12 +631,14 @@ teardown:
 
 ---
 "Post page_view analytics event - Missing session.id":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -595,12 +651,14 @@ teardown:
 
 ---
 "Post page_view analytics event - Missing user.id":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -613,12 +671,14 @@ teardown:
 
 ---
 "Post analytics event - Unknown event field":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ allowed_warnings, headers ]
 
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "nonexistent-event-type"

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/search/56_search_application_search_with_apikey.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/search/56_search_application_search_with_apikey.yml
@@ -1,4 +1,6 @@
 setup:
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
       indices.create:
         index: test-search-index1
@@ -27,6 +29,8 @@ setup:
               number_of_replicas: 0
 
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.put:
         name: test-search-application
         body:
@@ -51,6 +55,8 @@ setup:
                   type: string
 
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.put:
         name: test-search-application-1
         body:
@@ -110,10 +116,14 @@ setup:
         refresh: true
 
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.put_behavioral_analytics:
         name: my-test-analytics-collection
 ---
 teardown:
+  - requires:
+      test_runner_features: [ allowed_warnings ]
   - do:
       search_application.delete:
         name: test-search-application
@@ -145,18 +155,20 @@ teardown:
         ignore: 404
 
   - do:
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.delete_behavioral_analytics:
         name: my-test-analytics-collection
 
 ---
 "Query Search Application with API key":
-  - skip:
-      features: headers
+  - requires:
+      test_runner_features: [ headers, allowed_warnings ]
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
       security.create_api_key:
-        body:  >
+        body: >
           {
             "name": "search-application-api-key",
             "role_descriptors": {
@@ -176,10 +188,10 @@ teardown:
           }
 
   - match: { name: "search-application-api-key" }
-  - set: { encoded: api_key_encoded  }
+  - set: { encoded: api_key_encoded }
   - set: { id: api_key_id }
 
-# Query Search Application with default parameters:
+  # Query Search Application with default parameters:
   - do:
       headers:
         Authorization: ApiKey ${api_key_encoded}
@@ -191,7 +203,7 @@ teardown:
   - match: { hits.hits.1._id: "doc2" }
 
 
-# Query Search Application overriding part of the parameters:
+  # Query Search Application overriding part of the parameters:
   - do:
       headers:
         Authorization: ApiKey ${api_key_encoded}
@@ -205,7 +217,7 @@ teardown:
   - match: { hits.total.value: 1 }
   - match: { hits.hits.0._id: "doc1" }
 
-# Query Search Application overriding all parameters:
+  # Query Search Application overriding all parameters:
   - do:
       headers:
         Authorization: ApiKey ${api_key_encoded}
@@ -220,7 +232,7 @@ teardown:
   - match: { hits.total.value: 1 }
   - match: { hits.hits.0._id: "doc2" }
 
-# Query Search Application with list of parameters:
+  # Query Search Application with list of parameters:
   - do:
       headers:
         Authorization: ApiKey ${api_key_encoded}
@@ -241,7 +253,7 @@ teardown:
   - match: { hits.total.value: 1 }
   - match: { hits.hits.0._id: "doc2" }
 
-# Query Search Application with invalid parameter validation:
+  # Query Search Application with invalid parameter validation:
   - do:
       catch: "bad_request"
       headers:
@@ -253,7 +265,7 @@ teardown:
             field_name: field3
             field_value: 35
 
-# Query Search Application without required parameter:
+  # Query Search Application without required parameter:
   - do:
       catch: "bad_request"
       headers:
@@ -264,7 +276,7 @@ teardown:
           params:
             field_value: test
 
-# Query Search Application - not found:
+  # Query Search Application - not found:
   - do:
       catch: forbidden
       headers:
@@ -276,11 +288,13 @@ teardown:
             field_name: field3
             field_value: value3
 
-# Get Analytics Collection should be rejected due to a workflow restriction
+  # Get Analytics Collection should be rejected due to a workflow restriction
   - do:
       catch: forbidden
       headers:
         Authorization: ApiKey ${api_key_encoded}
+      allowed_warnings:
+        - "Behavioral Analytics is deprecated and will be removed in a future release."
       search_application.get_behavioral_analytics:
         name:
   - match: { status: 403 }
@@ -288,7 +302,7 @@ teardown:
   - match: { error.root_cause.0.type: role_restriction_exception }
   - match: { error.root_cause.0.reason: "access restricted by workflow" }
 
-# Get API key should not be allowed
+  # Get API key should not be allowed
   - do:
       catch: forbidden
       headers:
@@ -300,18 +314,18 @@ teardown:
   - match: { error.root_cause.0.type: role_restriction_exception }
   - match: { error.root_cause.0.reason: "access restricted by workflow" }
 
-# Authenticate with API key should not be allowed
+  # Authenticate with API key should not be allowed
   - do:
       catch: forbidden
       headers:
         Authorization: ApiKey ${api_key_encoded}
-      security.authenticate: {}
+      security.authenticate: { }
   - match: { status: 403 }
   - match: { error.type: security_exception }
   - match: { error.root_cause.0.type: role_restriction_exception }
   - match: { error.root_cause.0.reason: "access restricted by workflow" }
 
-# Direct index search should be rejected due to a workflow restriction
+  # Direct index search should be rejected due to a workflow restriction
   - do:
       catch: forbidden
       headers:
@@ -327,11 +341,11 @@ teardown:
   - match: { error.root_cause.0.type: role_restriction_exception }
   - match: { error.root_cause.0.reason: "access restricted by workflow" }
 
-# Creating an API key which can only search 'test-search-application-1'
+  # Creating an API key which can only search 'test-search-application-1'
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
       security.create_api_key:
-        body:  >
+        body: >
           {
             "name": "search-application-1-api-key",
             "role_descriptors": {
@@ -350,10 +364,10 @@ teardown:
           }
 
   - match: { name: "search-application-1-api-key" }
-  - set: { encoded: api_key_encoded_1  }
+  - set: { encoded: api_key_encoded_1 }
   - set: { id: api_key_id_1 }
 
-# Query Search Application 'test-search-application' should be denied since API key (api_key_encoded_1) does not have required index privilege
+  # Query Search Application 'test-search-application' should be denied since API key (api_key_encoded_1) does not have required index privilege
   - do:
       catch: forbidden
       headers:
@@ -364,7 +378,7 @@ teardown:
   - match: { error.type: security_exception }
   - match: { error.reason: "action [indices:data/read/xpack/application/search_application/search] is unauthorized for API key id [${api_key_id_1}] of user [entsearch-user] on indices [test-search-application], this action is granted by the index privileges [read,all]" }
 
-# Query Search Application 'test-search-application-1' with new API key (api_key_encoded_1) should be allowed:
+  # Query Search Application 'test-search-application-1' with new API key (api_key_encoded_1) should be allowed:
   - do:
       headers:
         Authorization: ApiKey ${api_key_encoded_1}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -233,6 +233,10 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
 
     private final boolean enabled;
 
+    // NOTE: Behavioral Analytics is deprecated in 9.0 but not 8.x.
+    public static final String BEHAVIORAL_ANALYTICS_DEPRECATION_MESSAGE =
+        "Behavioral Analytics is deprecated and will be removed in a future release.";
+
     public EnterpriseSearch(Settings settings) {
         this.enabled = XPackSettings.ENTERPRISE_SEARCH_ENABLED.get(settings);
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollection.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollection.java
@@ -28,7 +28,9 @@ import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.E
 
 /**
  * The {@link AnalyticsCollection} model.
+ * @deprecated in 9.0
  */
+@Deprecated
 public class AnalyticsCollection implements Writeable, ToXContentObject {
 
     private static final ObjectParser<AnalyticsCollection, String> PARSER = ObjectParser.fromBuilder(

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionResolver.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionResolver.java
@@ -28,7 +28,9 @@ import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.E
 
 /**
  * A service that allows the resolution of {@link AnalyticsCollection} by name.
+ * @deprecated in 9.0
  */
+@Deprecated
 public class AnalyticsCollectionResolver {
     private final IndexNameExpressionResolver indexNameExpressionResolver;
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionService.java
@@ -33,7 +33,9 @@ import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
  * Until we have more specific need the {@link AnalyticsCollection} is just another representation
  * of a {@link org.elasticsearch.cluster.metadata.DataStream}.
  * As a consequence, this service is mostly a facade for the data stream API.
+ * @deprecated in 9.0
  */
+@Deprecated
 public class AnalyticsCollectionService {
 
     private static final Logger logger = LogManager.getLogger(AnalyticsCollectionService.class);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsConstants.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsConstants.java
@@ -7,6 +7,10 @@
 
 package org.elasticsearch.xpack.application.analytics;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class AnalyticsConstants {
 
     private AnalyticsConstants() {}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsEventIngestService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsEventIngestService.java
@@ -17,7 +17,9 @@ import java.util.Objects;
 
 /**
  * Event emitter will index Analytics events submitted through a @{PostAnalyticsEventAction.Request} request.
+ * @deprecated in 9.0
  */
+@Deprecated
 public class AnalyticsEventIngestService {
     private final AnalyticsCollectionResolver collectionResolver;
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
@@ -31,6 +31,10 @@ import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.R
 import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.TEMPLATE_VERSION_VARIABLE;
 import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
 
     // This number must be incremented when we make changes to built-in templates.

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/DeleteAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/DeleteAnalyticsCollectionAction.java
@@ -24,6 +24,10 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class DeleteAnalyticsCollectionAction {
 
     public static final String NAME = "cluster:admin/xpack/application/analytics/delete";

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/GetAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/GetAnalyticsCollectionAction.java
@@ -25,6 +25,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class GetAnalyticsCollectionAction {
 
     public static final String NAME = "cluster:admin/xpack/application/analytics/get";

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
@@ -36,6 +36,10 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class PostAnalyticsEventAction {
 
     public static final String NAME = "cluster:admin/xpack/application/analytics/post_event";

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PutAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PutAnalyticsCollectionAction.java
@@ -23,6 +23,10 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class PutAnalyticsCollectionAction {
 
     public static final String NAME = "cluster:admin/xpack/application/analytics/put";

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestDeleteAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestDeleteAnalyticsCollectionAction.java
@@ -23,6 +23,10 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 @ServerlessScope(Scope.PUBLIC)
 public class RestDeleteAnalyticsCollectionAction extends EnterpriseSearchBaseRestHandler {
     public RestDeleteAnalyticsCollectionAction(XPackLicenseState licenseState) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestGetAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestGetAnalyticsCollectionAction.java
@@ -23,6 +23,10 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 @ServerlessScope(Scope.PUBLIC)
 public class RestGetAnalyticsCollectionAction extends EnterpriseSearchBaseRestHandler {
     public RestGetAnalyticsCollectionAction(XPackLicenseState licenseState) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
@@ -29,6 +29,10 @@ import java.util.Map;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 @ServerlessScope(Scope.PUBLIC)
 public class RestPostAnalyticsEventAction extends EnterpriseSearchBaseRestHandler {
     public RestPostAnalyticsEventAction(XPackLicenseState licenseState) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPutAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPutAnalyticsCollectionAction.java
@@ -24,6 +24,10 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 @ServerlessScope(Scope.PUBLIC)
 public class RestPutAnalyticsCollectionAction extends EnterpriseSearchBaseRestHandler {
     public RestPutAnalyticsCollectionAction(XPackLicenseState licenseState) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportDeleteAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportDeleteAnalyticsCollectionAction.java
@@ -15,6 +15,8 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
@@ -22,6 +24,13 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.application.analytics.AnalyticsCollectionService;
 
+import static org.elasticsearch.xpack.application.EnterpriseSearch.BEHAVIORAL_ANALYTICS_API_ENDPOINT;
+import static org.elasticsearch.xpack.application.EnterpriseSearch.BEHAVIORAL_ANALYTICS_DEPRECATION_MESSAGE;
+
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class TransportDeleteAnalyticsCollectionAction extends AcknowledgedTransportMasterNodeAction<
     DeleteAnalyticsCollectionAction.Request> {
 
@@ -59,6 +68,8 @@ public class TransportDeleteAnalyticsCollectionAction extends AcknowledgedTransp
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) {
+        DeprecationLogger.getLogger(TransportDeleteAnalyticsCollectionAction.class)
+            .warn(DeprecationCategory.API, BEHAVIORAL_ANALYTICS_API_ENDPOINT, BEHAVIORAL_ANALYTICS_DEPRECATION_MESSAGE);
         analyticsCollectionService.deleteAnalyticsCollection(state, request, listener.map(v -> AcknowledgedResponse.TRUE));
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionAction.java
@@ -13,6 +13,8 @@ import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
@@ -20,6 +22,13 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.application.analytics.AnalyticsCollectionService;
 
+import static org.elasticsearch.xpack.application.EnterpriseSearch.BEHAVIORAL_ANALYTICS_API_ENDPOINT;
+import static org.elasticsearch.xpack.application.EnterpriseSearch.BEHAVIORAL_ANALYTICS_DEPRECATION_MESSAGE;
+
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class TransportGetAnalyticsCollectionAction extends TransportMasterNodeReadAction<
     GetAnalyticsCollectionAction.Request,
     GetAnalyticsCollectionAction.Response> {
@@ -54,6 +63,8 @@ public class TransportGetAnalyticsCollectionAction extends TransportMasterNodeRe
         ClusterState state,
         ActionListener<GetAnalyticsCollectionAction.Response> listener
     ) {
+        DeprecationLogger.getLogger(TransportDeleteAnalyticsCollectionAction.class)
+            .warn(DeprecationCategory.API, BEHAVIORAL_ANALYTICS_API_ENDPOINT, BEHAVIORAL_ANALYTICS_DEPRECATION_MESSAGE);
         analyticsCollectionService.getAnalyticsCollection(state, request, listener);
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPostAnalyticsEventAction.java
@@ -10,17 +10,25 @@ package org.elasticsearch.xpack.application.analytics.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.application.analytics.AnalyticsEventIngestService;
 
+import static org.elasticsearch.xpack.application.EnterpriseSearch.BEHAVIORAL_ANALYTICS_API_ENDPOINT;
+import static org.elasticsearch.xpack.application.EnterpriseSearch.BEHAVIORAL_ANALYTICS_DEPRECATION_MESSAGE;
+
 /**
  * Transport implementation for the {@link PostAnalyticsEventAction}.
  * It executes the {@link AnalyticsEventIngestService#addEvent} method if the XPack license is valid, else it calls
  * the listener's onFailure method with the appropriate exception.
+ * @deprecated in 9.0
  */
+@Deprecated
 public class TransportPostAnalyticsEventAction extends HandledTransportAction<
     PostAnalyticsEventAction.Request,
     PostAnalyticsEventAction.Response> {
@@ -31,7 +39,8 @@ public class TransportPostAnalyticsEventAction extends HandledTransportAction<
     public TransportPostAnalyticsEventAction(
         TransportService transportService,
         ActionFilters actionFilters,
-        AnalyticsEventIngestService eventEmitterService
+        AnalyticsEventIngestService eventEmitterService,
+        ClusterService clusterService
     ) {
         super(
             PostAnalyticsEventAction.NAME,
@@ -49,6 +58,8 @@ public class TransportPostAnalyticsEventAction extends HandledTransportAction<
         PostAnalyticsEventAction.Request request,
         ActionListener<PostAnalyticsEventAction.Response> listener
     ) {
+        DeprecationLogger.getLogger(TransportDeleteAnalyticsCollectionAction.class)
+            .warn(DeprecationCategory.API, BEHAVIORAL_ANALYTICS_API_ENDPOINT, BEHAVIORAL_ANALYTICS_DEPRECATION_MESSAGE);
         this.eventEmitterService.addEvent(request, listener);
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionAction.java
@@ -14,13 +14,23 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.application.analytics.AnalyticsCollectionService;
 
+import static org.elasticsearch.xpack.application.EnterpriseSearch.BEHAVIORAL_ANALYTICS_API_ENDPOINT;
+import static org.elasticsearch.xpack.application.EnterpriseSearch.BEHAVIORAL_ANALYTICS_DEPRECATION_MESSAGE;
+
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class TransportPutAnalyticsCollectionAction extends TransportMasterNodeAction<
     PutAnalyticsCollectionAction.Request,
     PutAnalyticsCollectionAction.Response> {
@@ -33,7 +43,8 @@ public class TransportPutAnalyticsCollectionAction extends TransportMasterNodeAc
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        AnalyticsCollectionService analyticsCollectionService
+        AnalyticsCollectionService analyticsCollectionService,
+        FeatureService featureService
     ) {
         super(
             PutAnalyticsCollectionAction.NAME,
@@ -60,6 +71,8 @@ public class TransportPutAnalyticsCollectionAction extends TransportMasterNodeAc
         ClusterState state,
         ActionListener<PutAnalyticsCollectionAction.Response> listener
     ) {
+        DeprecationLogger.getLogger(TransportDeleteAnalyticsCollectionAction.class)
+            .warn(DeprecationCategory.API, BEHAVIORAL_ANALYTICS_API_ENDPOINT, BEHAVIORAL_ANALYTICS_DEPRECATION_MESSAGE);
         analyticsCollectionService.putAnalyticsCollection(state, request, listener);
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEvent.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEvent.java
@@ -31,7 +31,9 @@ import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.E
 
 /**
  * This class represents Analytics events object meant to be emitted to the event queue.
+ * @deprecated in 9.0
  */
+@Deprecated
 public class AnalyticsEvent implements Writeable, ToXContentObject {
 
     public static final ParseField TIMESTAMP_FIELD = new ParseField("@timestamp");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactory.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactory.java
@@ -29,7 +29,9 @@ import static org.elasticsearch.xpack.application.analytics.event.AnalyticsEvent
 
 /**
  * A utility class for parsing {@link AnalyticsEvent} objects from payloads (such as HTTP POST request bodies) or input streams.
+ * @deprecated in 9.0
  */
+@Deprecated
 public class AnalyticsEventFactory {
 
     public static final AnalyticsEventFactory INSTANCE = new AnalyticsEventFactory();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/event/PageViewAnalyticsEvent.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/event/PageViewAnalyticsEvent.java
@@ -22,6 +22,10 @@ import static org.elasticsearch.xpack.application.analytics.event.parser.field.P
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SessionAnalyticsEventField.SESSION_FIELD;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.UserAnalyticsEventField.USER_FIELD;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class PageViewAnalyticsEvent {
     private static final ObjectParser<AnalyticsEvent.Builder, AnalyticsEvent.Context> PARSER = ObjectParser.fromBuilder(
         "page_view_event",

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/event/SearchAnalyticsEvent.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/event/SearchAnalyticsEvent.java
@@ -20,6 +20,10 @@ import static org.elasticsearch.xpack.application.analytics.event.parser.field.S
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SessionAnalyticsEventField.SESSION_FIELD;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.UserAnalyticsEventField.USER_FIELD;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class SearchAnalyticsEvent {
     private static final ObjectParser<AnalyticsEvent.Builder, AnalyticsEvent.Context> PARSER = ObjectParser.fromBuilder(
         "search_event",

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/event/SearchClickAnalyticsEvent.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/event/SearchClickAnalyticsEvent.java
@@ -24,6 +24,10 @@ import static org.elasticsearch.xpack.application.analytics.event.parser.field.S
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SessionAnalyticsEventField.SESSION_FIELD;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.UserAnalyticsEventField.USER_FIELD;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class SearchClickAnalyticsEvent {
 
     private static final ObjectParser<AnalyticsEvent.Builder, AnalyticsEvent.Context> PARSER = ObjectParser.fromBuilder(

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/DocumentAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/DocumentAnalyticsEventField.java
@@ -18,6 +18,10 @@ import java.util.Map;
 
 import static org.elasticsearch.common.Strings.requireNonBlank;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class DocumentAnalyticsEventField {
 
     public static final ParseField DOCUMENT_FIELD = new ParseField("document");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/PageAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/PageAnalyticsEventField.java
@@ -16,6 +16,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class PageAnalyticsEventField {
     public static final ParseField PAGE_FIELD = new ParseField("page");
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/PaginationAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/PaginationAnalyticsEventField.java
@@ -17,6 +17,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class PaginationAnalyticsEventField {
 
     public static final ParseField PAGINATION_FIELD = new ParseField("page");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchAnalyticsEventField.java
@@ -20,6 +20,10 @@ import static org.elasticsearch.xpack.application.analytics.event.parser.field.P
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SearchFiltersAnalyticsEventField.SEARCH_FILTERS_FIELD;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SortOrderAnalyticsEventField.SORT_FIELD;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class SearchAnalyticsEventField {
     public static final ParseField SEARCH_FIELD = new ParseField("search");
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchFiltersAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchFiltersAnalyticsEventField.java
@@ -18,6 +18,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class SearchFiltersAnalyticsEventField {
     public static final ParseField SEARCH_FILTERS_FIELD = new ParseField("filters");
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchResultAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchResultAnalyticsEventField.java
@@ -19,6 +19,10 @@ import java.util.Map;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.DocumentAnalyticsEventField.DOCUMENT_FIELD;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.PageAnalyticsEventField.PAGE_FIELD;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class SearchResultAnalyticsEventField {
     public static final ParseField SEARCH_RESULTS_TOTAL_FIELD = new ParseField("total_results");
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SessionAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SessionAnalyticsEventField.java
@@ -20,6 +20,10 @@ import java.util.Map;
 
 import static org.elasticsearch.common.Strings.requireNonBlank;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class SessionAnalyticsEventField {
     public static final ParseField SESSION_FIELD = new ParseField("session");
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SortOrderAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SortOrderAnalyticsEventField.java
@@ -18,6 +18,10 @@ import java.util.Map;
 
 import static org.elasticsearch.common.Strings.requireNonBlank;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class SortOrderAnalyticsEventField {
 
     public static final ParseField SORT_FIELD = new ParseField("sort");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/UserAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/UserAnalyticsEventField.java
@@ -19,6 +19,10 @@ import java.util.Map;
 
 import static org.elasticsearch.common.Strings.requireNonBlank;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class UserAnalyticsEventField {
     public static final ParseField USER_FIELD = new ParseField("user");
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventEmitter.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventEmitter.java
@@ -34,6 +34,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 
+/**
+ * @deprecated in 9.0
+ */
+@Deprecated
 public class AnalyticsEventEmitter extends AbstractLifecycleComponent {
 
     private static final Logger logger = LogManager.getLogger(AnalyticsEventEmitter.class);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventIngestConfig.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventIngestConfig.java
@@ -20,7 +20,9 @@ import org.elasticsearch.injection.guice.Inject;
  *  - flush_delay: the maximum delay between two flushes (default: 10s.)
  *  - max_events_per_bulk: the maximum number of events that can be added to the bulk before flushing the bulk (default: 1000)
  *  - max_number_of_retries: the maximum number of retries when bulk execution fails (default: 3)
+ * @deprecated in 9.0
  */
+@Deprecated
 public class AnalyticsEventIngestConfig {
     private static final String SETTING_ROOT_PATH = "xpack.applications.behavioral_analytics.ingest";
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/BulkProcessorFactory.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/BulkProcessorFactory.java
@@ -26,7 +26,9 @@ import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 
 /**
  * Event ingest is done through a {@link BulkProcessor2}. This class is responsible for instantiating the bulk processor.
+ * @deprecated in 9.0
  */
+@Deprecated
 public class BulkProcessorFactory {
     private static final Logger logger = LogManager.getLogger(AnalyticsEventEmitter.class);
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Deprecate Behavioral Analytics CRUD apis (#122960)