### PR TITLE
More flexible settings pattern

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
@@ -35,8 +35,7 @@ public class EntitlementBootstrap {
     public record BootstrapArgs(
         Map<String, Policy> pluginPolicies,
         Function<Class<?>, String> pluginResolver,
-        Function<String, String> settingResolver,
-        Function<String, Stream<String>> settingGlobResolver,
+        Function<String, Stream<String>> settingResolver,
         Path[] dataDirs,
         Path[] sharedRepoDirs,
         Path configDir,
@@ -51,7 +50,6 @@ public class EntitlementBootstrap {
             requireNonNull(pluginPolicies);
             requireNonNull(pluginResolver);
             requireNonNull(settingResolver);
-            requireNonNull(settingGlobResolver);
             requireNonNull(dataDirs);
             if (dataDirs.length == 0) {
                 throw new IllegalArgumentException("must provide at least one data directory");
@@ -78,8 +76,7 @@ public class EntitlementBootstrap {
      *
      * @param pluginPolicies a map holding policies for plugins (and modules), by plugin (or module) name.
      * @param pluginResolver a functor to map a Java Class to the plugin it belongs to (the plugin name).
-     * @param settingResolver a functor to resolve the value of an Elasticsearch setting.
-     * @param settingGlobResolver a functor to resolve a glob expression for one or more Elasticsearch settings.
+     * @param settingResolver a functor to resolve a setting name pattern for one or more Elasticsearch settings.
      * @param dataDirs       data directories for Elasticsearch
      * @param sharedRepoDirs       shared repository directories for Elasticsearch
      * @param configDir      the config directory for Elasticsearch
@@ -93,8 +90,7 @@ public class EntitlementBootstrap {
     public static void bootstrap(
         Map<String, Policy> pluginPolicies,
         Function<Class<?>, String> pluginResolver,
-        Function<String, String> settingResolver,
-        Function<String, Stream<String>> settingGlobResolver,
+        Function<String, Stream<String>> settingResolver,
         Path[] dataDirs,
         Path[] sharedRepoDirs,
         Path configDir,
@@ -113,7 +109,6 @@ public class EntitlementBootstrap {
             pluginPolicies,
             pluginResolver,
             settingResolver,
-            settingGlobResolver,
             dataDirs,
             sharedRepoDirs,
             configDir,

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -144,8 +144,7 @@ public class EntitlementInitialization {
             bootstrapArgs.dataDirs(),
             bootstrapArgs.sharedRepoDirs(),
             bootstrapArgs.tempDir(),
-            bootstrapArgs.settingResolver(),
-            bootstrapArgs.settingGlobResolver()
+            bootstrapArgs.settingResolver()
         );
 
         List<Scope> serverScopes = new ArrayList<>();

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PathLookup.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PathLookup.java
@@ -19,6 +19,5 @@ public record PathLookup(
     Path[] dataDirs,
     Path[] sharedRepoDirs,
     Path tempDir,
-    Function<String, String> settingResolver,
-    Function<String, Stream<String>> settingGlobResolver
+    Function<String, Stream<String>> settingResolver
 ) {}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
@@ -232,13 +232,7 @@ public record FilesEntitlement(List<FileData> filesData) implements Entitlement 
 
         @Override
         public Stream<Path> resolveRelativePaths(PathLookup pathLookup) {
-            Stream<String> result;
-            if (setting.contains("*")) {
-                result = pathLookup.settingGlobResolver().apply(setting);
-            } else {
-                String path = pathLookup.settingResolver().apply(setting);
-                result = path == null ? Stream.of() : Stream.of(path);
-            }
+            Stream<String> result = pathLookup.settingResolver().apply(setting);
             if (ignoreUrl) {
                 result = result.filter(s -> s.toLowerCase(Locale.ROOT).startsWith("https://") == false);
             }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
@@ -50,8 +50,7 @@ public class FileAccessTreeTests extends ESTestCase {
         new Path[] { Path.of("/data1"), Path.of("/data2") },
         new Path[] { Path.of("/shared1"), Path.of("/shared2") },
         Path.of("/tmp"),
-        setting -> settings.get(setting),
-        glob -> settings.getValues(glob)
+        pattern -> settings.getValues(pattern)
     );
 
     public void testEmpty() {

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
@@ -51,7 +51,7 @@ public class FileAccessTreeTests extends ESTestCase {
         new Path[] { Path.of("/shared1"), Path.of("/shared2") },
         Path.of("/tmp"),
         setting -> settings.get(setting),
-        glob -> settings.getGlobValues(glob)
+        glob -> settings.getValues(glob)
     );
 
     public void testEmpty() {

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
@@ -71,8 +71,7 @@ public class PolicyManagerTests extends ESTestCase {
                 new Path[] { TEST_BASE_DIR.resolve("/data1/"), TEST_BASE_DIR.resolve("/data2") },
                 new Path[] { TEST_BASE_DIR.resolve("/shared1"), TEST_BASE_DIR.resolve("/shared2") },
                 TEST_BASE_DIR.resolve("/temp"),
-                Settings.EMPTY::get,
-                Settings.EMPTY::getGlobValues
+                Settings.EMPTY::getValues
             );
         } catch (Exception e) {
             throw new IllegalStateException(e);

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlementTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlementTests.java
@@ -48,8 +48,7 @@ public class FilesEntitlementTests extends ESTestCase {
         new Path[] { Path.of("/data1"), Path.of("/data2") },
         new Path[] { Path.of("/shared1"), Path.of("/shared2") },
         Path.of("/tmp"),
-        setting -> settings.get(setting),
-        glob -> settings.getGlobValues(glob)
+        pattern -> settings.getValues(pattern)
     );
 
     public void testEmptyBuild() {

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -248,8 +248,7 @@ class Elasticsearch {
             EntitlementBootstrap.bootstrap(
                 pluginPolicies,
                 pluginsResolver::resolveClassToPluginName,
-                nodeEnv.settings()::get,
-                nodeEnv.settings()::getGlobValues,
+                nodeEnv.settings()::getValues,
                 nodeEnv.dataDirs(),
                 nodeEnv.repoDirs(),
                 nodeEnv.configDir(),

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
@@ -704,9 +705,21 @@ public class SettingsTests extends ESTestCase {
     }
 
     public void testGlobValues() throws IOException {
-        Settings test = Settings.builder().put("foo.x.bar", "1").put("foo.y.bar", "2").build();
-        var values = test.getGlobValues("foo.*.bar").toList();
+        Settings test = Settings.builder().put("foo.x.bar", "1").build();
+
+        // no values
+        assertThat(test.getValues("foo.*.baz").toList(), empty());
+        assertThat(test.getValues("fuz.*.bar").toList(), empty());
+
+        var values = test.getValues("foo.*.bar").toList();
+        assertThat(values, containsInAnyOrder("1"));
+
+        test = Settings.builder().put("foo.x.bar", "1").put("foo.y.bar", "2").build();
+        values = test.getValues("foo.*.bar").toList();
         assertThat(values, containsInAnyOrder("1", "2"));
+
+        values = test.getValues("foo.x.bar").toList();
+        assertThat(values, contains("1"));
     }
 
 }


### PR DESCRIPTION
This commit reworks the settings globs to be more useable. Primarily it expands the values so that the settings may be lists, iterating over each value. Additionally it simplifies the function to also allow non-glob settings so that this single method may be used to lookup all values for a given setting pattern, whether it contains a glob or not.