### PR TITLE
[8.x] Use IDENTITY constants when creating stats in TrainedModelsStatsAction (#123894)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
@@ -92,7 +92,7 @@ public class GetTrainedModelsStatsAction extends ActionType<GetTrainedModelsStat
             private final int pipelineCount;
 
             private static final IngestStats EMPTY_INGEST_STATS = new IngestStats(
-                new IngestStats.Stats(0, 0, 0, 0),
+                IngestStats.Stats.IDENTITY,
                 Collections.emptyList(),
                 Collections.emptyMap()
             );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
@@ -428,24 +428,11 @@ public class TransportGetTrainedModelsStatsAction extends TransportAction<
             .stream()
             .filter(pipelineStat -> pipelineIds.contains(pipelineStat.pipelineId()))
             .collect(Collectors.toList());
-        CounterMetric ingestCount = new CounterMetric();
-        CounterMetric ingestTimeInMillis = new CounterMetric();
-        CounterMetric ingestCurrent = new CounterMetric();
-        CounterMetric ingestFailedCount = new CounterMetric();
+        IngestStatsAccumulator accumulator = new IngestStatsAccumulator();
 
-        filteredPipelineStats.forEach(pipelineStat -> {
-            IngestStats.Stats stats = pipelineStat.stats();
-            ingestCount.inc(stats.ingestCount());
-            ingestTimeInMillis.inc(stats.ingestTimeInMillis());
-            ingestCurrent.inc(stats.ingestCurrent());
-            ingestFailedCount.inc(stats.ingestFailedCount());
-        });
+        filteredPipelineStats.forEach(pipelineStat -> accumulator.inc(pipelineStat.stats()));
 
-        return new IngestStats(
-            new IngestStats.Stats(ingestCount.count(), ingestTimeInMillis.count(), ingestCurrent.count(), ingestFailedCount.count()),
-            filteredPipelineStats,
-            filteredProcessorStats
-        );
+        return new IngestStats(accumulator.build(), filteredPipelineStats, filteredProcessorStats);
     }
 
     private static IngestStats mergeStats(List<IngestStats> ingestStatsList) {
@@ -515,7 +502,13 @@ public class TransportGetTrainedModelsStatsAction extends TransportAction<
         }
 
         IngestStats.Stats build() {
-            return new IngestStats.Stats(ingestCount.count(), ingestTimeInMillis.count(), ingestCurrent.count(), ingestFailedCount.count());
+            IngestStats.Stats stats = new IngestStats.Stats(
+                ingestCount.count(),
+                ingestTimeInMillis.count(),
+                ingestCurrent.count(),
+                ingestFailedCount.count()
+            );
+            return stats.equals(IngestStats.Stats.IDENTITY) ? IngestStats.Stats.IDENTITY : stats;
         }
     }
 
@@ -535,7 +528,8 @@ public class TransportGetTrainedModelsStatsAction extends TransportAction<
         }
 
         IngestStats.ByteStats buildByteStats() {
-            return new IngestStats.ByteStats(ingestBytesConsumed.count(), ingestBytesProduced.count());
+            IngestStats.ByteStats byteStats = new IngestStats.ByteStats(ingestBytesConsumed.count(), ingestBytesProduced.count());
+            return byteStats.equals(IngestStats.ByteStats.IDENTITY) ? IngestStats.ByteStats.IDENTITY : byteStats;
         }
 
     }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Use IDENTITY constants when creating stats in TrainedModelsStatsAction (#123894)