### PR TITLE
Removing incorrect use of constant_keyword field type from deprecation logger mapping

### DIFF
--- a/docs/changelog/125048.yaml
+++ b/docs/changelog/125048.yaml
@@ -1,0 +1,6 @@
+pr: 125048
+summary: Removing incorrect use of `constant_keyword` field type from deprecation
+  logger mapping
+area: Infra/Logging
+type: bug
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/deprecation/deprecation-indexing-mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/deprecation/deprecation-indexing-mappings.json
@@ -20,14 +20,13 @@
         "data_stream": {
           "properties": {
             "type": {
-              "type": "constant_keyword",
-              "value": "logs"
+              "type": "keyword"
             },
             "dataset": {
-              "type": "constant_keyword"
+              "type": "keyword"
             },
             "namespace": {
-              "type": "constant_keyword"
+              "type": "keyword"
             }
           }
         },


### PR DESCRIPTION
The mapping for the deprecation logger defines `data_stream.type`, `data_stream.dataset`, and `data_stream.namespace` as constant_keyword fields, with `data_stream.type` being restricted to being `logs`. These fields can have different values for different data streams though. Assuming its type is `logs`, the first entry written doesn't cause a problem because the mapping is not strict and gets updated to have the constant be whatever was inserted. But if the deprecation logger then writes a different value to one of the constant_keyword fields, we get an error like this (seen on an actual cluster in the process of upgrading):
```
[instance-0000000005] Bulk write of deprecation logs encountered some failures: [[4VK3j5UBamJ0EqvgUJmJ org.elasticsearch.index.mapper.DocumentParsingException: [1:87] failed to parse field [data_stream.dataset] of type [constant_keyword] in document with id '4VK3j5UBamJ0EqvgUJmJ'. Preview of field's value: 'elasticsearch.deprecation']]
```