### PR TITLE
Cleanup RegisteredDomainProcessorTests

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -76,16 +76,16 @@ public class RegisteredDomainProcessorTests extends ESTestCase {
 
         var processor = new RegisteredDomainProcessor(null, null, "domain", "", false);
 
-        IngestDocument input = TestIngestDocument.withDefaultVersion(source);
-        IngestDocument output = processor.execute(input);
+        IngestDocument document = TestIngestDocument.withDefaultVersion(source);
+        processor.execute(document);
 
-        String domain = output.getFieldValue(domainField, String.class);
+        String domain = document.getFieldValue(domainField, String.class);
         assertThat(domain, is("www.google.co.uk"));
-        String registeredDomain = output.getFieldValue(registeredDomainField, String.class);
+        String registeredDomain = document.getFieldValue(registeredDomainField, String.class);
         assertThat(registeredDomain, is("google.co.uk"));
-        String eTLD = output.getFieldValue(topLevelDomainField, String.class);
+        String eTLD = document.getFieldValue(topLevelDomainField, String.class);
         assertThat(eTLD, is("co.uk"));
-        String subdomain = output.getFieldValue(subdomainField, String.class);
+        String subdomain = document.getFieldValue(subdomainField, String.class);
         assertThat(subdomain, is("www"));
     }
 
