### PR TITLE
Allow skip shards with _tier and _index in ES|QL

### DIFF
--- a/docs/changelog/123728.yaml
+++ b/docs/changelog/123728.yaml
@@ -1,0 +1,5 @@
+pr: 123728
+summary: Allow skip shards with `_tier` and `_index` in ES|QL
+area: ES|QL
+type: enhancement
+issues: []

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -332,9 +332,6 @@ tests:
 - class: org.elasticsearch.entitlement.runtime.policy.PolicyManagerTests
   method: testFilesEntitlementsWithExclusive
   issue: https://github.com/elastic/elasticsearch/issues/123657
-- class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
-  method: test {p0=search.vectors/41_knn_search_bbq_hnsw/Test knn search}
-  issue: https://github.com/elastic/elasticsearch/issues/123727
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -332,6 +332,9 @@ tests:
 - class: org.elasticsearch.entitlement.runtime.policy.PolicyManagerTests
   method: testFilesEntitlementsWithExclusive
   issue: https://github.com/elastic/elasticsearch/issues/123657
+- class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
+  method: test {p0=search.vectors/41_knn_search_bbq_hnsw/Test knn search}
+  issue: https://github.com/elastic/elasticsearch/issues/123727
 
 # Examples:
 #

--- a/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.ConstantFieldType;
+import org.elasticsearch.index.mapper.IndexFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.ValueFetcher;
@@ -26,6 +27,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.LongSupplier;
 
 /**
@@ -38,6 +40,13 @@ import java.util.function.LongSupplier;
 public class CoordinatorRewriteContext extends QueryRewriteContext {
 
     public static final String TIER_FIELD_NAME = "_tier";
+
+    public static final Set<String> SUPPORTED_FIELDS = Set.of(
+        DataStream.TIMESTAMP_FIELD_NAME,
+        IndexMetadata.EVENT_INGESTED_FIELD_NAME,
+        TIER_FIELD_NAME,
+        IndexFieldMapper.NAME
+    );
 
     static final ConstantFieldType TIER_FIELD_TYPE = new ConstantFieldType(TIER_FIELD_NAME, Map.of()) {
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -52,6 +52,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static java.util.Arrays.asList;
 import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.DOC_VALUES;
@@ -179,10 +180,13 @@ public class PlannerUtils {
     }
 
     /**
-     * Extracts the ES query for the <code>@timestamp</code> field for the passed plan.
+     * Extracts a filter that can be used to skip unmatched shards on the coordinator.
      */
-    public static QueryBuilder requestTimestampFilter(PhysicalPlan plan) {
-        return detectFilter(plan, "@timestamp");
+    private static final Set<String> CAN_MATCH_FIELDS = Set.of("@timestamp", "event.ingested");
+
+    public static QueryBuilder canMatchFilter(PhysicalPlan plan) {
+        // metadata field like _index, _tier
+        return detectFilter(plan, f -> CAN_MATCH_FIELDS.contains(f) || f.startsWith("_"));
     }
 
     /**
@@ -190,12 +194,11 @@ public class PlannerUtils {
      * We currently only use this filter for the @timestamp field, which is always a date field. Any tests that wish to use this should
      * take care to not use it with TEXT fields.
      */
-    static QueryBuilder detectFilter(PhysicalPlan plan, String fieldName) {
+    static QueryBuilder detectFilter(PhysicalPlan plan, Predicate<String> fieldName) {
         // first position is the REST filter, the second the query filter
-        var requestFilter = new QueryBuilder[] { null, null };
-
+        final List<QueryBuilder> requestFilters = new ArrayList<>();
         plan.forEachDown(FragmentExec.class, fe -> {
-            requestFilter[0] = fe.esFilter();
+            requestFilters.add(fe.esFilter());
             // detect filter inside the query
             fe.fragment().forEachUp(Filter.class, f -> {
                 // the only filter that can be pushed down is that on top of the relation
@@ -208,7 +211,7 @@ public class PlannerUtils {
                     for (var exp : conjunctions) {
                         var refs = new AttributeSet(exp.references());
                         // remove literals or attributes that match by name
-                        boolean matchesField = refs.removeIf(e -> fieldName.equals(e.name()));
+                        boolean matchesField = refs.removeIf(e -> fieldName.test(e.name()));
                         // the expression only contains the target reference
                         // and the expression is pushable (functions can be fully translated)
                         if (matchesField && refs.isEmpty() && canPushToSource(exp)) {
@@ -216,13 +219,13 @@ public class PlannerUtils {
                         }
                     }
                 }
-                if (matches.size() > 0) {
-                    requestFilter[1] = TRANSLATOR_HANDLER.asQuery(Predicates.combineAnd(matches)).asBuilder();
+                if (matches.isEmpty() == false) {
+                    requestFilters.add(TRANSLATOR_HANDLER.asQuery(Predicates.combineAnd(matches)).asBuilder());
                 }
             });
         });
 
-        return Queries.combine(FILTER, asList(requestFilter));
+        return Queries.combine(FILTER, requestFilters);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.CoordinatorRewriteContext;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
@@ -182,11 +183,8 @@ public class PlannerUtils {
     /**
      * Extracts a filter that can be used to skip unmatched shards on the coordinator.
      */
-    private static final Set<String> CAN_MATCH_FIELDS = Set.of("@timestamp", "event.ingested");
-
     public static QueryBuilder canMatchFilter(PhysicalPlan plan) {
-        // metadata field like _index, _tier
-        return detectFilter(plan, f -> CAN_MATCH_FIELDS.contains(f) || f.startsWith("_"));
+        return detectFilter(plan, CoordinatorRewriteContext.SUPPORTED_FIELDS::contains);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -184,7 +184,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             clusterAlias,
             concreteIndices,
             originalIndices,
-            PlannerUtils.requestTimestampFilter(dataNodePlan),
+            PlannerUtils.canMatchFilter(dataNodePlan),
             runOnTaskFailure,
             ActionListener.releaseAfter(outListener, exchangeSource.addEmptySink())
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/FilterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/FilterTests.java
@@ -318,7 +318,7 @@ public class FilterTests extends ESTestCase {
     }
 
     private QueryBuilder filterQueryForTransportNodes(PhysicalPlan plan) {
-        return PlannerUtils.detectFilter(plan, EMP_NO);
+        return PlannerUtils.detectFilter(plan, EMP_NO::equals);
     }
 
     @Override


### PR DESCRIPTION
This change adds support for skipping shards with `event.ingested` fields and metadata fields (_tier, _index). This should allow ES|QL to skip unmatched shards and avoid sending requests to the data nodes.