### PR TITLE
[8.18] Missing geoip policy (#123597)

### DIFF
--- a/modules/ingest-geoip/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/ingest-geoip/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,4 +1,5 @@
 org.elasticsearch.ingest.geoip:
+  - outbound_network
   - files:
       - relative_path: "ingest-geoip"
         relative_to: config


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Missing geoip policy (#123597)