### PR TITLE
[9.0] Remove @UpdateForV9 annotation in FullClusterRestartIT.java (#124474)

### DIFF
--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
@@ -12,7 +12,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ObjectPath;
@@ -26,7 +25,6 @@ import java.util.List;
 import static org.elasticsearch.Version.V_8_12_0;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
-@UpdateForV9(owner = UpdateForV9.Owner.ENTERPRISE_SEARCH) // Investigate what needs to be added in terms of 9.0 migration testing
 public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCase {
     // DSL was introduced with version 8.12.0 of ES.
     private static final Version DSL_DEFAULT_RETENTION_VERSION = V_8_12_0;


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Remove @UpdateForV9 annotation in FullClusterRestartIT.java (#124474)