### PR TITLE
[8.x] Add jdk.management.agent module to server boot layer on start (#123938)

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcessBuilder.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcessBuilder.java
@@ -109,6 +109,7 @@ public class ServerProcessBuilder {
             esHome.resolve("lib").toString(),
             // Special circumstances require some modules (not depended on by the main server module) to be explicitly added:
             "--add-modules=jdk.net", // needed to reflectively set extended socket options
+            "--add-modules=jdk.management.agent", // needed by external debug tools to grab thread and heap dumps
             // we control the module path, which may have additional modules not required by server
             "--add-modules=ALL-MODULE-PATH",
             "-m",

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -187,7 +187,7 @@ public class Docker {
                 Thread.sleep(STARTUP_SLEEP_INTERVAL_MILLISECONDS);
 
                 // Set COLUMNS so that `ps` doesn't truncate its output
-                psOutput = dockerShell.run("bash -c 'COLUMNS=2000 ps ax'").stdout();
+                psOutput = dockerShell.run("bash -c 'COLUMNS=3000 ps ax'").stdout();
 
                 if (psOutput.contains("org.elasticsearch.bootstrap.Elasticsearch")) {
                     isElasticsearchRunning = true;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add jdk.management.agent module to server boot layer on start (#123938)