### PR TITLE
Mark `index.merge.policy.max_merge_at_once_explicit` not to be accepted in v10

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -167,6 +167,13 @@ public class Setting<T> implements ToXContentObject {
         IndexSettingDeprecatedInV8AndRemovedInV9,
 
         /**
+         * Indicates that this index-level setting was deprecated in {@link Version#V_9_1_0} and is
+         * forbidden in indices created from V10 onwards.
+         * TODO Should be checked in {@link Setting#isDeprecatedAndRemoved}
+         */
+        IndexSettingDeprecatedInV9AndRemovedInV10,
+
+        /**
          * Indicates that this setting is accessible by non-operator users (public) in serverless
          * Users will be allowed to set and see values of this setting.
          * All other settings will be rejected when used on a PUT request
@@ -188,7 +195,8 @@ public class Setting<T> implements ToXContentObject {
         Property.Deprecated,
         Property.DeprecatedWarning,
         Property.IndexSettingDeprecatedInV7AndRemovedInV8,
-        Property.IndexSettingDeprecatedInV8AndRemovedInV9
+        Property.IndexSettingDeprecatedInV8AndRemovedInV9,
+        Property.IndexSettingDeprecatedInV9AndRemovedInV10
     );
 
     @SuppressWarnings("this-escape")
@@ -229,6 +237,7 @@ public class Setting<T> implements ToXContentObject {
             checkPropertyRequiresIndexScope(propertiesAsSet, Property.PrivateIndex);
             checkPropertyRequiresIndexScope(propertiesAsSet, Property.IndexSettingDeprecatedInV7AndRemovedInV8);
             checkPropertyRequiresIndexScope(propertiesAsSet, Property.IndexSettingDeprecatedInV8AndRemovedInV9);
+            checkPropertyRequiresIndexScope(propertiesAsSet, Property.IndexSettingDeprecatedInV9AndRemovedInV10);
             checkPropertyRequiresNodeScope(propertiesAsSet);
             this.properties = propertiesAsSet;
         }
@@ -464,7 +473,8 @@ public class Setting<T> implements ToXContentObject {
         return properties.contains(Property.Deprecated)
             || properties.contains(Property.DeprecatedWarning)
             || properties.contains(Property.IndexSettingDeprecatedInV7AndRemovedInV8)
-            || properties.contains(Property.IndexSettingDeprecatedInV8AndRemovedInV9);
+            || properties.contains(Property.IndexSettingDeprecatedInV8AndRemovedInV9)
+            || properties.contains(Property.IndexSettingDeprecatedInV9AndRemovedInV10);
     }
 
     private boolean isDeprecatedWarningOnly() {

--- a/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
@@ -236,7 +236,7 @@ public final class MergePolicyConfig {
         "index.merge.policy.max_merge_at_once_explicit",
         30,
         2,
-        Property.Deprecated, // When removing in 9.0 follow the approach of IndexSettingDeprecatedInV7AndRemovedInV8
+        Property.IndexSettingDeprecatedInV9AndRemovedInV10,
         Property.Dynamic,
         Property.IndexScope
     );

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -1529,6 +1529,19 @@ public class SettingTests extends ESTestCase {
             IllegalArgumentException.class,
             () -> Setting.boolSetting("a.bool.setting", true, Property.DeprecatedWarning, Property.IndexSettingDeprecatedInV8AndRemovedInV9)
         );
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> Setting.boolSetting("a.bool.setting", true, Property.Deprecated, Property.IndexSettingDeprecatedInV9AndRemovedInV10)
+        );
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> Setting.boolSetting(
+                "a.bool.setting",
+                true,
+                Property.DeprecatedWarning,
+                Property.IndexSettingDeprecatedInV9AndRemovedInV10
+            )
+        );
     }
 
     public void testIntSettingBounds() {


### PR DESCRIPTION
Introduce `Property.IndexSettingDeprecatedInV9AndRemovedInV10` property setting to mark index settings that accepted on 9.x indices, but not on 10.0.

`Property.IndexSettingDeprecatedInV8AndRemovedInV9` doesn't have any specific checks in `AbstractScopedSettings#validateDeprecatedAndRemovedSetting`, so didn't add any checks for `IndexSettingDeprecatedInV9AndRemovedInV10`. It's currently used just as a marker.

See #80574, #90264, #120334
See ES-11224
