### PR TITLE
[9.0] Drop unused `prefix` and `suffix` from string collection utils (#124353)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
@@ -350,9 +350,9 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
     @Override
     public String getDescription() {
         final StringBuilder stringBuilder = new StringBuilder("repositories[");
-        Strings.collectionToDelimitedStringWithLimit(Arrays.asList(repositories), ",", "", "", 512, stringBuilder);
+        Strings.collectionToDelimitedStringWithLimit(Arrays.asList(repositories), ",", 512, stringBuilder);
         stringBuilder.append("], snapshots[");
-        Strings.collectionToDelimitedStringWithLimit(Arrays.asList(snapshots), ",", "", "", 1024, stringBuilder);
+        Strings.collectionToDelimitedStringWithLimit(Arrays.asList(snapshots), ",", 1024, stringBuilder);
         stringBuilder.append("]");
         return stringBuilder.toString();
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotRequest.java
@@ -114,7 +114,7 @@ public class GetShardSnapshotRequest extends MasterNodeRequest<GetShardSnapshotR
     @Override
     public String getDescription() {
         final StringBuilder stringBuilder = new StringBuilder("shard").append(shardId).append(", repositories[");
-        Strings.collectionToDelimitedStringWithLimit(repositories, ",", "", "", 1024, stringBuilder);
+        Strings.collectionToDelimitedStringWithLimit(repositories, ",", 1024, stringBuilder);
         stringBuilder.append("]");
         return stringBuilder.toString();
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequest.java
@@ -145,7 +145,7 @@ public class SnapshotsStatusRequest extends MasterNodeRequest<SnapshotsStatusReq
     @Override
     public String getDescription() {
         final StringBuilder stringBuilder = new StringBuilder("repository[").append(repository).append("], snapshots[");
-        Strings.collectionToDelimitedStringWithLimit(Arrays.asList(snapshots), ",", "", "", 1024, stringBuilder);
+        Strings.collectionToDelimitedStringWithLimit(Arrays.asList(snapshots), ",", 1024, stringBuilder);
         stringBuilder.append("]");
         return stringBuilder.toString();
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/LazyRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/LazyRolloverAction.java
@@ -201,8 +201,9 @@ public final class LazyRolloverAction extends ActionType<RolloverResponse> {
             }
 
             if (state != batchExecutionContext.initialState()) {
-                var reason = new StringBuilder();
-                Strings.collectionToDelimitedStringWithLimit(results, ",", "lazy bulk rollover [", "]", 1024, reason);
+                var reason = new StringBuilder("lazy bulk rollover [");
+                Strings.collectionToDelimitedStringWithLimit(results, ",", 1024, reason);
+                reason.append(']');
                 try (var ignored = batchExecutionContext.dropHeadersContext()) {
                     state = allocationService.reroute(state, reason.toString(), listener.reroute());
                 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -517,8 +517,9 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
             }
 
             if (state != batchExecutionContext.initialState()) {
-                var reason = new StringBuilder();
-                Strings.collectionToDelimitedStringWithLimit(results, ",", "bulk rollover [", "]", 1024, reason);
+                var reason = new StringBuilder("bulk rollover [");
+                Strings.collectionToDelimitedStringWithLimit(results, ",", 1024, reason);
+                reason.append(']');
                 try (var ignored = batchExecutionContext.dropHeadersContext()) {
                     state = allocationService.reroute(state, reason.toString(), listener.reroute());
                 }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
@@ -158,7 +158,7 @@ class FieldCapabilitiesNodeRequest extends ActionRequest implements IndicesReque
     @Override
     public String getDescription() {
         final StringBuilder stringBuilder = new StringBuilder("shards[");
-        Strings.collectionToDelimitedStringWithLimit(shardIds, ",", "", "", 1024, stringBuilder);
+        Strings.collectionToDelimitedStringWithLimit(shardIds, ",", 1024, stringBuilder);
         return completeDescription(stringBuilder, fields, filters, allowedTypes, includeEmptyFields);
     }
 
@@ -170,11 +170,11 @@ class FieldCapabilitiesNodeRequest extends ActionRequest implements IndicesReque
         boolean includeEmptyFields
     ) {
         stringBuilder.append("], fields[");
-        Strings.collectionToDelimitedStringWithLimit(Arrays.asList(fields), ",", "", "", 1024, stringBuilder);
+        Strings.collectionToDelimitedStringWithLimit(Arrays.asList(fields), ",", 1024, stringBuilder);
         stringBuilder.append("], filters[");
-        Strings.collectionToDelimitedString(Arrays.asList(filters), ",", "", "", stringBuilder);
+        Strings.collectionToDelimitedString(Arrays.asList(filters), ",", stringBuilder);
         stringBuilder.append("], types[");
-        Strings.collectionToDelimitedString(Arrays.asList(allowedTypes), ",", "", "", stringBuilder);
+        Strings.collectionToDelimitedString(Arrays.asList(allowedTypes), ",", stringBuilder);
         stringBuilder.append("], includeEmptyFields[");
         stringBuilder.append(includeEmptyFields);
         stringBuilder.append("]");

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -289,7 +289,7 @@ public final class FieldCapabilitiesRequest extends ActionRequest implements Ind
     @Override
     public String getDescription() {
         final StringBuilder stringBuilder = new StringBuilder("indices[");
-        Strings.collectionToDelimitedStringWithLimit(Arrays.asList(indices), ",", "", "", 1024, stringBuilder);
+        Strings.collectionToDelimitedStringWithLimit(Arrays.asList(indices), ",", 1024, stringBuilder);
         return FieldCapabilitiesNodeRequest.completeDescription(stringBuilder, fields, filters, types, includeEmptyFields);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -74,8 +74,6 @@ public interface ClusterStateTaskExecutor<T extends ClusterStateTaskListener> {
         Strings.collectionToDelimitedStringWithLimit(
             (Iterable<String>) () -> tasks.stream().map(Object::toString).filter(s -> s.isEmpty() == false).iterator(),
             ", ",
-            "",
-            "",
             1024,
             output
         );

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -1167,8 +1167,6 @@ public class MetadataIndexStateService {
                 Strings.collectionToDelimitedStringWithLimit(
                     indicesToOpen.stream().map(i -> (CharSequence) i.getIndex().toString()).toList(),
                     ",",
-                    "",
-                    "",
                     512,
                     indexNames
                 );

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -1695,7 +1695,7 @@ public class MasterService extends AbstractLifecycleComponent {
                 Strings.collectionToDelimitedStringWithLimit((Iterable<String>) () -> tasksBySource.entrySet().stream().map(entry -> {
                     var tasksDescription = executor.describeTasks(entry.getValue());
                     return tasksDescription.isEmpty() ? entry.getKey() : entry.getKey() + "[" + tasksDescription + "]";
-                }).filter(s -> s.isEmpty() == false).iterator(), ", ", "", "", MAX_TASK_DESCRIPTION_CHARS, output);
+                }).filter(s -> s.isEmpty() == false).iterator(), ", ", MAX_TASK_DESCRIPTION_CHARS, output);
                 if (output.length() > MAX_TASK_DESCRIPTION_CHARS) {
                     output.append(" (").append(tasks.size()).append(" tasks in total)");
                 }

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -546,54 +546,43 @@ public class Strings {
      * String. E.g. useful for <code>toString()</code> implementations.
      *
      * @param coll   the Collection to display
-     * @param delim  the delimiter to use (probably a ",")
-     * @param prefix the String to start each element with
-     * @param suffix the String to end each element with
+     * @param delimiter  the delimiter to use (probably a ",")
      * @return the delimited String
      */
-    public static String collectionToDelimitedString(Iterable<?> coll, String delim, String prefix, String suffix) {
+    public static String collectionToDelimitedString(Iterable<?> coll, String delimiter) {
         StringBuilder sb = new StringBuilder();
-        collectionToDelimitedString(coll, delim, prefix, suffix, sb);
+        collectionToDelimitedString(coll, delimiter, sb);
         return sb.toString();
     }
 
-    public static void collectionToDelimitedString(Iterable<?> coll, String delim, String prefix, String suffix, StringBuilder sb) {
+    public static void collectionToDelimitedString(Iterable<?> coll, String delimiter, StringBuilder sb) {
         Iterator<?> it = coll.iterator();
         while (it.hasNext()) {
-            sb.append(prefix).append(it.next()).append(suffix);
+            sb.append(it.next());
             if (it.hasNext()) {
-                sb.append(delim);
+                sb.append(delimiter);
             }
         }
     }
 
     /**
-     * Converts a collection of items to a string like {@link #collectionToDelimitedString(Iterable, String, String, String, StringBuilder)}
+     * Converts a collection of items to a string like {@link #collectionToDelimitedString(Iterable, String, StringBuilder)}
      * except that it stops if the string gets too long and just indicates how many items were omitted.
      *
      * @param coll        the collection of items to display
-     * @param delim       the delimiter to write between the items (usually {@code ","})
-     * @param prefix      a string to write before each item (usually {@code ""} or {@code "["})
-     * @param suffix      a string to write after each item (usually {@code ""} or {@code "]"})
+     * @param delimiter   the delimiter to write between the items (e.g. {@code ","})
      * @param appendLimit if this many characters have been appended to the string and there are still items to display then the remaining
      *                    items are omitted
      */
-    public static void collectionToDelimitedStringWithLimit(
-        Iterable<?> coll,
-        String delim,
-        String prefix,
-        String suffix,
-        int appendLimit,
-        StringBuilder sb
-    ) {
+    public static void collectionToDelimitedStringWithLimit(Iterable<?> coll, String delimiter, int appendLimit, StringBuilder sb) {
         final Iterator<?> it = coll.iterator();
         final long lengthLimit = sb.length() + appendLimit; // long to avoid overflow
         int count = 0;
         while (it.hasNext()) {
-            sb.append(prefix).append(it.next()).append(suffix);
+            sb.append(it.next());
             count += 1;
             if (it.hasNext()) {
-                sb.append(delim);
+                sb.append(delimiter);
                 if (sb.length() > lengthLimit) {
                     int omitted = 0;
                     while (it.hasNext()) {
@@ -604,18 +593,6 @@ public class Strings {
                 }
             }
         }
-    }
-
-    /**
-     * Convenience method to return a Collection as a delimited (e.g. CSV)
-     * String. E.g. useful for <code>toString()</code> implementations.
-     *
-     * @param coll  the Collection to display
-     * @param delim the delimiter to use (probably a ",")
-     * @return the delimited String
-     */
-    public static String collectionToDelimitedString(Iterable<?> coll, String delim) {
-        return collectionToDelimitedString(coll, delim, "", "");
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2511,8 +2511,6 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
                             Strings.collectionToDelimitedStringWithLimit(
                                 deleteEntry.snapshots().stream().map(SnapshotId::getName).toList(),
                                 ",",
-                                "",
-                                "",
                                 1024,
                                 sb
                             );

--- a/server/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -228,51 +228,47 @@ public class StringsTests extends ESTestCase {
 
     public void testCollectionToDelimitedStringWithLimitZero() {
         final String delimiter = randomFrom("", ",", ", ", "/");
-        final String prefix = randomFrom("", "[");
-        final String suffix = randomFrom("", "]");
 
         final int count = between(0, 100);
         final List<String> strings = new ArrayList<>(count);
         while (strings.size() < count) {
             // avoid starting with a sequence of empty appends, it makes the assertions much messier
-            final int minLength = strings.isEmpty() && delimiter.isEmpty() && prefix.isEmpty() && suffix.isEmpty() ? 1 : 0;
+            final int minLength = strings.isEmpty() && delimiter.isEmpty() ? 1 : 0;
             strings.add(randomAlphaOfLength(between(minLength, 10)));
         }
 
         final StringBuilder stringBuilder = new StringBuilder();
-        collectionToDelimitedStringWithLimit(strings, delimiter, prefix, suffix, 0, stringBuilder);
+        collectionToDelimitedStringWithLimit(strings, delimiter, 0, stringBuilder);
         final String completelyTruncatedDescription = stringBuilder.toString();
 
         if (count == 0) {
             assertThat(completelyTruncatedDescription, equalTo(""));
         } else if (count == 1) {
-            assertThat(completelyTruncatedDescription, equalTo(prefix + strings.get(0) + suffix));
+            assertThat(completelyTruncatedDescription, equalTo(strings.get(0)));
         } else {
             assertThat(
                 completelyTruncatedDescription,
-                equalTo(prefix + strings.get(0) + suffix + delimiter + "... (" + count + " in total, " + (count - 1) + " omitted)")
+                equalTo(strings.get(0) + delimiter + "... (" + count + " in total, " + (count - 1) + " omitted)")
             );
         }
     }
 
     public void testCollectionToDelimitedStringWithLimitTruncation() {
         final String delimiter = randomFrom("", ",", ", ", "/");
-        final String prefix = randomFrom("", "[");
-        final String suffix = randomFrom("", "]");
 
         final int count = between(2, 100);
         final List<String> strings = new ArrayList<>(count);
         while (strings.size() < count) {
             // avoid empty appends, it makes the assertions much messier
-            final int minLength = delimiter.isEmpty() && prefix.isEmpty() && suffix.isEmpty() ? 1 : 0;
+            final int minLength = delimiter.isEmpty() ? 1 : 0;
             strings.add(randomAlphaOfLength(between(minLength, 10)));
         }
 
-        final int fullDescriptionLength = collectionToDelimitedString(strings, delimiter, prefix, suffix).length();
-        final int lastItemSize = prefix.length() + strings.get(count - 1).length() + suffix.length();
+        final int fullDescriptionLength = collectionToDelimitedString(strings, delimiter).length();
+        final int lastItemSize = strings.get(count - 1).length();
         final int truncatedLength = between(0, fullDescriptionLength - lastItemSize - 1);
         final StringBuilder stringBuilder = new StringBuilder();
-        collectionToDelimitedStringWithLimit(strings, delimiter, prefix, suffix, truncatedLength, stringBuilder);
+        collectionToDelimitedStringWithLimit(strings, delimiter, truncatedLength, stringBuilder);
         final String truncatedDescription = stringBuilder.toString();
 
         assertThat(truncatedDescription, allOf(containsString("... (" + count + " in total,"), endsWith(" omitted)")));
@@ -280,14 +276,12 @@ public class StringsTests extends ESTestCase {
         assertThat(
             truncatedDescription,
             truncatedDescription.length(),
-            lessThanOrEqualTo(truncatedLength + (prefix + "0123456789" + suffix + delimiter + "... (999 in total, 999 omitted)").length())
+            lessThanOrEqualTo(truncatedLength + ("0123456789" + delimiter + "... (999 in total, 999 omitted)").length())
         );
     }
 
     public void testCollectionToDelimitedStringWithLimitNoTruncation() {
         final String delimiter = randomFrom("", ",", ", ", "/");
-        final String prefix = randomFrom("", "[");
-        final String suffix = randomFrom("", "]");
 
         final int count = between(1, 100);
         final List<String> strings = new ArrayList<>(count);
@@ -295,17 +289,17 @@ public class StringsTests extends ESTestCase {
             strings.add(randomAlphaOfLength(between(0, 10)));
         }
 
-        final String fullDescription = collectionToDelimitedString(strings, delimiter, prefix, suffix);
+        final String fullDescription = collectionToDelimitedString(strings, delimiter);
         for (String string : strings) {
-            assertThat(fullDescription, containsString(prefix + string + suffix));
+            assertThat(fullDescription, containsString(string));
         }
 
-        final int lastItemSize = prefix.length() + strings.get(count - 1).length() + suffix.length();
+        final int lastItemSize = strings.get(count - 1).length();
         final int minLimit = fullDescription.length() - lastItemSize;
         final int limit = randomFrom(between(minLimit, fullDescription.length()), between(minLimit, Integer.MAX_VALUE), Integer.MAX_VALUE);
 
         final StringBuilder stringBuilder = new StringBuilder();
-        collectionToDelimitedStringWithLimit(strings, delimiter, prefix, suffix, limit, stringBuilder);
+        collectionToDelimitedStringWithLimit(strings, delimiter, limit, stringBuilder);
         assertThat(stringBuilder.toString(), equalTo(fullDescription));
     }
 

--- a/server/src/test/java/org/elasticsearch/http/CorsHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/http/CorsHandlerTests.java
@@ -56,12 +56,12 @@ public class CorsHandlerTests extends ESTestCase {
     public void testCorsConfig() {
         final Set<String> methods = new HashSet<>(Arrays.asList("get", "options", "post"));
         final Set<String> headers = new HashSet<>(Arrays.asList("Content-Type", "Content-Length"));
-        final String prefix = randomBoolean() ? " " : ""; // sometimes have a leading whitespace between comma delimited elements
+        final String maybeSpace = randomFrom(" ", ""); // sometimes have a leading whitespace between comma delimited elements
         final Settings settings = Settings.builder()
             .put(SETTING_CORS_ENABLED.getKey(), true)
             .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), "*")
-            .put(SETTING_CORS_ALLOW_METHODS.getKey(), collectionToDelimitedString(methods, ",", prefix, ""))
-            .put(SETTING_CORS_ALLOW_HEADERS.getKey(), collectionToDelimitedString(headers, ",", prefix, ""))
+            .put(SETTING_CORS_ALLOW_METHODS.getKey(), maybeSpace + collectionToDelimitedString(methods, "," + maybeSpace))
+            .put(SETTING_CORS_ALLOW_HEADERS.getKey(), maybeSpace + collectionToDelimitedString(headers, "," + maybeSpace))
             .put(SETTING_CORS_ALLOW_CREDENTIALS.getKey(), true)
             .build();
         final CorsHandler.Config corsConfig = CorsHandler.buildConfig(settings);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -605,7 +605,12 @@ public class JobManager {
 
     private static void appendCommaSeparatedSet(Set<String> items, StringBuilder sb) {
         sb.append("[");
-        Strings.collectionToDelimitedString(items, ", ", "'", "'", sb);
+        if (items.isEmpty() == false) {
+            // surround each item with single-quotes
+            sb.append('\'');
+            Strings.collectionToDelimitedString(items, "', '", sb);
+            sb.append('\'');
+        }
         sb.append("]");
     }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStackTracesAction.java
@@ -628,7 +628,7 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
 
             if (missingStackTraces.isEmpty() == false) {
                 StringBuilder stringBuilder = new StringBuilder();
-                Strings.collectionToDelimitedStringWithLimit(missingStackTraces, ",", "", "", 80, stringBuilder);
+                Strings.collectionToDelimitedStringWithLimit(missingStackTraces, ",", 80, stringBuilder);
                 log.warn("CO2/cost calculator: missing trace events for StackTraceID [" + stringBuilder + "].");
             }
         }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Drop unused `prefix` and `suffix` from string collection utils (#124353)