### PR TITLE
Effectively iterate stats for DesiredBalanceMetrics

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceMetrics.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceMetrics.java
@@ -226,9 +226,8 @@ public class DesiredBalanceMetrics {
         }
         var stats = weightStatsPerNodeRef.get();
         List<DoubleWithAttributes> doubles = new ArrayList<>(stats.size());
-        for (var node : stats.keySet()) {
-            var stat = stats.get(node);
-            doubles.add(new DoubleWithAttributes(stat.nodeWeight(), getNodeAttributes(node)));
+        for (var e : stats.entrySet()) {
+            doubles.add(new DoubleWithAttributes(e.getValue().nodeWeight(), getNodeAttributes(e.getKey())));
         }
         return doubles;
     }
@@ -239,8 +238,8 @@ public class DesiredBalanceMetrics {
         }
         var stats = weightStatsPerNodeRef.get();
         List<DoubleWithAttributes> doubles = new ArrayList<>(stats.size());
-        for (var node : stats.keySet()) {
-            doubles.add(new DoubleWithAttributes(stats.get(node).writeLoad(), getNodeAttributes(node)));
+        for (var e : stats.entrySet()) {
+            doubles.add(new DoubleWithAttributes(e.getValue().writeLoad(), getNodeAttributes(e.getKey())));
         }
         return doubles;
     }
@@ -251,8 +250,8 @@ public class DesiredBalanceMetrics {
         }
         var stats = weightStatsPerNodeRef.get();
         List<DoubleWithAttributes> doubles = new ArrayList<>(stats.size());
-        for (var node : stats.keySet()) {
-            doubles.add(new DoubleWithAttributes(stats.get(node).diskUsageInBytes(), getNodeAttributes(node)));
+        for (var e : stats.entrySet()) {
+            doubles.add(new DoubleWithAttributes(e.getValue().diskUsageInBytes(), getNodeAttributes(e.getKey())));
         }
         return doubles;
     }
@@ -263,8 +262,8 @@ public class DesiredBalanceMetrics {
         }
         var stats = weightStatsPerNodeRef.get();
         List<LongWithAttributes> values = new ArrayList<>(stats.size());
-        for (var node : stats.keySet()) {
-            values.add(new LongWithAttributes(stats.get(node).shardCount(), getNodeAttributes(node)));
+        for (var e : stats.entrySet()) {
+            values.add(new LongWithAttributes(e.getValue().shardCount(), getNodeAttributes(e.getKey())));
         }
         return values;
     }
@@ -275,8 +274,8 @@ public class DesiredBalanceMetrics {
         }
         var stats = allocationStatsPerNodeRef.get();
         List<LongWithAttributes> values = new ArrayList<>(stats.size());
-        for (var node : stats.keySet()) {
-            values.add(new LongWithAttributes(stats.get(node).currentDiskUsage(), getNodeAttributes(node)));
+        for (var e : stats.entrySet()) {
+            values.add(new LongWithAttributes(e.getValue().currentDiskUsage(), getNodeAttributes(e.getKey())));
         }
         return values;
     }
@@ -287,8 +286,8 @@ public class DesiredBalanceMetrics {
         }
         var stats = allocationStatsPerNodeRef.get();
         List<DoubleWithAttributes> doubles = new ArrayList<>(stats.size());
-        for (var node : stats.keySet()) {
-            doubles.add(new DoubleWithAttributes(stats.get(node).forecastedIngestLoad(), getNodeAttributes(node)));
+        for (var e : stats.entrySet()) {
+            doubles.add(new DoubleWithAttributes(e.getValue().forecastedIngestLoad(), getNodeAttributes(e.getKey())));
         }
         return doubles;
     }
@@ -299,8 +298,8 @@ public class DesiredBalanceMetrics {
         }
         var stats = allocationStatsPerNodeRef.get();
         List<LongWithAttributes> values = new ArrayList<>(stats.size());
-        for (var node : stats.keySet()) {
-            values.add(new LongWithAttributes(stats.get(node).shards(), getNodeAttributes(node)));
+        for (var e : stats.entrySet()) {
+            values.add(new LongWithAttributes(e.getValue().shards(), getNodeAttributes(e.getKey())));
         }
         return values;
     }
@@ -311,8 +310,8 @@ public class DesiredBalanceMetrics {
         }
         var stats = allocationStatsPerNodeRef.get();
         List<LongWithAttributes> values = new ArrayList<>(stats.size());
-        for (var node : stats.keySet()) {
-            values.add(new LongWithAttributes(stats.get(node).forecastedDiskUsage(), getNodeAttributes(node)));
+        for (var e : stats.entrySet()) {
+            values.add(new LongWithAttributes(e.getValue().forecastedDiskUsage(), getNodeAttributes(e.getKey())));
         }
         return values;
     }
@@ -323,8 +322,8 @@ public class DesiredBalanceMetrics {
         }
         var stats = allocationStatsPerNodeRef.get();
         List<LongWithAttributes> values = new ArrayList<>(stats.size());
-        for (var node : stats.keySet()) {
-            values.add(new LongWithAttributes(stats.get(node).undesiredShards(), getNodeAttributes(node)));
+        for (var e : stats.entrySet()) {
+            values.add(new LongWithAttributes(e.getValue().undesiredShards(), getNodeAttributes(e.getKey())));
         }
         return values;
     }
@@ -335,8 +334,8 @@ public class DesiredBalanceMetrics {
         }
         var stats = allocationStatsPerNodeRef.get();
         List<DoubleWithAttributes> doubles = new ArrayList<>(stats.size());
-        for (var node : stats.keySet()) {
-            doubles.add(new DoubleWithAttributes(stats.get(node).currentNodeWeight(), getNodeAttributes(node)));
+        for (var e : stats.entrySet()) {
+            doubles.add(new DoubleWithAttributes(e.getValue().currentNodeWeight(), getNodeAttributes(e.getKey())));
         }
         return doubles;
     }


### PR DESCRIPTION
We don't need to do a lookup for every in the map to iterate over it, we can just use an iterator provided by `Map.entrySet`

