### PR TITLE
[9.0] Adjust exception thrown when unable to load hunspell dict (#123743)

### DIFF
--- a/docs/changelog/123743.yaml
+++ b/docs/changelog/123743.yaml
@@ -1,0 +1,5 @@
+pr: 123743
+summary: Adjust exception thrown when unable to load hunspell dict
+area: Analysis
+type: bug
+issues: []

--- a/modules/analysis-common/build.gradle
+++ b/modules/analysis-common/build.gradle
@@ -6,8 +6,6 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import org.elasticsearch.gradle.Version
-
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
@@ -36,6 +34,7 @@ artifacts {
 
 tasks.named("yamlRestCompatTestTransform").configure { task ->
   task.replaceValueInMatch("tokens.0.token", "absenț", "romanian")
+  task.skipTest("indices.analyze/15_analyze/Custom analyzer is not buildable", "error response changed with #123743")
 }
 
 tasks.named("yamlRestTest").configure {

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/15_analyze.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/15_analyze.yml
@@ -64,11 +64,11 @@
 "Custom analyzer is not buildable":
   - requires:
       test_runner_features: [ capabilities ]
-      reason: This capability required to run test
       capabilities:
-        - method: GET
-          path: /_analyze
-          capabilities: [ wrong_custom_analyzer_returns_400 ]
+        - method: PUT
+          path: /{index}
+          capabilities: [ hunspell_dict_400 ]
+      reason: "bugfix 'hunspell_dict_400' capability required"
 
   - do:
       catch: bad_request
@@ -80,7 +80,3 @@
           filter:
             type: hunspell
             locale: en_US
-
-  - match: { status: 400 }
-  - match: { error.type: illegal_argument_exception }
-  - match: { error.reason: "Can not build a custom analyzer" }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
@@ -214,3 +214,30 @@
             index.mode: lookup
             index.number_of_shards: 2
 
+---
+"Create index with hunspell missing dict":
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ hunspell_dict_400 ]
+      reason: "bugfix 'hunspell_dict_400' capability required"
+
+  - do:
+      catch: bad_request
+      indices.create:
+        index: bad_hunspell_index
+        body:
+          settings:
+            analysis:
+              analyzer:
+                en:
+                  tokenizer: standard
+                  filter:
+                    - my_en_US_dict_stemmer
+                filter:
+                  my_en_US_dict_stemmer:
+                  type: hunspell
+                  locale: en_US
+                  dedup: false

--- a/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
@@ -99,7 +99,7 @@ public final class HunspellService {
             try {
                 return loadDictionary(locale, settings, env);
             } catch (Exception e) {
-                throw new IllegalStateException("failed to load hunspell dictionary for locale: " + locale, e);
+                throw new IllegalArgumentException("failed to load hunspell dictionary for locale: " + locale, e);
             }
         };
         if (HUNSPELL_LAZY_LOAD.get(settings) == false) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
@@ -28,9 +28,12 @@ public class CreateIndexCapabilities {
 
     private static final String NESTED_DENSE_VECTOR_SYNTHETIC_TEST = "nested_dense_vector_synthetic_test";
 
+    private static final String HUNSPELL_DICT_400 = "hunspell_dict_400";
+
     public static final Set<String> CAPABILITIES = Set.of(
         LOGSDB_INDEX_MODE_CAPABILITY,
         LOOKUP_INDEX_MODE_CAPABILITY,
-        NESTED_DENSE_VECTOR_SYNTHETIC_TEST
+        NESTED_DENSE_VECTOR_SYNTHETIC_TEST,
+        HUNSPELL_DICT_400
     );
 }

--- a/server/src/test/java/org/elasticsearch/indices/analyze/HunspellServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analyze/HunspellServiceTests.java
@@ -64,7 +64,7 @@ public class HunspellServiceTests extends ESTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .build();
 
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
             final Environment environment = new Environment(settings, getDataPath("/indices/analyze/no_aff_conf_dir"));
             new HunspellService(settings, environment, emptyMap()).getDictionary("en_US");
         });
@@ -78,7 +78,7 @@ public class HunspellServiceTests extends ESTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .build();
 
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
             final Environment environment = new Environment(settings, getDataPath("/indices/analyze/two_aff_conf_dir"));
             new HunspellService(settings, environment, emptyMap()).getDictionary("en_US");
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Adjust exception thrown when unable to load hunspell dict (#123743)](https://github.com/elastic/elasticsearch/pull/123743)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)