### PR TITLE
[8.x] Disable queryable built-in feature in docs YAML tests (#124684)

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -119,6 +119,7 @@ testClusters.matching { it.name == "yamlRestTest"}.configureEach {
 
   // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
   systemProperty 'es.transport.cname_in_publish_address', 'true'
+  systemProperty 'es.queryable_built_in_roles_enabled', 'false'
 
 
   requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -402,21 +402,12 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/121474
 - class: org.elasticsearch.xpack.application.CohereServiceUpgradeIT
   issue: https://github.com/elastic/elasticsearch/issues/121537
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/snapshot-restore/apis/get-snapshot-api/line_488}
-  issue: https://github.com/elastic/elasticsearch/issues/121611
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/rest-api/common-options/line_102}
-  issue: https://github.com/elastic/elasticsearch/issues/121748
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/*}
   issue: https://github.com/elastic/elasticsearch/issues/120816
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/*}
   issue: https://github.com/elastic/elasticsearch/issues/120816
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/cat/allocation/cat-allocation-example}
-  issue: https://github.com/elastic/elasticsearch/issues/121976
 - class: org.elasticsearch.xpack.security.authc.ldap.GroupMappingIT
   issue: https://github.com/elastic/elasticsearch/issues/121291
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
@@ -441,9 +432,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
   issue: https://github.com/elastic/elasticsearch/issues/122755
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/troubleshooting/troubleshooting-unbalanced-cluster/line_24}
-  issue: https://github.com/elastic/elasticsearch/issues/122983
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=data_stream/80_resolve_index_data_streams/Resolve index with hidden and closed indices}
   issue: https://github.com/elastic/elasticsearch/issues/123081


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Disable queryable built-in feature in docs YAML tests (#124684)](https://github.com/elastic/elasticsearch/pull/124684)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)