### PR TITLE
Suppress known entitlement warnings

### DIFF
--- a/modules/ingest-attachment/src/main/config/log4j2.properties
+++ b/modules/ingest-attachment/src/main/config/log4j2.properties
@@ -9,3 +9,6 @@ logger.org_apache_fontbox.level = off
 
 logger.org_apache_xmlbeans.name = org.apache.xmlbeans
 logger.org_apache_xmlbeans.level = off
+
+logger.entitlements_ingest_attachment.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.ingest-attachment.ALL-UNNAMED
+logger.entitlements_ingest_attachment.level = error

--- a/modules/repository-gcs/src/main/config/log4j2.properties
+++ b/modules/repository-gcs/src/main/config/log4j2.properties
@@ -1,3 +1,2 @@
-logger.org_elasticsearch_entitlement_runtime_policy_PolicyManager.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.repository-gcs.ALL-UNNAMED
-logger.org_elasticsearch_entitlement_runtime_policy_PolicyManager.level = error
-
+logger.entitlements_repository_gcs.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.repository-gcs.ALL-UNNAMED
+logger.entitlements_repository_gcs.level = error

--- a/modules/repository-s3/src/main/config/log4j2.properties
+++ b/modules/repository-s3/src/main/config/log4j2.properties
@@ -13,6 +13,6 @@ logger.com_amazonaws_auth_profile_internal_BasicProfileConfigFileLoader.level = 
 logger.com_amazonaws_services_s3_internal_UseArnRegionResolver.name = com.amazonaws.services.s3.internal.UseArnRegionResolver
 logger.com_amazonaws_services_s3_internal_UseArnRegionResolver.level = error
 
-logger.org_elasticsearch_entitlement_runtime_policy_PolicyManager.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.repository-s3.ALL-UNNAMED
-logger.org_elasticsearch_entitlement_runtime_policy_PolicyManager.level = error
+logger.entitlements_repository_s3.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.repository-s3.ALL-UNNAMED
+logger.entitlements_repository_s3.level = error
 

--- a/plugins/discovery-ec2/config/discovery-ec2/log4j2.properties
+++ b/plugins/discovery-ec2/config/discovery-ec2/log4j2.properties
@@ -12,3 +12,6 @@ logger.com_amazonaws_auth_profile_internal_BasicProfileConfigFileLoader.level = 
 
 logger.com_amazonaws_services_s3_internal_UseArnRegionResolver.name = com.amazonaws.services.s3.internal.UseArnRegionResolver
 logger.com_amazonaws_services_s3_internal_UseArnRegionResolver.level = error
+
+logger.entitlements_discovery_ec2.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.discovery-ec2.ALL-UNNAMED
+logger.entitlements_discovery_ec2.level = error

--- a/plugins/discovery-gce/build.gradle
+++ b/plugins/discovery-gce/build.gradle
@@ -44,6 +44,10 @@ tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
 }
 
+esplugin.bundleSpec.from('config/discovery-gce') {
+  into 'config'
+}
+
 tasks.named("check").configure {
   // also execute the QA tests when testing the plugin
   dependsOn 'qa:gce:check'

--- a/plugins/discovery-gce/config/discovery-gce/log4j2.properties
+++ b/plugins/discovery-gce/config/discovery-gce/log4j2.properties
@@ -1,0 +1,3 @@
+logger.entitlements_discovery_gce.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.discovery-gce.ALL-UNNAMED
+logger.entitlements_discovery_gce.level = error
+

--- a/x-pack/plugin/inference/src/main/config/log4j2.properties
+++ b/x-pack/plugin/inference/src/main/config/log4j2.properties
@@ -1,0 +1,3 @@
+logger.entitlements_inference.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.inference.software.amazon.awssdk.profiles
+logger.entitlements_inference.level = error
+


### PR DESCRIPTION
The work here is to copy over the settings from https://github.com/elastic/elasticsearch-serverless/pull/3639 and distribute them into the right `log4j2.properties` files.

See ES-11258.