### PR TITLE
Grant Lucene expressions module create classloader entitlement

### DIFF
--- a/modules/lang-expression/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/lang-expression/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,2 +1,2 @@
-org.elasticsearch.script.expression:
+org.apache.lucene.expressions:
   - create_class_loader


### PR DESCRIPTION
Expressions create a classloader within Lucene, not the Elasticsearch module. This commit fixes the policy to grant the entitlement to the Lucene module.