### PR TITLE
Consolidate path setting files entitlements to config

### DIFF
--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserFailureTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserFailureTests.java
@@ -75,7 +75,7 @@ public class PolicyParserFailureTests extends ESTestCase {
         assertEquals(
             "[2:5] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
                 + "for entitlement type [files]: a files entitlement entry must contain one of "
-                + "[path, relative_path, path_setting, relative_path_setting]",
+                + "[path, relative_path, path_setting]",
             ppe.getMessage()
         );
     }
@@ -89,7 +89,7 @@ public class PolicyParserFailureTests extends ESTestCase {
         assertEquals(
             "[2:5] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
                 + "for entitlement type [files]: a files entitlement entry must contain one of "
-                + "[path, relative_path, path_setting, relative_path_setting]",
+                + "[path, relative_path, path_setting]",
             ppe.getMessage()
         );
     }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
@@ -182,7 +182,8 @@ public class PolicyParserTests extends ESTestCase {
                       mode: "read"
                     - path: '%s'
                       mode: "read_write"
-                    - config_path_setting: foo.bar
+                    - path_setting: foo.bar
+                      basedir_if_relative: config
                       mode: read
                 """, relativePathToFile, relativePathToDir, TEST_ABSOLUTE_PATH_TO_FILE).getBytes(StandardCharsets.UTF_8)),
             "test-policy.yaml",
@@ -199,7 +200,7 @@ public class PolicyParserTests extends ESTestCase {
                                 Map.of("relative_path", relativePathToFile, "mode", "read_write", "relative_to", "data"),
                                 Map.of("relative_path", relativePathToDir, "mode", "read", "relative_to", "config"),
                                 Map.of("path", TEST_ABSOLUTE_PATH_TO_FILE, "mode", "read_write"),
-                                Map.of("config_path_setting", "foo.bar", "mode", "read")
+                                Map.of("path_setting", "foo.bar", "basedir_if_relative", "config", "mode", "read")
                             )
                         )
                     )

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserTests.java
@@ -182,10 +182,7 @@ public class PolicyParserTests extends ESTestCase {
                       mode: "read"
                     - path: '%s'
                       mode: "read_write"
-                    - path_setting: foo.bar
-                      mode: read
-                    - relative_path_setting: foo.bar
-                      relative_to: config
+                    - config_path_setting: foo.bar
                       mode: read
                 """, relativePathToFile, relativePathToDir, TEST_ABSOLUTE_PATH_TO_FILE).getBytes(StandardCharsets.UTF_8)),
             "test-policy.yaml",
@@ -202,8 +199,7 @@ public class PolicyParserTests extends ESTestCase {
                                 Map.of("relative_path", relativePathToFile, "mode", "read_write", "relative_to", "data"),
                                 Map.of("relative_path", relativePathToDir, "mode", "read", "relative_to", "config"),
                                 Map.of("path", TEST_ABSOLUTE_PATH_TO_FILE, "mode", "read_write"),
-                                Map.of("path_setting", "foo.bar", "mode", "read"),
-                                Map.of("relative_path_setting", "foo.bar", "relative_to", "config", "mode", "read")
+                                Map.of("config_path_setting", "foo.bar", "mode", "read")
                             )
                         )
                     )

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlementTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlementTests.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement.BaseDir.CONFIG;
 import static org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement.Mode.READ;
 import static org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement.Mode.READ_WRITE;
 import static org.hamcrest.Matchers.contains;
