### PR TITLE
[8.18] Fix enrollment packaging test when running on Java 24 (#123650)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
@@ -141,12 +141,21 @@ public class EnrollmentProcessTests extends PackagingTestCase {
                 );
             }
 
-            final String tokenValue = result.stdout()
+            final List<String> filteredResult = result.stdout()
                 .lines()
                 .filter(line -> line.startsWith("WARNING:") == false)
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("Failed to find any non-warning output lines"));
-            enrollmentTokenHolder.set(tokenValue);
+                .filter(line -> line.matches("\\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\[main\\].*") == false)
+                .toList();
+
+            if (filteredResult.size() > 1) {
+                throw new AssertionError(
+                    "Result from elasticsearch-create-enrollment-token contains unexpected output. Output was: \n" + result.stdout()
+                );
+            } else if (filteredResult.isEmpty()) {
+                throw new AssertionError("Failed to find any non-warning output lines. Output was: \n" + result.stdout());
+            }
+
+            enrollmentTokenHolder.set(filteredResult.getFirst());
         }, 30, TimeUnit.SECONDS);
 
         return enrollmentTokenHolder.get();

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/EnrollmentProcessTests.java
@@ -155,7 +155,7 @@ public class EnrollmentProcessTests extends PackagingTestCase {
                 throw new AssertionError("Failed to find any non-warning output lines. Output was: \n" + result.stdout());
             }
 
-            enrollmentTokenHolder.set(filteredResult.getFirst());
+            enrollmentTokenHolder.set(filteredResult.get(0));
         }, 30, TimeUnit.SECONDS);
 
         return enrollmentTokenHolder.get();


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix enrollment packaging test when running on Java 24 (#123650)