### PR TITLE
[8.18] [8.x][DOCS] Document source-related restrictions (#124317)

### DIFF
--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -58,6 +58,9 @@ and <<docs-reindex,`reindex`>> APIs.
   automatically.
 ==================================================
 
+NOTE: You can't disable the `_source` field for indexes with <<index-mode-setting,`index_mode`>> 
+set to `logsdb` or `time_series`.
+
 TIP: If disk space is a concern, rather increase the
 <<index-codec,compression level>> instead of disabling the `_source`.
 

--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -49,6 +49,8 @@ document. Similarly, malformed values of fields that use <<ignore-malformed,`ign
 Some field types have additional restrictions. These restrictions are documented in the **synthetic `_source`** section
 of the field type's <<mapping-types,documentation>>.
 
+Synthetic source is not supported in <<snapshots-source-only-repository,source-only>> snapshot repositories. To store indexes that use synthetic `_source`, choose a different repository type.
+
 [[synthetic-source-modifications]]
 ===== Synthetic `_source` modifications
 


### PR DESCRIPTION
Backports the following commits to 8.18:
 - [8.x][DOCS] Document source-related restrictions (#124317)