### PR TITLE
Ensure we always use vectorization in Lucene

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
@@ -66,6 +66,8 @@ final class SystemJvmOptions {
                 "-Dlog4j2.disable.jmx=true",
                 "-Dlog4j2.formatMsgNoLookups=true",
                 "-Djava.locale.providers=CLDR",
+                // Enable vectorization for whatever version we are running. This ensures we use vectorization even when running EA builds.
+                "-Dorg.apache.lucene.vectorization.upperJavaFeatureVersion=" + Runtime.version().feature(),
                 // Pass through distribution type
                 "-Des.distribution.type=" + distroType
             ),


### PR DESCRIPTION
By default Lucene only uses vectorization up to the JDK version available at the time of its release. When testing against EA versions, we want to still use vectorization. This commit adds a sysprop to force lucene to use the current version for vectorization.