### PR TITLE
[8.17] ESQL: Reduce iteration complexity for plan traversal (#123427)

### DIFF
--- a/docs/changelog/123427.yaml
+++ b/docs/changelog/123427.yaml
@@ -1,0 +1,5 @@
+pr: 123427
+summary: Reduce iteration complexity for plan traversal
+area: ES|QL
+type: bug
+issues: []


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [ESQL: Reduce iteration complexity for plan traversal (#123427)](https://github.com/elastic/elasticsearch/pull/123427)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)