### PR TITLE
[8.18] Fix potential block leak in LuceneSourceOperator (#123835)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
@@ -232,12 +232,13 @@ public class LuceneSourceOperator extends LuceneOperator {
         if (docs.getPositionCount() == upToPositions) {
             return docs;
         }
-        try (var slice = blockFactory.newIntVectorFixedBuilder(upToPositions)) {
-            for (int i = 0; i < upToPositions; i++) {
-                slice.appendInt(docs.getInt(i));
+        try (docs) {
+            try (var slice = blockFactory.newIntVectorFixedBuilder(upToPositions)) {
+                for (int i = 0; i < upToPositions; i++) {
+                    slice.appendInt(docs.getInt(i));
+                }
+                return slice.build();
             }
-            docs.close();
-            return slice.build();
         }
     }
 
@@ -247,12 +248,13 @@ public class LuceneSourceOperator extends LuceneOperator {
         if (scores.getPositionCount() == upToPositions) {
             return scores;
         }
-        try (var slice = blockFactory.newDoubleVectorBuilder(upToPositions)) {
-            for (int i = 0; i < upToPositions; i++) {
-                slice.appendDouble(scores.getDouble(i));
+        try (scores) {
+            try (var slice = blockFactory.newDoubleVectorBuilder(upToPositions)) {
+                for (int i = 0; i < upToPositions; i++) {
+                    slice.appendDouble(scores.getDouble(i));
+                }
+                return slice.build();
             }
-            scores.close();
-            return slice.build();
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Fix potential block leak in LuceneSourceOperator (#123835)](https://github.com/elastic/elasticsearch/pull/123835)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)