### PR TITLE
[8.x] Entitle inference to access AWS credentials (#123750)

### DIFF
--- a/x-pack/plugin/inference/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/inference/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,2 +1,35 @@
 com.google.api.client:
   - set_https_connection_properties
+  - outbound_network
+software.amazon.awssdk.utils:
+  - manage_threads
+  - outbound_network
+# AmazonBedrockInferenceClient uses NettyNioAsyncHttpClient, so we grant network permissions (and thread permissions,
+# as it is async) to the related modules
+software.amazon.awssdk.http.nio.netty:
+  - manage_threads
+  - outbound_network
+io.netty.common:
+  - outbound_network
+  - manage_threads
+  - files:
+      - path: "/etc/os-release"
+        mode: "read"
+      - path: "/usr/lib/os-release"
+        mode: "read"
+      - path: "/proc/sys/net/core/somaxconn"
+        mode: read
+io.netty.transport:
+  - manage_threads
+  - outbound_network
+# AWS Clients always try to access the credentials and config files, even if we configure otherwise
+# This should be "fixed" (as in, it will handle SecurityException correctly)
+# by https://github.com/aws/aws-sdk-java-v2/pull/5904. Once confirmed and libraries are updated, these could be removed.
+software.amazon.awssdk.profiles:
+  - files:
+    - relative_path: .aws/credentials
+      relative_to: home
+      mode: read
+    - relative_path: .aws/config
+      relative_to: home
+      mode: read


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Entitle inference to access AWS credentials (#123750)