### PR TITLE
Change constructor to private for ProjectMetadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ProjectMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ProjectMetadata.java
@@ -100,7 +100,7 @@ public class ProjectMetadata implements Iterable<IndexMetadata>, Diffable<Projec
     private final IndexVersion oldestIndexVersion;
 
     @SuppressWarnings("this-escape")
-    public ProjectMetadata(
+    private ProjectMetadata(
         ProjectId id,
         ImmutableOpenMap<String, IndexMetadata> indices,
         ImmutableOpenMap<String, Set<Index>> aliasedIndices,


### PR DESCRIPTION
Similar to Metadata, the constructor should be private since we expect it to be created with the Builder.
