### PR TITLE
[Entitlements] Fix AbstractDelegateHttpsURLConnection "this" parameter type

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -520,7 +520,7 @@ public interface EntitlementChecker {
 
     void check$sun_net_www_protocol_https_AbstractDelegateHttpsURLConnection$connect(
         Class<?> callerClass,
-        javax.net.ssl.HttpsURLConnection that
+        java.net.HttpURLConnection that
     );
 
     void check$sun_net_www_protocol_mailto_MailToURLConnection$connect(Class<?> callerClass, java.net.URLConnection that);

--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -518,10 +518,7 @@ public interface EntitlementChecker {
         Class<?>[] classes
     );
 
-    void check$sun_net_www_protocol_https_AbstractDelegateHttpsURLConnection$connect(
-        Class<?> callerClass,
-        java.net.HttpURLConnection that
-    );
+    void check$sun_net_www_protocol_https_AbstractDelegateHttpsURLConnection$connect(Class<?> callerClass, java.net.HttpURLConnection that);
 
     void check$sun_net_www_protocol_mailto_MailToURLConnection$connect(Class<?> callerClass, java.net.URLConnection that);
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -1180,7 +1180,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     @Override
     public void check$sun_net_www_protocol_https_AbstractDelegateHttpsURLConnection$connect(
         Class<?> callerClass,
-        javax.net.ssl.HttpsURLConnection that
+        java.net.HttpURLConnection that
     ) {
         policyManager.checkOutboundNetworkAccess(callerClass);
     }


### PR DESCRIPTION
Our check methods injected by the instrumenter receive "this" as the second parameter. 
For internal classes like `AbstractDelegateHttpsURLConnection` we generally use a base type; in this case we were using `javax.net.ssl.HttpsURLConnection`, which is incorrect as `AbstractDelegateHttpsURLConnection` derives from `java.net.HttpURLConnection`. 
This was not failing in our tests because we don't actually use that parameter in that check function.

Also, it was not failing on `transform`, just on `retransformClasses`, and only in JDK 24. Apparently, JDK 24 introduced new validation there (to be confirmed).

And it was failing just on cloud as the APM agent there (which is loaded before our agent) connects to a http*s* endpoint - our IT tests, and `./gradlew run --with-apm-server`, use a http endpoint. Using https makes the JVM load `AbstractDelegateHttpsURLConnection`, making it one of the classes we need to retransform, triggering the VerifyError.
