### PR TITLE
[8.x] Add missing OpenAI and Watsonx inference APIs (#124989)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_openai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_openai.json
@@ -1,0 +1,35 @@
+{
+  "inference.put_openai": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-openai.html",
+      "description": "Configure an OpenAI inference endpoint"
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_inference/{task_type}/{openai_inference_id}",
+          "methods": ["PUT"],
+          "parts": {
+            "task_type": {
+              "type": "string",
+              "description": "The task type"
+            },
+            "openai_inference_id": {
+              "type": "string",
+              "description": "The inference ID"
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "The inference endpoint's task and service settings"
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
@@ -1,0 +1,35 @@
+{
+  "inference.put_watsonx": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-watsonx-ai.html",
+      "description": "Configure a Watsonx inference endpoint"
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_inference/{task_type}/{watsonx_inference_id}",
+          "methods": ["PUT"],
+          "parts": {
+            "task_type": {
+              "type": "string",
+              "description": "The task type"
+            },
+            "watsonx_inference_id": {
+              "type": "string",
+              "description": "The inference Id"
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "The inference endpoint's task and service settings"
+    }
+  }
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add missing OpenAI and Watsonx inference APIs (#124989)