### PR TITLE
Fix the source of concurrency issues in script sorting

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
@@ -114,7 +114,9 @@ public class BytesRefFieldComparatorSource extends IndexFieldData.XFieldComparat
                         } else {
                             final BitSet rootDocs = nested.rootDocs(context);
                             final DocIdSetIterator innerDocs = nested.innerDocs(context);
-                            final int maxChildren = nested.getNestedSort() != null ? nested.getNestedSort().getMaxChildren() : Integer.MAX_VALUE;
+                            final int maxChildren = nested.getNestedSort() != null
+                                ? nested.getNestedSort().getMaxChildren()
+                                : Integer.MAX_VALUE;
                             selectedValues = sortMode.select(values, missingBytes, rootDocs, innerDocs, maxChildren);
                         }
                         return selectedValues;
@@ -122,7 +124,7 @@ public class BytesRefFieldComparatorSource extends IndexFieldData.XFieldComparat
 
                     @Override
                     public void setScorer(Scorable scorer) {
-                        BytesRefFieldComparatorSource.this.setScorer(context,  scorer);
+                        BytesRefFieldComparatorSource.this.setScorer(context, scorer);
                     }
                 };
             }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
@@ -71,7 +71,7 @@ public class DoubleValuesComparatorSource extends IndexFieldData.XFieldComparato
         }
     }
 
-    protected void setScorer(Scorable scorer) {}
+    protected void setScorer(LeafReaderContext context, Scorable scorer) {}
 
     @Override
     public FieldComparator<?> newComparator(String fieldname, int numHits, Pruning enableSkipping, boolean reversed) {
@@ -91,7 +91,7 @@ public class DoubleValuesComparatorSource extends IndexFieldData.XFieldComparato
 
                     @Override
                     public void setScorer(Scorable scorer) {
-                        DoubleValuesComparatorSource.this.setScorer(scorer);
+                        DoubleValuesComparatorSource.this.setScorer(context, scorer);
                     }
                 };
             }


### PR DESCRIPTION
We explicitly disable search concurrency when sorting by script, because there are known issues with the script sorting implementation that assumes segments are searched sequentially. This commit addresses that, which was a bad design relying on assumptions that no longer hold.
