### PR TITLE
[8.x] [ML] Set inference API stability to stable (#116828)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-inference-api.html",
       "description": "Delete an inference endpoint"
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.get.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference-api.html",
       "description":"Get an inference endpoint"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/post-inference-api.html",
       "description":"Perform inference"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference-api.html",
       "description":"Configure an inference endpoint for use in the Inference API"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_inference.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_inference.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/post-stream-inference-api.html",
       "description":"Perform streaming inference"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "text/event-stream"],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ML] Set inference API stability to stable (#116828)](https://github.com/elastic/elasticsearch/pull/116828)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)