### PR TITLE
[9.0] Missing policies for netty, discovery-azure and repository-s3 (#123696)

### DIFF
--- a/modules/repository-s3/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/repository-s3/src/main/plugin-metadata/entitlement-policy.yaml
@@ -8,3 +8,8 @@ ALL-UNNAMED:
     - relative_path: ".aws/"
       relative_to: "home"
       mode: "read"
+  # The security policy permission states this is "only for tests": org.elasticsearch.repositories.s3.S3RepositoryPlugin
+  # TODO: check this is actually needed, and if we can isolate it to a test-only policy
+  - write_system_properties:
+      properties:
+        - es.allow_insecure_settings

--- a/modules/transport-netty4/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/transport-netty4/src/main/plugin-metadata/entitlement-policy.yaml
@@ -2,6 +2,12 @@ io.netty.transport:
   - inbound_network
   - outbound_network
   - manage_threads
+  # Netty NioEventLoop wants to change this, because of https://bugs.openjdk.java.net/browse/JDK-6427854
+  # the bug says it only happened rarely, and that its fixed, but apparently it still happens rarely!
+  # TODO: copied over from the security policy. Check if this is still valid
+  - write_system_properties:
+      properties:
+        - sun.nio.ch.bugLevel
 io.netty.common:
   - inbound_network
   - outbound_network

--- a/plugins/discovery-azure-classic/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/plugins/discovery-azure-classic/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,0 +1,2 @@
+ALL-UNNAMED:
+  - outbound_network


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Missing policies for netty, discovery-azure and repository-s3 (#123696)