### PR TITLE
Enable and fix testFailOnUnavailableShards

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/CanMatchIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/CanMatchIT.java
@@ -18,7 +18,6 @@ import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
@@ -30,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
 import static org.hamcrest.Matchers.containsString;
@@ -48,7 +48,7 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
      * Make sure that we don't send data-node requests to the target shards which won't match the query
      */
     public void testCanMatch() {
-        ElasticsearchAssertions.assertAcked(
+        assertAcked(
             client().admin()
                 .indices()
                 .prepareCreate("events_2022")
@@ -60,9 +60,7 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
             .add(new IndexRequest().source("@timestamp", "2022-05-02", "uid", "u1"))
             .add(new IndexRequest().source("@timestamp", "2022-12-15", "uid", "u1"))
             .get();
-        ElasticsearchAssertions.assertAcked(
-            client().admin().indices().prepareCreate("events_2023").setMapping("@timestamp", "type=date", "uid", "type=keyword")
-        );
+        assertAcked(client().admin().indices().prepareCreate("events_2023").setMapping("@timestamp", "type=date", "uid", "type=keyword"));
         client().prepareBulk("events_2023")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .add(new IndexRequest().source("@timestamp", "2023-01-15", "uid", "u2"))
@@ -72,15 +70,17 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
             .get();
         try {
             Set<String> queriedIndices = ConcurrentCollections.newConcurrentSet();
-            for (TransportService ts : internalCluster().getInstances(TransportService.class)) {
-                MockTransportService transportService = (MockTransportService) ts;
-                transportService.addRequestHandlingBehavior(ComputeService.DATA_ACTION_NAME, (handler, request, channel, task) -> {
-                    DataNodeRequest dataNodeRequest = (DataNodeRequest) request;
-                    for (ShardId shardId : dataNodeRequest.shardIds()) {
-                        queriedIndices.add(shardId.getIndexName());
+            for (var transportService : internalCluster().getInstances(TransportService.class)) {
+                as(transportService, MockTransportService.class).addRequestHandlingBehavior(
+                    ComputeService.DATA_ACTION_NAME,
+                    (handler, request, channel, task) -> {
+                        DataNodeRequest dataNodeRequest = (DataNodeRequest) request;
+                        for (ShardId shardId : dataNodeRequest.shardIds()) {
+                            queriedIndices.add(shardId.getIndexName());
+                        }
+                        handler.messageReceived(request, channel, task);
                     }
-                    handler.messageReceived(request, channel, task);
-                });
+                );
             }
             try (EsqlQueryResponse resp = run("from events_*", randomPragmas(), new RangeQueryBuilder("@timestamp").gte("2023-01-01"))) {
                 assertThat(getValuesList(resp), hasSize(4));
@@ -118,14 +118,14 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 queriedIndices.clear();
             }
         } finally {
-            for (TransportService ts : internalCluster().getInstances(TransportService.class)) {
-                ((MockTransportService) ts).clearAllRules();
+            for (var transportService : internalCluster().getInstances(TransportService.class)) {
+                as(transportService, MockTransportService.class).clearAllRules();
             }
         }
     }
 
     public void testAliasFilters() {
-        ElasticsearchAssertions.assertAcked(
+        assertAcked(
             client().admin()
                 .indices()
                 .prepareCreate("employees")
@@ -141,7 +141,7 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
             .add(new IndexRequest().source("emp_no", 106, "dept", "sales", "hired", "2012-08-09", "salary", 30.1))
             .get();
 
-        ElasticsearchAssertions.assertAcked(
+        assertAcked(
             client().admin()
                 .indices()
                 .prepareAliases(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
@@ -209,11 +209,10 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103749")
     public void testFailOnUnavailableShards() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(2);
         String logsOnlyNode = internalCluster().startDataOnlyNode();
-        ElasticsearchAssertions.assertAcked(
+        assertAcked(
             client().admin()
                 .indices()
                 .prepareCreate("events")
@@ -230,7 +229,7 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
             .add(new IndexRequest().source("timestamp", 2, "message", "b"))
             .add(new IndexRequest().source("timestamp", 3, "message", "c"))
             .get();
-        ElasticsearchAssertions.assertAcked(
+        assertAcked(
             client().admin()
                 .indices()
                 .prepareCreate("logs")
@@ -246,13 +245,17 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
             .add(new IndexRequest().source("timestamp", 10, "message", "aa"))
             .add(new IndexRequest().source("timestamp", 11, "message", "bb"))
             .get();
+
+        // when all shards available
         try (EsqlQueryResponse resp = run("from events,logs | KEEP timestamp,message")) {
             assertThat(getValuesList(resp), hasSize(5));
-            internalCluster().stopNode(logsOnlyNode);
-            ensureClusterSizeConsistency();
-            Exception error = expectThrows(Exception.class, () -> run("from events,logs | KEEP timestamp,message"));
-            assertThat(error.getMessage(), containsString("no shard copies found"));
         }
+
+        internalCluster().stopNode(logsOnlyNode);
+        ensureClusterSizeConsistency();
+
+        // when one shard is unavailable
+        expectThrows(Exception.class, containsString("no shard copies found"), () -> run("from events,logs | KEEP timestamp,message"));
     }
 
     public void testSkipOnIndexName() {
@@ -261,9 +264,7 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
         Map<String, Integer> indexToNumDocs = new HashMap<>();
         for (int i = 0; i < numIndices; i++) {
             String index = "events-" + i;
-            ElasticsearchAssertions.assertAcked(
-                client().admin().indices().prepareCreate(index).setMapping("timestamp", "type=long", "message", "type=keyword")
-            );
+            assertAcked(client().admin().indices().prepareCreate(index).setMapping("timestamp", "type=long", "message", "type=keyword"));
             BulkRequestBuilder bulk = client().prepareBulk(index).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             int docs = between(1, 5);
             long timestamp = 1;
@@ -274,15 +275,17 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
             indexToNumDocs.put(index, docs);
         }
         Set<String> queriedIndices = ConcurrentCollections.newConcurrentSet();
-        for (TransportService ts : internalCluster().getInstances(TransportService.class)) {
-            MockTransportService mockTransportService = as(ts, MockTransportService.class);
-            mockTransportService.addRequestHandlingBehavior(ComputeService.DATA_ACTION_NAME, (handler, request, channel, task) -> {
-                DataNodeRequest dataNodeRequest = (DataNodeRequest) request;
-                for (ShardId shardId : dataNodeRequest.shardIds()) {
-                    queriedIndices.add(shardId.getIndexName());
+        for (var transportService : internalCluster().getInstances(TransportService.class)) {
+            as(transportService, MockTransportService.class).addRequestHandlingBehavior(
+                ComputeService.DATA_ACTION_NAME,
+                (handler, request, channel, task) -> {
+                    DataNodeRequest dataNodeRequest = (DataNodeRequest) request;
+                    for (ShardId shardId : dataNodeRequest.shardIds()) {
+                        queriedIndices.add(shardId.getIndexName());
+                    }
+                    handler.messageReceived(request, channel, task);
                 }
-                handler.messageReceived(request, channel, task);
-            });
+            );
         }
         try {
             for (int i = 0; i < numIndices; i++) {
@@ -294,9 +297,8 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 assertThat(queriedIndices, equalTo(Set.of(index)));
             }
         } finally {
-            for (TransportService ts : internalCluster().getInstances(TransportService.class)) {
-                MockTransportService mockTransportService = as(ts, MockTransportService.class);
-                mockTransportService.clearAllRules();
+            for (var transportService : internalCluster().getInstances(TransportService.class)) {
+                as(transportService, MockTransportService.class).clearAllRules();
             }
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
@@ -429,9 +429,6 @@ abstract class DataNodeRequestSender {
             Map<ShardId, TargetShard> shards = new HashMap<>();
             for (SearchShardsGroup group : resp.getGroups()) {
                 var shardId = group.shardId();
-                if (concreteIndices.contains(shardId.getIndexName()) == false) {
-                    continue;
-                }
                 totalShards++;
                 if (group.skipped()) {
                     skippedShards++;


### PR DESCRIPTION
This enables `testFailOnUnavailableShards`.

This was originally pointing to the issue that is closed.
After enabling it I noticed that we were silently searching only in available shards.

This change attempts to fix this test.