### PR TITLE
[8.17] Use ordered maps for PipelineConfiguration xcontent deserialization (#123403)

### DIFF
--- a/docs/changelog/123403.yaml
+++ b/docs/changelog/123403.yaml
@@ -1,0 +1,5 @@
+pr: 123403
+summary: Use ordered maps for `PipelineConfiguration` xcontent deserialization
+area: Ingest Node
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -46,7 +46,7 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
     static {
         PARSER.declareString(Builder::setId, new ParseField("id"));
         PARSER.declareField(
-            (parser, builder, aVoid) -> builder.setConfig(parser.map()),
+            (parser, builder, aVoid) -> builder.setConfig(parser.mapOrdered()),
             new ParseField("config"),
             ObjectParser.ValueType.OBJECT
         );


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Use ordered maps for PipelineConfiguration xcontent deserialization (#123403)