### PR TITLE
[9.0] Change setting's deprecation message wording (#120718)

### DIFF
--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/RepositoryCredentialsTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/RepositoryCredentialsTests.java
@@ -107,8 +107,10 @@ public class RepositoryCredentialsTests extends ESSingleNodeTestCase {
         assertThat(credentials.getAWSSecretKey(), is("insecure_aws_secret"));
 
         assertCriticalWarnings(
-            "[access_key] setting was deprecated in Elasticsearch and will be removed in a future release.",
-            "[secret_key] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[access_key] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version.",
+            "[secret_key] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version.",
             S3Repository.INSECURE_CREDENTIALS_DEPRECATION_WARNING
         );
     }
@@ -193,8 +195,10 @@ public class RepositoryCredentialsTests extends ESSingleNodeTestCase {
 
         if (hasInsecureSettings) {
             assertCriticalWarnings(
-                "[access_key] setting was deprecated in Elasticsearch and will be removed in a future release.",
-                "[secret_key] setting was deprecated in Elasticsearch and will be removed in a future release.",
+                "[access_key] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                    + "See the breaking changes documentation for the next major version.",
+                "[secret_key] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                    + "See the breaking changes documentation for the next major version.",
                 S3Repository.INSECURE_CREDENTIALS_DEPRECATION_WARNING
             );
         }

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
@@ -189,7 +189,8 @@ public class ClusterModuleTests extends ModuleTestCase {
         ClusterModule module = newClusterModuleWithShardsAllocator(settings, "custom", FakeShardsAllocator::new);
         assertEquals(FakeShardsAllocator.class, module.shardsAllocator.getClass());
         assertCriticalWarnings(
-            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version."
         );
     }
 
@@ -219,7 +220,8 @@ public class ClusterModuleTests extends ModuleTestCase {
         );
         assertEquals("Unknown ShardsAllocator [dne]", e.getMessage());
         assertCriticalWarnings(
-            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version."
         );
     }
 
