### PR TITLE
[ML] Avoid unnecessary calls to Task#getDescription in model download

### DIFF
--- a/docs/changelog/124527.yaml
+++ b/docs/changelog/124527.yaml
@@ -1,0 +1,5 @@
+pr: 124527
+summary: Avoid unnecessary calls to Task#getDescription in model download
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/124527.yaml
+++ b/docs/changelog/124527.yaml
@@ -1,5 +1,5 @@
 pr: 124527
-summary: Avoid unnecessary calls to Task#getDescription in model download
+summary: Avoid potentially throwing calls to Task#getDescription in model download
 area: Machine Learning
 type: bug
 issues: []

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
@@ -151,7 +151,7 @@ public class TransportLoadTrainedModelPackage extends TransportMasterNodeAction<
 
         ModelDownloadTask inProgress = null;
         for (var task : tasks) {
-            if (task instanceof ModelDownloadTask downloadTask && (description.equals(task.getDescription()))) {
+            if (task instanceof ModelDownloadTask downloadTask && (description.equals(downloadTask.getDescription()))) {
                 inProgress = downloadTask;
                 break;
             }

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
@@ -151,7 +151,7 @@ public class TransportLoadTrainedModelPackage extends TransportMasterNodeAction<
 
         ModelDownloadTask inProgress = null;
         for (var task : tasks) {
-            if (description.equals(task.getDescription()) && task instanceof ModelDownloadTask downloadTask) {
+            if (task instanceof ModelDownloadTask downloadTask && (description.equals(task.getDescription()))) {
                 inProgress = downloadTask;
                 break;
             }


### PR DESCRIPTION
The model download code checks for an existing download task by iterating over the currently running tasks comparing the task description. The call to `getDescription()` can sometimes throw- see the stack trace below. 

This change rearranges the conditional check so that `getDescription()` is only called on instances of `ModelDownloadTask`. 

```
Caused by: java.lang.UnsupportedOperationException: This should not be XContent serialized
	at org.elasticsearch.inference@9.1.0-SNAPSHOT/org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankBuilder.doXContent(TextSimilarityRankBuilder.java:106)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.search.rank.RankBuilder.toXContent(RankBuilder.java:70)
	at org.elasticsearch.xcontent@9.1.0-SNAPSHOT/org.elasticsearch.xcontent.XContentBuilder.value(XContentBuilder.java:993)
	at org.elasticsearch.xcontent@9.1.0-SNAPSHOT/org.elasticsearch.xcontent.XContentBuilder.value(XContentBuilder.java:982)
	at org.elasticsearch.xcontent@9.1.0-SNAPSHOT/org.elasticsearch.xcontent.XContentBuilder.field(XContentBuilder.java:974)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.search.builder.SearchSourceBuilder.innerToXContent(SearchSourceBuilder.java:1713)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.search.builder.SearchSourceBuilder.toXContent(SearchSourceBuilder.java:1852)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.common.xcontent.XContentHelper.toXContent(XContentHelper.java:653)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.common.xcontent.XContentHelper.toXContent(XContentHelper.java:633)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.search.builder.SearchSourceBuilder.toString(SearchSourceBuilder.java:2177)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.search.SearchRequest.buildDescription(SearchRequest.java:747)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:215)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1709)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:727)
Caused by: java.lang.UnsupportedOperationException: This should not be XContent serialized

	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.search.MultiSearchRequest$1.getDescription(MultiSearchRequest.java:381)
	at org.elasticsearch.xpack.ml.packageloader.action.TransportLoadTrainedModelPackage.handleDownloadInProgress(TransportLoadTrainedModelPackage.java:154)
```