### PR TITLE
[8.18] Unmute GeoGridAggAndQueryConsistencyIT testGeoShapeGeoHash (#124301)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -188,9 +188,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testProcessFileChanges
   issue: https://github.com/elastic/elasticsearch/issues/115280
-- class: org.elasticsearch.xpack.spatial.search.GeoGridAggAndQueryConsistencyIT
-  method: testGeoShapeGeoHash
-  issue: https://github.com/elastic/elasticsearch/issues/115664
 - class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
   issue: https://github.com/elastic/elasticsearch/issues/116126
 - class: org.elasticsearch.upgrades.FullClusterRestartIT


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Unmute GeoGridAggAndQueryConsistencyIT testGeoShapeGeoHash (#124301)