### PR TITLE
[8.x] [TEST] Remove flaky checks on snapshot shard stats (#123458)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -462,6 +462,4 @@ tests:
 - class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
   method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
   issue: https://github.com/elastic/elasticsearch/issues/121625
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=snapshot/10_basic/Failed to snapshot indices with synthetic source}
-  issue: https://github.com/elastic/elasticsearch/issues/120332
+

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -115,7 +115,10 @@ setup:
         snapshot: test_snapshot_2
         wait_for_completion: true
         body: |
-          { "indices": "test_synthetic" }
+          { 
+            "indices": "test_synthetic",
+            "include_global_state": false
+          }
 
   - match: { snapshot.snapshot: test_snapshot_2 }
   - match: { snapshot.state : PARTIAL }
@@ -132,7 +135,10 @@ setup:
         snapshot: test_snapshot_3
         wait_for_completion: true
         body: |
-          { "indices": "test_*" }
+          { 
+            "indices": "test_*",
+            "include_global_state": false
+          }
 
   - match: { snapshot.snapshot: test_snapshot_3 }
   - match: { snapshot.state : PARTIAL }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[TEST] Remove flaky checks on snapshot shard stats (#123458)](https://github.com/elastic/elasticsearch/pull/123458)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)