### PR TITLE
[9.0] ESQL: Reuse child outputSet inside the plan where possible (#124611)

### DIFF
--- a/docs/changelog/124611.yaml
+++ b/docs/changelog/124611.yaml
@@ -1,0 +1,5 @@
+pr: 124611
+summary: Reuse child `outputSet` inside the plan where possible
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnaryPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnaryPlan.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.esql.plan.logical;
 
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Collections;
@@ -20,6 +21,7 @@ import java.util.Objects;
 public abstract class UnaryPlan extends LogicalPlan {
 
     private final LogicalPlan child;
+    private AttributeSet lazyOutputSet;
 
     protected UnaryPlan(Source source, LogicalPlan child) {
         super(source, Collections.singletonList(child));
@@ -40,6 +42,14 @@ public abstract class UnaryPlan extends LogicalPlan {
     @Override
     public List<Attribute> output() {
         return child.output();
+    }
+
+    public AttributeSet outputSet() {
+        if (lazyOutputSet == null) {
+            List<Attribute> output = output();
+            lazyOutputSet = (output == child.output() ? child.outputSet() : new AttributeSet(output));
+        }
+        return lazyOutputSet;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FilterExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FilterExec.java
@@ -9,14 +9,12 @@ package org.elasticsearch.xpack.esql.plan.physical;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Objects;
 
 public class FilterExec extends UnaryExec {
@@ -61,11 +59,6 @@ public class FilterExec extends UnaryExec {
 
     public Expression condition() {
         return condition;
-    }
-
-    @Override
-    public List<Attribute> output() {
-        return child().output();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/UnaryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/UnaryExec.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.plan.physical;
 
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Collections;
@@ -17,6 +18,7 @@ import java.util.Objects;
 public abstract class UnaryExec extends PhysicalPlan {
 
     private final PhysicalPlan child;
+    private AttributeSet lazyOutputSet;
 
     protected UnaryExec(Source source, PhysicalPlan child) {
         super(source, Collections.singletonList(child));
@@ -37,6 +39,16 @@ public abstract class UnaryExec extends PhysicalPlan {
     @Override
     public List<Attribute> output() {
         return child.output();
+    }
+
+    @Override
+    public AttributeSet outputSet() {
+        if (lazyOutputSet == null) {
+            List<Attribute> output = output();
+            lazyOutputSet = (output == child.output() ? child.outputSet() : new AttributeSet(output));
+            return lazyOutputSet;
+        }
+        return lazyOutputSet;
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 9.0:
 - ESQL: Reuse child outputSet inside the plan where possible (#124611)