### PR TITLE
Disable the IntelliJ inspection for string templates

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -9,6 +9,7 @@
     <inspection_tool class="PointlessBooleanExpression" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_ignoreExpressionsContainingConstants" value="true" />
     </inspection_tool>
+    <inspection_tool class="StringTemplateMigration" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="jol" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>


### PR DESCRIPTION
IntelliJ has been suggesting switching to string templates (at least it has for me). This is unhelpful advice, since the feature was only ever a tech preview and was removed in more recent JVMs. This change disables that inspection.