### PR TITLE
Add temporary workaround for IntelliJ editorconfig bug

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -209,7 +209,9 @@ indent_size = 4
 max_line_length = 140
 ij_java_class_count_to_use_import_on_demand = 999
 ij_java_names_count_to_use_import_on_demand = 999
-ij_java_imports_layout = *,|,com.**,|,io.**,|,org.**,|,java.**,|,javax.**,|,$*
+# The first '@*,' is a workaround for https://youtrack.jetbrains.com/issue/IDEA-368382/Auto-import-puts-java-imports-first-even-when-Editor-Code-style-Java-Import-layout-puts-them-last
+# it should be removed once that is fixed
+ij_java_imports_layout = @*,*,|,com.**,|,org.**,|,java.**,|,javax.**,|,$*
 
 [*.json]
 indent_size = 2


### PR DESCRIPTION
Workaround described [here](https://youtrack.jetbrains.com/issue/IDEA-368382/Auto-import-puts-java-imports-first-even-when-Editor-Code-style-Java-Import-layout-puts-them-last#workaround)

Also removed specific config for `io.**` as it should not be necessary when this is all working correctly