### PR TITLE
[9.0] [Entitlements] Exclude `java.desktop` from system modules (#124563)

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/module-info.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/module-info.java
@@ -18,4 +18,5 @@ module org.elasticsearch.entitlement.qa.test {
     requires java.logging;
     requires java.net.http;
     requires jdk.net;
+    requires java.desktop;
 }

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
@@ -35,6 +35,8 @@ import java.util.logging.FileHandler;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
+import javax.imageio.stream.FileImageInputStream;
+
 import static java.nio.charset.Charset.defaultCharset;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -559,6 +561,14 @@ class FileCheckActions {
         // an overload distinct from ofFile with no OpenOptions, and so it needs its
         // own instrumentation and its own test.
         HttpResponse.BodySubscribers.ofFile(readFile(), CREATE, WRITE);
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void javaDesktopFileAccess() throws Exception {
+        // Test file access from a java.desktop class. We explicitly exclude that module from the "system modules", so we expect
+        // any sensitive operation from java.desktop to fail.
+        var file = EntitledActions.createTempFileForRead();
+        new FileImageInputStream(file.toFile()).close();
     }
 
     private FileCheckActions() {}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -67,6 +67,8 @@ public class PolicyManager {
 
     static final Class<?> DEFAULT_FILESYSTEM_CLASS = PathUtils.getDefaultFileSystem().getClass();
 
+    static final Set<String> MODULES_EXCLUDED_FROM_SYSTEM_MODULES = Set.of("java.desktop");
+
     /**
      * @param componentName the plugin name; or else one of the special component names
      *                      like {@link #SERVER_COMPONENT_NAME} or {@link #APM_AGENT_COMPONENT_NAME}.
@@ -141,7 +143,13 @@ public class PolicyManager {
             // entitlements is a "system" module, we can do anything from it
             Stream.of(PolicyManager.class.getModule()),
             // anything in the boot layer is also part of the system
-            ModuleLayer.boot().modules().stream().filter(m -> systemModulesDescriptors.contains(m.getDescriptor()))
+            ModuleLayer.boot()
+                .modules()
+                .stream()
+                .filter(
+                    m -> systemModulesDescriptors.contains(m.getDescriptor())
+                        && MODULES_EXCLUDED_FROM_SYSTEM_MODULES.contains(m.getName()) == false
+                )
         ).collect(Collectors.toUnmodifiableSet());
     }
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [Entitlements] Exclude `java.desktop` from system modules (#124563)