### PR TITLE
Fix server entitlements for fips

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -242,7 +242,14 @@ public class EntitlementInitialization {
         if (trustStorePath != null) {
             Collections.addAll(
                 serverScopes,
-                new Scope("org.bouncycastle.fips.tls", List.of(new FilesEntitlement(List.of(FileData.ofPath(trustStorePath, READ))))),
+                new Scope(
+                    "org.bouncycastle.fips.tls",
+                    List.of(
+                        new FilesEntitlement(List.of(FileData.ofPath(trustStorePath, READ))),
+                        new ManageThreadsEntitlement(),
+                        new OutboundNetworkEntitlement()
+                    )
+                ),
                 new Scope(
                     "org.bouncycastle.fips.core",
                     // read to lib dir is required for checksum validation


### PR DESCRIPTION
Luckily this reproduced well:
```
./gradlew ":x-pack:plugin:ml:qa:ml-with-security:yamlRestTest" --tests "org.elasticsearch.smoketest.MlWithSecurityIT.test {yaml=ml/3rd_party_deployment/Test start deployment fails while model download in progress}" -Dtests.seed=99F573B82F44BF3B -Dtests.locale=tg -Dtests.timezone=Asia/Kolkata -Druntime.java=23 -Dtests.fips.enabled=true
```