### PR TITLE
[Entitlements] Use the correct format for the `EntitlementInstrumented` annotation descriptor

### DIFF
--- a/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterImpl.java
+++ b/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterImpl.java
@@ -93,7 +93,7 @@ public class InstrumenterImpl implements Instrumenter {
 
     class EntitlementClassVisitor extends ClassVisitor {
 
-        private static final String ENTITLEMENT_ANNOTATION = Type.getDescriptor(EntitlementInstrumented.class);
+        private static final String ENTITLEMENT_ANNOTATION_DESCRIPTOR = Type.getDescriptor(EntitlementInstrumented.class);
 
         private final String className;
 
@@ -112,7 +112,7 @@ public class InstrumenterImpl implements Instrumenter {
 
         @Override
         public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
-            if (visible && descriptor.equals(ENTITLEMENT_ANNOTATION)) {
+            if (visible && descriptor.equals(ENTITLEMENT_ANNOTATION_DESCRIPTOR)) {
                 isAnnotationPresent = true;
                 annotationNeeded = false;
             }
@@ -178,7 +178,7 @@ public class InstrumenterImpl implements Instrumenter {
         private void addClassAnnotationIfNeeded() {
             if (annotationNeeded) {
                 // logger.debug("Adding {} annotation", ENTITLEMENT_ANNOTATION);
-                AnnotationVisitor av = cv.visitAnnotation(ENTITLEMENT_ANNOTATION, true);
+                AnnotationVisitor av = cv.visitAnnotation(ENTITLEMENT_ANNOTATION_DESCRIPTOR, true);
                 if (av != null) {
                     av.visitEnd();
                 }

--- a/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterImpl.java
+++ b/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterImpl.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.entitlement.instrumentation.impl;
 
 import org.elasticsearch.entitlement.instrumentation.CheckMethod;
+import org.elasticsearch.entitlement.instrumentation.EntitlementInstrumented;
 import org.elasticsearch.entitlement.instrumentation.Instrumenter;
 import org.elasticsearch.entitlement.instrumentation.MethodKey;
 import org.elasticsearch.logging.LogManager;
@@ -92,7 +93,7 @@ public class InstrumenterImpl implements Instrumenter {
 
     class EntitlementClassVisitor extends ClassVisitor {
 
-        private static final String ENTITLEMENT_ANNOTATION = "EntitlementInstrumented";
+        private static final String ENTITLEMENT_ANNOTATION = Type.getDescriptor(EntitlementInstrumented.class);
 
         private final String className;
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/EntitlementInstrumented.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/EntitlementInstrumented.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.instrumentation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EntitlementInstrumented {
+}


### PR DESCRIPTION
Currently we are not using any type for the `EntitlementInstrumented` annotation, on the assumption that we just need to tag a class somehow.
However, when we use the ASM [CheckClassAdapter](https://asm.ow2.io/javadoc/org/objectweb/asm/util/CheckClassAdapter.html) to verify the instrumented bytecode, verification fails because "EntitlementInstrumented" is not a valid descriptor. This does not seem to be a problem with the JDK verifier _at the moment_, but in order to avoid any problem (and make it possible to use ASM CheckClassAdapter for verification), this should be a correctly formatted descriptor.

This PR introduces a real type for the `EntitlementInstrumented` annotation, so we can create a valid descriptor for it. We could have just used a string in the correct format, but this could still have caused problems if the verification is further tightened in the future. Using a real type is the safer alternative. 