### PR TITLE
[8.17] Clarify 'inference_id' usage in ELSER semantic search guide (#124854)

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -187,7 +187,7 @@ GET my-index/_search
    "query":{
       "sparse_vector":{
          "field": "content_embedding",
-         "inference_id": "my-elser-endpoint",
+         "inference_id": "my-elser-endpoint", 
          "query": "How to avoid muscle soreness after running?"
       }
    }


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Clarify 'inference_id' usage in ELSER semantic search guide (#124854)