### PR TITLE
[8.x] Improve DownsampleActionSingleNodeTests testing (#124550)

### DIFF
--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -1117,25 +1117,31 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
     }
 
     private void bulkIndex(final String indexName, final SourceSupplier sourceSupplier, int docCount) throws IOException {
-        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
-        bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        for (int i = 0; i < docCount; i++) {
-            IndexRequest indexRequest = new IndexRequest(indexName).opType(DocWriteRequest.OpType.CREATE);
-            XContentBuilder source = sourceSupplier.get();
-            indexRequest.source(source);
-            bulkRequestBuilder.add(indexRequest);
-        }
-        BulkResponse bulkResponse = bulkRequestBuilder.get();
+        // Index in such a way that we always have multiple segments, so that we test DownsampleShardIndexer in a more realistic scenario:
+        // (also makes failures more reproducible)
         int duplicates = 0;
-        for (BulkItemResponse response : bulkResponse.getItems()) {
-            if (response.isFailed()) {
-                if (response.getFailure().getCause() instanceof VersionConflictEngineException) {
-                    // A duplicate event was created by random generator. We should not fail for this
-                    // reason.
-                    logger.debug("We tried to insert a duplicate: [{}]", response.getFailureMessage());
-                    duplicates++;
-                } else {
-                    fail("Failed to index data: " + bulkResponse.buildFailureMessage());
+        for (int i = 0; i < docCount;) {
+            BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
+            bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            int max = Math.min(i + 100, docCount);
+            for (int j = i; j < max; j++) {
+                IndexRequest indexRequest = new IndexRequest(indexName).opType(DocWriteRequest.OpType.CREATE);
+                XContentBuilder source = sourceSupplier.get();
+                indexRequest.source(source);
+                bulkRequestBuilder.add(indexRequest);
+            }
+            i = max;
+            BulkResponse bulkResponse = bulkRequestBuilder.get();
+            for (BulkItemResponse response : bulkResponse.getItems()) {
+                if (response.isFailed()) {
+                    if (response.getFailure().getCause() instanceof VersionConflictEngineException) {
+                        // A duplicate event was created by random generator. We should not fail for this
+                        // reason.
+                        logger.debug("We tried to insert a duplicate: [{}]", response.getFailureMessage());
+                        duplicates++;
+                    } else {
+                        fail("Failed to index data: " + bulkResponse.buildFailureMessage());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Improve DownsampleActionSingleNodeTests testing (#124550)