### PR TITLE
[8.18] Make NotEntitledException inherit from SecurityException for compatibility purposes (#123984)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/NotEntitledException.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/NotEntitledException.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.entitlement.runtime.api;
 
-public class NotEntitledException extends RuntimeException {
+public class NotEntitledException extends SecurityException {
     public NotEntitledException(String message) {
         super(message);
     }


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Make NotEntitledException inherit from SecurityException for compatibility purposes (#123984)