### PR TITLE
Explicit import layout for packages begin with io

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -209,7 +209,7 @@ indent_size = 4
 max_line_length = 140
 ij_java_class_count_to_use_import_on_demand = 999
 ij_java_names_count_to_use_import_on_demand = 999
-ij_java_imports_layout = *,|,com.**,|,org.**,|,java.**,|,javax.**,|,$*
+ij_java_imports_layout = *,|,com.**,|,io.**,|,org.**,|,java.**,|,javax.**,|,$*
 
 [*.json]
 indent_size = 2


### PR DESCRIPTION
This PR adds explicit import layout for io.* packages so that their import orders are consistent between IDE and CLI. Without it, the IDE places the io.* imports at the bottom of the import list. See AbstractRepositoryS3RestTestCase for such an example.
