### PR TITLE
Remove seemingly fixed test mute

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -125,9 +125,6 @@ tests:
 - class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
   method: testShardChangesNoOperation
   issue: https://github.com/elastic/elasticsearch/issues/118800
-- class: org.elasticsearch.cluster.service.MasterServiceTests
-  method: testThreadContext
-  issue: https://github.com/elastic/elasticsearch/issues/118914
 - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectoryRunAsIT
   issue: https://github.com/elastic/elasticsearch/issues/115727
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT


### PR DESCRIPTION
This test seems to have been fixed by https://github.com/elastic/elasticsearch/pull/118926 but the
mute entry is still there.