### PR TITLE
[8.x] Merge template mappings properly during validation (#124784)

### DIFF
--- a/docs/changelog/124784.yaml
+++ b/docs/changelog/124784.yaml
@@ -1,0 +1,6 @@
+pr: 124784
+summary: Merge template mappings properly during validation
+area: Mapping
+type: bug
+issues:
+ - 123372

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1858,7 +1858,7 @@ public class MetadataIndexTemplateService {
             createdIndex = dummyIndexService.index();
 
             if (mappings != null) {
-                dummyIndexService.mapperService().merge(MapperService.SINGLE_MAPPING_NAME, mappings, MergeReason.MAPPING_UPDATE);
+                dummyIndexService.mapperService().merge(MapperService.SINGLE_MAPPING_NAME, mappings, MergeReason.INDEX_TEMPLATE);
             }
 
         } finally {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -2593,6 +2593,59 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         );
     }
 
+    public void testComposableTemplateWithSubobjectsFalseObjectAndSubfield() throws Exception {
+        MetadataIndexTemplateService service = getMetadataIndexTemplateService();
+        ProjectMetadata project = ProjectMetadata.builder(randomProjectIdOrDefault()).build();
+
+        ComponentTemplate subobjects = new ComponentTemplate(new Template(null, new CompressedXContent("""
+            {
+              "properties": {
+                "foo": {
+                   "type": "object",
+                   "subobjects": false
+                 },
+                 "foo.bar": {
+                   "type": "keyword"
+                 }
+              }
+            }
+            """), null), null, null);
+
+        project = service.addComponentTemplate(project, true, "subobjects", subobjects);
+        ComposableIndexTemplate it = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of("test-*"))
+            .template(new Template(null, null, null))
+            .componentTemplates(List.of("subobjects", "field_mapping"))
+            .priority(0L)
+            .version(1L)
+            .build();
+        project = service.addIndexTemplateV2(project, true, "composable-template", it);
+
+        List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(project, "composable-template", "test-index");
+
+        assertNotNull(mappings);
+        assertThat(mappings.size(), equalTo(1));
+        List<Map<String, Object>> parsedMappings = mappings.stream().map(m -> {
+            try {
+                return MapperService.parseMapping(NamedXContentRegistry.EMPTY, m);
+            } catch (Exception e) {
+                logger.error(e);
+                fail("failed to parse mappings: " + m.string());
+                return null;
+            }
+        }).toList();
+
+        assertThat(
+            parsedMappings.get(0),
+            equalTo(
+                Map.of(
+                    "_doc",
+                    Map.of("properties", Map.of("foo.bar", Map.of("type", "keyword"), "foo", Map.of("type", "object", "subobjects", false)))
+                )
+            )
+        );
+    }
+
     public void testAddIndexTemplateWithDeprecatedComponentTemplate() throws Exception {
         ClusterState state = ClusterState.EMPTY_STATE;
         final MetadataIndexTemplateService service = getMetadataIndexTemplateService();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -2595,7 +2595,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
 
     public void testComposableTemplateWithSubobjectsFalseObjectAndSubfield() throws Exception {
         MetadataIndexTemplateService service = getMetadataIndexTemplateService();
-        ProjectMetadata project = ProjectMetadata.builder(randomProjectIdOrDefault()).build();
+        ClusterState state = ClusterState.EMPTY_STATE;
 
         ComponentTemplate subobjects = new ComponentTemplate(new Template(null, new CompressedXContent("""
             {
@@ -2611,7 +2611,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             }
             """), null), null, null);
 
-        project = service.addComponentTemplate(project, true, "subobjects", subobjects);
+        state = service.addComponentTemplate(state, true, "subobjects", subobjects);
         ComposableIndexTemplate it = ComposableIndexTemplate.builder()
             .indexPatterns(List.of("test-*"))
             .template(new Template(null, null, null))
@@ -2619,9 +2619,9 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             .priority(0L)
             .version(1L)
             .build();
-        project = service.addIndexTemplateV2(project, true, "composable-template", it);
+        state = service.addIndexTemplateV2(state, true, "composable-template", it);
 
-        List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(project, "composable-template", "test-index");
+        List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(state, "composable-template", "test-index");
 
         assertNotNull(mappings);
         assertThat(mappings.size(), equalTo(1));


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Merge template mappings properly during validation (#124784)