### PR TITLE
[8.18] Skip selected tests in SSLErrorMessageFileTests that rely on SecurityManager to block access to resources. (#123484)

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.jdk.RuntimeVersionFeature;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.junit.Before;
@@ -362,6 +363,11 @@ public class SSLErrorMessageFileTests extends ESTestCase {
         String configKey,
         BiConsumer<String, Settings.Builder> configure
     ) throws Exception {
+        assumeTrue(
+            "Requires Security Manager to block access, entitlements are not checked for unit tests",
+            RuntimeVersionFeature.isSecurityManagerAvailable()
+        );
+
         final String prefix = randomSslPrefix();
         final Settings.Builder settings = Settings.builder();
         configure.accept(prefix, settings);


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Skip selected tests in SSLErrorMessageFileTests that rely on SecurityManager to block access to resources. (#123484)