### PR TITLE
Add inbound_network entitlement to hdfs plugin

### DIFF
--- a/plugins/repository-hdfs/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/plugins/repository-hdfs/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,6 +1,7 @@
 ALL-UNNAMED:
   - manage_threads
   - outbound_network
+  - inbound_network # this is a requirement based on the security manager policy
   - load_native_libraries
   - write_system_properties:
       properties:


### PR DESCRIPTION
The security manager policy has permissions for inbound network accept and listen. This change adds this to our entitlements policy as well.