### PR TITLE
Revert "Add temporary workaround for IntelliJ editorconfig bug (#123954)"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -209,7 +209,7 @@ indent_size = 4
 max_line_length = 140
 ij_java_class_count_to_use_import_on_demand = 999
 ij_java_names_count_to_use_import_on_demand = 999
-ij_java_imports_layout = *,|,com.**,|,io.**,|,org.**,|,java.**,|,javax.**,|,$*
+ij_java_imports_layout = *,|,com.**,|,org.**,|,java.**,|,javax.**,|,$*
 
 [*.json]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -209,9 +209,7 @@ indent_size = 4
 max_line_length = 140
 ij_java_class_count_to_use_import_on_demand = 999
 ij_java_names_count_to_use_import_on_demand = 999
-# The first '@*,' is a workaround for https://youtrack.jetbrains.com/issue/IDEA-368382/Auto-import-puts-java-imports-first-even-when-Editor-Code-style-Java-Import-layout-puts-them-last
-# it should be removed once that is fixed
-ij_java_imports_layout = @*,*,|,com.**,|,org.**,|,java.**,|,javax.**,|,$*
+ij_java_imports_layout = *,|,com.**,|,io.**,|,org.**,|,java.**,|,javax.**,|,$*
 
 [*.json]
 indent_size = 2


### PR DESCRIPTION
This reverts commit 2f14649f1678884d8440225c807c2418c3e97918.

The issue is resolved in IntelliJ 2024.3.4.1