### PR TITLE
Prepare backport of transport version STORED_SCRIPT_CONTENT_LENGTH to 9.0

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -157,6 +157,7 @@ public class TransportVersions {
     public static final TransportVersion BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_90 = def(9_000_0_06);
     public static final TransportVersion RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR_90 = def(9_000_0_07);
     public static final TransportVersion RE_REMOVE_MIN_COMPATIBLE_SHARD_NODE_90 = def(9_000_0_08);
+    public static final TransportVersion STORED_SCRIPT_CONTENT_LENGTH_90 = def(9_000_0_09);
     public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED = def(9_001_0_00);
     public static final TransportVersion REMOVE_SNAPSHOT_FAILURES = def(9_002_0_00);
     public static final TransportVersion TRANSPORT_STATS_HANDLING_TIME_REQUIRED = def(9_003_0_00);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequest.java
@@ -45,7 +45,8 @@ public class PutStoredScriptRequest extends AcknowledgedRequest<PutStoredScriptR
     public PutStoredScriptRequest(StreamInput in) throws IOException {
         super(in);
         id = in.readOptionalString();
-        if (in.getTransportVersion().onOrAfter(TransportVersions.STORED_SCRIPT_CONTENT_LENGTH)) {
+        if (in.getTransportVersion().isPatchFrom(TransportVersions.STORED_SCRIPT_CONTENT_LENGTH_90)
+            || in.getTransportVersion().onOrAfter(TransportVersions.STORED_SCRIPT_CONTENT_LENGTH)) {
             contentLength = in.readVInt();
         } else {
             BytesReference content = in.readBytesReference();
@@ -105,7 +106,8 @@ public class PutStoredScriptRequest extends AcknowledgedRequest<PutStoredScriptR
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeOptionalString(id);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.STORED_SCRIPT_CONTENT_LENGTH)) {
+        if (out.getTransportVersion().isPatchFrom(TransportVersions.STORED_SCRIPT_CONTENT_LENGTH_90)
+            || out.getTransportVersion().onOrAfter(TransportVersions.STORED_SCRIPT_CONTENT_LENGTH)) {
             out.writeVInt(contentLength);
         } else {
             // generate a bytes reference of the correct size (the content isn't actually used in 8.18)


### PR DESCRIPTION
Prepare backport of transport version STORED_SCRIPT_CONTENT_LENGTH to 9.0

Relates to https://github.com/elastic/elasticsearch/pull/123860