### PR TITLE
Fix enrollment packaging test when running on Java 24

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
@@ -141,12 +141,19 @@ public class EnrollmentProcessTests extends PackagingTestCase {
                 );
             }
 
-            final String tokenValue = result.stdout()
+            final List<String> filteredResult = result.stdout()
                 .lines()
                 .filter(line -> line.startsWith("WARNING:") == false)
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("Failed to find any non-warning output lines"));
-            enrollmentTokenHolder.set(tokenValue);
+                .filter(line -> line.matches("\\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\[main\\].*") == false)
+                .toList();
+
+            if (filteredResult.size() > 1) {
+                throw new AssertionError("Result from elasticsearch-create-enrollment-token contains unexpected output.");
+            } else if (filteredResult.isEmpty()) {
+                throw new AssertionError("Failed to find any non-warning output lines");
+            }
+
+            enrollmentTokenHolder.set(filteredResult.getFirst());
         }, 30, TimeUnit.SECONDS);
 
         return enrollmentTokenHolder.get();

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
@@ -148,9 +148,11 @@ public class EnrollmentProcessTests extends PackagingTestCase {
                 .toList();
 
             if (filteredResult.size() > 1) {
-                throw new AssertionError("Result from elasticsearch-create-enrollment-token contains unexpected output.");
+                throw new AssertionError(
+                    "Result from elasticsearch-create-enrollment-token contains unexpected output. Output was: \n" + result.stdout()
+                );
             } else if (filteredResult.isEmpty()) {
-                throw new AssertionError("Failed to find any non-warning output lines");
+                throw new AssertionError("Failed to find any non-warning output lines. Output was: \n" + result.stdout());
             }
 
             enrollmentTokenHolder.set(filteredResult.getFirst());


### PR DESCRIPTION
Fixes failures in EnrollmentProcessTests when running on Java 24. On later versions of java the `elasticsearch-create-enrollment-token` CLI tool produces additional warning output about deprecated ciphers. This breaks the parsing logic in our test to extract the enrollment token from the CLI output. Here we add some additional filtering, as well as some better error messages when the response output doesn't match what we expect.