### PR TITLE
Enable FIPS entitlements based on `org.bouncycastle.fips.approved_only`.

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -50,7 +50,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.LinkOption;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchService;
 import java.nio.file.attribute.FileAttribute;
@@ -249,7 +248,7 @@ public class EntitlementInitialization {
             String trustStore = System.getProperty("javax.net.ssl.trustStore");
             Path trustStorePath = trustStore != null
                 ? Path.of(trustStore)
-                : Paths.get(System.getProperty("java.home")).resolve("lib/security/jssecacerts");
+                : Path.of(System.getProperty("java.home")).resolve("lib/security/jssecacerts");
 
             Collections.addAll(
                 serverScopes,


### PR DESCRIPTION
When enabling FIPS `javax.net.ssl.trustStore` is not necessarily set. This change adds FIPS entitlements based on `org.bouncycastle.fips.approved_only=true`, which enforces usage of FIPS approved functionality only.

Additionally, this PR grants read access to a custom trust store if provided via `javax.net.ssl.trustStore`, otherwise read access to the default JDK trust store is granted.

Relates to ES-11025.
