### PR TITLE
[9.0] Remove seemingly fixed test mute (#124207)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -134,9 +134,6 @@ tests:
 - class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
   method: testShardChangesNoOperation
   issue: https://github.com/elastic/elasticsearch/issues/118800
-- class: org.elasticsearch.cluster.service.MasterServiceTests
-  method: testThreadContext
-  issue: https://github.com/elastic/elasticsearch/issues/118914
 - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectoryRunAsIT
   issue: https://github.com/elastic/elasticsearch/issues/115727
 - class: org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapperTests


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Remove seemingly fixed test mute (#124207)