### PR TITLE
[8.18] Test-fix testAcceptsMismatchedServerlessBuildHash #121869 (#122332)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -84,7 +84,7 @@ public class TransportService extends AbstractLifecycleComponent
     /**
      * A feature flag enabling transport upgrades for serverless.
      */
-    private static final String SERVERLESS_TRANSPORT_SYSTEM_PROPERTY = "es.serverless_transport";
+    static final String SERVERLESS_TRANSPORT_SYSTEM_PROPERTY = "es.serverless_transport";
     private static final boolean SERVERLESS_TRANSPORT_FEATURE_FLAG = Booleans.parseBoolean(
         System.getProperty(SERVERLESS_TRANSPORT_SYSTEM_PROPERTY),
         false

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -377,7 +377,8 @@ public class TransportServiceHandshakeTests extends ESTestCase {
     public void testAcceptsMismatchedServerlessBuildHash() {
         assumeTrue("Current build needs to be a snapshot", Build.current().isSnapshot());
         assumeTrue("Security manager needs to be disabled", System.getSecurityManager() == null);
-        System.setProperty("es.serverless", Boolean.TRUE.toString());   // security manager blocks this
+        System.setProperty(TransportService.SERVERLESS_TRANSPORT_SYSTEM_PROPERTY, Boolean.TRUE.toString());   // security manager blocks
+                                                                                                              // this
         try {
             final DisruptingTransportInterceptor transportInterceptorA = new DisruptingTransportInterceptor();
             final DisruptingTransportInterceptor transportInterceptorB = new DisruptingTransportInterceptor();
@@ -404,7 +405,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             AbstractSimpleTransportTestCase.connectToNode(transportServiceA, transportServiceB.getLocalNode(), TestProfiles.LIGHT_PROFILE);
             assertTrue(transportServiceA.nodeConnected(transportServiceB.getLocalNode()));
         } finally {
-            System.clearProperty("es.serverless");
+            System.clearProperty(TransportService.SERVERLESS_TRANSPORT_SYSTEM_PROPERTY);
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Test-fix testAcceptsMismatchedServerlessBuildHash #121869 (#122332)](https://github.com/elastic/elasticsearch/pull/122332)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)