### PR TITLE
[8.18] [ML] Avoid potentially throwing calls to Task#getDescription in model download

### DIFF
--- a/docs/changelog/124527.yaml
+++ b/docs/changelog/124527.yaml
@@ -1,0 +1,5 @@
+pr: 124527
+summary: Avoid potentially throwing calls to Task#getDescription in model download
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
@@ -153,7 +153,7 @@ public class TransportLoadTrainedModelPackage extends TransportMasterNodeAction<
 
         ModelDownloadTask inProgress = null;
         for (var task : tasks) {
-            if (description.equals(task.getDescription()) && task instanceof ModelDownloadTask downloadTask) {
+            if (task instanceof ModelDownloadTask downloadTask && (description.equals(downloadTask.getDescription()))) {
                 inProgress = downloadTask;
                 break;
             }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ML] Avoid potentially throwing calls to Task#getDescription in model download](https://github.com/elastic/elasticsearch/pull/124527)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)