### PR TITLE
Grant read access to the config dir

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
@@ -138,8 +138,9 @@ public final class FileAccessTree {
             });
         }
 
-        // everything has access to the temp dir and the jdk
+        // everything has access to the temp dir, config dir and the jdk
         addPathAndMaybeLink.accept(pathLookup.tempDir(), Mode.READ_WRITE);
+        addPathAndMaybeLink.accept(pathLookup.configDir(), Mode.READ);
 
         // TODO: watcher uses javax.activation which looks for known mime types configuration, should this be global or explicit in watcher?
         Path jdk = Paths.get(System.getProperty("java.home"));

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
@@ -140,6 +140,7 @@ public final class FileAccessTree {
 
         // everything has access to the temp dir, config dir and the jdk
         addPathAndMaybeLink.accept(pathLookup.tempDir(), Mode.READ_WRITE);
+        // TODO: this grants read access to the config dir for all modules until explicit read entitlements can be added
         addPathAndMaybeLink.accept(pathLookup.configDir(), Mode.READ);
 
         // TODO: watcher uses javax.activation which looks for known mime types configuration, should this be global or explicit in watcher?

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
@@ -289,6 +289,12 @@ public class FileAccessTreeTests extends ESTestCase {
         assertThat(tree.canWrite(TEST_PATH_LOOKUP.tempDir()), is(true));
     }
 
+    public void testConfigDirAccess() {
+        var tree = FileAccessTree.of("test-component", "test-module", FilesEntitlement.EMPTY, TEST_PATH_LOOKUP, List.of());
+        assertThat(tree.canRead(TEST_PATH_LOOKUP.configDir()), is(true));
+        assertThat(tree.canWrite(TEST_PATH_LOOKUP.configDir()), is(false));
+    }
+
     public void testBasicExclusiveAccess() {
         var tree = accessTree(entitlement("foo", "read"), exclusivePaths("test-component", "test-module", "foo"));
         assertThat(tree.canRead(path("foo")), is(true));

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
@@ -136,7 +136,7 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testReadWithRelativePath() {
-        for (var dir : List.of("config", "home")) {
+        for (var dir : List.of("home")) {
             var tree = accessTree(entitlement(Map.of("relative_path", "foo", "mode", "read", "relative_to", dir)), List.of());
             assertThat(tree.canRead(path("foo")), is(false));
 
@@ -153,7 +153,7 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testWriteWithRelativePath() {
-        for (var dir : List.of("config", "home")) {
+        for (var dir : List.of("home")) {
             var tree = accessTree(entitlement(Map.of("relative_path", "foo", "mode", "read_write", "relative_to", dir)), List.of());
             assertThat(tree.canWrite(path("/" + dir + "/foo")), is(true));
             assertThat(tree.canWrite(path("/" + dir + "/foo/subdir")), is(true));


### PR DESCRIPTION
This matches what Security Manager permissions Elasticsearch had for all plugins.