### PR TITLE
Change default ciphers for JDK 24

### DIFF
--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfigurationLoader.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfigurationLoader.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
@@ -62,7 +63,7 @@ public abstract class SslConfigurationLoader {
 
     static final List<String> DEFAULT_PROTOCOLS = List.of("TLSv1.3", "TLSv1.2");
 
-    private static final List<String> JDK12_CIPHERS = List.of(
+    private static final List<String> JDK24_CIPHERS = List.of(
         // TLSv1.3 cipher has PFS, AEAD, hardware support
         "TLS_AES_256_GCM_SHA384",
         "TLS_AES_128_GCM_SHA256",
@@ -96,22 +97,27 @@ public abstract class SslConfigurationLoader {
 
         // PFS, hardware support
         "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-
-        // AEAD, hardware support
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-
-        // hardware support
-        "TLS_RSA_WITH_AES_256_CBC_SHA256",
-        "TLS_RSA_WITH_AES_128_CBC_SHA256",
-
-        // hardware support
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_CBC_SHA"
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
     );
 
-    static final List<String> DEFAULT_CIPHERS = JDK12_CIPHERS;
+    private static final List<String> JDK12_CIPHERS = Stream.concat(
+        JDK24_CIPHERS.stream(),
+        List.of(
+            // AEAD, hardware support
+            "TLS_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_RSA_WITH_AES_128_GCM_SHA256",
+
+            // hardware support
+            "TLS_RSA_WITH_AES_256_CBC_SHA256",
+            "TLS_RSA_WITH_AES_128_CBC_SHA256",
+
+            // hardware support
+            "TLS_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_RSA_WITH_AES_128_CBC_SHA"
+        ).stream()
+    ).toList();
+
+    static final List<String> DEFAULT_CIPHERS = Runtime.version().feature() >= 24 ? JDK24_CIPHERS : JDK12_CIPHERS;
     private static final char[] EMPTY_PASSWORD = new char[0];
     public static final List<X509Field> GLOBAL_DEFAULT_RESTRICTED_TRUST_FIELDS = List.of(X509Field.SAN_OTHERNAME_COMMONNAME);
 


### PR DESCRIPTION
Java 24 removed some ciphers. This commit changes the default ciphers SslService loads depending on the JDK version.