### PR TITLE
Fix failure in ScalingThreadPoolTests after addition of merge scheduler

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -396,9 +396,6 @@ tests:
 - class: org.elasticsearch.xpack.ilm.DataStreamAndIndexLifecycleMixingTests
   method: testGetDataStreamResponse
   issue: https://github.com/elastic/elasticsearch/issues/125083
-- class: org.elasticsearch.threadpool.ScalingThreadPoolTests
-  method: testScalingThreadPoolConfiguration
-  issue: https://github.com/elastic/elasticsearch/issues/125142
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test012SecurityCanBeDisabled
   issue: https://github.com/elastic/elasticsearch/issues/116636

--- a/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
@@ -119,6 +119,7 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
         sizes.put(ThreadPool.Names.SNAPSHOT_META, n -> Math.min(n * 3, 50));
         sizes.put(ThreadPool.Names.FETCH_SHARD_STARTED, ThreadPool::twiceAllocatedProcessors);
         sizes.put(ThreadPool.Names.FETCH_SHARD_STORE, ThreadPool::twiceAllocatedProcessors);
+        sizes.put(ThreadPool.Names.MERGE, Function.identity());
         return sizes.get(threadPoolName).apply(numberOfProcessors);
     }
 


### PR DESCRIPTION
Fixes occassional failures in `ScalingThreadPoolTests` as a result of the new scheduler added in https://github.com/elastic/elasticsearch/pull/120869.

Resolves https://github.com/elastic/elasticsearch/issues/125142