### PR TITLE
Add inbound_network entitlement to repository-hdfs plugin

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/InboundNetworkEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/InboundNetworkEntitlement.java
@@ -15,6 +15,6 @@ import org.elasticsearch.entitlement.runtime.policy.ExternalEntitlement;
  * Describes an entitlement for inbound network actions (listen/accept/receive)
  */
 public record InboundNetworkEntitlement() implements Entitlement {
-    @ExternalEntitlement
+    @ExternalEntitlement(esModulesOnly = false)
     public InboundNetworkEntitlement {}
 }

--- a/plugins/repository-hdfs/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/plugins/repository-hdfs/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,5 +1,6 @@
 ALL-UNNAMED:
   - manage_threads
+  - inbound_network # required for kerberos principals which specify a host component
   - outbound_network
   - load_native_libraries
   - write_system_properties:


### PR DESCRIPTION
The hadoop client requires opening a local socket in scenarios where the configured kerberos principal specifies a host. This change makes the `InboundNetworkEntitlement` available to plugins, and grants this entitlement to the `repository-hdfs` plugin.