### PR TITLE
[8.18] Include network access for watcher plugin (#123653)

### DIFF
--- a/x-pack/plugin/watcher/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/watcher/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,5 +1,11 @@
 ALL-UNNAMED:
   - manage_threads
+  # the original policy has java.net.SocketPermission "*", "accept,connect"
+  # but a comment stating it was "needed for multiple server implementations used in tests"
+  # TODO: this is likely not needed, but including here to be on the safe side until
+  # we can track down whether it's really needed
+  - inbound_network
+  - outbound_network
   - files:
     - relative_path: ".mime.types"
       relative_to: "home"


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Include network access for watcher plugin (#123653)