### PR TITLE
[8.x] Use mock block factory in breaker tests (#122965)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactoryProvider.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactoryProvider.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+public record BlockFactoryProvider(BlockFactory blockFactory) {
+
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlAsyncGetResultsAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlAsyncGetResultsAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BlockFactoryProvider;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -44,7 +45,7 @@ public class TransportEsqlAsyncGetResultsAction extends AbstractTransportQlAsync
         Client client,
         ThreadPool threadPool,
         BigArrays bigArrays,
-        BlockFactory blockFactory
+        BlockFactoryProvider blockFactoryProvider
     ) {
         super(
             EsqlAsyncGetResultAction.NAME,
@@ -57,7 +58,7 @@ public class TransportEsqlAsyncGetResultsAction extends AbstractTransportQlAsync
             bigArrays,
             EsqlQueryTask.class
         );
-        this.blockFactory = blockFactory;
+        this.blockFactory = blockFactoryProvider.blockFactory();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlAsyncStopAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlAsyncStopAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BlockFactoryProvider;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
@@ -64,13 +65,13 @@ public class TransportEsqlAsyncStopAction extends HandledTransportAction<AsyncSt
         TransportEsqlAsyncGetResultsAction getResultsAction,
         Client client,
         ExchangeService exchangeService,
-        BlockFactory blockFactory
+        BlockFactoryProvider blockFactoryProvider
     ) {
         super(EsqlAsyncStopAction.NAME, transportService, actionFilters, AsyncStopRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.queryAction = queryAction;
         this.getResultsAction = getResultsAction;
         this.exchangeService = exchangeService;
-        this.blockFactory = blockFactory;
+        this.blockFactory = blockFactoryProvider.blockFactory();
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.security = new AsyncSearchSecurity(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -20,7 +20,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BlockFactoryProvider;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.injection.guice.Inject;
@@ -92,7 +92,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
         ClusterService clusterService,
         ThreadPool threadPool,
         BigArrays bigArrays,
-        BlockFactory blockFactory,
+        BlockFactoryProvider blockFactoryProvider,
         Client client,
         NamedWriteableRegistry registry,
         IndexNameExpressionResolver indexNameExpressionResolver,
@@ -114,14 +114,14 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             lookupLookupShardContextFactory,
             transportService,
             bigArrays,
-            blockFactory
+            blockFactoryProvider.blockFactory()
         );
         this.lookupFromIndexService = new LookupFromIndexService(
             clusterService,
             lookupLookupShardContextFactory,
             transportService,
             bigArrays,
-            blockFactory
+            blockFactoryProvider.blockFactory()
         );
         this.computeService = new ComputeService(
             searchService,
@@ -132,7 +132,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             clusterService,
             threadPool,
             bigArrays,
-            blockFactory
+            blockFactoryProvider.blockFactory()
         );
         this.asyncTaskManagementService = new AsyncTaskManagementService<>(
             XPackPlugin.ASYNC_RESULTS_INDEX,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Use mock block factory in breaker tests (#122965)](https://github.com/elastic/elasticsearch/pull/122965)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)