### PR TITLE
[8.x] Add more logging around testStopQueryLocal to see what's going on (#124911)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -426,9 +426,6 @@ tests:
 - class: org.elasticsearch.ingest.geoip.GeoIpDownloaderCliIT
   method: testGeoIpDatabasesDownloadNoGeoipProcessors
   issue: https://github.com/elastic/elasticsearch/issues/122683
-- class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
-  method: testStopQueryLocal
-  issue: https://github.com/elastic/elasticsearch/issues/121672
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
   issue: https://github.com/elastic/elasticsearch/issues/122755

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
@@ -302,7 +302,16 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
 
     @Override
     public String toString() {
-        return "EsqlExecutionInfo{" + "overallTook=" + overallTook + ", clusterInfo=" + clusterInfo + '}';
+        return "EsqlExecutionInfo{"
+            + "overallTook="
+            + overallTook
+            + ", isPartial="
+            + isPartial
+            + ", isStopped="
+            + isStopped
+            + ", clusterInfo="
+            + clusterInfo
+            + '}';
     }
 
     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add more logging around testStopQueryLocal to see what&#x27;s going on (#124911)](https://github.com/elastic/elasticsearch/pull/124911)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)