### PR TITLE
DateProcessor refactoring

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -116,8 +116,8 @@ public final class DateProcessor extends AbstractProcessor {
         final ZoneId documentTimezone;
         final Locale documentLocale;
         try {
-            documentTimezone = newDateTimeZone(timezone == null ? null : document.renderTemplate(timezone));
-            documentLocale = newLocale(locale == null ? null : document.renderTemplate(locale));
+            documentTimezone = getTimezone(document);
+            documentLocale = getLocale(document);
         } catch (Exception e) {
             throw new IllegalArgumentException("unable to parse date [" + value + "]", e);
         }
@@ -147,12 +147,14 @@ public final class DateProcessor extends AbstractProcessor {
         return TYPE;
     }
 
-    TemplateScript.Factory getTimezone() {
-        return timezone;
+    // visible for testing
+    ZoneId getTimezone(IngestDocument document) {
+        return newDateTimeZone(timezone == null ? null : document.renderTemplate(timezone));
     }
 
-    TemplateScript.Factory getLocale() {
-        return locale;
+    // visible for testing
+    Locale getLocale(IngestDocument document) {
+        return newLocale(locale == null ? null : document.renderTemplate(locale));
     }
 
     String getField() {

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -94,14 +94,6 @@ public final class DateProcessor extends AbstractProcessor {
         formatter = DateFormatter.forPattern(this.outputFormat);
     }
 
-    private static ZoneId newDateTimeZone(String timezone) {
-        return timezone == null ? ZoneOffset.UTC : ZoneId.of(timezone);
-    }
-
-    private static Locale newLocale(String locale) {
-        return locale == null ? Locale.ENGLISH : LocaleUtils.parse(locale);
-    }
-
     @Override
     public IngestDocument execute(IngestDocument document) {
         Object obj = document.getFieldValue(field, Object.class);
@@ -149,12 +141,22 @@ public final class DateProcessor extends AbstractProcessor {
 
     // visible for testing
     ZoneId getTimezone(IngestDocument document) {
-        return newDateTimeZone(timezone == null ? null : document.renderTemplate(timezone));
+        String value = timezone == null ? null : document.renderTemplate(timezone);
+        if (value == null) {
+            return ZoneOffset.UTC;
+        } else {
+            return ZoneId.of(value);
+        }
     }
 
     // visible for testing
     Locale getLocale(IngestDocument document) {
-        return newLocale(locale == null ? null : document.renderTemplate(locale));
+        String value = locale == null ? null : document.renderTemplate(locale);
+        if (value == null) {
+            return Locale.ENGLISH;
+        } else {
+            return LocaleUtils.parse(value);
+        }
     }
 
     String getField() {

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -115,10 +115,9 @@ public final class DateProcessor extends AbstractProcessor {
         // extract the timezone and locale to use for date parsing
         final ZoneId documentTimezone;
         final Locale documentLocale;
-        final Map<String, Object> sourceAndMetadata = document.getSourceAndMetadata();
         try {
-            documentTimezone = newDateTimeZone(timezone == null ? null : timezone.newInstance(sourceAndMetadata).execute());
-            documentLocale = newLocale(locale == null ? null : locale.newInstance(sourceAndMetadata).execute());
+            documentTimezone = newDateTimeZone(timezone == null ? null : document.renderTemplate(timezone));
+            documentLocale = newLocale(locale == null ? null : document.renderTemplate(locale));
         } catch (Exception e) {
             throw new IllegalArgumentException("unable to parse date [" + value + "]", e);
         }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorFactoryTests.java
@@ -84,7 +84,7 @@ public class DateProcessorFactoryTests extends ESTestCase {
         String sourceField = randomAlphaOfLengthBetween(1, 10);
         config.put("field", sourceField);
         config.put("formats", List.of("dd/MM/yyyyy"));
-        Locale locale = randomFrom(Locale.GERMANY, Locale.FRENCH, Locale.ROOT);
+        Locale locale = randomFrom(Locale.GERMANY, Locale.FRENCH, Locale.CANADA);
         config.put("locale", locale.toLanguageTag());
 
         DateProcessor processor = factory.create(null, null, null, config, null);

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorFactoryTests.java
@@ -10,11 +10,14 @@
 package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.ingest.TestTemplateService;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -43,8 +46,8 @@ public class DateProcessorFactoryTests extends ESTestCase {
         assertThat(processor.getField(), equalTo(sourceField));
         assertThat(processor.getTargetField(), equalTo(DateProcessor.DEFAULT_TARGET_FIELD));
         assertThat(processor.getFormats(), equalTo(List.of("dd/MM/yyyyy")));
-        assertNull(processor.getLocale());
-        assertNull(processor.getTimezone());
+        assertThat(processor.getTimezone(null), equalTo(ZoneOffset.UTC));
+        assertThat(processor.getLocale(null), equalTo(Locale.ENGLISH));
     }
 
     public void testMatchFieldIsMandatory() throws Exception {
@@ -85,7 +88,8 @@ public class DateProcessorFactoryTests extends ESTestCase {
         config.put("locale", locale.toLanguageTag());
 
         DateProcessor processor = factory.create(null, null, null, config, null);
-        assertThat(processor.getLocale().newInstance(Map.of()).execute(), equalTo(locale.toLanguageTag()));
+        IngestDocument document = RandomDocumentPicks.randomIngestDocument(random(), Map.of());
+        assertThat(processor.getLocale(document), equalTo(locale));
     }
 
     public void testParseTimezone() throws Exception {
@@ -97,7 +101,8 @@ public class DateProcessorFactoryTests extends ESTestCase {
         ZoneId timezone = randomZone();
         config.put("timezone", timezone.getId());
         DateProcessor processor = factory.create(null, null, null, config, null);
-        assertThat(processor.getTimezone().newInstance(Map.of()).execute(), equalTo(timezone.getId()));
+        IngestDocument document = RandomDocumentPicks.randomIngestDocument(random(), Map.of());
+        assertThat(processor.getTimezone(document), equalTo(timezone));
     }
 
     public void testParseMatchFormats() throws Exception {


### PR DESCRIPTION
This is just a refactoring PR, it cleans up some code and encapsulates the template application logic to the internals of the `DateProcessor` rather than exposing it quite as directly. There's a performance improvement coming that builds on this, but this ain't it.

For the record, though, I do think this version of the logic is easier to follow.