### PR TITLE
[9.0] Query rules: Check if MGET request failed when we retrieve query rules (#123616)

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/rules/81_query_rules_retriever_no_rulesets.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/rules/81_query_rules_retriever_no_rulesets.yml
@@ -1,0 +1,32 @@
+setup:
+  - do:
+      bulk:
+        refresh: true
+        index: test-index1
+        body:
+          - index:
+              _id: foo
+          - { "text": "foo - pinned doc for foo" }
+
+---
+"query rules retriever when the .query-rules system index is missing":
+  - skip:
+      features: [ headers ]
+  - do:
+      search:
+        index: test-index1
+        body:
+          retriever:
+            rule:
+              match_criteria:
+                foo: foo
+                bar: bar
+              ruleset_ids:
+                abc
+              retriever:
+                standard:
+                  query:
+                    query_string:
+                      query: bar
+          explain: true
+      catch: "missing"

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
@@ -252,8 +252,15 @@ public class RuleQueryBuilder extends AbstractQueryBuilder<RuleQueryBuilder> {
 
                     for (MultiGetItemResponse item : multiGetResponse) {
                         String rulesetId = item.getId();
+                        // this usually happens when the system index does not exist because no query rules were created yet
+                        if (item.isFailed()) {
+                            listener.onFailure(item.getFailure().getFailure());
+                            return;
+                        }
+
                         GetResponse getResponse = item.getResponse();
 
+                        // this happens when an individual query ruleset cannot be found
                         if (getResponse.isExists() == false) {
                             listener.onFailure(new ResourceNotFoundException("query ruleset " + rulesetId + " not found"));
                             return;


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Query rules: Check if MGET request failed when we retrieve query rules (#123616)