### PR TITLE
[8.x] Document allow_partial_results (#125044)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query.json
@@ -34,6 +34,11 @@
         "type": "boolean",
         "description": "Should entirely null columns be removed from the results? Their name and type will be returning in a new `all_columns` section.",
         "default": false
+      },
+      "allow_partial_results": {
+        "type": "boolean",
+        "description": "If `true`, partial results will be returned if there are shard failures, but\nthe query can continue to execute on other clusters and shards.",
+        "default": false
       }
     },
     "body":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.query.json
@@ -34,6 +34,11 @@
         "type": "boolean",
         "description": "Should entirely null columns be removed from the results? Their name and type will be returning in a new `all_columns` section.",
         "default": false
+      },
+      "allow_partial_results": {
+        "type": "boolean",
+        "description": "If `true`, partial results will be returned if there are shard failures, but\nthe query can continue to execute on other clusters and shards.",
+        "default": false
       }
     },
     "body":{


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Document allow_partial_results (#125044)