### PR TITLE
[8.x] Make NotEntitledException inherit from AccessControlException for compatibility purposes (#124321)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/NotEntitledException.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/NotEntitledException.java
@@ -9,12 +9,10 @@
 
 package org.elasticsearch.entitlement.runtime.api;
 
-public class NotEntitledException extends SecurityException {
+import java.security.AccessControlException;
+
+public class NotEntitledException extends AccessControlException {
     public NotEntitledException(String message) {
         super(message);
-    }
-
-    public NotEntitledException(String message, Throwable cause) {
-        super(message, cause);
     }
 }

--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/PemKeyConfig.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/PemKeyConfig.java
@@ -10,11 +10,9 @@
 package org.elasticsearch.common.ssl;
 
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.entitlement.runtime.api.NotEntitledException;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.AccessControlException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.PrivateKey;
@@ -126,10 +124,8 @@ public final class PemKeyConfig implements SslKeyConfig {
                 throw new SslConfigException("could not load ssl private key file [" + path + "]");
             }
             return privateKey;
-        } catch (AccessControlException e) {
+        } catch (SecurityException e) {
             throw SslFileUtil.accessControlFailure(KEY_FILE_TYPE, List.of(path), e, configBasePath);
-        } catch (NotEntitledException e) {
-            throw SslFileUtil.notEntitledFailure(KEY_FILE_TYPE, List.of(path), e, configBasePath);
         } catch (IOException e) {
             throw SslFileUtil.ioException(KEY_FILE_TYPE, List.of(path), e);
         } catch (GeneralSecurityException e) {
@@ -140,7 +136,7 @@ public final class PemKeyConfig implements SslKeyConfig {
     private List<Certificate> getCertificates(Path path) {
         try {
             return PemUtils.readCertificates(Collections.singleton(path));
-        } catch (AccessControlException e) {
+        } catch (SecurityException e) {
             throw SslFileUtil.accessControlFailure(CERT_FILE_TYPE, List.of(path), e, configBasePath);
         } catch (IOException e) {
             throw SslFileUtil.ioException(CERT_FILE_TYPE, List.of(path), e);

--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/PemTrustConfig.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/PemTrustConfig.java
@@ -9,12 +9,9 @@
 
 package org.elasticsearch.common.ssl;
 
-import org.elasticsearch.entitlement.runtime.api.NotEntitledException;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.security.AccessControlException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
@@ -99,10 +96,8 @@ public final class PemTrustConfig implements SslTrustConfig {
     private List<Certificate> readCertificates(List<Path> paths) {
         try {
             return PemUtils.readCertificates(paths);
-        } catch (AccessControlException e) {
+        } catch (SecurityException e) {
             throw SslFileUtil.accessControlFailure(CA_FILE_TYPE, paths, e, basePath);
-        } catch (NotEntitledException e) {
-            throw SslFileUtil.notEntitledFailure(CA_FILE_TYPE, paths, e, basePath);
         } catch (IOException e) {
             throw SslFileUtil.ioException(CA_FILE_TYPE, paths, e);
         } catch (GeneralSecurityException e) {

--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/PemUtils.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/PemUtils.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.common.ssl;
 
 import org.elasticsearch.core.CharArrays;
-import org.elasticsearch.entitlement.runtime.api.NotEntitledException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -19,7 +18,6 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessControlException;
 import java.security.AlgorithmParameters;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
@@ -111,10 +109,8 @@ public final class PemUtils {
                 throw new SslConfigException("could not load ssl private key file [" + path + "]");
             }
             return privateKey;
-        } catch (AccessControlException e) {
+        } catch (SecurityException e) {
             throw SslFileUtil.accessControlFailure("PEM private key", List.of(path), e, null);
-        } catch (NotEntitledException e) {
-            throw SslFileUtil.notEntitledFailure("PEM private key", List.of(path), e, null);
         } catch (IOException e) {
             throw SslFileUtil.ioException("PEM private key", List.of(path), e);
         } catch (GeneralSecurityException e) {

--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslFileUtil.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslFileUtil.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.security.AccessControlException;
 import java.security.GeneralSecurityException;
 import java.security.UnrecoverableKeyException;
 import java.util.List;
@@ -84,7 +83,7 @@ final class SslFileUtil {
         return innerAccessControlFailure(fileType, paths, cause, basePath);
     }
 
-    static SslConfigException accessControlFailure(String fileType, List<Path> paths, AccessControlException cause, Path basePath) {
+    static SslConfigException accessControlFailure(String fileType, List<Path> paths, SecurityException cause, Path basePath) {
         return innerAccessControlFailure(fileType, paths, cause, basePath);
     }
 

--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/StoreKeyConfig.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/StoreKeyConfig.java
@@ -11,11 +11,9 @@ package org.elasticsearch.common.ssl;
 
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.entitlement.runtime.api.NotEntitledException;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.AccessControlException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -167,10 +165,8 @@ public class StoreKeyConfig implements SslKeyConfig {
     private KeyStore readKeyStore(Path path) {
         try {
             return KeyStoreUtil.readKeyStore(path, type, storePassword);
-        } catch (AccessControlException e) {
+        } catch (SecurityException e) {
             throw SslFileUtil.accessControlFailure("[" + type + "] keystore", List.of(path), e, configBasePath);
-        } catch (NotEntitledException e) {
-            throw SslFileUtil.notEntitledFailure("[" + type + "] keystore", List.of(path), e, configBasePath);
         } catch (IOException e) {
             throw SslFileUtil.ioException("[" + type + "] keystore", List.of(path), e);
         } catch (GeneralSecurityException e) {

--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/StoreTrustConfig.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/StoreTrustConfig.java
@@ -9,11 +9,8 @@
 
 package org.elasticsearch.common.ssl;
 
-import org.elasticsearch.entitlement.runtime.api.NotEntitledException;
-
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.AccessControlException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
@@ -95,10 +92,8 @@ public final class StoreTrustConfig implements SslTrustConfig {
     private KeyStore readKeyStore(Path path) {
         try {
             return KeyStoreUtil.readKeyStore(path, type, password);
-        } catch (AccessControlException e) {
+        } catch (SecurityException e) {
             throw SslFileUtil.accessControlFailure(fileTypeForException(), List.of(path), e, configBasePath);
-        } catch (NotEntitledException e) {
-            throw SslFileUtil.notEntitledFailure(fileTypeForException(), List.of(path), e, configBasePath);
         } catch (IOException e) {
             throw SslFileUtil.ioException(fileTypeForException(), List.of(path), e, getAdditionalErrorDetails());
         } catch (GeneralSecurityException e) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationReloader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationReloader.java
@@ -12,7 +12,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.ssl.SslConfiguration;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.entitlement.runtime.api.NotEntitledException;
 import org.elasticsearch.watcher.FileChangesListener;
 import org.elasticsearch.watcher.FileWatcher;
 import org.elasticsearch.watcher.ResourceWatcherService;
@@ -20,7 +19,6 @@ import org.elasticsearch.watcher.ResourceWatcherService.Frequency;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.AccessControlException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -110,7 +108,7 @@ public final class SSLConfigurationReloader {
             fileWatcher.addListener(changeListener);
             try {
                 resourceWatcherService.add(fileWatcher, Frequency.HIGH);
-            } catch (IOException | AccessControlException | NotEntitledException e) {
+            } catch (IOException | SecurityException e) {
                 logger.error("failed to start watching directory [{}] for ssl configurations [{}] - {}", path, configurations, e);
             }
         });


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Make NotEntitledException inherit from AccessControlException for compatibility purposes (#124321)