### PR TITLE
text_similarity_reranker add  a check to check if the reank field exists

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/rank/FieldBasedRerankerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/rank/FieldBasedRerankerIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.rank.context.QueryPhaseRankCoordinatorContext;
 import org.elasticsearch.search.rank.context.QueryPhaseRankShardContext;
@@ -185,7 +186,7 @@ public class FieldBasedRerankerIT extends AbstractRerankerIT {
         }
 
         @Override
-        public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+        public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
             return new RankFeaturePhaseRankShardContext(field) {
                 @Override
                 public RankShardResult buildRankFeatureShardResult(SearchHits hits, int shardId) {
@@ -330,7 +331,7 @@ public class FieldBasedRerankerIT extends AbstractRerankerIT {
         }
 
         @Override
-        public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+        public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
             if (this.throwingRankBuilderType == ThrowingRankBuilderType.THROWING_RANK_FEATURE_PHASE_SHARD_CONTEXT)
                 return new RankFeaturePhaseRankShardContext(field) {
                     @Override
@@ -339,7 +340,7 @@ public class FieldBasedRerankerIT extends AbstractRerankerIT {
                     }
                 };
             else {
-                return super.buildRankFeaturePhaseShardContext();
+                return super.buildRankFeaturePhaseShardContext(searchContext);
             }
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/rank/MockedRequestActionBasedRerankerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/rank/MockedRequestActionBasedRerankerIT.java
@@ -542,7 +542,7 @@ public class MockedRequestActionBasedRerankerIT extends AbstractRerankerIT {
                     }
                 };
             else {
-                return super.buildRankFeaturePhaseShardContext();
+                return super.buildRankFeaturePhaseShardContext(searchContext);
             }
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/rank/MockedRequestActionBasedRerankerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/rank/MockedRequestActionBasedRerankerIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.rank.context.QueryPhaseRankCoordinatorContext;
 import org.elasticsearch.search.rank.context.QueryPhaseRankShardContext;
@@ -389,7 +390,7 @@ public class MockedRequestActionBasedRerankerIT extends AbstractRerankerIT {
         }
 
         @Override
-        public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+        public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
             return new RerankingRankFeaturePhaseRankShardContext(field);
         }
 
@@ -532,7 +533,7 @@ public class MockedRequestActionBasedRerankerIT extends AbstractRerankerIT {
         }
 
         @Override
