### PR TITLE
[8.x] Include network access for monitoring plugin (#123651)

### DIFF
--- a/x-pack/plugin/monitoring/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/monitoring/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,2 +1,8 @@
 ALL-UNNAMED:
   - set_https_connection_properties # potentially required by apache.httpcomponents
+  # the original policy has java.net.SocketPermission "*", "accept,connect"
+  # but a comment stating it was "needed for multiple server implementations used in tests"
+  # TODO: this is likely not needed, but including here to be on the safe side until
+  # we can track down whether it's really needed
+  - outbound_network
+  - inbound_network


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Include network access for monitoring plugin (#123651)