### PR TITLE
[8.18] [ML] Allowing deletion of default endpoints while using force true (#124781)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportDeleteInferenceEndpointAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportDeleteInferenceEndpointAction.java
@@ -18,8 +18,8 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.inference.InferenceServiceRegistry;
 import org.elasticsearch.inference.UnparsedModel;
@@ -53,7 +53,6 @@ public class TransportDeleteInferenceEndpointAction extends TransportMasterNodeA
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        IndexNameExpressionResolver indexNameExpressionResolver,
         ModelRegistry modelRegistry,
         InferenceServiceRegistry serviceRegistry
     ) {
@@ -88,17 +87,6 @@ public class TransportDeleteInferenceEndpointAction extends TransportMasterNodeA
         ClusterState state,
         ActionListener<DeleteInferenceEndpointAction.Response> masterListener
     ) {
-        if (modelRegistry.containsDefaultConfigId(request.getInferenceEndpointId())) {
-            masterListener.onFailure(
-                new ElasticsearchStatusException(
-                    "[{}] is a reserved inference endpoint. Cannot delete a reserved inference endpoint.",
-                    RestStatus.BAD_REQUEST,
-                    request.getInferenceEndpointId()
-                )
-            );
-            return;
-        }
-
         SubscribableListener.<UnparsedModel>newForked(modelConfigListener -> {
             // Get the model from the registry
 
@@ -119,6 +107,18 @@ public class TransportDeleteInferenceEndpointAction extends TransportMasterNodeA
                 var errorString = endpointIsReferencedInPipelinesOrIndexes(state, request.getInferenceEndpointId());
                 if (errorString != null) {
                     listener.onFailure(new ElasticsearchStatusException(errorString, RestStatus.CONFLICT));
+                    return;
+                } else if (isInferenceIdReserved(request.getInferenceEndpointId())) {
+                    listener.onFailure(
+                        new ElasticsearchStatusException(
+                            Strings.format(
+                                "[%s] is a reserved inference endpoint. Use the force=true query parameter "
+                                    + "to delete the inference endpoint.",
+                                request.getInferenceEndpointId()
+                            ),
+                            RestStatus.BAD_REQUEST
+                        )
+                    );
                     return;
                 }
             }
@@ -186,6 +186,10 @@ public class TransportDeleteInferenceEndpointAction extends TransportMasterNodeA
             return buildErrorString(inferenceEndpointId, pipelines, indexes);
         }
         return null;
+    }
+
+    private boolean isInferenceIdReserved(String inferenceEndpointId) {
+        return modelRegistry.containsDefaultConfigId(inferenceEndpointId);
     }
 
     private static String buildErrorString(String inferenceEndpointId, Set<String> pipelines, Set<String> indexes) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportDeleteInferenceEndpointActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportDeleteInferenceEndpointActionTests.java
@@ -8,17 +8,16 @@
 package org.elasticsearch.xpack.inference.action;
 
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceService;
 import org.elasticsearch.inference.InferenceServiceRegistry;
