### PR TITLE
Avoiding a race condition where pending indices count is 0 at start of data stream reindex

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/GetMigrationReindexStatusTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/GetMigrationReindexStatusTransportAction.java
@@ -145,7 +145,7 @@ public class GetMigrationReindexStatusTransportAction extends HandledTransportAc
     }
 
     /*
-     * This method feches doc counts for all indices in inProgressIndices (and the indices they are being reindexed into). After
+     * This method fetches doc counts for all indices in inProgressIndices (and the indices they are being reindexed into). After
      * successfully fetching those, reportStatus is called.
      */
     private void fetchInProgressStatsAndReportStatus(

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
@@ -94,7 +94,7 @@ public class ReindexDataStreamPersistentTaskExecutor extends PersistentTasksExec
             id,
             type,
             action,
-            "id=" + taskInProgress.getId(),
+            "Reindexing data stream " + taskInProgress.getParams().getSourceDataStream(),
             parentTaskId,
             headers
         );

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamTask.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamTask.java
@@ -55,6 +55,7 @@ public class ReindexDataStreamTask extends AllocatedPersistentTask {
         this.persistentTaskStartTime = persistentTaskStartTime;
         this.initialTotalIndices = initialTotalIndices;
         this.initialTotalIndicesToBeUpgraded = initialTotalIndicesToBeUpgraded;
+        this.pending.set(initialTotalIndicesToBeUpgraded);
         this.completeTask = new RunOnce(() -> {
             if (exception == null) {
                 markAsCompleted();


### PR DESCRIPTION
For a very short time, the pending indices count is 0. Since [ReindexDataStreamEnrichedStatus](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamEnrichedStatus.java#L79) uses the pending count to compute the number of successes shown in the upgrade assistant, the upgrade assistant very briefly shows 100% success when a task starts. This fixes that by initializing pending to totalIndicesToBeUpgraded rather than to 0.

I have also tacked on two things that have been bugging me: a misspelled word in a comment, and a difficult-to-read task description.