### PR TITLE
Add some utility functions for handling Maxmind geoip results

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
@@ -209,9 +209,9 @@ final class MaxmindIpDataLookups {
                 switch (property) {
                     case IP -> data.put("ip", response.getTraits().getIpAddress());
                     case COUNTRY_IN_EUROPEAN_UNION -> {
-                        if (country.getIsoCode() != null) {
-                            // isInEuropeanUnion is a boolean so it can't be null. But it really only makes sense if we have a country
-                            data.put("country_in_european_union", country.isInEuropeanUnion());
+                        Boolean isInEuropeanUnion = isInEuropeanUnion(country);
+                        if (isInEuropeanUnion != null) {
+                            data.put("country_in_european_union", isInEuropeanUnion);
                         }
                     }
                     case COUNTRY_ISO_CODE -> {
@@ -288,9 +288,9 @@ final class MaxmindIpDataLookups {
                         }
                     }
                     case REGISTERED_COUNTRY_IN_EUROPEAN_UNION -> {
-                        if (registeredCountry.getIsoCode() != null) {
-                            // isInEuropeanUnion is a boolean so it can't be null. But it really only makes sense if we have a country
-                            data.put("registered_country_in_european_union", registeredCountry.isInEuropeanUnion());
+                        Boolean isInEuropeanUnion = isInEuropeanUnion(registeredCountry);
+                        if (isInEuropeanUnion != null) {
+                            data.put("registered_country_in_european_union", isInEuropeanUnion);
                         }
                     }
                     case REGISTERED_COUNTRY_ISO_CODE -> {
@@ -353,9 +353,9 @@ final class MaxmindIpDataLookups {
                 switch (property) {
                     case IP -> data.put("ip", response.getTraits().getIpAddress());
                     case COUNTRY_IN_EUROPEAN_UNION -> {
-                        if (country.getIsoCode() != null) {
-                            // isInEuropeanUnion is a boolean so it can't be null. But it really only makes sense if we have a country
-                            data.put("country_in_european_union", country.isInEuropeanUnion());
+                        Boolean isInEuropeanUnion = isInEuropeanUnion(country);
+                        if (isInEuropeanUnion != null) {
+                            data.put("country_in_european_union", isInEuropeanUnion);
                         }
                     }
                     case COUNTRY_ISO_CODE -> {
@@ -383,9 +383,9 @@ final class MaxmindIpDataLookups {
                         }
                     }
                     case REGISTERED_COUNTRY_IN_EUROPEAN_UNION -> {
-                        if (registeredCountry.getIsoCode() != null) {
-                            // isInEuropeanUnion is a boolean so it can't be null. But it really only makes sense if we have a country
-                            data.put("registered_country_in_european_union", registeredCountry.isInEuropeanUnion());
+                        Boolean isInEuropeanUnion = isInEuropeanUnion(registeredCountry);
+                        if (isInEuropeanUnion != null) {
+                            data.put("registered_country_in_european_union", isInEuropeanUnion);
                         }
                     }
                     case REGISTERED_COUNTRY_ISO_CODE -> {
@@ -480,9 +480,9 @@ final class MaxmindIpDataLookups {
                         }
                     }
                     case COUNTRY_IN_EUROPEAN_UNION -> {
-                        if (country.getIsoCode() != null) {
-                            // isInEuropeanUnion is a boolean so it can't be null. But it really only makes sense if we have a country
-                            data.put("country_in_european_union", country.isInEuropeanUnion());
+                        Boolean isInEuropeanUnion = isInEuropeanUnion(country);
+                        if (isInEuropeanUnion != null) {
+                            data.put("country_in_european_union", isInEuropeanUnion);
                         }
                     }
                     case COUNTRY_ISO_CODE -> {
@@ -639,9 +639,9 @@ final class MaxmindIpDataLookups {
                         }
                     }
                     case REGISTERED_COUNTRY_IN_EUROPEAN_UNION -> {
-                        if (registeredCountry.getIsoCode() != null) {
-                            // isInEuropeanUnion is a boolean so it can't be null. But it really only makes sense if we have a country
-                            data.put("registered_country_in_european_union", registeredCountry.isInEuropeanUnion());
+                        Boolean isInEuropeanUnion = isInEuropeanUnion(registeredCountry);
+                        if (isInEuropeanUnion != null) {
+                            data.put("registered_country_in_european_union", isInEuropeanUnion);
                         }
                     }
                     case REGISTERED_COUNTRY_ISO_CODE -> {
@@ -775,5 +775,12 @@ final class MaxmindIpDataLookups {
          * @return a mapping of properties for the ip from the response
          */
         protected abstract Map<String, Object> transform(RESPONSE response);
+    }
+
+    @Nullable
+    private static Boolean isInEuropeanUnion(com.maxmind.geoip2.record.Country country) {
+        // isInEuropeanUnion is a lowercase-b boolean so it cannot be null, but it really only makes sense for us to return a value
+        // for this if there's actually a real country here, as opposed to an empty null-object country, so we check for an iso code first
+        return (country.getIsoCode() == null) ? null : country.isInEuropeanUnion();
     }
 }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
@@ -266,7 +266,7 @@ final class MaxmindIpDataLookups {
                         Double latitude = location.getLatitude();
                         Double longitude = location.getLongitude();
                         if (latitude != null && longitude != null) {
-                            Map<String, Object> locationObject = new HashMap<>();
+                            Map<String, Object> locationObject = HashMap.newHashMap(2);
                             locationObject.put("lat", latitude);
                             locationObject.put("lon", longitude);
                             data.put("location", locationObject);
@@ -539,7 +539,7 @@ final class MaxmindIpDataLookups {
                         Double latitude = location.getLatitude();
                         Double longitude = location.getLongitude();
                         if (latitude != null && longitude != null) {
-                            Map<String, Object> locationObject = new HashMap<>();
+                            Map<String, Object> locationObject = HashMap.newHashMap(2);
                             locationObject.put("lat", latitude);
                             locationObject.put("lon", longitude);
                             data.put("location", locationObject);

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
@@ -239,12 +239,8 @@ final class MaxmindIpDataLookups {
                         }
                     }
                     case REGION_ISO_CODE -> {
-                        // ISO 3166-2 code for country subdivisions.
-                        // See iso.org/iso-3166-country-codes.html
-                        String countryIso = country.getIsoCode();
-                        String subdivisionIso = subdivision.getIsoCode();
-                        if (countryIso != null && subdivisionIso != null) {
-                            String regionIsoCode = countryIso + "-" + subdivisionIso;
+                        String regionIsoCode = regionIsoCode(country, subdivision);
+                        if (regionIsoCode != null) {
                             data.put("region_iso_code", regionIsoCode);
                         }
                     }
@@ -510,12 +506,8 @@ final class MaxmindIpDataLookups {
                         }
                     }
                     case REGION_ISO_CODE -> {
-                        // ISO 3166-2 code for country subdivisions.
-                        // See iso.org/iso-3166-country-codes.html
-                        String countryIso = country.getIsoCode();
-                        String subdivisionIso = subdivision.getIsoCode();
-                        if (countryIso != null && subdivisionIso != null) {
-                            String regionIsoCode = countryIso + "-" + subdivisionIso;
+                        String regionIsoCode = regionIsoCode(country, subdivision);
+                        if (regionIsoCode != null) {
                             data.put("region_iso_code", regionIsoCode);
                         }
                     }
@@ -782,5 +774,17 @@ final class MaxmindIpDataLookups {
         // isInEuropeanUnion is a lowercase-b boolean so it cannot be null, but it really only makes sense for us to return a value
         // for this if there's actually a real country here, as opposed to an empty null-object country, so we check for an iso code first
         return (country.getIsoCode() == null) ? null : country.isInEuropeanUnion();
+    }
+
+    @Nullable
+    private static String regionIsoCode(final com.maxmind.geoip2.record.Country country, final Subdivision subdivision) {
+        // ISO 3166-2 code for country subdivisions, see https://www.iso.org/iso-3166-country-codes.html
+        final String countryIso = country.getIsoCode();
+        final String subdivisionIso = subdivision.getIsoCode();
+        if (countryIso != null && subdivisionIso != null) {
+            return countryIso + "-" + subdivisionIso;
+        } else {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
This is just a refactoring PR -- we have some repeated blocks of the same logic, so I'm extracting them into utility methods and then using those utility methods. 

Note: I can't `auto-backport` because the `HashMap.newHashMap(2)` change isn't going to be going back to 8.x (that branch has a minimum java compatible version of 17, so we can't use `HashMap.newHashMap(...)` which is a 19-ism).