### PR TITLE
Use the correct id for the multi-project transport version

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -206,16 +206,7 @@ public class TransportVersions {
     public static final TransportVersion BYTE_SIZE_VALUE_ALWAYS_USES_BYTES = def(9_015_0_00);
     public static final TransportVersion ESQL_SERIALIZE_SOURCE_FUNCTIONS_WARNINGS = def(9_016_0_00);
     public static final TransportVersion ESQL_DRIVER_NODE_DESCRIPTION = def(9_017_0_00);
-
-    /*
-     * WARNING: DO NOT MERGE INTO MAIN!
-     * This is the transport version used for all multi-project changes.
-     * This is above any possible transport version that could exist on main during multi-project branch development.
-     * We don't care about BwC during initial development. Before this code is merged into main,
-     * this variable needs to be changed to a regular transport version following the same rules as above.
-     */
-    @FixForMultiProject
-    public static final TransportVersion MULTI_PROJECT = def(9_999_990);
+    public static final TransportVersion MULTI_PROJECT = def(9_018_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
The multi-project transport version needs to be sequential