### PR TITLE
[9.0] Disable queryable built-in feature in docs YAML tests (#124684)

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -121,6 +121,7 @@ testClusters.matching { it.name == "yamlRestTest"}.configureEach {
 
   // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
   systemProperty 'es.transport.cname_in_publish_address', 'true'
+  systemProperty 'es.queryable_built_in_roles_enabled', 'false'
 
 
   requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -228,12 +228,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/120816
 - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectorySessionFactoryTests
   issue: https://github.com/elastic/elasticsearch/issues/121285
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/snapshot-restore/apis/get-snapshot-api/line_357}
-  issue: https://github.com/elastic/elasticsearch/issues/121287
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/index-modules/slowlog/line_102}
-  issue: https://github.com/elastic/elasticsearch/issues/121288
 - class: org.elasticsearch.env.NodeEnvironmentTests
   method: testGetBestDowngradeVersion
   issue: https://github.com/elastic/elasticsearch/issues/121316


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Disable queryable built-in feature in docs YAML tests (#124684)](https://github.com/elastic/elasticsearch/pull/124684)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)