### PR TITLE
Relax profiles assertions

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -493,26 +493,16 @@ public class RestEsqlIT extends RestEsqlTestCase {
             if (operators.contains("LuceneSourceOperator")) {
                 assertMap(sleeps, matchesMap().entry("counts", Map.of()).entry("first", List.of()).entry("last", List.of()));
             } else if (operators.contains("ExchangeSourceOperator")) {
-                if (operators.contains("ExchangeSinkOperator")) {
-                    assertMap(sleeps, matchesMap().entry("counts", matchesMap().entry("exchange empty", greaterThan(0))).extraOk());
-                    @SuppressWarnings("unchecked")
-                    List<Map<String, Object>> first = (List<Map<String, Object>>) sleeps.get("first");
-                    for (Map<String, Object> s : first) {
-                        assertMap(s, sleepMatcher);
-                    }
-                    @SuppressWarnings("unchecked")
-                    List<Map<String, Object>> last = (List<Map<String, Object>>) sleeps.get("last");
-                    for (Map<String, Object> s : last) {
-                        assertMap(s, sleepMatcher);
-                    }
-
-                } else {
-                    assertMap(
-                        sleeps,
-                        matchesMap().entry("counts", matchesMap().entry("exchange empty", 1))
-                            .entry("first", List.of(sleepMatcher))
-                            .entry("last", List.of(sleepMatcher))
-                    );
+                assertMap(sleeps, matchesMap().entry("counts", matchesMap().entry("exchange empty", greaterThan(0))).extraOk());
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> first = (List<Map<String, Object>>) sleeps.get("first");
+                for (Map<String, Object> s : first) {
+                    assertMap(s, sleepMatcher);
+                }
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> last = (List<Map<String, Object>>) sleeps.get("last");
+                for (Map<String, Object> s : last) {
+                    assertMap(s, sleepMatcher);
                 }
             } else {
                 fail("unknown signature: " + operators);


### PR DESCRIPTION
If the final driver is woken up before the exchange buffer is finished, there will be two sleeps in its profile instead of one. We don't need these assertions to be so precise. This change relaxes the assertions to allow reduce operators to have more than one sleep.

Closes #123210