### PR TITLE
Fix ES|QL query log file suffix in LogType

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/LogType.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/LogType.java
@@ -15,7 +15,7 @@ public enum LogType {
     AUDIT("%s_audit.json"),
     SEARCH_SLOW("%s_index_search_slowlog.json"),
     INDEXING_SLOW("%s_index_indexing_slowlog.json"),
-    ESQL_SLOW("%s_esql_slowlog.json"),
+    ESQL_QUERY("%s_esql_querylog.json"),
     DEPRECATION("%s_deprecation.json");
 
     private final String filenameFormat;


### PR DESCRIPTION
I noticed it while backporting, this slipped during the renaming SlowLog -> QueryLog.
It's just for consistency with the other logs, as the constant is not used for now.