### PR TITLE
Set cause on create index request in create from action

### DIFF
--- a/docs/changelog/124363.yaml
+++ b/docs/changelog/124363.yaml
@@ -1,0 +1,5 @@
+pr: 124363
+summary: Set cause on create index request in create from action
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
@@ -109,6 +109,7 @@ public class CreateIndexFromSourceTransportAction extends HandledTransportAction
         }
 
         var createIndexRequest = new CreateIndexRequest(request.destIndex()).settings(settings);
+        createIndexRequest.cause("create-index-from-source");
         if (mergeMappings.isEmpty() == false) {
             createIndexRequest.mapping(mergeMappings);
         }


### PR DESCRIPTION
In the create-index-from-source action, we should set the cause of the create index request so that it is clear in the logs. Without setting cause on the request, the default value of `api` is used.