### PR TITLE
[8.18] Fix EQL double invoking listener (#124918)

### DIFF
--- a/docs/changelog/124918.yaml
+++ b/docs/changelog/124918.yaml
@@ -1,0 +1,5 @@
+pr: 124918
+summary: Fix EQL double invoking listener
+area: EQL
+type: bug
+issues: []

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -171,6 +171,7 @@ public class TumblingWindow implements Executable {
     private void tumbleWindow(int currentStage, ActionListener<Payload> listener) {
         if (allowPartialSequenceResults == false && shardFailures.isEmpty() == false) {
             doPayload(listener);
+            return;
         }
         if (currentStage > matcher.firstPositiveStage && matcher.hasCandidates() == false) {
             if (restartWindowFromTailQuery) {


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix EQL double invoking listener (#124918)