### PR TITLE
Remove unused method from AutoCreateIndex

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/AutoCreateIndex.java
+++ b/server/src/main/java/org/elasticsearch/action/support/AutoCreateIndex.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.action.support;
 
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
@@ -21,7 +20,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Booleans;
-import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.indices.SystemIndices;
@@ -56,12 +54,6 @@ public final class AutoCreateIndex {
         this.systemIndices = systemIndices;
         this.autoCreate = AUTO_CREATE_INDEX_SETTING.get(settings);
         clusterSettings.addSettingsUpdateConsumer(AUTO_CREATE_INDEX_SETTING, this::setAutoCreate);
-    }
-
-    @FixForMultiProject
-    @Deprecated
-    public boolean shouldAutoCreate(String index, ClusterState state) {
-        return shouldAutoCreate(index, state.metadata().getProject());
     }
 
     /**


### PR DESCRIPTION
The method

    AutoCreateIndex.shouldAutoCreate(String, ClusterState)

is deprecated and not used. This commit removes it.
