### PR TITLE
[8.x] Add manage_threads entitlement for reactor.core (#125037)

### DIFF
--- a/modules/repository-azure/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/repository-azure/src/main/plugin-metadata/entitlement-policy.yaml
@@ -14,3 +14,5 @@ com.azure.identity:
     - relative_path: "storage-azure/" #/config/storage-azure/azure-federated-token
       relative_to: config
       mode: read
+reactor.core:
+  - manage_threads


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add manage_threads entitlement for reactor.core (#125037)