### PR TITLE
[8.18] Revert "missing file entitlement used by google-http-client for oauth2 (#123985)" (#124329)

### DIFF
--- a/modules/repository-gcs/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/repository-gcs/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,16 +1,3 @@
 ALL-UNNAMED:
   - set_https_connection_properties # required by google-http-client
   - outbound_network
-  - files:
-      - relative_path: ".config/gcloud"
-        relative_to: "home"
-        mode: "read"
-        platform: "linux"
-      - relative_path: ".config/gcloud"
-        relative_to: "home"
-        mode: "read"
-        platform: "macos"
-      - relative_path: "AppData\\Roaming\\gcloud"
-        relative_to: "home"
-        mode: "read"
-        platform: "windows"

--- a/plugins/discovery-gce/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/plugins/discovery-gce/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,16 +1,3 @@
 ALL-UNNAMED:
   - set_https_connection_properties # required by google-http-client
   - outbound_network
-  - files:
-      - relative_path: ".config/gcloud"
-        relative_to: "home"
-        mode: "read"
-        platform: "linux"
-      - relative_path: ".config/gcloud"
-        relative_to: "home"
-        mode: "read"
-        platform: "macos"
-      - relative_path: "AppData\\Roaming\\gcloud"
-        relative_to: "home"
-        mode: "read"
-        platform: "windows"


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Revert "missing file entitlement used by google-http-client for oauth2 (#123985)" (#124329)