### PR TITLE
[8.18] Have create index return a bad request on poor formatting (#123761)

### DIFF
--- a/docs/changelog/123761.yaml
+++ b/docs/changelog/123761.yaml
@@ -1,0 +1,5 @@
+pr: 123761
+summary: Have create index return a bad request on poor formatting
+area: Infra/Core
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
@@ -215,6 +215,44 @@
             index.number_of_shards: 2
 
 ---
+"Poorly formatted request returns bad_request":
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ poorly_formatted_bad_request ]
+      reason: "requires poorly_formatted_bad_request bug fix"
+
+  - do:
+      catch: bad_request
+      indices.create:
+        index: test_index
+        body:
+          mappings: "bad mappings"
+
+  - do:
+      catch: bad_request
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            properties: "bad properties"
+
+  - do:
+      catch: bad_request
+      indices.create:
+        index: test_index
+        body:
+          settings: "bad settings"
+
+  - do:
+      catch: bad_request
+      indices.create:
+        index: test_index
+        body:
+          aliases: "bad alias"
+---
 "Create index with hunspell missing dict":
   - requires:
       test_runner_features: [ capabilities ]

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -410,22 +410,29 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         for (Map.Entry<String, ?> entry : source.entrySet()) {
             String name = entry.getKey();
             if (SETTINGS.match(name, deprecationHandler)) {
-                if (entry.getValue() instanceof Map == false) {
-                    throw new ElasticsearchParseException("key [settings] must be an object");
-                }
+                validateIsMap(SETTINGS.getPreferredName(), entry.getValue());
                 settings((Map<String, Object>) entry.getValue());
             } else if (MAPPINGS.match(name, deprecationHandler)) {
+                validateIsMap(MAPPINGS.getPreferredName(), entry.getValue());
                 Map<String, Object> mappings = (Map<String, Object>) entry.getValue();
                 for (Map.Entry<String, Object> entry1 : mappings.entrySet()) {
+                    validateIsMap(entry1.getKey(), entry1.getValue());
                     mapping(entry1.getKey(), (Map<String, Object>) entry1.getValue());
                 }
             } else if (ALIASES.match(name, deprecationHandler)) {
+                validateIsMap(ALIASES.getPreferredName(), entry.getValue());
                 aliases((Map<String, Object>) entry.getValue());
             } else {
                 throw new ElasticsearchParseException("unknown key [{}] for create index", name);
             }
         }
         return this;
+    }
+
+    static void validateIsMap(String key, Object value) {
+        if (value instanceof Map == false) {
+            throw new ElasticsearchParseException("key [{}] must be an object", key);
+        }
     }
 
     public String mappings() {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
@@ -28,12 +28,15 @@ public class CreateIndexCapabilities {
 
     private static final String NESTED_DENSE_VECTOR_SYNTHETIC_TEST = "nested_dense_vector_synthetic_test";
 
+    private static final String POORLY_FORMATTED_BAD_REQUEST = "poorly_formatted_bad_request";
+
     private static final String HUNSPELL_DICT_400 = "hunspell_dict_400";
 
     public static final Set<String> CAPABILITIES = Set.of(
         LOGSDB_INDEX_MODE_CAPABILITY,
         LOOKUP_INDEX_MODE_CAPABILITY,
         NESTED_DENSE_VECTOR_SYNTHETIC_TEST,
+        POORLY_FORMATTED_BAD_REQUEST,
         HUNSPELL_DICT_400
     );
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Have create index return a bad request on poor formatting (#123761)](https://github.com/elastic/elasticsearch/pull/123761)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)