### PR TITLE
AutoCreation waits for active shards in the right project context

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService;
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService.CreateDataStreamClusterStateUpdateRequest;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
@@ -195,7 +194,7 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                     public void onAllNodesAcked() {
                         ActiveShardsObserver.waitForActiveShards(
                             clusterService,
-                            Metadata.DEFAULT_PROJECT_ID,
+                            projectId,
                             indexNames.toArray(String[]::new),
                             ActiveShardCount.DEFAULT,
                             request.ackTimeout(),


### PR DESCRIPTION
This PR replaces the default project ID with the actual project while waiting for active shards after index auto-creation similar to how wait is done for explicit index creation.

