### PR TITLE
[8.18] [Deprecation] Update URL (#124259) (#124269)

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecker.java
@@ -103,7 +103,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
                 return new DeprecationIssue(
                     DeprecationIssue.Level.CRITICAL,
                     "One or more Transforms write to this index with a compatibility version < 8.0",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html"
+                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
                         + "#breaking_90_transform_destination_index",
                     Strings.format(
                         "This index was created in version [%s] and requires action before upgrading to 9.0. The following transforms are "
@@ -119,7 +119,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
                 return new DeprecationIssue(
                     DeprecationIssue.Level.CRITICAL,
                     "Old index with a compatibility version < 8.0",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html",
+                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html",
                     "This index has version: " + currentCompatibilityVersion.toReleaseVersion(),
                     false,
                     Map.of("reindex_required", true)
@@ -146,7 +146,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
                 return new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
                     "One or more Transforms write to this old index with a compatibility version < 8.0",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html"
+                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
                         + "#breaking_90_transform_destination_index",
                     Strings.format(
                         "This index was created in version [%s] and will be supported as a read-only index in 9.0. The following "
@@ -162,7 +162,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
                 return new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
                     "Old index with a compatibility version < 8.0 has been ignored",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-9.0.html",
+                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html",
                     "This read-only index has version: "
                         + currentCompatibilityVersion.toReleaseVersion()
                         + " and will be supported as read-only in 9.0",

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
@@ -80,7 +80,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
         DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "Old index with a compatibility version < 8.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html",
+            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html",
             "This index has version: " + OLD_VERSION.toReleaseVersion(),
             false,
             singletonMap("reindex_required", true)
@@ -104,8 +104,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
         var expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "One or more Transforms write to this index with a compatibility version < 8.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html"
-                + "#breaking_90_transform_destination_index",
+            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html#breaking_90_transform_destination_index",
             "This index was created in version ["
                 + OLD_VERSION.toReleaseVersion()
                 + "] and requires action before upgrading to 9.0. "
@@ -131,8 +130,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
         var expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "One or more Transforms write to this index with a compatibility version < 8.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html"
-                + "#breaking_90_transform_destination_index",
+            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html#breaking_90_transform_destination_index",
             "This index was created in version ["
                 + OLD_VERSION.toReleaseVersion()
                 + "] and requires action before upgrading to 9.0. "
@@ -162,7 +160,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
                 new DeprecationIssue(
                     DeprecationIssue.Level.CRITICAL,
                     "One or more Transforms write to this index with a compatibility version < 8.0",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html"
+                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
                         + "#breaking_90_transform_destination_index",
                     "This index was created in version ["
                         + OLD_VERSION.toReleaseVersion()
@@ -178,7 +176,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
                 new DeprecationIssue(
                     DeprecationIssue.Level.CRITICAL,
                     "One or more Transforms write to this index with a compatibility version < 8.0",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html"
+                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
                         + "#breaking_90_transform_destination_index",
                     "This index was created in version ["
                         + OLD_VERSION.toReleaseVersion()
@@ -285,7 +283,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
         DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.WARNING,
             "Old index with a compatibility version < 8.0 has been ignored",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-9.0.html",
+            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html",
             "This read-only index has version: " + OLD_VERSION.toReleaseVersion() + " and will be supported as read-only in 9.0",
             false,
             singletonMap("reindex_required", true)
@@ -336,8 +334,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
         var expected = new DeprecationIssue(
             DeprecationIssue.Level.WARNING,
             "One or more Transforms write to this old index with a compatibility version < 8.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html"
-                + "#breaking_90_transform_destination_index",
+            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html#breaking_90_transform_destination_index",
             "This index was created in version ["
                 + OLD_VERSION.toReleaseVersion()
                 + "] and will be supported as a read-only index in 9.0. "
@@ -363,8 +360,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
         var expected = new DeprecationIssue(
             DeprecationIssue.Level.WARNING,
             "One or more Transforms write to this old index with a compatibility version < 8.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html"
-                + "#breaking_90_transform_destination_index",
+            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html#breaking_90_transform_destination_index",
             "This index was created in version ["
                 + OLD_VERSION.toReleaseVersion()
                 + "] and will be supported as a read-only index in 9.0. "
@@ -394,7 +390,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
                 new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
                     "One or more Transforms write to this old index with a compatibility version < 8.0",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html"
+                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
                         + "#breaking_90_transform_destination_index",
                     "This index was created in version ["
                         + OLD_VERSION.toReleaseVersion()
@@ -410,7 +406,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
                 new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
                     "One or more Transforms write to this old index with a compatibility version < 8.0",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-9.0.html"
+                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
                         + "#breaking_90_transform_destination_index",
                     "This index was created in version ["
                         + OLD_VERSION.toReleaseVersion()


### PR DESCRIPTION
Backports the following commits to 8.18:
 - [Deprecation] Update URL (#124259) (#124269)