### PR TITLE
Mark keep_alive as optional in open_point_in_time API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -54,7 +54,6 @@
       "keep_alive": {
         "type": "string",
         "description": "Specific the time to live for the point in time",
-        "required": true
       },
       "allow_partial_search_results": {
         "type": "boolean",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -53,7 +53,7 @@
       },
       "keep_alive": {
         "type": "string",
-        "description": "Specific the time to live for the point in time",
+        "description": "Specific the time to live for the point in time"
       },
       "allow_partial_search_results": {
         "type": "boolean",


### PR DESCRIPTION
`keep_alive` is an optional parameter:

https://github.com/elastic/elasticsearch/blob/30dd38bc97bb9271c807732093e99f9cd494c2f9/server/src/main/java/org/elasticsearch/action/search/RestOpenPointInTimeAction.java#L50