### PR TITLE
[9.0] [DOCS] Document source-related restrictions (#124011)

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/mapping-source-field.md
+++ b/docs/reference/elasticsearch/mapping-reference/mapping-source-field.md
@@ -48,6 +48,7 @@ For all other field types, the original value of the field is stored as is, in t
 
 Some field types have additional restrictions. These restrictions are documented in the **synthetic `_source`** section of the field type’s [documentation](/reference/elasticsearch/mapping-reference/field-data-types.md).
 
+Synthetic source is not supported in [source-only](docs-content://deploy-manage/tools/snapshot-and-restore/source-only-repository.md) snapshot repositories. To store indexes that use synthetic `_source`, choose a different repository type.
 
 ### Synthetic `_source` modifications [synthetic-source-modifications]
 
@@ -316,6 +317,10 @@ Users often disable the `_source` field without thinking about the consequences,
 * The ability to debug queries or aggregations by viewing the original document used at index time.
 * Potentially in the future, the ability to repair index corruption automatically.
 
+::::
+
+::::{note}
+You can't disable the `_source` field for indexes with [`index_mode`](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting) set to `logsdb` or `time_series`.
 ::::
 
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [DOCS] Document source-related restrictions (#124011)