### PR TITLE
[8.18] fix testReadBlobWithPrematureConnectionClose jdk24 (#122655)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -356,6 +356,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
                 containsString("premature end of chunk coded message body: closing chunk expected"),
                 containsString("premature end of content-length delimited message body"),
                 containsString("connection closed prematurely"),
+                containsString("premature eof"),
                 // if we didn't call exchange.getResponseBody().flush() then we might not even have sent the response headers:
                 alwaysFlushBody ? never() : containsString("the target server failed to respond")
             )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [fix testReadBlobWithPrematureConnectionClose jdk24 (#122655)](https://github.com/elastic/elasticsearch/pull/122655)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)