### PR TITLE
[8.18] Skip internal logging in compat check (#123940)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/JarApiComparisonTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/JarApiComparisonTask.java
@@ -111,7 +111,11 @@ public abstract class JarApiComparisonTask extends PrecommitTask {
         List<String> classNames() throws IOException {
             Pattern classEnding = Pattern.compile(".*\\.class$");
             try (JarFile jf = new JarFile(this.path)) {
-                return jf.stream().map(ZipEntry::getName).filter(classEnding.asMatchPredicate()).collect(Collectors.toList());
+                return jf.stream()
+                    .map(ZipEntry::getName)
+                    .filter(classEnding.asMatchPredicate())
+                    .filter(c -> c.startsWith("org/elasticsearch/logging/internal/") == false)
+                    .collect(Collectors.toList());
             }
         }
 


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Skip internal logging in compat check (#123940)