### PR TITLE
[9.0] Skip security manager hack test on jdk 24+ (#122070)

### DIFF
--- a/server/src/test/java/org/elasticsearch/bootstrap/NoSecurityManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/NoSecurityManagerTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.bootstrap;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.elasticsearch.jdk.RuntimeVersionFeature;
 import org.elasticsearch.test.GraalVMThreadsFilter;
 
 import static org.hamcrest.Matchers.is;
@@ -20,6 +21,7 @@ import static org.hamcrest.Matchers.is;
 public class NoSecurityManagerTests extends LuceneTestCase {
 
     public void testPrepopulateSecurityCaller() {
+        assumeTrue("security manager must be available", RuntimeVersionFeature.isSecurityManagerAvailable());
         assumeTrue("Unexpected security manager:" + System.getSecurityManager(), System.getSecurityManager() == null);
         boolean isAtLeastJava17 = Runtime.version().feature() >= 17;
         boolean isPrepopulated = Security.prepopulateSecurityCaller();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Skip security manager hack test on jdk 24+ (#122070)](https://github.com/elastic/elasticsearch/pull/122070)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)