### PR TITLE
Adjusting 41_knn_search_bbq_hnsw tests to have explicit refresh

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -276,9 +276,6 @@ tests:
 - class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
   method: testDuplicatePrunedPaths
   issue: https://github.com/elastic/elasticsearch/issues/124006
-- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/41_knn_search_bbq_hnsw/Vector rescoring has same scoring as exact search for kNN section}
-  issue: https://github.com/elastic/elasticsearch/issues/124052
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
   issue: https://github.com/elastic/elasticsearch/issues/120814

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
@@ -75,6 +75,9 @@ setup:
       indices.forcemerge:
         index: bbq_hnsw
         max_num_segments: 1
+
+  - do:
+      indices.refresh: { }
 ---
 "Test knn search":
   - requires:


### PR DESCRIPTION
This should handle any weird flakiness with CoreWithMultipleProjectsClientYamlTestSuiteIT, if not, involve `CoreWithMultipleProjectsClientYamlTestSuiteIT` authors as its the only runner failing "Vector rescoring has same scoring as exact search for kNN section" right now