### PR TITLE
[Inference API] Fix output stream ordering in InferenceActionProxy

### DIFF
--- a/docs/changelog/124225.yaml
+++ b/docs/changelog/124225.yaml
@@ -1,0 +1,5 @@
+pr: 124225
+summary: "[Inference API] Fix output stream ordering in `InferenceActionProxy`"
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceActionProxy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceActionProxy.java
@@ -105,8 +105,8 @@ public class InferenceActionProxy extends ActionType<InferenceAction.Response> {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeString(inferenceEntityId);
             taskType.writeTo(out);
+            out.writeString(inferenceEntityId);
             out.writeBytesReference(content);
             XContentHelper.writeTo(out, contentType);
             out.writeTimeValue(timeout);


### PR DESCRIPTION
While working on propagating product use case I've noticed an ordering issue in the stream output of `InferenceActionProxy`: `taskType` was written after `inferenceEntityId`, but the reading side expects it the other way around. I assume we need/should backport this?