### PR TITLE
[8.x] ES|QL: Support `::date` in inline cast (#123460)

### DIFF
--- a/docs/changelog/123460.yaml
+++ b/docs/changelog/123460.yaml
@@ -1,0 +1,6 @@
+pr: 123460
+summary: "ES|QL: Support `::date` in inline cast"
+area: ES|QL
+type: enhancement
+issues:
+  - 116746

--- a/docs/reference/esql/functions/kibana/inline_cast.json
+++ b/docs/reference/esql/functions/kibana/inline_cast.json
@@ -3,6 +3,7 @@
   "boolean" : "to_boolean",
   "cartesian_point" : "to_cartesianpoint",
   "cartesian_shape" : "to_cartesianshape",
+  "date" : "to_datetime",
   "date_nanos" : "to_date_nanos",
   "date_period" : "to_dateperiod",
   "datetime" : "to_datetime",

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -407,6 +407,7 @@ public enum DataType {
         map.put("bool", BOOLEAN);
         map.put("int", INTEGER);
         map.put("string", KEYWORD);
+        map.put("date", DataType.DATETIME);
         NAME_OR_ALIAS_TO_TYPE = Collections.unmodifiableMap(map);
     }
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/convert.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/convert.csv-spec
@@ -74,6 +74,15 @@ ROW date="1985-01-01T00:00:00Z"::datetime, zero=0::datetime
 1985-01-01T00:00:00.000Z|1970-01-01T00:00:00.000Z
 ;
 
+convertToDate
+required_capability: casting_operator_for_date
+ROW date="1985-01-01T00:00:00Z"::date, zero=0::date
+;
+
+ date:datetime          | zero:datetime
+1985-01-01T00:00:00.000Z|1970-01-01T00:00:00.000Z
+;
+
 convertToVersion
 required_capability: casting_operator
 ROW ver="1.2.3"::version
@@ -350,4 +359,95 @@ z = birth_date + 3 hours + 3 minutes::time_duration, w = birth_date + (3 hours +
 
 birth_date:datetime  |x:datetime           |y:datetime           |z:datetime           |w:datetime
 1953-09-02T00:00:00Z |1953-09-02T03:00:00Z |1953-09-01T21:00:00Z |1953-09-02T03:03:00Z |1953-09-02T03:03:00Z
+;
+
+convertToDatePeriodWithDateCasting
+required_capability: cast_string_literal_to_temporal_amount
+required_capability: casting_operator_for_date
+row x = "2024-01-01"::date 
+| eval y = x + "3 DAYS"::date_period
+;
+
+x:datetime |y:datetime
+2024-01-01 |2024-01-04
+;
+
+convertToTimeDurationWithDateCasting
+required_capability: cast_string_literal_to_temporal_amount
+required_capability: casting_operator_for_date
+row x = "2024-01-01"::date 
+| eval y = x + "3 hours"::time_duration
+;
+
+x:datetime |y:datetime
+2024-01-01 |2024-01-01T03:00:00.000Z
+;
+
+convertToDatePeriodTimeDurationWithDateCasting
+required_capability: cast_string_literal_to_temporal_amount
+required_capability: casting_operator_for_date
+row x = "2024-01-01"::date + "3 hours"::time_duration, y = "2024-01-01"::date - to_timeduration("3 hours"),
+z = "2024-01-01"::date + "3 DAYS"::date_period, w = "2024-01-01"::date - to_dateperiod("3 days")
+| keep x, y, z, w;
+
+x:datetime               |y:datetime               |z:datetime               |w:datetime
+2024-01-01T03:00:00.000Z |2023-12-31T21:00:00.000Z |2024-01-04T00:00:00.000Z |2023-12-29T00:00:00.000Z
+;
+
+convertToDatePeriodNestedWithDateCasting
+required_capability: cast_string_literal_to_temporal_amount
+required_capability: casting_operator_for_date
+row x = "2024-01-01"::date
+| eval y = x + to_dateperiod("3 days"::date_period)
+;
+
+x:datetime |y:datetime
+2024-01-01 |2024-01-04
+;
+
+convertToTimeDurationNestedWithDateCasting
+required_capability: cast_string_literal_to_temporal_amount
+required_capability: casting_operator_for_date
+row x = "2024-01-01"::date
+| eval y = x + to_timeduration("3 hours"::time_duration)
+;
+
+x:datetime |y:datetime
+2024-01-01 |2024-01-01T03:00:00.000Z
+;
+
+testEvalWithDateCasting
+required_capability: casting_operator_for_date
+row x = "1986-06-26T00:00:00.000Z"
+| eval y = x::date, z = y + 10 years 
+;
+
+x:keyword                   | y:datetime                | z:datetime
+1986-06-26T00:00:00.000Z    | 1986-06-26T00:00:00.000Z  | 1996-06-26T00:00:00.000Z
+;
+
+
+filteringWithDateCasting
+required_capability: casting_operator_for_date
+from employees
+| where birth_date < "2023-08-25T11:25:41.052Z"::date - 70 years
+| sort emp_no
+| keep emp_no, birth_date;
+
+emp_no:integer  | birth_date:datetime
+10006           | 1953-04-20T00:00:00.000Z
+10009           | 1952-04-19T00:00:00.000Z
+10019           | 1953-01-23T00:00:00.000Z
+10020           | 1952-12-24T00:00:00.000Z
+10022           | 1952-07-08T00:00:00.000Z
+10026           | 1953-04-03T00:00:00.000Z
+10035           | 1953-02-08T00:00:00.000Z
+10051           | 1953-07-28T00:00:00.000Z
+10063           | 1952-08-06T00:00:00.000Z
+10066           | 1952-11-13T00:00:00.000Z
+10067           | 1953-01-07T00:00:00.000Z
+10072           | 1952-05-15T00:00:00.000Z
+10076           | 1952-06-13T00:00:00.000Z
+10097           | 1952-02-27T00:00:00.000Z
+10100           | 1953-04-21T00:00:00.000Z
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -713,7 +713,12 @@ public class EsqlCapabilities {
         /**
          * Full text functions can be scored when being part of a disjunction
          */
-        FULL_TEXT_FUNCTIONS_DISJUNCTIONS_SCORE;
+        FULL_TEXT_FUNCTIONS_DISJUNCTIONS_SCORE,
+
+        /**
+         * Support for the ::date casting operator
+         */
+        CASTING_OPERATOR_FOR_DATE;
 
         private final boolean enabled;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [ES|QL: Support &#x60;::date&#x60; in inline cast (#123460)](https://github.com/elastic/elasticsearch/pull/123460)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)