### PR TITLE
Include stack trace in Not Entitled warning

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -555,11 +555,7 @@ public class PolicyManager {
             var moduleName = callerClass.getModule().getName();
             var loggerSuffix = "." + componentName + "." + ((moduleName == null) ? ALL_UNNAMED : moduleName);
             var notEntitledLogger = LogManager.getLogger(PolicyManager.class.getName() + loggerSuffix);
-            String frameInfoSuffix = StackWalker.getInstance(RETAIN_CLASS_REFERENCE)
-                .walk(this::findRequestingFrame)
-                .map(frame -> "\n\tat " + frame)
-                .orElse("");
-            notEntitledLogger.warn("Not entitled: " + message + frameInfoSuffix);
+            notEntitledLogger.warn("Not entitled: " + message, exception);
         }
         throw exception;
     }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -555,7 +555,7 @@ public class PolicyManager {
             var moduleName = callerClass.getModule().getName();
             var loggerSuffix = "." + componentName + "." + ((moduleName == null) ? ALL_UNNAMED : moduleName);
             var notEntitledLogger = LogManager.getLogger(PolicyManager.class.getName() + loggerSuffix);
-            notEntitledLogger.warn("Not entitled: " + message, exception);
+            notEntitledLogger.warn("Not entitled:", exception);
         }
         throw exception;
     }


### PR DESCRIPTION
We can't always trust all environments to capture the stack trace for these, and we sometimes want them. Let's take matters into our own hands.