@@ -127,16 +127,16 @@ public class RegisteredDomainProcessorTests extends ESTestCase {
 
         var processor = new RegisteredDomainProcessor(null, null, "domain", "url", ignoreMissing);
 
-        IngestDocument input = TestIngestDocument.withDefaultVersion(source);
-        IngestDocument output = processor.execute(input);
+        IngestDocument document = TestIngestDocument.withDefaultVersion(source);
+        processor.execute(document);
 
-        String domain = output.getFieldValue(domainField, String.class, expectedDomain == null);
+        String domain = document.getFieldValue(domainField, String.class, expectedDomain == null);
         assertThat(domain, is(expectedDomain));
-        String registeredDomain = output.getFieldValue(registeredDomainField, String.class, expectedRegisteredDomain == null);
+        String registeredDomain = document.getFieldValue(registeredDomainField, String.class, expectedRegisteredDomain == null);
         assertThat(registeredDomain, is(expectedRegisteredDomain));
-        String eTLD = output.getFieldValue(topLevelDomainField, String.class, expectedETLD == null);
+        String eTLD = document.getFieldValue(topLevelDomainField, String.class, expectedETLD == null);
         assertThat(eTLD, is(expectedETLD));
-        String subdomain = output.getFieldValue(subdomainField, String.class, expectedSubdomain == null);
+        String subdomain = document.getFieldValue(subdomainField, String.class, expectedSubdomain == null);
         assertThat(subdomain, is(expectedSubdomain));
     }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -127,23 +127,12 @@ public class RegisteredDomainProcessorTests extends ESTestCase {
         String expectedETLD,
         String expectedSubdomain
     ) throws Exception {
-        testRegisteredDomainProcessor(source, expectedDomain, expectedRegisteredDomain, expectedETLD, expectedSubdomain, true);
-    }
-
-    private void testRegisteredDomainProcessor(
-        Map<String, Object> source,
-        String expectedDomain,
-        String expectedRegisteredDomain,
-        String expectedETLD,
-        String expectedSubdomain,
-        boolean ignoreMissing
-    ) throws Exception {
         String domainField = "url.domain";
         String registeredDomainField = "url.registered_domain";
         String topLevelDomainField = "url.top_level_domain";
         String subdomainField = "url.subdomain";
 
-        var processor = new RegisteredDomainProcessor(null, null, "domain", "url", ignoreMissing);
+        var processor = new RegisteredDomainProcessor(null, null, "domain", "url", true);
 
         IngestDocument document = TestIngestDocument.withDefaultVersion(source);
         processor.execute(document);

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Test parsing of an eTLD from a FQDN. The list of eTLDs is maintained here:
@@ -80,13 +80,13 @@ public class RegisteredDomainProcessorTests extends ESTestCase {
         IngestDocument output = processor.execute(input);
 
         String domain = output.getFieldValue(domainField, String.class);
-        assertThat(domain, equalTo("www.google.co.uk"));
+        assertThat(domain, is("www.google.co.uk"));
         String registeredDomain = output.getFieldValue(registeredDomainField, String.class);
-        assertThat(registeredDomain, equalTo("google.co.uk"));
+        assertThat(registeredDomain, is("google.co.uk"));
         String eTLD = output.getFieldValue(topLevelDomainField, String.class);
-        assertThat(eTLD, equalTo("co.uk"));
+        assertThat(eTLD, is("co.uk"));
         String subdomain = output.getFieldValue(subdomainField, String.class);
-        assertThat(subdomain, equalTo("www"));
+        assertThat(subdomain, is("www"));
     }
 
     public void testError() throws Exception {
@@ -131,12 +131,12 @@ public class RegisteredDomainProcessorTests extends ESTestCase {
         IngestDocument output = processor.execute(input);
 
         String domain = output.getFieldValue(domainField, String.class, expectedDomain == null);
-        assertThat(domain, equalTo(expectedDomain));
+        assertThat(domain, is(expectedDomain));
         String registeredDomain = output.getFieldValue(registeredDomainField, String.class, expectedRegisteredDomain == null);
-        assertThat(registeredDomain, equalTo(expectedRegisteredDomain));
+        assertThat(registeredDomain, is(expectedRegisteredDomain));
         String eTLD = output.getFieldValue(topLevelDomainField, String.class, expectedETLD == null);
-        assertThat(eTLD, equalTo(expectedETLD));
+        assertThat(eTLD, is(expectedETLD));
         String subdomain = output.getFieldValue(subdomainField, String.class, expectedSubdomain == null);
-        assertThat(subdomain, equalTo(expectedSubdomain));
+        assertThat(subdomain, is(expectedSubdomain));
     }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -13,9 +13,11 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.TestIngestDocument;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static java.util.Map.entry;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -98,6 +100,23 @@ public class RegisteredDomainProcessorTests extends ESTestCase {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> processor.execute(document));
             assertThat(e.getMessage(), is("unable to set domain information for document"));
             assertThat(document.getSource(), is(Map.of("domain", "$")));
+        }
+    }
+
+    public void testIgnoreMissing() throws Exception {
+        {
+            var processor = new RegisteredDomainProcessor(null, null, "domain", "", false);
+            IngestDocument document = TestIngestDocument.withDefaultVersion(Map.of());
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> processor.execute(document));
+            assertThat(e.getMessage(), is("field [domain] not present as part of path [domain]"));
+            assertThat(document.getSource(), is(anEmptyMap()));
+        }
+
+        {
+            var processor = new RegisteredDomainProcessor(null, null, "domain", "", true);
+            IngestDocument document = TestIngestDocument.withDefaultVersion(Collections.singletonMap("domain", null));
+            processor.execute(document);
+            assertThat(document.getSource(), is(Collections.singletonMap("domain", null)));
         }
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -21,8 +21,8 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  * Test parsing of an eTLD from a FQDN. The list of eTLDs is maintained here:
  *   https://github.com/publicsuffix/list/blob/master/public_suffix_list.dat
