### PR TITLE
[TEST] Remove flaky checks on snapshot shard stats

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -161,9 +161,6 @@ tests:
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldSourceOnlyRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/120080
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=snapshot/10_basic/Failed to snapshot indices with synthetic source}
-  issue: https://github.com/elastic/elasticsearch/issues/120332
 - class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
   method: testCleanShardFollowTaskAfterDeleteFollower
   issue: https://github.com/elastic/elasticsearch/issues/120339

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -117,8 +117,6 @@ setup:
 
   - match: { snapshot.snapshot: test_snapshot_2 }
   - match: { snapshot.state : PARTIAL }
-  - match: { snapshot.shards.successful: 0 }
-  - match: { snapshot.shards.failed : 1 }
   - match: { snapshot.failures.0.index: "test_synthetic" }
   - match: { snapshot.failures.0.reason : "IllegalStateException[Can't snapshot _source only on an index that has incomplete source ie. has _source disabled or filters the source]" }
   - is_true: snapshot.version
@@ -134,8 +132,6 @@ setup:
 
   - match: { snapshot.snapshot: test_snapshot_3 }
   - match: { snapshot.state : PARTIAL }
-  - match: { snapshot.shards.successful: 1 }
-  - match: { snapshot.shards.failed : 1 }
   - match: { snapshot.failures.0.index: "test_synthetic" }
   - match: { snapshot.failures.0.reason: "IllegalStateException[Can't snapshot _source only on an index that has incomplete source ie. has _source disabled or filters the source]" }
   - is_true: snapshot.version

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -113,10 +113,15 @@ setup:
         snapshot: test_snapshot_2
         wait_for_completion: true
         body: |
-          { "indices": "test_synthetic" }
+          { 
+            "indices": "test_synthetic",
+            "include_global_state": false
+          }
 
   - match: { snapshot.snapshot: test_snapshot_2 }
   - match: { snapshot.state : PARTIAL }
+  - match: { snapshot.shards.successful: 0 }
+  - match: { snapshot.shards.failed : 1 }
   - match: { snapshot.failures.0.index: "test_synthetic" }
   - match: { snapshot.failures.0.reason : "IllegalStateException[Can't snapshot _source only on an index that has incomplete source ie. has _source disabled or filters the source]" }
   - is_true: snapshot.version
@@ -128,10 +133,15 @@ setup:
         snapshot: test_snapshot_3
         wait_for_completion: true
         body: |
-          { "indices": "test_*" }
+          { 
+            "indices": "test_*",
+            "include_global_state": false
+          }
 
   - match: { snapshot.snapshot: test_snapshot_3 }
   - match: { snapshot.state : PARTIAL }
+  - match: { snapshot.shards.successful: 1 }
+  - match: { snapshot.shards.failed : 1 }
   - match: { snapshot.failures.0.index: "test_synthetic" }
   - match: { snapshot.failures.0.reason: "IllegalStateException[Can't snapshot _source only on an index that has incomplete source ie. has _source disabled or filters the source]" }
   - is_true: snapshot.version


### PR DESCRIPTION
Snapshot shard statistics seem to pick up unrelated files, leading to flakiness.

Fixes #120332