### PR TITLE
Fix cluster and node name in driver

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -198,8 +198,8 @@ public class LocalExecutionPlanner {
             new DriverFactory(
                 new DriverSupplier(
                     taskDescription,
-                    Node.NODE_NAME_SETTING.get(settings),
                     ClusterName.CLUSTER_NAME_SETTING.get(settings).value(),
+                    Node.NODE_NAME_SETTING.get(settings),
                     context.bigArrays,
                     context.blockFactory,
                     physicalOperation,


### PR DESCRIPTION
Parameters were accidentally swapped. This change fixes that.