- *
- * Effective TLDs (eTLS) are not the same as DNS TLDs. Uses for eTLDs are listed here.
+ * <p>
+ * Effective TLDs (eTLDs) are not the same as DNS TLDs. Uses for eTLDs are listed here:
  *   https://publicsuffix.org/learn/
  */
 public class RegisteredDomainProcessorTests extends ESTestCase {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -28,39 +28,30 @@ import static org.hamcrest.Matchers.is;
  *   https://publicsuffix.org/learn/
  */
 public class RegisteredDomainProcessorTests extends ESTestCase {
-    private Map<String, Object> buildEvent(String domain) {
-        return Map.of("domain", domain);
-    }
 
     public void testBasic() throws Exception {
-        testRegisteredDomainProcessor(buildEvent("www.google.com"), "www.google.com", "google.com", "com", "www");
-        testRegisteredDomainProcessor(buildEvent("google.com"), "google.com", "google.com", "com", null);
-        testRegisteredDomainProcessor(buildEvent(""), null, null, null, null);
-        testRegisteredDomainProcessor(buildEvent("."), null, null, null, null);
-        testRegisteredDomainProcessor(buildEvent("$"), null, null, null, null);
-        testRegisteredDomainProcessor(buildEvent("foo.bar.baz"), null, null, null, null);
-        testRegisteredDomainProcessor(buildEvent("www.books.amazon.co.uk"), "www.books.amazon.co.uk", "amazon.co.uk", "co.uk", "www.books");
+        testRegisteredDomainProcessor("www.google.com", "www.google.com", "google.com", "com", "www");
+        testRegisteredDomainProcessor("google.com", "google.com", "google.com", "com", null);
+        testRegisteredDomainProcessor("", null, null, null, null);
+        testRegisteredDomainProcessor(".", null, null, null, null);
+        testRegisteredDomainProcessor("$", null, null, null, null);
+        testRegisteredDomainProcessor("foo.bar.baz", null, null, null, null);
+        testRegisteredDomainProcessor("www.books.amazon.co.uk", "www.books.amazon.co.uk", "amazon.co.uk", "co.uk", "www.books");
         // Verify "com" is returned as the eTLD, for that FQDN or subdomain
-        testRegisteredDomainProcessor(buildEvent("com"), "com", null, "com", null);
-        testRegisteredDomainProcessor(buildEvent("example.com"), "example.com", "example.com", "com", null);
-        testRegisteredDomainProcessor(buildEvent("googleapis.com"), "googleapis.com", "googleapis.com", "com", null);
+        testRegisteredDomainProcessor("com", "com", null, "com", null);
+        testRegisteredDomainProcessor("example.com", "example.com", "example.com", "com", null);
+        testRegisteredDomainProcessor("googleapis.com", "googleapis.com", "googleapis.com", "com", null);
         testRegisteredDomainProcessor(
-            buildEvent("content-autofill.googleapis.com"),
+            "content-autofill.googleapis.com",
             "content-autofill.googleapis.com",
             "googleapis.com",
             "com",
             "content-autofill"
         );
         // Verify "ssl.fastly.net" is returned as the eTLD, for that FQDN or subdomain
+        testRegisteredDomainProcessor("global.ssl.fastly.net", "global.ssl.fastly.net", "global.ssl.fastly.net", "ssl.fastly.net", null);
         testRegisteredDomainProcessor(
-            buildEvent("global.ssl.fastly.net"),
-            "global.ssl.fastly.net",
-            "global.ssl.fastly.net",
-            "ssl.fastly.net",
-            null
-        );
-        testRegisteredDomainProcessor(
-            buildEvent("1.www.global.ssl.fastly.net"),
+            "1.www.global.ssl.fastly.net",
             "1.www.global.ssl.fastly.net",
             "global.ssl.fastly.net",
             "ssl.fastly.net",
@@ -121,7 +112,7 @@ public class RegisteredDomainProcessorTests extends ESTestCase {
     }
 
     private void testRegisteredDomainProcessor(
-        Map<String, Object> source,
+        String fqdn,
         String expectedDomain,
         String expectedRegisteredDomain,
         String expectedETLD,
@@ -134,7 +125,7 @@ public class RegisteredDomainProcessorTests extends ESTestCase {
 
         var processor = new RegisteredDomainProcessor(null, null, "domain", "url", true);
 
-        IngestDocument document = TestIngestDocument.withDefaultVersion(source);
+        IngestDocument document = TestIngestDocument.withDefaultVersion(Map.of("domain", fqdn));
         processor.execute(document);
 
         String domain = document.getFieldValue(domainField, String.class, expectedDomain == null);


### PR DESCRIPTION
Cleans up these tests to make them a bit simpler (to my eyes), and adds a new more-explicit of the existing `ignore_missing` functionality.

There are more PRs coming that touch the RegisteredDomainProcessor and its tests, this is just me shaving off a relatively independent ball of work into a PR.