### PR TITLE
[Entitlements] Add a check for filesystem mismatch

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
@@ -203,7 +203,7 @@ public final class FileAccessTree {
     }
 
     private boolean checkPath(String path, String[] paths) {
-        logger.debug(() -> Strings.format("checking [%s] against [%s]", path, String.join(",", paths)));
+        logger.trace(() -> Strings.format("checking [%s] against [%s]", path, String.join(",", paths)));
         if (paths.length == 0) {
             return false;
         }
@@ -221,7 +221,7 @@ public final class FileAccessTree {
     }
 
     private static boolean isParent(String maybeParent, String path) {
-        logger.debug(() -> Strings.format("checking isParent [%s] for [%s]", maybeParent, path));
+        logger.trace(() -> Strings.format("checking isParent [%s] for [%s]", maybeParent, path));
         return path.startsWith(maybeParent) && path.startsWith(FILE_SEPARATOR, maybeParent.length());
     }
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.entitlement.runtime.policy;
 
+import org.elasticsearch.core.Strings;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement.Mode;
 import org.elasticsearch.logging.LogManager;
@@ -202,6 +203,7 @@ public final class FileAccessTree {
     }
 
     private boolean checkPath(String path, String[] paths) {
+        logger.debug(() -> Strings.format("checking [%s] against [%s]", path, String.join(",", paths)));
         if (paths.length == 0) {
             return false;
         }
@@ -219,6 +221,7 @@ public final class FileAccessTree {
     }
 
     private static boolean isParent(String maybeParent, String path) {
+        logger.debug(() -> Strings.format("checking isParent [%s] for [%s]", maybeParent, path));
         return path.startsWith(maybeParent) && path.startsWith(FILE_SEPARATOR, maybeParent.length());
     }
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -34,7 +34,6 @@ import java.io.File;
 import java.lang.StackWalker.StackFrame;
 import java.lang.module.ModuleFinder;
 import java.lang.module.ModuleReference;
-import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -312,12 +311,14 @@ public class PolicyManager {
     public void checkFileRead(Class<?> callerClass, Path path) {
         var pathFileSystemClass = path.getFileSystem().getClass();
         if (path.getFileSystem().getClass() != DEFAULT_FILESYSTEM_CLASS) {
-            logger.info(() -> Strings.format(
-                "File entitlement trivially allowed: path [%s] is for a different FileSystem class [%s], default is [%s]",
-                path.toString(),
-                pathFileSystemClass.getName(),
-                DEFAULT_FILESYSTEM_CLASS.getName()
-            ));
+            logger.info(
+                () -> Strings.format(
+                    "File entitlement trivially allowed: path [%s] is for a different FileSystem class [%s], default is [%s]",
+                    path.toString(),
+                    pathFileSystemClass.getName(),
+                    DEFAULT_FILESYSTEM_CLASS.getName()
+                )
+            );
             return;
         }
         var requestingClass = requestingClass(callerClass);

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -308,10 +308,10 @@ public class PolicyManager {
         checkFileRead(callerClass, file.toPath());
     }
 
-    public void checkFileRead(Class<?> callerClass, Path path) {
+    private static boolean isPathOnDefaultFilesystem(Path path) {
         var pathFileSystemClass = path.getFileSystem().getClass();
         if (path.getFileSystem().getClass() != DEFAULT_FILESYSTEM_CLASS) {
-            logger.info(
+            logger.debug(
                 () -> Strings.format(
                     "File entitlement trivially allowed: path [%s] is for a different FileSystem class [%s], default is [%s]",
                     path.toString(),
@@ -319,6 +319,13 @@ public class PolicyManager {
                     DEFAULT_FILESYSTEM_CLASS.getName()
                 )
             );
+            return false;
+        }
+        return true;
+    }
+
+    public void checkFileRead(Class<?> callerClass, Path path) {
+        if (isPathOnDefaultFilesystem(path) == false) {
             return;
         }
         var requestingClass = requestingClass(callerClass);
@@ -347,6 +354,9 @@ public class PolicyManager {
     }
 
     public void checkFileWrite(Class<?> callerClass, Path path) {
+        if (isPathOnDefaultFilesystem(path) == false) {
+            return;
+        }
         var requestingClass = requestingClass(callerClass);
         if (isTriviallyAllowed(requestingClass)) {
             return;

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -311,7 +311,7 @@ public class PolicyManager {
     private static boolean isPathOnDefaultFilesystem(Path path) {
         var pathFileSystemClass = path.getFileSystem().getClass();
         if (path.getFileSystem().getClass() != DEFAULT_FILESYSTEM_CLASS) {
-            logger.debug(
+            logger.trace(
                 () -> Strings.format(
                     "File entitlement trivially allowed: path [%s] is for a different FileSystem class [%s], default is [%s]",
                     path.toString(),

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
@@ -108,7 +108,6 @@ public record FilesEntitlement(List<FileData> filesData) implements Entitlement 
                 // Unix/BSD absolute
                 return true;
             }
-
             return isWindowsAbsolutePath(path);
         }
 


### PR DESCRIPTION
NIO Files function accept an arbitrary Path object; this objects may be of different classes/come from FileSystems different from the default one, which is the one that provide access to the file systems accessible to the Java virtual machine, and which we are trying to protect. 

For example: you can pass a  `ZipPath` (created by a `ZipFileSystem`) to `Files.exists(Path)`, to check for contents of a Zip file. This works, but check for entitlements on that `ZipPath` is not correct. 

While checking for Files entitlements, we should skip checks on Paths coming from different FileSystems, as they do not intersect with the Paths we are protecting. This PR adds a condition to do that.