### PR TITLE
Refactor RegisteredDomainProcessorTests

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RegisteredDomainProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RegisteredDomainProcessor.java
@@ -11,6 +11,7 @@ package org.elasticsearch.ingest.common;
 
 import org.apache.http.conn.util.PublicSuffixMatcher;
 import org.apache.http.conn.util.PublicSuffixMatcherLoader;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
@@ -85,7 +86,7 @@ public class RegisteredDomainProcessor extends AbstractProcessor {
     @Nullable
     // visible for testing
     static DomainInfo getRegisteredDomain(@Nullable String fqdn) {
-        if (fqdn == null) {
+        if (Strings.hasText(fqdn) == false) {
             return null;
         }
         String registeredDomain = SUFFIX_MATCHER.getDomainRoot(fqdn);

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -11,14 +11,17 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.TestIngestDocument;
+import org.elasticsearch.ingest.common.RegisteredDomainProcessor.DomainInfo;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
 import java.util.Map;
 
 import static java.util.Map.entry;
+import static org.elasticsearch.ingest.common.RegisteredDomainProcessor.getRegisteredDomain;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Test parsing of an eTLD from a FQDN. The list of eTLDs is maintained here:
@@ -29,33 +32,33 @@ import static org.hamcrest.Matchers.is;
  */
 public class RegisteredDomainProcessorTests extends ESTestCase {
 
-    public void testGetRegisteredDomain() throws Exception {
-        testRegisteredDomainProcessor("www.google.com", "www.google.com", "google.com", "com", "www");
-        testRegisteredDomainProcessor("google.com", "google.com", "google.com", "com", null);
-        testRegisteredDomainProcessor("", null, null, null, null);
-        testRegisteredDomainProcessor(".", null, null, null, null);
-        testRegisteredDomainProcessor("$", null, null, null, null);
-        testRegisteredDomainProcessor("foo.bar.baz", null, null, null, null);
-        testRegisteredDomainProcessor("www.books.amazon.co.uk", "www.books.amazon.co.uk", "amazon.co.uk", "co.uk", "www.books");
+    public void testGetRegisteredDomain() {
+        assertThat(getRegisteredDomain("www.google.com"), is(new DomainInfo("www.google.com", "google.com", "com", "www")));
+        assertThat(getRegisteredDomain("google.com"), is(new DomainInfo("google.com", "google.com", "com", null)));
+        assertThat(getRegisteredDomain(""), nullValue());
+        assertThat(getRegisteredDomain("."), nullValue());
+        assertThat(getRegisteredDomain("$"), nullValue());
+        assertThat(getRegisteredDomain("foo.bar.baz"), nullValue());
+        assertThat(
+            getRegisteredDomain("www.books.amazon.co.uk"),
+            is(new DomainInfo("www.books.amazon.co.uk", "amazon.co.uk", "co.uk", "www.books"))
+        );
         // Verify "com" is returned as the eTLD, for that FQDN or subdomain
-        testRegisteredDomainProcessor("com", "com", null, "com", null);
-        testRegisteredDomainProcessor("example.com", "example.com", "example.com", "com", null);
-        testRegisteredDomainProcessor("googleapis.com", "googleapis.com", "googleapis.com", "com", null);
-        testRegisteredDomainProcessor(
-            "content-autofill.googleapis.com",
-            "content-autofill.googleapis.com",
-            "googleapis.com",
-            "com",
-            "content-autofill"
+        assertThat(getRegisteredDomain("com"), is(new DomainInfo("com", null, "com", null)));
+        assertThat(getRegisteredDomain("example.com"), is(new DomainInfo("example.com", "example.com", "com", null)));
+        assertThat(getRegisteredDomain("googleapis.com"), is(new DomainInfo("googleapis.com", "googleapis.com", "com", null)));
+        assertThat(
+            getRegisteredDomain("content-autofill.googleapis.com"),
+            is(new DomainInfo("content-autofill.googleapis.com", "googleapis.com", "com", "content-autofill"))
         );
         // Verify "ssl.fastly.net" is returned as the eTLD, for that FQDN or subdomain
-        testRegisteredDomainProcessor("global.ssl.fastly.net", "global.ssl.fastly.net", "global.ssl.fastly.net", "ssl.fastly.net", null);
-        testRegisteredDomainProcessor(
-            "1.www.global.ssl.fastly.net",
-            "1.www.global.ssl.fastly.net",
-            "global.ssl.fastly.net",
-            "ssl.fastly.net",
-            "1.www"
+        assertThat(
+            getRegisteredDomain("global.ssl.fastly.net"),
+            is(new DomainInfo("global.ssl.fastly.net", "global.ssl.fastly.net", "ssl.fastly.net", null))
+        );
+        assertThat(
+            getRegisteredDomain("1.www.global.ssl.fastly.net"),
+            is(new DomainInfo("1.www.global.ssl.fastly.net", "global.ssl.fastly.net", "ssl.fastly.net", "1.www"))
         );
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -35,7 +35,9 @@ public class RegisteredDomainProcessorTests extends ESTestCase {
     public void testGetRegisteredDomain() {
         assertThat(getRegisteredDomain("www.google.com"), is(new DomainInfo("www.google.com", "google.com", "com", "www")));
         assertThat(getRegisteredDomain("google.com"), is(new DomainInfo("google.com", "google.com", "com", null)));
+        assertThat(getRegisteredDomain(null), nullValue());
         assertThat(getRegisteredDomain(""), nullValue());
+        assertThat(getRegisteredDomain(" "), nullValue());
         assertThat(getRegisteredDomain("."), nullValue());
         assertThat(getRegisteredDomain("$"), nullValue());
         assertThat(getRegisteredDomain("foo.bar.baz"), nullValue());

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.is;
  */
 public class RegisteredDomainProcessorTests extends ESTestCase {
 
-    public void testBasic() throws Exception {
+    public void testGetRegisteredDomain() throws Exception {
         testRegisteredDomainProcessor("www.google.com", "www.google.com", "google.com", "com", "www");
         testRegisteredDomainProcessor("google.com", "google.com", "google.com", "com", null);
         testRegisteredDomainProcessor("", null, null, null, null);

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -59,6 +59,70 @@ public class RegisteredDomainProcessorTests extends ESTestCase {
         );
     }
 
+    public void testBasic() throws Exception {
+        var processor = new RegisteredDomainProcessor(null, null, "input", "output", false);
+        {
+            IngestDocument document = TestIngestDocument.withDefaultVersion(Map.of("input", "www.google.co.uk"));
+            processor.execute(document);
+            assertThat(
+                document.getSource(),
+                is(
+                    Map.ofEntries(
+                        entry("input", "www.google.co.uk"),
+                        entry(
+                            "output",
+                            Map.ofEntries(
+                                entry("domain", "www.google.co.uk"),
+                                entry("registered_domain", "google.co.uk"),
+                                entry("top_level_domain", "co.uk"),
+                                entry("subdomain", "www")
+                            )
+                        )
+                    )
+                )
+            );
+        }
+        {
+            IngestDocument document = TestIngestDocument.withDefaultVersion(Map.of("input", "example.com"));
+            processor.execute(document);
+            assertThat(
+                document.getSource(),
+                is(
+                    Map.ofEntries(
+                        entry("input", "example.com"),
+                        entry(
+                            "output",
+                            Map.ofEntries(
+                                entry("domain", "example.com"),
+                                entry("registered_domain", "example.com"),
+                                entry("top_level_domain", "com")
+                            )
+                        )
+                    )
+                )
+            );
+        }
+        {
+            IngestDocument document = TestIngestDocument.withDefaultVersion(Map.of("input", "com"));
+            processor.execute(document);
+            assertThat(
+                document.getSource(),
+                is(
+                    Map.ofEntries(
+                        entry("input", "com"),
+                        entry(
+                            "output",
+                            Map.ofEntries(
+                                entry("domain", "com"), //
+                                entry("top_level_domain", "com")
+                            )
+                        )
+                    )
+                )
+            );
+        }
+    }
+
     public void testUseRoot() throws Exception {
         var processor = new RegisteredDomainProcessor(null, null, "domain", "", false);
         IngestDocument document = TestIngestDocument.withDefaultVersion(Map.of("domain", "www.google.co.uk"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -177,31 +177,4 @@ public class RegisteredDomainProcessorTests extends ESTestCase {
             assertThat(document.getSource(), is(Collections.singletonMap("domain", null)));
         }
     }
-
-    private void testRegisteredDomainProcessor(
-        String fqdn,
-        String expectedDomain,
-        String expectedRegisteredDomain,
-        String expectedETLD,
-        String expectedSubdomain
-    ) throws Exception {
-        String domainField = "url.domain";
-        String registeredDomainField = "url.registered_domain";
-        String topLevelDomainField = "url.top_level_domain";
-        String subdomainField = "url.subdomain";
-
-        var processor = new RegisteredDomainProcessor(null, null, "domain", "url", true);
-
-        IngestDocument document = TestIngestDocument.withDefaultVersion(Map.of("domain", fqdn));
-        processor.execute(document);
-
-        String domain = document.getFieldValue(domainField, String.class, expectedDomain == null);
-        assertThat(domain, is(expectedDomain));
-        String registeredDomain = document.getFieldValue(registeredDomainField, String.class, expectedRegisteredDomain == null);
-        assertThat(registeredDomain, is(expectedRegisteredDomain));
-        String eTLD = document.getFieldValue(topLevelDomainField, String.class, expectedETLD == null);
-        assertThat(eTLD, is(expectedETLD));
-        String subdomain = document.getFieldValue(subdomainField, String.class, expectedSubdomain == null);
-        assertThat(subdomain, is(expectedSubdomain));
-    }
 }


### PR DESCRIPTION
Follow up to #124118 and #124123

The latter PR exposed some methods for testing purposes, but this PR actually takes advantage of that -- I wanted it to be more obvious that the rewriting of the tests didn't change the behavior of the tests (hence the separate PRs).

Technically there is a change to the source as well, don't miss that.