### PR TITLE
[IDEA] Enable Gradle Configuration Cache for Gradle Test Runner

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -133,7 +133,7 @@ develocity {
         }
       } else {
         tag 'LOCAL'
-        if(providers.systemProperty('idea.active').present) {
+        if (providers.systemProperty('idea.active').present) {
           tag 'IDEA'
         }
       }

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -133,6 +133,9 @@ develocity {
         }
       } else {
         tag 'LOCAL'
+        if(providers.systemProperty('idea.active').present) {
+          tag 'IDEA'
+        }
       }
     }
   }

--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -174,7 +174,7 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
 
   // this path is produced by the extractLibs task above
   String testLibraryPath = TestUtil.getTestLibraryPath("${elasticsearchProject.left()}/libs/native/libraries/build/platform")
-
+  def enableIdeaCC = providers.gradleProperty("org.elasticsearch.idea-configuration-cache").getOrElse("true").toBoolean()
   idea {
     project {
       vcs = 'Git'
@@ -201,6 +201,13 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
           javac {
             generateDeprecationWarnings = false
             preferTargetJDKCompiler = false
+          }
+        }
+        runConfigurations {
+          defaults(org.jetbrains.gradle.ext.Gradle) {
+            scriptParameters = enableIdeaCC ? [
+              '--configuration-cache'
+            ].join(' ') : ''
           }
         }
         runConfigurations {

--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -209,8 +209,6 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
               '--configuration-cache'
             ].join(' ') : ''
           }
-        }
-        runConfigurations {
           defaults(JUnit) {
             vmParameters = [
               '-ea',

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ org.gradle.dependency.verification.console=verbose
 
 # allow user to specify toolchain via the RUNTIME_JAVA_HOME environment variable
 org.gradle.java.installations.fromEnv=RUNTIME_JAVA_HOME
+
+# if configuration cache enabled then enable parallel support too
+org.gradle.configuration-cache.parallel=true


### PR DESCRIPTION
To speed up repetitives test runs relying on the Idea Gradle Runner for the majority of tests in our codebase.
We added a flag to disable it explicitly if it does not work for certain scenarios.

This can be locally set to false by adding `org.elasticsearch.idea-configuration-cache=false` in `~/.gradle/gradle.properties`