### PR TITLE
Fix  broken cross-repo links, versions in search connectors docker instructions

### DIFF
--- a/docs/reference/community-contributed.md
+++ b/docs/reference/community-contributed.md
@@ -42,7 +42,7 @@ a number of clients that have been contributed by the community for various lang
 
 ## Go [go]
 
-Also see the [official Elasticsearch Go client](go-elasticsearch://docs/reference/index.md).
+Also see the [official Elasticsearch Go client](go-elasticsearch://reference/index.md).
 
 * [elastigo](https://github.com/mattbaird/elastigo): Go client. **Last commit more than a year ago**
 
@@ -56,7 +56,7 @@ Also see the [official Elasticsearch Go client](go-elasticsearch://docs/referenc
 
 ## Java [java]
 
-Also see the [official Elasticsearch Java client](elasticsearch-java://docs/reference/index.md).
+Also see the [official Elasticsearch Java client](elasticsearch-java://reference/index.md).
 
 * [Flummi](https://github.com/otto-de/flummi): Java Rest client with comprehensive Query DSL API.
 
@@ -64,15 +64,15 @@ Also see the [official Elasticsearch Java client](elasticsearch-java://docs/refe
 
 ## JavaScript [javascript]
 
-See the [official Elasticsearch JavaScript client](elasticsearch-js://docs/reference/index.md).
+See the [official Elasticsearch JavaScript client](elasticsearch-js://reference/index.md).
 
 ## Julia [julia]
 
-* [ElasticsearchClient.jl](https://github.com/OpenSesame/ElasticsearchClient.jl): Elasticsearch client inspired by the [official Elasticsearch Ruby client](elasticsearch-ruby://docs/reference/index.md).
+* [ElasticsearchClient.jl](https://github.com/OpenSesame/ElasticsearchClient.jl): Elasticsearch client inspired by the [official Elasticsearch Ruby client](elasticsearch-ruby://reference/index.md).
 
 ## Kotlin [kotlin]
 
-* [ES Kotlin](https://github.com/mbuhot/eskotlin): Elasticsearch Query DSL for kotlin based on the [official Elasticsearch Java client](elasticsearch-java://docs/reference/index.md). **Last commit more than a year ago**
+* [ES Kotlin](https://github.com/mbuhot/eskotlin): Elasticsearch Query DSL for kotlin based on the [official Elasticsearch Java client](elasticsearch-java://reference/index.md). **Last commit more than a year ago**
 
 * [ES Kotlin Wrapper Client](https://github.com/jillesvangurp/es-kotlin-wrapper-client): Kotlin extension functions and abstractions for the [official Elasticsearch high-level client](https://www.elastic.co/guide/en/elasticsearch/client/java-api/current/index.html). Aims to reduce the amount of boilerplate needed to do searches, bulk indexing and other common things users do with the client. **No longer maintained**
 
@@ -82,7 +82,7 @@ See the [official Elasticsearch JavaScript client](elasticsearch-js://docs/refer
 
 ## .NET [dotnet]
 
-See the [official Elasticsearch .NET client](elasticsearch-net://docs/reference/index.md).
+See the [official Elasticsearch .NET client](elasticsearch-net://reference/index.md).
 
 ## Perl [perl]
 
@@ -92,7 +92,7 @@ Also see the [official Elasticsearch Perl client](https://www.elastic.co/guide/e
 
 ## PHP [php]
 
-Also see the [official Elasticsearch PHP client](elasticsearch-php://docs/reference/index.md).
+Also see the [official Elasticsearch PHP client](elasticsearch-php://reference/index.md).
 
 * [Elastica](https://github.com/ruflin/Elastica): PHP client.
 
@@ -102,7 +102,7 @@ Also see the [official Elasticsearch PHP client](elasticsearch-php://docs/refere
 
 ## Python [python]
 
-See the [official Elasticsearch Python client](elasticsearch-py://docs/reference/index.md).
+See the [official Elasticsearch Python client](elasticsearch-py://reference/index.md).
 
 ## R [r]
 
@@ -114,7 +114,7 @@ See the [official Elasticsearch Python client](elasticsearch-py://docs/reference
 
 ## Ruby [ruby]
 
-Also see the [official Elasticsearch Ruby client](elasticsearch-ruby://docs/reference/index.md).
+Also see the [official Elasticsearch Ruby client](elasticsearch-ruby://reference/index.md).
 
 * [chewy](https://github.com/toptal/chewy): An ODM and wrapper for the official Elasticsearch client.
 
@@ -128,7 +128,7 @@ Also see the [official Elasticsearch Ruby client](elasticsearch-ruby://docs/refe
 
 ## Rust [rust]
 
-Also see the [official Elasticsearch Rust client](elasticsearch-rs://docs/reference/index.md).
+Also see the [official Elasticsearch Rust client](elasticsearch-rs://reference/index.md).
 
 * [rs-es](https://github.com/benashford/rs-es): A REST API client with a strongly-typed Query DSL. **Last commit more than a year ago**
 

--- a/docs/reference/elasticsearch-plugins/cloud/ec-adding-elastic-plugins.md
+++ b/docs/reference/elasticsearch-plugins/cloud/ec-adding-elastic-plugins.md
@@ -9,7 +9,7 @@ You can use a variety of official plugins that are compatible with your version 
 
 ## Before you begin [ec_before_you_begin_6]
 
-Some restrictions apply when adding plugins. To learn more, check [Restrictions for {{es}} and {{kib}} plugins](cloud://docs/release-notes/cloud-hosted/known-issues.md#ec-restrictions-plugins).
+Some restrictions apply when adding plugins. To learn more, check [Restrictions for {{es}} and {{kib}} plugins](cloud://release-notes/cloud-hosted/known-issues.md#ec-restrictions-plugins).
 
 Only Gold, Platinum, Enterprise and Private subscriptions, running version 2.4.6 or later, have access to uploading custom plugins. All subscription levels, including Standard, can upload scripts and dictionaries.
 

--- a/docs/reference/elasticsearch-plugins/cloud/ec-adding-plugins.md
+++ b/docs/reference/elasticsearch-plugins/cloud/ec-adding-plugins.md
@@ -24,7 +24,7 @@ To learn more about the official and community-sourced plugins, refer to [{{es}}
 
 For a detailed guide with examples of using the Elasticsearch Service API to create, get information about, update, and delete extensions and plugins, check [Managing plugins and extensions through the API](/reference/elasticsearch-plugins/cloud/ec-plugins-guide.md\).
 
-Plugins are not supported for {{kib}}. To learn more, check [Restrictions for {{es}} and {{kib}} plugins](cloud://docs/release-notes/cloud-hosted/known-issues.md#ec-restrictions-plugins).
+Plugins are not supported for {{kib}}. To learn more, check [Restrictions for {{es}} and {{kib}} plugins](cloud://release-notes/cloud-hosted/known-issues.md#ec-restrictions-plugins).
 
 
 

--- a/docs/reference/elasticsearch-plugins/integrations.md
+++ b/docs/reference/elasticsearch-plugins/integrations.md
@@ -71,7 +71,7 @@ Integrations are not plugins, but are external tools or modules that make it eas
 
 ### Supported by Elastic: [_supported_by_elastic_2]
 
-* [es-hadoop](elasticsearch-hadoop://reference/preface.md): Elasticsearch real-time search and analytics natively integrated with Hadoop. Supports Map/Reduce, Cascading, Apache Hive, Apache Pig, Apache Spark and Apache Storm.
+* [es-hadoop](elasticsearch-hadoop://docs/reference/preface.md): Elasticsearch real-time search and analytics natively integrated with Hadoop. Supports Map/Reduce, Cascading, Apache Hive, Apache Pig, Apache Spark and Apache Storm.
 
 
 ### Supported by the community: [_supported_by_the_community_5]

--- a/docs/reference/elasticsearch-plugins/integrations.md
+++ b/docs/reference/elasticsearch-plugins/integrations.md
@@ -71,7 +71,7 @@ Integrations are not plugins, but are external tools or modules that make it eas
 
 ### Supported by Elastic: [_supported_by_elastic_2]
 
-* [es-hadoop](elasticsearch-hadoop://reference/preface.md): Elasticsearch real-time search and analytics natively integrated with Hadoop. Supports Map/Reduce, Cascading, Apache Hive, Apache Pig, Apache Spark and Apache Storm.
+* [es-hadoop](https://www.elastic.co/elasticsearch/hadoop): Elasticsearch real-time search and analytics natively integrated with Hadoop. Supports Map/Reduce, Cascading, Apache Hive, Apache Pig, Apache Spark and Apache Storm.
 
 
 ### Supported by the community: [_supported_by_the_community_5]

--- a/docs/reference/elasticsearch-plugins/integrations.md
+++ b/docs/reference/elasticsearch-plugins/integrations.md
@@ -71,7 +71,7 @@ Integrations are not plugins, but are external tools or modules that make it eas
 
 ### Supported by Elastic: [_supported_by_elastic_2]
 
-* [es-hadoop](elasticsearch-hadoop://docs/reference/preface.md): Elasticsearch real-time search and analytics natively integrated with Hadoop. Supports Map/Reduce, Cascading, Apache Hive, Apache Pig, Apache Spark and Apache Storm.
+* [es-hadoop](elasticsearch-hadoop://reference/preface.md): Elasticsearch real-time search and analytics natively integrated with Hadoop. Supports Map/Reduce, Cascading, Apache Hive, Apache Pig, Apache Spark and Apache Storm.
 
 
 ### Supported by the community: [_supported_by_the_community_5]

--- a/docs/reference/elasticsearch-plugins/integrations.md
+++ b/docs/reference/elasticsearch-plugins/integrations.md
@@ -20,10 +20,10 @@ Integrations are not plugins, but are external tools or modules that make it eas
 
 ### Supported by Elastic: [_supported_by_elastic]
 
-* [Logstash output to Elasticsearch](logstash://docs/reference/plugins-outputs-elasticsearch.md): The Logstash `elasticsearch` output plugin.
-* [Elasticsearch input to Logstash](logstash://docs/reference/plugins-inputs-elasticsearch.md) The Logstash `elasticsearch` input plugin.
-* [Elasticsearch event filtering in Logstash](logstash://docs/reference/plugins-filters-elasticsearch.md) The Logstash `elasticsearch` filter plugin.
-* [Elasticsearch bulk codec](logstash://docs/reference/plugins-codecs-es_bulk.md) The Logstash `es_bulk` plugin decodes the Elasticsearch bulk format into individual events.
+* [Logstash output to Elasticsearch](logstash://reference/plugins-outputs-elasticsearch.md): The Logstash `elasticsearch` output plugin.
+* [Elasticsearch input to Logstash](logstash://reference/plugins-inputs-elasticsearch.md) The Logstash `elasticsearch` input plugin.
+* [Elasticsearch event filtering in Logstash](logstash://reference/plugins-filters-elasticsearch.md) The Logstash `elasticsearch` filter plugin.
+* [Elasticsearch bulk codec](logstash://reference/plugins-codecs-es_bulk.md) The Logstash `es_bulk` plugin decodes the Elasticsearch bulk format into individual events.
 
 
 ### Supported by the community: [_supported_by_the_community_2]
@@ -71,7 +71,7 @@ Integrations are not plugins, but are external tools or modules that make it eas
 
 ### Supported by Elastic: [_supported_by_elastic_2]
 
-* [es-hadoop](elasticsearch-hadoop://docs/reference/preface.md): Elasticsearch real-time search and analytics natively integrated with Hadoop. Supports Map/Reduce, Cascading, Apache Hive, Apache Pig, Apache Spark and Apache Storm.
+* [es-hadoop](elasticsearch-hadoop://reference/preface.md): Elasticsearch real-time search and analytics natively integrated with Hadoop. Supports Map/Reduce, Cascading, Apache Hive, Apache Pig, Apache Spark and Apache Storm.
 
 
 ### Supported by the community: [_supported_by_the_community_5]

--- a/docs/reference/elasticsearch/configuration-reference/elastic-cloud-serverless-elasticsearch-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/elastic-cloud-serverless-elasticsearch-settings.md
@@ -151,7 +151,7 @@ The following features are planned for future support in all {{serverless-full}}
 The following features are not available in {{es-serverless}} and are not planned for future support:
 
 * [Custom plugins and bundles](docs-content://deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md)
-* [{{es}} for Apache Hadoop](elasticsearch-hadoop://reference/elasticsearch-for-apache-hadoop.md)
+* {{es}} for Apache Hadoop
 * [Scripted metric aggregations](/reference/data-analysis/aggregations/search-aggregations-metrics-scripted-metric-aggregation.md)
 * Managed web crawler: You can use the [self-managed web crawler](https://github.com/elastic/crawler) instead.
 * Managed Search connectors: You can use [self-managed Search connectors](/reference/ingestion-tools/search-connectors/self-managed-connectors.md) instead.

--- a/docs/reference/elasticsearch/configuration-reference/elastic-cloud-serverless-elasticsearch-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/elastic-cloud-serverless-elasticsearch-settings.md
@@ -151,7 +151,7 @@ The following features are planned for future support in all {{serverless-full}}
 The following features are not available in {{es-serverless}} and are not planned for future support:
 
 * [Custom plugins and bundles](docs-content://deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md)
-* [{{es}} for Apache Hadoop](elasticsearch-hadoop://reference/elasticsearch-for-apache-hadoop.md)
+* [{{es}} for Apache Hadoop](elasticsearch-hadoop://docs/reference/elasticsearch-for-apache-hadoop.md)
 * [Scripted metric aggregations](/reference/data-analysis/aggregations/search-aggregations-metrics-scripted-metric-aggregation.md)
 * Managed web crawler: You can use the [self-managed web crawler](https://github.com/elastic/crawler) instead.
 * Managed Search connectors: You can use [self-managed Search connectors](/reference/ingestion-tools/search-connectors/self-managed-connectors.md) instead.

--- a/docs/reference/elasticsearch/configuration-reference/elastic-cloud-serverless-elasticsearch-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/elastic-cloud-serverless-elasticsearch-settings.md
@@ -151,7 +151,7 @@ The following features are planned for future support in all {{serverless-full}}
 The following features are not available in {{es-serverless}} and are not planned for future support:
 
 * [Custom plugins and bundles](docs-content://deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md)
-* [{{es}} for Apache Hadoop](elasticsearch-hadoop://docs/reference/elasticsearch-for-apache-hadoop.md)
+* [{{es}} for Apache Hadoop](elasticsearch-hadoop://reference/elasticsearch-for-apache-hadoop.md)
 * [Scripted metric aggregations](/reference/data-analysis/aggregations/search-aggregations-metrics-scripted-metric-aggregation.md)
 * Managed web crawler: You can use the [self-managed web crawler](https://github.com/elastic/crawler) instead.
 * Managed Search connectors: You can use [self-managed Search connectors](/reference/ingestion-tools/search-connectors/self-managed-connectors.md) instead.

--- a/docs/reference/elasticsearch/configuration-reference/monitoring-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/monitoring-settings.md
@@ -18,7 +18,7 @@ By default, {{es}} {{monitor-features}} are enabled but data collection is disab
 
 Except where noted otherwise, these settings can be dynamically updated on a live cluster with the [cluster-update-settings](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-settings) API.
 
-To adjust how monitoring data is displayed in the monitoring UI, configure [`xpack.monitoring` settings](kibana://docs/reference/configuration-reference/monitoring-settings.md) in `kibana.yml`. To control how monitoring data is collected from {{ls}}, configure monitoring settings in `logstash.yml`.
+To adjust how monitoring data is displayed in the monitoring UI, configure [`xpack.monitoring` settings](kibana://reference/configuration-reference/monitoring-settings.md) in `kibana.yml`. To control how monitoring data is collected from {{ls}}, configure monitoring settings in `logstash.yml`.
 
 For more information, see [Monitor a cluster](docs-content://deploy-manage/monitor.md).
 

--- a/docs/reference/elasticsearch/configuration-reference/security-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/security-settings.md
@@ -17,7 +17,7 @@ All of these settings can be added to the `elasticsearch.yml` configuration file
 `xpack.security.enabled`
 :   ([Static](docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md#static-cluster-setting)) Defaults to `true`, which enables {{es}} {{security-features}} on the node. This setting must be enabled to use Elasticsearch’s authentication, authorization and audit features.<br>
 
-    If set to `false`, {{security-features}} are disabled, which is not recommended. It also affects all {{kib}} instances that connect to this {{es}} instance; you do not need to disable {{security-features}} in those `kibana.yml` files. For more information about disabling {{security-features}} in specific {{kib}} instances, see [{{kib}} security settings](kibana://docs/reference/configuration-reference/security-settings.md).
+    If set to `false`, {{security-features}} are disabled, which is not recommended. It also affects all {{kib}} instances that connect to this {{es}} instance; you do not need to disable {{security-features}} in those `kibana.yml` files. For more information about disabling {{security-features}} in specific {{kib}} instances, see [{{kib}} security settings](kibana://reference/configuration-reference/security-settings.md).
 
 
 `xpack.security.autoconfiguration.enabled`

--- a/docs/reference/elasticsearch/configuration-reference/watcher-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/watcher-settings.md
@@ -309,7 +309,7 @@ $$$email-account-attributes$$$
 :   ([Static](docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md#static-cluster-setting)) Set to `false` to completely disable HTML sanitation. Not recommended. Defaults to `true`.
 
 `xpack.notification.reporting.warning.kbn-csv-contains-formulas.text`
-:   ([Dynamic](docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md#dynamic-cluster-setting)) Specifies a custom message, which is sent if the formula verification criteria for CSV files from {{kib}}'s [`xpack.reporting.csv.checkForFormulas`](kibana://docs/reference/configuration-reference/reporting-settings.md#reporting-csv-settings) is `true`. Use `%s` in the message as a placeholder for the filename. Defaults to `Warning: The attachment [%s] contains characters which spreadsheet applications may interpret as formulas. Please ensure that the attachment is safe prior to opening.`
+:   ([Dynamic](docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md#dynamic-cluster-setting)) Specifies a custom message, which is sent if the formula verification criteria for CSV files from {{kib}}'s [`xpack.reporting.csv.checkForFormulas`](kibana://reference/configuration-reference/reporting-settings.md#reporting-csv-settings) is `true`. Use `%s` in the message as a placeholder for the filename. Defaults to `Warning: The attachment [%s] contains characters which spreadsheet applications may interpret as formulas. Please ensure that the attachment is safe prior to opening.`
 
 
 ## {{watcher}} Email TLS/SSL settings [ssl-notification-smtp-settings]

--- a/docs/reference/elasticsearch/rest-apis/paginate-search-results.md
+++ b/docs/reference/elasticsearch/rest-apis/paginate-search-results.md
@@ -290,7 +290,7 @@ Python
 :   See [elasticsearch.helpers.*](https://elasticsearch-py.readthedocs.io/en/stable/helpers.md)
 
 JavaScript
-:   See [client.helpers.*](elasticsearch-js://docs/reference/client-helpers.md)
+:   See [client.helpers.*](elasticsearch-js://reference/client-helpers.md)
 
 ::::
 

--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -567,7 +567,7 @@ You have the following options:
 * Use the the built-in [Elastic Rerank](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put) cross-encoder model via the inference API’s {{es}} service.
 * Use the [Cohere Rerank inference endpoint](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put) with the `rerank` task type.
 * Use the [Google Vertex AI inference endpoint](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put) with the `rerank` task type.
-* Upload a model to {{es}} with [Eland](eland://docs/reference/machine-learning.md#ml-nlp-pytorch) using the `text_similarity` NLP task type.
+* Upload a model to {{es}} with [Eland](eland://reference/machine-learning.md#ml-nlp-pytorch) using the `text_similarity` NLP task type.
 
     * Then set up an [{{es}} service inference endpoint](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put) with the `rerank` task type.
     * Refer to the [example](#text-similarity-reranker-retriever-example-eland) on this page for a step-by-step guide.
@@ -727,7 +727,7 @@ GET /index/_search
 
 ### Example: Semantic re-ranking with a Hugging Face model [text-similarity-reranker-retriever-example-eland]
 
-The following example uses the `cross-encoder/ms-marco-MiniLM-L-6-v2` model from Hugging Face to rerank search results based on semantic similarity. The model must be uploaded to {{es}} using [Eland](eland://docs/reference/machine-learning.md#ml-nlp-pytorch).
+The following example uses the `cross-encoder/ms-marco-MiniLM-L-6-v2` model from Hugging Face to rerank search results based on semantic similarity. The model must be uploaded to {{es}} using [Eland](eland://reference/machine-learning.md#ml-nlp-pytorch).
 
 ::::{tip}
 Refer to [the Elastic NLP model reference](docs-content://explore-analyze/machine-learning/nlp/ml-nlp-model-ref.md#ml-nlp-model-ref-text-similarity) for a list of third party text similarity models supported by {{es}}.
@@ -743,7 +743,7 @@ Follow these steps to load the model and create a semantic re-ranker.
     python -m pip install eland[pytorch]
     ```
 
-2. Upload the model to {{es}} using Eland. This example assumes you have an Elastic Cloud deployment and an API key. Refer to the [Eland documentation](eland://docs/reference/machine-learning.md#ml-nlp-pytorch-auth) for more authentication options.
+2. Upload the model to {{es}} using Eland. This example assumes you have an Elastic Cloud deployment and an API key. Refer to the [Eland documentation](eland://reference/machine-learning.md#ml-nlp-pytorch-auth) for more authentication options.
 
     ```sh
     eland_import_hub_model \

--- a/docs/reference/elasticsearch/roles.md
+++ b/docs/reference/elasticsearch/roles.md
@@ -74,7 +74,7 @@ $$$built-in-roles-logstash-admin$$$ `logstash_admin`
 :   Grants access to the `.logstash*` indices for managing configurations, and grants necessary access for logstash-specific APIs exposed by the logstash x-pack plugin.
 
 $$$built-in-roles-logstash-system$$$ `logstash_system`
-:   Grants access necessary for the Logstash system user to send system-level data (such as monitoring) to {{es}}. For more information, see [Configuring Security in Logstash](logstash://docs/reference/secure-connection.md).
+:   Grants access necessary for the Logstash system user to send system-level data (such as monitoring) to {{es}}. For more information, see [Configuring Security in Logstash](logstash://reference/secure-connection.md).
 
     ::::{note}
     * This role should not be assigned to users as the granted permissions may change between releases.

--- a/docs/reference/ingestion-tools/enrich-processor/community-id-processor.md
+++ b/docs/reference/ingestion-tools/enrich-processor/community-id-processor.md
@@ -9,7 +9,7 @@ mapped_pages:
 
 Computes the Community ID for network flow data as defined in the [Community ID Specification](https://github.com/corelight/community-id-spec). You can use a community ID to correlate network events related to a single flow.
 
-The community ID processor reads network flow data from related [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)) fields by default. If you use the ECS, no configuration is required.
+The community ID processor reads network flow data from related [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)) fields by default. If you use the ECS, no configuration is required.
 
 $$$community-id-options$$$
 

--- a/docs/reference/ingestion-tools/enrich-processor/grok-processor.md
+++ b/docs/reference/ingestion-tools/enrich-processor/grok-processor.md
@@ -22,7 +22,7 @@ $$$grok-options$$$
 | `field` | yes | - | The field to use for grok expression parsing |
 | `patterns` | yes | - | An ordered list of grok expression to match and extract named captures with. Returns on the first expression in the list that matches. |
 | `pattern_definitions` | no | - | A map of pattern-name and pattern tuples defining custom patterns to be used by the current processor. Patterns matching existing names will override the pre-existing definition. |
-| `ecs_compatibility` | no | `disabled` | Must be `disabled` or `v1`. If `v1`, the processor uses patterns with [Elastic Common Schema (ECS)](ecs://docs/reference/ecs-field-reference.md) field names. |
+| `ecs_compatibility` | no | `disabled` | Must be `disabled` or `v1`. If `v1`, the processor uses patterns with [Elastic Common Schema (ECS)](ecs://reference/ecs-field-reference.md) field names. |
 | `trace_match` | no | false | when true, `_ingest._grok_match_index` will be inserted into your matched document’s metadata with the index into the pattern found in `patterns` that matched. |
 | `ignore_missing` | no | false | If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document |
 | `description` | no | - | Description of the processor. Useful for describing the purpose of the processor or its configuration. |
@@ -215,7 +215,7 @@ The above request will return a response body containing a key-value representat
 }
 ```
 
-By default, the API returns a list of legacy Grok patterns. These legacy patterns predate the [Elastic Common Schema (ECS)](ecs://docs/reference/ecs-field-reference.md) and don’t use ECS field names. To return patterns that extract ECS field names, specify `v1` in the optional `ecs_compatibility` query parameter.
+By default, the API returns a list of legacy Grok patterns. These legacy patterns predate the [Elastic Common Schema (ECS)](ecs://reference/ecs-field-reference.md) and don’t use ECS field names. To return patterns that extract ECS field names, specify `v1` in the optional `ecs_compatibility` query parameter.
 
 ```console
 GET _ingest/processor/grok?ecs_compatibility=v1

--- a/docs/reference/ingestion-tools/enrich-processor/network-direction-processor.md
+++ b/docs/reference/ingestion-tools/enrich-processor/network-direction-processor.md
@@ -9,7 +9,7 @@ mapped_pages:
 
 Calculates the network direction given a source IP address, destination IP address, and a list of internal networks.
 
-The network direction processor reads IP addresses from [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)) fields by default. If you use the ECS, only the `internal_networks` option must be specified.
+The network direction processor reads IP addresses from [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)) fields by default. If you use the ECS, only the `internal_networks` option must be specified.
 
 $$$network-direction-options$$$
 

--- a/docs/reference/ingestion-tools/enrich-processor/redact-processor.md
+++ b/docs/reference/ingestion-tools/enrich-processor/redact-processor.md
@@ -11,7 +11,7 @@ The Redact processor uses the Grok rules engine to obscure text in the input doc
 
 {{es}} comes packaged with a number of useful predefined [patterns](https://github.com/elastic/elasticsearch/blob/master/libs/grok/src/main/resources/patterns/ecs-v1) that can be conveniently referenced by the Redact processor. If one of those does not suit your needs, create a new pattern with a custom pattern definition. The Redact processor replaces every occurrence of a match. If there are multiple matches all will be replaced with the pattern name.
 
-The Redact processor is compatible with [Elastic Common Schema (ECS)](ecs://docs/reference/ecs-field-reference.md) patterns. Legacy Grok patterns are not supported.
+The Redact processor is compatible with [Elastic Common Schema (ECS)](ecs://reference/ecs-field-reference.md) patterns. Legacy Grok patterns are not supported.
 
 ## Using the Redact processor in a pipeline [using-redact]
 

--- a/docs/reference/ingestion-tools/search-connectors/api-tutorial.md
+++ b/docs/reference/ingestion-tools/search-connectors/api-tutorial.md
@@ -40,7 +40,7 @@ docker run -p 9200:9200 -d --name elasticsearch \
   -e "xpack.security.enabled=false" \
   -e "xpack.security.http.ssl.enabled=false" \
   -e "xpack.license.self_generated.type=trial" \
-  docker.elastic.co/elasticsearch/elasticsearch:9.0.0-beta1
+  docker.elastic.co/elasticsearch/elasticsearch:9.0.0
 ```
 
 ::::{warning}
@@ -258,7 +258,7 @@ docker run \
 --rm \
 --tty -i \
 --network host \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-azure-blob.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-azure-blob.md
@@ -189,7 +189,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-box.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-box.md
@@ -237,7 +237,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-confluence.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-confluence.md
@@ -247,7 +247,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-content-extraction.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-content-extraction.md
@@ -100,7 +100,7 @@ Local content extraction is available for the following self-managed connectors:
 
 Self-hosted content extraction is handled by a **separate** extraction service.
 
-The versions for the extraction service do not align with the Elastic stack. For versions after `8.11.x` (including 9.0.0-beta1), you should use extraction service version `0.3.x`.
+The versions for the extraction service do not align with the Elastic stack. For versions after `8.11.x` (including 9.0.0), you should use extraction service version `0.3.x`.
 
 You can run the service with the following command:
 

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-dropbox.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-dropbox.md
@@ -257,7 +257,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-github.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-github.md
@@ -282,7 +282,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-gmail.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-gmail.md
@@ -217,7 +217,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-google-cloud.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-google-cloud.md
@@ -103,7 +103,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-google-drive.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-google-drive.md
@@ -170,7 +170,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-graphql.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-graphql.md
@@ -88,7 +88,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-jira.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-jira.md
@@ -247,7 +247,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-logs.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-logs.md
@@ -37,7 +37,7 @@ You can filter by `service.type`:
 
 ## Logs reference [es-connectors-logs-reference]
 
-Logs use Elastic Common Schema (ECS), without extensions. See [the ECS Reference^](ecs://docs/reference/index.md) for more information.
+Logs use Elastic Common Schema (ECS), without extensions. See [the ECS Reference^](ecs://reference/index.md) for more information.
 
 The fields logged are:
 

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-mongodb.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-mongodb.md
@@ -315,7 +315,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-ms-sql.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-ms-sql.md
@@ -243,7 +243,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-mysql.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-mysql.md
@@ -317,7 +317,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-network-drive.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-network-drive.md
@@ -150,7 +150,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-notion.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-notion.md
@@ -172,7 +172,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-onedrive.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-onedrive.md
@@ -179,7 +179,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-oracle.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-oracle.md
@@ -238,7 +238,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-outlook.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-outlook.md
@@ -235,7 +235,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-postgresql.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-postgresql.md
@@ -256,7 +256,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-redis.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-redis.md
@@ -86,7 +86,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-run-from-docker.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-run-from-docker.md
@@ -7,9 +7,7 @@ mapped_pages:
 
 ::::{tip}
 Use our [Docker Compose quickstart](/reference/ingestion-tools/search-connectors/es-connectors-docker-compose-quickstart.md) to quickly get started with a full Elastic Stack deployment using Connectors.
-
 ::::
-
 
 Instead of running the Connectors Service from source, you can use the official Docker image to run the service in a container.
 
@@ -59,13 +57,13 @@ docker run \
 --rm \
 --tty -i \
 --network host \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```
 
 ::::{tip}
-For unreleased versions, append the `-SNAPSHOT` suffix to the version number. For example, `docker.elastic.co/integrations/elastic-connectors:8.14.0.0-SNAPSHOT`.
+For unreleased versions, append the `-SNAPSHOT` suffix to the version number. For example, `docker.elastic.co/integrations/elastic-connectors:9.0.0-SNAPSHOT`.
 
 ::::
 

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-s3.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-s3.md
@@ -211,7 +211,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-salesforce.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-salesforce.md
@@ -235,7 +235,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-servicenow.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-servicenow.md
@@ -265,7 +265,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-sharepoint-online.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-sharepoint-online.md
@@ -326,7 +326,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-sharepoint.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-sharepoint.md
@@ -237,7 +237,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-slack.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-slack.md
@@ -198,7 +198,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-teams.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-teams.md
@@ -228,7 +228,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/ingestion-tools/search-connectors/es-connectors-zoom.md
+++ b/docs/reference/ingestion-tools/search-connectors/es-connectors-zoom.md
@@ -227,7 +227,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/integrations/elastic-connectors:9.0.0-beta1.0 \
+docker.elastic.co/integrations/elastic-connectors:9.0.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ```

--- a/docs/reference/query-languages/eql-ex-threat-detection.md
+++ b/docs/reference/query-languages/eql-ex-threat-detection.md
@@ -18,7 +18,7 @@ One common variant of regsvr32 misuse is a [Squiblydoo attack](https://attack.mi
 
 ## Setup [eql-ex-threat-detection-setup]
 
-This tutorial uses a test dataset from [Atomic Red Team](https://github.com/redcanaryco/atomic-red-team) that includes events imitating a Squiblydoo attack. The data has been mapped to [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)) fields.
+This tutorial uses a test dataset from [Atomic Red Team](https://github.com/redcanaryco/atomic-red-team) that includes events imitating a Squiblydoo attack. The data has been mapped to [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)) fields.
 
 To get started:
 

--- a/docs/reference/query-languages/eql-syntax.md
+++ b/docs/reference/query-languages/eql-syntax.md
@@ -16,7 +16,7 @@ EQL queries require an event category and a matching condition. The `where` keyw
 event_category where condition
 ```
 
-An event category is an indexed value of the [event category field](/reference/query-languages/eql.md#eql-required-fields). By default, the [EQL search API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-search) uses the `event.category` field from the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). You can specify another event category field using the API’s [`event_category_field`](/reference/query-languages/eql.md#specify-a-timestamp-or-event-category-field) parameter.
+An event category is an indexed value of the [event category field](/reference/query-languages/eql.md#eql-required-fields). By default, the [EQL search API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-search) uses the `event.category` field from the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). You can specify another event category field using the API’s [`event_category_field`](/reference/query-languages/eql.md#specify-a-timestamp-or-event-category-field) parameter.
 
 For example, the following EQL query matches events with an event category of `process` and a `process.name` of `svchost.exe`:
 

--- a/docs/reference/query-languages/eql.md
+++ b/docs/reference/query-languages/eql.md
@@ -25,14 +25,14 @@ Event Query Language (EQL) is a query language for event-based time series data,
 
 ## Required fields [eql-required-fields]
 
-With the exception of sample queries, EQL searches require that the searched data stream or index  contains a *timestamp* field. By default, EQL uses the `@timestamp` field from the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+With the exception of sample queries, EQL searches require that the searched data stream or index  contains a *timestamp* field. By default, EQL uses the `@timestamp` field from the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 EQL searches also require an *event category* field, unless you use the [`any` keyword](/reference/query-languages/eql-syntax.md#eql-syntax-match-any-event-category) to search for  documents without an event category field. By default, EQL uses the ECS `event.category` field.
 
 To use a different timestamp or event category field, see [Specify a timestamp or event category field](#specify-a-timestamp-or-event-category-field).
 
 ::::{tip}
-While no schema is required to use EQL, we recommend using the [ECS](ecs://docs/reference/index.md). EQL searches are designed to work with core ECS fields by default.
+While no schema is required to use EQL, we recommend using the [ECS](ecs://reference/index.md). EQL searches are designed to work with core ECS fields by default.
 ::::
 
 
@@ -1043,7 +1043,7 @@ The API returns:
 
 ## Specify a timestamp or event category field [specify-a-timestamp-or-event-category-field]
 
-The EQL search API uses the `@timestamp` and `event.category` fields from the [ECS](ecs://docs/reference/index.md) by default. To specify different fields, use the `timestamp_field` and `event_category_field` parameters:
+The EQL search API uses the `@timestamp` and `event.category` fields from the [ECS](ecs://reference/index.md) by default. To specify different fields, use the `timestamp_field` and `event_category_field` parameters:
 
 ```console
 GET /my-data-stream/_eql/search
@@ -1065,7 +1065,7 @@ By default, the EQL search API returns matching hits by timestamp. If two or mor
 
 If you don’t specify a tiebreaker field or the events also share the same tiebreaker value, {{es}} considers the events concurrent and may not return them in a consistent sort order.
 
-To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you use the [ECS](ecs://docs/reference/index.md), we recommend using `event.sequence` as the tiebreaker field.
+To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you use the [ECS](ecs://reference/index.md), we recommend using `event.sequence` as the tiebreaker field.
 
 ```console
 GET /my-data-stream/_eql/search

--- a/docs/reference/query-languages/esql/esql-enrich-data.md
+++ b/docs/reference/query-languages/esql/esql-enrich-data.md
@@ -93,7 +93,7 @@ To begin, add documents to one or more source indices. These documents should co
 
 You can manage source indices just like regular {{es}} indices using the [document](https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-document) and [index](https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-indices) APIs.
 
-You also can set up [{{beats}}](beats://docs/reference/index.md), such as a [{{filebeat}}](beats://docs/reference/filebeat/filebeat-installation-configuration.md), to automatically send and index documents to your source indices. See [Getting started with {{beats}}](beats://docs/reference/index.md).
+You also can set up [{{beats}}](beats://docs/reference/index.md), such as a [{{filebeat}}](beats://docs/reference/filebeat/filebeat-installation-configuration.md), to automatically send and index documents to your source indices. See [Getting started with {{beats}}](beats://reference/index.md).
 
 
 ### Create an enrich policy [esql-create-enrich-policy]

--- a/docs/reference/query-languages/esql/esql-process-data-with-dissect-grok.md
+++ b/docs/reference/query-languages/esql/esql-process-data-with-dissect-grok.md
@@ -13,7 +13,7 @@ Your data may contain unstructured strings that you want to structure. This make
 :alt: unstructured data
 :::
 
-{{es}} can structure your data at index time or query time. At index time, you can use the [Dissect](/reference/ingestion-tools/enrich-processor/dissect-processor.md) and [Grok](/reference/ingestion-tools/enrich-processor/grok-processor.md) ingest processors, or the {{ls}} [Dissect](logstash://reference/plugins-filters-dissect.md) and [Grok](logstash://docs/reference/plugins-filters-grok.md) filters. At query time, you can use the {{esql}} [`DISSECT`](/reference/query-languages/esql/esql-commands.md#esql-dissect) and [`GROK`](/reference/query-languages/esql/esql-commands.md#esql-grok) commands.
+{{es}} can structure your data at index time or query time. At index time, you can use the [Dissect](/reference/ingestion-tools/enrich-processor/dissect-processor.md) and [Grok](/reference/ingestion-tools/enrich-processor/grok-processor.md) ingest processors, or the {{ls}} [Dissect](logstash://reference/plugins-filters-dissect.md) and [Grok](logstash://reference/plugins-filters-grok.md) filters. At query time, you can use the {{esql}} [`DISSECT`](/reference/query-languages/esql/esql-commands.md#esql-dissect) and [`GROK`](/reference/query-languages/esql/esql-commands.md#esql-grok) commands.
 
 ## `DISSECT` or `GROK`? Or both? [esql-grok-or-dissect]
 

--- a/docs/reference/query-languages/esql/esql-process-data-with-dissect-grok.md
+++ b/docs/reference/query-languages/esql/esql-process-data-with-dissect-grok.md
@@ -13,7 +13,7 @@ Your data may contain unstructured strings that you want to structure. This make
 :alt: unstructured data
 :::
 
-{{es}} can structure your data at index time or query time. At index time, you can use the [Dissect](/reference/ingestion-tools/enrich-processor/dissect-processor.md) and [Grok](/reference/ingestion-tools/enrich-processor/grok-processor.md) ingest processors, or the {{ls}} [Dissect](logstash://docs/reference/plugins-filters-dissect.md) and [Grok](logstash://docs/reference/plugins-filters-grok.md) filters. At query time, you can use the {{esql}} [`DISSECT`](/reference/query-languages/esql/esql-commands.md#esql-dissect) and [`GROK`](/reference/query-languages/esql/esql-commands.md#esql-grok) commands.
+{{es}} can structure your data at index time or query time. At index time, you can use the [Dissect](/reference/ingestion-tools/enrich-processor/dissect-processor.md) and [Grok](/reference/ingestion-tools/enrich-processor/grok-processor.md) ingest processors, or the {{ls}} [Dissect](logstash://reference/plugins-filters-dissect.md) and [Grok](logstash://docs/reference/plugins-filters-grok.md) filters. At query time, you can use the {{esql}} [`DISSECT`](/reference/query-languages/esql/esql-commands.md#esql-dissect) and [`GROK`](/reference/query-languages/esql/esql-commands.md#esql-grok) commands.
 
 ## `DISSECT` or `GROK`? Or both? [esql-grok-or-dissect]
 

--- a/docs/reference/query-languages/kql.md
+++ b/docs/reference/query-languages/kql.md
@@ -102,7 +102,7 @@ To search for documents matching a pattern, use the wildcard syntax. For example
 http.response.status_code: 4*
 ```
 
-By default, leading wildcards are not allowed for performance reasons. You can modify this with the [`query:allowLeadingWildcards`](kibana://docs/reference/advanced-settings.md#query-allowleadingwildcards) advanced setting.
+By default, leading wildcards are not allowed for performance reasons. You can modify this with the [`query:allowLeadingWildcards`](kibana://reference/advanced-settings.md#query-allowleadingwildcards) advanced setting.
 
 ::::{note}
 Only `*` is currently supported. This matches zero or more characters.


### PR DESCRIPTION
- Closes https://github.com/elastic/docs-content/issues/332
Recreates https://github.com/elastic/elasticsearch/pull/121778 in 9.0 docs

- Fixes some broken cross-repo links