### PR TITLE
[8.17] Don't generate stacktrace in TaskCancelledException (#125002)

### DIFF
--- a/docs/changelog/125002.yaml
+++ b/docs/changelog/125002.yaml
@@ -1,0 +1,5 @@
+pr: 125002
+summary: Don't generate stacktrace in `TaskCancelledException`
+area: Search
+type: bug
+issues: []

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/SearchCancellationIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/SearchCancellationIT.java
@@ -102,8 +102,8 @@ public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
             .addAggregation(
                 timeSeriesAggregationBuilder.subAggregation(
                     new ScriptedMetricAggregationBuilder("sub_agg").initScript(
-                            new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.INIT_SCRIPT_NAME, Collections.emptyMap())
-                        )
+                        new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.INIT_SCRIPT_NAME, Collections.emptyMap())
+                    )
                         .mapScript(
                             new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.MAP_BLOCK_SCRIPT_NAME, Collections.emptyMap())
                         )

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/SearchCancellationIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/SearchCancellationIT.java
@@ -42,6 +42,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
 
@@ -101,8 +102,8 @@ public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
             .addAggregation(
                 timeSeriesAggregationBuilder.subAggregation(
                     new ScriptedMetricAggregationBuilder("sub_agg").initScript(
-                        new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.INIT_SCRIPT_NAME, Collections.emptyMap())
-                    )
+                            new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.INIT_SCRIPT_NAME, Collections.emptyMap())
+                        )
                         .mapScript(
                             new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.MAP_BLOCK_SCRIPT_NAME, Collections.emptyMap())
                         )
@@ -124,7 +125,9 @@ public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
         logger.info("All shards failed with", ex);
         if (lowLevelCancellation) {
             // Ensure that we cancelled in TimeSeriesIndexSearcher and not in reduce phase
-            assertThat(ExceptionsHelper.stackTrace(ex), containsString("TimeSeriesIndexSearcher"));
+            assertThat(ExceptionsHelper.stackTrace(ex), not(containsString("not building sub-aggregations due to task cancellation")));
+        } else {
+            assertThat(ExceptionsHelper.stackTrace(ex), containsString("not building sub-aggregations due to task cancellation"));
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/tasks/TaskCancelledException.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskCancelledException.java
@@ -28,6 +28,11 @@ public class TaskCancelledException extends ElasticsearchException {
     }
 
     @Override
+    public Throwable fillInStackTrace() {
+        return this;  // this exception doesn't imply a bug, no need for a stack trace
+    }
+
+    @Override
     public RestStatus status() {
         // Tasks are typically cancelled at the request of the client, so a 4xx status code is more accurate than the default of 500 (and
         // means we don't log every cancellation at WARN level). There's no perfect match for cancellation in the available status codes,


### PR DESCRIPTION
Backports the following commits to 8.17:

- Don't generate stacktrace in TaskCancelledException (https://github.com/elastic/elasticsearch/pull/125002)