### PR TITLE
[9.0] Fix stack trace in `ActionListener#assertOnce` (#124672)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -390,7 +390,9 @@ public interface ActionListener<Response> {
 
                 private void assertFirstRun() {
                     var previousRun = firstCompletion.compareAndExchange(null, new ElasticsearchException("executed already"));
-                    assert previousRun == null : "[" + delegate + "] " + previousRun; // reports the stack traces of both completions
+                    assert previousRun == null
+                        // reports the stack traces of both completions
+                        : new AssertionError("[" + delegate + "]", previousRun);
                 }
 
                 @Override


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Fix stack trace in `ActionListener#assertOnce` (#124672)