### PR TITLE
[8.18] Re-enable testCancelFailedSearchWhenPartialResultDisallowed, the issue should already be fixed (#124510)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -238,7 +238,6 @@ public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99929")
     public void testCancelFailedSearchWhenPartialResultDisallowed() throws Exception {
         // Have at least two nodes so that we have parallel execution of two request guaranteed even if max concurrent requests per node
         // are limited to 1


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Re-enable testCancelFailedSearchWhenPartialResultDisallowed, the issue should already be fixed (#124510)