@@ -227,7 +229,8 @@ public class ClusterModuleTests extends ModuleTestCase {
         Settings settings = Settings.builder().put(ClusterModule.SHARDS_ALLOCATOR_TYPE_SETTING.getKey(), "bad").build();
         expectThrows(NullPointerException.class, () -> newClusterModuleWithShardsAllocator(settings, "bad", () -> null));
         assertCriticalWarnings(
-            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version."
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
@@ -704,7 +704,8 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
             }
         );
         assertCriticalWarnings(
-            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version."
         );
 
         Metadata metadata = Metadata.builder()

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
@@ -449,7 +449,8 @@ public class IndexBalanceTests extends ESAllocationTestCase {
 
         final var allocationService = createAllocationService(settings);
         assertCriticalWarnings(
-            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version."
         );
 
         assertTrue(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationTests.java
@@ -200,7 +200,8 @@ public class ThrottlingAllocationTests extends ESAllocationTestCase {
             snapshotsInfoService
         );
         assertCriticalWarnings(
-            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version."
         );
         logger.info("Building initial routing table");
 

--- a/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
@@ -112,7 +112,8 @@ public class PerFieldMapperCodecTests extends ESTestCase {
         assertThat(perFieldMapperCodec.useBloomFilter("_id"), is(false));
         assertThat(perFieldMapperCodec.getPostingsFormatForField("_id"), instanceOf(ES812PostingsFormat.class));
         assertWarnings(
-            "[index.bloom_filter_for_id_field.enabled] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[index.bloom_filter_for_id_field.enabled] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
@@ -362,7 +362,8 @@ public class InternalSnapshotsInfoServiceTests extends ESTestCase {
                 snapshotsInfoService
             );
             assertCriticalWarnings(
-                "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+                "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                    + "See the breaking changes documentation for the next major version."
             );
             applyClusterState(
                 "starting shards for " + indexName,

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -2202,7 +2202,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     snapshotsInfoService
                 );
                 assertCriticalWarnings(
-                    "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+                    "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                        + "See the breaking changes documentation for the next major version."
                 );
                 rerouteService = new BatchedRerouteService(clusterService, allocationService::reroute);
                 rerouteServiceSetOnce.set(rerouteService);

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceLifecycleTests.java
@@ -171,7 +171,8 @@ public class TransportServiceLifecycleTests extends ESTestCase {
             assertEquals("simulated exception in sendRequest", getSendRequestException(future, IOException.class).getMessage());
         }
         assertWarnings(
-            "[transport.enable_stack_protection] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[transport.enable_stack_protection] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version."
         );
     }
 
@@ -264,7 +265,8 @@ public class TransportServiceLifecycleTests extends ESTestCase {
         onConnectionClosedUsesHandlerExecutor(settings, executorName, expectedExecutor);
         if (withSetting) {
             assertWarnings(
-                "[transport.enable_stack_protection] setting was deprecated in Elasticsearch and will be removed in a future release."
+                "[transport.enable_stack_protection] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                    + "See the breaking changes documentation for the next major version."
             );
         }
     }
@@ -276,7 +278,8 @@ public class TransportServiceLifecycleTests extends ESTestCase {
             ThreadPool.Names.GENERIC
         );
         assertWarnings(
-            "[transport.enable_stack_protection] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[transport.enable_stack_protection] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version."
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -234,7 +234,10 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
     protected List<String> filteredWarnings() {
         return Stream.concat(
             super.filteredWarnings().stream(),
-            Stream.of("[index.data_path] setting was deprecated in Elasticsearch and will be removed in a future release.")
+            Stream.of(
+                "[index.data_path] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                    + "See the deprecation documentation for the next major version."
+            )
         ).collect(Collectors.toList());
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -699,15 +699,14 @@ public abstract class ESTestCase extends LuceneTestCase {
      */
     protected final void assertSettingDeprecationsAndWarnings(final Setting<?>[] settings, final DeprecationWarning... warnings) {
         assertWarnings(true, Stream.concat(Arrays.stream(settings).map(setting -> {
-            String warningMessage = String.format(
-                Locale.ROOT,
-                "[%s] setting was deprecated in Elasticsearch and will be removed in a future release.",
-                setting.getKey()
+            Level level = setting.getProperties().contains(Setting.Property.Deprecated) ? DeprecationLogger.CRITICAL : Level.WARN;
+            String warningMessage = Strings.format(
+                "[%s] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                    + "See the %s documentation for the next major version.",
+                setting.getKey(),
+                (level == Level.WARN) ? "deprecation" : "breaking changes"
             );
-            return new DeprecationWarning(
-                setting.getProperties().contains(Setting.Property.Deprecated) ? DeprecationLogger.CRITICAL : Level.WARN,
-                warningMessage
-            );
+            return new DeprecationWarning(level, warningMessage);
         }), Arrays.stream(warnings)).toArray(DeprecationWarning[]::new));
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollectorTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollectorTests.java
@@ -152,7 +152,7 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.ccr.stats.timeout] setting was deprecated in Elasticsearch and will be removed in "
-                + "a future release."
+                + "a future release. See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -130,7 +130,8 @@ public class DeprecationHttpIT extends ESRestTestCase {
     }
 
     private Matcher<String> matchDeprecationWarning(Setting<?> setting) {
-        var format = "[%s] setting was deprecated in Elasticsearch and will be removed in a future release.";
+        var format = "[%s] setting was deprecated in Elasticsearch and will be removed in a future release. "
+            + "See the deprecation documentation for the next major version.";
         return equalTo(Strings.format(format, setting.getKey()));
     }
 

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -591,8 +591,9 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
         assertWarnings(
             "[script.context.field.max_compilations_rate] setting was deprecated in Elasticsearch and will be"
-                + " removed in a future release.",
-            "[script.context.score.max_compilations_rate] setting was deprecated in Elasticsearch and will be removed in a future release."
+                + " removed in a future release. See the deprecation documentation for the next major version.",
+            "[script.context.score.max_compilations_rate] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -628,8 +629,9 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
         assertWarnings(
             "[script.context.update.max_compilations_rate] setting was deprecated in Elasticsearch and will be"
-                + " removed in a future release.",
-            "[script.context.filter.cache_max_size] setting was deprecated in Elasticsearch and will be removed in a future release."
+                + " removed in a future release. See the deprecation documentation for the next major version.",
+            "[script.context.filter.cache_max_size] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -665,8 +667,10 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         );
 
         assertWarnings(
-            "[script.context.update.cache_max_size] setting was deprecated in Elasticsearch and will be removed in a future release.",
-            "[script.context.filter.cache_max_size] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[script.context.update.cache_max_size] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
+            "[script.context.filter.cache_max_size] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -702,8 +706,10 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         );
 
         assertWarnings(
-            "[script.context.interval.cache_expire] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[script.context.interval.cache_expire] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
             "[script.context.moving-function.cache_expire] setting was deprecated in Elasticsearch and will be removed in a future release."
+                + " See the deprecation documentation for the next major version."
         );
     }
 
@@ -760,7 +766,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             true,
             new DeprecationWarning(
                 Level.WARN,
-                "[indices.lifecycle.step.master_timeout] setting was deprecated in Elasticsearch and will be removed in a future release."
+                "[indices.lifecycle.step.master_timeout] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                    + "See the deprecation documentation for the next major version."
             )
         );
     }
@@ -782,7 +789,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             true,
             new DeprecationWarning(
                 Level.WARN,
-                "[xpack.eql.enabled] setting was deprecated in Elasticsearch and will be removed in a future release."
+                "[xpack.eql.enabled] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                    + "See the deprecation documentation for the next major version."
             )
         );
     }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPluginTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPluginTests.java
@@ -53,7 +53,10 @@ public class EnrichPluginTests extends ESTestCase {
     @Override
     protected List<String> filteredWarnings() {
         final var warnings = super.filteredWarnings();
-        warnings.add("[enrich.cache.size] setting was deprecated in Elasticsearch and will be removed in a future release.");
+        warnings.add(
+            "[enrich.cache.size] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version."
+        );
         warnings.add(
             "The [enrich.cache.size] setting is deprecated and will be removed in a future version. Please use [enrich.cache_size] instead."
         );

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollectorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollectorTests.java
@@ -146,7 +146,7 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.enrich.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/TimeSeriesRestDriver.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/TimeSeriesRestDriver.java
@@ -96,7 +96,8 @@ public final class TimeSeriesRestDriver {
         RequestOptions consumeWarningsOptions = RequestOptions.DEFAULT.toBuilder()
             .setWarningsHandler(warnings -> warnings.isEmpty() == false && List.of("""
                 [indices.lifecycle.rollover.only_if_has_documents] setting was deprecated in Elasticsearch \
-                and will be removed in a future release.""").equals(warnings) == false)
+                and will be removed in a future release. \
+                See the deprecation documentation for the next major version.""").equals(warnings) == false)
             .build();
 
         Request explainRequest = new Request("GET", indexPattern + "/_ilm/explain");

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringHistoryDurationSettingsTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringHistoryDurationSettingsTests.java
@@ -21,7 +21,8 @@ public class MonitoringHistoryDurationSettingsTests extends ESTestCase {
         // Note: this verifies the semantics because this is taken for granted that it never returns null!
         assertEquals(sevenDays, MonitoringField.HISTORY_DURATION.get(buildSettings(MonitoringField.HISTORY_DURATION.getKey(), null)));
         assertWarnings(
-            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -32,7 +33,8 @@ public class MonitoringHistoryDurationSettingsTests extends ESTestCase {
             MonitoringField.HISTORY_DURATION.get(buildSettings(MonitoringField.HISTORY_DURATION.getKey(), "24h"))
         );
         assertWarnings(
-            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -44,7 +46,8 @@ public class MonitoringHistoryDurationSettingsTests extends ESTestCase {
             () -> MonitoringField.HISTORY_DURATION.get(buildSettings(MonitoringField.HISTORY_DURATION.getKey(), oneSecondEarly))
         );
         assertWarnings(
-            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
@@ -110,7 +110,8 @@ public class MonitoringServiceTests extends ESTestCase {
         // take down threads
         monitoringService.setMonitoringActive(false);
         assertWarnings(
-            "[xpack.monitoring.collection.interval] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.collection.interval] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -135,8 +136,10 @@ public class MonitoringServiceTests extends ESTestCase {
 
         assertThat(exporter.getExportsCount(), equalTo(1));
         assertWarnings(
-            "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release.",
-            "[xpack.monitoring.collection.interval] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
+            "[xpack.monitoring.collection.interval] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
@@ -59,7 +59,8 @@ public class CleanerServiceTests extends ESTestCase {
             new CleanerService(settings, clusterSettings, threadPool);
         } finally {
             assertWarnings(
-                "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release."
+                "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                    + "See the deprecation documentation for the next major version."
             );
         }
     }
@@ -71,7 +72,8 @@ public class CleanerServiceTests extends ESTestCase {
         assertEquals(expected, new CleanerService(settings, clusterSettings, threadPool).getRetention());
 
         assertWarnings(
-            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.history.duration] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsCollectorTests.java
@@ -296,7 +296,7 @@ public class ClusterStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.cluster.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -367,7 +367,7 @@ public class ClusterStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.cluster.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -432,7 +432,7 @@ public class ClusterStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.cluster.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollectorTests.java
@@ -168,10 +168,11 @@ public class IndexRecoveryCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.index.recovery.timeout] setting was deprecated in Elasticsearch and will be "
-                + "removed in a future release.",
+                + "removed in a future release. See the deprecation documentation for the next major version.",
             "[xpack.monitoring.collection.index.recovery.active_only] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release.",
-            "[xpack.monitoring.collection.indices] setting was deprecated in Elasticsearch and will be removed in a future release."
+                + "in a future release. See the deprecation documentation for the next major version.",
+            "[xpack.monitoring.collection.indices] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -227,7 +228,7 @@ public class IndexRecoveryCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.index.recovery.timeout] setting was deprecated in Elasticsearch and will be "
-                + "removed in a future release."
+                + "removed in a future release. See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
@@ -171,7 +171,7 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.index.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -212,7 +212,7 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.index.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollectorTests.java
@@ -144,7 +144,7 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.ml.job.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -181,7 +181,7 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.ml.job.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsCollectorTests.java
@@ -70,7 +70,7 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.node.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -128,7 +128,7 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.node.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -162,7 +162,7 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
 
         assertWarnings(
             "[xpack.monitoring.collection.node.stats.timeout] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollectorTests.java
@@ -138,7 +138,8 @@ public class ShardsCollectorTests extends BaseCollectorTestCase {
         }
 
         assertWarnings(
-            "[xpack.monitoring.collection.indices] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.collection.indices] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ClusterAlertsUtilTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ClusterAlertsUtilTests.java
@@ -117,7 +117,7 @@ public class ClusterAlertsUtilTests extends ESTestCase {
 
         assertWarnings(
             "[xpack.monitoring.exporters._random.cluster_alerts.management.blacklist] setting was deprecated in Elasticsearch "
-                + "and will be removed in a future release."
+                + "and will be removed in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -128,7 +128,7 @@ public class ClusterAlertsUtilTests extends ESTestCase {
 
         assertWarnings(
             "[xpack.monitoring.exporters.any.cluster_alerts.management.blacklist] setting was deprecated in Elasticsearch "
-                + "and will be removed in a future release."
+                + "and will be removed in a future release. See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
@@ -123,7 +123,7 @@ public class ExportersTests extends ESTestCase {
         assertThat(e.getCause(), hasToString(containsString("host list for [" + prefix + ".host] is empty")));
         assertWarnings(
             "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a "
-                + "future release."
+                + "future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -141,7 +141,7 @@ public class ExportersTests extends ESTestCase {
         assertThat(e.getCause(), hasToString(containsString("Unknown pattern letter: j")));
         assertWarnings(
             "[xpack.monitoring.exporters.example.index.name.time_format] setting was deprecated in Elasticsearch and will "
-                + "be removed in a future release."
+                + "be removed in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -199,7 +199,7 @@ public class ExportersTests extends ESTestCase {
 
         assertWarnings(
             "[xpack.monitoring.exporters._name.enabled] setting was deprecated in Elasticsearch and will be removed in a "
-                + "future release."
+                + "future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -295,12 +295,14 @@ public class ExportersTests extends ESTestCase {
         assertEquals(settings.get("xpack.monitoring.exporters._name1.cluster_alerts.management.blacklist"), "false");
 
         assertWarnings(
-            "[xpack.monitoring.exporters._name1.type] setting was deprecated in Elasticsearch and will be removed in a future release.",
-            "[xpack.monitoring.exporters._name0.type] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[xpack.monitoring.exporters._name1.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
+            "[xpack.monitoring.exporters._name0.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
             "[xpack.monitoring.exporters._name0.cluster_alerts.management.blacklist] setting was deprecated in Elasticsearch and will "
-                + "be removed in a future release.",
+                + "be removed in a future release. See the deprecation documentation for the next major version.",
             "[xpack.monitoring.exporters._name1.cluster_alerts.management.blacklist] setting was deprecated in Elasticsearch and will "
-                + "be removed in a future release."
+                + "be removed in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -347,7 +349,7 @@ public class ExportersTests extends ESTestCase {
 
         assertWarnings(
             "[xpack.monitoring.exporters.explicitly_disabled.enabled] setting was deprecated in Elasticsearch and will be "
-                + "removed in a future release."
+                + "removed in a future release. See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
@@ -397,9 +397,9 @@ public class HttpExporterResourceTests extends AbstractPublishableHttpResourceTe
 
         assertWarnings(
             "[xpack.monitoring.migration.decommission_alerts] setting was deprecated in Elasticsearch and will be "
-                + "removed in a future release.",
+                + "removed in a future release. See the deprecation documentation for the next major version.",
             "[xpack.monitoring.exporters._http.cluster_alerts.management.enabled] setting was deprecated in Elasticsearch and "
-                + "will be removed in a future release."
+                + "will be removed in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -469,7 +469,7 @@ public class HttpExporterResourceTests extends AbstractPublishableHttpResourceTe
 
         assertWarnings(
             "[xpack.monitoring.exporters._http.cluster_alerts.management.enabled] setting was deprecated in Elasticsearch "
-                + "and will be removed in a future release."
+                + "and will be removed in a future release. See the deprecation documentation for the next major version."
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
@@ -106,7 +106,7 @@ public class HttpExporterTests extends ESTestCase {
             builder.putList(prefix + ".host", Collections.emptyList());
             expectedWarnings.add(
                 "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed "
-                    + "in a future release."
+                    + "in a future release. See the deprecation documentation for the next major version."
             );
         }
         final Settings settings = builder.build();
@@ -119,7 +119,7 @@ public class HttpExporterTests extends ESTestCase {
         assertThat(e.getCause(), hasToString(containsString("host list for [" + prefix + ".host] is empty")));
         expectedWarnings.add(
             "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
         assertWarnings(expectedWarnings.toArray(new String[0]));
     }
@@ -143,7 +143,7 @@ public class HttpExporterTests extends ESTestCase {
         HttpExporter.HOST_SETTING.getConcreteSetting(prefix + ".host").get(settings);
         assertWarnings(
             "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a "
-                + "future release."
+                + "future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -156,8 +156,10 @@ public class HttpExporterTests extends ESTestCase {
         final SettingsException e = expectThrows(SettingsException.class, () -> clusterSettings.validate(settings, true));
         assertThat(e, hasToString(containsString("[" + prefix + ".host] is set but type is [local]")));
         assertWarnings(
-            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release.",
-            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
+            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -180,9 +182,10 @@ public class HttpExporterTests extends ESTestCase {
         final SettingsException e = expectThrows(SettingsException.class, () -> clusterSettings.validate(settings, true));
         assertThat(e, hasToString(containsString("[" + prefix + settingName + "] is set but type is [local]")));
         assertWarnings(
-            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release.",
+            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
             "[xpack.monitoring.exporters.example.auth.secure_password] setting was deprecated in Elasticsearch and will be removed in a "
-                + "future release."
+                + "future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -200,8 +203,10 @@ public class HttpExporterTests extends ESTestCase {
         assertThat(e.getCause().getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(e.getCause().getCause(), hasToString(containsString("HttpHosts do not use paths [/].")));
         assertWarnings(
-            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
-            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
+            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -226,8 +231,10 @@ public class HttpExporterTests extends ESTestCase {
         assertThat(e.getCause(), instanceOf(SettingsException.class));
         assertThat(e.getCause(), hasToString(containsString("[" + prefix + ".host] must use a consistent scheme: http or https")));
         assertWarnings(
-            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
-            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.exporters.example.host] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
+            "[xpack.monitoring.exporters.example.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -255,8 +262,10 @@ public class HttpExporterTests extends ESTestCase {
         assertThat(exception.getMessage(), equalTo(expected));
 
         assertWarnings(
-            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -282,8 +291,10 @@ public class HttpExporterTests extends ESTestCase {
 
         assertThat(exception.getMessage(), equalTo(expected));
         assertWarnings(
-            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -323,9 +334,9 @@ public class HttpExporterTests extends ESTestCase {
         );
         assertWarnings(
             "[xpack.monitoring.exporters._http.cluster_alerts.management.blacklist] setting was deprecated in Elasticsearch"
-                + " and will be removed in a future release.",
+                + " and will be removed in a future release. See the deprecation documentation for the next major version.",
             "[xpack.monitoring.exporters._http.cluster_alerts.management.enabled] setting was deprecated in Elasticsearch"
-                + " and will be removed in a future release."
+                + " and will be removed in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -342,8 +353,10 @@ public class HttpExporterTests extends ESTestCase {
 
         new HttpExporter(config, sslService, threadContext, coordinator).close();
         assertWarnings(
-            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -371,7 +384,7 @@ public class HttpExporterTests extends ESTestCase {
         assertThat(e.getCause(), hasToString(containsString(expected)));
         assertWarnings(
             "[xpack.monitoring.exporters._http.proxy.base_path] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release."
+                + "in a future release. See the deprecation documentation for the next major version."
         );
     }
 
@@ -385,10 +398,12 @@ public class HttpExporterTests extends ESTestCase {
             .put("xpack.monitoring.exporters._http.type", "http")
             .put("xpack.monitoring.exporters._http.host", "http://localhost:9200");
         expectedWarnings.add(
-            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
         expectedWarnings.add(
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
 
         // use basic auth
@@ -400,7 +415,7 @@ public class HttpExporterTests extends ESTestCase {
             builder.setSecureSettings(mockSecureSettings);
             expectedWarnings.add(
                 "[xpack.monitoring.exporters._http.auth.username] setting was deprecated in Elasticsearch and will be "
-                    + "removed in a future release."
+                    + "removed in a future release. See the deprecation documentation for the next major version."
             );
         }
 
@@ -431,7 +446,8 @@ public class HttpExporterTests extends ESTestCase {
         assertNull(provider);
 
         assertWarnings(
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -474,9 +490,11 @@ public class HttpExporterTests extends ESTestCase {
 
         assertWarnings(
             "[xpack.monitoring.exporters._http.sniff.enabled] setting was deprecated in Elasticsearch and will be removed "
-                + "in a future release.",
-            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release.",
-            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release."
+                + "in a future release. See the deprecation documentation for the next major version.",
+            "[xpack.monitoring.exporters._http.host] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version.",
+            "[xpack.monitoring.exporters._http.type] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
         );
     }
 
@@ -491,7 +509,8 @@ public class HttpExporterTests extends ESTestCase {
             builder.put("xpack.monitoring.exporters._http.cluster_alerts.management.enabled", true);
             warningsExpected.add(
                 "[xpack.monitoring.exporters._http.cluster_alerts.management.enabled] setting was deprecated in "
-                    + "Elasticsearch and will be removed in a future release."
+                    + "Elasticsearch and will be removed in a future release. "
+                    + "See the deprecation documentation for the next major version."
             );
         }
 
@@ -499,7 +518,8 @@ public class HttpExporterTests extends ESTestCase {
             builder.put("xpack.monitoring.exporters._http.index.template.master_timeout", templateTimeout.getStringRep());
             warningsExpected.add(
                 "[xpack.monitoring.exporters._http.index.template.master_timeout] setting was deprecated in "
-                    + "Elasticsearch and will be removed in a future release."
+                    + "Elasticsearch and will be removed in a future release. "
+                    + "See the deprecation documentation for the next major version."
             );
         }
 
@@ -572,7 +592,7 @@ public class HttpExporterTests extends ESTestCase {
             assertThat(parameters.remove("timeout"), equalTo(bulkTimeout.toString()));
             assertWarnings(
                 "[xpack.monitoring.exporters._http.bulk.timeout] setting was deprecated in Elasticsearch and will be removed "
-                    + "in a future release."
+                    + "in a future release. See the deprecation documentation for the next major version."
             );
         } else {
             assertNull(parameters.remove("timeout"));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
@@ -157,7 +157,10 @@ public class TransportNodeEnrollmentActionTests extends ESTestCase {
         assertThat(response.getNodesAddresses(), hasSize(numberOfNodes));
         assertThat(nodesInfoRequests, hasSize(1));
 
-        assertWarnings("[keystore.password] setting was deprecated in Elasticsearch and will be removed in a future release.");
+        assertWarnings(
+            "[keystore.password] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the deprecation documentation for the next major version."
+        );
     }
 
     private void assertSameCertificate(String cert, Path original, char[] originalPassword, boolean isCa) throws Exception {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
@@ -5,7 +5,7 @@
 
   - do:
       allowed_warnings:
-        - "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release."
+        - "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
       cluster.put_settings:
         body:
           persistent:
@@ -176,7 +176,7 @@
 
   - do:
       allowed_warnings:
-        - "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release."
+        - "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
       cluster.put_settings:
         body:
           persistent:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/20_privileges.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/20_privileges.yml
@@ -80,7 +80,7 @@ teardown:
 
   - do:
       allowed_warnings:
-        - "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release."
+        - "[xpack.monitoring.collection.enabled] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
       cluster.put_settings:
         body:
           persistent:


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Change setting's deprecation message wording (#120718)