### PR TITLE
[9.0] [IDEA] Enable Gradle Configuration Cache for Gradle Test Runner (#123552)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -133,6 +133,9 @@ develocity {
         }
       } else {
         tag 'LOCAL'
+        if (providers.systemProperty('idea.active').present) {
+          tag 'IDEA'
+        }
       }
     }
   }

--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -174,7 +174,7 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
 
   // this path is produced by the extractLibs task above
   String testLibraryPath = TestUtil.getTestLibraryPath("${elasticsearchProject.left()}/libs/native/libraries/build/platform")
-
+  def enableIdeaCC = providers.gradleProperty("org.elasticsearch.idea-configuration-cache").getOrElse("true").toBoolean()
   idea {
     project {
       vcs = 'Git'
@@ -204,6 +204,11 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
           }
         }
         runConfigurations {
+          defaults(org.jetbrains.gradle.ext.Gradle) {
+            scriptParameters = enableIdeaCC ? [
+              '--configuration-cache'
+            ].join(' ') : ''
+          }
           defaults(JUnit) {
             vmParameters = [
               '-ea',

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ org.gradle.dependency.verification.console=verbose
 
 # allow user to specify toolchain via the RUNTIME_JAVA_HOME environment variable
 org.gradle.java.installations.fromEnv=RUNTIME_JAVA_HOME
+
+# if configuration cache enabled then enable parallel support too
+org.gradle.configuration-cache.parallel=true


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [IDEA] Enable Gradle Configuration Cache for Gradle Test Runner (#123552)