### PR TITLE
[9.0] Align `TransportVersion#bestKnownVersion` with 8.x (#123801)

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -131,7 +131,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
      *         there are no such versions.
      */
     public TransportVersion bestKnownVersion() {
-        if (VersionsHolder.ALL_VERSIONS_MAP.containsKey(id)) {
+        if (isKnown()) {
             return this;
         }
         TransportVersion bestSoFar = TransportVersions.ZERO;


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Align `TransportVersion#bestKnownVersion` with 8.x (#123801)