### PR TITLE
[ES|QL] Fix ScoringIT test-release

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/ScoringIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/ScoringIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.kql.KqlPlugin;
 import org.junit.Before;
 
@@ -33,7 +34,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 
 public class ScoringIT extends AbstractEsqlIntegTestCase {
-
     private final String matchingClause;
 
     @Override
@@ -48,7 +48,11 @@ public class ScoringIT extends AbstractEsqlIntegTestCase {
         params.add(new Object[] { "content:\"fox\"" });
         params.add(new Object[] { "qstr(\"content: fox\")" });
         params.add(new Object[] { "kql(\"content*: fox\")" });
-        params.add(new Object[] { "term(content, \"fox\")" });
+
+        if (EsqlCapabilities.Cap.TERM_FUNCTION.isEnabled()) {
+            params.add(new Object[] { "term(content, \"fox\")" });
+        }
+
         return params;
     }
 


### PR DESCRIPTION
Just found that `ScoringIT` is broken in `test-release`.
This can be fixed easily by adding a test to check if the term query is enabled.