### PR TITLE
Unmute MetricsApmIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -267,9 +267,6 @@ tests:
 - class: org.elasticsearch.test.apmintegration.TracesApmIT
   method: testApmIntegration
   issue: https://github.com/elastic/elasticsearch/issues/122129
-- class: org.elasticsearch.test.apmintegration.MetricsApmIT
-  method: testApmIntegration
-  issue: https://github.com/elastic/elasticsearch/issues/124291
 
 # Examples:
 #


### PR DESCRIPTION
Unmute MetricsApmIT (closes #124291).
This was already fixed by https://github.com/elastic/elasticsearch/pull/123744.