### PR TITLE
[9.0] Remove subs attribute (#124551)

### DIFF
--- a/docs/reference/query-languages/sql-limitations.md
+++ b/docs/reference/query-languages/sql-limitations.md
@@ -116,13 +116,13 @@ SELECT age, MAX(salary) - MIN(salary) AS diff FROM test GROUP BY age ORDER BY di
 Using sub-selects (`SELECT X FROM (SELECT Y)`) is **supported to a small degree**: any sub-select that can be "flattened" into a single
 `SELECT` is possible with {es-sql}. For example:
 
-```sql subs=attributes,macros
+```sql 
 include-tagged::{sql-specs}/docs/docs.csv-spec[limitationSubSelect]
 ```
 
 The query above is possible because it is equivalent with:
 
-```sql subs="attributes,macros
+```sql
 include-tagged::{sql-specs}/docs/docs.csv-spec[limitationSubSelectRewritten]
 ```
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Remove subs attribute (#124551)](https://github.com/elastic/elasticsearch/pull/124551)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)