### PR TITLE
[8.x] [Entitlements] Use the correct format for the `EntitlementInstrumented` annotation descriptor (#124310)

### DIFF
--- a/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterImpl.java
+++ b/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterImpl.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.entitlement.instrumentation.impl;
 
 import org.elasticsearch.entitlement.instrumentation.CheckMethod;
+import org.elasticsearch.entitlement.instrumentation.EntitlementInstrumented;
 import org.elasticsearch.entitlement.instrumentation.Instrumenter;
 import org.elasticsearch.entitlement.instrumentation.MethodKey;
 import org.elasticsearch.logging.LogManager;
@@ -92,7 +93,7 @@ public class InstrumenterImpl implements Instrumenter {
 
     class EntitlementClassVisitor extends ClassVisitor {
 
-        private static final String ENTITLEMENT_ANNOTATION = "EntitlementInstrumented";
+        private static final String ENTITLEMENT_ANNOTATION_DESCRIPTOR = Type.getDescriptor(EntitlementInstrumented.class);
 
         private final String className;
 
@@ -111,7 +112,7 @@ public class InstrumenterImpl implements Instrumenter {
 
         @Override
         public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
-            if (visible && descriptor.equals(ENTITLEMENT_ANNOTATION)) {
+            if (visible && descriptor.equals(ENTITLEMENT_ANNOTATION_DESCRIPTOR)) {
                 isAnnotationPresent = true;
                 annotationNeeded = false;
             }
@@ -177,7 +178,7 @@ public class InstrumenterImpl implements Instrumenter {
         private void addClassAnnotationIfNeeded() {
             if (annotationNeeded) {
                 // logger.debug("Adding {} annotation", ENTITLEMENT_ANNOTATION);
-                AnnotationVisitor av = cv.visitAnnotation(ENTITLEMENT_ANNOTATION, true);
+                AnnotationVisitor av = cv.visitAnnotation(ENTITLEMENT_ANNOTATION_DESCRIPTOR, true);
                 if (av != null) {
                     av.visitEnd();
                 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/EntitlementInstrumented.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/EntitlementInstrumented.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.instrumentation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EntitlementInstrumented {
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [Entitlements] Use the correct format for the `EntitlementInstrumented` annotation descriptor (#124310)