### PR TITLE
Add missing capabilities

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -987,8 +987,8 @@ from hosts
 | keep description
 | sort description;
 
-warning:Line 2:9: evaluation of [starts_with(description, \"epsilon\")] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+warningRegex: evaluation of \[starts_with\(description, \\\"epsilon\\\"\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex: java.lang.IllegalArgumentException: single-value function encountered multi-value
 
 description:text
 epsilon gw instance

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1272,8 +1272,8 @@ from hosts
 | keep description
 | sort description;
 
-warning:Line 2:9: evaluation of [ends_with(description, \"host\")] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+warningRegex: evaluation of \[ends_with\(description, \\\"host\\\"\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex: java.lang.IllegalArgumentException: single-value function encountered multi-value
 
 description:text
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1294,7 +1294,8 @@ beta         | Kubernetes cluster
 ;
 
 lucenePushdownMultipleIndices
-required_capability: casting_operator, index_metadata_field
+required_capability: index_metadata_field
+required_capability: casting_operator
 
 from airports* metadata _index
 | where starts_with(name::keyword, "Sahn") and ends_with(abbrev, "UH")
@@ -1340,7 +1341,8 @@ RUH            | King Khalid Int'l
 ;
 
 lucenePushdownMultipleAnd
-required_capability: casting_operator, index_metadata_field
+required_capability: index_metadata_field
+required_capability: casting_operator
 
 from airports metadata _index
 | where starts_with(name::keyword, "Sahn") and ends_with(abbrev, "UH")
@@ -1365,7 +1367,8 @@ LUH            | Sahnewal  | 9
 ;
 
 lucenePushdownMixOrAnd
-required_capability: casting_operator, index_metadata_field
+required_capability: index_metadata_field
+required_capability: casting_operator
 
 from airports* metadata _index
 | where starts_with(name::keyword, "Sahn") or (starts_with(abbrev, "G") and ends_with(name::keyword, "Falls Int'l"))

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1294,6 +1294,7 @@ beta         | Kubernetes cluster
 ;
 
 lucenePushdownMultipleIndices
+required_capability: casting_operator, index_metadata_field
 
 from airports* metadata _index
 | where starts_with(name::keyword, "Sahn") and ends_with(abbrev, "UH")
@@ -1310,6 +1311,7 @@ LUH            | Sahnewal  | airports_web
 ;
 
 lucenePushdownOr
+required_capability: casting_operator
 
 from airports
 | where starts_with(name::keyword, "Sahn") or ends_with(abbrev, "UH")
@@ -1323,6 +1325,7 @@ RUH            | King Khalid Int'l
 ;
 
 lucenePushdownMultipleOr
+required_capability: casting_operator
 
 from airports
 | where starts_with(name::keyword, "Sahn") or ends_with(abbrev, "UH") or starts_with(abbrev, "OOL")
@@ -1337,6 +1340,7 @@ RUH            | King Khalid Int'l
 ;
 
 lucenePushdownMultipleAnd
+required_capability: casting_operator, index_metadata_field
 
 from airports metadata _index
 | where starts_with(name::keyword, "Sahn") and ends_with(abbrev, "UH")
@@ -1349,6 +1353,7 @@ LUH            | Sahnewal  | airports
 ;
 
 lucenePushdownMixAndOr
+required_capability: casting_operator
 
 from airports
 | where starts_with(name::keyword, "Sahn") and (starts_with(name::keyword, "Abc") or ends_with(abbrev, "UH"))
@@ -1360,6 +1365,7 @@ LUH            | Sahnewal  | 9
 ;
 
 lucenePushdownMixOrAnd
+required_capability: casting_operator, index_metadata_field
 
 from airports* metadata _index
 | where starts_with(name::keyword, "Sahn") or (starts_with(abbrev, "G") and ends_with(name::keyword, "Falls Int'l"))


### PR DESCRIPTION
The tests failed for older versions.
This change declares required capabilities so that versions without them could be skipped

Related to: https://github.com/elastic/elasticsearch/pull/123381
Closes: #124614