### PR TITLE
Avoid reading unnecessary dimension values when downsampling

### DIFF
--- a/docs/changelog/124451.yaml
+++ b/docs/changelog/124451.yaml
@@ -1,0 +1,5 @@
+pr: 124451
+summary: Improve downsample dimension processing
+area: Downsampling
+type: bug
+issues: []

--- a/docs/changelog/124451.yaml
+++ b/docs/changelog/124451.yaml
@@ -1,5 +1,5 @@
 pr: 124451
-summary: Improve downsample dimension processing
+summary: Improve downsample performance by avoiding to read unnecessary dimension values when downsampling.
 area: Downsampling
 type: bug
 issues: []


### PR DESCRIPTION
Read dimension values once per tsid/bucket docid range instead of for each document being processed.
The dimension value within a bucket-interval docid range is always to same and this avoids unnecessary reads.

Latency of downsampling the tsdb track index into a 1 hour interval downsample index drop by ~16% (running on my local machine).