### PR TITLE
Add cache support in `TransportGetAllocationStatsAction`

### DIFF
--- a/docs/changelog/124898.yaml
+++ b/docs/changelog/124898.yaml
@@ -1,0 +1,6 @@
+pr: 124898
+summary: Add cache support in `TransportGetAllocationStatsAction`
+area: Allocation
+type: enhancement
+issues:
+ - 110716

--- a/docs/reference/elasticsearch/configuration-reference/cluster-level-shard-allocation-routing-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/cluster-level-shard-allocation-routing-settings.md
@@ -19,6 +19,7 @@ There are a number of settings available to control the shard allocation process
 * [Disk-based shard allocation settings](#disk-based-shard-allocation) explains how Elasticsearch takes available disk space into account, and the related settings.
 * [Shard allocation awareness](docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/shard-allocation-awareness.md) and [Forced awareness](docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/shard-allocation-awareness.md#forced-awareness) control how shards can be distributed across different racks or availability zones.
 * [Cluster-level shard allocation filtering](#cluster-shard-allocation-filtering) allows certain nodes or groups of nodes excluded from allocation so that they can be decommissioned.
+* [Cluster-level node allocation stats cache settings](#node-allocation-stats-cache) control the node allocation statistics cache on the master node.
 
 Besides these, there are a few other [miscellaneous cluster-level settings](/reference/elasticsearch/configuration-reference/miscellaneous-cluster-settings.md).
 
@@ -233,7 +234,7 @@ You can use [custom node attributes](/reference/elasticsearch/configuration-refe
 :   ([Dynamic](docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md#dynamic-cluster-setting)) The shard allocation awareness values that must exist for shards to be reallocated in case of location failure. Learn more about [forced awareness](docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/shard-allocation-awareness.md#forced-awareness).
 
 
-## Cluster-level shard allocation filterin [cluster-shard-allocation-filtering]
+## Cluster-level shard allocation filtering [cluster-shard-allocation-filtering]
 
 You can use cluster-level shard allocation filters to control where {{es}} allocates shards from any index. These cluster wide filters are applied in conjunction with [per-index allocation filtering](/reference/elasticsearch/index-settings/shard-allocation.md) and [allocation awareness](docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/shard-allocation-awareness.md).
 
@@ -303,4 +304,7 @@ PUT _cluster/settings
 ```
 
 
+## Node Allocation Stats Cache [node-allocation-stats-cache]
 
+`cluster.routing.allocation.stats.cache.ttl`
+:   ([Dynamic](docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md#dynamic-cluster-setting)) Calculating the node allocation stats for a [Get node statistics API call](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-stats) can become expensive on the master for clusters with a high number of nodes. To prevent overloading the master the node allocation stats are cached on the master for 1 minute `1m` by default.  This setting can be used to adjust the cache time to live value, if necessary, keeping in mind the tradeoff between the freshness of the statistics and the processing costs on the master.  The cache can be disabled (not recommended) by setting the value to `0s` (the minimum value). The maximum value is 10 minutes `10m`.

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
@@ -224,29 +224,22 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
 
         void setTTL(TimeValue ttl) {
             ttlMillis = ttl.millis();
-
             if (ttlMillis == 0L) {
                 cachedStats.set(null);
             }
         }
 
         Map<String, NodeAllocationStats> get() {
-
             if (ttlMillis == 0L) {
                 return null;
             }
 
+            // We don't set the atomic ref to null here upon expiration since we know it is about to be replaced with a fresh instance.
             final var stats = cachedStats.get();
-
-            if (stats == null || threadPool.relativeTimeInMillis() - stats.timestampMillis > ttlMillis) {
-                return null;
-            }
-
-            return stats.stats;
+            return stats == null || threadPool.relativeTimeInMillis() - stats.timestampMillis > ttlMillis ? null : stats.stats;
         }
 
         void put(Map<String, NodeAllocationStats> stats) {
-
             if (ttlMillis > 0L) {
                 cachedStats.set(new CachedAllocationStats(stats, threadPool.relativeTimeInMillis()));
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
@@ -208,7 +208,7 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
         }
     }
 
-    private record CachedAllocationStats(Map<String, NodeAllocationStats> stats, long timestampMsecs) {}
+    private record CachedAllocationStats(Map<String, NodeAllocationStats> stats, long timestampMillis) {}
 
     private static class AllocationStatsCache {
         private final long maxAgeMillis;
@@ -229,7 +229,7 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
 
             final var stats = cachedStats.get();
 
-            if (stats == null || threadPool.relativeTimeInMillis() - stats.timestampMsecs > maxAgeMillis) {
+            if (stats == null || threadPool.relativeTimeInMillis() - stats.timestampMillis > maxAgeMillis) {
                 return null;
             }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.common.settings;
 
 import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.action.admin.cluster.allocation.TransportGetAllocationStatsAction;
 import org.elasticsearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
 import org.elasticsearch.action.admin.indices.close.TransportCloseIndexAction;
 import org.elasticsearch.action.bulk.IncrementalBulkService;
@@ -633,6 +634,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         DataStreamGlobalRetentionSettings.DATA_STREAMS_MAX_RETENTION_SETTING,
         ShardsAvailabilityHealthIndicatorService.REPLICA_UNASSIGNED_BUFFER_TIME,
         DataStream.isFailureStoreFeatureFlagEnabled() ? DataStreamFailureStoreSettings.DATA_STREAM_FAILURE_STORED_ENABLED_SETTING : null,
-        IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_SETTING
+        IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_SETTING,
+        TransportGetAllocationStatsAction.CACHE_MAX_AGE_SETTING
     ).filter(Objects::nonNull).collect(toSet());
 }

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -635,6 +635,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
         ShardsAvailabilityHealthIndicatorService.REPLICA_UNASSIGNED_BUFFER_TIME,
         DataStream.isFailureStoreFeatureFlagEnabled() ? DataStreamFailureStoreSettings.DATA_STREAM_FAILURE_STORED_ENABLED_SETTING : null,
         IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_SETTING,
-        TransportGetAllocationStatsAction.CACHE_MAX_AGE_SETTING
+        TransportGetAllocationStatsAction.CACHE_TTL_SETTING
     ).filter(Objects::nonNull).collect(toSet());
 }


### PR DESCRIPTION
Adds a new dynamic setting
`TransportGetAllocationStatsAction.CACHE_TTL_SETTING` `"cluster.routing.allocation.stats.cache.ttl"` to configure the time to live for cached `NodeAllocationStats` on the master.  The default value is currently 1 minute per the suggestion in issue #110716.

Closes #110716