### PR TITLE
[8.18] Add fips attribute to .fleet-agents docs (#123406)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -102,6 +102,9 @@
                     "unprivileged": {
                       "type": "boolean"
                     },
+                    "fips": {
+                      "type": "boolean"
+                    },
                     "version": {
                       "type": "text",
                       "fields": {


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Add fips attribute to .fleet-agents docs (#123406)