### PR TITLE
[8.18] Don't generate stacktrace in TaskCancelledException (#125002)

### DIFF
--- a/docs/changelog/125002.yaml
+++ b/docs/changelog/125002.yaml
@@ -1,0 +1,5 @@
+pr: 125002
+summary: Don't generate stacktrace in `TaskCancelledException`
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/tasks/TaskCancelledException.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskCancelledException.java
@@ -28,6 +28,11 @@ public class TaskCancelledException extends ElasticsearchException {
     }
 
     @Override
+    public Throwable fillInStackTrace() {
+        return this;  // this exception doesn't imply a bug, no need for a stack trace
+    }
+
+    @Override
     public RestStatus status() {
         // Tasks are typically cancelled at the request of the client, so a 4xx status code is more accurate than the default of 500 (and
         // means we don't log every cancellation at WARN level). There's no perfect match for cancellation in the available status codes,


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Don't generate stacktrace in TaskCancelledException (#125002)