@@ -97,33 +98,49 @@ public class FilesEntitlementTests extends ESTestCase {
     }
 
     public void testPathSettingResolve() {
-        var entitlement = FilesEntitlement.build(List.of(Map.of("config_path_setting", "foo.bar", "mode", "read")));
+        var entitlement = FilesEntitlement.build(List.of(Map.of("path_setting", "foo.bar", "basedir_if_relative", "config", "mode", "read")));
         var filesData = entitlement.filesData();
-        assertThat(filesData, contains(FileData.ofConfigPathSetting("foo.bar", READ, false)));
+        assertThat(filesData, contains(FileData.ofPathSetting("foo.bar", CONFIG, READ, false)));
 
-        var fileData = FileData.ofConfigPathSetting("foo.bar", READ, false);
+        var fileData = FileData.ofPathSetting("foo.bar", CONFIG, READ, false);
         // empty settings
         assertThat(fileData.resolvePaths(TEST_PATH_LOOKUP).toList(), empty());
 
-        fileData = FileData.ofConfigPathSetting("foo.bar", READ, false);
+        fileData = FileData.ofPathSetting("foo.bar", CONFIG, READ, false);
         settings = Settings.builder().put("foo.bar", "/setting/path").build();
         assertThat(fileData.resolvePaths(TEST_PATH_LOOKUP).toList(), contains(Path.of("/setting/path")));
 
-        fileData = FileData.ofConfigPathSetting("foo.*.bar", READ, false);
+        fileData = FileData.ofPathSetting("foo.*.bar", CONFIG, READ, false);
         settings = Settings.builder().put("foo.baz.bar", "/setting/path").build();
         assertThat(fileData.resolvePaths(TEST_PATH_LOOKUP).toList(), contains(Path.of("/setting/path")));
 
-        fileData = FileData.ofConfigPathSetting("foo.*.bar", READ, false);
+        fileData = FileData.ofPathSetting("foo.*.bar", CONFIG, READ, false);
         settings = Settings.builder().put("foo.baz.bar", "/setting/path").put("foo.baz2.bar", "/other/path").build();
         assertThat(fileData.resolvePaths(TEST_PATH_LOOKUP).toList(), containsInAnyOrder(Path.of("/setting/path"), Path.of("/other/path")));
 
-        fileData = FileData.ofConfigPathSetting("foo.bar", READ, false);
+        fileData = FileData.ofPathSetting("foo.bar", CONFIG, READ, false);
         settings = Settings.builder().put("foo.bar", "relative_path").build();
         assertThat(fileData.resolvePaths(TEST_PATH_LOOKUP).toList(), contains(Path.of("/config/relative_path")));
     }
 
+    public void testPathSettingBasedirValidation() {
+        var e = expectThrows(
+            PolicyValidationException.class,
+            () -> FilesEntitlement.build(List.of(Map.of("path", "/foo", "mode", "read", "basedir_if_relative", "config")))
+        );
+        assertThat(e.getMessage(), is("'basedir_if_relative' may only be used with 'path_setting'"));
+
+        e = expectThrows(
+            PolicyValidationException.class,
+            () -> FilesEntitlement.build(
+                List.of(Map.of("relative_path", "foo", "relative_to", "config", "mode", "read", "basedir_if_relative", "config"))
+            )
+        );
+        assertThat(e.getMessage(), is("'basedir_if_relative' may only be used with 'path_setting'"));
+    }
+
     public void testPathSettingIgnoreUrl() {
-        var fileData = FileData.ofConfigPathSetting("foo.*.bar", READ, true);
+        var fileData = FileData.ofPathSetting("foo.*.bar", CONFIG, READ, true);
         settings = Settings.builder().put("foo.nonurl.bar", "/setting/path").put("foo.url.bar", "https://mysite").build();
         assertThat(fileData.resolvePaths(TEST_PATH_LOOKUP).toList(), contains(Path.of("/setting/path")));
     }
@@ -133,7 +150,7 @@ public class FilesEntitlementTests extends ESTestCase {
             PolicyValidationException.class,
             () -> FilesEntitlement.build(List.of(Map.of("path", "/foo", "mode", "read", "ignore_url", true)))
         );
-        assertThat(e.getMessage(), is("'ignore_url' may only be used with 'config_path_setting'"));
+        assertThat(e.getMessage(), is("'ignore_url' may only be used with 'path_setting'"));
 
         e = expectThrows(
             PolicyValidationException.class,
@@ -141,7 +158,7 @@ public class FilesEntitlementTests extends ESTestCase {
                 List.of(Map.of("relative_path", "foo", "relative_to", "config", "mode", "read", "ignore_url", true))
             )
         );
-        assertThat(e.getMessage(), is("'ignore_url' may only be used with 'config_path_setting'"));
+        assertThat(e.getMessage(), is("'ignore_url' may only be used with 'path_setting'"));
     }
 
     public void testExclusiveParsing() throws Exception {

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlementTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlementTests.java
@@ -98,7 +98,9 @@ public class FilesEntitlementTests extends ESTestCase {
     }
 
     public void testPathSettingResolve() {
-        var entitlement = FilesEntitlement.build(List.of(Map.of("path_setting", "foo.bar", "basedir_if_relative", "config", "mode", "read")));
+        var entitlement = FilesEntitlement.build(
+            List.of(Map.of("path_setting", "foo.bar", "basedir_if_relative", "config", "mode", "read"))
+        );
         var filesData = entitlement.filesData();
         assertThat(filesData, contains(FileData.ofPathSetting("foo.bar", CONFIG, READ, false)));
 


### PR DESCRIPTION
The setting based paths could be either absolute or relative, and they are always relative to the config dir. This commit removes the relative_path_setting property, and adds a mandatory basedir_if_relative property.