### PR TITLE
Add `manage_threads` entitlement for `reactor.core`

### DIFF
--- a/modules/repository-azure/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/repository-azure/src/main/plugin-metadata/entitlement-policy.yaml
@@ -14,3 +14,5 @@ com.azure.identity:
     - relative_path: "storage-azure/" #/config/storage-azure/azure-federated-token
       relative_to: config
       mode: read
+reactor.core:
+  - manage_threads


### PR DESCRIPTION
This adds the `manage_threads` entitlement for `reactor.core` as part of the azure-repository module. It looks like this is a requirement for offloading azure blob store work.