### PR TITLE
Leverage scorer supplier in QueryFeatureExtractor

### DIFF
--- a/docs/changelog/125259.yaml
+++ b/docs/changelog/125259.yaml
@@ -1,0 +1,5 @@
+pr: 125259
+summary: Leverage scorer supplier in `QueryFeatureExtractor`
+area: Ranking
+type: enhancement
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/QueryFeatureExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/QueryFeatureExtractor.java
@@ -47,9 +47,12 @@ public class QueryFeatureExtractor implements FeatureExtractor {
             if (weight == null) {
                 continue;
             }
-            Scorer scorer = weight.scorer(segmentContext);
-            if (scorer != null) {
-                subScorers.add(new FeatureDisiWrapper(scorer, featureNames.get(i)));
+            var scorerSupplier = weight.scorerSupplier(segmentContext);
+            if (scorerSupplier != null) {
+                var scorer = scorerSupplier.get(0L);
+                if (scorer != null) {
+                    subScorers.add(new FeatureDisiWrapper(scorer, featureNames.get(i)));
+                }
             }
         }
         approximation = subScorers.size() > 0 ? new DisjunctionDISIApproximation(subScorers) : null;


### PR DESCRIPTION
Follow up of #125103 that leverages scorer supplier to create queries optimised to run on top docs only.