### PR TITLE
Add some logging to `CrossClusterIT#testCancel()`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -158,9 +158,6 @@ tests:
 - class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
   method: testCleanShardFollowTaskAfterDeleteFollower
   issue: https://github.com/elastic/elasticsearch/issues/120339
-- class: org.elasticsearch.search.ccs.CrossClusterIT
-  method: testCancel
-  issue: https://github.com/elastic/elasticsearch/issues/108061
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testInvalidJSON
   issue: https://github.com/elastic/elasticsearch/issues/120482

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterIT.java
@@ -312,7 +312,7 @@ public class CrossClusterIT extends AbstractMultiClustersTestCase {
         }
 
         SearchListenerPlugin.allowQueryPhase();
-        logger.info("Query phase resumed");
+        logger.info("Query phase resumed: " + queryFuture.state());
         try {
             queryFuture.get();
             fail("query should have failed");


### PR DESCRIPTION
I could neither reproduce this issue in my dev environment nor in a Linux VM with the recommended stress tool. Let's see if some logging could be of help.

Edit: This PR did help. Fixed the test here: https://github.com/elastic/elasticsearch/pull/125206.