### PR TITLE
Skip internal logging in compat check

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/JarApiComparisonTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/JarApiComparisonTask.java
@@ -111,7 +111,10 @@ public abstract class JarApiComparisonTask extends PrecommitTask {
         List<String> classNames() throws IOException {
             Pattern classEnding = Pattern.compile(".*\\.class$");
             try (JarFile jf = new JarFile(this.path)) {
-                return jf.stream().map(ZipEntry::getName).filter(classEnding.asMatchPredicate()).collect(Collectors.toList());
+                return jf.stream().map(ZipEntry::getName)
+                    .filter(classEnding.asMatchPredicate())
+                    .filter(c -> c.startsWith("org/elasticsearch/logging/internal/") == false)
+                    .collect(Collectors.toList());
             }
         }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/JarApiComparisonTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/JarApiComparisonTask.java
@@ -111,7 +111,8 @@ public abstract class JarApiComparisonTask extends PrecommitTask {
         List<String> classNames() throws IOException {
             Pattern classEnding = Pattern.compile(".*\\.class$");
             try (JarFile jf = new JarFile(this.path)) {
-                return jf.stream().map(ZipEntry::getName)
+                return jf.stream()
+                    .map(ZipEntry::getName)
                     .filter(classEnding.asMatchPredicate())
                     .filter(c -> c.startsWith("org/elasticsearch/logging/internal/") == false)
                     .collect(Collectors.toList());


### PR DESCRIPTION
The stable API compatibility checks ensure public jars don't change their APIs in incompatible ways. Yet the logging jar has an internal package which can change arbitrarily. This commit adds a temporary workaround to skip the internal logging package until the compat check can be made to look at module-info.