### PR TITLE
Silence AWS entitlement warnings from ALL-UNNAMED

### DIFF
--- a/modules/repository-s3/src/main/config/log4j2.properties
+++ b/modules/repository-s3/src/main/config/log4j2.properties
@@ -13,6 +13,6 @@ logger.com_amazonaws_auth_profile_internal_BasicProfileConfigFileLoader.level = 
 logger.com_amazonaws_services_s3_internal_UseArnRegionResolver.name = com.amazonaws.services.s3.internal.UseArnRegionResolver
 logger.com_amazonaws_services_s3_internal_UseArnRegionResolver.level = error
 
-logger.org_elasticsearch_entitlement_runtime_policy_PolicyManager.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.repository-s3.software.amazon.awssdk.profiles
+logger.org_elasticsearch_entitlement_runtime_policy_PolicyManager.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.repository-s3.ALL-UNNAMED
 logger.org_elasticsearch_entitlement_runtime_policy_PolicyManager.level = error
 


### PR DESCRIPTION
We've observed entitlement warnings from `repository-s3` coming from the unnamed module. I had thought it would come from `software.amazon.awssdk.profiles` because of [this](https://github.com/aws/aws-sdk-java-v2/blob/68200df44543338086fa00267980e78dc4b4bc02/core/profiles/pom.xml#L89), but no such luck.