### PR TITLE
Unmute GeoGridAggAndQueryConsistencyIT testGeoShapeGeoHash

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -185,9 +185,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testProcessFileChanges
   issue: https://github.com/elastic/elasticsearch/issues/115280
-- class: org.elasticsearch.xpack.spatial.search.GeoGridAggAndQueryConsistencyIT
-  method: testGeoShapeGeoHash
-  issue: https://github.com/elastic/elasticsearch/issues/115664
 - class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
   issue: https://github.com/elastic/elasticsearch/issues/116126
 - class: org.elasticsearch.upgrades.FullClusterRestartIT


### PR DESCRIPTION
This has long been fixed, the unmute just fell off the radar.

closes #115664
