### PR TITLE
[8.x] Remove `index.merge.policy.max_merge_at_once_explicit` deprecation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
@@ -236,7 +236,7 @@ public final class MergePolicyConfig {
         "index.merge.policy.max_merge_at_once_explicit",
         30,
         2,
-        Property.Deprecated, // When removing in 9.0 follow the approach of IndexSettingDeprecatedInV7AndRemovedInV8
+        // When removing in 9.0 follow the approach of IndexSettingDeprecatedInV7AndRemovedInV8
         Property.Dynamic,
         Property.IndexScope
     );


### PR DESCRIPTION
This setting is not getting removed in ES 9.0, so its usage should not generate a critical deprecation warning. This is an index setting and should have been marked as `IndexSettingDeprecatedInV8AndRemovedInV9`, but we can't change that in 8.x and will mark it as `IndexSettingDeprecatedInV9AndRemovedInV10` in 9.0

See #80574, #90264
See ES-11224