### PR TITLE
Generate compatible versions artifact in distributions dir

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,7 +241,7 @@ def generateUpgradeCompatibilityFile = tasks.register("generateUpgradeCompatibil
 }
 
 def upgradeCompatibilityZip = tasks.register("upgradeCompatibilityZip", Zip) {
-  archiveFile.set(project.layout.buildDirectory.file("rolling-upgrade-compatible-${VersionProperties.elasticsearch}.zip"))
+  archiveFile.set(project.layout.buildDirectory.file("distributions/rolling-upgrade-compatible-${VersionProperties.elasticsearch}.zip"))
   from(generateUpgradeCompatibilityFile)
 }
 


### PR DESCRIPTION
Release manager expects artifacts to reside in the `build/distributions` directory by convention. Update this take to place the zip file in that location.