### PR TITLE
Deduplicate created objects when deserializing InternalAggregations in SearchResponse

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.stream.DelayableWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -92,7 +93,15 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
     public SearchResponse(StreamInput in) throws IOException {
         super(in);
         this.hits = SearchHits.readFrom(in, true);
-        this.aggregations = in.readBoolean() ? InternalAggregations.readFrom(in) : null;
+        if (in.readBoolean()) {
+            // deserialize the aggregations trying to deduplicate the object created
+            // TODO: use DelayableWriteable instead.
+            this.aggregations = InternalAggregations.readFrom(
+                DelayableWriteable.wrapWithDeduplicatorStreamInput(in, in.getTransportVersion(), in.namedWriteableRegistry())
+            );
+        } else {
+            this.aggregations = null;
+        }
         this.suggest = in.readBoolean() ? new Suggest(in) : null;
         this.timedOut = in.readBoolean();
         this.terminatedEarly = in.readOptionalBoolean();


### PR DESCRIPTION
Looking into heap dump of a cluster performing a CCS, I observed a huge amount of duplicated objects coming from deserializing the internal aggregations from the remove clusters search responses:

<img width="1203" alt="image" src="https://github.com/user-attachments/assets/5fffcbb8-b18e-47f4-ba6a-3315482623ed" />

We observed a very [similar situation](https://github.com/elastic/elasticsearch/pull/112707) in coordination nodes for standard searches and it was introduced a mechanism to deduplicate objects inside DelayedWritable. This commit proposes to expose the deduplicator stream and use it when deserializing InternalAggregations in SearchResponse.