### PR TITLE
[8.18] Abort pending deletion on IndicesService stop (#123569)

### DIFF
--- a/docs/changelog/123569.yaml
+++ b/docs/changelog/123569.yaml
@@ -1,0 +1,5 @@
+pr: 123569
+summary: Abort pending deletion on `IndicesService` close
+area: Store
+type: enhancement
+issues: []


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Abort pending deletion on IndicesService stop (#123569)](https://github.com/elastic/elasticsearch/pull/123569)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)