### PR TITLE
[8.x] Unmute CrossClusterQueryWithPartialResultsIT tests (#123943)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -462,6 +462,3 @@ tests:
 - class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
   method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
   issue: https://github.com/elastic/elasticsearch/issues/121625
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
-  method: testPartialResults
-  issue: https://github.com/elastic/elasticsearch/issues/123101


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Unmute CrossClusterQueryWithPartialResultsIT tests (#123943)](https://github.com/elastic/elasticsearch/pull/123943)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)