### PR TITLE
Updating deprecation info frozen index check to include whether index is in a data stream

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecker.java
@@ -253,6 +253,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
         Boolean isIndexFrozen = FrozenEngine.INDEX_FROZEN.get(indexMetadata.getSettings());
         if (Boolean.TRUE.equals(isIndexFrozen)) {
             String indexName = indexMetadata.getIndex().getName();
+            boolean isInDataStream = clusterState.metadata().findDataStreams(indexName).get(indexName) != null;
             return new DeprecationIssue(
                 DeprecationIssue.Level.CRITICAL,
                 "Index [" + indexName + "] is a frozen index. The frozen indices feature is deprecated and will be removed in version 9.0.",
@@ -261,7 +262,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
                     + " (The legacy frozen indices feature no longer offers any advantages."
                     + " You may consider cold or frozen tiers in place of frozen indices.)",
                 false,
-                null
+                Map.of("is_in_data_stream", isInDataStream)
             );
         }
         return null;

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
@@ -599,7 +599,6 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
         settings.put(FrozenEngine.INDEX_FROZEN.getKey(), true);
         IndexMetadata indexMetadata = IndexMetadata.builder("test").settings(settings).numberOfShards(1).numberOfReplicas(0).build();
         DataStream dataStream = newInstance(randomAlphaOfLength(10), List.of(indexMetadata.getIndex()));
-        Metadata metadata = Metadata.builder().dataStreams(Map.of(dataStream.getName(), dataStream), Map.of()).build();
         ClusterState state = ClusterState.builder(ClusterState.EMPTY_STATE)
             .metadata(Metadata.builder().put(indexMetadata, true).dataStreams(Map.of(dataStream.getName(), dataStream), Map.of()))
             .build();


### PR DESCRIPTION
This adds a metadata block to the deprecation info api response for frozen indices, like:
```
        "_meta": {
          "is_in_data_stream": true
        }
```
so that the caller knows whether the frozen index belongs to a data stream.