### PR TITLE
[Inference API] Align Get/Update Inference APIs with index API pattern

### DIFF
--- a/docs/changelog/124179.yaml
+++ b/docs/changelog/124179.yaml
@@ -1,0 +1,5 @@
+pr: 124179
+summary: Align Get/Update Inference APIs with index API pattern
+area: Inference
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -185,6 +185,7 @@ public class TransportVersions {
     public static final TransportVersion RE_REMOVE_MIN_COMPATIBLE_SHARD_NODE = def(9_021_0_00);
     public static final TransportVersion UNASSIGENEDINFO_RESHARD_ADDED = def(9_022_0_00);
     public static final TransportVersion INCLUDE_INDEX_MODE_IN_GET_DATA_STREAM = def(9_023_0_00);
+    public static final TransportVersion INFERENCE_API_WILDCARD_ALLOWED = def(9_024_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
## Motivation
Existing Inference APIs (`GET`/`POST _inference/<task_type>/<inference_id>`) only support single-ID operations, creating friction for bulk management scenarios like credential rotation. This PR aligns their behavior with standard [Index APIs](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-index.html#get-index-api-path-params) by adding wildcard(`*`) and comma-separated list support.

## Key Changes
1. Support wildcards (`prod_*`) and comma-separated IDs (`model_a,model_b`)
2. Batch operation implementation
3. Maintained backward compatibility for single-ID usage
4. Update API now returns `endpoints[]` array wrapping multiple `ModelConfigurations`

## Usage Examples
```bash
# Batch GET with wildcard and explicit IDs
GET _inference/text_embedding/prod_*,staging_model

# Wildcard credential update
POST _inference/completion/*openai*  
{
  "service_settings": {
    "api_key": "${NEW_KEY}", 
    "rate_limit": { "requests_per_minute": 1000 }
  }
}
```
**Standardized Response Format:**

```
{
  "endpoints": [
    {
      "inference_id": "openai-completion",
      "task_type": "completion",
      "service": "openai",
      "service_settings": {
        "model_id": "gpt-3.5-turbo",
        "rate_limit": { "requests_per_minute": 1000 }
      }
    },
    ...  // Additional endpoints
  ]
}
```

## Testing
• Verified cluster rolling upgrades
