### PR TITLE
[Test] Add test for AWS SDKv1 swallowing exception at IndexputStream close time

### DIFF
--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -426,36 +426,36 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
             } else if ("PUT".equals(requestComponents.method())
                 && requestComponents.query().contains("uploadId=TEST")
                 && requestComponents.query().contains("partNumber=")) {
-                // upload part request
-                MD5DigestCalculatingInputStream md5 = new MD5DigestCalculatingInputStream(exchange.getRequestBody());
-                BytesReference bytes = Streams.readFully(md5);
-                assertThat((long) bytes.length(), anyOf(equalTo(lastPartSize), equalTo(bufferSize.getBytes())));
-                assertThat(contentLength, anyOf(equalTo(lastPartSize), equalTo(bufferSize.getBytes())));
+                    // upload part request
+                    MD5DigestCalculatingInputStream md5 = new MD5DigestCalculatingInputStream(exchange.getRequestBody());
+                    BytesReference bytes = Streams.readFully(md5);
+                    assertThat((long) bytes.length(), anyOf(equalTo(lastPartSize), equalTo(bufferSize.getBytes())));
+                    assertThat(contentLength, anyOf(equalTo(lastPartSize), equalTo(bufferSize.getBytes())));
 
-                if (countDownUploads.decrementAndGet() % 2 == 0) {
-                    exchange.getResponseHeaders().add("ETag", Base16.encodeAsString(md5.getMd5Digest()));
-                    exchange.sendResponseHeaders(HttpStatus.SC_OK, -1);
-                    exchange.close();
-                    return;
-                }
+                    if (countDownUploads.decrementAndGet() % 2 == 0) {
+                        exchange.getResponseHeaders().add("ETag", Base16.encodeAsString(md5.getMd5Digest()));
+                        exchange.sendResponseHeaders(HttpStatus.SC_OK, -1);
+                        exchange.close();
+                        return;
+                    }
 
-            } else if ("POST".equals(requestComponents.method()) && requestComponents.query().equals("uploadId=TEST")) {
-                // complete multipart upload request
-                if (countDownComplete.countDown()) {
-                    Streams.readFully(exchange.getRequestBody());
-                    byte[] response = ("""
+                } else if ("POST".equals(requestComponents.method()) && requestComponents.query().equals("uploadId=TEST")) {
+                    // complete multipart upload request
+                    if (countDownComplete.countDown()) {
+                        Streams.readFully(exchange.getRequestBody());
+                        byte[] response = ("""
                             <?xml version="1.0" encoding="UTF-8"?>
                             <CompleteMultipartUploadResult>
                               <Bucket>bucket</Bucket>
                               <Key>write_large_blob</Key>
                             </CompleteMultipartUploadResult>""").getBytes(StandardCharsets.UTF_8);
-                    exchange.getResponseHeaders().add("Content-Type", "application/xml");
-                    exchange.sendResponseHeaders(HttpStatus.SC_OK, response.length);
-                    exchange.getResponseBody().write(response);
-                    exchange.close();
-                    return;
+                        exchange.getResponseHeaders().add("Content-Type", "application/xml");
+                        exchange.sendResponseHeaders(HttpStatus.SC_OK, response.length);
+                        exchange.getResponseBody().write(response);
+                        exchange.close();
+                        return;
+                    }
                 }
-            }
 
             // sends an error back or let the request time out
             if (useTimeout == false) {
@@ -528,35 +528,35 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
             } else if ("PUT".equals(requestComponents.method())
                 && requestComponents.query().contains("uploadId=TEST")
                 && requestComponents.query().contains("partNumber=")) {
-                // upload part request
-                MD5DigestCalculatingInputStream md5 = new MD5DigestCalculatingInputStream(exchange.getRequestBody());
-                BytesReference bytes = Streams.readFully(md5);
+                    // upload part request
+                    MD5DigestCalculatingInputStream md5 = new MD5DigestCalculatingInputStream(exchange.getRequestBody());
+                    BytesReference bytes = Streams.readFully(md5);
 
-                if (counterUploads.incrementAndGet() % 2 == 0) {
-                    bytesReceived.addAndGet(bytes.length());
-                    exchange.getResponseHeaders().add("ETag", Base16.encodeAsString(md5.getMd5Digest()));
-                    exchange.sendResponseHeaders(HttpStatus.SC_OK, -1);
-                    exchange.close();
-                    return;
-                }
+                    if (counterUploads.incrementAndGet() % 2 == 0) {
+                        bytesReceived.addAndGet(bytes.length());
+                        exchange.getResponseHeaders().add("ETag", Base16.encodeAsString(md5.getMd5Digest()));
+                        exchange.sendResponseHeaders(HttpStatus.SC_OK, -1);
+                        exchange.close();
+                        return;
+                    }
 
-            } else if ("POST".equals(requestComponents.method()) && requestComponents.query().equals("uploadId=TEST")) {
-                // complete multipart upload request
-                if (countDownComplete.countDown()) {
-                    Streams.readFully(exchange.getRequestBody());
-                    byte[] response = ("""
+                } else if ("POST".equals(requestComponents.method()) && requestComponents.query().equals("uploadId=TEST")) {
+                    // complete multipart upload request
+                    if (countDownComplete.countDown()) {
+                        Streams.readFully(exchange.getRequestBody());
+                        byte[] response = ("""
                             <?xml version="1.0" encoding="UTF-8"?>
                             <CompleteMultipartUploadResult>
                               <Bucket>bucket</Bucket>
                               <Key>write_large_blob_streaming</Key>
                             </CompleteMultipartUploadResult>""").getBytes(StandardCharsets.UTF_8);
-                    exchange.getResponseHeaders().add("Content-Type", "application/xml");
-                    exchange.sendResponseHeaders(HttpStatus.SC_OK, response.length);
-                    exchange.getResponseBody().write(response);
-                    exchange.close();
-                    return;
+                        exchange.getResponseHeaders().add("Content-Type", "application/xml");
+                        exchange.sendResponseHeaders(HttpStatus.SC_OK, response.length);
+                        exchange.getResponseBody().write(response);
+                        exchange.close();
+                        return;
+                    }
                 }
-            }
 
             // sends an error back or let the request time out
             if (useTimeout == false) {


### PR DESCRIPTION
This pull request adds a unit test to demonstrate a specific behavior of the AWS SDKv1, which closes the `InputStream` used to upload a blob only after the HTTP request has been sent (this is to accomodate for retries). The SDK then swallows any exception thrown when closing the `InputStream` which has the effect to hide any potential CorruptIndexException that could have been detected at that time.

Relates ES-10931