### PR TITLE
[Entitlements] Missing geoip policy

### DIFF
--- a/modules/ingest-geoip/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/ingest-geoip/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,4 +1,5 @@
 org.elasticsearch.ingest.geoip:
+  - outbound_network
   - files:
       - relative_path: "ingest-geoip"
         relative_to: config


### PR DESCRIPTION
Relates to ES-10031

Missing policy due to missing URLConnection checks, to be backfilled by https://github.com/elastic/elasticsearch/pull/123503 et. similar