### PR TITLE
[8.18] fix bbq memory size estimate (#124022)

### DIFF
--- a/docs/reference/how-to/knn-search.asciidoc
+++ b/docs/reference/how-to/knn-search.asciidoc
@@ -76,7 +76,7 @@ Here are estimates for different element types and quantization levels:
 * `element_type: float`: `num_vectors * num_dimensions * 4`
 * `element_type: float` with `quantization: int8`: `num_vectors * (num_dimensions + 4)`
 * `element_type: float` with `quantization: int4`: `num_vectors * (num_dimensions/2 + 4)`
-* `element_type: float` with `quantization: bbq`: `num_vectors * (num_dimensions/8 + 12)`
+* `element_type: float` with `quantization: bbq`: `num_vectors * (num_dimensions/8 + 14)`
 * `element_type: byte`: `num_vectors * num_dimensions`
 * `element_type: bit`: `num_vectors * (num_dimensions/8)`
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [fix bbq memory size estimate (#124022)](https://github.com/elastic/elasticsearch/pull/124022)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)