### PR TITLE
[ML] Return a Conflict status code if the model deployment is stopped by a user

### DIFF
--- a/docs/changelog/125204.yaml
+++ b/docs/changelog/125204.yaml
@@ -1,0 +1,6 @@
+pr: 125204
+summary: Return a Conflict status code if the model deployment is stopped by a user
+area: Machine Learning
+type: bug
+issues:
+ - 123745

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractControlMessagePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractControlMessagePyTorchAction.java
@@ -87,7 +87,7 @@ abstract class AbstractControlMessagePyTorchAction<T> extends AbstractPyTorchAct
 
     private void processResponse(PyTorchResult result) {
         if (result.isError()) {
-            onFailure(result.errorResult().error());
+            onFailure(result.errorResult());
             return;
         }
         onSuccess(getResult(result));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
@@ -178,7 +178,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
         NlpTask.ResultProcessor inferenceResultsProcessor
     ) {
         if (pyTorchResult.isError()) {
-            onFailure(pyTorchResult.errorResult().error());
+            onFailure(pyTorchResult.errorResult());
             return;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
@@ -130,11 +130,12 @@ public class PyTorchResultProcessor {
             var errorResult = new ErrorResult(
                 isStopping
                     ? "inference canceled as process is stopping"
-                    : "inference native process died unexpectedly with failure [" + e.getMessage() + "]"
+                    : "inference native process died unexpectedly with failure [" + e.getMessage() + "]",
+                isStopping
             );
             notifyAndClearPendingResults(errorResult);
         } finally {
-            notifyAndClearPendingResults(new ErrorResult("inference canceled as process is stopping"));
+            notifyAndClearPendingResults(new ErrorResult("inference canceled as process is stopping", true));
             processorCompletionLatch.countDown();
         }
         logger.debug(() -> "[" + modelId + "] Results processing finished");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ErrorResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ErrorResult.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public record ErrorResult(String error) implements ToXContentObject {
+public record ErrorResult(String error, boolean isStopping) implements ToXContentObject {
 
     public static final ParseField ERROR = new ParseField("error");
 
@@ -22,6 +22,10 @@ public record ErrorResult(String error) implements ToXContentObject {
         "error",
         a -> new ErrorResult((String) a[0])
     );
+
+    public ErrorResult(String error) {
+        this(error, false);
+    }
 
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), ERROR);


### PR DESCRIPTION
If a user stops a trained model deployment while it is being used any pending requests are failed with an 500 Internal Server Error status code. The status code is incorrect in this case as the process has been stopped by the user. If the process has crashed a 500 status code is still returned.

Closes #123745