### PR TITLE
Revert fail-fast disconnect strategy for `_resolve/cluster`

### DIFF
--- a/docs/changelog/124241.yaml
+++ b/docs/changelog/124241.yaml
@@ -1,0 +1,5 @@
+pr: 124241
+summary: Revert fail-fast disconnect strategy for `_resolve/cluster`
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
@@ -140,7 +140,7 @@ public class TransportResolveClusterAction extends HandledTransportAction<Resolv
                 RemoteClusterClient remoteClusterClient = remoteClusterService.getRemoteClusterClient(
                     clusterAlias,
                     searchCoordinationExecutor,
-                    RemoteClusterService.DisconnectedStrategy.FAIL_IF_DISCONNECTED
+                    RemoteClusterService.DisconnectedStrategy.RECONNECT_IF_DISCONNECTED
                 );
                 var remoteRequest = new ResolveClusterActionRequest(originalIndices.indices(), request.indicesOptions());
                 // allow cancellation requests to propagate to remote clusters


### PR DESCRIPTION
Changing the disconnect strategy was the first solution for the long wait times that user could potentially see when invoking this API. However, we reverted this change in favour of the new timeout parameter. Unfortunately, the change in disconnect strategy targeted more broader versions than the timeout parameter PR (which contained the revert). This PR fixes this discrepancy.

Problematic PR: https://github.com/elastic/elasticsearch/pull/119516.
PR that reverted the problematic commit with a proper fix (timeout parameter): https://github.com/elastic/elasticsearch/pull/120542. Unfortunately, this is the PR that did not properly back port the fix because it was decided that it'd be an enhancement rather than a fix.