### PR TITLE
[9.0] [Profiling] Fix NullPointerExceptions by accepting dotted field names (#124506)

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/StackTrace.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/StackTrace.java
@@ -184,7 +184,15 @@ final class StackTrace implements ToXContentObject {
 
     public static StackTrace fromSource(Map<String, Object> source) {
         String inputFrameIDs = ObjectPath.eval(PATH_FRAME_IDS, source);
+        if (inputFrameIDs == null) {
+            // If synthetic source is disabled, fallback to dotted field names.
+            inputFrameIDs = (String) source.get("Stacktrace.frame.ids");
+        }
         String inputFrameTypes = ObjectPath.eval(PATH_FRAME_TYPES, source);
+        if (inputFrameTypes == null) {
+            // If synthetic source is disabled, fallback to dotted field names.
+            inputFrameTypes = (String) source.get("Stacktrace.frame.types");
+        }
         int countsFrameIDs = inputFrameIDs.length() / BASE64_FRAME_ID_LENGTH;
 
         String[] fileIDs = new String[countsFrameIDs];

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStackTracesAction.java
@@ -788,7 +788,12 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
                 if (executable.getResponse().isExists()) {
                     // Duplicates are expected as we query multiple indices - do a quick pre-check before we deserialize a response
                     if (executables.containsKey(executable.getId()) == false) {
-                        String fileName = ObjectPath.eval(PATH_FILE_NAME, executable.getResponse().getSource());
+                        Map<String, Object> source = executable.getResponse().getSource();
+                        String fileName = ObjectPath.eval(PATH_FILE_NAME, source);
+                        if (fileName == null) {
+                            // If synthetic source is disabled, read from dotted field names.
+                            fileName = (String) source.get("Executable.file.name");
+                        }
                         if (fileName != null) {
                             executables.putIfAbsent(executable.getId(), fileName);
                         } else {


### PR DESCRIPTION
* [Profiling] Fix NullPointerExceptions by accepting dotted field names

Profiling uses synthetic source and thus expects nested field names in query responses. With 8.17+, synthetic source is available only to Enterprise (or higher) subscriptions, so that smaller subscriptions have dotted field names in query responses. The profiling plugin relies on nested field names and runs into NullPointerExceptions if these are not found.

This PR fixes the NullPointerExceptions that could happen with dotted field names.
