### PR TITLE
[8.x] [Tests] Simplify classpath for analytics javaRestTests (#124274)

### DIFF
--- a/x-pack/plugin/analytics/build.gradle
+++ b/x-pack/plugin/analytics/build.gradle
@@ -14,11 +14,10 @@ base {
   archivesName = 'x-pack-analytics'
 }
 
-tasks.named('javaRestTest') {
-  usesDefaultDistribution()
-}
-
 dependencies {
+  clusterModules project(':modules:aggregations')
+  clusterPlugins project(':x-pack:plugin:analytics')
+
   api 'org.apache.commons:commons-math3:3.6.1'
   compileOnly project(path: xpackModule('core'))
   compileOnly project(":server")

--- a/x-pack/plugin/analytics/src/javaRestTest/java/org/elasticsearch/multiterms/AggsTimeoutIT.java
+++ b/x-pack/plugin/analytics/src/javaRestTest/java/org/elasticsearch/multiterms/AggsTimeoutIT.java
@@ -53,12 +53,9 @@ public class AggsTimeoutIT extends ESRestTestCase {
 
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .distribution(DistributionType.DEFAULT)
-        .setting("xpack.watcher.enabled", "false")
-        .setting("xpack.ml.enabled", "false")
-        .setting("xpack.security.enabled", "false")
-        .setting("xpack.security.transport.ssl.enabled", "false")
-        .setting("xpack.security.http.ssl.enabled", "false")
+        .distribution(DistributionType.INTEG_TEST)
+        .plugin("x-pack-analytics")
+        .module("aggregations")
         .jvmArg("-Xmx1g")
         .build();
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [Tests] Simplify classpath for analytics javaRestTests (#124274)