### PR TITLE
Flush when writing to Netty transport channels

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
@@ -138,9 +138,6 @@ public class Netty4TcpChannel implements TcpChannel {
 
     @Override
     public void sendMessage(BytesReference reference, ActionListener<Void> listener) {
-        // Use ImmediateEventExecutor.INSTANCE since we want to be able to complete this promise, and any waiting listeners, even if the
-        // channel's event loop has shut down. Normally this completion will happen on the channel's event loop anyway because the write op
-        // can only be completed by some network event from this point on. However...
         final Channel channel = this.channel;
         final var promise = Netty4Utils.asChannelPromise(listener, channel);
         var eventLoop = channel.eventLoop();

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
@@ -13,8 +13,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.DefaultChannelPromise;
-import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.internal.PlatformDependent;
 
 import org.elasticsearch.action.ActionListener;
@@ -144,9 +142,7 @@ public class Netty4TcpChannel implements TcpChannel {
         // channel's event loop has shut down. Normally this completion will happen on the channel's event loop anyway because the write op
         // can only be completed by some network event from this point on. However...
         final Channel channel = this.channel;
-        final var promise = new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
-        addListener(promise, listener);
-        assert Netty4Utils.assertCorrectPromiseListenerThreading(promise);
+        final var promise = Netty4Utils.asChannelPromise(listener, channel);
         var eventLoop = channel.eventLoop();
         if (eventLoop.inEventLoop()) {
             // from the eventloop we minimize allocations and latency by forwarding the current queue and the new message and triggering

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
@@ -143,11 +143,11 @@ public class Netty4TcpChannel implements TcpChannel {
         var eventLoop = channel.eventLoop();
         if (eventLoop.inEventLoop()) {
             // from the eventloop we minimize allocations and latency by forwarding the current queue and the new message and triggering
-            // one flush after wards
+            // the flush task after
             flushQueue();
             channel.writeAndFlush(reference, promise);
         } else {
-            // We are not on the channel's transport thread, queue the write and trigger a flush task
+            // We are not on the channel's eventloop thread, queue the write and submit the flush task
             if (sendQueue.offer(new Tuple<>(reference, promise)) == false) {
                 channel.writeAndFlush(reference, promise);
             } else {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -17,6 +17,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.EventLoop;
 import io.netty.util.NettyRuntime;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -201,15 +202,15 @@ public class Netty4Utils {
         addListener(promise, listener);
         assert assertCorrectPromiseListenerThreading(promise);
         channel.writeAndFlush(message, promise);
-        handleTerminatedEventLoop(channel, promise);
+        handleTerminatedEventLoop(channel.eventLoop(), promise);
     }
 
-    static void handleTerminatedEventLoop(Channel channel, DefaultChannelPromise promise) {
-        if (channel.eventLoop().isShuttingDown()) {
-            // ... if we get here thesn the event loop may already have terminated, and https://github.com/netty/netty/issues/8007 means
-            // that we cannot know if the preceding writeAndFlush made it onto its queue before shutdown or whether it will just vanish
-            // without a trace, so to avoid a leak we must double-check that the final listener is completed.
-            channel.eventLoop().terminationFuture().addListener(ignored ->
+    static void handleTerminatedEventLoop(EventLoop eventLoop, DefaultChannelPromise promise) {
+        if (eventLoop.isShuttingDown()) {
+            // ... if we get here then the event loop may already have terminated, and https://github.com/netty/netty/issues/8007 means that
+            // we cannot know if the preceding writeAndFlush made it onto its queue before shutdown or whether it will just vanish without a
+            // trace, so to avoid a leak we must double-check that the final listener is completed.
+            eventLoop.terminationFuture().addListener(ignored ->
             // NB the promise executor is ImmediateEventExecutor.INSTANCE which means this call to tryFailure() will ensure its completion,
             // and the completion of any waiting listeners, without forking away from the current thread. The current thread might be the
             // thread that was running the event loop since that's where the terminationFuture is completed, or it might be a thread which


### PR DESCRIPTION
I think it's worthwhile trying to coalesce writes off of the event loop thread already. ES is sending a lot of tiny messages in some situations and always flushes directly after each of them. This should help a bit with the very low IPC we see for transport threads by making the write loop a bit tighter and just having fewer calls all the way through to the actual channel.

This is the cache misses on this code path to illustrate the problem.

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/e1bf9baa-1449-4fa0-ae0e-552428574d3a" />


Plus, fewer packets/frames should make the Network behave a little smoother in general.