### PR TITLE
Explicitly pass project ID in simulate pipeline request

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.ingest;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -130,6 +131,7 @@ public class SimulatePipelineRequest extends ActionRequest implements ToXContent
     static final String SIMULATED_PIPELINE_ID = "_simulate_pipeline";
 
     static Parsed parseWithPipelineId(
+        ProjectId projectId,
         String pipelineId,
         Map<String, Object> config,
         boolean verbose,
@@ -139,7 +141,7 @@ public class SimulatePipelineRequest extends ActionRequest implements ToXContent
         if (pipelineId == null) {
             throw new IllegalArgumentException("param [pipeline] is null");
         }
-        Pipeline pipeline = ingestService.getPipeline(pipelineId);
+        Pipeline pipeline = ingestService.getPipeline(projectId, pipelineId);
         if (pipeline == null) {
             throw new IllegalArgumentException("pipeline [" + pipelineId + "] does not exist");
         }

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineTransportAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -49,6 +50,7 @@ public class SimulatePipelineTransportAction extends HandledTransportAction<Simu
     private final IngestService ingestService;
     private final SimulateExecutionService executionService;
     private final TransportService transportService;
+    private final ProjectResolver projectResolver;
     private volatile TimeValue ingestNodeTransportActionTimeout;
     // ThreadLocal because our unit testing framework does not like sharing Randoms across threads
     private final ThreadLocal<Random> random = ThreadLocal.withInitial(Randomness::get);
@@ -58,7 +60,8 @@ public class SimulatePipelineTransportAction extends HandledTransportAction<Simu
         ThreadPool threadPool,
         TransportService transportService,
         ActionFilters actionFilters,
-        IngestService ingestService
+        IngestService ingestService,
+        ProjectResolver projectResolver
     ) {
         super(
             SimulatePipelineAction.NAME,
@@ -70,6 +73,7 @@ public class SimulatePipelineTransportAction extends HandledTransportAction<Simu
         this.ingestService = ingestService;
         this.executionService = new SimulateExecutionService(threadPool);
         this.transportService = transportService;
+        this.projectResolver = projectResolver;
         this.ingestNodeTransportActionTimeout = INGEST_NODE_TRANSPORT_ACTION_TIMEOUT.get(ingestService.getClusterService().getSettings());
         ingestService.getClusterService()
             .getClusterSettings()
@@ -96,9 +100,11 @@ public class SimulatePipelineTransportAction extends HandledTransportAction<Simu
         }
         try {
             if (discoveryNodes.getLocalNode().isIngestNode()) {
+                final var projectId = projectResolver.getProjectId();
                 final SimulatePipelineRequest.Parsed simulateRequest;
                 if (request.getId() != null) {
                     simulateRequest = SimulatePipelineRequest.parseWithPipelineId(
+                        projectId,
                         request.getId(),
                         source,
                         request.isVerbose(),


### PR DESCRIPTION
Instead of implicitly relying on the `IngestService` to resolve the project ID, the simulate pipeline request should do this and pass the project ID explicitly.