### PR TITLE
Adjust error message in AbstractBlobContainerRetriesTestCase for Jdk 24

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -282,6 +282,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
             exception.getMessage().toLowerCase(Locale.ROOT),
             anyOf(
                 containsString("read timed out"),
+                containsString("premature eof"),
                 containsString("premature end of chunk coded message body: closing chunk expected"),
                 containsString("Read timed out"),
                 containsString("unexpected end of file from server")
@@ -351,6 +352,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
             exception.getMessage().toLowerCase(Locale.ROOT),
             anyOf(
                 // closing the connection after sending the headers and some incomplete body might yield one of these:
+                containsString("premature eof"),
                 containsString("premature end of chunk coded message body: closing chunk expected"),
                 containsString("premature end of content-length delimited message body"),
                 containsString("connection closed prematurely"),


### PR DESCRIPTION
The error message changed again for JDK 24, looks like this was the case for JDK 23 as well (see https://github.com/elastic/elasticsearch/pull/113609)

```
java.lang.AssertionError: 
Expected: (a string containing "premature end of chunk coded message body: closing chunk expected" or a string containing "premature end of content-length delimited message body" or a string containing "connection closed prematurely" or never matches) |  
but: was "premature eof"
```