### PR TITLE
Unumte testWatcherWithApiKey

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -248,9 +248,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/121625
 - class: org.elasticsearch.xpack.application.CohereServiceUpgradeIT
   issue: https://github.com/elastic/elasticsearch/issues/121537
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testWatcherWithApiKey {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/122061
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
   issue: https://github.com/elastic/elasticsearch/issues/122102


### PR DESCRIPTION
Un-muting a test. It appears the automation was bit too aggressive and the 2 failures seems environmental. 

closes #122061