### PR TITLE
[Tests] Fix copying files for test cluster

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1328,10 +1328,10 @@ public class ElasticsearchNode implements TestClusterConfiguration {
 
                 @Override
                 public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-                    if (exc.getCause() instanceof NoSuchFileException cause) {
+                    if (exc instanceof NoSuchFileException noFileException) {
                         // Ignore these files that are sometimes left behind by the JVM
-                        if (cause.getFile() != null && cause.getFile().contains(".attach_pid")) {
-                            LOGGER.info("Ignoring file left behind by JVM: {}", cause.getFile());
+                        if (noFileException.getFile() != null && noFileException.getFile().contains(".attach_pid")) {
+                            LOGGER.info("Ignoring file left behind by JVM: {}", noFileException.getFile());
                             return FileVisitResult.CONTINUE;
                         } else {
                             throw exc;

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1303,6 +1303,11 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                 @Override
                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
                     Path relativeDestination = sourceRoot.relativize(dir);
+                    if (relativeDestination.getNameCount() <= 1) {
+                        return FileVisitResult.CONTINUE;
+                    }
+                    // Throw away the first name as the archives have everything in a single top level folder we are not interested in
+                    relativeDestination = relativeDestination.subpath(1, relativeDestination.getNameCount());
                     Path destination = destinationRoot.resolve(relativeDestination);
                     Files.createDirectories(destination);
                     return FileVisitResult.CONTINUE;
@@ -1311,6 +1316,11 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                 @Override
                 public FileVisitResult visitFile(Path source, BasicFileAttributes attrs) {
                     Path relativeDestination = sourceRoot.relativize(source);
+                    if (relativeDestination.getNameCount() <= 1) {
+                        return FileVisitResult.CONTINUE;
+                    }
+                    // Throw away the first name as the archives have everything in a single top level folder we are not interested in
+                    relativeDestination = relativeDestination.subpath(1, relativeDestination.getNameCount());
                     Path destination = destinationRoot.resolve(relativeDestination);
                     syncMethod.accept(destination, source);
                     return FileVisitResult.CONTINUE;

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1302,7 +1302,9 @@ public class ElasticsearchNode implements TestClusterConfiguration {
             Files.walkFileTree(sourceRoot, new SimpleFileVisitor<>() {
                 @Override
                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                    Files.createDirectories(dir);
+                    Path relativeDestination = sourceRoot.relativize(dir);
+                    Path destination = destinationRoot.resolve(relativeDestination);
+                    Files.createDirectories(destination);
                     return FileVisitResult.CONTINUE;
                 }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1314,7 +1314,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                 }
 
                 @Override
-                public FileVisitResult visitFile(Path source, BasicFileAttributes attrs) {
+                public FileVisitResult visitFile(Path source, BasicFileAttributes attrs) throws IOException {
                     Path relativeDestination = sourceRoot.relativize(source);
                     if (relativeDestination.getNameCount() <= 1) {
                         return FileVisitResult.CONTINUE;
@@ -1322,6 +1322,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                     // Throw away the first name as the archives have everything in a single top level folder we are not interested in
                     relativeDestination = relativeDestination.subpath(1, relativeDestination.getNameCount());
                     Path destination = destinationRoot.resolve(relativeDestination);
+                    Files.createDirectories(destination.getParent());
                     syncMethod.accept(destination, source);
                     return FileVisitResult.CONTINUE;
                 }
@@ -1333,12 +1334,9 @@ public class ElasticsearchNode implements TestClusterConfiguration {
                         if (noFileException.getFile() != null && noFileException.getFile().contains(".attach_pid")) {
                             LOGGER.info("Ignoring file left behind by JVM: {}", noFileException.getFile());
                             return FileVisitResult.CONTINUE;
-                        } else {
-                            throw exc;
                         }
-                    } else {
-                        throw exc;
                     }
+                    throw exc;
                 }
             });
         } catch (IOException e) {

--- a/test/test-clusters/build.gradle
+++ b/test/test-clusters/build.gradle
@@ -9,6 +9,10 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
   implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
   implementation "org.elasticsearch.gradle:reaper"
+
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 }
 
 tasks.named("processResources").configure {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
@@ -132,9 +132,10 @@ public final class IOUtils {
                 }
 
                 @Override
-                public FileVisitResult visitFile(Path source, BasicFileAttributes attrs) {
+                public FileVisitResult visitFile(Path source, BasicFileAttributes attrs) throws IOException {
                     Path relativeDestination = sourceRoot.relativize(source);
                     Path destination = destinationRoot.resolve(relativeDestination);
+                    Files.createDirectories(destination.getParent());
                     syncMethod.accept(destination, source);
                     return FileVisitResult.CONTINUE;
                 }
@@ -146,12 +147,9 @@ public final class IOUtils {
                         if (noFileException.getFile() != null && noFileException.getFile().contains(".attach_pid")) {
                             LOGGER.info("Ignoring file left behind by JVM: {}", noFileException.getFile());
                             return FileVisitResult.CONTINUE;
-                        } else {
-                            throw exc;
                         }
-                    } else {
-                        throw exc;
                     }
+                    throw exc;
                 }
             });
         } catch (IOException e) {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
@@ -141,10 +141,10 @@ public final class IOUtils {
 
                 @Override
                 public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-                    if (exc.getCause() instanceof NoSuchFileException cause) {
+                    if (exc instanceof NoSuchFileException noFileException) {
                         // Ignore these files that are sometimes left behind by the JVM
-                        if (cause.getFile() != null && cause.getFile().contains(".attach_pid")) {
-                            LOGGER.info("Ignoring file left behind by JVM: {}", cause.getFile());
+                        if (noFileException.getFile() != null && noFileException.getFile().contains(".attach_pid")) {
+                            LOGGER.info("Ignoring file left behind by JVM: {}", noFileException.getFile());
                             return FileVisitResult.CONTINUE;
                         } else {
                             throw exc;

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
@@ -125,7 +125,9 @@ public final class IOUtils {
             Files.walkFileTree(sourceRoot, new SimpleFileVisitor<>() {
                 @Override
                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                    Files.createDirectories(dir);
+                    Path relativeDestination = sourceRoot.relativize(dir);
+                    Path destination = destinationRoot.resolve(relativeDestination);
+                    Files.createDirectories(destination);
                     return FileVisitResult.CONTINUE;
                 }
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
@@ -120,33 +120,37 @@ public final class IOUtils {
         assert Files.exists(destinationRoot) == false;
         try (Stream<Path> stream = Files.walk(sourceRoot)) {
             stream.forEach(source -> {
-                Path relativeDestination = sourceRoot.relativize(source);
+                try {
+                    Path relativeDestination = sourceRoot.relativize(source);
 
-                Path destination = destinationRoot.resolve(relativeDestination);
-                if (Files.isDirectory(source)) {
-                    try {
-                        Files.createDirectories(destination);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException("Can't create directory " + destination.getParent(), e);
+                    Path destination = destinationRoot.resolve(relativeDestination);
+                    if (Files.isDirectory(source)) {
+                        try {
+                            Files.createDirectories(destination);
+                        } catch (IOException e) {
+                            throw new UncheckedIOException("Can't create directory " + destination.getParent(), e);
+                        }
+                    } else {
+                        try {
+                            Files.createDirectories(destination.getParent());
+                        } catch (IOException e) {
+                            throw new UncheckedIOException("Can't create directory " + destination.getParent(), e);
+                        }
+                        syncMethod.accept(destination, source);
                     }
-                } else {
-                    try {
-                        Files.createDirectories(destination.getParent());
-                    } catch (IOException e) {
-                        throw new UncheckedIOException("Can't create directory " + destination.getParent(), e);
+                } catch (UncheckedIOException e) {
+                    if (e.getCause() instanceof NoSuchFileException cause) {
+                        // Ignore these files that are sometimes left behind by the JVM
+                        if (cause.getFile() != null && cause.getFile().contains(".attach_pid")) {
+                            LOGGER.info("Ignoring file left behind by JVM: {}", cause.getFile());
+                        } else {
+                            throw e;
+                        }
+                    } else {
+                        throw e;
                     }
-                    syncMethod.accept(destination, source);
                 }
             });
-        } catch (UncheckedIOException e) {
-            if (e.getCause() instanceof NoSuchFileException cause) {
-                // Ignore these files that are sometimes left behind by the JVM
-                if (cause.getFile() == null || cause.getFile().contains(".attach_pid") == false) {
-                    throw new UncheckedIOException(cause);
-                }
-            } else {
-                throw e;
-            }
         } catch (IOException e) {
             throw new UncheckedIOException("Can't walk source " + sourceRoot, e);
         }

--- a/test/test-clusters/src/test/java/org/elasticsearch/test/cluster/util/IOUtilsTests.java
+++ b/test/test-clusters/src/test/java/org/elasticsearch/test/cluster/util/IOUtilsTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.cluster.util;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
+import static org.junit.Assert.assertThrows;
+
+public class IOUtilsTests {
+
+    @Test
+    public void testSyncWithLinks() throws IOException {
+        // given
+        Path sourceDir = Files.createTempDirectory("sourceDir");
+        Files.createFile(sourceDir.resolve("file1.txt"));
+        Files.createFile(sourceDir.resolve("file2.txt"));
+        Files.createDirectory(sourceDir.resolve("nestedDir"));
+        Files.createFile(sourceDir.resolve("nestedDir").resolve("file3.txt"));
+
+        Path baseDestinationDir = Files.createTempDirectory("baseDestinationDir");
+        Path destinationDir = baseDestinationDir.resolve("destinationDir");
+
+        // when
+        IOUtils.syncWithLinks(sourceDir, destinationDir);
+
+        // then
+        assertFileExists(destinationDir.resolve("file1.txt"));
+        assertFileExists(destinationDir.resolve("file2.txt"));
+        assertFileExists(destinationDir.resolve("nestedDir").resolve("file3.txt"));
+    }
+
+    private void assertFileExists(Path path) throws IOException {
+        assertThat("File " + path + " doesn't exist", Files.exists(path), is(true));
+        assertThat("File " + path + " is not a regular file", Files.isRegularFile(path), is(true));
+        assertThat("File " + path + " is not readable", Files.isReadable(path), is(true));
+        if (OS.current() != OS.WINDOWS) {
+            assertThat("Expected 2 hard links", Files.getAttribute(path, "unix:nlink"), is(2));
+        }
+    }
+
+    @Test
+    public void testSyncWithLinksThrowExceptionWhenDestinationIsNotWritable() throws IOException {
+        // given
+        Path sourceDir = Files.createTempDirectory("sourceDir");
+        Files.createFile(sourceDir.resolve("file1.txt"));
+
+        Path baseDestinationDir = Files.createTempDirectory("baseDestinationDir");
+        Path destinationDir = baseDestinationDir.resolve("destinationDir");
+
+        baseDestinationDir.toFile().setWritable(false);
+
+        // when
+        UncheckedIOException ex = assertThrows(UncheckedIOException.class, () -> IOUtils.syncWithLinks(sourceDir, destinationDir));
+
+        // then
+        assertThat(ex.getCause(), isA(IOException.class));
+        assertThat(ex.getCause().getMessage(), containsString("destinationDir"));
+    }
+}


### PR DESCRIPTION
In case when file with `.attach_pid` in name was stored in distribution and then deleted, the exception could stop copying/linking files without any sign of issue. The files were then missing in the cluster used in the tests causing failures (sometimes - depending on which files haven't been copied).
