### PR TITLE
Relax memory barrier from org.elasticsearch.action.search.AbstractSearchAsyncAction#hasShardResponse

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -494,7 +494,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     protected void onShardResult(Result result) {
         assert result.getShardIndex() != -1 : "shard index is not set";
         assert result.getSearchShardTarget() != null : "search shard target must not be null";
-        hasShardResponse.set(true);
+        hasShardResponse.compareAndExchangeRelease(false, true);
         if (logger.isTraceEnabled()) {
             logger.trace("got first-phase result from {}", result != null ? result.getSearchShardTarget() : null);
         }
@@ -734,7 +734,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         // can return a null response if the request rewrites to match none rather
         // than creating an empty response in the search thread pool.
         // Note that, we have to disable this shortcut for queries that create a context (scroll and search context).
-        shardRequest.canReturnNullResponseIfMatchNoDocs(hasShardResponse.get() && shardRequest.scroll() == null);
+        shardRequest.canReturnNullResponseIfMatchNoDocs(shardRequest.scroll() == null && hasShardResponse.getAcquire());
         return shardRequest;
     }
 


### PR DESCRIPTION
Make this thing introduce less ordering by only writing as needed. While this may be a tiny performance win, the main motivation for this is to remove one source of unpredictable happens-before across transport and search threads to make bugs more likely to surface despite low thread counts in tests.
