### PR TITLE
[8.18] Introduce the constant ByteStats.IDENTITY (#123857)

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestPipelineMetric.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestPipelineMetric.java
@@ -52,7 +52,12 @@ public class IngestPipelineMetric extends IngestMetric {
      * Creates a serializable representation for these metrics.
      */
     IngestStats.ByteStats createByteStats() {
-        return new IngestStats.ByteStats(this.bytesIngested.count(), this.bytesProduced.count());
+        long bytesIngested = this.bytesIngested.count();
+        long bytesProduced = this.bytesProduced.count();
+        if (bytesIngested == 0L && bytesProduced == 0L) {
+            return IngestStats.ByteStats.IDENTITY;
+        }
+        return new IngestStats.ByteStats(bytesIngested, bytesProduced);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
@@ -74,7 +74,7 @@ public record IngestStats(Stats totalStats, List<PipelineStat> pipelineStats, Ma
         for (var i = 0; i < size; i++) {
             var pipelineId = in.readString();
             var pipelineStat = readStats(in);
-            var byteStat = in.getTransportVersion().onOrAfter(TransportVersions.V_8_15_0) ? new ByteStats(in) : new ByteStats(0, 0);
+            var byteStat = in.getTransportVersion().onOrAfter(TransportVersions.V_8_15_0) ? readByteStats(in) : ByteStats.IDENTITY;
             pipelineStats.add(new PipelineStat(pipelineId, pipelineStat, byteStat));
             int processorsSize = in.readVInt();
             var processorStatsPerPipeline = new ArrayList<ProcessorStat>(processorsSize);
@@ -289,13 +289,21 @@ public record IngestStats(Stats totalStats, List<PipelineStat> pipelineStats, Ma
         }
     }
 
+    static ByteStats readByteStats(StreamInput in) throws IOException {
+        long bytesIngested = in.readVLong();
+        long bytesProduced = in.readVLong();
+        if (bytesProduced == 0L && bytesIngested == 0L) {
+            return ByteStats.IDENTITY;
+        }
+        return new ByteStats(bytesIngested, bytesProduced);
+    }
+
     /**
      * Container for ingested byte stats
      */
     public record ByteStats(long bytesIngested, long bytesProduced) implements Writeable, ToXContentFragment {
-        public ByteStats(StreamInput in) throws IOException {
-            this(in.readVLong(), in.readVLong());
-        }
+
+        public static final ByteStats IDENTITY = new ByteStats(0L, 0L);
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
@@ -319,6 +327,11 @@ public record IngestStats(Stats totalStats, List<PipelineStat> pipelineStats, Ma
         }
 
         static ByteStats merge(ByteStats first, ByteStats second) {
+            if (first == IDENTITY) {
+                return second;
+            } else if (second == IDENTITY) {
+                return first;
+            }
             return new ByteStats((first.bytesIngested + second.bytesIngested), first.bytesProduced + second.bytesProduced);
         }
     }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
@@ -63,6 +64,39 @@ public class IngestStatsTests extends ESTestCase {
         assertThat(processorStats.get(0).type(), sameInstance(set));
         assertThat(processorStats.get(1).type(), sameInstance(set));
         assertThat(processorStats.get(2).type(), sameInstance(set));
+    }
+
+    public void testBytesStatsSerialization() throws IOException {
+        {
+            IngestPipelineMetric metric = new IngestPipelineMetric();
+            IngestStats.ByteStats byteStats = metric.createByteStats();
+            assertThat(byteStats, sameInstance(IngestStats.ByteStats.IDENTITY));
+
+            IngestStats.ByteStats serializedByteStats = serialize(byteStats);
+            assertThat(serializedByteStats, sameInstance(IngestStats.ByteStats.IDENTITY));
+            assertThat(IngestStats.ByteStats.merge(IngestStats.ByteStats.IDENTITY, byteStats), sameInstance(byteStats));
+        }
+        {
+            long ingestBytes = randomLongBetween(0, Long.MAX_VALUE);
+            long producedBytes = randomLongBetween(0, Long.MAX_VALUE);
+            IngestPipelineMetric metric = new IngestPipelineMetric();
+            metric.preIngestBytes(ingestBytes);
+            metric.postIngestBytes(producedBytes);
+            IngestStats.ByteStats byteStats = metric.createByteStats();
+            assertThat(byteStats.bytesIngested(), equalTo(ingestBytes));
+            assertThat(byteStats.bytesProduced(), equalTo(producedBytes));
+
+            IngestStats.ByteStats serializedByteStats = serialize(byteStats);
+            assertThat(serializedByteStats.bytesIngested(), equalTo(ingestBytes));
+            assertThat(serializedByteStats.bytesProduced(), equalTo(producedBytes));
+
+            assertThat(IngestStats.ByteStats.merge(byteStats, IngestStats.ByteStats.IDENTITY), sameInstance(byteStats));
+            assertThat(IngestStats.ByteStats.merge(IngestStats.ByteStats.IDENTITY, byteStats), sameInstance(byteStats));
+            assertThat(
+                IngestStats.ByteStats.merge(IngestStats.ByteStats.IDENTITY, IngestStats.ByteStats.IDENTITY),
+                sameInstance(IngestStats.ByteStats.IDENTITY)
+            );
+        }
     }
 
     public void testStatsMerge() {
@@ -271,6 +305,13 @@ public class IngestStatsTests extends ESTestCase {
         stats.writeTo(out);
         var in = out.bytes().streamInput();
         return IngestStats.read(in);
+    }
+
+    private static IngestStats.ByteStats serialize(IngestStats.ByteStats stats) throws IOException {
+        var out = new BytesStreamOutput();
+        stats.writeTo(out);
+        var in = out.bytes().streamInput();
+        return IngestStats.readByteStats(in);
     }
 
     private static void assertIngestStats(IngestStats ingestStats, IngestStats serializedStats) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
@@ -106,7 +106,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                             pipelineStat -> new IngestStats.PipelineStat(
                                                 pipelineStat.pipelineId(),
                                                 pipelineStat.stats(),
-                                                new IngestStats.ByteStats(0, 0)
+                                                IngestStats.ByteStats.IDENTITY
                                             )
                                         )
                                         .toList(),
@@ -141,7 +141,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                             pipelineStat -> new IngestStats.PipelineStat(
                                                 pipelineStat.pipelineId(),
                                                 pipelineStat.stats(),
-                                                new IngestStats.ByteStats(0, 0)
+                                                IngestStats.ByteStats.IDENTITY
                                             )
                                         )
                                         .toList(),
@@ -214,7 +214,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                             pipelineStat -> new IngestStats.PipelineStat(
                                                 pipelineStat.pipelineId(),
                                                 pipelineStat.stats(),
-                                                new IngestStats.ByteStats(0, 0)
+                                                IngestStats.ByteStats.IDENTITY
                                             )
                                         )
                                         .toList(),
@@ -287,7 +287,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                             pipelineStat -> new IngestStats.PipelineStat(
                                                 pipelineStat.pipelineId(),
                                                 pipelineStat.stats(),
-                                                new IngestStats.ByteStats(0, 0)
+                                                IngestStats.ByteStats.IDENTITY
                                             )
                                         )
                                         .toList(),
@@ -360,7 +360,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                             pipelineStat -> new IngestStats.PipelineStat(
                                                 pipelineStat.pipelineId(),
                                                 pipelineStat.stats(),
-                                                new IngestStats.ByteStats(0, 0)
+                                                IngestStats.ByteStats.IDENTITY
                                             )
                                         )
                                         .toList(),
@@ -434,7 +434,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                             pipelineStat -> new IngestStats.PipelineStat(
                                                 pipelineStat.pipelineId(),
                                                 pipelineStat.stats(),
-                                                new IngestStats.ByteStats(0, 0)
+                                                IngestStats.ByteStats.IDENTITY
                                             )
                                         )
                                         .toList(),
@@ -508,7 +508,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                             pipelineStat -> new IngestStats.PipelineStat(
                                                 pipelineStat.pipelineId(),
                                                 pipelineStat.stats(),
-                                                new IngestStats.ByteStats(0, 0)
+                                                IngestStats.ByteStats.IDENTITY
                                             )
                                         )
                                         .toList(),
@@ -582,7 +582,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                             pipelineStat -> new IngestStats.PipelineStat(
                                                 pipelineStat.pipelineId(),
                                                 pipelineStat.stats(),
-                                                new IngestStats.ByteStats(0, 0)
+                                                IngestStats.ByteStats.IDENTITY
                                             )
                                         )
                                         .toList(),


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Introduce the constant ByteStats.IDENTITY (#123857)