### PR TITLE
[8.18] Updating description of stream API (#124209)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_completion.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_completion.json
@@ -2,7 +2,7 @@
   "inference.stream_completion": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/post-stream-inference-api.html",
-      "description": "Perform streaming inference"
+      "description": "Perform streaming completion inference"
     },
     "stability": "stable",
     "visibility": "public",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Updating description of stream API (#124209)](https://github.com/elastic/elasticsearch/pull/124209)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)