### PR TITLE
[8.x] [ML] Provide model_size_stats as soon as an anomaly detection job is opened (#124638)

### DIFF
--- a/docs/changelog/124638.yaml
+++ b/docs/changelog/124638.yaml
@@ -1,0 +1,6 @@
+pr: 124638
+summary: Provide model size statistics as soon as an anomaly detection job is opened
+area: Machine Learning
+type: bug
+issues:
+ - 121168

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
@@ -348,7 +348,21 @@ public class AutodetectCommunicator implements Closeable {
     }
 
     public ModelSizeStats getModelSizeStats() {
+        if (isModelSizeStatsAvailable() == false) {
+            return createDefaultModelStats();
+        }
         return autodetectResultProcessor.modelSizeStats();
+    }
+
+    private boolean isModelSizeStatsAvailable() {
+        ModelSizeStats modelSizeStats = autodetectResultProcessor.modelSizeStats();
+        return modelSizeStats.getModelBytesMemoryLimit() != null;
+    }
+
+    private ModelSizeStats createDefaultModelStats() {
+        return new ModelSizeStats.Builder(job.getId()).setModelBytesMemoryLimit(job.getAnalysisLimits().getModelMemoryLimit())
+            .setAssignmentMemoryBasis(ModelSizeStats.AssignmentMemoryBasis.MODEL_MEMORY_LIMIT)
+            .build();
     }
 
     public TimingStats getTimingStats() {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Provide model_size_stats as soon as an anomaly detection job is opened (#124638)