### PR TITLE
[Entitlements] Exclude `java.desktop` from system modules

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/module-info.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/module-info.java
@@ -18,4 +18,5 @@ module org.elasticsearch.entitlement.qa.test {
     requires java.logging;
     requires java.net.http;
     requires jdk.net;
+    requires java.desktop;
 }

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
@@ -35,6 +35,8 @@ import java.util.logging.FileHandler;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
+import javax.imageio.stream.FileImageInputStream;
+
 import static java.nio.charset.Charset.defaultCharset;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -559,6 +561,14 @@ class FileCheckActions {
         // an overload distinct from ofFile with no OpenOptions, and so it needs its
         // own instrumentation and its own test.
         HttpResponse.BodySubscribers.ofFile(readFile(), CREATE, WRITE);
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void javaDesktopFileAccess() throws Exception {
+        // Test file access from a java.desktop class. We explicitly exclude that module from the "system modules", so we expect
+        // any sensitive operation from java.desktop to fail.
+        var file = EntitledActions.createTempFileForRead();
+        new FileImageInputStream(file.toFile()).close();
     }
 
     private FileCheckActions() {}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -67,6 +67,8 @@ public class PolicyManager {
 
     static final Class<?> DEFAULT_FILESYSTEM_CLASS = PathUtils.getDefaultFileSystem().getClass();
 
+    static final Set<String> MODULES_EXCLUDED_FROM_SYSTEM_MODULES = Set.of("java.desktop");
+
     /**
      * @param componentName the plugin name; or else one of the special component names
      *                      like {@link #SERVER_COMPONENT_NAME} or {@link #APM_AGENT_COMPONENT_NAME}.
@@ -141,7 +143,13 @@ public class PolicyManager {
             // entitlements is a "system" module, we can do anything from it
             Stream.of(PolicyManager.class.getModule()),
             // anything in the boot layer is also part of the system
-            ModuleLayer.boot().modules().stream().filter(m -> systemModulesDescriptors.contains(m.getDescriptor()))
+            ModuleLayer.boot()
+                .modules()
+                .stream()
+                .filter(
+                    m -> systemModulesDescriptors.contains(m.getDescriptor())
+                        && MODULES_EXCLUDED_FROM_SYSTEM_MODULES.contains(m.getName()) == false
+                )
         ).collect(Collectors.toUnmodifiableSet());
     }
 


### PR DESCRIPTION
When we realized we have missed instrumentation of `URL.openConnection` methods, we tried to see if we could also chase usages of these functions across the codebase, as an alternative to instrument `URLConnection` classes (the return type). There were many uses, and complex ones, so we ended up doing the `URLConnection` instrumentation, but we also realized that Elasticsearch still loads the `java.desktop` module. Collective memory seems to remember we have it for just a couple of encoding/decoding functions; however, since we now "skip" verification for system modules, all calls to file and network operations form `java.desktop` are permitted, which exposes a huge surface (there might be something exploitable there).

This PR removes the `java.desktop` module explicitly (with the ability to add more if we need to) from the set of "system modules". We should not need any entitlement for `java.desktop` (we should barely use it, and not use it for any sensitive operation); however if it turns out that we need let `java.desktop` perform some sensitive operation, we can explicitly add that back to the server policy, e.g. adding:
```
new Scope("java.desktop", List.of(new LoadNativeLibrariesEntitlement())),
```
to `serverScopes` in `EntitlementInitialization`.

Testing this with a IT test is difficult/impossible, as we are talking about server policies.
I've tested this manually in the following way:

- add this code to server (e.g. where we perform self-checks after Entitlement bootstrap):
```
try {
   var x = ImageIO.read(nodeEnv.configDir().resolve("image.png").toFile());
   logger.info("ImageIO Entitled");
} catch (NotEntitledException e) {
   logger.info("ImageIO Not entitled");
}
```
(ImageIO is just a "convenient" class I found in `java.desktop`
- run it as it is today --> "ImageIO Entitled"
- add `java.desktop` to `MODULES_EXCLUDED_FROM_SYSTEM_MODULES` --> "ImageIO Not entitled"
- add `new Scope("java.desktop", List.of(new LoadNativeLibrariesEntitlement()))` to `serverScopes` in `EntitlementInitialization` --> "ImageIO Entitled"

I have also:
- observed with the trace logs that access to config is granted by the basic FileAccessTree policy we have
- tried to add the entitlement to a modularized plugin: it does not work (it complains that the module is not in the list of this plugin modules, which is correct)
- tried to add the entitlement to a non-modularized plugin: this of course passes checks
  -  but does not grant access (because the module is still considered a `(server)` module): see next point
- adding the code above to the plugin makes it fail (this is the only thing we can write a IT test for -- added!)
- tried to add the entitlement to `server`: adding the code above to a plugin works correctly (server policy + call to sensitive method from a plugin)

Relates to: ES-11008