### PR TITLE
[9.0] Add .monitoring exemption to `DotPrefixValidator` (#124158)

### DIFF
--- a/modules/dot-prefix-validation/src/main/java/org/elasticsearch/validation/DotPrefixValidator.java
+++ b/modules/dot-prefix-validation/src/main/java/org/elasticsearch/validation/DotPrefixValidator.java
@@ -73,7 +73,12 @@ public abstract class DotPrefixValidator<RequestType> implements MappedActionFil
             "\\.ml-state-\\d+",
             "\\.slo-observability\\.sli-v\\d+.*",
             "\\.slo-observability\\.summary-v\\d+.*",
-            "\\.entities\\.v\\d+\\.latest\\..*"
+            "\\.entities\\.v\\d+\\.latest\\..*",
+            "\\.monitoring-es-8-.*",
+            "\\.monitoring-logstash-8-.*",
+            "\\.monitoring-kibana-8-.*",
+            "\\.monitoring-beats-8-.*",
+            "\\.monitoring-ent-search-8-.*"
         ),
         (patternList) -> patternList.forEach(pattern -> {
             try {

--- a/modules/dot-prefix-validation/src/test/java/org/elasticsearch/validation/DotPrefixValidatorTests.java
+++ b/modules/dot-prefix-validation/src/test/java/org/elasticsearch/validation/DotPrefixValidatorTests.java
@@ -67,7 +67,7 @@ public class DotPrefixValidatorTests extends ESTestCase {
 
         // Test ignored patterns
         nonOpV.validateIndices(Set.of(".ml-state-21309"));
-        nonOpV.validateIndices(Set.of(">.ml-state-21309>"));
+        nonOpV.validateIndices(Set.of("<.ml-state-21309>"));
         nonOpV.validateIndices(Set.of(".slo-observability.sli-v2"));
         nonOpV.validateIndices(Set.of(".slo-observability.sli-v2.3"));
         nonOpV.validateIndices(Set.of(".slo-observability.sli-v2.3-2024-01-01"));
@@ -79,6 +79,16 @@ public class DotPrefixValidatorTests extends ESTestCase {
         nonOpV.validateIndices(Set.of(".entities.v1.latest.builtin_services_from_ecs_data"));
         nonOpV.validateIndices(Set.of(".entities.v92.latest.eggplant.potato"));
         nonOpV.validateIndices(Set.of("<.entities.v12.latest.eggplant-{M{yyyy-MM-dd|UTC}}>"));
+        nonOpV.validateIndices(Set.of(".monitoring-es-8-thing"));
+        nonOpV.validateIndices(Set.of("<.monitoring-es-8-thing>"));
+        nonOpV.validateIndices(Set.of(".monitoring-logstash-8-thing"));
+        nonOpV.validateIndices(Set.of("<.monitoring-logstash-8-thing>"));
+        nonOpV.validateIndices(Set.of(".monitoring-kibana-8-thing"));
+        nonOpV.validateIndices(Set.of("<.monitoring-kibana-8-thing>"));
+        nonOpV.validateIndices(Set.of(".monitoring-beats-8-thing"));
+        nonOpV.validateIndices(Set.of("<.monitoring-beats-8-thing>"));
+        nonOpV.validateIndices(Set.of(".monitoring-ent-search-8-thing"));
+        nonOpV.validateIndices(Set.of("<.monitoring-ent-search-8-thing>"));
 
         // Test pattern added to the settings
         nonOpV.validateIndices(Set.of(".potato5"));


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Add .monitoring exemption to `DotPrefixValidator` (#124158)