### PR TITLE
[8.x] Grant Lucene expressions module create classloader entitlement (#123424)

### DIFF
--- a/modules/lang-expression/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/lang-expression/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,2 +1,2 @@
-org.elasticsearch.script.expression:
+org.apache.lucene.expressions:
   - create_class_loader


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Grant Lucene expressions module create classloader entitlement (#123424)