### PR TITLE
[9.0] Skip selected tests in SSLErrorMessageFileTests that rely on SecurityManager to block access to resources. (#123484)

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.jdk.RuntimeVersionFeature;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.junit.Before;
@@ -362,6 +363,11 @@ public class SSLErrorMessageFileTests extends ESTestCase {
         String configKey,
         BiConsumer<String, Settings.Builder> configure
     ) throws Exception {
+        assumeTrue(
+            "Requires Security Manager to block access, entitlements are not checked for unit tests",
+            RuntimeVersionFeature.isSecurityManagerAvailable()
+        );
+
         final String prefix = randomSslPrefix();
         final Settings.Builder settings = Settings.builder();
         configure.accept(prefix, settings);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Skip selected tests in SSLErrorMessageFileTests that rely on SecurityManager to block access to resources. (#123484)](https://github.com/elastic/elasticsearch/pull/123484)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)