-import org.elasticsearch.inference.MinimalServiceSettings;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.UnparsedModel;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -28,9 +27,16 @@ import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.Map;
+import java.util.Optional;
+
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TransportDeleteInferenceEndpointActionTests extends ESTestCase {
 
@@ -38,21 +44,22 @@ public class TransportDeleteInferenceEndpointActionTests extends ESTestCase {
 
     private TransportDeleteInferenceEndpointAction action;
     private ThreadPool threadPool;
-    private ModelRegistry modelRegistry;
+    private ModelRegistry mockModelRegistry;
+    private InferenceServiceRegistry mockInferenceServiceRegistry;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        modelRegistry = new ModelRegistry(mock(Client.class));
         threadPool = createThreadPool(inferenceUtilityPool());
+        mockModelRegistry = mock(ModelRegistry.class);
+        mockInferenceServiceRegistry = mock(InferenceServiceRegistry.class);
         action = new TransportDeleteInferenceEndpointAction(
             mock(TransportService.class),
             mock(ClusterService.class),
             threadPool,
             mock(ActionFilters.class),
-            mock(IndexNameExpressionResolver.class),
-            modelRegistry,
-            mock(InferenceServiceRegistry.class)
+            mockModelRegistry,
+            mockInferenceServiceRegistry
         );
     }
 
@@ -62,24 +69,63 @@ public class TransportDeleteInferenceEndpointActionTests extends ESTestCase {
         terminate(threadPool);
     }
 
-    public void testFailsToDelete_ADefaultEndpoint() {
-        modelRegistry.addDefaultIds(
-            new InferenceService.DefaultConfigId("model-id", MinimalServiceSettings.chatCompletion(), mock(InferenceService.class))
-        );
+    public void testFailsToDelete_ADefaultEndpoint_WithoutPassingForceQueryParameter() {
+        doAnswer(invocationOnMock -> {
+            ActionListener<UnparsedModel> listener = invocationOnMock.getArgument(1);
+            listener.onResponse(new UnparsedModel("model_id", TaskType.COMPLETION, "service", Map.of(), Map.of()));
+            return Void.TYPE;
+        }).when(mockModelRegistry).getModel(anyString(), any());
+        when(mockModelRegistry.containsDefaultConfigId(anyString())).thenReturn(true);
 
         var listener = new PlainActionFuture<DeleteInferenceEndpointAction.Response>();
 
         action.masterOperation(
             mock(Task.class),
-            new DeleteInferenceEndpointAction.Request("model-id", TaskType.CHAT_COMPLETION, true, false),
-            mock(ClusterState.class),
+            new DeleteInferenceEndpointAction.Request("model-id", TaskType.COMPLETION, false, false),
+            ClusterState.EMPTY_STATE,
             listener
         );
 
         var exception = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
         assertThat(
             exception.getMessage(),
-            is("[model-id] is a reserved inference endpoint. " + "Cannot delete a reserved inference endpoint.")
+            is("[model-id] is a reserved inference endpoint. Use the force=true query parameter to delete the inference endpoint.")
         );
+    }
+
+    public void testDeletesDefaultEndpoint_WhenForceIsTrue() {
+        doAnswer(invocationOnMock -> {
+            ActionListener<UnparsedModel> listener = invocationOnMock.getArgument(1);
+            listener.onResponse(new UnparsedModel("model_id", TaskType.COMPLETION, "service", Map.of(), Map.of()));
+            return Void.TYPE;
+        }).when(mockModelRegistry).getModel(anyString(), any());
+        when(mockModelRegistry.containsDefaultConfigId(anyString())).thenReturn(true);
+        doAnswer(invocationOnMock -> {
+            ActionListener<Boolean> listener = invocationOnMock.getArgument(1);
+            listener.onResponse(true);
+            return Void.TYPE;
+        }).when(mockModelRegistry).deleteModel(anyString(), any());
+
+        var mockService = mock(InferenceService.class);
+        doAnswer(invocationOnMock -> {
+            ActionListener<Boolean> listener = invocationOnMock.getArgument(1);
+            listener.onResponse(true);
+            return Void.TYPE;
+        }).when(mockService).stop(any(), any());
+
+        when(mockInferenceServiceRegistry.getService(anyString())).thenReturn(Optional.of(mockService));
+
+        var listener = new PlainActionFuture<DeleteInferenceEndpointAction.Response>();
+
+        action.masterOperation(
+            mock(Task.class),
+            new DeleteInferenceEndpointAction.Request("model-id", TaskType.COMPLETION, true, false),
+            ClusterState.EMPTY_STATE,
+            listener
+        );
+
+        var response = listener.actionGet(TIMEOUT);
+
+        assertTrue(response.isAcknowledged());
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ML] Allowing deletion of default endpoints while using force&#x3D;true (#124781)](https://github.com/elastic/elasticsearch/pull/124781)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)