### PR TITLE
[8.17] Adjust the versions for :modules:ingest-geoip:qa:full-cluster-restart (#123635)

### DIFF
--- a/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
+++ b/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(":qa:full-cluster-restart"), "javaRestTest"))
 }
 
-buildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("8.15.0")) { bwcVersion, baseName ->
+buildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("8.16.0")) { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [8.x] Adjust the versions for :modules:ingest-geoip:qa:full-cluster-restart (#123635)