### PR TITLE
Adjust BWC for block serialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -148,6 +148,7 @@ public class TransportVersions {
     public static final TransportVersion RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR_8_19 = def(8_841_0_07);
     public static final TransportVersion INFERENCE_CONTEXT_8_X = def(8_841_0_08);
     public static final TransportVersion ML_INFERENCE_DEEPSEEK_8_19 = def(8_841_0_09);
+    public static final TransportVersion ESQL_SERIALIZE_BLOCK_TYPE_CODE_8_19 = def(8_841_0_10);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0 = def(9_000_0_00);
     public static final TransportVersion REMOVE_SNAPSHOT_FAILURES_90 = def(9_000_0_01);
     public static final TransportVersion TRANSPORT_STATS_HANDLING_TIME_REQUIRED_90 = def(9_000_0_02);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
@@ -122,7 +122,8 @@ public enum ElementType {
      * Read element type from an input stream
      */
     static ElementType readFrom(StreamInput in) throws IOException {
-        if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_SERIALIZE_BLOCK_TYPE_CODE)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_SERIALIZE_BLOCK_TYPE_CODE)
+            || in.getTransportVersion().isPatchFrom(TransportVersions.ESQL_SERIALIZE_BLOCK_TYPE_CODE_8_19)) {
             byte b = in.readByte();
             return values()[b];
         } else {
@@ -136,7 +137,8 @@ public enum ElementType {
     }
 
     void writeTo(StreamOutput out) throws IOException {
-        if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_SERIALIZE_BLOCK_TYPE_CODE)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_SERIALIZE_BLOCK_TYPE_CODE)
+            || out.getTransportVersion().isPatchFrom(TransportVersions.ESQL_SERIALIZE_BLOCK_TYPE_CODE_8_19)) {
             out.writeByte(writableCode);
         } else {
             out.writeString(legacyWritableName);


### PR DESCRIPTION
Adjust wire version after backporting to 8.x.

Relates #124394