### PR TITLE
[8.18] remove addess to home/.aws for repository-s3 (#124190)

### DIFF
--- a/modules/repository-s3/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/repository-s3/src/main/plugin-metadata/entitlement-policy.yaml
@@ -5,9 +5,6 @@ ALL-UNNAMED:
     - relative_path: "repository-s3/aws-web-identity-token-file"
       relative_to: "config"
       mode: "read"
-    - relative_path: ".aws/"
-      relative_to: "home"
-      mode: "read"
   # The security policy permission states this is "only for tests": org.elasticsearch.repositories.s3.S3RepositoryPlugin
   # TODO: check this is actually needed, and if we can isolate it to a test-only policy
   - write_system_properties:


### PR DESCRIPTION
Backports the following commits to 8.18:
 - remove addess to home/.aws for repository-s3 (#124190)