### PR TITLE
[8.16] Fix configuration cache compatibility issues (#124073)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -133,7 +133,7 @@ develocity {
         }
       } else {
         tag 'LOCAL'
-        if (providers.systemProperty('idea.active').present) {
+        if (System.getProperty('idea.active') == 'true') {
           tag 'IDEA'
         }
       }

--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -51,13 +51,12 @@ esplugin.bundleSpec.from('config/discovery-ec2') {
 }
 
 tasks.register("writeTestJavaPolicy") {
+  boolean inFips = buildParams.inFipsJvm
+  inputs.property("inFipsJvm", inFips)
+  final File javaPolicy = new File(layout.buildDirectory.asFile.get(), "tmp/java.policy")
+  outputs.file(javaPolicy)
   doLast {
-    final File tmp = file("${buildDir}/tmp")
-    if (tmp.exists() == false && tmp.mkdirs() == false) {
-      throw new GradleException("failed to create temporary directory [${tmp}]")
-    }
-    final File javaPolicy = file("${tmp}/java.policy")
-    if (buildParams.inFipsJvm) {
+    if (inFips) {
       javaPolicy.write(
         [
           "grant {",
@@ -100,9 +99,9 @@ tasks.named("test").configure {
   // this is needed to manipulate com.amazonaws.sdk.ec2MetadataServiceEndpointOverride system property
   // it is better rather disable security manager at all with `systemProperty 'tests.security.manager', 'false'`
   if (buildParams.inFipsJvm){
-    nonInputProperties.systemProperty 'java.security.policy', "=file://${buildDir}/tmp/java.policy"
+    nonInputProperties.systemProperty 'java.security.policy', "=file://${layout.buildDirectory.asFile.get()}/tmp/java.policy"
   } else {
-    nonInputProperties.systemProperty 'java.security.policy', "file://${buildDir}/tmp/java.policy"
+    nonInputProperties.systemProperty 'java.security.policy', "file://${layout.buildDirectory.asFile.get()}/tmp/java.policy"
   }
 }
 


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Fix configuration cache compatibility issues (#124073)