### PR TITLE
Fix wording on node roles

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -46,7 +46,8 @@ The following additional roles are available:
 
 * `voting_only`
 
-[[coordinating-only-node]]If you leave `node.roles` unset, then the node is considered to be a <<coordinating-only-node-role,coordinating only node>>.
+[[coordinating-only-node]]If you set `node.roles` to an empty array (`node.roles: [ ]`),
+then the node is considered to be a <<coordinating-only-node-role,coordinating only node>>.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
In the 8.17 docs there is a statement that intends to say that nodes without roles are coordinating-only nodes. However, the wording was misleading because it referred to  leaving the setting _unset_ rather than explicitly setting it to _empty_.
