### PR TITLE
[8.x] Downgrade `cluster.routing.allocation.type` deprecation to a warning

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -109,7 +109,7 @@ public class ClusterModule extends AbstractModule {
         DESIRED_BALANCE_ALLOCATOR,
         Function.identity(),
         Property.NodeScope,
-        Property.Deprecated
+        Property.DeprecatedWarning
     );
 
     private final ClusterService clusterService;

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
@@ -188,7 +188,7 @@ public class ClusterModuleTests extends ModuleTestCase {
         Settings settings = Settings.builder().put(ClusterModule.SHARDS_ALLOCATOR_TYPE_SETTING.getKey(), "custom").build();
         ClusterModule module = newClusterModuleWithShardsAllocator(settings, "custom", FakeShardsAllocator::new);
         assertEquals(FakeShardsAllocator.class, module.shardsAllocator.getClass());
-        assertCriticalWarnings(
+        assertWarnings(
             "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
@@ -218,7 +218,7 @@ public class ClusterModuleTests extends ModuleTestCase {
             )
         );
         assertEquals("Unknown ShardsAllocator [dne]", e.getMessage());
-        assertCriticalWarnings(
+        assertWarnings(
             "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }
@@ -226,7 +226,7 @@ public class ClusterModuleTests extends ModuleTestCase {
     public void testShardsAllocatorFactoryNull() {
         Settings settings = Settings.builder().put(ClusterModule.SHARDS_ALLOCATOR_TYPE_SETTING.getKey(), "bad").build();
         expectThrows(NullPointerException.class, () -> newClusterModuleWithShardsAllocator(settings, "bad", () -> null));
-        assertCriticalWarnings(
+        assertWarnings(
             "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
@@ -703,7 +703,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
                 }
             }
         );
-        assertCriticalWarnings(
+        assertWarnings(
             "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
@@ -448,7 +448,7 @@ public class IndexBalanceTests extends ESAllocationTestCase {
             .build();
 
         final var allocationService = createAllocationService(settings);
-        assertCriticalWarnings(
+        assertWarnings(
             "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationTests.java
@@ -199,7 +199,7 @@ public class ThrottlingAllocationTests extends ESAllocationTestCase {
             EmptyClusterInfoService.INSTANCE,
             snapshotsInfoService
         );
-        assertCriticalWarnings(
+        assertWarnings(
             "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
         );
         logger.info("Building initial routing table");

--- a/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
@@ -361,7 +361,7 @@ public class InternalSnapshotsInfoServiceTests extends ESTestCase {
                     .build(),
                 snapshotsInfoService
             );
-            assertCriticalWarnings(
+            assertWarnings(
                 "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
             );
             applyClusterState(

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -2204,7 +2204,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                         .build(),
                     snapshotsInfoService
                 );
-                assertCriticalWarnings(
+                assertWarnings(
                     "[cluster.routing.allocation.type] setting was deprecated in Elasticsearch and will be removed in a future release."
                 );
                 rerouteService = new BatchedRerouteService(clusterService, allocationService::reroute);


### PR DESCRIPTION
This setting is not getting removed in ES 9.0, so its usage should not generate a critical deprecation warning.


See #94066
See ES-11224
