### PR TITLE
[DOCS] Fix bbq memory size estimate

### DIFF
--- a/docs/reference/how-to/knn-search.asciidoc
+++ b/docs/reference/how-to/knn-search.asciidoc
@@ -76,7 +76,7 @@ Here are estimates for different element types and quantization levels:
 * `element_type: float`: `num_vectors * num_dimensions * 4`
 * `element_type: float` with `quantization: int8`: `num_vectors * (num_dimensions + 4)`
 * `element_type: float` with `quantization: int4`: `num_vectors * (num_dimensions/2 + 4)`
-* `element_type: float` with `quantization: bbq`: `num_vectors * (num_dimensions/8 + 12)`
+* `element_type: float` with `quantization: bbq`: `num_vectors * (num_dimensions/8 + 14)`
 * `element_type: byte`: `num_vectors * num_dimensions`
 * `element_type: bit`: `num_vectors * (num_dimensions/8)`
 


### PR DESCRIPTION
If I understand correctly, the memory size of bbq is num_vectors * (num_dimensions/8 + 14)

14 bits consisting of 3 floats and a short value.