### PR TITLE
[9.0] ESQL: Add capability to prevent failing tests after Starts/EndsWith pushdown

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -980,6 +980,7 @@ beta         | Kubernetes cluster
 ;
 
 startsWithLucenePushdownIgnoreMultivalues
+required_capability: starts_with_ends_with_lucene_pushdown
 
 from hosts
 | where starts_with(description, "epsilon")
@@ -1246,6 +1247,7 @@ beta         | Kubernetes cluster
 ;
 
 endsWithLucenePushdownIgnoreMultivalues
+required_capability: starts_with_ends_with_lucene_pushdown
 
 from hosts
 | where ends_with(description, "host")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -827,6 +827,12 @@ public class EsqlCapabilities {
         MIXED_NUMERIC_TYPES_IN_CASE_GREATEST_LEAST,
 
         /**
+         * Lucene query pushdown to StartsWith and EndsWith functions.
+         * This capability was created to avoid receiving wrong warnings from old nodes in mixed clusters
+         */
+        STARTS_WITH_ENDS_WITH_LUCENE_PUSHDOWN,
+
+        /**
          * Full text functions can be scored when being part of a disjunction
          */
         FULL_TEXT_FUNCTIONS_DISJUNCTIONS_SCORE;


### PR DESCRIPTION
Manual 9.0 backport of https://github.com/elastic/elasticsearch/pull/124764