### PR TITLE
[8.x] Add missing cause param to indices.put_template API (#125189)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -37,6 +37,11 @@
         "description":"Whether the index template should only be added if new or can also replace an existing one",
         "default":false
       },
+      "cause":{
+        "type":"string",
+        "description": "User defined reason for creating/updating the index template",
+        "default":""
+      },
       "master_timeout":{
         "type":"time",
         "description":"Specify timeout for connection to master"


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add missing cause param to indices.put_template API (#125189)