### PR TITLE
[9.0] Remove @UpdateForV9 usages that are related to security manager removal (#123690)

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
@@ -12,7 +12,6 @@ package org.elasticsearch.server.cli;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Booleans;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.jdk.RuntimeVersionFeature;
 
 import java.io.IOException;
@@ -150,7 +149,6 @@ final class SystemJvmOptions {
         return Stream.of();
     }
 
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
     private static Stream<String> maybeAllowSecurityManager(boolean useEntitlements) {
         if (RuntimeVersionFeature.isSecurityManagerAvailable()) {
             // Will become conditional on useEntitlements once entitlements can run without SM

--- a/libs/core/src/main/java/org/elasticsearch/jdk/RuntimeVersionFeature.java
+++ b/libs/core/src/main/java/org/elasticsearch/jdk/RuntimeVersionFeature.java
@@ -9,12 +9,9 @@
 
 package org.elasticsearch.jdk;
 
-import org.elasticsearch.core.UpdateForV9;
-
 public class RuntimeVersionFeature {
     private RuntimeVersionFeature() {}
 
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA) // Remove once we removed all references to SecurityManager in code
     public static boolean isSecurityManagerAvailable() {
         return Runtime.version().feature() < 24;
     }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Remove @UpdateForV9 usages that are related to security manager removal (#123690)