### PR TITLE
Drop cluster scope method from RoleMappingMetadata

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
@@ -60,11 +60,6 @@ public final class RoleMappingMetadata extends AbstractNamedDiffable<Metadata.Pr
 
     private static final RoleMappingMetadata EMPTY = new RoleMappingMetadata(Set.of());
 
-    public static RoleMappingMetadata getFromClusterState(ClusterState clusterState) {
-        final ProjectMetadata project = clusterState.metadata().getProject();
-        return getFromProject(project);
-    }
-
     public static RoleMappingMetadata getFromProject(ProjectMetadata project) {
         return project.custom(RoleMappingMetadata.TYPE, RoleMappingMetadata.EMPTY);
     }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.security;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.integration.RoleMappingFileSettingsIT;
 import org.elasticsearch.reservedstate.service.FileSettingsService;
@@ -272,9 +273,10 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
     }
 
     private void assertRoleMappingsInClusterState(ClusterState clusterState, ExpressionRoleMapping... expectedRoleMappings) {
+        final var project = clusterState.metadata().getProject(ProjectId.DEFAULT);
         String[] expectedRoleMappingNames = Arrays.stream(expectedRoleMappings).map(ExpressionRoleMapping::getName).toArray(String[]::new);
         assertRoleMappingReservedMetadata(clusterState, expectedRoleMappingNames);
-        var actualRoleMappings = new ArrayList<>(RoleMappingMetadata.getFromClusterState(clusterState).getRoleMappings());
+        var actualRoleMappings = new ArrayList<>(RoleMappingMetadata.getFromProject(project).getRoleMappings());
         assertThat(actualRoleMappings, containsInAnyOrder(expectedRoleMappings));
     }
 


### PR DESCRIPTION
This removes `getFromClusterState` from `RoleMappingMetadata` and replaces its use in the 2 test classes that were still using it
