### PR TITLE
[8.18] Use regexes to match monitoring tests with messages that change in v9 (#124080)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
@@ -1,11 +1,11 @@
 ---
 "Bulk indexing of monitoring data":
   - skip:
-      features: ["allowed_warnings"]
+      features: ["allowed_warnings_regex"]
 
   - do:
-      allowed_warnings:
-        - "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release."
+      allowed_warnings_regex:
+        - "\\[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.*"
       cluster.put_settings:
         body:
           persistent:
@@ -172,11 +172,11 @@
 ---
 "Bulk indexing of monitoring data on closed indices should throw an export exception":
   - skip:
-      features: ["allowed_warnings"]
+      features: ["allowed_warnings", "allowed_warnings_regex"]
 
   - do:
-      allowed_warnings:
-        - "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release."
+      allowed_warnings_regex:
+        - "\\[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.*"
       cluster.put_settings:
         body:
           persistent:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/20_privileges.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/20_privileges.yml
@@ -76,11 +76,11 @@ teardown:
 ---
 "Monitoring Bulk API":
   - skip:
-      features: ["catch_unauthorized", "allowed_warnings"]
+      features: ["catch_unauthorized", "allowed_warnings_regex"]
 
   - do:
-      allowed_warnings:
-        - "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release."
+      allowed_warnings_regex:
+        - "\\[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.*"
       cluster.put_settings:
         body:
           persistent:


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Use regexes to match monitoring tests with messages that change in v9 (#124080)