### PR TITLE
Adjust the versions for :modules:ingest-geoip:qa:full-cluster-restart

### DIFF
--- a/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
+++ b/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(":qa:full-cluster-restart"), "javaRestTest"))
 }
 
-buildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("8.15.0")) { bwcVersion, baseName ->
+buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)


### PR DESCRIPTION
On 9.0 and up, we only have to worry about versions that are already by definition going to be `.onOrAfter("8.15.0")`, so there's no point in having the version check.

Related to https://github.com/elastic/elasticsearch/issues/123374 and https://github.com/elastic/elasticsearch/issues/123375, but https://github.com/elastic/elasticsearch/pull/123635 (also related!) is actually the PR that'll close those two test failure issues.