### PR TITLE
ESQL: Add capability to prevent failing tests after Starts/EndsWith Lucene pushdown

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -981,6 +981,7 @@ beta         | Kubernetes cluster
 ;
 
 startsWithLucenePushdownIgnoreMultivalues
+required_capability: starts_with_ends_with_lucene_pushdown
 
 from hosts
 | where starts_with(description, "epsilon")
@@ -1266,6 +1267,7 @@ beta         | Kubernetes cluster
 ;
 
 endsWithLucenePushdownIgnoreMultivalues
+required_capability: starts_with_ends_with_lucene_pushdown
 
 from hosts
 | where ends_with(description, "host")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -873,6 +873,12 @@ public class EsqlCapabilities {
         RRF(Build.current().isSnapshot()),
 
         /**
+         * Lucene query pushdown to StartsWith and EndsWith functions.
+         * This capability was created to avoid receiving wrong warnings from old nodes in mixed clusters
+         */
+        STARTS_WITH_ENDS_WITH_LUCENE_PUSHDOWN,
+
+        /**
          * Full text functions can be scored when being part of a disjunction
          */
         FULL_TEXT_FUNCTIONS_DISJUNCTIONS_SCORE;


### PR DESCRIPTION
Continuation of https://github.com/elastic/elasticsearch/pull/124625, after different issues arised.

Closes https://github.com/elastic/elasticsearch/issues/124693
Closes https://github.com/elastic/elasticsearch/issues/124745
Closes https://github.com/elastic/elasticsearch/issues/124829

The failing BWC tests are checking <8.14 mixed cluster nodes, and SingleValueQuery is sometimes emitting warnings with an empty source.
After some investigation, it's locally reproducible (not 100% of the time though). I was looking for some non-serialized Source that we serialized after that version, but I couldn't find anything relevant. So given that this only impacts warnings in old mixed clusters, this change should be enough.