### PR TITLE
[8.x] Avoiding a race condition where pending indices count is 0 at start of data stream reindex (#123765)

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/GetMigrationReindexStatusTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/GetMigrationReindexStatusTransportAction.java
@@ -145,7 +145,7 @@ public class GetMigrationReindexStatusTransportAction extends HandledTransportAc
     }
 
     /*
-     * This method feches doc counts for all indices in inProgressIndices (and the indices they are being reindexed into). After
+     * This method fetches doc counts for all indices in inProgressIndices (and the indices they are being reindexed into). After
      * successfully fetching those, reportStatus is called.
      */
     private void fetchInProgressStatsAndReportStatus(

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamPersistentTaskExecutor.java
@@ -93,7 +93,7 @@ public class ReindexDataStreamPersistentTaskExecutor extends PersistentTasksExec
             id,
             type,
             action,
-            "id=" + taskInProgress.getId(),
+            "Reindexing data stream " + taskInProgress.getParams().getSourceDataStream(),
             parentTaskId,
             headers
         );

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamTask.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamTask.java
@@ -55,6 +55,7 @@ public class ReindexDataStreamTask extends AllocatedPersistentTask {
         this.persistentTaskStartTime = persistentTaskStartTime;
         this.initialTotalIndices = initialTotalIndices;
         this.initialTotalIndicesToBeUpgraded = initialTotalIndicesToBeUpgraded;
+        this.pending.set(initialTotalIndicesToBeUpgraded);
         this.completeTask = new RunOnce(() -> {
             if (exception == null) {
                 markAsCompleted();


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Avoiding a race condition where pending indices count is 0 at start of data stream reindex (#123765)