### PR TITLE
Fix system data stream snapshot bug

### DIFF
--- a/docs/changelog/124931.yaml
+++ b/docs/changelog/124931.yaml
@@ -1,0 +1,5 @@
+pr: 124931
+summary: Fix system data stream snapshot bug
+area: "Snapshot/Restore, Infra/Core"
+type: bug
+issues: []

--- a/docs/changelog/124931.yaml
+++ b/docs/changelog/124931.yaml
@@ -1,5 +1,5 @@
 pr: 124931
-summary: Fix system data stream snapshot bug
-area: "Snapshot/Restore, Infra/Core"
+summary: This PR fixes a bug whereby partial snapshots of system datastreams could be used to restore system features.
+area: "Snapshot/Restore"
 type: bug
 issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemResourceSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemResourceSnapshotIT.java
@@ -898,7 +898,6 @@ public class SystemResourceSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertThat(snapshottedIndices, allOf(hasItem(regularIndex), not(hasItem(SystemIndexTestPlugin.SYSTEM_INDEX_NAME))));
     }
 
-    // TODO, Do we need to test this for Datastreams?
     /**
      * Ensures that if we can only capture a partial snapshot of a system index, then the feature state associated with that index is
      * not included in the snapshot, because it would not be safe to restore that feature state.
@@ -1202,7 +1201,7 @@ public class SystemResourceSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         @Override
         public String getFeatureName() {
-            return SystemDataStreamTestPlugin.class.getSimpleName();
+            return SystemDataStreamManyShardsTestPlugin.class.getSimpleName();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -4127,7 +4127,15 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
 
                 if (featureSystemIndices.size() > 0 || featureAssociatedIndices.size() > 0 || featureDataStreamBackingIndices.size() > 0) {
 
-                    featureStates.add(new SnapshotFeatureInfo(featureName, List.copyOf(featureSystemIndices)));
+                    featureStates.add(
+                        new SnapshotFeatureInfo(
+                            featureName,
+                            List.copyOf(
+                                Stream.concat(featureSystemIndices.stream(), featureDataStreamBackingIndices.stream())
+                                    .collect(Collectors.toSet())
+                            )
+                        )
+                    );
                     indexNames.addAll(featureSystemIndices);
                     indexNames.addAll(featureAssociatedIndices);
                     indexNames.addAll(featureDataStreamBackingIndices);


### PR DESCRIPTION
This PR fixes a bug in the snapshot service that was allowing partial snapshots to restore features that use system data streams.