### PR TITLE
[Entitlements] Add load_native_libraries entitlement to java.desktop

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -213,6 +213,7 @@ public class EntitlementInitialization {
                     new FilesEntitlement(serverModuleFileDatas)
                 )
             ),
+            new Scope("java.desktop", List.of(new LoadNativeLibrariesEntitlement())),
             new Scope("org.apache.httpcomponents.httpclient", List.of(new OutboundNetworkEntitlement())),
             new Scope("io.netty.transport", List.of(new InboundNetworkEntitlement(), new OutboundNetworkEntitlement())),
             new Scope(


### PR DESCRIPTION
The `ingest-attachment` module uses Tika to parse some content; Tika in turn uses some libraries from java.desktop to perform its tasks. 

In turn, the JDK loads one (or more) native libraries for its implementation as part of class initialization. This means we need to grant `load_native_libraries` to java.desktop so that because AWT can load libraries for itself.