-        public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+        public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
             if (this.throwingRankBuilderType == ThrowingRankBuilderType.THROWING_RANK_FEATURE_PHASE_SHARD_CONTEXT)
                 return new RankFeaturePhaseRankShardContext(field) {
                     @Override

--- a/server/src/main/java/org/elasticsearch/search/rank/RankBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/RankBuilder.java
@@ -21,6 +21,7 @@ import org.elasticsearch.core.UpdateForV10;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.rank.context.QueryPhaseRankCoordinatorContext;
 import org.elasticsearch.search.rank.context.QueryPhaseRankShardContext;
 import org.elasticsearch.search.rank.context.RankFeaturePhaseRankCoordinatorContext;
@@ -106,7 +107,7 @@ public abstract class RankBuilder implements VersionedNamedWriteable, ToXContent
      * Generates a context used to execute the rank feature phase on the shard. This is responsible for retrieving any needed
      * feature data, and passing them back to the coordinator through the appropriate {@link  RankShardResult}.
      */
-    public abstract RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext();
+    public abstract RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext);
 
     /**
      * Generates a context used to perform global ranking during the RankFeature phase,

--- a/server/src/main/java/org/elasticsearch/search/rank/feature/RankFeatureShardPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/feature/RankFeatureShardPhase.java
@@ -68,7 +68,7 @@ public final class RankFeatureShardPhase {
         }
 
         RankFeaturePhaseRankShardContext rankFeaturePhaseRankShardContext = searchContext.request().source().rankBuilder() != null
-            ? searchContext.request().source().rankBuilder().buildRankFeaturePhaseShardContext()
+            ? searchContext.request().source().rankBuilder().buildRankFeaturePhaseShardContext(searchContext)
             : null;
         if (rankFeaturePhaseRankShardContext != null) {
             // TODO: here we populate the profile part of the fetchResult as well
@@ -94,7 +94,7 @@ public final class RankFeatureShardPhase {
 
     private static RankFeaturePhaseRankShardContext shardContext(SearchContext searchContext) {
         return searchContext.request().source() != null && searchContext.request().source().rankBuilder() != null
-            ? searchContext.request().source().rankBuilder().buildRankFeaturePhaseShardContext()
+            ? searchContext.request().source().rankBuilder().buildRankFeaturePhaseShardContext(searchContext)
             : null;
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/search/RankFeaturePhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/RankFeaturePhaseTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.rank.RankBuilder;
@@ -900,7 +901,7 @@ public class RankFeaturePhaseTests extends ESTestCase {
             }
 
             @Override
-            public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+            public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
                 return rankFeaturePhaseRankShardContext;
             }
 
@@ -976,7 +977,7 @@ public class RankFeaturePhaseTests extends ESTestCase {
         try {
             hits = SearchHits.unpooled(searchHits, new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), maxScore);
             // construct the appropriate RankFeatureDoc objects based on the rank builder
-            RankFeaturePhaseRankShardContext rankFeaturePhaseRankShardContext = shardRankBuilder.buildRankFeaturePhaseShardContext();
+            RankFeaturePhaseRankShardContext rankFeaturePhaseRankShardContext = shardRankBuilder.buildRankFeaturePhaseShardContext(null);
             RankFeatureShardResult rankShardResult = (RankFeatureShardResult) rankFeaturePhaseRankShardContext.buildRankFeatureShardResult(
                 hits,
                 shardTarget.getShardId().id()

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceSingleNodeTests.java
@@ -511,7 +511,7 @@ public class SearchServiceSingleNodeTests extends ESSingleNodeTestCase {
                             }
 
                             @Override
-                            public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+                            public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
                                 return new RankFeaturePhaseRankShardContext(rankFeatureFieldName) {
                                     @Override
                                     public RankShardResult buildRankFeatureShardResult(SearchHits hits, int shardId) {
@@ -748,7 +748,7 @@ public class SearchServiceSingleNodeTests extends ESSingleNodeTestCase {
                                 }
 
                                 @Override
-                                public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+                                public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
                                     return new RankFeaturePhaseRankShardContext(rankFeatureFieldName) {
                                         @Override
                                         public RankShardResult buildRankFeatureShardResult(SearchHits hits, int shardId) {
@@ -875,7 +875,7 @@ public class SearchServiceSingleNodeTests extends ESSingleNodeTestCase {
                             }
 
                             @Override
-                            public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+                            public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
                                 return new RankFeaturePhaseRankShardContext(rankFeatureFieldName) {
                                     @Override
                                     public RankShardResult buildRankFeatureShardResult(SearchHits hits, int shardId) {
@@ -1008,7 +1008,7 @@ public class SearchServiceSingleNodeTests extends ESSingleNodeTestCase {
                                 }
 
                                 @Override
-                                public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+                                public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
                                     return new RankFeaturePhaseRankShardContext(rankFeatureFieldName) {
                                         @Override
                                         public RankShardResult buildRankFeatureShardResult(SearchHits hits, int shardId) {
@@ -1136,7 +1136,7 @@ public class SearchServiceSingleNodeTests extends ESSingleNodeTestCase {
                                 }
 
                                 @Override
-                                public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+                                public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
                                     return new RankFeaturePhaseRankShardContext(rankFeatureFieldName) {
                                         @Override
                                         public RankShardResult buildRankFeatureShardResult(SearchHits hits, int shardId) {

--- a/server/src/test/java/org/elasticsearch/search/rank/RankFeatureShardPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rank/RankFeatureShardPhaseTests.java
@@ -152,7 +152,7 @@ public class RankFeatureShardPhaseTests extends ESTestCase {
             }
 
             @Override
-            public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+            public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
                 return new RankFeaturePhaseRankShardContext(field) {
                     @Override
                     public RankShardResult buildRankFeatureShardResult(SearchHits hits, int shardId) {

--- a/test/framework/src/main/java/org/elasticsearch/search/rank/TestRankBuilder.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/rank/TestRankBuilder.java
@@ -16,6 +16,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.rank.context.QueryPhaseRankCoordinatorContext;
 import org.elasticsearch.search.rank.context.QueryPhaseRankShardContext;
 import org.elasticsearch.search.rank.context.RankFeaturePhaseRankCoordinatorContext;
@@ -100,7 +101,7 @@ public class TestRankBuilder extends RankBuilder {
     }
 
     @Override
-    public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+    public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
         throw new UnsupportedOperationException();
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -30,6 +30,9 @@ public class InferenceFeatures implements FeatureSpecification {
     private static final NodeFeature TEST_RERANKING_SERVICE_PARSE_TEXT_AS_SCORE = new NodeFeature(
         "test_reranking_service.parse_text_as_score"
     );
+    private static final NodeFeature RERANKING_CHECK_FIELD_EXISTS = new NodeFeature(
+        "text_similarity_reranker.check_field_exists"
+    );
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -50,6 +53,7 @@ public class InferenceFeatures implements FeatureSpecification {
             SEMANTIC_TEXT_HIGHLIGHTER_DEFAULT,
             SEMANTIC_KNN_FILTER_FIX,
             TEST_RERANKING_SERVICE_PARSE_TEXT_AS_SCORE,
+            RERANKING_CHECK_FIELD_EXISTS,
             SemanticTextFieldMapper.SEMANTIC_TEXT_BIT_VECTOR_SUPPORT,
             SemanticTextFieldMapper.SEMANTIC_TEXT_HANDLE_EMPTY_INPUT
         );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/random/RandomRankBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/random/RandomRankBuilder.java
@@ -14,6 +14,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.rank.RankBuilder;
 import org.elasticsearch.search.rank.RankDoc;
 import org.elasticsearch.search.rank.context.QueryPhaseRankCoordinatorContext;
@@ -139,7 +140,7 @@ public class RandomRankBuilder extends RankBuilder {
     }
 
     @Override
-    public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+    public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
         return new RerankingRankFeaturePhaseRankShardContext(field);
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankBuilder.java
@@ -170,7 +170,13 @@ public class TextSimilarityRankBuilder extends RankBuilder {
     public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
 
         // check field in mapping
-        Mapper mapper = searchContext.indexShard().mapperService().mappingLookup().getMapper(field);
+        Mapper mapper;
+        try {
+            mapper = searchContext.indexShard().mapperService().mappingLookup().getMapper(field);
+        } catch (NullPointerException e) {
+            mapper = null;
+        }
+
         if (mapper == null) {
             throw new IllegalArgumentException("field [" + field + "] does not exist in mapping");
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankBuilder.java
@@ -14,8 +14,10 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicensedFeature;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.rank.RankBuilder;
 import org.elasticsearch.search.rank.RankDoc;
 import org.elasticsearch.search.rank.context.QueryPhaseRankCoordinatorContext;
@@ -165,7 +167,14 @@ public class TextSimilarityRankBuilder extends RankBuilder {
     }
 
     @Override
-    public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+    public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
+
+        // check field in mapping
+        Mapper mapper = searchContext.indexShard().mapperService().mappingLookup().getMapper(field);
+        if (mapper == null) {
+            throw new IllegalArgumentException("field [" + field + "] does not exist in mapping");
+        }
+
         return new RerankingRankFeaturePhaseRankShardContext(field);
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankTests.java
@@ -262,6 +262,18 @@ public class TextSimilarityRankTests extends ESSingleNodeTestCase {
         assertThat(ex.getDetailedMessage(), containsString("Reranker input document count and returned score count mismatch"));
     }
 
+    public void testRerankInputSizeAndInferenceResultsFieldMissing() {
+        SearchPhaseExecutionException ex = expectThrows(
+            SearchPhaseExecutionException.class,
+            // Execute search with text similarity reranking
+            client.prepareSearch()
+                .setRankBuilder(new TextSimilarityRankBuilder("missing_field", "my-rerank-model", "my query", 100, 0.0f, false))
+                .setQuery(QueryBuilders.matchAllQuery())
+        );
+        assertThat(ex.status(), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(ex.getDetailedMessage(), containsString("field [missing_field] does not exist in mapping"));
+    }
+
     private static Matcher<SearchHit> searchHitWith(int expectedRank, float expectedScore, String expectedText) {
         return allOf(
             hasRank(expectedRank),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityTestPlugin.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityTestPlugin.java
@@ -24,6 +24,7 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.rank.RankBuilder;
 import org.elasticsearch.search.rank.RankShardResult;
 import org.elasticsearch.search.rank.context.RankFeaturePhaseRankCoordinatorContext;
@@ -193,7 +194,7 @@ public class TextSimilarityTestPlugin extends Plugin implements ActionPlugin {
         }
 
         @Override
-        public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+        public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
             if (this.throwingRankBuilderType == AbstractRerankerIT.ThrowingRankBuilderType.THROWING_RANK_FEATURE_PHASE_SHARD_CONTEXT)
                 return new RankFeaturePhaseRankShardContext(field()) {
                     @Override
@@ -202,7 +203,7 @@ public class TextSimilarityTestPlugin extends Plugin implements ActionPlugin {
                     }
                 };
             else {
-                return super.buildRankFeaturePhaseShardContext();
+                return super.buildRankFeaturePhaseShardContext(searchContext);
             }
         }
 

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
@@ -379,3 +379,29 @@ setup:
   - match: { hits.total.value: 1 }
   - length: { hits.hits: 1 }
   - match: { hits.hits.0._id: "doc_1" }
+
+---
+"Text similarity reranking fails if the rerank field is missing":
+  - requires:
+      cluster_features: "text_similarity_reranker.check_field_exists"
+      reason: "text_similarity_reranker will check if field exists"
+
+  - do:
+      catch: /field \[missing_field\] does not exist in mapping/
+      search:
+        index: test-index
+        body:
+          track_total_hits: true
+          fields: [ "text", "topic" ]
+          retriever:
+            text_similarity_reranker:
+              retriever:
+                standard:
+                  query:
+                    term:
+                      topic: "science"
+              rank_window_size: 10
+              inference_id: my-rerank-model
+              inference_text: "How often does the moon hide the sun?"
+              field: missing_field
+          size: 10

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRankBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRankBuilder.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.rank.RankBuilder;
 import org.elasticsearch.search.rank.RankDoc;
 import org.elasticsearch.search.rank.context.QueryPhaseRankCoordinatorContext;
@@ -183,7 +184,7 @@ public class RRFRankBuilder extends RankBuilder {
     }
 
     @Override
-    public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+    public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext(SearchContext searchContext) {
         return null;
     }
 


### PR DESCRIPTION
When I use text_similarity_reranker, if the field is in correct, I find it return the results, but it don't rerank the result.
I don't know if the rerank work. And I find the results don't match the rerank query, it's hard to debug.
So I add the check to make sure the field exits.