### PR TITLE
Add shardCountBefore/After operations to IndexReshardingMetadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingMetadata.java
@@ -205,10 +205,27 @@ public class IndexReshardingMetadata implements ToXContentFragment, Writeable {
         return new IndexReshardingMetadata(IndexReshardingState.Split.newSplitByMultiple(shardCount, multiple));
     }
 
+    /**
+     * @return the split state of this metadata block, or throw IllegalArgumentException if this metadata doesn't represent a split
+     */
     public IndexReshardingState.Split getSplit() {
         return switch (state) {
             case IndexReshardingState.Noop ignored -> throw new IllegalArgumentException("resharding metadata is not a split");
             case IndexReshardingState.Split s -> s;
         };
+    }
+
+    /**
+     * @return the number of shards the index has at the start of this operation
+     */
+    public int shardCountBefore() {
+        return state.shardCountBefore();
+    }
+
+    /**
+     * @return the number of shards that the index will have when resharding completes
+     */
+    public int shardCountAfter() {
+        return state.shardCountAfter();
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingState.java
@@ -76,10 +76,14 @@ public abstract sealed class IndexReshardingState implements Writeable, ToXConte
         }
 
         @Override
-        public int shardCountBefore() { return 1; }
+        public int shardCountBefore() {
+            return 1;
+        }
 
         @Override
-        public int shardCountAfter() { return 1; }
+        public int shardCountAfter() {
+            return 1;
+        }
     }
 
     public static final class Split extends IndexReshardingState {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingState.java
@@ -29,6 +29,16 @@ import java.util.Objects;
  * concrete subclasses for the operations that are currently defined (which is only split for now).
  */
 public abstract sealed class IndexReshardingState implements Writeable, ToXContentFragment {
+    /**
+     * @return the number of shards the index has at the start of this operation
+     */
+    public abstract int shardCountBefore();
+
+    /**
+     * @return the number of shards that the index will have when resharding completes
+     */
+    public abstract int shardCountAfter();
+
     // This class exists only so that tests can check that IndexReshardingMetadata can support more than one kind of operation.
     // When we have another real operation such as Shrink this can be removed.
     public static final class Noop extends IndexReshardingState {
@@ -64,6 +74,12 @@ public abstract sealed class IndexReshardingState implements Writeable, ToXConte
         public int hashCode() {
             return 0;
         }
+
+        @Override
+        public int shardCountBefore() { return 1; }
+
+        @Override
+        public int shardCountAfter() { return 1; }
     }
 
     public static final class Split extends IndexReshardingState {
@@ -210,13 +226,13 @@ public abstract sealed class IndexReshardingState implements Writeable, ToXConte
             return Objects.hash(Arrays.hashCode(sourceShards), Arrays.hashCode(targetShards));
         }
 
-        // visible for testing
-        int oldShardCount() {
+        @Override
+        public int shardCountBefore() {
             return oldShardCount;
         }
 
-        // visible for testing
-        int newShardCount() {
+        @Override
+        public int shardCountAfter() {
             return newShardCount;
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingMetadataTests.java
@@ -21,8 +21,8 @@ public class IndexReshardingMetadataTests extends ESTestCase {
         var split = metadata.getSplit();
 
         // starting state is as expected
-        assert split.oldShardCount() == numShards;
-        assert split.newShardCount() == numShards * multiple;
+        assert metadata.shardCountBefore() == numShards;
+        assert metadata.shardCountAfter() == numShards * multiple;
         for (int i = 0; i < numShards; i++) {
             assert split.getSourceShardState(i) == IndexReshardingState.Split.SourceShardState.SOURCE;
         }


### PR DESCRIPTION
Any reshard operation will change shard count, so it makes sense to make this information available here.