### PR TITLE
[8.16] Revert fail-fast disconnect strategy for `_resolve/cluster` (#124241)

### DIFF
--- a/docs/changelog/124241.yaml
+++ b/docs/changelog/124241.yaml
@@ -1,0 +1,5 @@
+pr: 124241
+summary: Revert fail-fast disconnect strategy for `_resolve/cluster`
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
@@ -140,7 +140,7 @@ public class TransportResolveClusterAction extends HandledTransportAction<Resolv
                 RemoteClusterClient remoteClusterClient = remoteClusterService.getRemoteClusterClient(
                     clusterAlias,
                     searchCoordinationExecutor,
-                    RemoteClusterService.DisconnectedStrategy.FAIL_IF_DISCONNECTED
+                    RemoteClusterService.DisconnectedStrategy.RECONNECT_IF_DISCONNECTED
                 );
                 var remoteRequest = new ResolveClusterActionRequest(originalIndices.indices(), request.indicesOptions());
                 // allow cancellation requests to propagate to remote clusters


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Revert fail-fast disconnect strategy for `_resolve/cluster` (#124241)