### PR TITLE
[8.x] Fix IronBank hardening_manifest CI test (#124579)

### DIFF
--- a/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
+++ b/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
@@ -47,7 +47,7 @@ maintainers:
   - name: "Mark Vieira"
     email: "mark.vieira@elastic.co"
     username: "mark-vieira"
-  - name: "Rene Gröschke"
+  - name: "Rene Groeschke"
     email: "rene.groschke@elastic.co"
     username: "breskeby"
   - email: "klepal_alexander@bah.com"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix IronBank hardening_manifest CI test (#124579)](https://github.com/elastic/elasticsearch/pull/124579)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)