### PR TITLE
[8.x] Simplify Lucene60 and Luene62 codec constructors (#124054)

### DIFF
--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene60/Lucene60Codec.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene60/Lucene60Codec.java
@@ -38,8 +38,6 @@ import org.elasticsearch.xpack.lucene.bwc.codecs.lucene50.BWCLucene50PostingsFor
 import org.elasticsearch.xpack.lucene.bwc.codecs.lucene50.Lucene50SegmentInfoFormat;
 import org.elasticsearch.xpack.lucene.bwc.codecs.lucene54.Lucene54DocValuesFormat;
 
-import java.util.Objects;
-
 /**
  * Implements the Lucene 6.0 index format.
  *
@@ -71,21 +69,12 @@ public class Lucene60Codec extends BWCCodec {
     };
 
     /**
-     * Instantiates a new codec.
+     * Instantiates a new codec. Called by SPI.
      */
+    @SuppressWarnings("unused")
     public Lucene60Codec() {
-        this(Lucene50StoredFieldsFormat.Mode.BEST_SPEED);
-    }
-
-    /**
-     * Instantiates a new codec, specifying the stored fields compression
-     * mode to use.
-     * @param mode stored fields compression mode to use for newly
-     *             flushed/merged segments.
-     */
-    public Lucene60Codec(Lucene50StoredFieldsFormat.Mode mode) {
         super("Lucene60");
-        this.storedFieldsFormat = new Lucene50StoredFieldsFormat(Objects.requireNonNull(mode));
+        this.storedFieldsFormat = new Lucene50StoredFieldsFormat(Lucene50StoredFieldsFormat.Mode.BEST_SPEED);
     }
 
     @Override

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene62/Lucene62Codec.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene62/Lucene62Codec.java
@@ -38,8 +38,6 @@ import org.elasticsearch.xpack.lucene.bwc.codecs.lucene50.BWCLucene50PostingsFor
 import org.elasticsearch.xpack.lucene.bwc.codecs.lucene54.Lucene54DocValuesFormat;
 import org.elasticsearch.xpack.lucene.bwc.codecs.lucene60.Lucene60MetadataOnlyPointsFormat;
 
-import java.util.Objects;
-
 /**
  * Implements the Lucene 6.2 index format.
  *
@@ -70,13 +68,13 @@ public class Lucene62Codec extends BWCCodec {
         }
     };
 
+    /**
+     * Instantiates a new codec. Called by SPI.
+     */
+    @SuppressWarnings("unused")
     public Lucene62Codec() {
-        this(Lucene50StoredFieldsFormat.Mode.BEST_SPEED);
-    }
-
-    public Lucene62Codec(Lucene50StoredFieldsFormat.Mode mode) {
         super("Lucene62");
-        this.storedFieldsFormat = new Lucene50StoredFieldsFormat(Objects.requireNonNull(mode));
+        this.storedFieldsFormat = new Lucene50StoredFieldsFormat(Lucene50StoredFieldsFormat.Mode.BEST_SPEED);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Simplify Lucene60 and Luene62 codec constructors (#124054)