### PR TITLE
Ignore WET timezone in date utils tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -221,7 +221,8 @@ public abstract class ESTestCase extends LuceneTestCase {
                 "Europe/Kyiv", // part of tzdata2022c,
                 "Pacific/Kanton", // part of tzdata2021b
                 "Pacific/Niue",
-                "Antarctica/Vostok"
+                "Antarctica/Vostok",
+                "WET" // Western European timezone does not account for DST
             )
         )
     );


### PR DESCRIPTION
This timezone doesn't account for daylight savings time.

closes #124612