### PR TITLE
8.x branch backport for leting MLTQuery throw IAE when no analyzer is set (#124662)

### DIFF
--- a/docs/changelog/124662.yaml
+++ b/docs/changelog/124662.yaml
@@ -1,0 +1,6 @@
+pr: 124662
+summary: Let MLTQuery throw IAE when no analyzer is set
+area: Search
+type: bug
+issues:
+ - 124562

--- a/docs/changelog/125192.yaml
+++ b/docs/changelog/125192.yaml
@@ -1,0 +1,5 @@
+pr: 125192
+summary: 8.x branch backport for leting MLTQuery throw IAE when no analyzer is set
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -969,9 +969,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         // set analyzer
         Analyzer analyzerObj = context.getIndexAnalyzers().get(analyzer);
         if (analyzerObj == null) {
-            analyzerObj = context.getIndexAnalyzer(
-                f -> { throw new UnsupportedOperationException("No analyzer configured for field " + f); }
-            );
+            analyzerObj = context.getIndexAnalyzer(f -> { throw new IllegalArgumentException("No analyzer configured for field " + f); });
         }
         mltQuery.setAnalyzer(analyzer, analyzerObj);
 


### PR DESCRIPTION
* Let MLTQuery throw IAE when no analyzer is set

(cherry picked from commit c971d79a952f82b5f9a8ba85d3499d4213dbde7d)
