### PR TITLE
[8.x] Add forwards compatibility testing (#123436)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.fwc-test.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.fwc-test.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+
+def fwcVersions = buildParams.bwcVersions.released.findAll { it.major == VersionProperties.elasticsearchVersion.major &&  it.minor == VersionProperties.elasticsearchVersion.minor }
+def previousMinorSnapshot = buildParams.bwcVersions.unreleased.find { it.major == VersionProperties.elasticsearchVersion.major && it.minor == VersionProperties.elasticsearchVersion.minor - 1 }
+
+fwcVersions.each { fwcVersion ->
+  tasks.register("v${fwcVersion}#fwcTest", StandaloneRestIntegTestTask) {
+    usesBwcDistribution(previousMinorSnapshot)
+    usesBwcDistribution(fwcVersion)
+    systemProperty("tests.old_cluster_version", previousMinorSnapshot)
+    systemProperty("tests.new_cluster_version", fwcVersion)
+    nonInputProperties.systemProperty 'tests.fwc', 'true'
+  }
+}
+
+gradle.taskGraph.whenReady { graph ->
+  if (graph.allTasks.any { it.name.endsWith('#fwcTest') } && Boolean.parseBoolean(System.getProperty("tests.bwc.snapshot", "true"))) {
+    throw new GradleException("Running forward compatibility tests requires passing `-Dtests.bwc.snapshot=false`.")
+  }
+
+  if (graph.allTasks.any { it.name.endsWith('#fwcTest') } && graph.allTasks.any { it.name.endsWith('#bwcTest') }) {
+    throw new GradleException("Backward compatibility and forward compatibility tests cannot be executed in the same build.")
+  }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -138,7 +138,14 @@ public class BwcSetupExtension {
                 loggedExec.args("-DisCI");
             }
 
-            loggedExec.args("-Dbuild.snapshot=true", "-Dscan.tag.NESTED");
+            loggedExec.args("-Dscan.tag.NESTED");
+
+            if (System.getProperty("tests.bwc.snapshot", "true").equals("false")) {
+                loggedExec.args("-Dbuild.snapshot=false", "-Dlicense.key=x-pack/plugin/core/snapshot.key");
+            } else {
+                loggedExec.args("-Dbuild.snapshot=true");
+            }
+
             final LogLevel logLevel = project.getGradle().getStartParameter().getLogLevel();
             List<LogLevel> nonDefaultLogLevels = Arrays.asList(LogLevel.QUIET, LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG);
             if (nonDefaultLogLevels.contains(logLevel)) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -336,8 +336,9 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         String bwcTaskName = buildBwcTaskName(projectName);
         bwcSetupExtension.bwcTask(bwcTaskName, c -> {
             boolean useNativeExpanded = projectArtifact.expandedDistDir != null;
+            boolean isReleaseBuild = System.getProperty("tests.bwc.snapshot", "true").equals("false");
             File expectedOutputFile = useNativeExpanded
-                ? new File(projectArtifact.expandedDistDir, "elasticsearch-" + bwcVersion.get() + "-SNAPSHOT")
+                ? new File(projectArtifact.expandedDistDir, "elasticsearch-" + bwcVersion.get() + (isReleaseBuild ? "" : "-SNAPSHOT"))
                 : projectArtifact.distFile;
             c.getInputs().file(new File(project.getBuildDir(), "refspec"));
             if (useNativeExpanded) {

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -13,6 +13,7 @@ import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact-base'
 apply plugin: 'elasticsearch.bwc-test'
+apply plugin: 'elasticsearch.fwc-test'
 
 testArtifacts {
   registerTestArtifactFromSourceSet(sourceSets.javaRestTest)

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FeatureUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FeatureUpgradeIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.admin.cluster.migration.TransportGetFeatureUpgra
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.test.XContentTestUtils;
+import org.junit.BeforeClass;
 
 import java.util.Collections;
 import java.util.List;
@@ -28,6 +29,11 @@ public class FeatureUpgradeIT extends AbstractRollingUpgradeTestCase {
 
     public FeatureUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @BeforeClass
+    public static void ensureNotForwardCompatTest() {
+        assumeFalse("Only supported by bwc tests", Boolean.parseBoolean(System.getProperty("tests.fwc", "false")));
     }
 
     public void testGetFeatureUpgradeStatus() throws Exception {

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedRollingUpgradeTestCase.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedRollingUpgradeTestCase.java
@@ -103,8 +103,12 @@ public abstract class ParameterizedRollingUpgradeTestCase extends ESRestTestCase
             for (int n = 0; n < requestedUpgradedNodes; n++) {
                 if (upgradedNodes.add(n)) {
                     try {
-                        logger.info("Upgrading node {} to version {}", n, Version.CURRENT);
-                        getUpgradeCluster().upgradeNodeToVersion(n, Version.CURRENT);
+                        Version upgradeVersion = System.getProperty("tests.new_cluster_version") == null
+                            ? Version.CURRENT
+                            : Version.fromString(System.getProperty("tests.new_cluster_version"));
+
+                        logger.info("Upgrading node {} to version {}", n, upgradeVersion);
+                        getUpgradeCluster().upgradeNodeToVersion(n, upgradeVersion);
                     } catch (Exception e) {
                         upgradeFailed = true;
                         throw e;

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSystemPropertyProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSystemPropertyProvider.java
@@ -11,13 +11,21 @@ package org.elasticsearch.test.cluster.local;
 
 import org.elasticsearch.test.cluster.SystemPropertyProvider;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-
-import static java.util.Map.entry;
 
 public class DefaultSystemPropertyProvider implements SystemPropertyProvider {
     @Override
     public Map<String, String> get(LocalClusterSpec.LocalNodeSpec nodeSpec) {
-        return Map.ofEntries(entry("ingest.geoip.downloader.enabled.default", "false"), entry("tests.testfeatures.enabled", "true"));
+        Map<String, String> properties = new HashMap<>();
+        properties.put("ingest.geoip.downloader.enabled.default", "false");
+
+        // enable test features unless we are running forwards compatibility tests
+        if (Boolean.parseBoolean(System.getProperty("tests.fwc", "false")) == false) {
+            properties.put("tests.testfeatures.enabled", "true");
+        }
+
+        return Collections.unmodifiableMap(properties);
     }
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/distribution/SnapshotDistributionResolver.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/distribution/SnapshotDistributionResolver.java
@@ -36,9 +36,9 @@ public class SnapshotDistributionResolver implements DistributionResolver {
                     "Cannot locate Elasticsearch distribution. Directory at '" + distributionDir + "' does not exist."
                 );
             }
-
-            // Snapshot distributions are never release builds and always use the default distribution
-            return new DefaultDistributionDescriptor(version, true, distributionDir, DistributionType.DEFAULT);
+            
+            boolean isSnapshot = System.getProperty("tests.bwc.snapshot", "true").equals("false") == false;
+            return new DefaultDistributionDescriptor(version, isSnapshot, distributionDir, DistributionType.DEFAULT);
         }
 
         return delegate.resolve(version, type);

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/distribution/SnapshotDistributionResolver.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/distribution/SnapshotDistributionResolver.java
@@ -36,7 +36,7 @@ public class SnapshotDistributionResolver implements DistributionResolver {
                     "Cannot locate Elasticsearch distribution. Directory at '" + distributionDir + "' does not exist."
                 );
             }
-            
+
             boolean isSnapshot = System.getProperty("tests.bwc.snapshot", "true").equals("false") == false;
             return new DefaultDistributionDescriptor(version, isSnapshot, distributionDir, DistributionType.DEFAULT);
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add forwards compatibility testing (#123436)](https://github.com/elastic/elasticsearch/pull/123436)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)