### PR TITLE
[8.18] Disable queryable built-in feature in docs YAML tests (#124684)

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -119,6 +119,7 @@ testClusters.matching { it.name == "yamlRestTest"}.configureEach {
 
   // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
   systemProperty 'es.transport.cname_in_publish_address', 'true'
+  systemProperty 'es.queryable_built_in_roles_enabled', 'false'
 
 
   requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -447,9 +447,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
   method: testWithOnlyTrainingRowsAndTrainingPercentIsFifty_DependentVariableIsBoolean
   issue: https://github.com/elastic/elasticsearch/issues/123347
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/rest-api/common-options/line_102}
-  issue: https://github.com/elastic/elasticsearch/issues/121748
 - class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
   method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
   issue: https://github.com/elastic/elasticsearch/issues/121625
@@ -462,9 +459,6 @@ tests:
 - class: org.elasticsearch.gradle.internal.InternalBwcGitPluginFuncTest
   method: can resolve checkout folder as project artifact
   issue: https://github.com/elastic/elasticsearch/issues/119948
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/rest-api/common-options/line_125}
-  issue: https://github.com/elastic/elasticsearch/issues/121338
 - class: org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeToCharProcessorTests
   issue: https://github.com/elastic/elasticsearch/issues/120575
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Disable queryable built-in feature in docs YAML tests (#124684)](https://github.com/elastic/elasticsearch/pull/124684)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)