### PR TITLE
[8.x] Downgrade `transport.enable_stack_protection` deprecation to a warning

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -101,7 +101,7 @@ public class TransportService extends AbstractLifecycleComponent
         "transport.enable_stack_protection",
         false,
         Setting.Property.NodeScope,
-        Setting.Property.Deprecated
+        Setting.Property.DeprecatedWarning
     );
 
     private final AtomicBoolean handleIncomingRequests = new AtomicBoolean();


### PR DESCRIPTION
This setting is not getting removed in ES 9.0, so its usage should not generate a critical deprecation warning.

`TransportServiceLifecycleTests` already uses `assertWarnings` instead of `assertCriticalWarnings` and we don't distinguish between warning levels in assertions (See #80304)

See #109236
See ES-11224


