### PR TITLE
[8.18] Adjust exception thrown when unable to load hunspell dict (#123743)

### DIFF
--- a/docs/changelog/123743.yaml
+++ b/docs/changelog/123743.yaml
@@ -1,0 +1,5 @@
+pr: 123743
+summary: Adjust exception thrown when unable to load hunspell dict
+area: Analysis
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
@@ -214,3 +214,30 @@
             index.mode: lookup
             index.number_of_shards: 2
 
+---
+"Create index with hunspell missing dict":
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ hunspell_dict_400 ]
+      reason: "bugfix 'hunspell_dict_400' capability required"
+
+  - do:
+      catch: bad_request
+      indices.create:
+        index: bad_hunspell_index
+        body:
+          settings:
+            analysis:
+              analyzer:
+                en:
+                  tokenizer: standard
+                  filter:
+                    - my_en_US_dict_stemmer
+                filter:
+                  my_en_US_dict_stemmer:
+                  type: hunspell
+                  locale: en_US
+                  dedup: false

--- a/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
@@ -99,7 +99,7 @@ public final class HunspellService {
             try {
                 return loadDictionary(locale, settings, env);
             } catch (Exception e) {
-                throw new IllegalStateException("failed to load hunspell dictionary for locale: " + locale, e);
+                throw new IllegalArgumentException("failed to load hunspell dictionary for locale: " + locale, e);
             }
         };
         if (HUNSPELL_LAZY_LOAD.get(settings) == false) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
@@ -28,9 +28,12 @@ public class CreateIndexCapabilities {
 
     private static final String NESTED_DENSE_VECTOR_SYNTHETIC_TEST = "nested_dense_vector_synthetic_test";
 
+    private static final String HUNSPELL_DICT_400 = "hunspell_dict_400";
+
     public static final Set<String> CAPABILITIES = Set.of(
         LOGSDB_INDEX_MODE_CAPABILITY,
         LOOKUP_INDEX_MODE_CAPABILITY,
-        NESTED_DENSE_VECTOR_SYNTHETIC_TEST
+        NESTED_DENSE_VECTOR_SYNTHETIC_TEST,
+        HUNSPELL_DICT_400
     );
 }

--- a/server/src/test/java/org/elasticsearch/indices/analyze/HunspellServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analyze/HunspellServiceTests.java
@@ -64,7 +64,7 @@ public class HunspellServiceTests extends ESTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .build();
 
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
             final Environment environment = new Environment(settings, getDataPath("/indices/analyze/no_aff_conf_dir"));
             new HunspellService(settings, environment, emptyMap()).getDictionary("en_US");
         });
@@ -78,7 +78,7 @@ public class HunspellServiceTests extends ESTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .build();
 
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
             final Environment environment = new Environment(settings, getDataPath("/indices/analyze/two_aff_conf_dir"));
             new HunspellService(settings, environment, emptyMap()).getDictionary("en_US");
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Adjust exception thrown when unable to load hunspell dict (#123743)](https://github.com/elastic/elasticsearch/pull/123743)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)