### PR TITLE
[9.0] Avoid over collecting in Limit or Lucene Operator (#123296)

### DIFF
--- a/docs/changelog/123296.yaml
+++ b/docs/changelog/123296.yaml
@@ -1,0 +1,5 @@
+pr: 123296
+summary: Avoid over collecting in Limit or Lucene Operator
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
@@ -16,10 +16,10 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DocBlock;
 import org.elasticsearch.compute.data.DocVector;
 import org.elasticsearch.compute.data.DoubleVector;
-import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Limiter;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.Releasables;
 
@@ -37,6 +37,7 @@ public class LuceneSourceOperator extends LuceneOperator {
 
     private int currentPagePos = 0;
     private int remainingDocs;
+    private final Limiter limiter;
 
     private IntVector.Builder docsBuilder;
     private DoubleVector.Builder scoreBuilder;
@@ -46,6 +47,7 @@ public class LuceneSourceOperator extends LuceneOperator {
     public static class Factory extends LuceneOperator.Factory {
 
         private final int maxPageSize;
+        private final Limiter limiter;
 
         public Factory(
             List<? extends ShardContext> contexts,
@@ -58,11 +60,13 @@ public class LuceneSourceOperator extends LuceneOperator {
         ) {
             super(contexts, queryFunction, dataPartitioning, taskConcurrency, limit, scoring ? COMPLETE : COMPLETE_NO_SCORES);
             this.maxPageSize = maxPageSize;
+            // TODO: use a single limiter for multiple stage execution
+            this.limiter = limit == NO_LIMIT ? Limiter.NO_LIMIT : new Limiter(limit);
         }
 
         @Override
         public SourceOperator get(DriverContext driverContext) {
-            return new LuceneSourceOperator(driverContext.blockFactory(), maxPageSize, sliceQueue, limit, scoreMode);
+            return new LuceneSourceOperator(driverContext.blockFactory(), maxPageSize, sliceQueue, limit, limiter, scoreMode);
         }
 
         public int maxPageSize() {
@@ -84,10 +88,18 @@ public class LuceneSourceOperator extends LuceneOperator {
     }
 
     @SuppressWarnings("this-escape")
-    public LuceneSourceOperator(BlockFactory blockFactory, int maxPageSize, LuceneSliceQueue sliceQueue, int limit, ScoreMode scoreMode) {
+    public LuceneSourceOperator(
+        BlockFactory blockFactory,
+        int maxPageSize,
+        LuceneSliceQueue sliceQueue,
+        int limit,
+        Limiter limiter,
+        ScoreMode scoreMode
+    ) {
         super(blockFactory, maxPageSize, sliceQueue);
         this.minPageSize = Math.max(1, maxPageSize / 2);
         this.remainingDocs = limit;
+        this.limiter = limiter;
         int estimatedSize = Math.min(limit, maxPageSize);
         boolean success = false;
         try {
@@ -140,7 +152,7 @@ public class LuceneSourceOperator extends LuceneOperator {
 
     @Override
     public boolean isFinished() {
-        return doneCollecting || remainingDocs <= 0;
+        return doneCollecting || limiter.remaining() == 0;
     }
 
     @Override
@@ -160,6 +172,7 @@ public class LuceneSourceOperator extends LuceneOperator {
             if (scorer == null) {
                 return null;
             }
+            final int remainingDocsStart = remainingDocs = limiter.remaining();
             try {
                 scorer.scoreNextRange(
                     leafCollector,
@@ -171,28 +184,32 @@ public class LuceneSourceOperator extends LuceneOperator {
                 );
             } catch (CollectionTerminatedException ex) {
                 // The leaf collector terminated the execution
+                doneCollecting = true;
                 scorer.markAsDone();
             }
+            final int collectedDocs = remainingDocsStart - remainingDocs;
+            final int discardedDocs = collectedDocs - limiter.tryAccumulateHits(collectedDocs);
             Page page = null;
-            if (currentPagePos >= minPageSize || remainingDocs <= 0 || scorer.isDone()) {
-                IntBlock shard = null;
-                IntBlock leaf = null;
+            if (currentPagePos >= minPageSize || scorer.isDone() || (remainingDocs = limiter.remaining()) == 0) {
+                IntVector shard = null;
+                IntVector leaf = null;
                 IntVector docs = null;
                 DoubleVector scores = null;
                 DocBlock docBlock = null;
+                currentPagePos -= discardedDocs;
                 try {
-                    shard = blockFactory.newConstantIntBlockWith(scorer.shardContext().index(), currentPagePos);
-                    leaf = blockFactory.newConstantIntBlockWith(scorer.leafReaderContext().ord, currentPagePos);
-                    docs = docsBuilder.build();
+                    shard = blockFactory.newConstantIntVector(scorer.shardContext().index(), currentPagePos);
+                    leaf = blockFactory.newConstantIntVector(scorer.leafReaderContext().ord, currentPagePos);
+                    docs = buildDocsVector(currentPagePos);
                     docsBuilder = blockFactory.newIntVectorBuilder(Math.min(remainingDocs, maxPageSize));
-                    docBlock = new DocVector(shard.asVector(), leaf.asVector(), docs, true).asBlock();
+                    docBlock = new DocVector(shard, leaf, docs, true).asBlock();
                     shard = null;
                     leaf = null;
                     docs = null;
                     if (scoreBuilder == null) {
                         page = new Page(currentPagePos, docBlock);
                     } else {
-                        scores = scoreBuilder.build();
+                        scores = buildScoresVector(currentPagePos);
                         scoreBuilder = blockFactory.newDoubleVectorBuilder(Math.min(remainingDocs, maxPageSize));
                         page = new Page(currentPagePos, docBlock, scores.asBlock());
                     }
@@ -206,6 +223,36 @@ public class LuceneSourceOperator extends LuceneOperator {
             return page;
         } finally {
             processingNanos += System.nanoTime() - start;
+        }
+    }
+
+    private IntVector buildDocsVector(int upToPositions) {
+        final IntVector docs = docsBuilder.build();
+        assert docs.getPositionCount() >= upToPositions : docs.getPositionCount() + " < " + upToPositions;
+        if (docs.getPositionCount() == upToPositions) {
+            return docs;
+        }
+        try (var slice = blockFactory.newIntVectorFixedBuilder(upToPositions)) {
+            for (int i = 0; i < upToPositions; i++) {
+                slice.appendInt(docs.getInt(i));
+            }
+            docs.close();
+            return slice.build();
+        }
+    }
+
+    private DoubleVector buildScoresVector(int upToPositions) {
+        final DoubleVector scores = scoreBuilder.build();
+        assert scores.getPositionCount() >= upToPositions : scores.getPositionCount() + " < " + upToPositions;
+        if (scores.getPositionCount() == upToPositions) {
+            return scores;
+        }
+        try (var slice = blockFactory.newDoubleVectorBuilder(upToPositions)) {
+            for (int i = 0; i < upToPositions; i++) {
+                slice.appendDouble(scores.getDouble(i));
+            }
+            scores.close();
+            return slice.build();
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Limiter.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Limiter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A shared limiter used by multiple drivers to collect hits in parallel without exceeding the output limit.
+ * For example, if the query `FROM test-1,test-2 | LIMIT 100` is run with two drivers, and one driver (e.g., querying `test-1`)
+ * has collected 60 hits, then the other driver querying `test-2` should collect at most 40 hits.
+ */
+public class Limiter {
+    private final int limit;
+    private final AtomicInteger collected = new AtomicInteger();
+
+    public static Limiter NO_LIMIT = new Limiter(Integer.MAX_VALUE) {
+        @Override
+        public int tryAccumulateHits(int numHits) {
+            return numHits;
+        }
+
+        @Override
+        public int remaining() {
+            return Integer.MAX_VALUE;
+        }
+    };
+
+    public Limiter(int limit) {
+        this.limit = limit;
+    }
+
+    /**
+     * Returns the remaining number of hits that can be collected.
+     */
+    public int remaining() {
+        final int remaining = limit - collected.get();
+        assert remaining >= 0 : remaining;
+        return remaining;
+    }
+
+    /**
+     * Returns the limit of this limiter.
+     */
+    public int limit() {
+        return limit;
+    }
+
+    /**
+     * Tries to accumulate hits and returns the number of hits that has been accepted.
+     *
+     * @param numHits the number of hits to try to accumulate
+     * @return the accepted number of hits. If the returned number is less than the numHits,
+     * it means the limit has been reached and the difference can be discarded.
+     */
+    public int tryAccumulateHits(int numHits) {
+        while (true) {
+            int curVal = collected.get();
+            if (curVal >= limit) {
+                return 0;
+            }
+            final int toAccept = Math.min(limit - curVal, numHits);
+            if (collected.compareAndSet(curVal, curVal + toAccept)) {
+                return toAccept;
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
@@ -25,6 +25,8 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.Driver;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.operator.PageConsumerOperator;
+import org.elasticsearch.compute.operator.SinkOperator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.compute.test.AnyOperatorTestCase;
 import org.elasticsearch.compute.test.OperatorTestCase;
@@ -44,6 +46,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.both;
@@ -94,7 +97,16 @@ public class LuceneSourceOperatorTests extends AnyOperatorTestCase {
         ShardContext ctx = new MockShardContext(reader, 0);
         Function<ShardContext, Query> queryFunction = c -> new MatchAllDocsQuery();
         int maxPageSize = between(10, Math.max(10, numDocs));
-        return new LuceneSourceOperator.Factory(List.of(ctx), queryFunction, dataPartitioning, 1, maxPageSize, limit, scoring);
+        int taskConcurrency = randomIntBetween(1, 4);
+        return new LuceneSourceOperator.Factory(
+            List.of(ctx),
+            queryFunction,
+            dataPartitioning,
+            taskConcurrency,
+            maxPageSize,
+            limit,
+            scoring
+        );
     }
 
     @Override
@@ -120,23 +132,23 @@ public class LuceneSourceOperatorTests extends AnyOperatorTestCase {
 
     public void testEarlyTermination() {
         int size = between(1_000, 20_000);
-        int limit = between(10, size);
+        int limit = between(0, Integer.MAX_VALUE);
         LuceneSourceOperator.Factory factory = simple(randomFrom(DataPartitioning.values()), size, limit, scoring);
-        try (SourceOperator sourceOperator = factory.get(driverContext())) {
-            assertFalse(sourceOperator.isFinished());
-            int collected = 0;
-            while (sourceOperator.isFinished() == false) {
-                Page page = sourceOperator.getOutput();
-                if (page != null) {
-                    collected += page.getPositionCount();
-                    page.releaseBlocks();
-                }
-                if (collected >= limit) {
-                    assertTrue("source operator is not finished after reaching limit", sourceOperator.isFinished());
-                    assertThat(collected, equalTo(limit));
-                }
-            }
+        int taskConcurrency = factory.taskConcurrency();
+        final AtomicInteger receivedRows = new AtomicInteger();
+        List<Driver> drivers = new ArrayList<>();
+        for (int i = 0; i < taskConcurrency; i++) {
+            DriverContext driverContext = driverContext();
+            SourceOperator sourceOperator = factory.get(driverContext);
+            SinkOperator sinkOperator = new PageConsumerOperator(p -> {
+                receivedRows.addAndGet(p.getPositionCount());
+                p.releaseBlocks();
+            });
+            Driver driver = new Driver("driver" + i, driverContext, sourceOperator, List.of(), sinkOperator, () -> {});
+            drivers.add(driver);
         }
+        OperatorTestCase.runDriver(drivers);
+        assertThat(receivedRows.get(), equalTo(Math.min(limit, size)));
     }
 
     public void testEmpty() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -141,7 +141,7 @@ public class AsyncOperatorTests extends ESTestCase {
         if (randomBoolean()) {
             int limit = between(0, ids.size());
             it = ids.subList(0, limit).iterator();
-            intermediateOperators.add(new LimitOperator(limit));
+            intermediateOperators.add(new LimitOperator(new Limiter(limit)));
         } else {
             it = ids.iterator();
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
@@ -15,7 +15,9 @@ import org.elasticsearch.compute.test.RandomBlock;
 import org.elasticsearch.compute.test.SequenceLongBlockSourceOperator;
 import org.hamcrest.Matcher;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.LongStream;
 
 import static org.elasticsearch.compute.test.RandomBlock.randomElementType;
@@ -124,6 +126,49 @@ public class LimitOperatorTests extends OperatorTestCase {
                 assertTrue(op.isFinished());
             }
         }
+    }
+
+    public void testEarlyTermination() {
+        int numDrivers = between(1, 4);
+        final List<Driver> drivers = new ArrayList<>();
+        final int limit = between(1, 10_000);
+        final LimitOperator.Factory limitFactory = new LimitOperator.Factory(limit);
+        final AtomicInteger receivedRows = new AtomicInteger();
+        for (int i = 0; i < numDrivers; i++) {
+            DriverContext driverContext = driverContext();
+            SourceOperator sourceOperator = new SourceOperator() {
+                boolean finished = false;
+
+                @Override
+                public void finish() {
+                    finished = true;
+                }
+
+                @Override
+                public boolean isFinished() {
+                    return finished;
+                }
+
+                @Override
+                public Page getOutput() {
+                    return new Page(randomBlock(driverContext.blockFactory(), between(1, 100)));
+                }
+
+                @Override
+                public void close() {
+
+                }
+            };
+            SinkOperator sinkOperator = new PageConsumerOperator(p -> {
+                receivedRows.addAndGet(p.getPositionCount());
+                p.releaseBlocks();
+            });
+            drivers.add(
+                new Driver("driver" + i, driverContext, sourceOperator, List.of(limitFactory.get(driverContext)), sinkOperator, () -> {})
+            );
+        }
+        runDriver(drivers);
+        assertThat(receivedRows.get(), equalTo(limit));
     }
 
     Block randomBlock(BlockFactory blockFactory, int size) {


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Avoid over collecting in Limit or Lucene Operator (#123296)