### PR TITLE
Refactor IndexFieldCapabilities creation by adding a proper builder object

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/ResponseRewriterTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/ResponseRewriterTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class ResponseRewriterTests extends ESTestCase {
@@ -147,7 +146,7 @@ public class ResponseRewriterTests extends ESTestCase {
     }
 
     private static IndexFieldCapabilities fieldCaps(String name, String type, boolean isMetadata) {
-        return new IndexFieldCapabilities(name, type, isMetadata, true, true, false, null, Collections.emptyMap());
+        return new IndexFieldCapabilitiesBuilder(name, type).isMetadataField(isMetadata).build();
     }
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilitiesBuilder.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilitiesBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.fieldcaps;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.mapper.TimeSeriesParams;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class IndexFieldCapabilitiesBuilder {
+    private final String name;
+    private final String type;
+
+    private boolean isMetadataField;
+    private boolean isSearchable;
+    private boolean isAggregatable;
+    private boolean isDimension;
+    private @Nullable TimeSeriesParams.MetricType metricType;
+    private Map<String, String> meta;
+
+    public IndexFieldCapabilitiesBuilder(String name, String type) {
+        this.name = name;
+        this.type = type;
+
+        this.isSearchable = true;
+        this.isAggregatable = true;
+
+        this.meta = Collections.emptyMap();
+    }
+
+    public IndexFieldCapabilitiesBuilder isMetadataField(boolean isMetadataField) {
+        this.isMetadataField = isMetadataField;
+        return this;
+    }
+
+    public IndexFieldCapabilitiesBuilder isSearchable(boolean isSearchable) {
+        this.isSearchable = isSearchable;
+        return this;
+    }
+
+    public IndexFieldCapabilitiesBuilder isAggregatable(boolean isAggregatable) {
+        this.isAggregatable = isAggregatable;
+        return this;
+    }
+
+    public IndexFieldCapabilitiesBuilder isDimension(boolean isDimension) {
+        this.isDimension = isDimension;
+        return this;
+    }
+
+    public IndexFieldCapabilitiesBuilder metricType(TimeSeriesParams.MetricType metricType) {
+        this.metricType = metricType;
+        return this;
+    }
+
+    public IndexFieldCapabilitiesBuilder meta(@Nullable Map<String, String> meta) {
+        this.meta = meta != null ? new TreeMap<>(meta) : null;
+        return this;
+    }
+
+    public IndexFieldCapabilities build() {
+        return new IndexFieldCapabilities(name, type, isMetadataField, isSearchable, isAggregatable, isDimension, metricType, meta);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.Build;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponse;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.fieldcaps.IndexFieldCapabilities;
+import org.elasticsearch.action.fieldcaps.IndexFieldCapabilitiesBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
@@ -3186,7 +3187,6 @@ public class AnalyzerTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("Unknown column [_id]"));
     }
 
-    // TODO There's too much boilerplate involved here! We need a better way of creating FieldCapabilitiesResponses from a mapping or index.
     private static FieldCapabilitiesIndexResponse fieldCapabilitiesIndexResponse(
         String indexName,
         Map<String, IndexFieldCapabilities> fields
@@ -3195,7 +3195,7 @@ public class AnalyzerTests extends ESTestCase {
     }
 
     private static Map<String, IndexFieldCapabilities> messageResponseMap(String date) {
-        return Map.of("message", new IndexFieldCapabilities("message", date, false, true, true, false, null, null));
+        return Map.of("message", new IndexFieldCapabilitiesBuilder("message", date).build());
     }
 
     private void verifyUnsupported(String query, String errorMessage) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolverTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponse;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.fieldcaps.IndexFieldCapabilities;
+import org.elasticsearch.action.fieldcaps.IndexFieldCapabilitiesBuilder;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.FilterClient;
 import org.elasticsearch.cluster.ClusterName;
@@ -489,7 +490,7 @@ public class EnrichPolicyResolverTests extends ESTestCase {
             if (mapping != null) {
                 Map<String, IndexFieldCapabilities> fieldCaps = new HashMap<>();
                 for (Map.Entry<String, String> e : mapping.entrySet()) {
-                    var f = new IndexFieldCapabilities(e.getKey(), e.getValue(), false, false, false, false, null, Map.of());
+                    var f = new IndexFieldCapabilitiesBuilder(e.getKey(), e.getValue()).isSearchable(false).isAggregatable(false).build();
                     fieldCaps.put(e.getKey(), f);
                 }
                 var indexResponse = new FieldCapabilitiesIndexResponse(alias, null, fieldCaps, true, IndexMode.STANDARD);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesBuilder;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponse;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
-import org.elasticsearch.action.fieldcaps.IndexFieldCapabilities;
+import org.elasticsearch.action.fieldcaps.IndexFieldCapabilitiesBuilder;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -228,8 +228,8 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                     idx,
                     idx,
                     Map.ofEntries(
-                        Map.entry("foo", new IndexFieldCapabilities("foo", "integer", false, true, true, false, null, Map.of())),
-                        Map.entry("bar", new IndexFieldCapabilities("bar", "long", false, true, true, false, null, Map.of()))
+                        Map.entry("foo", new IndexFieldCapabilitiesBuilder("foo", "integer").build()),
+                        Map.entry("bar", new IndexFieldCapabilitiesBuilder("bar", "long").build())
                     ),
                     true,
                     IndexMode.STANDARD

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.esql.type;
 
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponse;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
-import org.elasticsearch.action.fieldcaps.IndexFieldCapabilities;
+import org.elasticsearch.action.fieldcaps.IndexFieldCapabilitiesBuilder;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 import org.elasticsearch.test.ESTestCase;
@@ -46,7 +46,7 @@ public class EsqlDataTypeRegistryTests extends ESTestCase {
             new FieldCapabilitiesIndexResponse(
                 idx,
                 idx,
-                Map.of(field, new IndexFieldCapabilities(field, esTypeName, false, true, true, false, metricType, Map.of())),
+                Map.of(field, new IndexFieldCapabilitiesBuilder(field, esTypeName).metricType(metricType).build()),
                 true,
                 IndexMode.TIME_SERIES
             )


### PR DESCRIPTION
A follow up to #121310.

Reduce boilerplate associated with creating `IndexFieldCapabilities` instances. Since it's a class with a large number of fields, it makes sense to define a builder object, as that can also help with all the Boolean and null blindness going on. As with `FieldCapabilitiesBuilder`, this is only used in tests, to avoid any potential performance hit in production code.