### PR TITLE
[8.x] Fix `TimeSeriesDataStreamsIT.testShrinkActionInPolicyWithoutHotPhase` (#123153)

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/TimeSeriesRestDriver.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/TimeSeriesRestDriver.java
@@ -455,6 +455,9 @@ public final class TimeSeriesRestDriver {
                     "GET",
                     SHRUNKEN_INDEX_PREFIX + "*" + originalIndex + "," + originalIndex + "/_ilm/explain"
                 );
+                // Sometimes, the original index might already have been deleted, so we need to ignore unavailable (concrete) indices.
+                explainRequest.addParameter("ignore_unavailable", Boolean.toString(true));
+                explainRequest.addParameter("expand_wildcards", "open,hidden");
                 explainRequest.addParameter("only_errors", Boolean.toString(false));
                 explainRequest.addParameter("only_managed", Boolean.toString(false));
                 Response response = client.performRequest(explainRequest);

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
@@ -119,7 +119,6 @@ public class TimeSeriesDataStreamsIT extends ESRestTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/70595")
     public void testShrinkActionInPolicyWithoutHotPhase() throws Exception {
         createNewSingletonPolicy(client(), policyName, "warm", new ShrinkAction(1, null, false));
         createComposableTemplate(client(), template, dataStream + "*", getTemplate(policyName));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix &#x60;TimeSeriesDataStreamsIT.testShrinkActionInPolicyWithoutHotPhase&#x60; (#123153)](https://github.com/elastic/elasticsearch/pull/123153)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)