### PR TITLE
[TEST] Unmute LogsdbIndexingRollingUpgradeIT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -339,15 +339,6 @@ tests:
 - class: org.elasticsearch.common.metrics.ExponentiallyWeightedMovingRateTests
   method: testEwmr_threadSafe
   issue: https://github.com/elastic/elasticsearch/issues/124692
-- class: org.elasticsearch.upgrades.LogsdbIndexingRollingUpgradeIT
-  method: testIndexing {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/124830
-- class: org.elasticsearch.upgrades.LogsdbIndexingRollingUpgradeIT
-  method: testIndexing {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/124831
-- class: org.elasticsearch.upgrades.LogsdbIndexingRollingUpgradeIT
-  method: testIndexing {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/124833
 - class: org.elasticsearch.xpack.ilm.DataStreamAndIndexLifecycleMixingTests
   method: testUpdateIndexTemplateToDataStreamLifecyclePreference
   issue: https://github.com/elastic/elasticsearch/issues/124837


### PR DESCRIPTION
These test failed briefly because https://github.com/elastic/elasticsearch/pull/124803 was merged and https://github.com/elastic/elasticsearch/pull/124787 wasn't.

Fixes #124830
Fixes #124831
Fixes #124833