### PR TITLE
[8.x] Mark semantic text as GA in docs

### DIFF
--- a/docs/changelog/124670.yaml
+++ b/docs/changelog/124670.yaml
@@ -1,9 +1,10 @@
 pr: 124670
-summary: "[8.x] Mark semantic text as GA in docs"
-area: Relevance
-type: docs
+summary: Release semantic_text as a GA feature
+area: Mapping
+type: feature
 issues: []
 highlight:
-  title: "[8.x] Mark semantic text as GA in docs"
-  body: Remove the beta warnings on the `semantic_text` docs
+  title: Release semantic_text as a GA feature
+  body: semantic_text is now an official GA (generally available) feature!
+        This field type allows you to easily set up and perform semantic search with minimal ramp up time.
   notable: true

--- a/docs/changelog/124670.yaml
+++ b/docs/changelog/124670.yaml
@@ -1,0 +1,9 @@
+pr: 124670
+summary: "[8.x] Mark semantic text as GA in docs"
+area: Relevance
+type: docs
+issues: []
+highlight:
+  title: "[8.x] Mark semantic text as GA in docs"
+  body: Remove the beta warnings on the `semantic_text` docs
+  notable: true

--- a/docs/reference/mapping/types/semantic-text.asciidoc
+++ b/docs/reference/mapping/types/semantic-text.asciidoc
@@ -5,14 +5,12 @@
 <titleabbrev>Semantic text</titleabbrev>
 ++++
 
-beta[]
-
 The `semantic_text` field type automatically generates embeddings for text content using an inference endpoint.
 Long passages are <<auto-text-chunking, automatically chunked>> to smaller sections to enable the processing of larger corpuses of text.
 
 The `semantic_text` field type specifies an inference endpoint identifier that will be used to generate embeddings.
 You can create the inference endpoint by using the <<put-inference-api>>.
-This field type and the <<query-dsl-semantic-query,`semantic` query>> type make it simpler to perform semantic search on your data. 
+This field type and the <<query-dsl-semantic-query,`semantic` query>> type make it simpler to perform semantic search on your data.
 The `semantic_text` field type may also be queried with <<query-dsl-match-query, match>>, <<query-dsl-sparse-vector-query, sparse_vector>> or <<query-dsl-knn-query, knn>> queries.
 
 If you don’t specify an inference endpoint, the `inference_id` field defaults to `.elser-2-elasticsearch`, a preconfigured endpoint for the elasticsearch service.
@@ -193,8 +191,8 @@ types and create an ingest pipeline with an
 <<inference-processor, {infer} processor>> to generate the embeddings.
 <<semantic-search-inference,This tutorial>> walks you through the process. In
 these cases - when you use `sparse_vector` or `dense_vector` field types instead
-of the `semantic_text` field type to customize indexing - using the 
-<<query-dsl-semantic-query,`semantic_query`>> is not supported for querying the 
+of the `semantic_text` field type to customize indexing - using the
+<<query-dsl-semantic-query,`semantic_query`>> is not supported for querying the
 field data.
 
 

--- a/docs/reference/query-dsl/semantic-query.asciidoc
+++ b/docs/reference/query-dsl/semantic-query.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>Semantic</titleabbrev>
 ++++
 
-beta[]
-
 The `semantic` query type enables you to perform <<semantic-search,semantic search>> on data stored in a <<semantic-text,`semantic_text`>> field.
 
 

--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>Semantic search with `semantic_text`</titleabbrev>
 ++++
 
-beta[]
-
 This tutorial shows you how to use the semantic text feature to perform semantic search on your data.
 
 Semantic text simplifies the {infer} workflow by providing {infer} at ingestion time and sensible default values automatically.
@@ -21,7 +19,7 @@ This tutorial uses the <<infer-service-elasticsearch,`elasticsearch` service>> f
 [[semantic-text-requirements]]
 ==== Requirements
 
-This tutorial uses the <<infer-service-elasticsearch,`elasticsearch` service>> for demonstration, which is created automatically as needed. 
+This tutorial uses the <<infer-service-elasticsearch,`elasticsearch` service>> for demonstration, which is created automatically as needed.
 To use the `semantic_text` field type with an {infer} service other than `elasticsearch` service, you must create an inference endpoint using the <<put-inference-api>>.
 
 
@@ -92,7 +90,7 @@ The reindexed data will be processed by the {infer} endpoint associated with the
 ------------------------------------------------------------
 POST _reindex?wait_for_completion=false
 {
-  "source": { 
+  "source": {
     "index": "test-data",
     "size": 10 <1>
   },
@@ -139,7 +137,7 @@ The {infer} endpoint used to generate the embeddings for the `semantic_text` fie
 GET semantic-embeddings/_search
 {
   "query": {
-    "semantic": { 
+    "semantic": {
       "field": "content", <1>
       "query": "How to avoid muscle soreness while running?" <2>
     }


### PR DESCRIPTION
Remove the beta warnings on the `semantic_text` docs
