### PR TITLE
[8.x] ESQL ScoringIT - Fix release test (#125250)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/ScoringIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/ScoringIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.kql.KqlPlugin;
 import org.junit.Before;
 
@@ -48,7 +49,9 @@ public class ScoringIT extends AbstractEsqlIntegTestCase {
         params.add(new Object[] { "content:\"fox\"" });
         params.add(new Object[] { "qstr(\"content: fox\")" });
         params.add(new Object[] { "kql(\"content*: fox\")" });
-        params.add(new Object[] { "term(content, \"fox\")" });
+        if (EsqlCapabilities.Cap.TERM_FUNCTION.isEnabled()) {
+            params.add(new Object[] { "term(content, \"fox\")" });
+        }
         return params;
     }
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL ScoringIT - Fix release test (#125250)