### PR TITLE
[8.x] Adjust the versions for :modules:ingest-geoip:qa:full-cluster-restart

### DIFF
--- a/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
+++ b/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(":qa:full-cluster-restart"), "javaRestTest"))
 }
 
-buildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("8.15.0")) { bwcVersion, baseName ->
+buildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("8.16.0")) { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)


### PR DESCRIPTION
Closes #123374
Closes #123375

There was an off-by-one error here: the `NamedXContent` that this test covers was introduced in 8.15.0, but the API that the test uses to test it was only introduced in 8.16.0. 🤕