### PR TITLE
[8.16] [8.x] [DOCS] Update servicenow search connector DLS limitation (#123865)

### DIFF
--- a/docs/reference/connector/docs/connectors-servicenow.asciidoc
+++ b/docs/reference/connector/docs/connectors-servicenow.asciidoc
@@ -144,6 +144,13 @@ For default services, connectors use the following roles to find users who have 
 
 For services other than these defaults, the connector iterates over access controls with `read` operations and finds the respective roles for those services.
 
+[IMPORTANT]
+====
+The ServiceNow connector applies access control at the service (table) level.
+This means documents within a given ServiceNow table share the same access control settings.
+Users with permission to a table can access all documents from that table in Elasticsearch.
+====
+
 [NOTE]
 ====
 The ServiceNow connector does not support scripted and conditional permissions.
@@ -378,6 +385,13 @@ For default services, connectors use the following roles to find users who have 
 |===
 
 For services other than these defaults, the connector iterates over access controls with `read` operations and finds the respective roles for those services.
+
+[IMPORTANT]
+====
+The ServiceNow connector applies access control at the service (table) level.
+This means documents within a given ServiceNow table share the same access control settings.
+Users with permission to a table can access all documents from that table in Elasticsearch.
+====
 
 [NOTE]
 ====


### PR DESCRIPTION
Backports the following commits to 8.16:
 - [8.x] [DOCS] Update servicenow search connector DLS limitation (#123865)