### PR TITLE
[CI] Disable multi-project tests in non-snapshot build tests

### DIFF
--- a/test/external-modules/multi-project/build.gradle
+++ b/test/external-modules/multi-project/build.gradle
@@ -17,3 +17,7 @@ dependencies {
 tasks.withType(StandaloneRestIntegTestTask).configureEach {
   usesDefaultDistribution()
 }
+
+tasks.named("javaRestTest").configure {
+  enabled = buildParams.snapshotBuild
+}

--- a/x-pack/plugin/security/qa/multi-project/build.gradle
+++ b/x-pack/plugin/security/qa/multi-project/build.gradle
@@ -6,4 +6,5 @@ dependencies {
 
 tasks.named('javaRestTest') {
   usesDefaultDistribution()
+  it.onlyIf("snapshot build") { buildParams.snapshotBuild }
 }

--- a/x-pack/qa/multi-project/build.gradle
+++ b/x-pack/qa/multi-project/build.gradle
@@ -3,4 +3,8 @@ subprojects {
   apply plugin: 'elasticsearch.bwc-test'
 
   group = 'org.elasticsearch.qa.multi-project'
+
+  tasks.named { it == "javaRestTest" || it == "yamlRestTest" }.configureEach {
+    it.onlyIf("snapshot build") { buildParams.snapshotBuild }
+  }
 }


### PR DESCRIPTION
Multi-project tests are not supposed to run on non-snapshot builds, e.g. in the release-test tasks.