### PR TITLE
Add an ignoreMissing parameter to IngestDocument's removeField method

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RemoveProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RemoveProcessor.java
@@ -59,15 +59,9 @@ public final class RemoveProcessor extends AbstractProcessor {
     }
 
     private void fieldsToRemoveProcessor(IngestDocument document) {
-        // micro-optimization note: actual for-each loops here rather than a .forEach because it happens to be ~5% faster in benchmarks
-        if (ignoreMissing) {
-            for (TemplateScript.Factory field : fieldsToRemove) {
-                removeWhenPresent(document, document.renderTemplate(field));
-            }
-        } else {
-            for (TemplateScript.Factory field : fieldsToRemove) {
-                document.removeField(document.renderTemplate(field));
-            }
+        // micro-optimization note: actual for-each loop here rather than a .forEach because it happens to be ~5% faster in benchmarks
+        for (TemplateScript.Factory field : fieldsToRemove) {
+            document.removeField(document.renderTemplate(field), ignoreMissing);
         }
     }
 
@@ -76,13 +70,7 @@ public final class RemoveProcessor extends AbstractProcessor {
             .stream()
             .filter(documentField -> IngestDocument.Metadata.isMetadata(documentField) == false)
             .filter(documentField -> shouldKeep(documentField, fieldsToKeep, document) == false)
-            .forEach(documentField -> removeWhenPresent(document, documentField));
-    }
-
-    private static void removeWhenPresent(IngestDocument document, String documentField) {
-        if (document.hasField(documentField)) {
-            document.removeField(documentField);
-        }
+            .forEach(documentField -> document.removeField(documentField, true));
     }
 
     static boolean shouldKeep(String documentField, List<TemplateScript.Factory> fieldsToKeep, IngestDocument document) {

--- a/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
@@ -850,6 +850,23 @@ public class IngestDocumentTests extends ESTestCase {
         assertThat(document.getIngestMetadata().size(), equalTo(0));
     }
 
+    public void testRemoveFieldIgnoreMissing() {
+        document.removeField("foo", randomBoolean());
+        assertThat(document.getSourceAndMetadata().size(), equalTo(10));
+        assertThat(document.getSourceAndMetadata().containsKey("foo"), equalTo(false));
+        document.removeField("_index", randomBoolean());
+        assertThat(document.getSourceAndMetadata().size(), equalTo(9));
+        assertThat(document.getSourceAndMetadata().containsKey("_index"), equalTo(false));
+
+        // if ignoreMissing is false, we throw an exception for values that aren't found
+        IllegalArgumentException e;
+        e = expectThrows(IllegalArgumentException.class, () -> document.removeField("fizz.some.nonsense", false));
+        assertThat(e.getMessage(), is("field [some] not present as part of path [fizz.some.nonsense]"));
+
+        // but no exception is thrown if ignoreMissing is true
+        document.removeField("fizz.some.nonsense", true);
+    }
+
     public void testRemoveInnerField() {
         document.removeField("fizz.buzz");
         assertThat(document.getSourceAndMetadata().size(), equalTo(11));


### PR DESCRIPTION
And use it in the `remove` processor. 

Related to #123891, and also this is a follow up to #124322 and #125051 (earlier nearby PRs that were laying the groundwork for this change).

Prior to this change, we had to traverse the document tree twice in the `remove` processor for each field that we wanted to remove: once to check whether the field existed (in the `hasField` call), and then once to actually remove the field (in the `removeField` call). This was necessary because `removeField` would throw an exception if the field didn't exist, so the call had to be guarded. By adding an `ignoreMissing` parameter to `removeField` we can remove the `hasField`-guarding and just specify that we don't care if the field doesn't exist (well, assuming `ignore_missing` has been set to `true` on the processor itself, which it typically is in the wild).

I'm labeling this as a `>refactoring` since there's no user-visible change in behavior, I'm just twiddling the code a bit so that it happens to be faster. On which note, this speeds up the `remove` processor by 30% -- I'm seeing that it's taking 290 microseconds per document rather than 413 on `main` (a further note: prior to #120573 it was taking 681 microseconds per document for the same benchmark).