### PR TITLE
[Entitlements] Print a warning during plugin installation if a legacy policy file is found

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
@@ -926,9 +926,12 @@ public class InstallPluginAction implements Closeable {
 
         Path legacyPolicyFile = tmpRoot.resolve(PluginDescriptor.ES_PLUGIN_POLICY);
         if (Files.exists(legacyPolicyFile)) {
-            terminal.errorPrintln("WARNING: this plugin contains a legacy Security Policy file. Starting with version 8.18, " +
-                "Entitlements replace SecurityManager as the security mechanism. Plugins must migrate their policy files to the new " +
-                "format. For more information, please refer to " + PluginSecurity.ENTITLEMENTS_DESCRIPTION_URL);
+            terminal.errorPrintln(
+                "WARNING: this plugin contains a legacy Security Policy file. Starting with version 8.18, "
+                    + "Entitlements replace SecurityManager as the security mechanism. Plugins must migrate their policy files to the new "
+                    + "format. For more information, please refer to "
+                    + PluginSecurity.ENTITLEMENTS_DESCRIPTION_URL
+            );
         }
 
         if (RuntimeVersionFeature.isSecurityManagerAvailable()) {

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
@@ -923,6 +923,14 @@ public class InstallPluginAction implements Closeable {
      */
     private PluginDescriptor installPlugin(InstallablePlugin descriptor, Path tmpRoot, List<Path> deleteOnFailure) throws Exception {
         final PluginDescriptor info = loadPluginInfo(tmpRoot);
+
+        Path legacyPolicyFile = tmpRoot.resolve(PluginDescriptor.ES_PLUGIN_POLICY);
+        if (Files.exists(legacyPolicyFile)) {
+            terminal.errorPrintln("WARNING: this plugin contains a legacy Security Policy file. Starting with version 8.18, " +
+                "Entitlements replace SecurityManager as the security mechanism. Plugins must migrate their policy files to the new " +
+                "format. For more information, please refer to " + PluginSecurity.ENTITLEMENTS_DESCRIPTION_URL);
+        }
+
         if (RuntimeVersionFeature.isSecurityManagerAvailable()) {
             PluginPolicyInfo pluginPolicy = PolicyUtil.getPluginPolicyInfo(tmpRoot, env.tmpDir());
             if (pluginPolicy != null) {

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/PluginSecurity.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/PluginSecurity.java
@@ -34,6 +34,9 @@ import java.util.stream.Collectors;
  */
 public class PluginSecurity {
 
+    public static final String ENTITLEMENTS_DESCRIPTION_URL =
+        "https://www.elastic.co/guide/en/elasticsearch/plugins/current/creating-classic-plugins.html";
+
     /**
      * prints/confirms policy exceptions with the user
      */


### PR DESCRIPTION
This PR adds a check and a warning message if the user is trying to install a plugin containing the legacy `plugin-security.policy` used by SecurityManager.

Relates to ES-10846