### PR TITLE
Report outcome of data node's shard snapshot master update

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
@@ -597,7 +597,7 @@ public class SnapshotShutdownIT extends AbstractSnapshotIntegTestCase {
                 "SnapshotShutdownProgressTracker index shard snapshot messages",
                 SnapshotShutdownProgressTracker.class.getCanonicalName(),
                 Level.INFO,
-                "statusDescription='finished: master notification attempt complete'"
+                "*successfully sent shard snapshot state [PAUSED_FOR_NODE_REMOVAL] update to the master node*"
             )
         );
 

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -689,15 +689,10 @@ public final class SnapshotShardsService extends AbstractLifecycleComponent impl
                                 snapshot.snapshot(),
                                 shardId,
                                 localShard.getValue().getShardSnapshotResult(),
-                                (outcomeInfoString) -> localShard.getValue().updateStatusDescription(
-                                    Strings.format("""
-                                        Data node already successfully finished shard snapshot, but a new master needed to be notified. New
-                                        remote master notification outcome: [%s]. The prior shard snapshot status description was [%s]
-                                        """,
-                                        outcomeInfoString,
-                                        indexShardSnapshotStatus.getStatusDescription()
-                                    )
-                                )
+                                (outcomeInfoString) -> localShard.getValue().updateStatusDescription(Strings.format("""
+                                    Data node already successfully finished shard snapshot, but a new master needed to be notified. New
+                                    remote master notification outcome: [%s]. The prior shard snapshot status description was [%s]
+                                    """, outcomeInfoString, indexShardSnapshotStatus.getStatusDescription()))
                             );
                         } else if (stage == Stage.FAILURE) {
                             // but we think the shard failed - we need to make new master know that the shard failed
@@ -715,15 +710,10 @@ public final class SnapshotShardsService extends AbstractLifecycleComponent impl
                                 localShard.getValue().generation(),
                                 // Update the original statusDescription with the latest remote master call outcome, but include the old
                                 // response. This will allow us to see when/whether the information reached the previous and current master.
-                                (outcomeInfoString) -> localShard.getValue().updateStatusDescription(
-                                    Strings.format("""
-                                        Data node already failed shard snapshot, but a new master needed to be notified. New remote master
-                                        notification outcome: [%s]. The prior shard snapshot status description was [%s]
-                                        """,
-                                        outcomeInfoString,
-                                        indexShardSnapshotStatus.getStatusDescription()
-                                    )
-                                )
+                                (outcomeInfoString) -> localShard.getValue().updateStatusDescription(Strings.format("""
+                                    Data node already failed shard snapshot, but a new master needed to be notified. New remote master
+                                    notification outcome: [%s]. The prior shard snapshot status description was [%s]
+                                    """, outcomeInfoString, indexShardSnapshotStatus.getStatusDescription()))
                             );
                         } else if (stage == Stage.PAUSED) {
                             // but we think the shard has paused - we need to make new master know that
@@ -737,16 +727,10 @@ public final class SnapshotShardsService extends AbstractLifecycleComponent impl
                                 ShardState.PAUSED_FOR_NODE_REMOVAL,
                                 indexShardSnapshotStatus.getFailure(),
                                 localShard.getValue().generation(),
-                                (outcomeInfoString) -> localShard.getValue()
-                                    .updateStatusDescription(
-                                        Strings.format("""
-                                            Data node already paused shard snapshot, but a new master needed to be notified. New remote
-                                            master notification outcome: [%s]. The prior shard snapshot status description was [%s]
-                                            """,
-                                            outcomeInfoString,
-                                            indexShardSnapshotStatus.getStatusDescription()
-                                        )
-                                    )
+                                (outcomeInfoString) -> localShard.getValue().updateStatusDescription(Strings.format("""
+                                    Data node already paused shard snapshot, but a new master needed to be notified. New remote
+                                    master notification outcome: [%s]. The prior shard snapshot status description was [%s]
+                                    """, outcomeInfoString, indexShardSnapshotStatus.getStatusDescription()))
                             );
                         }
                     }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -794,6 +794,7 @@ public final class SnapshotShardsService extends AbstractLifecycleComponent impl
         final ShardSnapshotStatus status,
         Consumer<String> postMasterNotificationAction
     ) {
+        snapshotShutdownProgressTracker.trackRequestSentToMaster(snapshot, shardId);
         ActionListener<Void> updateResultListener = new ActionListener<>() {
             @Override
             public void onResponse(Void aVoid) {


### PR DESCRIPTION
Improves the information in the IndexShardSnapshotStatus's
statusDescription field to include the success/failure of the remote
call to the master node to update the shard snapshot state. This
allows us to see if there is a discrepancy between the state of the
data node and the master node.

Closes ES-10991