### PR TITLE
GoogleCloudStorageBlobContainerRetriesTests setup fix

### DIFF
--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -155,7 +155,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
                     @Override
                     public HttpRequestInitializer getHttpRequestInitializer(ServiceOptions<?, ?> serviceOptions) {
                         // Add initializer/interceptor without interfering with any pre-existing ones
-                        HttpRequestInitializer httpRequestInitializer = super.getHttpRequestInitializer(serviceOptions);
+                        HttpRequestInitializer httpRequestInitializer = httpTransportOptions.getHttpRequestInitializer(serviceOptions);
                         return request -> {
                             if (httpRequestInitializer != null) {
                                 httpRequestInitializer.initialize(request);


### PR DESCRIPTION
When we wrap `HttpTransportOptions` we drop our HTTP interceptor (`GoogleCloudStorageHttpStatsCollector`) that we setup in `org.elasticsearch.repositories.gcs.GoogleCloudStorageService#createClient`.