### PR TITLE
Remove obsolete fields from PutStoredScriptRequest

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -206,6 +206,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_SERIALIZE_SOURCE_FUNCTIONS_WARNINGS = def(9_016_0_00);
     public static final TransportVersion ESQL_DRIVER_NODE_DESCRIPTION = def(9_017_0_00);
     public static final TransportVersion MULTI_PROJECT = def(9_018_0_00);
+    public static final TransportVersion STORED_SCRIPT_CONTENT_LENGTH = def(9_019_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPutStoredScriptAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPutStoredScriptAction.java
@@ -54,8 +54,7 @@ public class RestPutStoredScriptAction extends BaseRestHandler {
             getAckTimeout(request),
             request.param("id"),
             request.param("context"),
-            content,
-            request.getXContentType(),
+            content.length(),
             StoredScriptSource.parse(content, xContentType)
         );
         return channel -> client.execute(

--- a/server/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -687,12 +687,12 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
         PutStoredScriptRequest request,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        if (request.content().length() > maxSizeInBytes) {
+        if (request.contentLength() > maxSizeInBytes) {
             throw new IllegalArgumentException(
                 "exceeded max allowed stored script size in bytes ["
                     + maxSizeInBytes
                     + "] with size ["
-                    + request.content().length()
+                    + request.contentLength()
                     + "] for script ["
                     + request.id()
                     + "]"

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequestTests.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.action.admin.cluster.storedscripts;
 
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -22,6 +21,8 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.IOException;
 import java.util.Collections;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class PutStoredScriptRequestTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
@@ -30,18 +31,15 @@ public class PutStoredScriptRequestTests extends ESTestCase {
             TEST_REQUEST_TIMEOUT,
             "bar",
             "context",
-            new BytesArray("{}"),
-            XContentType.JSON,
+            0,
             new StoredScriptSource("foo", "bar", Collections.emptyMap())
         );
 
-        assertEquals(XContentType.JSON, storedScriptRequest.xContentType());
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             storedScriptRequest.writeTo(output);
 
             try (StreamInput in = output.bytes().streamInput()) {
                 PutStoredScriptRequest serialized = new PutStoredScriptRequest(in);
-                assertEquals(XContentType.JSON, serialized.xContentType());
                 assertEquals(storedScriptRequest.id(), serialized.id());
                 assertEquals(storedScriptRequest.context(), serialized.context());
             }
@@ -62,8 +60,7 @@ public class PutStoredScriptRequestTests extends ESTestCase {
             TEST_REQUEST_TIMEOUT,
             "test1",
             null,
-            expectedRequestBody,
-            xContentType,
+            expectedRequestBody.length(),
             StoredScriptSource.parse(expectedRequestBody, xContentType)
         );
 
@@ -73,7 +70,6 @@ public class PutStoredScriptRequestTests extends ESTestCase {
         requestBuilder.endObject();
 
         BytesReference actualRequestBody = BytesReference.bytes(requestBuilder);
-
-        assertEquals(expectedRequestBody, actualRequestBody);
+        assertThat(actualRequestBody.length(), equalTo(expectedRequestBody.length()));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/StoredScriptIntegTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/StoredScriptIntegTestUtils.java
@@ -39,8 +39,7 @@ public class StoredScriptIntegTestUtils {
             TEST_REQUEST_TIMEOUT,
             id,
             null,
-            jsonContent,
-            XContentType.JSON,
+            jsonContent.length(),
             StoredScriptSource.parse(jsonContent, XContentType.JSON)
         );
     }


### PR DESCRIPTION
Following on from #117566, remove the obsolete fields from 9.0