### PR TITLE
Change payload lower bound for GoogleCloudStorageBlobContainerStatsTests.testResumableWrite

### DIFF
--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerStatsTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerStatsTests.java
@@ -158,7 +158,7 @@ public class GoogleCloudStorageBlobContainerStatsTests extends ESTestCase {
 
         final OperationPurpose purpose = randomPurpose();
         final String blobName = randomIdentifier();
-        final int parts = between(1, 10);
+        final int parts = between(2, 10);
         final int maxPartSize = GoogleCloudStorageBlobStore.SDK_DEFAULT_CHUNK_SIZE;
         final int size = (parts - 1) * maxPartSize + between(1, maxPartSize);
         assert size >= store.getLargeBlobThresholdInBytes();

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -375,9 +375,6 @@ tests:
 - class: org.elasticsearch.lucene.spatial.CartesianCentroidCalculatorTests
   method: testAddDifferentDimensionalType
   issue: https://github.com/elastic/elasticsearch/issues/124609
-- class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobContainerStatsTests
-  method: testResumableWrite
-  issue: https://github.com/elastic/elasticsearch/issues/124648
 
 # Examples:
 #


### PR DESCRIPTION
Fixes #124648

We use [GCS resumable upload](https://cloud.google.com/storage/docs/resumable-uploads) at 5MB payload mark(`store.getLargeBlobThresholdInBytes`), test was failing with single small part that less than 5MB. This PR adjusts lower bound to always be larger than 5MB. The exact value is not very important, the goal of the test is to make several HTTP requests to the GoogleCloudStore.

Before, payload range would be between:
`[0 .. 9] * 15 Mbyte + [1 byte .. 15 Mbyte] = [1 byte .. 150 Mbyte]`
After change 
`[1 .. 9] * 15 Mbyte + [1 byte .. 15 Mbyte] = [~15 Mbyte .. 150 Mbyte]`