### PR TITLE
[8.x] Generate compatible versions artifact in distributions dir (#124119)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,7 +230,7 @@ def generateUpgradeCompatibilityFile = tasks.register("generateUpgradeCompatibil
 }
 
 def upgradeCompatibilityZip = tasks.register("upgradeCompatibilityZip", Zip) {
-  archiveFile.set(project.layout.buildDirectory.file("rolling-upgrade-compatible-${VersionProperties.elasticsearch}.zip"))
+  archiveFile.set(project.layout.buildDirectory.file("distributions/rolling-upgrade-compatible-${VersionProperties.elasticsearch}.zip"))
   from(generateUpgradeCompatibilityFile)
 }
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Generate compatible versions artifact in distributions dir (#124119)