### PR TITLE
[8.18] Avoid reading unnecessary dimension values when downsampling (#124451)

### DIFF
--- a/docs/changelog/124451.yaml
+++ b/docs/changelog/124451.yaml
@@ -1,0 +1,5 @@
+pr: 124451
+summary: Improve downsample performance by avoiding to read unnecessary dimension values when downsampling.
+area: Downsampling
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Avoid reading unnecessary dimension values when downsampling (#124451)