### PR TITLE
Update slm-put.asciidoc - Note how partial snapshots get deleted

### DIFF
--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -89,7 +89,8 @@ Retention rules used to retain and delete snapshots created by the policy.
 (Optional, <<time-units, time units>>)
 Time period after which a snapshot is considered expired and eligible for
 deletion. {slm-init} deletes expired snapshots based on the
-<<slm-retention-schedule,`slm.retention_schedule`>>.
+<<slm-retention-schedule,`slm.retention_schedule`>>. 
+`PARTIAL` snapshots will be removed according to this setting.
 
 `max_count`::
 (Optional, integer)

--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -90,7 +90,9 @@ Retention rules used to retain and delete snapshots created by the policy.
 Time period after which a snapshot is considered expired and eligible for
 deletion. {slm-init} deletes expired snapshots based on the
 <<slm-retention-schedule,`slm.retention_schedule`>>. 
-`PARTIAL` snapshots will be removed according to this setting.
+Snapshots with a <<get-snapshot-api-response-state,`state`>> of `PARTIAL` will 
+be removed according to this setting. If not set, `PARTIAL` snapshots are deleted 
+as soon as a newer successful snapshot exists.
 
 `max_count`::
 (Optional, integer)
@@ -102,7 +104,9 @@ only includes snapshots with a <<get-snapshot-api-response-state,`state`>> of
 
 `min_count`::
 (Optional, integer)
-Minimum number of snapshots to retain, even if the snapshots have expired.
+Minimum number of snapshots to retain, even if the snapshots have expired. This limit
+only includes snapshots with a <<get-snapshot-api-response-state,`state`>> of
+`SUCCESS`.  
 ====
 
 `schedule`::


### PR DESCRIPTION
Adding a note to explain partial snapshots are deleted based on `expire_after`

Related PR describing this: https://github.com/elastic/elasticsearch/pull/47833

Code has changed since then but the same logic seems to apply:
https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfiguration.java#L219-L236
