### PR TITLE
Fix potential block leak in LuceneSourceOperator

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -341,24 +341,10 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
   method: testCreateAndRestorePartialSearchableSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/123773
-- class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
-  method: testDropAllColumns
-  issue: https://github.com/elastic/elasticsearch/issues/123791
+
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
   issue: https://github.com/elastic/elasticsearch/issues/122755
-- class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
-  method: testFromStatsGroupingByDate
-  issue: https://github.com/elastic/elasticsearch/issues/123808
-- class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
-  method: testDefaultTruncationSizeSetting
-  issue: https://github.com/elastic/elasticsearch/issues/123809
-- class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
-  method: testFromStatsEvalWithPragma
-  issue: https://github.com/elastic/elasticsearch/issues/123810
-- class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
-  method: testProjectRenameEval
-  issue: https://github.com/elastic/elasticsearch/issues/123811
 
 # Examples:
 #

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
@@ -232,12 +232,13 @@ public class LuceneSourceOperator extends LuceneOperator {
         if (docs.getPositionCount() == upToPositions) {
             return docs;
         }
-        try (var slice = blockFactory.newIntVectorFixedBuilder(upToPositions)) {
-            for (int i = 0; i < upToPositions; i++) {
-                slice.appendInt(docs.getInt(i));
+        try (docs) {
+            try (var slice = blockFactory.newIntVectorFixedBuilder(upToPositions)) {
+                for (int i = 0; i < upToPositions; i++) {
+                    slice.appendInt(docs.getInt(i));
+                }
+                return slice.build();
             }
-            docs.close();
-            return slice.build();
         }
     }
 
@@ -247,12 +248,13 @@ public class LuceneSourceOperator extends LuceneOperator {
         if (scores.getPositionCount() == upToPositions) {
             return scores;
         }
-        try (var slice = blockFactory.newDoubleVectorBuilder(upToPositions)) {
-            for (int i = 0; i < upToPositions; i++) {
-                slice.appendDouble(scores.getDouble(i));
+        try (scores) {
+            try (var slice = blockFactory.newDoubleVectorBuilder(upToPositions)) {
+                for (int i = 0; i < upToPositions; i++) {
+                    slice.appendDouble(scores.getDouble(i));
+                }
+                return slice.build();
             }
-            scores.close();
-            return slice.build();
         }
     }
 


### PR DESCRIPTION
A follow-up to #123296 to address a potential block leak that may occur when a circuit-breaking exception is triggered while truncating the docs or scores blocks.

Relates  #123296