### PR TITLE
Add a faster path for single default project retrieving

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1683,6 +1683,8 @@ public class Metadata implements Diffable<Metadata>, ChunkedToXContent {
             assert assertProjectIdAndProjectMetadataConsistency();
             if (projectMetadata.size() == 1) {
                 final var entry = projectMetadata.entrySet().iterator().next();
+                // Map.of() with a single entry is highly optimized
+                // so we want take advantage of that performance boost for this common case of a single project
                 return Map.of(entry.getKey(), entry.getValue().build(skipNameCollisionChecks));
             } else {
                 return Collections.unmodifiableMap(Maps.transformValues(projectMetadata, m -> m.build(skipNameCollisionChecks)));


### PR DESCRIPTION
This PR makes single default project retrieving faster by using a single element map instead of a regular hash map.
