### PR TITLE
[CI] Reenable N-2 BWC tests for non-snapshot builds

### DIFF
--- a/qa/lucene-index-compatibility/build.gradle
+++ b/qa/lucene-index-compatibility/build.gradle
@@ -14,9 +14,6 @@ buildParams.bwcVersions.withLatestReadOnlyIndexCompatible { bwcVersion ->
   tasks.named("javaRestTest").configure {
     systemProperty("tests.minimum.index.compatible", bwcVersion)
     usesBwcDistribution(bwcVersion)
-
-    // Tests rely on unreleased code in 8.18 branch
-    enabled = buildParams.snapshotBuild
   }
 }
 


### PR DESCRIPTION
Those tests were disabled for `release-tests` because they were failing due to missing feature, CI was testing a 9.0 snapshot build against a 8.18 release build if I remember correctly.

I suppose that those issues are now sorted, so we can reenable the tests for `release-test` (actually I should have done it before).

Relates #119583
Closes #119550
