### PR TITLE
Make function score query rewrite a little cheaper

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.common.lucene.search.function;
 
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
@@ -81,8 +80,8 @@ public class FunctionScoreQuery extends Query {
         }
 
         @Override
-        protected ScoreFunction rewrite(IndexReader reader) throws IOException {
-            Query newFilter = filter.rewrite(new IndexSearcher(reader));
+        protected ScoreFunction rewrite(IndexSearcher searcher) throws IOException {
+            Query newFilter = filter.rewrite(searcher);
             if (newFilter == filter) {
                 return this;
             }
@@ -215,7 +214,7 @@ public class FunctionScoreQuery extends Query {
         ScoreFunction[] newFunctions = new ScoreFunction[functions.length];
         boolean needsRewrite = (newQ != subQuery);
         for (int i = 0; i < functions.length; i++) {
-            newFunctions[i] = functions[i].rewrite(searcher.getIndexReader());
+            newFunctions[i] = functions[i].rewrite(searcher);
             needsRewrite |= (newFunctions[i] != functions[i]);
         }
         if (needsRewrite) {

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
@@ -9,8 +9,8 @@
 
 package org.elasticsearch.common.lucene.search.function;
 
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -69,7 +69,7 @@ public abstract class ScoreFunction {
 
     protected abstract int doHashCode();
 
-    protected ScoreFunction rewrite(IndexReader reader) throws IOException {
+    protected ScoreFunction rewrite(IndexSearcher searcher) throws IOException {
         return this;
     }
 }


### PR DESCRIPTION
Just a random thing I noticed, this seemingly overlooked when porting to the new rewrite API. No need to create a new searcher, we already have one here.
