### PR TITLE
Disable logging in `ClusterFormationFailureHelper` on shutdown.

### DIFF
--- a/docs/changelog/125244.yaml
+++ b/docs/changelog/125244.yaml
@@ -1,0 +1,6 @@
+pr: 125244
+summary: Disable logging in `ClusterFormationFailureHelper` on shutdown
+area: Cluster Coordination
+type: bug
+issues:
+ - 105559

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -1104,6 +1104,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
             applierState = initialState;
             clusterApplier.setInitialState(initialState);
         }
+        clusterFormationFailureHelper.setLoggingEnabled(true);
     }
 
     public DiscoveryStats stats() {
@@ -1126,6 +1127,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
     protected void doStop() {
         configuredHostsResolver.stop();
         joinValidationService.stop();
+        clusterFormationFailureHelper.setLoggingEnabled(false);
     }
 
     @Override


### PR DESCRIPTION
Modifies `Coordinator` to enable logging in `ClusterFormationFailureHelper` when started and disables logging in `ClusterFormationFailureHelper` when stopped.  The warning scheduler handling and invariant check in the `Coordinator` are left as is, with the logging boolean set independently, eliminating the need to hold the `mutex` in `doStop()` when `Coordinator.stop()` is called when the `Node` is shutdown.

Closes #105559.