### PR TITLE
Cleanup command line setting errors

### DIFF
--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
@@ -185,7 +185,7 @@ public class ServerCliTests extends CommandTestCase {
     }
 
     public void testElasticsearchSettingCanNotBeDuplicated() throws Exception {
-        assertUsage(containsString("setting [foo] already set, saw [bar] and [baz]"), "-E", "foo=bar", "-E", "foo=baz");
+        assertUsage(containsString("setting [foo] set twice via command line -E"), "-E", "foo=bar", "-E", "foo=baz");
     }
 
     public void testUnknownOption() throws Exception {

--- a/server/src/main/java/org/elasticsearch/common/cli/EnvironmentAwareCommand.java
+++ b/server/src/main/java/org/elasticsearch/common/cli/EnvironmentAwareCommand.java
@@ -84,11 +84,7 @@ public abstract class EnvironmentAwareCommand extends Command {
                 throw new UserException(ExitCodes.USAGE, "setting [" + kvp.key + "] must not be empty");
             }
             if (settings.containsKey(kvp.key)) {
-                final String message = String.format(
-                    Locale.ROOT,
-                    "setting [%s] set twice via command line -E",
-                    kvp.key
-                );
+                final String message = String.format(Locale.ROOT, "setting [%s] set twice via command line -E", kvp.key);
                 throw new UserException(ExitCodes.USAGE, message);
             }
             settings.put(kvp.key, kvp.value);

--- a/server/src/main/java/org/elasticsearch/common/cli/EnvironmentAwareCommand.java
+++ b/server/src/main/java/org/elasticsearch/common/cli/EnvironmentAwareCommand.java
@@ -86,10 +86,8 @@ public abstract class EnvironmentAwareCommand extends Command {
             if (settings.containsKey(kvp.key)) {
                 final String message = String.format(
                     Locale.ROOT,
-                    "setting [%s] already set, saw [%s] and [%s]",
-                    kvp.key,
-                    settings.get(kvp.key),
-                    kvp.value
+                    "setting [%s] set twice via command line -E",
+                    kvp.key
                 );
                 throw new UserException(ExitCodes.USAGE, message);
             }
@@ -133,18 +131,17 @@ public abstract class EnvironmentAwareCommand extends Command {
         final Map<String, String> settings,
         final String setting,
         final String key
-    ) {
+    ) throws UserException {
         final String value = sysprops.get(key);
         if (value != null) {
             if (settings.containsKey(setting)) {
                 final String message = String.format(
                     Locale.ROOT,
-                    "duplicate setting [%s] found via command-line [%s] and system property [%s]",
+                    "setting [%s] found via command-line -E and system property [%s]",
                     setting,
-                    settings.get(setting),
-                    value
+                    key
                 );
-                throw new IllegalArgumentException(message);
+                throw new UserException(ExitCodes.USAGE, message);
             } else {
                 settings.put(setting, value);
             }


### PR DESCRIPTION
This commit improves the error cases when command line settings are found that are duplicates or conflict with special system properties.