### PR TITLE
ESQL: Don't run INLINESTATS optimizer tests in release builds

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -342,12 +342,6 @@ tests:
 - class: org.elasticsearch.xpack.ilm.DataStreamAndIndexLifecycleMixingTests
   method: testUpdateIndexTemplateToDataStreamLifecyclePreference
   issue: https://github.com/elastic/elasticsearch/issues/124837
-- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.PropagateInlineEvalsTests
-  method: testGroupingAliasingMoved_To_LeftSideOfJoin
-  issue: https://github.com/elastic/elasticsearch/issues/124839
-- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.PropagateInlineEvalsTests
-  method: testGroupingAliasingMoved_To_LeftSideOfJoin_WithExpression
-  issue: https://github.com/elastic/elasticsearch/issues/124838
 - class: org.elasticsearch.datastreams.lifecycle.DataStreamLifecycleServiceIT
   method: testAutomaticForceMerge
   issue: https://github.com/elastic/elasticsearch/issues/124846

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateInlineEvalsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateInlineEvalsTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerContext;
 import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
@@ -80,6 +81,7 @@ public class PropagateInlineEvalsTests extends ESTestCase {
      *     \_StubRelation[[emp_no{f}#11, languages{f}#14, gender{f}#13, y{r}#10]]
      */
     public void testGroupingAliasingMoved_To_LeftSideOfJoin() {
+        assumeTrue("Requires INLINESTATS", EsqlCapabilities.Cap.INLINESTATS_V5.isEnabled());
         var plan = plan("""
             from test
             | keep emp_no, languages, gender
@@ -122,6 +124,7 @@ public class PropagateInlineEvalsTests extends ESTestCase {
      * {r}#21]]
      */
     public void testGroupingAliasingMoved_To_LeftSideOfJoin_WithExpression() {
+        assumeTrue("Requires INLINESTATS", EsqlCapabilities.Cap.INLINESTATS_V5.isEnabled());
         var plan = plan("""
             from test
             | keep emp_no, languages, gender, last_name, first_name


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/124838
Fix https://github.com/elastic/elasticsearch/issues/124839