### PR TITLE
[8.x] Include failures in partial response (#124929)

### DIFF
--- a/docs/changelog/124929.yaml
+++ b/docs/changelog/124929.yaml
@@ -1,0 +1,5 @@
+pr: 124929
+summary: Include failures in partial response
+area: ES|QL
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -195,6 +195,7 @@ public class TransportVersions {
     public static final TransportVersion INFERENCE_CONTEXT_8_X = def(8_841_0_08);
     public static final TransportVersion ML_INFERENCE_DEEPSEEK_8_19 = def(8_841_0_09);
     public static final TransportVersion ESQL_SERIALIZE_BLOCK_TYPE_CODE = def(8_841_0_10);
+    public static final TransportVersion ESQL_FAILURE_FROM_REMOTE = def(8_841_0_11);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/test/external-modules/error-query/src/javaRestTest/java/org/elasticsearch/test/esql/EsqlPartialResultsIT.java
+++ b/test/external-modules/error-query/src/javaRestTest/java/org/elasticsearch/test/esql/EsqlPartialResultsIT.java
@@ -14,18 +14,22 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.ClassRule;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class EsqlPartialResultsIT extends ESRestTestCase {
@@ -97,6 +101,7 @@ public class EsqlPartialResultsIT extends ESRestTestCase {
         return okIds;
     }
 
+    @SuppressWarnings("unchecked")
     public void testPartialResult() throws Exception {
         Set<String> okIds = populateIndices();
         String query = """
@@ -113,11 +118,30 @@ public class EsqlPartialResultsIT extends ESRestTestCase {
             }
             Response resp = client().performRequest(request);
             Map<String, Object> results = entityAsMap(resp);
+            logger.info("--> results {}", results);
             assertThat(results.get("is_partial"), equalTo(true));
             List<?> columns = (List<?>) results.get("columns");
             assertThat(columns, equalTo(List.of(Map.of("name", "fail_me", "type", "long"), Map.of("name", "v", "type", "long"))));
             List<?> values = (List<?>) results.get("values");
             assertThat(values.size(), lessThanOrEqualTo(okIds.size()));
+            Map<String, Object> localInfo = (Map<String, Object>) XContentMapValues.extractValue(
+                results,
+                "_clusters",
+                "details",
+                "(local)"
+            );
+            assertNotNull(localInfo);
+            assertThat(XContentMapValues.extractValue(localInfo, "_shards", "successful"), equalTo(0));
+            assertThat(
+                XContentMapValues.extractValue(localInfo, "_shards", "failed"),
+                equalTo(XContentMapValues.extractValue(localInfo, "_shards", "total"))
+            );
+            List<Map<String, Object>> failures = (List<Map<String, Object>>) XContentMapValues.extractValue(localInfo, "failures");
+            assertThat(failures, hasSize(1));
+            assertThat(
+                failures.get(0).get("reason"),
+                equalTo(Map.of("type", "illegal_state_exception", "reason", "Accessing failing field"))
+            );
         }
         // allow_partial_results = false
         {
@@ -133,5 +157,81 @@ public class EsqlPartialResultsIT extends ESRestTestCase {
             assertThat(resp.getStatusLine().getStatusCode(), equalTo(500));
             assertThat(EntityUtils.toString(resp.getEntity()), containsString("Accessing failing field"));
         }
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testFailureFromRemote() throws Exception {
+        setupRemoteClusters();
+        try {
+            Set<String> okIds = populateIndices();
+            String query = """
+                {
+                  "query": "FROM *:ok-index,*:failing-index | LIMIT 100 | KEEP fail_me,v"
+                }
+                """;
+            // allow_partial_results = true
+            Request request = new Request("POST", "/_query");
+            request.setJsonEntity(query);
+            if (randomBoolean()) {
+                request.addParameter("allow_partial_results", "true");
+            }
+            Response resp = client().performRequest(request);
+            Map<String, Object> results = entityAsMap(resp);
+            logger.info("--> results {}", results);
+            assertThat(results.get("is_partial"), equalTo(true));
+            List<?> columns = (List<?>) results.get("columns");
+            assertThat(columns, equalTo(List.of(Map.of("name", "fail_me", "type", "long"), Map.of("name", "v", "type", "long"))));
+            List<?> values = (List<?>) results.get("values");
+            assertThat(values.size(), lessThanOrEqualTo(okIds.size()));
+            Map<String, Object> remoteCluster = (Map<String, Object>) XContentMapValues.extractValue(
+                results,
+                "_clusters",
+                "details",
+                "cluster_one"
+            );
+            assertNotNull(remoteCluster);
+            assertThat(XContentMapValues.extractValue(remoteCluster, "_shards", "successful"), equalTo(0));
+            assertThat(
+                XContentMapValues.extractValue(remoteCluster, "_shards", "failed"),
+                equalTo(XContentMapValues.extractValue(remoteCluster, "_shards", "total"))
+            );
+            List<Map<String, Object>> failures = (List<Map<String, Object>>) XContentMapValues.extractValue(remoteCluster, "failures");
+            assertThat(failures, hasSize(1));
+            assertThat(
+                failures.get(0).get("reason"),
+                equalTo(Map.of("type", "illegal_state_exception", "reason", "Accessing failing field"))
+            );
+        } finally {
+            removeRemoteCluster();
+        }
+    }
+
+    private void setupRemoteClusters() throws IOException {
+        String settings = String.format(Locale.ROOT, """
+            {
+                "persistent": {
+                    "cluster": {
+                        "remote": {
+                            "cluster_one": {
+                                "seeds": [ "%s" ],
+                                "skip_unavailable": false
+                            }
+                        }
+                    }
+                }
+            }
+            """, cluster.getTransportEndpoints());
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity(settings);
+        client().performRequest(request);
+    }
+
+    private void removeRemoteCluster() throws IOException {
+        Request settingsRequest = new Request("PUT", "/_cluster/settings");
+        settingsRequest.setJsonEntity("""
+            {"persistent": { "cluster.*": null}}
+            """);
+        client().performRequest(settingsRequest);
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlNodeFailureIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlNodeFailureIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.FailingFieldPlugin;
+import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
@@ -26,9 +27,12 @@ import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Make sure the failures on the data node come back as failures over the wire.
@@ -121,6 +125,10 @@ public class EsqlNodeFailureIT extends AbstractEsqlIntegTestCase {
                     assertThat(id, in(okIds));
                     assertTrue(actualIds.add(id));
                 }
+                EsqlExecutionInfo.Cluster localInfo = resp.getExecutionInfo().getCluster(RemoteClusterService.LOCAL_CLUSTER_GROUP_KEY);
+                assertThat(localInfo.getFailures(), not(empty()));
+                assertThat(localInfo.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.PARTIAL));
+                assertThat(localInfo.getFailures().get(0).reason(), containsString("Accessing failing field"));
             }
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
@@ -163,7 +163,8 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                 builder.setTook(executionInfo.tookSoFar());
             }
             if (v.getStatus() == EsqlExecutionInfo.Cluster.Status.RUNNING) {
-                if (executionInfo.isStopped() || resp.failedShards > 0) {
+                builder.setFailures(resp.failures);
+                if (executionInfo.isStopped() || resp.failedShards > 0 || resp.failures.isEmpty() == false) {
                     builder.setStatus(EsqlExecutionInfo.Cluster.Status.PARTIAL);
                 } else {
                     builder.setStatus(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL);
@@ -251,7 +252,7 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
         try (var computeListener = new ComputeListener(transportService.getThreadPool(), cancelQueryOnFailure, listener.map(profiles -> {
             final TimeValue took = TimeValue.timeValueNanos(System.nanoTime() - startTimeInNanos);
             final ComputeResponse r = finalResponse.get();
-            return new ComputeResponse(profiles, took, r.totalShards, r.successfulShards, r.skippedShards, r.failedShards);
+            return new ComputeResponse(profiles, took, r.totalShards, r.successfulShards, r.skippedShards, r.failedShards, r.failures);
         }))) {
             var exchangeSource = new ExchangeSourceHandler(
                 configuration.pragmas().exchangeBufferSize(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeResponse.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.plugin;
 
 import org.elasticsearch.TransportVersions;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.operator.DriverProfile;
@@ -29,9 +30,10 @@ final class ComputeResponse extends TransportResponse {
     public final int successfulShards;
     public final int skippedShards;
     public final int failedShards;
+    public final List<ShardSearchFailure> failures;
 
     ComputeResponse(List<DriverProfile> profiles) {
-        this(profiles, null, null, null, null, null);
+        this(profiles, null, null, null, null, null, List.of());
     }
 
     ComputeResponse(
@@ -40,7 +42,8 @@ final class ComputeResponse extends TransportResponse {
         Integer totalShards,
         Integer successfulShards,
         Integer skippedShards,
-        Integer failedShards
+        Integer failedShards,
+        List<ShardSearchFailure> failures
     ) {
         this.profiles = profiles;
         this.took = took;
@@ -48,6 +51,7 @@ final class ComputeResponse extends TransportResponse {
         this.successfulShards = successfulShards == null ? 0 : successfulShards.intValue();
         this.skippedShards = skippedShards == null ? 0 : skippedShards.intValue();
         this.failedShards = failedShards == null ? 0 : failedShards.intValue();
+        this.failures = failures;
     }
 
     ComputeResponse(StreamInput in) throws IOException {
@@ -74,6 +78,11 @@ final class ComputeResponse extends TransportResponse {
             this.skippedShards = 0;
             this.failedShards = 0;
         }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_FAILURE_FROM_REMOTE)) {
+            this.failures = in.readCollectionAsImmutableList(ShardSearchFailure::readShardSearchFailure);
+        } else {
+            this.failures = List.of();
+        }
     }
 
     @Override
@@ -92,6 +101,9 @@ final class ComputeResponse extends TransportResponse {
             out.writeVInt(successfulShards);
             out.writeVInt(skippedShards);
             out.writeVInt(failedShards);
+        }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_FAILURE_FROM_REMOTE)) {
+            out.writeCollection(failures, (o, v) -> v.writeTo(o));
         }
     }
 
@@ -117,5 +129,9 @@ final class ComputeResponse extends TransportResponse {
 
     public int getFailedShards() {
         return failedShards;
+    }
+
+    public List<ShardSearchFailure> getFailures() {
+        return failures;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -266,6 +266,7 @@ public class ComputeService {
                                         .setSuccessfulShards(r.getSuccessfulShards())
                                         .setSkippedShards(r.getSkippedShards())
                                         .setFailedShards(r.getFailedShards())
+                                        .setFailures(r.failures)
                                         .build()
                                 );
                                 dataNodesListener.onResponse(r.getProfiles());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -99,7 +99,13 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         ActionListener<ComputeResponse> outListener
     ) {
         final boolean allowPartialResults = configuration.allowPartialResults();
-        DataNodeRequestSender sender = new DataNodeRequestSender(transportService, esqlExecutor, parentTask, allowPartialResults) {
+        DataNodeRequestSender sender = new DataNodeRequestSender(
+            transportService,
+            esqlExecutor,
+            clusterAlias,
+            parentTask,
+            allowPartialResults
+        ) {
             @Override
             protected void sendRequest(
                 DiscoveryNode node,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSenderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSenderTests.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.esql.plugin.DataNodeRequestSender.NodeRequest;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
@@ -137,6 +138,10 @@ public class DataNodeRequestSenderTests extends ComputeTestCase {
             assertThat(resp.totalShards, equalTo(3));
             assertThat(resp.failedShards, equalTo(1));
             assertThat(resp.successfulShards, equalTo(2));
+            assertThat(resp.failures, not(empty()));
+            assertNotNull(resp.failures.get(0).shard());
+            assertThat(resp.failures.get(0).shard().getShardId(), equalTo(shard3));
+            assertThat(resp.failures.get(0).reason(), containsString("no shard copies found"));
         }
     }
 
@@ -321,7 +326,7 @@ public class DataNodeRequestSenderTests extends ComputeTestCase {
             TaskId.EMPTY_TASK_ID,
             Collections.emptyMap()
         );
-        DataNodeRequestSender requestSender = new DataNodeRequestSender(transportService, executor, task, allowPartialResults) {
+        DataNodeRequestSender requestSender = new DataNodeRequestSender(transportService, executor, "", task, allowPartialResults) {
             @Override
             void searchShards(
                 Task parentTask,


### PR DESCRIPTION
This will backport the following commits from `main` to `8.x`:
 - [Include failures in partial response (#124929)](https://github.com/elastic/elasticsearch/pull/124929)
