### PR TITLE
[8.x] Esql - fix some test failures due to results ordering  (#118692)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_nanos.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_nanos.csv-spec
@@ -707,7 +707,8 @@ required_capability: date_nanos_bucket
 
 FROM date_nanos 
 | WHERE millis > "2020-01-01" 
-| STATS ct = count(*) BY yr = BUCKET(nanos, 1 year);
+| STATS ct = count(*) BY yr = BUCKET(nanos, 1 year)
+| SORT yr DESC;
 
 ct:long | yr:date_nanos
 8       | 2023-01-01T00:00:00.000000000Z 
@@ -719,7 +720,8 @@ required_capability: date_nanos_bucket
 
 FROM date_nanos 
 | WHERE millis > "2020-01-01" 
-| STATS ct = count(*) BY yr = BUCKET(nanos, 5, "1999-01-01", NOW());
+| STATS ct = count(*) BY yr = BUCKET(nanos, 5, "1999-01-01", NOW())
+| SORT yr DESC;
 
 ct:long | yr:date_nanos
 8       | 2023-01-01T00:00:00.000000000Z 
@@ -731,7 +733,8 @@ required_capability: date_nanos_bucket
 
 FROM date_nanos 
 | WHERE millis > "2020-01-01" 
-| STATS ct = count(*) BY mo = BUCKET(nanos, 1 month);
+| STATS ct = count(*) BY mo = BUCKET(nanos, 1 month)
+| SORT mo DESC;
 
 ct:long | mo:date_nanos
 8       | 2023-10-01T00:00:00.000000000Z 
@@ -743,7 +746,8 @@ required_capability: date_nanos_bucket
 
 FROM date_nanos 
 | WHERE millis > "2020-01-01" 
-| STATS ct = count(*) BY mo = BUCKET(nanos, 20, "2023-01-01", "2023-12-31");
+| STATS ct = count(*) BY mo = BUCKET(nanos, 20, "2023-01-01", "2023-12-31")
+| SORT mo DESC;
 
 ct:long | mo:date_nanos
 8       | 2023-10-01T00:00:00.000000000Z 
@@ -755,11 +759,13 @@ required_capability: date_nanos_bucket
 
 FROM date_nanos 
 | WHERE millis > "2020-01-01" 
-| STATS ct = count(*) BY mo = BUCKET(nanos, 55, "2023-01-01", "2023-12-31");
+| STATS ct = count(*) BY mo = BUCKET(nanos, 55, "2023-01-01", "2023-12-31")
+| SORT mo DESC;
 
 ct:long | mo:date_nanos
 8       | 2023-10-23T00:00:00.000000000Z 
 ;
+
 Bucket Date nanos by 10 minutes
 required_capability: date_trunc_date_nanos
 required_capability: date_nanos_bucket
@@ -767,7 +773,8 @@ required_capability: string_literal_auto_casting
 
 FROM date_nanos 
 | WHERE millis > "2020-01-01" 
-| STATS ct = count(*) BY mn = BUCKET(nanos, 10 minutes);
+| STATS ct = count(*) BY mn = BUCKET(nanos, 10 minutes)
+| SORT mn DESC;
 
 ct:long | mn:date_nanos                 
 4       | 2023-10-23T13:50:00.000000000Z


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Esql - fix some test failures due to results ordering  (#118692)](https://github.com/elastic/elasticsearch/pull/118692)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)