### PR TITLE
[8.x] Failure Store Access Authorization (#123986)

### DIFF
--- a/plugins/examples/security-authorization-engine/src/main/java/org/elasticsearch/example/CustomAuthorizationEngine.java
+++ b/plugins/examples/security-authorization-engine/src/main/java/org/elasticsearch/example/CustomAuthorizationEngine.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.example;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.xpack.core.security.action.user.GetUserPrivilegesResponse;
@@ -34,7 +35,6 @@ import org.elasticsearch.xpack.core.security.user.User;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.function.Supplier;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -117,19 +117,19 @@ public class CustomAuthorizationEngine implements AuthorizationEngine {
     ) {
         if (isSuperuser(requestInfo.getAuthentication().getEffectiveSubject().getUser())) {
             listener.onResponse(new AuthorizedIndices() {
-                public Supplier<Set<String>> all() {
+                public Set<String> all(IndexComponentSelector selector) {
                     return () -> indicesLookup.keySet();
                 }
-                public boolean check(String name) {
+                public boolean check(String name, IndexComponentSelector selector) {
                     return indicesLookup.containsKey(name);
                 }
             });
         } else {
             listener.onResponse(new AuthorizedIndices() {
-                public Supplier<Set<String>> all() {
+                public Set<String> all(IndexComponentSelector selector) {
                     return () -> Set.of();
                 }
-                public boolean check(String name) {
+                public boolean check(String name, IndexComponentSelector selector) {
                     return false;
                 }
             });

--- a/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
@@ -72,6 +72,24 @@ public enum IndexComponentSelector implements Writeable {
         return KEY_REGISTRY.get(key);
     }
 
+    /**
+     * Like {@link #getByKey(String)} but throws an exception if the key is not recognised.
+     * @return the selector if recognized. `null` input will return `DATA`.
+     * @throws IllegalArgumentException if the key was not recognised.
+     */
+    public static IndexComponentSelector getByKeyOrThrow(@Nullable String key) {
+        if (key == null) {
+            return DATA;
+        }
+        IndexComponentSelector selector = getByKey(key);
+        if (selector == null) {
+            throw new IllegalArgumentException(
+                "Unknown key of index component selector [" + key + "], available options are: " + KEY_REGISTRY.keySet()
+            );
+        }
+        return selector;
+    }
+
     public static IndexComponentSelector read(StreamInput in) throws IOException {
         byte id = in.readByte();
         if (in.getTransportVersion().onOrAfter(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR_BACKPORT_8_19)

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -101,6 +101,13 @@ public interface IndexAbstraction {
     }
 
     /**
+     * @return whether this index abstraction is a failure index of a data stream
+     */
+    default boolean isFailureIndexOfDataStream() {
+        return false;
+    }
+
+    /**
      * An index abstraction type.
      */
     enum Type {
@@ -181,6 +188,11 @@ public interface IndexAbstraction {
         @Override
         public DataStream getParentDataStream() {
             return dataStream;
+        }
+
+        @Override
+        public boolean isFailureIndexOfDataStream() {
+            return getParentDataStream() != null && getParentDataStream().isFailureStoreIndex(getName());
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolver.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
 
 public class IndexAbstractionResolver {
 
@@ -37,8 +37,8 @@ public class IndexAbstractionResolver {
         Iterable<String> indices,
         IndicesOptions indicesOptions,
         Metadata metadata,
-        Supplier<Set<String>> allAuthorizedAndAvailable,
-        Predicate<String> isAuthorized,
+        Function<IndexComponentSelector, Set<String>> allAuthorizedAndAvailableBySelector,
+        BiPredicate<String, IndexComponentSelector> isAuthorized,
         boolean includeDataStreams
     ) {
         List<String> finalIndices = new ArrayList<>();
@@ -64,6 +64,7 @@ public class IndexAbstractionResolver {
                 );
             }
             indexAbstraction = expressionAndSelector.v1();
+            IndexComponentSelector selector = IndexComponentSelector.getByKeyOrThrow(selectorString);
 
             // we always need to check for date math expressions
             indexAbstraction = IndexNameExpressionResolver.resolveDateMathExpression(indexAbstraction);
@@ -71,7 +72,7 @@ public class IndexAbstractionResolver {
             if (indicesOptions.expandWildcardExpressions() && Regex.isSimpleMatchPattern(indexAbstraction)) {
                 wildcardSeen = true;
                 Set<String> resolvedIndices = new HashSet<>();
-                for (String authorizedIndex : allAuthorizedAndAvailable.get()) {
+                for (String authorizedIndex : allAuthorizedAndAvailableBySelector.apply(selector)) {
                     if (Regex.simpleMatch(indexAbstraction, authorizedIndex)
                         && isIndexVisible(
                             indexAbstraction,
@@ -102,7 +103,7 @@ public class IndexAbstractionResolver {
                 resolveSelectorsAndCollect(indexAbstraction, selectorString, indicesOptions, resolvedIndices, metadata);
                 if (minus) {
                     finalIndices.removeAll(resolvedIndices);
-                } else if (indicesOptions.ignoreUnavailable() == false || isAuthorized.test(indexAbstraction)) {
+                } else if (indicesOptions.ignoreUnavailable() == false || isAuthorized.test(indexAbstraction, selector)) {
                     // Unauthorized names are considered unavailable, so if `ignoreUnavailable` is `true` they should be silently
                     // discarded from the `finalIndices` list. Other "ways of unavailable" must be handled by the action
                     // handler, see: https://github.com/elastic/elasticsearch/issues/90215

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Assertions;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.Tuple;
@@ -831,6 +832,14 @@ public class IndexNameExpressionResolver {
         return expression.contains(SelectorResolver.SELECTOR_SEPARATOR);
     }
 
+    public static boolean hasSelector(@Nullable String expression, IndexComponentSelector selector) {
+        Objects.requireNonNull(selector, "null selectors not supported");
+        if (expression == null) {
+            return false;
+        }
+        return expression.endsWith(SelectorResolver.SELECTOR_SEPARATOR + selector.getKey());
+    }
+
     /**
      * @return If the specified string is a selector expression then this method returns the base expression and its selector part.
      */
@@ -850,6 +859,14 @@ public class IndexNameExpressionResolver {
         return selectorExpression == null || IndexComponentSelector.DATA.getKey().equals(selectorExpression)
             ? baseExpression
             : (baseExpression + SelectorResolver.SELECTOR_SEPARATOR + selectorExpression);
+    }
+
+    public static void assertExpressionHasNullOrDataSelector(String expression) {
+        if (Assertions.ENABLED) {
+            var tuple = splitSelectorExpression(expression);
+            assert tuple.v2() == null || IndexComponentSelector.DATA.getKey().equals(tuple.v2())
+                : "Expected expression [" + expression + "] to have a data selector but found [" + tuple.v2() + "]";
+        }
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/IndicesAccessControl.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/IndicesAccessControl.java
@@ -6,13 +6,13 @@
  */
 package org.elasticsearch.xpack.core.security.authz.accesscontrol;
 
+import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.CachedSupplier;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.core.security.authz.IndicesAndAliasesResolverField;
 import org.elasticsearch.xpack.core.security.authz.permission.DocumentPermissions;
 import org.elasticsearch.xpack.core.security.authz.permission.FieldPermissions;
@@ -56,13 +56,15 @@ public class IndicesAccessControl {
     }
 
     /**
-     * @return The document and field permissions for an index if exist, otherwise <code>null</code> is returned.
+     * @return The document and field permissions for an index if they exist, otherwise <code>null</code> is returned.
      *         If <code>null</code> is being returned this means that there are no field or document level restrictions.
      */
     @Nullable
     public IndexAccessControl getIndexPermissions(String index) {
-        Tuple<String, String> indexAndSelector = IndexNameExpressionResolver.splitSelectorExpression(index);
-        return this.getAllIndexPermissions().get(indexAndSelector.v1());
+        assert false == IndexNameExpressionResolver.hasSelectorSuffix(index)
+            || IndexNameExpressionResolver.hasSelector(index, IndexComponentSelector.FAILURES)
+            : "index name [" + index + "] cannot have explicit selector other than ::failures";
+        return getAllIndexPermissions().get(index);
     }
 
     public boolean hasIndexPermissions(String index) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -142,17 +142,33 @@ public final class IndicesPermission {
     }
 
     private IsResourceAuthorizedPredicate buildIndexMatcherPredicateForAction(String action) {
-        final Set<String> ordinaryIndices = new HashSet<>();
-        final Set<String> restrictedIndices = new HashSet<>();
+        final Set<String> dataAccessOrdinaryIndices = new HashSet<>();
+        final Set<String> failuresAccessOrdinaryIndices = new HashSet<>();
+        final Set<String> dataAccessRestrictedIndices = new HashSet<>();
+        final Set<String> failuresAccessRestrictedIndices = new HashSet<>();
         final Set<String> grantMappingUpdatesOnIndices = new HashSet<>();
         final Set<String> grantMappingUpdatesOnRestrictedIndices = new HashSet<>();
         final boolean isMappingUpdateAction = isMappingUpdateAction(action);
         for (final Group group : groups) {
             if (group.actionMatcher.test(action)) {
+                final List<String> indexList = Arrays.asList(group.indices());
+                final boolean dataAccess = group.checkSelector(IndexComponentSelector.DATA);
+                final boolean failuresAccess = group.checkSelector(IndexComponentSelector.FAILURES);
+                assert dataAccess || failuresAccess : "group must grant access at least one of [DATA, FAILURES] selectors";
                 if (group.allowRestrictedIndices) {
-                    restrictedIndices.addAll(Arrays.asList(group.indices()));
+                    if (dataAccess) {
+                        dataAccessRestrictedIndices.addAll(indexList);
+                    }
+                    if (failuresAccess) {
+                        failuresAccessRestrictedIndices.addAll(indexList);
+                    }
                 } else {
-                    ordinaryIndices.addAll(Arrays.asList(group.indices()));
+                    if (dataAccess) {
+                        dataAccessOrdinaryIndices.addAll(indexList);
+                    }
+                    if (failuresAccess) {
+                        failuresAccessOrdinaryIndices.addAll(indexList);
+                    }
                 }
             } else if (isMappingUpdateAction && containsPrivilegeThatGrantsMappingUpdatesForBwc(group)) {
                 // special BWC case for certain privileges: allow put mapping on indices and aliases (but not on data streams), even if
@@ -164,30 +180,44 @@ public final class IndicesPermission {
                 }
             }
         }
-        final StringMatcher nameMatcher = indexMatcher(ordinaryIndices, restrictedIndices);
+        final StringMatcher dataAccessNameMatcher = indexMatcher(dataAccessOrdinaryIndices, dataAccessRestrictedIndices);
+        final StringMatcher failuresAccessNameMatcher = indexMatcher(failuresAccessOrdinaryIndices, failuresAccessRestrictedIndices);
         final StringMatcher bwcSpecialCaseMatcher = indexMatcher(grantMappingUpdatesOnIndices, grantMappingUpdatesOnRestrictedIndices);
-        return new IsResourceAuthorizedPredicate(nameMatcher, bwcSpecialCaseMatcher);
+        return new IsResourceAuthorizedPredicate(dataAccessNameMatcher, failuresAccessNameMatcher, bwcSpecialCaseMatcher);
     }
 
     /**
      * This encapsulates the authorization test for resources.
      * There is an additional test for resources that are missing or that are not a datastream or a backing index.
      */
-    public static class IsResourceAuthorizedPredicate implements BiPredicate<String, IndexAbstraction> {
+    public static class IsResourceAuthorizedPredicate {
 
-        private final BiPredicate<String, IndexAbstraction> biPredicate;
+        private final BiPredicate<String, IndexAbstraction> isAuthorizedForDataAccess;
+        private final BiPredicate<String, IndexAbstraction> isAuthorizedForFailuresAccess;
 
         // public for tests
-        public IsResourceAuthorizedPredicate(StringMatcher resourceNameMatcher, StringMatcher additionalNonDatastreamNameMatcher) {
+        public IsResourceAuthorizedPredicate(
+            StringMatcher dataResourceNameMatcher,
+            StringMatcher failuresResourceNameMatcher,
+            StringMatcher additionalNonDatastreamNameMatcher
+        ) {
             this((String name, @Nullable IndexAbstraction indexAbstraction) -> {
                 assert indexAbstraction == null || name.equals(indexAbstraction.getName());
-                return resourceNameMatcher.test(name)
+                return dataResourceNameMatcher.test(name)
                     || (isPartOfDatastream(indexAbstraction) == false && additionalNonDatastreamNameMatcher.test(name));
+            }, (String name, @Nullable IndexAbstraction indexAbstraction) -> {
+                assert indexAbstraction == null || name.equals(indexAbstraction.getName());
+                // we can't enforce that the abstraction is part of a data stream since we need to account for non-existent resources
+                return failuresResourceNameMatcher.test(name);
             });
         }
 
-        private IsResourceAuthorizedPredicate(BiPredicate<String, IndexAbstraction> biPredicate) {
-            this.biPredicate = biPredicate;
+        private IsResourceAuthorizedPredicate(
+            BiPredicate<String, IndexAbstraction> isAuthorizedForDataAccess,
+            BiPredicate<String, IndexAbstraction> isAuthorizedForFailuresAccess
+        ) {
+            this.isAuthorizedForDataAccess = isAuthorizedForDataAccess;
+            this.isAuthorizedForFailuresAccess = isAuthorizedForFailuresAccess;
         }
 
         /**
@@ -195,18 +225,25 @@ public final class IndicesPermission {
         * return a new {@link IsResourceAuthorizedPredicate} instance that is equivalent to the conjunction of
         * authorization tests of that other instance and this one.
         */
-        @Override
-        public final IsResourceAuthorizedPredicate and(BiPredicate<? super String, ? super IndexAbstraction> other) {
-            return new IsResourceAuthorizedPredicate(this.biPredicate.and(other));
+        public final IsResourceAuthorizedPredicate and(IsResourceAuthorizedPredicate other) {
+            return new IsResourceAuthorizedPredicate(
+                this.isAuthorizedForDataAccess.and(other.isAuthorizedForDataAccess),
+                this.isAuthorizedForFailuresAccess.and(other.isAuthorizedForFailuresAccess)
+            );
+        }
+
+        // TODO remove me (this has >700 usages in tests which would make for a horrible diff; will remove this once the main PR is merged)
+        public boolean test(IndexAbstraction indexAbstraction) {
+            return test(indexAbstraction.getName(), indexAbstraction, IndexComponentSelector.DATA);
         }
 
         /**
          * Verifies if access is authorized to the given {@param indexAbstraction} resource.
-         * The resource must exist. Otherwise, use the {@link #test(String, IndexAbstraction)} method.
+         * The resource must exist. Otherwise, use the {@link #test(String, IndexAbstraction, IndexComponentSelector)} method.
          * Returns {@code true} if access to the given resource is authorized or {@code false} otherwise.
          */
-        public final boolean test(IndexAbstraction indexAbstraction) {
-            return test(indexAbstraction.getName(), indexAbstraction);
+        public boolean test(IndexAbstraction indexAbstraction, IndexComponentSelector selector) {
+            return test(indexAbstraction.getName(), indexAbstraction, selector);
         }
 
         /**
@@ -215,9 +252,10 @@ public final class IndicesPermission {
          * if it doesn't.
          * Returns {@code true} if access to the given resource is authorized or {@code false} otherwise.
          */
-        @Override
-        public boolean test(String name, @Nullable IndexAbstraction indexAbstraction) {
-            return biPredicate.test(name, indexAbstraction);
+        public boolean test(String name, @Nullable IndexAbstraction indexAbstraction, IndexComponentSelector selector) {
+            return IndexComponentSelector.FAILURES.equals(selector)
+                ? isAuthorizedForFailuresAccess.test(name, indexAbstraction)
+                : isAuthorizedForDataAccess.test(name, indexAbstraction);
         }
 
         private static boolean isPartOfDatastream(IndexAbstraction indexAbstraction) {
@@ -283,6 +321,7 @@ public final class IndicesPermission {
             combineIndexGroups && checkForIndexPatterns.stream().anyMatch(Automatons::isLuceneRegex)
         );
         for (String forIndexPattern : checkForIndexPatterns) {
+            IndexNameExpressionResolver.assertExpressionHasNullOrDataSelector(forIndexPattern);
             Automaton checkIndexAutomaton = Automatons.patterns(forIndexPattern);
             if (false == allowRestrictedIndices && false == isConcreteRestrictedIndex(forIndexPattern)) {
                 checkIndexAutomaton = Automatons.minusAndMinimize(checkIndexAutomaton, restrictedIndices.getAutomaton());
@@ -338,9 +377,12 @@ public final class IndicesPermission {
     }
 
     public Automaton allowedActionsMatcher(String index) {
+        Tuple<String, String> tuple = IndexNameExpressionResolver.splitSelectorExpression(index);
+        String indexName = tuple.v1();
+        IndexComponentSelector selector = IndexComponentSelector.getByKey(tuple.v2());
         List<Automaton> automatonList = new ArrayList<>();
         for (Group group : groups) {
-            if (group.indexNameMatcher.test(index)) {
+            if (group.checkSelector(selector) && group.indexNameMatcher.test(indexName)) {
                 automatonList.add(group.privilege.getAutomaton());
             }
         }
@@ -373,15 +415,6 @@ public final class IndicesPermission {
             assert name != null : "Resource name cannot be null";
             assert abstraction == null || abstraction.getName().equals(name)
                 : "Index abstraction has unexpected name [" + abstraction.getName() + "] vs [" + name + "]";
-            assert abstraction == null
-                || selector == null
-                || IndexComponentSelector.FAILURES.equals(selector) == false
-                || abstraction.isDataStreamRelated()
-                : "Invalid index component selector ["
-                    + selector.getKey()
-                    + "] applied to abstraction of type ["
-                    + abstraction.getType()
-                    + "]";
             this.name = name;
             this.indexAbstraction = abstraction;
             this.selector = selector;
@@ -411,11 +444,19 @@ public final class IndicesPermission {
         public boolean checkIndex(Group group) {
             final DataStream ds = indexAbstraction == null ? null : indexAbstraction.getParentDataStream();
             if (ds != null) {
-                if (group.checkIndex(ds.getName())) {
-                    return true;
-                }
+                if (indexAbstraction.isFailureIndexOfDataStream()) {
+                    // failure indices are special: when accessed directly (not through ::failures on parent data stream) they are accessed
+                    // implicitly as data. However, authz to the parent data stream happens via the failures selector
+                    if (group.checkSelector(IndexComponentSelector.FAILURES) && group.checkIndex(ds.getName())) {
+                        return true;
+                    }
+                } else if (IndexComponentSelector.DATA.equals(selector) || selector == null) {
+                    if (group.checkSelector(IndexComponentSelector.DATA) && group.checkIndex(ds.getName())) {
+                        return true;
+                    }
+                } // we don't support granting access to a backing index with a failure selector via the parent data stream
             }
-            return group.checkIndex(name);
+            return group.checkSelector(selector) && group.checkIndex(name);
         }
 
         /**
@@ -478,6 +519,13 @@ public final class IndicesPermission {
         public boolean canHaveBackingIndices() {
             return indexAbstraction != null && indexAbstraction.getType() != IndexAbstraction.Type.CONCRETE_INDEX;
         }
+
+        public String nameWithSelector() {
+            String combined = IndexNameExpressionResolver.combineSelector(name, selector);
+            assert false != IndexComponentSelector.FAILURES.equals(selector) || name.equals(combined)
+                : "Only failures selectors should result in explicit selectors suffix";
+            return combined;
+        }
     }
 
     /**
@@ -500,18 +548,20 @@ public final class IndicesPermission {
         int totalResourceCount = 0;
         Map<String, IndexAbstraction> lookup = metadata.getIndicesLookup();
         for (String indexOrAlias : requestedIndicesOrAliases) {
-            // Remove any selectors from abstraction name. Discard them for this check as we do not have access control for them (yet)
+            // Remove any selectors from abstraction name. Access control is based on the `selector` field of the IndexResource
             Tuple<String, String> expressionAndSelector = IndexNameExpressionResolver.splitSelectorExpression(indexOrAlias);
             indexOrAlias = expressionAndSelector.v1();
             IndexComponentSelector selector = expressionAndSelector.v2() == null
                 ? null
                 : IndexComponentSelector.getByKey(expressionAndSelector.v2());
             final IndexResource resource = new IndexResource(indexOrAlias, lookup.get(indexOrAlias), selector);
-            resources.put(resource.name, resource);
+            // We can't use resource.name here because we may be accessing a data stream _and_ its failure store,
+            // where the selector-free name is the same for both and thus ambiguous.
+            resources.put(resource.nameWithSelector(), resource);
             totalResourceCount += resource.size(lookup);
         }
 
-        final boolean overallGranted = isActionGranted(action, resources);
+        final boolean overallGranted = isActionGranted(action, resources.values());
         final int finalTotalResourceCount = totalResourceCount;
         final Supplier<Map<String, IndicesAccessControl.IndexAccessControl>> indexPermissions = () -> buildIndicesAccessControl(
             action,
@@ -540,10 +590,11 @@ public final class IndicesPermission {
 
         final boolean isMappingUpdateAction = isMappingUpdateAction(action);
 
-        for (IndexResource resource : requestedResources.values()) {
+        for (Map.Entry<String, IndexResource> resourceEntry : requestedResources.entrySet()) {
             // true if ANY group covers the given index AND the given action
             boolean granted = false;
-
+            final String resourceName = resourceEntry.getKey();
+            final IndexResource resource = resourceEntry.getValue();
             final Collection<String> concreteIndices = resource.resolveConcreteIndices(metadata);
             for (Group group : groups) {
                 // the group covers the given index OR the given index is a backing index and the group covers the parent data stream
@@ -590,9 +641,9 @@ public final class IndicesPermission {
                                 roleQueriesByIndex.put(index, docPermissions);
                             }
 
-                            if (index.equals(resource.name) == false) {
-                                fieldPermissionsByIndex.put(resource.name, fieldPermissions);
-                                roleQueriesByIndex.put(resource.name, docPermissions);
+                            if (index.equals(resourceName) == false) {
+                                fieldPermissionsByIndex.put(resourceName, fieldPermissions);
+                                roleQueriesByIndex.put(resourceName, docPermissions);
                             }
                         }
                     }
@@ -600,10 +651,11 @@ public final class IndicesPermission {
             }
 
             if (granted) {
-                grantedResources.add(resource.name);
+                grantedResources.add(resourceName);
+
                 if (resource.canHaveBackingIndices()) {
                     for (String concreteIndex : concreteIndices) {
-                        // If the name appear directly as part of the requested indices, it takes precedence over implicit access
+                        // If the name appears directly as part of the requested indices, it takes precedence over implicit access
                         if (false == requestedResources.containsKey(concreteIndex)) {
                             grantedResources.add(concreteIndex);
                         }
@@ -639,11 +691,11 @@ public final class IndicesPermission {
      * Returns {@code true} if action is granted for all {@code requestedResources}.
      * If action is not granted for at least one resource, this method will return {@code false}.
      */
-    private boolean isActionGranted(final String action, final Map<String, IndexResource> requestedResources) {
+    private boolean isActionGranted(final String action, final Collection<IndexResource> requestedResources) {
 
         final boolean isMappingUpdateAction = isMappingUpdateAction(action);
 
-        for (IndexResource resource : requestedResources.values()) {
+        for (IndexResource resource : requestedResources) {
             // true if ANY group covers the given index AND the given action
             boolean granted = false;
             // true if ANY group, which contains certain ingest privileges, covers the given index AND the action is a mapping update for
@@ -758,6 +810,11 @@ public final class IndicesPermission {
         // Map of privilege automaton object references (cached by IndexPrivilege::CACHE)
         Map<Automaton, Automaton> allAutomatons = new HashMap<>();
         for (Group group : groups) {
+            // TODO support failure store privileges
+            // we also check that the group does not support data access to avoid erroneously filtering out `all` privilege groups
+            if (group.checkSelector(IndexComponentSelector.FAILURES) && false == group.checkSelector(IndexComponentSelector.DATA)) {
+                continue;
+            }
             Automaton indexAutomaton = group.getIndexMatcherAutomaton();
             allAutomatons.compute(
                 group.privilege().getAutomaton(),
@@ -864,8 +921,8 @@ public final class IndicesPermission {
             return query != null;
         }
 
-        public boolean checkSelector(IndexComponentSelector selector) {
-            return selectorPredicate.test(selector);
+        public boolean checkSelector(@Nullable IndexComponentSelector selector) {
+            return selectorPredicate.test(selector == null ? IndexComponentSelector.DATA : selector);
         }
 
         public boolean allowRestrictedIndices() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.downsample.DownsampleAction;
 import org.elasticsearch.action.index.TransportIndexAction;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.search.TransportSearchScrollAction;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.frozen.action.FreezeIndexAction;
@@ -247,12 +248,25 @@ public class InternalUsers {
         new RoleDescriptor(
             UsernamesField.LAZY_ROLLOVER_ROLE,
             new String[] {},
-            new RoleDescriptor.IndicesPrivileges[] {
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("*")
-                    .privileges(LazyRolloverAction.NAME)
-                    .allowRestrictedIndices(true)
-                    .build() },
+            DataStream.isFailureStoreFeatureFlagEnabled()
+                ? new RoleDescriptor.IndicesPrivileges[] {
+                    RoleDescriptor.IndicesPrivileges.builder()
+                        .indices("*")
+                        .privileges(LazyRolloverAction.NAME)
+                        .allowRestrictedIndices(true)
+                        .build(),
+                    RoleDescriptor.IndicesPrivileges.builder()
+                        .indices("*")
+                        // needed to rollover failure store
+                        .privileges("manage_failure_store")
+                        .allowRestrictedIndices(true)
+                        .build() }
+                : new RoleDescriptor.IndicesPrivileges[] {
+                    RoleDescriptor.IndicesPrivileges.builder()
+                        .indices("*")
+                        .privileges(LazyRolloverAction.NAME)
+                        .allowRestrictedIndices(true)
+                        .build(), },
             null,
             null,
             new String[] {},

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/profile/ProfileHasPrivilegesRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/profile/ProfileHasPrivilegesRequestTests.java
@@ -18,6 +18,8 @@ import org.elasticsearch.xpack.core.security.authz.privilege.IndexPrivilege;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
@@ -134,11 +136,18 @@ public class ProfileHasPrivilegesRequestTests extends AbstractWireSerializingTes
         )];
         for (int i = 0; i < indicesPrivileges.length; i++) {
             indicesPrivileges[i] = RoleDescriptor.IndicesPrivileges.builder()
-                .privileges(randomSubsetOf(randomIntBetween(1, 5), IndexPrivilege.names()))
+                .privileges(randomSubsetOf(randomIntBetween(1, 5), validPrivilegeNames()))
                 .indices(randomList(1, 3, () -> randomAlphaOfLengthBetween(2, 8) + (randomBoolean() ? "*" : "")))
                 .build();
         }
         return indicesPrivileges;
+    }
+
+    private static Set<String> validPrivilegeNames() {
+        return IndexPrivilege.names()
+            .stream()
+            .filter(name -> false == name.equals("read_failure_store") && false == name.equals("manage_failure_store"))
+            .collect(Collectors.toSet());
     }
 
     private static RoleDescriptor.ApplicationResourcePrivileges[] randomApplicationResourcePrivileges(boolean allowEmpty) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRoleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRoleTests.java
@@ -509,22 +509,22 @@ public class LimitedRoleTests extends ESTestCase {
 
     public void testAllowedIndicesMatcher() {
         Role fromRole = Role.builder(EMPTY_RESTRICTED_INDICES, "a-role").add(IndexPrivilege.READ, "ind-1*").build();
-        assertThat(fromRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1")), is(true));
-        assertThat(fromRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-11")), is(true));
-        assertThat(fromRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2")), is(false));
+        assertThat(fromRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1"), null), is(true));
+        assertThat(fromRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-11"), null), is(true));
+        assertThat(fromRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2"), null), is(false));
 
         {
             Role limitedByRole = Role.builder(EMPTY_RESTRICTED_INDICES, "limited-role").add(IndexPrivilege.READ, "ind-1", "ind-2").build();
             assertThat(
-                limitedByRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1")),
+                limitedByRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1"), null),
                 is(true)
             );
             assertThat(
-                limitedByRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-11")),
+                limitedByRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-11"), null),
                 is(false)
             );
             assertThat(
-                limitedByRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2")),
+                limitedByRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2"), null),
                 is(true)
             );
             Role role;
@@ -533,18 +533,18 @@ public class LimitedRoleTests extends ESTestCase {
             } else {
                 role = fromRole.limitedBy(limitedByRole);
             }
-            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1")), is(true));
-            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-11")), is(false));
-            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2")), is(false));
+            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1"), null), is(true));
+            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-11"), null), is(false));
+            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2"), null), is(false));
         }
         {
             Role limitedByRole = Role.builder(EMPTY_RESTRICTED_INDICES, "limited-role").add(IndexPrivilege.READ, "ind-*").build();
             assertThat(
-                limitedByRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1")),
+                limitedByRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1"), null),
                 is(true)
             );
             assertThat(
-                limitedByRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2")),
+                limitedByRole.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2"), null),
                 is(true)
             );
             Role role;
@@ -553,16 +553,16 @@ public class LimitedRoleTests extends ESTestCase {
             } else {
                 role = fromRole.limitedBy(limitedByRole);
             }
-            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1")), is(true));
-            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2")), is(false));
+            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1"), null), is(true));
+            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2"), null), is(false));
         }
     }
 
     public void testAllowedIndicesMatcherWithNestedRole() {
         Role role = Role.builder(EMPTY_RESTRICTED_INDICES, "a-role").add(IndexPrivilege.READ, "ind-1*").build();
-        assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1")), is(true));
-        assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-11")), is(true));
-        assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2")), is(false));
+        assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1"), null), is(true));
+        assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-11"), null), is(true));
+        assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2"), null), is(false));
 
         final int depth = randomIntBetween(2, 4);
         boolean index11Excluded = false;
@@ -578,12 +578,12 @@ public class LimitedRoleTests extends ESTestCase {
             } else {
                 role = role.limitedBy(limitedByRole);
             }
-            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1")), is(true));
+            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-1"), null), is(true));
             assertThat(
-                role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-11")),
+                role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-11"), null),
                 is(false == index11Excluded)
             );
-            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2")), is(false));
+            assertThat(role.allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(mockIndexAbstraction("ind-2"), null), is(false));
         }
     }
 
@@ -624,6 +624,101 @@ public class LimitedRoleTests extends ESTestCase {
         rolePredicate = Automatons.predicate(roleAutomaton);
         assertThat(rolePredicate.test(TransportSearchAction.TYPE.name()), is(false));
         assertThat(rolePredicate.test(TransportBulkAction.NAME), is(false));
+    }
+
+    public void testAllowedActionsMatcherWithSelectors() {
+        Role fromRole = Role.builder(EMPTY_RESTRICTED_INDICES, "fromRole")
+            .add(IndexPrivilege.READ_FAILURE_STORE, "ind*")
+            .add(IndexPrivilege.READ, "ind*")
+            .add(IndexPrivilege.READ_FAILURE_STORE, "metric")
+            .add(IndexPrivilege.READ, "logs")
+            .build();
+        Automaton fromRoleAutomaton = fromRole.allowedActionsMatcher("index1");
+        Predicate<String> fromRolePredicate = Automatons.predicate(fromRoleAutomaton);
+        assertThat(fromRolePredicate.test(TransportSearchAction.TYPE.name()), is(true));
+
+        fromRoleAutomaton = fromRole.allowedActionsMatcher("index1::failures");
+        fromRolePredicate = Automatons.predicate(fromRoleAutomaton);
+        assertThat(fromRolePredicate.test(TransportSearchAction.TYPE.name()), is(true));
+
+        fromRoleAutomaton = fromRole.allowedActionsMatcher("metric");
+        fromRolePredicate = Automatons.predicate(fromRoleAutomaton);
+        assertThat(fromRolePredicate.test(TransportSearchAction.TYPE.name()), is(false));
+
+        fromRoleAutomaton = fromRole.allowedActionsMatcher("metric::failures");
+        fromRolePredicate = Automatons.predicate(fromRoleAutomaton);
+        assertThat(fromRolePredicate.test(TransportSearchAction.TYPE.name()), is(true));
+
+        fromRoleAutomaton = fromRole.allowedActionsMatcher("logs");
+        fromRolePredicate = Automatons.predicate(fromRoleAutomaton);
+        assertThat(fromRolePredicate.test(TransportSearchAction.TYPE.name()), is(true));
+
+        fromRoleAutomaton = fromRole.allowedActionsMatcher("logs::failures");
+        fromRolePredicate = Automatons.predicate(fromRoleAutomaton);
+        assertThat(fromRolePredicate.test(TransportSearchAction.TYPE.name()), is(false));
+
+        Role limitedByRole = Role.builder(EMPTY_RESTRICTED_INDICES, "limitedRole")
+            .add(IndexPrivilege.READ, "index1", "index2")
+            .add(IndexPrivilege.READ_FAILURE_STORE, "index3")
+            .build();
+        Automaton limitedByRoleAutomaton = limitedByRole.allowedActionsMatcher("index1");
+        Predicate<String> limitedByRolePredicated = Automatons.predicate(limitedByRoleAutomaton);
+        assertThat(limitedByRolePredicated.test(TransportSearchAction.TYPE.name()), is(true));
+
+        limitedByRoleAutomaton = limitedByRole.allowedActionsMatcher("index1");
+        limitedByRolePredicated = Automatons.predicate(limitedByRoleAutomaton);
+        assertThat(limitedByRolePredicated.test(TransportSearchAction.TYPE.name()), is(true));
+
+        limitedByRoleAutomaton = limitedByRole.allowedActionsMatcher("index1::failures");
+        limitedByRolePredicated = Automatons.predicate(limitedByRoleAutomaton);
+        assertThat(limitedByRolePredicated.test(TransportSearchAction.TYPE.name()), is(false));
+
+        limitedByRoleAutomaton = limitedByRole.allowedActionsMatcher("index3");
+        limitedByRolePredicated = Automatons.predicate(limitedByRoleAutomaton);
+        assertThat(limitedByRolePredicated.test(TransportSearchAction.TYPE.name()), is(false));
+
+        limitedByRoleAutomaton = limitedByRole.allowedActionsMatcher("index3::failures");
+        limitedByRolePredicated = Automatons.predicate(limitedByRoleAutomaton);
+        assertThat(limitedByRolePredicated.test(TransportSearchAction.TYPE.name()), is(true));
+
+        Role role;
+        if (randomBoolean()) {
+            role = limitedByRole.limitedBy(fromRole);
+        } else {
+            role = fromRole.limitedBy(limitedByRole);
+        }
+
+        Automaton roleAutomaton = role.allowedActionsMatcher("index1");
+        Predicate<String> rolePredicate = Automatons.predicate(roleAutomaton);
+        assertThat(rolePredicate.test(TransportSearchAction.TYPE.name()), is(true));
+
+        roleAutomaton = role.allowedActionsMatcher("index1::failures");
+        rolePredicate = Automatons.predicate(roleAutomaton);
+        assertThat(rolePredicate.test(TransportSearchAction.TYPE.name()), is(false));
+
+        roleAutomaton = role.allowedActionsMatcher("index3");
+        rolePredicate = Automatons.predicate(roleAutomaton);
+        assertThat(rolePredicate.test(TransportSearchAction.TYPE.name()), is(false));
+
+        roleAutomaton = role.allowedActionsMatcher("index3::failures");
+        rolePredicate = Automatons.predicate(roleAutomaton);
+        assertThat(rolePredicate.test(TransportSearchAction.TYPE.name()), is(true));
+
+        roleAutomaton = role.allowedActionsMatcher("metric");
+        rolePredicate = Automatons.predicate(roleAutomaton);
+        assertThat(rolePredicate.test(TransportSearchAction.TYPE.name()), is(false));
+
+        roleAutomaton = role.allowedActionsMatcher("metric::failures");
+        rolePredicate = Automatons.predicate(roleAutomaton);
+        assertThat(rolePredicate.test(TransportSearchAction.TYPE.name()), is(false));
+
+        roleAutomaton = role.allowedActionsMatcher("logs");
+        rolePredicate = Automatons.predicate(roleAutomaton);
+        assertThat(rolePredicate.test(TransportSearchAction.TYPE.name()), is(false));
+
+        roleAutomaton = role.allowedActionsMatcher("logs::failures");
+        rolePredicate = Automatons.predicate(roleAutomaton);
+        assertThat(rolePredicate.test(TransportSearchAction.TYPE.name()), is(false));
     }
 
     public void testCheckClusterPrivilege() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
@@ -376,7 +376,7 @@ public class InternalUsersTests extends ESTestCase {
         final IndexAbstraction.ConcreteIndex index = new IndexAbstraction.ConcreteIndex(metadata);
         assertThat(
             "Role " + role + ", action " + action + " access to " + indexName,
-            role.allowedIndicesMatcher(action).test(index),
+            role.allowedIndicesMatcher(action).test(index, null),
             is(expectedValue)
         );
     }

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata.DownsampleTaskStatus;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
@@ -204,7 +205,8 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
     ) {
         long startTime = client.threadPool().relativeTimeInMillis();
         String sourceIndexName = request.getSourceIndex();
-
+        IndexNameExpressionResolver.assertExpressionHasNullOrDataSelector(sourceIndexName);
+        IndexNameExpressionResolver.assertExpressionHasNullOrDataSelector(request.getTargetIndex());
         final IndicesAccessControl indicesAccessControl = threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
         if (indicesAccessControl != null) {
             final IndicesAccessControl.IndexAccessControl indexPermissions = indicesAccessControl.getIndexPermissions(sourceIndexName);

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
@@ -7,25 +7,56 @@
 
 package org.elasticsearch.xpack.security.failurestore;
 
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchResponseUtils;
+import org.elasticsearch.test.TestSecurityClient;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.SecurityOnTrialLicenseRestTestCase;
+import org.junit.Before;
 import org.junit.ClassRule;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class FailureStoreSecurityRestIT extends ESRestTestCase {
+
+    private TestSecurityClient securityClient;
+
+    private Map<String, String> apiKeys = new HashMap<>();
 
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
@@ -44,17 +75,38 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
-    public void testGetUserPrivileges() throws IOException {
-        Request userRequest = new Request("PUT", "/_security/user/user");
-        userRequest.setJsonEntity("""
-            {
-              "password": "x-pack-test-password",
-              "roles": ["role"]
-            }
-            """);
-        assertOK(adminClient().performRequest(userRequest));
+    private static final String ASYNC_SEARCH_TIMEOUT = "30s";
 
-        putRole("""
+    private static final String ADMIN_USER = "admin_user";
+
+    private static final String DATA_ACCESS = "data_access";
+    private static final String BACKING_INDEX_DATA_ACCESS = "backing_index_data_access";
+    private static final String BACKING_INDEX_FAILURE_ACCESS = "backing_index_failure_access";
+    private static final String FAILURE_INDEX_DATA_ACCESS = "failure_index_data_access";
+    private static final String FAILURE_INDEX_FAILURE_ACCESS = "failure_index_failure_access";
+    private static final String STAR_READ_ONLY_ACCESS = "star_read_only";
+    private static final String FAILURE_STORE_ACCESS = "failure_store_access";
+    private static final String BOTH_ACCESS = "both_access";
+    private static final String WRITE_ACCESS = "write_access";
+    private static final String MANAGE_ACCESS = "manage_access";
+    private static final String MANAGE_FAILURE_STORE_ACCESS = "manage_failure_store_access";
+    private static final SecureString PASSWORD = new SecureString("admin-password");
+
+    @Before
+    public void setup() throws IOException {
+        apiKeys = new HashMap<>();
+        createUser(WRITE_ACCESS, PASSWORD, WRITE_ACCESS);
+        upsertRole(Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [{"names": ["test*"], "privileges": ["write", "auto_configure"]}]
+            }"""), WRITE_ACCESS);
+    }
+
+    public void testGetUserPrivileges() throws IOException {
+        createUser("user", PASSWORD, "role");
+
+        upsertRole("""
             {
               "cluster": ["all"],
               "indices": [
@@ -64,7 +116,7 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
                 }
               ]
             }
-            """);
+            """, "role");
         expectUserPrivilegesResponse("""
             {
               "cluster": ["all"],
@@ -83,7 +135,7 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
               "run_as": []
             }""");
 
-        putRole("""
+        upsertRole("""
             {
               "cluster": ["all"],
               "indices": [
@@ -93,7 +145,7 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
                 }
               ]
             }
-            """);
+            """, "role");
         expectUserPrivilegesResponse("""
             {
               "cluster": ["all"],
@@ -108,7 +160,7 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
               "run_as": []
             }""");
 
-        putRole("""
+        upsertRole("""
             {
               "cluster": ["all"],
               "indices": [
@@ -118,7 +170,7 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
                 }
               ]
             }
-            """);
+            """, "role");
         expectUserPrivilegesResponse("""
             {
               "cluster": ["all"],
@@ -132,27 +184,1647 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
               "applications": [],
               "run_as": []
             }""");
+
+        upsertRole("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["*"],
+                  "privileges": ["read", "read_failure_store"]
+                },
+                {
+                  "names": ["*"],
+                  "privileges": ["write", "manage_failure_store"]
+                }
+              ]
+            }
+            """, "role");
+        expectUserPrivilegesResponse("""
+            {
+              "cluster": ["all"],
+              "global": [],
+              "indices": [
+                {
+                  "names": ["*"],
+                  "privileges": ["read", "write"],
+                  "allow_restricted_indices": false
+                },
+                {
+                  "names": ["*"],
+                  "privileges": ["manage_failure_store", "read_failure_store"],
+                  "allow_restricted_indices": false
+                }],
+              "applications": [],
+              "run_as": []
+            }""");
+    }
+
+    public void testRoleWithSelectorInIndexPattern() throws Exception {
+        setupDataStream();
+
+        createUser("user", PASSWORD, "role");
+        upsertRole("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["*::failures"],
+                  "privileges": ["read"]
+                }
+              ]
+            }""", "role");
+        createAndStoreApiKey("user", null);
+
+        expectThrows("user", new Search("test1::failures"), 403);
+        expectSearch("user", new Search("*::failures"));
+
+        upsertRole("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["test1::failures"],
+                  "privileges": ["read"]
+                }
+              ]
+            }""", "role");
+
+        expectThrows("user", new Search("test1::failures"), 403);
+        expectSearch("user", new Search("*::failures"));
+
+        upsertRole("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["*::failures"],
+                  "privileges": ["read_failure_store"]
+                }
+              ]
+            }""", "role");
+        expectThrows("user", new Search("test1::failures"), 403);
+        expectSearch("user", new Search("*::failures"));
+
+        upsertRole("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["test1::failures"],
+                  "privileges": ["read_failure_store"]
+                }
+              ]
+            }""", "role");
+        expectThrows("user", new Search("test1::failures"), 403);
+        expectSearch("user", new Search("*::failures"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testFailureStoreAccess() throws Exception {
+        List<String> docIds = setupDataStream();
+        assertThat(docIds.size(), equalTo(2));
+        assertThat(docIds, hasItem("1"));
+        String dataDocId = "1";
+        String failuresDocId = docIds.stream().filter(id -> false == id.equals(dataDocId)).findFirst().get();
+
+        Tuple<String, String> backingIndices = getSingleDataAndFailureIndices("test1");
+        String dataIndexName = backingIndices.v1();
+        String failureIndexName = backingIndices.v2();
+
+        createUser(DATA_ACCESS, PASSWORD, DATA_ACCESS);
+        upsertRole(Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [{"names": ["test*"], "privileges": ["read"]}]
+            }"""), DATA_ACCESS);
+        createAndStoreApiKey(DATA_ACCESS, randomBoolean() ? null : """
+            {
+              "role": {
+                "cluster": ["all"],
+                "indices": [{"names": ["test*"], "privileges": ["read"]}]
+              }
+            }
+            """);
+
+        createUser(STAR_READ_ONLY_ACCESS, PASSWORD, STAR_READ_ONLY_ACCESS);
+        upsertRole(Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [{"names": ["*"], "privileges": ["read"]}]
+            }"""), STAR_READ_ONLY_ACCESS);
+        createAndStoreApiKey(STAR_READ_ONLY_ACCESS, randomBoolean() ? null : """
+            {
+              "role": {
+                "cluster": ["all"],
+                "indices": [{"names": ["*"], "privileges": ["read"]}]
+              }
+            }
+            """);
+
+        createUser(FAILURE_STORE_ACCESS, PASSWORD, FAILURE_STORE_ACCESS);
+        upsertRole(Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [{"names": ["test*"], "privileges": ["read_failure_store"]}]
+            }"""), FAILURE_STORE_ACCESS);
+        createAndStoreApiKey(FAILURE_STORE_ACCESS, randomBoolean() ? null : """
+            {
+              "role": {
+                "cluster": ["all"],
+                "indices": [{"names": ["test*"], "privileges": ["read_failure_store"]}]
+              }
+            }
+            """);
+
+        if (randomBoolean()) {
+            createUser(BOTH_ACCESS, PASSWORD, BOTH_ACCESS);
+            upsertRole(Strings.format("""
+                {
+                  "cluster": ["all"],
+                  "indices": [{"names": ["test*"], "privileges": ["read", "read_failure_store"]}]
+                }"""), BOTH_ACCESS);
+            createAndStoreApiKey(BOTH_ACCESS, randomBoolean() ? null : """
+                {
+                  "role": {
+                    "cluster": ["all"],
+                    "indices": [{"names": ["test*"], "privileges": ["read", "read_failure_store"]}]
+                  }
+                }
+                """);
+        } else {
+            createUser(BOTH_ACCESS, PASSWORD, DATA_ACCESS, FAILURE_STORE_ACCESS);
+            createAndStoreApiKey(BOTH_ACCESS, randomBoolean() ? null : """
+                {
+                  "role": {
+                    "cluster": ["all"],
+                    "indices": [{"names": ["test*"], "privileges": ["read", "read_failure_store"]}]
+                  }
+                }
+                """);
+        }
+
+        createAndStoreApiKey(WRITE_ACCESS, randomBoolean() ? null : """
+            {
+              "role": {
+                "cluster": ["all"],
+                "indices": [{"names": ["test*"], "privileges": ["write", "auto_configure"]}]
+              }
+            }
+            """);
+
+        createUser(BACKING_INDEX_DATA_ACCESS, PASSWORD, BACKING_INDEX_DATA_ACCESS);
+        upsertRole(Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [{"names": ["%s"], "privileges": ["read"]}]
+            }""", dataIndexName), BACKING_INDEX_DATA_ACCESS);
+        createAndStoreApiKey(BACKING_INDEX_DATA_ACCESS, null);
+
+        createUser(BACKING_INDEX_FAILURE_ACCESS, PASSWORD, BACKING_INDEX_FAILURE_ACCESS);
+        upsertRole(Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [{"names": ["%s"], "privileges": ["read_failure_store"]}]
+            }""", dataIndexName), BACKING_INDEX_FAILURE_ACCESS);
+        createAndStoreApiKey(BACKING_INDEX_FAILURE_ACCESS, null);
+
+        createUser(FAILURE_INDEX_DATA_ACCESS, PASSWORD, FAILURE_INDEX_DATA_ACCESS);
+        upsertRole(Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [{"names": ["%s"], "privileges": ["read"]}]
+            }""", failureIndexName), FAILURE_INDEX_DATA_ACCESS);
+        createAndStoreApiKey(FAILURE_INDEX_DATA_ACCESS, null);
+
+        createUser(FAILURE_INDEX_FAILURE_ACCESS, PASSWORD, FAILURE_INDEX_FAILURE_ACCESS);
+        upsertRole(Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [{"names": ["%s"], "privileges": ["read_failure_store"]}]
+            }""", failureIndexName), FAILURE_INDEX_FAILURE_ACCESS);
+        createAndStoreApiKey(FAILURE_INDEX_FAILURE_ACCESS, null);
+
+        Request aliasRequest = new Request("POST", "/_aliases");
+        aliasRequest.setJsonEntity("""
+            {
+              "actions": [
+                {
+                  "add": {
+                    "index": "test1",
+                    "alias": "test-alias"
+                  }
+                }
+              ]
+            }
+            """);
+        assertOK(adminClient().performRequest(aliasRequest));
+
+        List<String> users = List.of(
+            DATA_ACCESS,
+            FAILURE_STORE_ACCESS,
+            STAR_READ_ONLY_ACCESS,
+            BOTH_ACCESS,
+            ADMIN_USER,
+            BACKING_INDEX_DATA_ACCESS,
+            BACKING_INDEX_FAILURE_ACCESS,
+            FAILURE_INDEX_DATA_ACCESS,
+            FAILURE_INDEX_FAILURE_ACCESS
+        );
+
+        // search data
+        {
+            var request = new Search(randomFrom("test1::data", "test1"));
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test1", "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test-alias");
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test-alias", "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test*");
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("*1");
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        // note expand_wildcards does not include hidden here
+        for (var request : List.of(new Search("*"), new Search("_all"), new Search(""))) {
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS,
+                        BACKING_INDEX_DATA_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(".ds*");
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, BACKING_INDEX_DATA_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(dataIndexName);
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, BACKING_INDEX_DATA_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(dataIndexName, "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, BACKING_INDEX_DATA_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test2");
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS:
+                        expectThrows(user, request, 404);
+                        break;
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_DATA_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test2", "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, FAILURE_STORE_ACCESS, BACKING_INDEX_DATA_ACCESS,
+                        BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+
+        // search failures
+        {
+            var request = new Search("test1::failures");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    case ADMIN_USER, FAILURE_STORE_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test1::failures", "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    case ADMIN_USER, FAILURE_STORE_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test-alias::failures");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    case ADMIN_USER, FAILURE_STORE_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test-alias::failures", "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    case ADMIN_USER, FAILURE_STORE_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test*::failures");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    case ADMIN_USER, FAILURE_STORE_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("*1::failures");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    case ADMIN_USER, FAILURE_STORE_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("*::failures");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    case ADMIN_USER, FAILURE_STORE_ACCESS, BOTH_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(".fs*");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    case ADMIN_USER, FAILURE_STORE_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(failureIndexName);
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    case ADMIN_USER, FAILURE_STORE_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(failureIndexName, "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    case ADMIN_USER, FAILURE_STORE_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(failureIndexName + "::failures");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_DATA_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    case FAILURE_STORE_ACCESS, BOTH_ACCESS, ADMIN_USER, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectThrows(user, request, 404);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(failureIndexName + "::failures", "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, FAILURE_STORE_ACCESS, ADMIN_USER, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, BACKING_INDEX_DATA_ACCESS,
+                        BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(dataIndexName + "::failures");
+            for (var user : users) {
+                switch (user) {
+                    case STAR_READ_ONLY_ACCESS, BOTH_ACCESS, DATA_ACCESS, FAILURE_STORE_ACCESS, FAILURE_INDEX_DATA_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS, BACKING_INDEX_DATA_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    case ADMIN_USER, BACKING_INDEX_FAILURE_ACCESS:
+                        expectThrows(user, request, 404);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(dataIndexName + "::failures", "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, FAILURE_STORE_ACCESS, ADMIN_USER, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, BACKING_INDEX_DATA_ACCESS,
+                        BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(".fs*::failures");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, FAILURE_STORE_ACCESS, ADMIN_USER, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, BACKING_INDEX_DATA_ACCESS,
+                        BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search(".ds*::failures");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, FAILURE_STORE_ACCESS, ADMIN_USER, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, BACKING_INDEX_DATA_ACCESS,
+                        BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test2::failures");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    case ADMIN_USER, FAILURE_STORE_ACCESS, BOTH_ACCESS:
+                        expectThrows(user, request, 404);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test2::failures", "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case ADMIN_USER, DATA_ACCESS, STAR_READ_ONLY_ACCESS, BOTH_ACCESS, FAILURE_STORE_ACCESS, BACKING_INDEX_DATA_ACCESS,
+                        BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+
+        // mixed access
+        {
+            var request = new Search("test1,test1::failures");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, FAILURE_STORE_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    case ADMIN_USER, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test1,test1::failures", "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    case ADMIN_USER, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId, failuresDocId);
+                        break;
+                    case BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test1," + failureIndexName);
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, FAILURE_STORE_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    case ADMIN_USER, BOTH_ACCESS, STAR_READ_ONLY_ACCESS:
+                        expectSearch(user, request, dataDocId, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test1," + failureIndexName, "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    case ADMIN_USER, BOTH_ACCESS, STAR_READ_ONLY_ACCESS:
+                        expectSearch(user, request, dataDocId, failuresDocId);
+                        break;
+                    case BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test1::failures," + dataIndexName);
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, FAILURE_STORE_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    case ADMIN_USER, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test1::failures," + dataIndexName, "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case DATA_ACCESS, BACKING_INDEX_DATA_ACCESS, STAR_READ_ONLY_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case FAILURE_STORE_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    case ADMIN_USER, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId, failuresDocId);
+                        break;
+                    case BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test1,*::failures");
+            for (var user : users) {
+                switch (user) {
+                    case FAILURE_STORE_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS,
+                        FAILURE_INDEX_FAILURE_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case ADMIN_USER, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test1,*::failures", "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case FAILURE_STORE_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case ADMIN_USER, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId, failuresDocId);
+                        break;
+                    case BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test1::failures,*");
+            for (var user : users) {
+                switch (user) {
+                    case FAILURE_STORE_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS, BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS,
+                        FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectThrows(user, request, 403);
+                        break;
+                    case ADMIN_USER, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId, failuresDocId);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("test1::failures,*", "?ignore_unavailable=true");
+            for (var user : users) {
+                switch (user) {
+                    case FAILURE_STORE_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case ADMIN_USER, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId, failuresDocId);
+                        break;
+                    case BACKING_INDEX_DATA_ACCESS, BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_DATA_ACCESS, FAILURE_INDEX_FAILURE_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+        {
+            var request = new Search("*::failures,*");
+            for (var user : users) {
+                switch (user) {
+                    case FAILURE_STORE_ACCESS:
+                        expectSearch(user, request, failuresDocId);
+                        break;
+                    case DATA_ACCESS, STAR_READ_ONLY_ACCESS:
+                        expectSearch(user, request, dataDocId);
+                        break;
+                    case ADMIN_USER, BOTH_ACCESS:
+                        expectSearch(user, request, dataDocId, failuresDocId);
+                        break;
+                    case BACKING_INDEX_FAILURE_ACCESS, FAILURE_INDEX_FAILURE_ACCESS, BACKING_INDEX_DATA_ACCESS, FAILURE_INDEX_DATA_ACCESS:
+                        expectSearch(user, request);
+                        break;
+                    default:
+                        fail("must cover user: " + user);
+                }
+            }
+        }
+    }
+
+    public void testWriteOperations() throws IOException {
+        setupDataStream();
+        Tuple<String, String> backingIndices = getSingleDataAndFailureIndices("test1");
+        String dataIndexName = backingIndices.v1();
+        String failureIndexName = backingIndices.v2();
+
+        createUser(MANAGE_ACCESS, PASSWORD, MANAGE_ACCESS);
+        upsertRole(Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [{"names": ["test*"], "privileges": ["manage"]}]
+            }"""), MANAGE_ACCESS);
+        createAndStoreApiKey(MANAGE_ACCESS, randomBoolean() ? null : """
+            {
+              "role": {
+                "cluster": ["all"],
+                "indices": [{"names": ["test*"], "privileges": ["manage"]}]
+              }
+            }
+            """);
+
+        createUser(MANAGE_FAILURE_STORE_ACCESS, PASSWORD, MANAGE_FAILURE_STORE_ACCESS);
+        upsertRole(Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [{"names": ["test*"], "privileges": ["manage_failure_store"]}]
+            }"""), MANAGE_FAILURE_STORE_ACCESS);
+        createAndStoreApiKey(MANAGE_FAILURE_STORE_ACCESS, randomBoolean() ? null : """
+            {
+              "role": {
+                "cluster": ["all"],
+                "indices": [{"names": ["test*"], "privileges": ["manage_failure_store"]}]
+              }
+            }
+            """);
+
+        // user with manage access to data stream does NOT get direct access to failure index
+        expectThrows(() -> deleteIndex(MANAGE_ACCESS, failureIndexName), 403);
+        expectThrows(() -> deleteIndex(MANAGE_ACCESS, dataIndexName), 400);
+        // manage_failure_store user COULD delete failure index (not valid because it's a write index, but allow security-wise)
+        expectThrows(() -> deleteIndex(MANAGE_FAILURE_STORE_ACCESS, dataIndexName), 403);
+        expectThrows(() -> deleteIndex(MANAGE_FAILURE_STORE_ACCESS, failureIndexName), 400);
+        expectThrows(() -> deleteDataStream(MANAGE_FAILURE_STORE_ACCESS, dataIndexName), 403);
+
+        expectThrows(() -> deleteDataStream(MANAGE_FAILURE_STORE_ACCESS, "test1"), 403);
+        expectThrows(() -> deleteDataStream(MANAGE_FAILURE_STORE_ACCESS, "test1::failures"), 403);
+
+        // manage user can delete data stream
+        deleteDataStream(MANAGE_ACCESS, "test1");
+
+        // deleting data stream deletes everything, including failure index
+        expectThrows(() -> adminClient().performRequest(new Request("GET", "/test1/_search")), 404);
+        expectThrows(() -> adminClient().performRequest(new Request("GET", "/" + dataIndexName + "/_search")), 404);
+        expectThrows(() -> adminClient().performRequest(new Request("GET", "/test1::failures/_search")), 404);
+        expectThrows(() -> adminClient().performRequest(new Request("GET", "/" + failureIndexName + "/_search")), 404);
+    }
+
+    public void testFailureStoreAccessWithApiKeys() throws Exception {
+        List<String> docIds = setupDataStream();
+        assertThat(docIds.size(), equalTo(2));
+        assertThat(docIds, hasItem("1"));
+        String dataDocId = "1";
+        String failuresDocId = docIds.stream().filter(id -> false == id.equals(dataDocId)).findFirst().get();
+
+        Tuple<String, String> backingIndices = getSingleDataAndFailureIndices("test1");
+        String dataIndexName = backingIndices.v1();
+        String failureIndexName = backingIndices.v2();
+
+        var user = "user";
+        var role = "role";
+        createUser(user, PASSWORD, role);
+        upsertRole("""
+            {
+                "cluster": ["all"],
+                "indices": [
+                    {
+                        "names": ["*"],
+                        "privileges": ["read_failure_store"]
+                    }
+                ]
+            }
+            """, role);
+
+        String apiKey = createApiKey(user, """
+            {
+                "role": {
+                    "cluster": ["all"],
+                    "indices": [{"names": ["test1"], "privileges": ["read_failure_store"]}]
+                }
+            }""");
+
+        expectSearchWithApiKey(apiKey, new Search("test1::failures"), failuresDocId);
+        expectSearchWithApiKey(apiKey, new Search(failureIndexName), failuresDocId);
+        expectThrowsWithApiKey(apiKey, new Search(dataIndexName), 403);
+        expectThrowsWithApiKey(apiKey, new Search("test1"), 403);
+
+        apiKey = createApiKey(user, """
+            {
+                "role": {
+                    "cluster": ["all"],
+                    "indices": [{"names": ["test1"], "privileges": ["read_failure_store", "read"]}]
+                }
+            }""");
+
+        expectSearchWithApiKey(apiKey, new Search("test1::failures"), failuresDocId);
+        expectSearchWithApiKey(apiKey, new Search(failureIndexName), failuresDocId);
+        expectThrowsWithApiKey(apiKey, new Search(dataIndexName), 403);
+        expectThrowsWithApiKey(apiKey, new Search("test1"), 403);
+
+        apiKey = createApiKey(user, """
+            {
+                "role": {
+                    "cluster": ["all"],
+                    "indices": [{"names": ["test2"], "privileges": ["read_failure_store", "read"]}]
+                }
+            }""");
+
+        expectThrowsWithApiKey(apiKey, new Search("test1::failures"), 403);
+        expectThrowsWithApiKey(apiKey, new Search(failureIndexName), 403);
+        expectThrowsWithApiKey(apiKey, new Search(dataIndexName), 403);
+        expectThrowsWithApiKey(apiKey, new Search("test1"), 403);
+
+        apiKey = createApiKey(user, """
+            {
+                "role": {
+                    "cluster": ["all"],
+                    "indices": [
+                        {"names": ["test1"], "privileges": ["read_failure_store"]},
+                        {"names": ["*"], "privileges": ["read"]}
+                    ]
+                }
+            }""");
+
+        expectSearchWithApiKey(apiKey, new Search("test1::failures"), failuresDocId);
+        expectSearchWithApiKey(apiKey, new Search(failureIndexName), failuresDocId);
+        expectThrowsWithApiKey(apiKey, new Search(dataIndexName), 403);
+        expectThrowsWithApiKey(apiKey, new Search("test1"), 403);
+
+        apiKey = createApiKey(user, """
+            {
+                "role": {
+                    "cluster": ["all"],
+                    "indices": [
+                        {"names": ["*"], "privileges": ["read"]}
+                    ]
+                }
+            }""");
+
+        expectThrowsWithApiKey(apiKey, new Search("test1::failures"), 403);
+        // funky but correct: assigned role descriptors grant direct access to failure index, limited-by to failure store
+        expectSearchWithApiKey(apiKey, new Search(failureIndexName), failuresDocId);
+        expectThrowsWithApiKey(apiKey, new Search(dataIndexName), 403);
+        expectThrowsWithApiKey(apiKey, new Search("test1"), 403);
+
+        upsertRole("""
+            {
+                "cluster": ["all"],
+                "indices": [
+                    {
+                        "names": ["*"],
+                        "privileges": ["read"]
+                    }
+                ]
+            }
+            """, role);
+        apiKey = createApiKey(user, """
+            {
+                "role": {
+                    "cluster": ["all"],
+                    "indices": [
+                        {"names": ["test1"], "privileges": ["read_failure_store"]}
+                    ]
+                }
+            }""");
+        expectThrowsWithApiKey(apiKey, new Search("test1::failures"), 403);
+        // funky but correct: limited-by role descriptors grant direct access to failure index, assigned to failure store
+        expectSearchWithApiKey(apiKey, new Search(failureIndexName), failuresDocId);
+        expectThrowsWithApiKey(apiKey, new Search(dataIndexName), 403);
+        expectThrowsWithApiKey(apiKey, new Search("test1"), 403);
+    }
+
+    public void testPit() throws Exception {
+        List<String> docIds = setupDataStream();
+        String dataDocId = "1";
+        String failuresDocId = docIds.stream().filter(id -> false == id.equals(dataDocId)).findFirst().get();
+
+        createUser("user", PASSWORD, "role");
+        upsertRole("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["test*"],
+                  "privileges": ["read"]
+                }
+              ]
+            }""", "role");
+
+        {
+            expectThrows(
+                () -> performRequest("user", new Request("POST", Strings.format("/%s/_pit?keep_alive=1m", "test1::failures"))),
+                403
+            );
+            Response pitResponse = performRequest("user", new Request("POST", Strings.format("/%s/_pit?keep_alive=1m", "test1")));
+            assertOK(pitResponse);
+            String pitId = ObjectPath.createFromResponse(pitResponse).evaluate("id");
+            assertThat(pitId, notNullValue());
+
+            var searchRequest = new Request("POST", "/_search");
+            searchRequest.setJsonEntity(Strings.format("""
+                {
+                    "pit": {
+                        "id": "%s"
+                    }
+                }
+                """, pitId));
+            Response searchResponse = performRequest("user", searchRequest);
+            expectSearch(searchResponse, dataDocId);
+        }
+
+        upsertRole("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["test*"],
+                  "privileges": ["read_failure_store"]
+                }
+              ]
+            }""", "role");
+
+        {
+            expectThrows(() -> performRequest("user", new Request("POST", Strings.format("/%s/_pit?keep_alive=1m", "test1"))), 403);
+            Response pitResponse = performRequest("user", new Request("POST", Strings.format("/%s/_pit?keep_alive=1m", "test1::failures")));
+            assertOK(pitResponse);
+            String pitId = ObjectPath.createFromResponse(pitResponse).evaluate("id");
+            assertThat(pitId, notNullValue());
+
+            var searchRequest = new Request("POST", "/_search");
+            searchRequest.setJsonEntity(Strings.format("""
+                {
+                    "pit": {
+                        "id": "%s"
+                    }
+                }
+                """, pitId));
+            Response searchResponse = performRequest("user", searchRequest);
+            expectSearch(searchResponse, failuresDocId);
+        }
+    }
+
+    public void testDlsFls() throws Exception {
+        setupDataStream();
+
+        Tuple<String, String> backingIndices = getSingleDataAndFailureIndices("test1");
+        String dataIndexName = backingIndices.v1();
+        String failureIndexName = backingIndices.v2();
+
+        String user = "user";
+        String role = "role";
+        createUser(user, PASSWORD, role);
+        upsertRole("""
+            {
+                 "cluster": ["all"],
+                 "indices": [
+                     {
+                        "names": ["test*"],
+                        "privileges": ["read", "read_failure_store"],
+                        "field_security": {
+                            "grant": ["@timestamp", "age"]
+                        }
+                     }
+                 ]
+             }""", role);
+
+        // FLS applies to regular data stream
+        assertSearchResponseContainsExpectedIndicesAndFields(
+            performRequest(user, new Search(randomFrom("test1", "test1::data")).toSearchRequest()),
+            Map.of(dataIndexName, Set.of("@timestamp", "age"))
+        );
+
+        // FLS sort of applies to failure store
+        // TODO this will change with FLS handling
+        assertSearchResponseContainsExpectedIndicesAndFields(
+            performRequest(user, new Search("test1::failures").toSearchRequest()),
+            Map.of(failureIndexName, Set.of("@timestamp"))
+        );
+
+        upsertRole(Strings.format("""
+            {
+                 "cluster": ["all"],
+                 "indices": [
+                     {
+                        "names": ["%s"],
+                        "privileges": ["read"],
+                        "field_security": {
+                            "grant": ["@timestamp", "age"]
+                        }
+                     },
+                     {
+                        "names": ["test*"],
+                        "privileges": ["read_failure_store"],
+                        "field_security": {
+                            "grant": ["@timestamp", "age"]
+                        }
+                     }
+                 ]
+             }""", randomFrom("test*", "test1")), role);
+
+        // FLS applies to regular data stream
+        assertSearchResponseContainsExpectedIndicesAndFields(
+            performRequest(user, new Search(randomFrom("test1", "test1::data")).toSearchRequest()),
+            Map.of(dataIndexName, Set.of("@timestamp", "age"))
+        );
+
+        // FLS sort of applies to failure store
+        // TODO this will change with FLS handling
+        assertSearchResponseContainsExpectedIndicesAndFields(
+            performRequest(user, new Search("test1::failures").toSearchRequest()),
+            Map.of(failureIndexName, Set.of("@timestamp"))
+        );
+
+        upsertRole("""
+            {
+                 "cluster": ["all"],
+                 "indices": [
+                     {
+                        "names": ["test*"],
+                        "privileges": ["read"],
+                        "field_security": {
+                            "grant": ["@timestamp", "age"]
+                        }
+                     },
+                     {
+                        "names": ["test*"],
+                        "privileges": ["read_failure_store"]
+                     }
+                 ]
+             }""", role);
+
+        // since there is a section without FLS, no FLS applies
+        assertSearchResponseContainsExpectedIndicesAndFields(
+            performRequest(user, new Search(randomFrom("test1", "test1::data")).toSearchRequest()),
+            Map.of(dataIndexName, Set.of("@timestamp", "age", "name", "email"))
+        );
+
+        assertSearchResponseContainsExpectedIndicesAndFields(
+            performRequest(user, new Search("test1::failures").toSearchRequest()),
+            Map.of(failureIndexName, Set.of("@timestamp", "document", "error"))
+        );
+
+        // DLS
+        String dataIndexDocId = "1";
+        upsertRole("""
+            {
+                 "cluster": ["all"],
+                 "indices": [
+                     {
+                        "names": ["test*"],
+                        "privileges": ["read", "read_failure_store"],
+                        "query":{"term":{"name":{"value":"not-jack"}}}
+                     }
+                 ]
+             }""", role);
+        // DLS applies and no docs match the query
+        expectSearch(user, new Search(randomFrom("test1", "test1::data")));
+        expectSearch(user, new Search("test1::failures"));
+
+        upsertRole("""
+            {
+                 "cluster": ["all"],
+                 "indices": [
+                     {
+                        "names": ["test*"],
+                        "privileges": ["read", "read_failure_store"],
+                        "query":{"term":{"name":{"value":"jack"}}}
+                     }
+                 ]
+             }""", role);
+        // DLS applies and doc matches the query
+        expectSearch(user, new Search(randomFrom("test1", "test1::data")), dataIndexDocId);
+        expectSearch(user, new Search("test1::failures"));
+
+        upsertRole("""
+            {
+                 "cluster": ["all"],
+                 "indices": [
+                     {
+                        "names": ["test*"],
+                        "privileges": ["read"],
+                        "query":{"term":{"name":{"value":"not-jack"}}}
+                     },
+                     {
+                        "names": ["test*"],
+                        "privileges": ["read_failure_store"]
+                     }
+                 ]
+             }""", role);
+        // DLS does not apply because there is a section without DLS
+        expectSearch(user, new Search(randomFrom("test1", "test1::data")), dataIndexDocId);
+    }
+
+    private static void expectThrows(ThrowingRunnable runnable, int statusCode) {
+        var ex = expectThrows(ResponseException.class, runnable);
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(statusCode));
+    }
+
+    private void expectThrows(String user, Search search, int statusCode) {
+        expectThrows(() -> performRequest(user, search.toSearchRequest()), statusCode);
+        expectThrows(() -> performRequest(user, search.toAsyncSearchRequest()), statusCode);
+    }
+
+    private void expectSearch(String user, Search search, String... docIds) throws Exception {
+        expectSearch(performRequestMaybeUsingApiKey(user, search.toSearchRequest()), docIds);
+        expectAsyncSearch(performRequestMaybeUsingApiKey(user, search.toAsyncSearchRequest()), docIds);
+    }
+
+    private void expectSearchWithApiKey(String apiKey, Search search, String... docIds) throws Exception {
+        expectSearch(performRequestWithApiKey(apiKey, search.toSearchRequest()), docIds);
+        expectAsyncSearch(performRequestWithApiKey(apiKey, search.toAsyncSearchRequest()), docIds);
+    }
+
+    private void expectThrowsWithApiKey(String apiKey, Search search, int statusCode) {
+        expectThrows(() -> performRequestWithApiKey(apiKey, search.toSearchRequest()), statusCode);
+        expectThrows(() -> performRequestWithApiKey(apiKey, search.toAsyncSearchRequest()), statusCode);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void expectAsyncSearch(Response response, String... docIds) throws IOException {
+        assertOK(response);
+        ObjectPath resp = ObjectPath.createFromResponse(response);
+        Boolean isRunning = resp.evaluate("is_running");
+        Boolean isPartial = resp.evaluate("is_partial");
+        assertThat(isRunning, is(false));
+        assertThat(isPartial, is(false));
+
+        List<Object> hits = resp.evaluate("response.hits.hits");
+        List<String> actual = hits.stream().map(h -> (String) ((Map<String, Object>) h).get("_id")).toList();
+
+        assertThat(actual, containsInAnyOrder(docIds));
+    }
+
+    private static void expectSearch(Response response, String... docIds) throws IOException {
+        assertOK(response);
+        final SearchResponse searchResponse = SearchResponseUtils.parseSearchResponse(responseAsParser(response));
+        try {
+            SearchHit[] hits = searchResponse.getHits().getHits();
+            assertThat(hits.length, equalTo(docIds.length));
+            List<String> actualDocIds = Arrays.stream(hits).map(SearchHit::getId).toList();
+            assertThat(actualDocIds, containsInAnyOrder(docIds));
+        } finally {
+            searchResponse.decRef();
+        }
+    }
+
+    private record Search(String searchTarget, String pathParamString) {
+        Search(String searchTarget) {
+            this(searchTarget, "");
+        }
+
+        Request toSearchRequest() {
+            return new Request("POST", Strings.format("/%s/_search%s", searchTarget, pathParamString));
+        }
+
+        Request toAsyncSearchRequest() {
+            var pathParam = pathParamString.isEmpty()
+                ? "?wait_for_completion_timeout=" + ASYNC_SEARCH_TIMEOUT
+                : pathParamString + "&wait_for_completion_timeout=" + ASYNC_SEARCH_TIMEOUT;
+            return new Request("POST", Strings.format("/%s/_async_search%s", searchTarget, pathParam));
+        }
+    }
+
+    private List<String> setupDataStream() throws IOException {
+        createTemplates();
+        return randomBoolean() ? populateDataStreamWithBulkRequest() : populateDataStreamWithDocRequests();
+    }
+
+    private void createTemplates() throws IOException {
+        var componentTemplateRequest = new Request("PUT", "/_component_template/component1");
+        componentTemplateRequest.setJsonEntity("""
+            {
+                "template": {
+                    "mappings": {
+                        "properties": {
+                            "@timestamp": {
+                                "type": "date"
+                            },
+                            "age": {
+                                "type": "integer"
+                            },
+                            "email": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "text"
+                            }
+                        }
+                    },
+                    "data_stream_options": {
+                      "failure_store": {
+                        "enabled": true
+                      }
+                    }
+                }
+            }
+            """);
+        assertOK(adminClient().performRequest(componentTemplateRequest));
+
+        var indexTemplateRequest = new Request("PUT", "/_index_template/template1");
+        indexTemplateRequest.setJsonEntity("""
+            {
+                "index_patterns": ["test*"],
+                "data_stream": {},
+                "priority": 500,
+                "composed_of": ["component1"]
+            }
+            """);
+        assertOK(adminClient().performRequest(indexTemplateRequest));
+    }
+
+    private List<String> populateDataStreamWithDocRequests() throws IOException {
+        List<String> ids = new ArrayList<>();
+
+        var dataStreamName = "test1";
+        var docRequest = new Request("PUT", "/" + dataStreamName + "/_doc/1?refresh=true&op_type=create");
+        docRequest.setJsonEntity("""
+            {
+               "@timestamp": 1,
+               "age" : 1,
+               "name" : "jack",
+               "email" : "jack@example.com"
+            }
+            """);
+        Response response = performRequest(WRITE_ACCESS, docRequest);
+        assertOK(response);
+        Map<String, Object> responseAsMap = responseAsMap(response);
+        ids.add((String) responseAsMap.get("_id"));
+
+        docRequest = new Request("PUT", "/" + dataStreamName + "/_doc/2?refresh=true&op_type=create");
+        docRequest.setJsonEntity("""
+            {
+               "@timestamp": 2,
+               "age" : "this should be an int",
+               "name" : "jack",
+               "email" : "jack@example.com"
+            }
+            """);
+        response = performRequest(WRITE_ACCESS, docRequest);
+        assertOK(response);
+        responseAsMap = responseAsMap(response);
+        ids.add((String) responseAsMap.get("_id"));
+
+        return ids;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> populateDataStreamWithBulkRequest() throws IOException {
+        var bulkRequest = new Request("POST", "/_bulk?refresh=true");
+        bulkRequest.setJsonEntity("""
+            { "create" : { "_index" : "test1", "_id" : "1" } }
+            { "@timestamp": 1, "age" : 1, "name" : "jack", "email" : "jack@example.com" }
+            { "create" : { "_index" : "test1", "_id" : "2" } }
+            { "@timestamp": 2, "age" : "this should be an int", "name" : "jack", "email" : "jack@example.com" }
+            """);
+        Response response = performRequest(WRITE_ACCESS, bulkRequest);
+        assertOK(response);
+        // we need this dance because the ID for the failed document is random, **not** 2
+        Map<String, Object> stringObjectMap = responseAsMap(response);
+        List<Object> items = (List<Object>) stringObjectMap.get("items");
+        List<String> ids = new ArrayList<>();
+        for (Object item : items) {
+            Map<String, Object> itemMap = (Map<String, Object>) item;
+            Map<String, Object> create = (Map<String, Object>) itemMap.get("create");
+            assertThat(create.get("status"), equalTo(201));
+            ids.add((String) create.get("_id"));
+        }
+        return ids;
+    }
+
+    private void deleteDataStream(String user, String dataStreamName) throws IOException {
+        assertOK(performRequest(user, new Request("DELETE", "/_data_stream/" + dataStreamName)));
+    }
+
+    private void deleteIndex(String user, String indexName) throws IOException {
+        assertOK(performRequest(user, new Request("DELETE", "/" + indexName)));
+    }
+
+    private Response performRequest(String user, Request request) throws IOException {
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", basicAuthHeaderValue(user, PASSWORD)).build());
+        return client().performRequest(request);
+    }
+
+    private Response performRequestMaybeUsingApiKey(String user, Request request) throws IOException {
+        if (randomBoolean() && apiKeys.containsKey(user)) {
+            return performRequestWithApiKey(apiKeys.get(user), request);
+        } else {
+            return performRequest(user, request);
+        }
+    }
+
+    private static Response performRequestWithApiKey(String apiKey, Request request) throws IOException {
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "ApiKey " + apiKey).build());
+        return client().performRequest(request);
     }
 
     private static void expectUserPrivilegesResponse(String userPrivilegesResponse) throws IOException {
         Request request = new Request("GET", "/_security/user/_privileges");
-        request.setOptions(
-            request.getOptions()
-                .toBuilder()
-                .addHeader("Authorization", basicAuthHeaderValue("user", new SecureString("x-pack-test-password".toCharArray())))
-        );
+        request.setOptions(request.getOptions().toBuilder().addHeader("Authorization", basicAuthHeaderValue("user", PASSWORD)));
         Response response = client().performRequest(request);
         assertOK(response);
         assertThat(responseAsMap(response), equalTo(mapFromJson(userPrivilegesResponse)));
     }
 
-    private static void putRole(String rolePayload) throws IOException {
-        Request roleRequest = new Request("PUT", "/_security/role/role");
-        roleRequest.setJsonEntity(rolePayload);
-        assertOK(adminClient().performRequest(roleRequest));
-    }
-
     private static Map<String, Object> mapFromJson(String json) {
         return XContentHelper.convertToMap(JsonXContent.jsonXContent, json, false);
+    }
+
+    protected TestSecurityClient getSecurityClient() {
+        if (securityClient == null) {
+            securityClient = new TestSecurityClient(adminClient());
+        }
+        return securityClient;
+    }
+
+    protected void createUser(String username, SecureString password, String... roles) throws IOException {
+        getSecurityClient().putUser(new User(username, roles), password);
+    }
+
+    protected String createAndStoreApiKey(String username, @Nullable String roleDescriptors) throws IOException {
+        assertThat("API key already registered for user: " + username, apiKeys.containsKey(username), is(false));
+        apiKeys.put(username, createApiKey(username, roleDescriptors));
+        return createApiKey(username, roleDescriptors);
+    }
+
+    private String createApiKey(String username, String roleDescriptors) throws IOException {
+        var request = new Request("POST", "/_security/api_key");
+        if (roleDescriptors == null) {
+            request.setJsonEntity("""
+                {
+                    "name": "test-api-key"
+                }
+                """);
+        } else {
+            request.setJsonEntity(Strings.format("""
+                {
+                    "name": "test-api-key",
+                    "role_descriptors": %s
+                }
+                """, roleDescriptors));
+        }
+        Response response = performRequest(username, request);
+        assertOK(response);
+        Map<String, Object> responseAsMap = responseAsMap(response);
+        return (String) responseAsMap.get("encoded");
+    }
+
+    protected void upsertRole(String roleDescriptor, String roleName) throws IOException {
+        Request createRoleRequest = roleRequest(roleDescriptor, roleName);
+        Response createRoleResponse = adminClient().performRequest(createRoleRequest);
+        assertOK(createRoleResponse);
+    }
+
+    protected Request roleRequest(String roleDescriptor, String roleName) {
+        Request createRoleRequest;
+        if (randomBoolean()) {
+            createRoleRequest = new Request(randomFrom(HttpPut.METHOD_NAME, HttpPost.METHOD_NAME), "/_security/role/" + roleName);
+            createRoleRequest.setJsonEntity(roleDescriptor);
+        } else {
+            createRoleRequest = new Request(HttpPost.METHOD_NAME, "/_security/role");
+            createRoleRequest.setJsonEntity(org.elasticsearch.core.Strings.format("""
+                {"roles": {"%s": %s}}
+                """, roleName, roleDescriptor));
+        }
+        return createRoleRequest;
+    }
+
+    protected void assertSearchResponseContainsExpectedIndicesAndFields(
+        Response searchResponse,
+        Map<String, Set<String>> expectedIndicesAndFields
+    ) {
+        try {
+            assertOK(searchResponse);
+            var response = SearchResponseUtils.responseAsSearchResponse(searchResponse);
+            try {
+                final var searchResult = Arrays.stream(response.getHits().getHits())
+                    .collect(Collectors.toMap(SearchHit::getIndex, SearchHit::getSourceAsMap));
+
+                assertThat(searchResult.keySet(), equalTo(expectedIndicesAndFields.keySet()));
+                for (String index : expectedIndicesAndFields.keySet()) {
+                    Set<String> expectedFields = expectedIndicesAndFields.get(index);
+                    assertThat(searchResult.get(index).keySet(), equalTo(expectedFields));
+                }
+            } finally {
+                response.decRef();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Tuple<List<String>, List<String>> getDataAndFailureIndices(String dataStreamName) throws IOException {
+        Request dataStream = new Request("GET", "/_data_stream/" + dataStreamName);
+        Response response = adminClient().performRequest(dataStream);
+        Map<String, Object> dataStreams = entityAsMap(response);
+        assertEquals(Collections.singletonList("test1"), XContentMapValues.extractValue("data_streams.name", dataStreams));
+        List<String> dataIndexNames = (List<String>) XContentMapValues.extractValue("data_streams.indices.index_name", dataStreams);
+        List<String> failureIndexNames = (List<String>) XContentMapValues.extractValue(
+            "data_streams.failure_store.indices.index_name",
+            dataStreams
+        );
+        return new Tuple<>(dataIndexNames, failureIndexNames);
+    }
+
+    private Tuple<String, String> getSingleDataAndFailureIndices(String dataStreamName) throws IOException {
+        Tuple<List<String>, List<String>> indices = getDataAndFailureIndices(dataStreamName);
+        assertThat(indices.v1().size(), equalTo(1));
+        assertThat(indices.v2().size(), equalTo(1));
+        return new Tuple<>(indices.v1().get(0), indices.v2().get(0));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -2201,6 +2201,7 @@ public class Security extends Plugin
                     return FieldPredicate.ACCEPT_ALL;
                 }
                 assert indicesAccessControl.isGranted();
+                IndexNameExpressionResolver.assertExpressionHasNullOrDataSelector(index);
                 IndicesAccessControl.IndexAccessControl indexPermissions = indicesAccessControl.getIndexPermissions(index);
                 if (indexPermissions == null) {
                     return FieldPredicate.ACCEPT_ALL;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -392,9 +392,7 @@ class IndicesAndAliasesResolver {
                 );
                 aliasesRequest.replaceAliases(aliases.toArray(new String[aliases.size()]));
             }
-            if (indicesReplacedWithNoIndices)
-
-            {
+            if (indicesReplacedWithNoIndices) {
                 if (indicesRequest instanceof GetAliasesRequest == false) {
                     throw new IllegalStateException(
                         GetAliasesRequest.class.getSimpleName()

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -359,9 +359,7 @@ class IndicesAndAliasesResolver {
                 resolvedIndicesBuilder.addRemote(split.getRemote());
             }
 
-            if (resolvedIndicesBuilder.isEmpty())
-
-            {
+            if (resolvedIndicesBuilder.isEmpty()) {
                 if (indicesOptions.allowNoIndices()) {
                     // this is how we tell es core to return an empty response, we can let the request through being sure
                     // that the '-*' wildcard expression will be resolved to no indices. We can't let empty indices through

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -47,8 +47,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
+import java.util.function.BiPredicate;
 
 import static org.elasticsearch.xpack.core.security.authz.IndicesAndAliasesResolverField.NO_INDEX_PLACEHOLDER;
 
@@ -322,7 +321,8 @@ class IndicesAndAliasesResolver {
                     );
                 }
                 if (indicesOptions.expandWildcardExpressions()) {
-                    for (String authorizedIndex : authorizedIndices.all().get()) {
+                    IndexComponentSelector selector = IndexComponentSelector.getByKeyOrThrow(allIndicesPatternSelector);
+                    for (String authorizedIndex : authorizedIndices.all(selector)) {
                         if (IndexAbstractionResolver.isIndexVisible(
                             "*",
                             allIndicesPatternSelector,
@@ -351,7 +351,7 @@ class IndicesAndAliasesResolver {
                     split.getLocal(),
                     indicesOptions,
                     metadata,
-                    authorizedIndices.all(),
+                    authorizedIndices::all,
                     authorizedIndices::check,
                     indicesRequest.includeDataStreams()
                 );
@@ -359,7 +359,9 @@ class IndicesAndAliasesResolver {
                 resolvedIndicesBuilder.addRemote(split.getRemote());
             }
 
-            if (resolvedIndicesBuilder.isEmpty()) {
+            if (resolvedIndicesBuilder.isEmpty())
+
+            {
                 if (indicesOptions.allowNoIndices()) {
                     // this is how we tell es core to return an empty response, we can let the request through being sure
                     // that the '-*' wildcard expression will be resolved to no indices. We can't let empty indices through
@@ -388,11 +390,13 @@ class IndicesAndAliasesResolver {
             if (aliasesRequest.expandAliasesWildcards()) {
                 List<String> aliases = replaceWildcardsWithAuthorizedAliases(
                     aliasesRequest.aliases(),
-                    loadAuthorizedAliases(authorizedIndices.all(), metadata)
+                    loadAuthorizedAliases(authorizedIndices, metadata)
                 );
                 aliasesRequest.replaceAliases(aliases.toArray(new String[aliases.size()]));
             }
-            if (indicesReplacedWithNoIndices) {
+            if (indicesReplacedWithNoIndices)
+
+            {
                 if (indicesRequest instanceof GetAliasesRequest == false) {
                     throw new IllegalStateException(
                         GetAliasesRequest.class.getSimpleName()
@@ -430,8 +434,13 @@ class IndicesAndAliasesResolver {
      * request's concrete index is not in the list of authorized indices, then we need to look to
      * see if this can be authorized against an alias
      */
-    static String getPutMappingIndexOrAlias(PutMappingRequest request, Predicate<String> isAuthorized, Metadata metadata) {
+    static String getPutMappingIndexOrAlias(
+        PutMappingRequest request,
+        BiPredicate<String, IndexComponentSelector> isAuthorized,
+        Metadata metadata
+    ) {
         final String concreteIndexName = request.getConcreteIndex().getName();
+        assert IndexNameExpressionResolver.hasSelectorSuffix(concreteIndexName) == false : "selectors are not allowed in this context";
 
         // validate that the concrete index exists, otherwise there is no remapping that we could do
         final IndexAbstraction indexAbstraction = metadata.getIndicesLookup().get(concreteIndexName);
@@ -446,7 +455,8 @@ class IndicesAndAliasesResolver {
                     + indexAbstraction.getType().getDisplayName()
                     + "], but a concrete index is expected"
             );
-        } else if (isAuthorized.test(concreteIndexName)) {
+            // we know this is implicit data access (as opposed to another selector) so the default selector check is correct
+        } else if (isAuthorized.test(concreteIndexName, IndexComponentSelector.DATA)) {
             // user is authorized to put mappings for this index
             resolvedAliasOrIndex = concreteIndexName;
         } else {
@@ -455,7 +465,12 @@ class IndicesAndAliasesResolver {
             Map<String, List<AliasMetadata>> foundAliases = metadata.findAllAliases(new String[] { concreteIndexName });
             List<AliasMetadata> aliasMetadata = foundAliases.get(concreteIndexName);
             if (aliasMetadata != null) {
-                Optional<String> foundAlias = aliasMetadata.stream().map(AliasMetadata::alias).filter(isAuthorized).filter(aliasName -> {
+                Optional<String> foundAlias = aliasMetadata.stream().map(AliasMetadata::alias).filter(aliasName -> {
+                    // we know this is implicit data access (as opposed to another selector) so the default selector check is correct
+                    assert IndexNameExpressionResolver.hasSelectorSuffix(aliasName) == false : "selectors are not allowed in this context";
+                    if (false == isAuthorized.test(aliasName, IndexComponentSelector.DATA)) {
+                        return false;
+                    }
                     IndexAbstraction alias = metadata.getIndicesLookup().get(aliasName);
                     List<Index> indices = alias.getIndices();
                     if (indices.size() == 1) {
@@ -467,6 +482,7 @@ class IndicesAndAliasesResolver {
                     }
                 }).findFirst();
                 resolvedAliasOrIndex = foundAlias.orElse(concreteIndexName);
+
             } else {
                 resolvedAliasOrIndex = concreteIndexName;
             }
@@ -475,16 +491,17 @@ class IndicesAndAliasesResolver {
         return resolvedAliasOrIndex;
     }
 
-    private static List<String> loadAuthorizedAliases(Supplier<Set<String>> authorizedIndices, Metadata metadata) {
+    private static List<String> loadAuthorizedAliases(AuthorizationEngine.AuthorizedIndices authorizedIndices, Metadata metadata) {
         List<String> authorizedAliases = new ArrayList<>();
         SortedMap<String, IndexAbstraction> existingAliases = metadata.getIndicesLookup();
-        for (String authorizedIndex : authorizedIndices.get()) {
+        for (String authorizedIndex : authorizedIndices.all(IndexComponentSelector.DATA)) {
             IndexAbstraction indexAbstraction = existingAliases.get(authorizedIndex);
             if (indexAbstraction != null && indexAbstraction.getType() == IndexAbstraction.Type.ALIAS) {
                 authorizedAliases.add(authorizedIndex);
             }
         }
         return authorizedAliases;
+
     }
 
     private static List<String> replaceWildcardsWithAuthorizedAliases(String[] aliases, List<String> authorizedAliases) {
@@ -497,6 +514,7 @@ class IndicesAndAliasesResolver {
         }
 
         for (String aliasExpression : aliases) {
+            IndexNameExpressionResolver.assertExpressionHasNullOrDataSelector(aliasExpression);
             boolean include = true;
             if (aliasExpression.charAt(0) == '-') {
                 include = false;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -497,7 +497,6 @@ class IndicesAndAliasesResolver {
             }
         }
         return authorizedAliases;
-
     }
 
     private static List<String> replaceWildcardsWithAuthorizedAliases(String[] aliases, List<String> authorizedAliases) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -478,7 +478,6 @@ class IndicesAndAliasesResolver {
                     }
                 }).findFirst();
                 resolvedAliasOrIndex = foundAlias.orElse(concreteIndexName);
-
             } else {
                 resolvedAliasOrIndex = concreteIndexName;
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -31,6 +31,7 @@ import org.elasticsearch.action.search.TransportClearScrollAction;
 import org.elasticsearch.action.search.TransportClosePointInTimeAction;
 import org.elasticsearch.action.search.TransportMultiSearchAction;
 import org.elasticsearch.action.search.TransportSearchScrollAction;
+import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.action.termvectors.MultiTermVectorsAction;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
@@ -105,6 +106,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -874,15 +876,19 @@ public class RBACEngine implements AuthorizationEngine {
             // TODO: can this be done smarter? I think there are usually more indices/aliases in the cluster then indices defined a roles?
             if (includeDataStreams) {
                 for (IndexAbstraction indexAbstraction : lookup.values()) {
-                    if (predicate.test(indexAbstraction)) {
+                    // failure indices are special: when accessed directly (not through ::failures on parent data stream) they are accessed
+                    // implicitly as data. However, authz to the parent data stream happens via the failures selector
+                    if (indexAbstraction.isFailureIndexOfDataStream()
+                        && predicate.test(indexAbstraction.getParentDataStream(), IndexComponentSelector.FAILURES)) {
+                        indicesAndAliases.add(indexAbstraction.getName());
+                        // we know this is a failure index, and it's authorized so no need to check further
+                        continue;
+                    }
+                    if (predicate.test(indexAbstraction, IndexComponentSelector.DATA)) {
                         indicesAndAliases.add(indexAbstraction.getName());
                         if (indexAbstraction.getType() == IndexAbstraction.Type.DATA_STREAM) {
                             // add data stream and its backing indices for any authorized data streams
                             for (Index index : indexAbstraction.getIndices()) {
-                                indicesAndAliases.add(index.getName());
-                            }
-                            // TODO: We need to limit if a data stream's failure indices should return here.
-                            for (Index index : ((DataStream) indexAbstraction).getFailureIndices()) {
                                 indicesAndAliases.add(index.getName());
                             }
                         }
@@ -890,26 +896,56 @@ public class RBACEngine implements AuthorizationEngine {
                 }
             } else {
                 for (IndexAbstraction indexAbstraction : lookup.values()) {
-                    if (indexAbstraction.getType() != IndexAbstraction.Type.DATA_STREAM && predicate.test(indexAbstraction)) {
+                    if (indexAbstraction.getType() != IndexAbstraction.Type.DATA_STREAM
+                        // data check is correct, even for failure indices -- in this context, we treat them as regular indices, and
+                        // only include them if direct data access to them is granted (e.g., if a role has `read` over "*")
+                        && predicate.test(indexAbstraction, IndexComponentSelector.DATA)) {
                         indicesAndAliases.add(indexAbstraction.getName());
                     }
                 }
             }
             timeChecker.accept(indicesAndAliases);
             return indicesAndAliases;
-        }, name -> {
+        }, () -> {
+            // TODO handle time checking in a follow-up
+            Set<String> indicesAndAliases = new HashSet<>();
+            if (includeDataStreams) {
+                for (IndexAbstraction indexAbstraction : lookup.values()) {
+                    if (indexAbstraction.getType() == IndexAbstraction.Type.DATA_STREAM
+                        && predicate.test(indexAbstraction, IndexComponentSelector.FAILURES)) {
+                        indicesAndAliases.add(indexAbstraction.getName());
+                        // add data stream and its backing failure indices for any authorized data streams
+                        for (Index index : ((DataStream) indexAbstraction).getFailureIndices()) {
+                            indicesAndAliases.add(index.getName());
+                        }
+                    }
+                }
+            }
+            return indicesAndAliases;
+        }, (name, selector) -> {
             final IndexAbstraction indexAbstraction = lookup.get(name);
             if (indexAbstraction == null) {
                 // test access (by name) to a resource that does not currently exist
                 // the action handler must handle the case of accessing resources that do not exist
-                return predicate.test(name, null);
-            } else {
-                // We check the parent data stream first if there is one. For testing requested indices, this is most likely
-                // more efficient than checking the index name first because we recommend grant privileges over data stream
-                // instead of backing indices.
-                return (indexAbstraction.getParentDataStream() != null && predicate.test(indexAbstraction.getParentDataStream()))
-                    || predicate.test(indexAbstraction);
+                return predicate.test(name, null, selector);
             }
+            // We check the parent data stream first if there is one. For testing requested indices, this is most likely
+            // more efficient than checking the index name first because we recommend grant privileges over data stream
+            // instead of backing indices.
+            if (indexAbstraction.getParentDataStream() != null) {
+                if (indexAbstraction.isFailureIndexOfDataStream()) {
+                    // access to failure indices is authorized via failures-based selectors on the parent data stream _not_ via data
+                    // ones
+                    if (predicate.test(indexAbstraction.getParentDataStream(), IndexComponentSelector.FAILURES)) {
+                        return true;
+                    }
+                } else if (IndexComponentSelector.DATA.equals(selector) || selector == null) {
+                    if (predicate.test(indexAbstraction.getParentDataStream(), IndexComponentSelector.DATA)) {
+                        return true;
+                    }
+                } // we don't support granting access to a backing index with a failure selector via the parent data stream
+            }
+            return predicate.test(indexAbstraction, selector);
         });
     }
 
@@ -1034,23 +1070,32 @@ public class RBACEngine implements AuthorizationEngine {
     }
 
     static final class AuthorizedIndices implements AuthorizationEngine.AuthorizedIndices {
+        private final CachedSupplier<Set<String>> authorizedAndAvailableDataResources;
+        private final CachedSupplier<Set<String>> authorizedAndAvailableFailuresResources;
+        private final BiPredicate<String, IndexComponentSelector> isAuthorizedPredicate;
 
-        private final CachedSupplier<Set<String>> allAuthorizedAndAvailableSupplier;
-        private final Predicate<String> isAuthorizedPredicate;
-
-        AuthorizedIndices(Supplier<Set<String>> allAuthorizedAndAvailableSupplier, Predicate<String> isAuthorizedPredicate) {
-            this.allAuthorizedAndAvailableSupplier = CachedSupplier.wrap(allAuthorizedAndAvailableSupplier);
+        AuthorizedIndices(
+            Supplier<Set<String>> authorizedAndAvailableDataResources,
+            Supplier<Set<String>> authorizedAndAvailableFailuresResources,
+            BiPredicate<String, IndexComponentSelector> isAuthorizedPredicate
+        ) {
+            this.authorizedAndAvailableDataResources = CachedSupplier.wrap(authorizedAndAvailableDataResources);
+            this.authorizedAndAvailableFailuresResources = CachedSupplier.wrap(authorizedAndAvailableFailuresResources);
             this.isAuthorizedPredicate = Objects.requireNonNull(isAuthorizedPredicate);
         }
 
         @Override
-        public Supplier<Set<String>> all() {
-            return allAuthorizedAndAvailableSupplier;
+        public Set<String> all(IndexComponentSelector selector) {
+            Objects.requireNonNull(selector, "must specify a selector to get authorized indices");
+            return IndexComponentSelector.FAILURES.equals(selector)
+                ? authorizedAndAvailableFailuresResources.get()
+                : authorizedAndAvailableDataResources.get();
         }
 
         @Override
-        public boolean check(String name) {
-            return this.isAuthorizedPredicate.test(name);
+        public boolean check(String name, IndexComponentSelector selector) {
+            Objects.requireNonNull(selector, "must specify a selector for authorization check");
+            return isAuthorizedPredicate.test(name, selector);
         }
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestGetBuiltinPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestGetBuiltinPrivilegesAction.java
@@ -42,7 +42,7 @@ public class RestGetBuiltinPrivilegesAction extends SecurityBaseRestHandler {
 
     private static final Logger logger = LogManager.getLogger(RestGetBuiltinPrivilegesAction.class);
     // TODO remove this once we can update docs tests again
-    private static final Set<String> FAILURE_STORE_PRIVILEGES_TO_EXCLUDE = Set.of("read_failure_store");
+    private static final Set<String> FAILURE_STORE_PRIVILEGES_TO_EXCLUDE = Set.of("read_failure_store", "manage_failure_store");
     private final GetBuiltinPrivilegesResponseTranslator responseTranslator;
 
     public RestGetBuiltinPrivilegesAction(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizedIndicesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizedIndicesTests.java
@@ -290,7 +290,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
         AuthorizedIndices authorizedIndices = RBACEngine.resolveAuthorizedIndicesFromRole(
             roles,
             getRequestInfo(TransportSearchAction.TYPE.name()),
-            metadata.getProject().getIndicesLookup(),
+            metadata.getIndicesLookup(),
             () -> ignore -> {}
         );
         assertThat(authorizedIndices.all(IndexComponentSelector.DATA), containsInAnyOrder("a1", "a2", "aaaaaa", "b", "ab"));
@@ -467,7 +467,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
         AuthorizedIndices authorizedIndices = RBACEngine.resolveAuthorizedIndicesFromRole(
             roles,
             requestInfo,
-            metadata.getProject().getIndicesLookup(),
+            metadata.getIndicesLookup(),
             () -> ignore -> {}
         );
         assertAuthorizedFor(
@@ -552,7 +552,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
         AuthorizedIndices authorizedIndices = RBACEngine.resolveAuthorizedIndicesFromRole(
             roles,
             requestInfo,
-            metadata.getProject().getIndicesLookup(),
+            metadata.getIndicesLookup(),
             () -> ignore -> {}
         );
         assertAuthorizedFor(
@@ -633,7 +633,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
         AuthorizedIndices authorizedIndices = RBACEngine.resolveAuthorizedIndicesFromRole(
             roles,
             getRequestInfo(TransportSearchAction.TYPE.name()),
-            metadata.getProject().getIndicesLookup(),
+            metadata.getIndicesLookup(),
             () -> ignore -> {}
         );
         assertAuthorizedFor(authorizedIndices, IndexComponentSelector.DATA, "a1", "a2", "aaaaaa");

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizedIndicesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizedIndicesTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.security.authz;
 
 import org.elasticsearch.action.admin.indices.resolve.ResolveIndexAction;
 import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -55,7 +56,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
             Metadata.EMPTY_METADATA.getIndicesLookup(),
             () -> ignore -> {}
         );
-        assertTrue(authorizedIndices.all().get().isEmpty());
+        assertTrue(authorizedIndices.all(IndexComponentSelector.DATA).isEmpty());
     }
 
     public void testAuthorizedIndicesUserWithSomeRoles() {
@@ -115,15 +116,15 @@ public class AuthorizedIndicesTests extends ESTestCase {
             metadata.getIndicesLookup(),
             () -> ignore -> {}
         );
-        assertThat(authorizedIndices.all().get(), containsInAnyOrder("a1", "a2", "aaaaaa", "b", "ab"));
-        assertThat(authorizedIndices.all().get(), not(contains("bbbbb")));
-        assertThat(authorizedIndices.check("bbbbb"), is(false));
-        assertThat(authorizedIndices.all().get(), not(contains("ba")));
-        assertThat(authorizedIndices.check("ba"), is(false));
-        assertThat(authorizedIndices.all().get(), not(contains(internalSecurityIndex)));
-        assertThat(authorizedIndices.check(internalSecurityIndex), is(false));
-        assertThat(authorizedIndices.all().get(), not(contains(SecuritySystemIndices.SECURITY_MAIN_ALIAS)));
-        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), containsInAnyOrder("a1", "a2", "aaaaaa", "b", "ab"));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains("bbbbb")));
+        assertThat(authorizedIndices.check("bbbbb", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains("ba")));
+        assertThat(authorizedIndices.check("ba", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains(internalSecurityIndex)));
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains(SecuritySystemIndices.SECURITY_MAIN_ALIAS)));
+        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS, IndexComponentSelector.DATA), is(false));
     }
 
     public void testAuthorizedIndicesUserWithSomeRolesEmptyMetadata() {
@@ -134,7 +135,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
             Metadata.EMPTY_METADATA.getIndicesLookup(),
             () -> ignore -> {}
         );
-        assertTrue(authorizedIndices.all().get().isEmpty());
+        assertTrue(authorizedIndices.all(IndexComponentSelector.DATA).isEmpty());
     }
 
     public void testSecurityIndicesAreRemovedFromRegularUser() {
@@ -145,7 +146,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
             Metadata.EMPTY_METADATA.getIndicesLookup(),
             () -> ignore -> {}
         );
-        assertTrue(authorizedIndices.all().get().isEmpty());
+        assertTrue(authorizedIndices.all(IndexComponentSelector.DATA).isEmpty());
     }
 
     public void testSecurityIndicesAreRestrictedForDefaultRole() {
@@ -177,13 +178,13 @@ public class AuthorizedIndicesTests extends ESTestCase {
             metadata.getIndicesLookup(),
             () -> ignore -> {}
         );
-        assertThat(authorizedIndices.all().get(), containsInAnyOrder("an-index", "another-index"));
-        assertThat(authorizedIndices.check("an-index"), is(true));
-        assertThat(authorizedIndices.check("another-index"), is(true));
-        assertThat(authorizedIndices.all().get(), not(contains(internalSecurityIndex)));
-        assertThat(authorizedIndices.check(internalSecurityIndex), is(false));
-        assertThat(authorizedIndices.all().get(), not(contains(SecuritySystemIndices.SECURITY_MAIN_ALIAS)));
-        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), containsInAnyOrder("an-index", "another-index"));
+        assertThat(authorizedIndices.check("an-index", IndexComponentSelector.DATA), is(true));
+        assertThat(authorizedIndices.check("another-index", IndexComponentSelector.DATA), is(true));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains(internalSecurityIndex)));
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains(SecuritySystemIndices.SECURITY_MAIN_ALIAS)));
+        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS, IndexComponentSelector.DATA), is(false));
     }
 
     public void testSecurityIndicesAreNotRemovedFromUnrestrictedRole() {
@@ -216,7 +217,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
             () -> ignore -> {}
         );
         assertThat(
-            authorizedIndices.all().get(),
+            authorizedIndices.all(IndexComponentSelector.DATA),
             containsInAnyOrder("an-index", "another-index", SecuritySystemIndices.SECURITY_MAIN_ALIAS, internalSecurityIndex)
         );
 
@@ -227,7 +228,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
             () -> ignore -> {}
         );
         assertThat(
-            authorizedIndicesSuperUser.all().get(),
+            authorizedIndicesSuperUser.all(IndexComponentSelector.DATA),
             containsInAnyOrder("an-index", "another-index", SecuritySystemIndices.SECURITY_MAIN_ALIAS, internalSecurityIndex)
         );
     }
@@ -274,10 +275,92 @@ public class AuthorizedIndicesTests extends ESTestCase {
                 true
             )
             .put(new IndexMetadata.Builder(backingIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(DataStreamTestHelper.newInstance("adatastream1", List.of(new Index(backingIndex, "_na_"))))
+            .build();
+        final PlainActionFuture<Role> future = new PlainActionFuture<>();
+        final Set<RoleDescriptor> descriptors = Sets.newHashSet(aStarRole, bRole);
+        CompositeRolesStore.buildRoleFromDescriptors(
+            descriptors,
+            new FieldPermissionsCache(Settings.EMPTY),
+            null,
+            RESTRICTED_INDICES,
+            future
+        );
+        Role roles = future.actionGet();
+        AuthorizedIndices authorizedIndices = RBACEngine.resolveAuthorizedIndicesFromRole(
+            roles,
+            getRequestInfo(TransportSearchAction.TYPE.name()),
+            metadata.getProject().getIndicesLookup(),
+            () -> ignore -> {}
+        );
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), containsInAnyOrder("a1", "a2", "aaaaaa", "b", "ab"));
+        for (String resource : List.of("a1", "a2", "aaaaaa", "b", "ab")) {
+            assertThat(authorizedIndices.check(resource, IndexComponentSelector.DATA), is(true));
+        }
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains("bbbbb")));
+        assertThat(authorizedIndices.check("bbbbb", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains("ba")));
+        assertThat(authorizedIndices.check("ba", IndexComponentSelector.DATA), is(false));
+        // due to context, datastreams are excluded from wildcard expansion
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains("adatastream1")));
+        // but they are authorized when explicitly tested (they are not "unavailable" for the Security filter)
+        assertThat(authorizedIndices.check("adatastream1", IndexComponentSelector.DATA), is(true));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains(internalSecurityIndex)));
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains(SecuritySystemIndices.SECURITY_MAIN_ALIAS)));
+        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS, IndexComponentSelector.DATA), is(false));
+    }
+
+    public void testDataStreamsAreNotIncludedInAuthorizedIndicesWithFailuresSelectorAndAllPrivilege() {
+        assumeTrue("requires failure store", DataStream.isFailureStoreFeatureFlagEnabled());
+        RoleDescriptor aStarRole = new RoleDescriptor(
+            "a_star",
+            null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("a*").privileges("all").build() },
+            null
+        );
+        RoleDescriptor bRole = new RoleDescriptor(
+            "b",
+            null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("b").privileges("READ").build() },
+            null
+        );
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
+        final String internalSecurityIndex = randomFrom(
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_6,
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7
+        );
+        String backingIndex = DataStream.getDefaultBackingIndexName("adatastream1", 1);
+        String failureIndex = DataStream.getDefaultFailureStoreName("adatastream1", 1, 1);
+        Metadata metadata = Metadata.builder()
+            .put(new IndexMetadata.Builder("a1").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("a2").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("aaaaaa").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("bbbbb").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(
+                new IndexMetadata.Builder("b").settings(indexSettings)
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putAlias(new AliasMetadata.Builder("ab").build())
+                    .putAlias(new AliasMetadata.Builder("ba").build())
+                    .build(),
+                true
+            )
+            .put(
+                new IndexMetadata.Builder(internalSecurityIndex).settings(indexSettings)
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putAlias(new AliasMetadata.Builder(SecuritySystemIndices.SECURITY_MAIN_ALIAS).build())
+                    .build(),
+                true
+            )
+            .put(new IndexMetadata.Builder(backingIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder(failureIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
             .put(
                 DataStreamTestHelper.newInstance(
                     "adatastream1",
-                    List.of(new Index(DataStream.getDefaultBackingIndexName("adatastream1", 1), "_na_"))
+                    List.of(new Index(backingIndex, "_na_")),
+                    List.of(new Index(failureIndex, "_na_"))
                 )
             )
             .build();
@@ -297,22 +380,279 @@ public class AuthorizedIndicesTests extends ESTestCase {
             metadata.getIndicesLookup(),
             () -> ignore -> {}
         );
-        assertThat(authorizedIndices.all().get(), containsInAnyOrder("a1", "a2", "aaaaaa", "b", "ab"));
-        for (String resource : List.of("a1", "a2", "aaaaaa", "b", "ab")) {
-            assertThat(authorizedIndices.check(resource), is(true));
-        }
-        assertThat(authorizedIndices.all().get(), not(contains("bbbbb")));
-        assertThat(authorizedIndices.check("bbbbb"), is(false));
-        assertThat(authorizedIndices.all().get(), not(contains("ba")));
-        assertThat(authorizedIndices.check("ba"), is(false));
-        // due to context, datastreams are excluded from wildcard expansion
-        assertThat(authorizedIndices.all().get(), not(contains("adatastream1")));
-        // but they are authorized when explicitly tested (they are not "unavailable" for the Security filter)
-        assertThat(authorizedIndices.check("adatastream1"), is(true));
-        assertThat(authorizedIndices.all().get(), not(contains(internalSecurityIndex)));
-        assertThat(authorizedIndices.check(internalSecurityIndex), is(false));
-        assertThat(authorizedIndices.all().get(), not(contains(SecuritySystemIndices.SECURITY_MAIN_ALIAS)));
-        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS), is(false));
+        assertAuthorizedFor(authorizedIndices, IndexComponentSelector.DATA, "a1", "a2", "aaaaaa", "b", "ab");
+        assertAuthorizedFor(authorizedIndices, IndexComponentSelector.FAILURES);
+
+        assertThat(authorizedIndices.check("bbbbb", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check("bbbbb", IndexComponentSelector.FAILURES), is(false));
+
+        assertThat(authorizedIndices.check("ba", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check("ba", IndexComponentSelector.FAILURES), is(false));
+
+        // data are authorized when explicitly tested (they are not "unavailable" for the Security filter)
+        assertThat(authorizedIndices.check("adatastream1", IndexComponentSelector.DATA), is(true));
+        assertThat(authorizedIndices.check("adatastream1", IndexComponentSelector.FAILURES), is(true));
+
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.FAILURES), is(false));
+        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS, IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS, IndexComponentSelector.FAILURES), is(false));
+    }
+
+    public void testDataStreamsAreIncludedInAuthorizedIndicesWithFailuresSelectorAndAllPrivilege() {
+        assumeTrue("requires failure store", DataStream.isFailureStoreFeatureFlagEnabled());
+        RoleDescriptor aStarRole = new RoleDescriptor(
+            "a_star",
+            null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("a*").privileges("all").build() },
+            null
+        );
+        RoleDescriptor bRole = new RoleDescriptor(
+            "b",
+            null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("b").privileges("READ").build() },
+            null
+        );
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
+        final String internalSecurityIndex = randomFrom(
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_6,
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7
+        );
+        String backingIndex = DataStream.getDefaultBackingIndexName("adatastream1", 1);
+        String failureIndex = DataStream.getDefaultFailureStoreName("adatastream1", 1, 1);
+        Metadata metadata = Metadata.builder()
+            .put(new IndexMetadata.Builder("a1").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("a2").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("aaaaaa").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("bbbbb").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(
+                new IndexMetadata.Builder("b").settings(indexSettings)
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putAlias(new AliasMetadata.Builder("ab").build())
+                    .putAlias(new AliasMetadata.Builder("ba").build())
+                    .build(),
+                true
+            )
+            .put(
+                new IndexMetadata.Builder(internalSecurityIndex).settings(indexSettings)
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putAlias(new AliasMetadata.Builder(SecuritySystemIndices.SECURITY_MAIN_ALIAS).build())
+                    .build(),
+                true
+            )
+            .put(new IndexMetadata.Builder(backingIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder(failureIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(
+                DataStreamTestHelper.newInstance(
+                    "adatastream1",
+                    List.of(new Index(backingIndex, "_na_")),
+                    List.of(new Index(failureIndex, "_na_"))
+                )
+            )
+            .build();
+        final PlainActionFuture<Role> future = new PlainActionFuture<>();
+        final Set<RoleDescriptor> descriptors = Sets.newHashSet(aStarRole, bRole);
+        CompositeRolesStore.buildRoleFromDescriptors(
+            descriptors,
+            new FieldPermissionsCache(Settings.EMPTY),
+            null,
+            RESTRICTED_INDICES,
+            future
+        );
+        Role roles = future.actionGet();
+        TransportRequest request = new ResolveIndexAction.Request(new String[] { "a*" });
+        AuthorizationEngine.RequestInfo requestInfo = getRequestInfo(request, TransportSearchAction.TYPE.name());
+        AuthorizedIndices authorizedIndices = RBACEngine.resolveAuthorizedIndicesFromRole(
+            roles,
+            requestInfo,
+            metadata.getProject().getIndicesLookup(),
+            () -> ignore -> {}
+        );
+        assertAuthorizedFor(
+            authorizedIndices,
+            IndexComponentSelector.DATA,
+            "a1",
+            "a2",
+            "aaaaaa",
+            "b",
+            "ab",
+            "adatastream1",
+            backingIndex,
+            failureIndex
+        );
+        assertAuthorizedFor(authorizedIndices, IndexComponentSelector.FAILURES, "adatastream1", failureIndex);
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains("bbbbb")));
+        assertThat(authorizedIndices.check("bbbbb", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check("bbbbb", IndexComponentSelector.FAILURES), is(false));
+        assertThat(authorizedIndices.check("ba", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check("ba", IndexComponentSelector.FAILURES), is(false));
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.FAILURES), is(false));
+        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS, IndexComponentSelector.FAILURES), is(false));
+    }
+
+    public void testDataStreamsAreIncludedInAuthorizedIndicesWithFailuresSelector() {
+        assumeTrue("requires failure store", DataStream.isFailureStoreFeatureFlagEnabled());
+        RoleDescriptor aReadFailuresStarRole = new RoleDescriptor(
+            "a_read_failure_store",
+            null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("a*").privileges("read_failure_store").build() },
+            null
+        );
+        RoleDescriptor aReadRole = new RoleDescriptor(
+            "a_read",
+            null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("a*").privileges("read").build() },
+            null
+        );
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
+        final String internalSecurityIndex = randomFrom(
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_6,
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7
+        );
+        String backingIndex = DataStream.getDefaultBackingIndexName("adatastream1", 1);
+        String failureIndex = DataStream.getDefaultFailureStoreName("adatastream1", 1, 1);
+        Metadata metadata = Metadata.builder()
+            .put(new IndexMetadata.Builder("a1").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("a2").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("aaaaaa").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("bbbbb").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(
+                new IndexMetadata.Builder(internalSecurityIndex).settings(indexSettings)
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putAlias(new AliasMetadata.Builder(SecuritySystemIndices.SECURITY_MAIN_ALIAS).build())
+                    .build(),
+                true
+            )
+            .put(new IndexMetadata.Builder(backingIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder(failureIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(
+                DataStreamTestHelper.newInstance(
+                    "adatastream1",
+                    List.of(new Index(backingIndex, "_na_")),
+                    List.of(new Index(failureIndex, "_na_"))
+                )
+            )
+            .build();
+        final PlainActionFuture<Role> future = new PlainActionFuture<>();
+        final Set<RoleDescriptor> descriptors = Sets.newHashSet(aReadFailuresStarRole, aReadRole);
+        CompositeRolesStore.buildRoleFromDescriptors(
+            descriptors,
+            new FieldPermissionsCache(Settings.EMPTY),
+            null,
+            RESTRICTED_INDICES,
+            future
+        );
+        Role roles = future.actionGet();
+        TransportRequest request = new ResolveIndexAction.Request(new String[] { "a*" });
+        AuthorizationEngine.RequestInfo requestInfo = getRequestInfo(request, TransportSearchAction.TYPE.name());
+        AuthorizedIndices authorizedIndices = RBACEngine.resolveAuthorizedIndicesFromRole(
+            roles,
+            requestInfo,
+            metadata.getProject().getIndicesLookup(),
+            () -> ignore -> {}
+        );
+        assertAuthorizedFor(
+            authorizedIndices,
+            IndexComponentSelector.DATA,
+            "a1",
+            "a2",
+            "aaaaaa",
+            "adatastream1",
+            backingIndex,
+            failureIndex
+        );
+        assertAuthorizedFor(authorizedIndices, IndexComponentSelector.FAILURES, "adatastream1", failureIndex);
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains("bbbbb")));
+        assertThat(authorizedIndices.check("bbbbb", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check("bbbbb", IndexComponentSelector.FAILURES), is(false));
+        assertThat(authorizedIndices.check("ba", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check("ba", IndexComponentSelector.FAILURES), is(false));
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.FAILURES), is(false));
+        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS, IndexComponentSelector.FAILURES), is(false));
+    }
+
+    public void testDataStreamsAreNotIncludedInAuthorizedIndicesWithFailuresSelector() {
+        assumeTrue("requires failure store", DataStream.isFailureStoreFeatureFlagEnabled());
+        RoleDescriptor aReadFailuresStarRole = new RoleDescriptor(
+            "a_read_failure_store",
+            null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("a*").privileges("read_failure_store").build() },
+            null
+        );
+        RoleDescriptor aReadRole = new RoleDescriptor(
+            "a_read",
+            null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("a*").privileges("read").build() },
+            null
+        );
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
+        final String internalSecurityIndex = randomFrom(
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_6,
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7
+        );
+        String backingIndex = DataStream.getDefaultBackingIndexName("adatastream1", 1);
+        String failureIndex = DataStream.getDefaultFailureStoreName("adatastream1", 1, 1);
+        Metadata metadata = Metadata.builder()
+            .put(new IndexMetadata.Builder("a1").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("a2").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("aaaaaa").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("bbbbb").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(
+                new IndexMetadata.Builder(internalSecurityIndex).settings(indexSettings)
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putAlias(new AliasMetadata.Builder(SecuritySystemIndices.SECURITY_MAIN_ALIAS).build())
+                    .build(),
+                true
+            )
+            .put(new IndexMetadata.Builder(backingIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder(failureIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(
+                DataStreamTestHelper.newInstance(
+                    "adatastream1",
+                    List.of(new Index(backingIndex, "_na_")),
+                    List.of(new Index(failureIndex, "_na_"))
+                )
+            )
+            .build();
+        final PlainActionFuture<Role> future = new PlainActionFuture<>();
+        final Set<RoleDescriptor> descriptors = Sets.newHashSet(aReadFailuresStarRole, aReadRole);
+        CompositeRolesStore.buildRoleFromDescriptors(
+            descriptors,
+            new FieldPermissionsCache(Settings.EMPTY),
+            null,
+            RESTRICTED_INDICES,
+            future
+        );
+        Role roles = future.actionGet();
+        AuthorizedIndices authorizedIndices = RBACEngine.resolveAuthorizedIndicesFromRole(
+            roles,
+            getRequestInfo(TransportSearchAction.TYPE.name()),
+            metadata.getProject().getIndicesLookup(),
+            () -> ignore -> {}
+        );
+        assertAuthorizedFor(authorizedIndices, IndexComponentSelector.DATA, "a1", "a2", "aaaaaa");
+        assertAuthorizedFor(authorizedIndices, IndexComponentSelector.FAILURES);
+
+        assertThat(authorizedIndices.check("bbbbb", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check("bbbbb", IndexComponentSelector.FAILURES), is(false));
+
+        assertThat(authorizedIndices.check("ba", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check("ba", IndexComponentSelector.FAILURES), is(false));
+
+        // data are authorized when explicitly tested (they are not "unavailable" for the Security filter)
+        assertThat(authorizedIndices.check("adatastream1", IndexComponentSelector.DATA), is(true));
+        assertThat(authorizedIndices.check("adatastream1", IndexComponentSelector.FAILURES), is(true));
+
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.FAILURES), is(false));
+        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS, IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS, IndexComponentSelector.FAILURES), is(false));
     }
 
     public void testDataStreamsAreIncludedInAuthorizedIndices() {
@@ -357,12 +697,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
                 true
             )
             .put(new IndexMetadata.Builder(backingIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
-            .put(
-                DataStreamTestHelper.newInstance(
-                    "adatastream1",
-                    List.of(new Index(DataStream.getDefaultBackingIndexName("adatastream1", 1), "_na_"))
-                )
-            )
+            .put(DataStreamTestHelper.newInstance("adatastream1", List.of(new Index(backingIndex, "_na_"))))
             .build();
         final PlainActionFuture<Role> future = new PlainActionFuture<>();
         final Set<RoleDescriptor> descriptors = Sets.newHashSet(aStarRole, bRole);
@@ -382,15 +717,18 @@ public class AuthorizedIndicesTests extends ESTestCase {
             metadata.getIndicesLookup(),
             () -> ignore -> {}
         );
-        assertThat(authorizedIndices.all().get(), containsInAnyOrder("a1", "a2", "aaaaaa", "b", "ab", "adatastream1", backingIndex));
-        assertThat(authorizedIndices.all().get(), not(contains("bbbbb")));
-        assertThat(authorizedIndices.check("bbbbb"), is(false));
-        assertThat(authorizedIndices.all().get(), not(contains("ba")));
-        assertThat(authorizedIndices.check("ba"), is(false));
-        assertThat(authorizedIndices.all().get(), not(contains(internalSecurityIndex)));
-        assertThat(authorizedIndices.check(internalSecurityIndex), is(false));
-        assertThat(authorizedIndices.all().get(), not(contains(SecuritySystemIndices.SECURITY_MAIN_ALIAS)));
-        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS), is(false));
+        assertThat(
+            authorizedIndices.all(IndexComponentSelector.DATA),
+            containsInAnyOrder("a1", "a2", "aaaaaa", "b", "ab", "adatastream1", backingIndex)
+        );
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains("bbbbb")));
+        assertThat(authorizedIndices.check("bbbbb", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains("ba")));
+        assertThat(authorizedIndices.check("ba", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains(internalSecurityIndex)));
+        assertThat(authorizedIndices.check(internalSecurityIndex, IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(contains(SecuritySystemIndices.SECURITY_MAIN_ALIAS)));
+        assertThat(authorizedIndices.check(SecuritySystemIndices.SECURITY_MAIN_ALIAS, IndexComponentSelector.DATA), is(false));
     }
 
     public static AuthorizationEngine.RequestInfo getRequestInfo(String action) {
@@ -409,5 +747,16 @@ public class AuthorizedIndicesTests extends ESTestCase {
             action,
             null
         );
+    }
+
+    private static void assertAuthorizedFor(
+        AuthorizedIndices authorizedIndices,
+        IndexComponentSelector selector,
+        String... expectedIndices
+    ) {
+        assertThat(authorizedIndices.all(selector), containsInAnyOrder(expectedIndices));
+        for (String resource : expectedIndices) {
+            assertThat(authorizedIndices.check(resource, selector), is(true));
+        }
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.search.SearchShardsRequest;
 import org.elasticsearch.action.search.TransportMultiSearchAction;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.search.TransportSearchShardsAction;
+import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.termvectors.MultiTermVectorsRequest;
@@ -1933,7 +1934,11 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String index = "logs-00003"; // write index
         PutMappingRequest request = new PutMappingRequest(Strings.EMPTY_ARRAY).setConcreteIndex(new Index(index, UUIDs.base64UUID()));
         assert metadata.getIndicesLookup().get("logs-alias").getIndices().size() == 3;
-        String putMappingIndexOrAlias = IndicesAndAliasesResolver.getPutMappingIndexOrAlias(request, "logs-alias"::equals, metadata);
+        String putMappingIndexOrAlias = IndicesAndAliasesResolver.getPutMappingIndexOrAlias(
+            request,
+            (i, s) -> i.equals("logs-alias"),
+            metadata
+        );
         String message = "user is authorized to access `logs-alias` and the put mapping request is for a write index"
             + "so this should have returned the alias name";
         assertEquals(message, "logs-alias", putMappingIndexOrAlias);
@@ -1943,7 +1948,11 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String index = "logs-00002"; // read index
         PutMappingRequest request = new PutMappingRequest(Strings.EMPTY_ARRAY).setConcreteIndex(new Index(index, UUIDs.base64UUID()));
         assert metadata.getIndicesLookup().get("logs-alias").getIndices().size() == 3;
-        String putMappingIndexOrAlias = IndicesAndAliasesResolver.getPutMappingIndexOrAlias(request, "logs-alias"::equals, metadata);
+        String putMappingIndexOrAlias = IndicesAndAliasesResolver.getPutMappingIndexOrAlias(
+            request,
+            (i, s) -> i.equals("logs-alias"),
+            metadata
+        );
         String message = "user is authorized to access `logs-alias` and the put mapping request is for a read index"
             + "so this should have returned the concrete index as fallback";
         assertEquals(message, index, putMappingIndexOrAlias);
@@ -2217,14 +2226,14 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> dataStreams = List.of("logs-foo", "logs-foobar");
         final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
         for (String dsName : dataStreams) {
-            assertThat(authorizedIndices.all().get(), hasItem(dsName));
-            assertThat(authorizedIndices.check(dsName), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(dsName));
+            assertThat(authorizedIndices.check(dsName, IndexComponentSelector.DATA), is(true));
             DataStream dataStream = metadata.dataStreams().get(dsName);
-            assertThat(authorizedIndices.all().get(), hasItem(dsName));
-            assertThat(authorizedIndices.check(dsName), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(dsName));
+            assertThat(authorizedIndices.check(dsName, IndexComponentSelector.DATA), is(true));
             for (Index i : dataStream.getIndices()) {
-                assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-                assertThat(authorizedIndices.check(i.getName()), is(true));
+                assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+                assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
             }
         }
 
@@ -2256,14 +2265,14 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         // data streams and their backing indices should _not_ be in the authorized list since the backing indices
         // do not match the requested name
         final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
-        assertThat(authorizedIndices.all().get(), hasItem(dataStreamName));
-        assertThat(authorizedIndices.check(dataStreamName), is(true));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(dataStreamName));
+        assertThat(authorizedIndices.check(dataStreamName, IndexComponentSelector.DATA), is(true));
         DataStream dataStream = metadata.dataStreams().get(dataStreamName);
-        assertThat(authorizedIndices.all().get(), hasItem(dataStreamName));
-        assertThat(authorizedIndices.check(dataStreamName), is(true));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(dataStreamName));
+        assertThat(authorizedIndices.check(dataStreamName, IndexComponentSelector.DATA), is(true));
         for (Index i : dataStream.getIndices()) {
-            assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-            assertThat(authorizedIndices.check(i.getName()), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+            assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
         }
 
         // neither data streams nor their backing indices will be in the resolved list since the backing indices do not match the
@@ -2291,11 +2300,11 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, TransportSearchAction.TYPE.name(), request);
         for (String dsName : expectedDataStreams) {
             DataStream dataStream = metadata.dataStreams().get(dsName);
-            assertThat(authorizedIndices.all().get(), hasItem(dsName));
-            assertThat(authorizedIndices.check(dsName), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(dsName));
+            assertThat(authorizedIndices.check(dsName, IndexComponentSelector.DATA), is(true));
             for (Index i : dataStream.getIndices()) {
-                assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-                assertThat(authorizedIndices.check(i.getName()), is(true));
+                assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+                assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
             }
         }
 
@@ -2332,11 +2341,11 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, TransportSearchAction.TYPE.name(), request);
         // data streams and their backing indices should be in the authorized list
-        assertThat(authorizedIndices.all().get(), hasItem(dataStreamName));
-        assertThat(authorizedIndices.check(dataStreamName), is(true));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(dataStreamName));
+        assertThat(authorizedIndices.check(dataStreamName, IndexComponentSelector.DATA), is(true));
         for (Index i : dataStream.getIndices()) {
-            assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-            assertThat(authorizedIndices.check(i.getName()), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+            assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
         }
 
         ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
@@ -2365,15 +2374,15 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, TransportSearchAction.TYPE.name(), request);
         for (String dsName : expectedDataStreams) {
             DataStream dataStream = metadata.dataStreams().get(dsName);
-            assertThat(authorizedIndices.all().get(), hasItem(dsName));
-            assertThat(authorizedIndices.check(dsName), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(dsName));
+            assertThat(authorizedIndices.check(dsName, IndexComponentSelector.DATA), is(true));
             for (Index i : dataStream.getIndices()) {
-                assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-                assertThat(authorizedIndices.check(i.getName()), is(true));
+                assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+                assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
             }
             for (Index i : dataStream.getFailureIndices()) {
-                assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-                assertThat(authorizedIndices.check(i.getName()), is(true));
+                assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+                assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
             }
         }
 
@@ -2404,16 +2413,16 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         // data streams and their backing indices should _not_ be in the authorized list since the backing indices
         // did not match the requested pattern and the request does not support data streams
         final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
-        assertThat(authorizedIndices.all().get(), hasItem(dataStreamName));
-        assertThat(authorizedIndices.check(dataStreamName), is(true));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(dataStreamName));
+        assertThat(authorizedIndices.check(dataStreamName, IndexComponentSelector.DATA), is(true));
         DataStream dataStream = metadata.dataStreams().get(dataStreamName);
         for (Index i : dataStream.getIndices()) {
-            assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-            assertThat(authorizedIndices.check(i.getName()), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+            assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
         }
         for (Index i : dataStream.getFailureIndices()) {
-            assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-            assertThat(authorizedIndices.check(i.getName()), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+            assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
         }
 
         // neither data streams nor their backing indices will be in the resolved list since the request does not support data streams
@@ -2444,19 +2453,19 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         // data streams should _not_ be in the authorized list but their backing indices that matched both the requested pattern
         // and the authorized pattern should be in the list
         final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
-        assertThat(authorizedIndices.all().get(), not(hasItem("logs-foobar")));
-        assertThat(authorizedIndices.check("logs-foobar"), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(hasItem("logs-foobar")));
+        assertThat(authorizedIndices.check("logs-foobar", IndexComponentSelector.DATA), is(false));
         DataStream dataStream = metadata.dataStreams().get("logs-foobar");
-        assertThat(authorizedIndices.all().get(), not(hasItem(indexName)));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(hasItem(indexName)));
         // request pattern is subset of the authorized pattern, but be aware that patterns are never passed to #check in main code
-        assertThat(authorizedIndices.check(indexName), is(true));
+        assertThat(authorizedIndices.check(indexName, IndexComponentSelector.DATA), is(true));
         for (Index i : dataStream.getIndices()) {
-            assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-            assertThat(authorizedIndices.check(i.getName()), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+            assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
         }
         for (Index i : dataStream.getFailureIndices()) {
-            assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-            assertThat(authorizedIndices.check(i.getName()), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+            assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
         }
 
         // only the backing indices will be in the resolved list since the request does not support data streams
@@ -2484,14 +2493,14 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         // data streams should _not_ be in the authorized list but a single backing index that matched the requested pattern
         // and the authorized name should be in the list
         final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
-        assertThat(authorizedIndices.all().get(), not(hasItem("logs-foobar")));
-        assertThat(authorizedIndices.check("logs-foobar"), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(hasItem("logs-foobar")));
+        assertThat(authorizedIndices.check("logs-foobar", IndexComponentSelector.DATA), is(false));
 
         String expectedIndex = failureStore
             ? DataStream.getDefaultFailureStoreName("logs-foobar", 1, System.currentTimeMillis())
             : DataStream.getDefaultBackingIndexName("logs-foobar", 1);
-        assertThat(authorizedIndices.all().get(), hasItem(expectedIndex));
-        assertThat(authorizedIndices.check(expectedIndex), is(true));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(expectedIndex));
+        assertThat(authorizedIndices.check(expectedIndex, IndexComponentSelector.DATA), is(true));
 
         // only the single backing index will be in the resolved list since the request does not support data streams
         // but one of the backing indices matched the requested pattern
@@ -2516,19 +2525,19 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         // data streams should _not_ be in the authorized list but their backing indices that matched both the requested pattern
         // and the authorized pattern should be in the list
         final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
-        assertThat(authorizedIndices.all().get(), not(hasItem("logs-foobar")));
-        assertThat(authorizedIndices.check("logs-foobar"), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(hasItem("logs-foobar")));
+        assertThat(authorizedIndices.check("logs-foobar", IndexComponentSelector.DATA), is(false));
         DataStream dataStream = metadata.dataStreams().get("logs-foobar");
-        assertThat(authorizedIndices.all().get(), not(hasItem(indexName)));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(hasItem(indexName)));
         // request pattern is subset of the authorized pattern, but be aware that patterns are never passed to #check in main code
-        assertThat(authorizedIndices.check(indexName), is(true));
+        assertThat(authorizedIndices.check(indexName, IndexComponentSelector.DATA), is(true));
         for (Index i : dataStream.getIndices()) {
-            assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-            assertThat(authorizedIndices.check(i.getName()), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+            assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
         }
         for (Index i : dataStream.getFailureIndices()) {
-            assertThat(authorizedIndices.all().get(), hasItem(i.getName()));
-            assertThat(authorizedIndices.check(i.getName()), is(true));
+            assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(i.getName()));
+            assertThat(authorizedIndices.check(i.getName(), IndexComponentSelector.DATA), is(true));
         }
 
         // only the backing indices will be in the resolved list since the request does not support data streams
@@ -2559,10 +2568,10 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             ? DataStream.getDefaultFailureStoreName("logs-foobar", 1, System.currentTimeMillis())
             : DataStream.getDefaultBackingIndexName("logs-foobar", 1);
         final AuthorizedIndices authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
-        assertThat(authorizedIndices.all().get(), not(hasItem("logs-foobar")));
-        assertThat(authorizedIndices.check("logs-foobar"), is(false));
-        assertThat(authorizedIndices.all().get(), hasItem(expectedIndex));
-        assertThat(authorizedIndices.check(expectedIndex), is(true));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), not(hasItem("logs-foobar")));
+        assertThat(authorizedIndices.check("logs-foobar", IndexComponentSelector.DATA), is(false));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(expectedIndex));
+        assertThat(authorizedIndices.check(expectedIndex, IndexComponentSelector.DATA), is(true));
 
         // only the single backing index will be in the resolved list since the request does not support data streams
         // but one of the backing indices matched the requested pattern

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.delete.TransportDeleteAction;
 import org.elasticsearch.action.index.TransportIndexAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ElasticsearchClient;
@@ -1443,14 +1444,14 @@ public class RBACEngineTests extends ESTestCase {
             lookup,
             () -> ignore -> {}
         );
-        assertThat(authorizedIndices.all().get(), hasItem(dataStreamName));
-        assertThat(authorizedIndices.check(dataStreamName), is(true));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA), hasItem(dataStreamName));
+        assertThat(authorizedIndices.check(dataStreamName, IndexComponentSelector.DATA), is(true));
         assertThat(
-            authorizedIndices.all().get(),
-            hasItems(backingIndices.stream().map(im -> im.getIndex().getName()).collect(Collectors.toList()).toArray(Strings.EMPTY_ARRAY))
+            authorizedIndices.all(IndexComponentSelector.DATA),
+            hasItems(backingIndices.stream().map(im -> im.getIndex().getName()).toList().toArray(Strings.EMPTY_ARRAY))
         );
         for (String index : backingIndices.stream().map(im -> im.getIndex().getName()).toList()) {
-            assertThat(authorizedIndices.check(index), is(true));
+            assertThat(authorizedIndices.check(index, IndexComponentSelector.DATA), is(true));
         }
     }
 
@@ -1486,7 +1487,8 @@ public class RBACEngineTests extends ESTestCase {
             lookup,
             () -> ignore -> {}
         );
-        assertThat(authorizedIndices.all().get().isEmpty(), is(true));
+        assertThat(authorizedIndices.all(IndexComponentSelector.DATA).isEmpty(), is(true));
+        assertThat(authorizedIndices.all(IndexComponentSelector.FAILURES).isEmpty(), is(true));
     }
 
     public void testNoInfiniteRecursionForRBACAuthorizationInfoHashCode() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/IndicesPermissionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/IndicesPermissionTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.admin.indices.mapping.put.TransportAutoPutMappingAction;
 import org.elasticsearch.action.admin.indices.mapping.put.TransportPutMappingAction;
 import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
@@ -180,6 +181,269 @@ public class IndicesPermissionTests extends ESTestCase {
         assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().getSingleSetOfQueries(), hasSize(2));
         assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().getSingleSetOfQueries(), equalTo(bothQueries));
 
+    }
+
+    public void testAuthorizeDataStreamAccessWithFailuresSelector() {
+        Metadata.Builder builder = Metadata.builder();
+        String dataStreamName = randomAlphaOfLength(6);
+        int numBackingIndices = randomIntBetween(1, 3);
+        List<IndexMetadata> backingIndices = new ArrayList<>();
+        for (int backingIndexNumber = 1; backingIndexNumber <= numBackingIndices; backingIndexNumber++) {
+            backingIndices.add(createBackingIndexMetadata(DataStream.getDefaultBackingIndexName(dataStreamName, backingIndexNumber)));
+        }
+        DataStream ds = DataStreamTestHelper.newInstance(
+            dataStreamName,
+            backingIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList())
+        );
+        builder.put(ds);
+        for (IndexMetadata index : backingIndices) {
+            builder.put(index, false);
+        }
+        var metadata = builder.build().getProject();
+        FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
+
+        for (var privilege : List.of(IndexPrivilege.ALL, IndexPrivilege.READ)) {
+            Role role = Role.builder(RESTRICTED_INDICES, "_role")
+                .add(
+                    new FieldPermissions(fieldPermissionDef(null, null)),
+                    null,
+                    privilege,
+                    randomBoolean(),
+                    randomFrom(dataStreamName, dataStreamName + "*")
+                )
+                .build();
+            IndicesAccessControl permissions = role.authorize(
+                TransportSearchAction.TYPE.name(),
+                Sets.newHashSet(randomFrom(dataStreamName, dataStreamName + "::data")),
+                metadata,
+                fieldPermissionsCache
+            );
+            assertThat("for privilege " + privilege, permissions.isGranted(), is(true));
+            assertThat("for privilege " + privilege, permissions.hasIndexPermissions(dataStreamName + "::failures"), is(false));
+            assertThat("for privilege " + privilege, permissions.hasIndexPermissions(dataStreamName), is(true));
+        }
+
+        for (var privilege : List.of(IndexPrivilege.ALL, IndexPrivilege.READ_FAILURE_STORE)) {
+            Role role = Role.builder(RESTRICTED_INDICES, "_role")
+                .add(
+                    new FieldPermissions(fieldPermissionDef(null, null)),
+                    null,
+                    privilege,
+                    randomBoolean(),
+                    randomFrom(dataStreamName, dataStreamName + "*")
+                )
+                .build();
+            IndicesAccessControl permissions = role.authorize(
+                TransportSearchAction.TYPE.name(),
+                Sets.newHashSet(dataStreamName + "::failures"),
+                metadata,
+                fieldPermissionsCache
+            );
+            assertThat("for privilege " + privilege, permissions.isGranted(), is(true));
+            assertThat("for privilege " + privilege, permissions.hasIndexPermissions(dataStreamName + "::failures"), is(true));
+            assertThat("for privilege " + privilege, permissions.hasIndexPermissions(dataStreamName), is(false));
+        }
+
+        for (var privilege : List.of(IndexPrivilege.ALL, IndexPrivilege.READ_FAILURE_STORE)) {
+            Role role = Role.builder(RESTRICTED_INDICES, "_role")
+                .add(
+                    new FieldPermissions(fieldPermissionDef(null, null)),
+                    null,
+                    privilege,
+                    randomBoolean(),
+                    randomFrom(dataStreamName, dataStreamName + "*")
+                )
+                .build();
+            IndicesAccessControl permissions = role.authorize(
+                TransportSearchAction.TYPE.name(),
+                Sets.newHashSet(dataStreamName + "::failures"),
+                metadata,
+                fieldPermissionsCache
+            );
+
+            assertThat("for privilege " + privilege, permissions.isGranted(), is(true));
+            assertThat("for privilege " + privilege, permissions.hasIndexPermissions(dataStreamName + "::failures"), is(true));
+            assertThat("for privilege " + privilege, permissions.hasIndexPermissions(dataStreamName), is(false));
+        }
+
+        {
+            Role role = Role.builder(RESTRICTED_INDICES, "_role")
+                .add(
+                    new FieldPermissions(fieldPermissionDef(null, null)),
+                    null,
+                    IndexPrivilege.READ,
+                    randomBoolean(),
+                    randomFrom(dataStreamName, dataStreamName + "*")
+                )
+                .add(
+                    new FieldPermissions(fieldPermissionDef(null, null)),
+                    null,
+                    IndexPrivilege.READ_FAILURE_STORE,
+                    randomBoolean(),
+                    randomFrom(dataStreamName, dataStreamName + "*")
+                )
+                .build();
+            IndicesAccessControl permissions = role.authorize(
+                TransportSearchAction.TYPE.name(),
+                Sets.newHashSet(randomFrom(dataStreamName, dataStreamName + "::data"), dataStreamName + "::failures"),
+                metadata,
+                fieldPermissionsCache
+            );
+            assertThat(permissions.isGranted(), is(true));
+            assertThat(permissions.hasIndexPermissions(dataStreamName + "::failures"), is(true));
+            assertThat(permissions.hasIndexPermissions(dataStreamName), is(true));
+        }
+
+        {
+            Role role = Role.builder(RESTRICTED_INDICES, "_role")
+                .add(
+                    new FieldPermissions(fieldPermissionDef(null, null)),
+                    null,
+                    IndexPrivilege.ALL,
+                    randomBoolean(),
+                    randomFrom(dataStreamName, dataStreamName + "*")
+                )
+                .build();
+            IndicesAccessControl permissions = role.authorize(
+                TransportSearchAction.TYPE.name(),
+                Sets.newHashSet(randomFrom(dataStreamName, dataStreamName + "::data"), dataStreamName + "::failures"),
+                metadata,
+                fieldPermissionsCache
+            );
+            assertThat("for privilege " + IndexPrivilege.ALL, permissions.isGranted(), is(true));
+            assertThat("for privilege " + IndexPrivilege.ALL, permissions.hasIndexPermissions(dataStreamName + "::failures"), is(true));
+            assertThat("for privilege " + IndexPrivilege.ALL, permissions.hasIndexPermissions(dataStreamName), is(true));
+        }
+        {
+            Role role = Role.builder(RESTRICTED_INDICES, "_role")
+                .add(
+                    new FieldPermissions(fieldPermissionDef(null, null)),
+                    null,
+                    IndexPrivilege.READ_FAILURE_STORE,
+                    randomBoolean(),
+                    randomFrom(dataStreamName, dataStreamName + "*")
+                )
+                .build();
+            IndicesAccessControl permissions = role.authorize(
+                TransportSearchAction.TYPE.name(),
+                Sets.newHashSet(randomFrom(dataStreamName, dataStreamName + "::data"), dataStreamName + "::failures"),
+                metadata,
+                fieldPermissionsCache
+            );
+            assertThat("for privilege " + IndexPrivilege.READ_FAILURE_STORE, permissions.isGranted(), is(false));
+            assertThat(
+                "for privilege " + IndexPrivilege.READ_FAILURE_STORE,
+                permissions.hasIndexPermissions(dataStreamName + "::failures"),
+                is(true)
+            );
+            assertThat("for privilege " + IndexPrivilege.READ_FAILURE_STORE, permissions.hasIndexPermissions(dataStreamName), is(false));
+        }
+
+        {
+            Role role = Role.builder(RESTRICTED_INDICES, "_role")
+                .add(
+                    new FieldPermissions(fieldPermissionDef(null, null)),
+                    null,
+                    IndexPrivilege.READ,
+                    randomBoolean(),
+                    randomFrom(dataStreamName, dataStreamName + "*")
+                )
+                .build();
+            IndicesAccessControl permissions = role.authorize(
+                TransportSearchAction.TYPE.name(),
+                Sets.newHashSet(randomFrom(dataStreamName, dataStreamName + "::data"), dataStreamName + "::failures"),
+                metadata,
+                fieldPermissionsCache
+            );
+            assertThat("for privilege " + IndexPrivilege.READ, permissions.isGranted(), is(false));
+            assertThat("for privilege " + IndexPrivilege.READ, permissions.hasIndexPermissions(dataStreamName + "::failures"), is(false));
+            assertThat("for privilege " + IndexPrivilege.READ, permissions.hasIndexPermissions(dataStreamName), is(true));
+        }
+    }
+
+    public void testAuthorizeDataStreamFailureIndices() {
+        Metadata.Builder builder = Metadata.builder();
+        String dataStreamName = randomAlphaOfLength(6);
+        int numBackingIndices = randomIntBetween(1, 3);
+        List<IndexMetadata> backingIndices = new ArrayList<>();
+        for (int backingIndexNumber = 1; backingIndexNumber <= numBackingIndices; backingIndexNumber++) {
+            backingIndices.add(createBackingIndexMetadata(DataStream.getDefaultBackingIndexName(dataStreamName, backingIndexNumber)));
+        }
+        List<IndexMetadata> failureIndices = new ArrayList<>();
+        int numFailureIndices = randomIntBetween(1, 3);
+        for (int failureIndexNumber = 1; failureIndexNumber <= numFailureIndices; failureIndexNumber++) {
+            failureIndices.add(createBackingIndexMetadata(DataStream.getDefaultFailureStoreName(dataStreamName, failureIndexNumber, 1L)));
+        }
+        DataStream ds = DataStreamTestHelper.newInstance(
+            dataStreamName,
+            backingIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList()),
+            failureIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList())
+        );
+        builder.put(ds);
+        for (IndexMetadata index : backingIndices) {
+            builder.put(index, false);
+        }
+        for (IndexMetadata index : failureIndices) {
+            builder.put(index, false);
+        }
+        var metadata = builder.build().getProject();
+        FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
+
+        for (var privilege : List.of(IndexPrivilege.READ)) {
+            Role role = Role.builder(RESTRICTED_INDICES, "_role")
+                .add(
+                    new FieldPermissions(fieldPermissionDef(null, null)),
+                    null,
+                    privilege,
+                    randomBoolean(),
+                    randomFrom(dataStreamName, dataStreamName + "*")
+                )
+                .build();
+            String failureIndex = randomFrom(failureIndices).getIndex().getName();
+            IndicesAccessControl permissions = role.authorize(
+                TransportSearchAction.TYPE.name(),
+                Sets.newHashSet(failureIndex),
+                metadata,
+                fieldPermissionsCache
+            );
+            assertThat("for privilege " + privilege, permissions.isGranted(), is(false));
+            assertThat("for privilege " + privilege, permissions.hasIndexPermissions(failureIndex), is(false));
+
+            String dataIndex = randomFrom(backingIndices).getIndex().getName();
+            permissions = role.authorize(TransportSearchAction.TYPE.name(), Sets.newHashSet(dataIndex), metadata, fieldPermissionsCache);
+
+            assertThat("for privilege " + privilege, permissions.isGranted(), is(true));
+            assertThat("for privilege " + privilege, permissions.hasIndexPermissions(dataIndex), is(true));
+        }
+
+        for (var privilege : List.of(IndexPrivilege.READ_FAILURE_STORE)) {
+            Role role = Role.builder(RESTRICTED_INDICES, "_role")
+                .add(
+                    new FieldPermissions(fieldPermissionDef(null, null)),
+                    null,
+                    privilege,
+                    randomBoolean(),
+                    randomFrom(dataStreamName, dataStreamName + "*")
+                )
+                .build();
+
+            String failureIndex = randomFrom(failureIndices).getIndex().getName();
+            IndicesAccessControl permissions = role.authorize(
+                TransportSearchAction.TYPE.name(),
+                Sets.newHashSet(failureIndex),
+                metadata,
+                fieldPermissionsCache
+            );
+
+            assertThat("for privilege " + privilege, permissions.isGranted(), is(true));
+            assertThat("for privilege " + privilege, permissions.hasIndexPermissions(failureIndex), is(true));
+
+            String dataIndex = randomFrom(backingIndices).getIndex().getName();
+            permissions = role.authorize(TransportSearchAction.TYPE.name(), Sets.newHashSet(dataIndex), metadata, fieldPermissionsCache);
+
+            assertThat("for privilege " + privilege, permissions.isGranted(), is(false));
+            assertThat("for privilege " + privilege, permissions.hasIndexPermissions(dataIndex), is(false));
+        }
     }
 
     public void testAuthorizeMultipleGroupsMixedDls() {
@@ -698,14 +962,15 @@ public class IndicesPermissionTests extends ESTestCase {
         );
         IndicesPermission.IsResourceAuthorizedPredicate predicate = new IndicesPermission.IsResourceAuthorizedPredicate(
             StringMatcher.of("other"),
+            StringMatcher.of(),
             StringMatcher.of(dataStreamName, backingIndex.getName(), concreteIndex.getName(), alias.getName())
         );
         assertThat(predicate.test(dataStream), is(false));
         // test authorization for a missing resource with the datastream's name
-        assertThat(predicate.test(dataStream.getName(), null), is(true));
+        assertThat(predicate.test(dataStream.getName(), null, IndexComponentSelector.DATA), is(true));
         assertThat(predicate.test(backingIndex), is(false));
         // test authorization for a missing resource with the backing index's name
-        assertThat(predicate.test(backingIndex.getName(), null), is(true));
+        assertThat(predicate.test(backingIndex.getName(), null, IndexComponentSelector.DATA), is(true));
         assertThat(predicate.test(concreteIndex), is(true));
         assertThat(predicate.test(alias), is(true));
     }
@@ -713,10 +978,12 @@ public class IndicesPermissionTests extends ESTestCase {
     public void testResourceAuthorizedPredicateAnd() {
         IndicesPermission.IsResourceAuthorizedPredicate predicate1 = new IndicesPermission.IsResourceAuthorizedPredicate(
             StringMatcher.of("c", "a"),
+            StringMatcher.of(),
             StringMatcher.of("b", "d")
         );
         IndicesPermission.IsResourceAuthorizedPredicate predicate2 = new IndicesPermission.IsResourceAuthorizedPredicate(
             StringMatcher.of("c", "b"),
+            StringMatcher.of(),
             StringMatcher.of("a", "d")
         );
         Metadata.Builder mb = Metadata.builder(
@@ -745,6 +1012,75 @@ public class IndicesPermissionTests extends ESTestCase {
         assertThat(predicate.test(concreteIndexB), is(true));
         assertThat(predicate.test(concreteIndexC), is(true));
         assertThat(predicate.test(concreteIndexD), is(true));
+    }
+
+    public void testResourceAuthorizedPredicateAndWithFailures() {
+        IndicesPermission.IsResourceAuthorizedPredicate predicate1 = new IndicesPermission.IsResourceAuthorizedPredicate(
+            StringMatcher.of("c", "a"),
+            StringMatcher.of("e", "f"),
+            StringMatcher.of("b", "d")
+        );
+        IndicesPermission.IsResourceAuthorizedPredicate predicate2 = new IndicesPermission.IsResourceAuthorizedPredicate(
+            StringMatcher.of("c", "b"),
+            StringMatcher.of("a", "f", "g"),
+            StringMatcher.of("a", "d")
+        );
+        Metadata.Builder mb = Metadata.builder(
+            DataStreamTestHelper.getClusterStateWithDataStreams(
+                List.of(
+                    Tuple.tuple("a", 1),
+                    Tuple.tuple("b", 1),
+                    Tuple.tuple("c", 1),
+                    Tuple.tuple("d", 1),
+                    Tuple.tuple("e", 1),
+                    Tuple.tuple("f", 1)
+                ),
+                List.of(),
+                Instant.now().toEpochMilli(),
+                builder().build(),
+                1
+            ).getMetadata()
+        );
+        DataStream dataStreamA = mb.dataStream("a");
+        DataStream dataStreamB = mb.dataStream("b");
+        DataStream dataStreamC = mb.dataStream("c");
+        DataStream dataStreamD = mb.dataStream("d");
+        DataStream dataStreamE = mb.dataStream("e");
+        DataStream dataStreamF = mb.dataStream("f");
+        IndexAbstraction concreteIndexA = concreteIndexAbstraction("a");
+        IndexAbstraction concreteIndexB = concreteIndexAbstraction("b");
+        IndexAbstraction concreteIndexC = concreteIndexAbstraction("c");
+        IndexAbstraction concreteIndexD = concreteIndexAbstraction("d");
+        IndexAbstraction concreteIndexE = concreteIndexAbstraction("e");
+        IndexAbstraction concreteIndexF = concreteIndexAbstraction("f");
+        IndicesPermission.IsResourceAuthorizedPredicate predicate = predicate1.and(predicate2);
+        assertThat(predicate.test(dataStreamA), is(false));
+        assertThat(predicate.test(dataStreamB), is(false));
+        assertThat(predicate.test(dataStreamC), is(true));
+        assertThat(predicate.test(dataStreamD), is(false));
+        assertThat(predicate.test(dataStreamE), is(false));
+        assertThat(predicate.test(dataStreamF), is(false));
+
+        assertThat(predicate.test(dataStreamA, IndexComponentSelector.FAILURES), is(false));
+        assertThat(predicate.test(dataStreamB, IndexComponentSelector.FAILURES), is(false));
+        assertThat(predicate.test(dataStreamC, IndexComponentSelector.FAILURES), is(false));
+        assertThat(predicate.test(dataStreamD, IndexComponentSelector.FAILURES), is(false));
+        assertThat(predicate.test(dataStreamE, IndexComponentSelector.FAILURES), is(false));
+        assertThat(predicate.test(dataStreamF, IndexComponentSelector.FAILURES), is(true));
+
+        assertThat(predicate.test(concreteIndexA), is(true));
+        assertThat(predicate.test(concreteIndexB), is(true));
+        assertThat(predicate.test(concreteIndexC), is(true));
+        assertThat(predicate.test(concreteIndexD), is(true));
+        assertThat(predicate.test(concreteIndexE), is(false));
+        assertThat(predicate.test(concreteIndexF), is(false));
+
+        assertThat(predicate.test(concreteIndexA, IndexComponentSelector.FAILURES), is(false));
+        assertThat(predicate.test(concreteIndexB, IndexComponentSelector.FAILURES), is(false));
+        assertThat(predicate.test(concreteIndexC, IndexComponentSelector.FAILURES), is(false));
+        assertThat(predicate.test(concreteIndexD, IndexComponentSelector.FAILURES), is(false));
+        assertThat(predicate.test(concreteIndexE, IndexComponentSelector.FAILURES), is(false));
+        assertThat(predicate.test(concreteIndexF, IndexComponentSelector.FAILURES), is(true));
     }
 
     private static IndexAbstraction concreteIndexAbstraction(String name) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/IndicesPermissionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/IndicesPermissionTests.java
@@ -199,7 +199,7 @@ public class IndicesPermissionTests extends ESTestCase {
         for (IndexMetadata index : backingIndices) {
             builder.put(index, false);
         }
-        var metadata = builder.build().getProject();
+        var metadata = builder.build();
         FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
 
         for (var privilege : List.of(IndexPrivilege.ALL, IndexPrivilege.READ)) {
@@ -386,7 +386,7 @@ public class IndicesPermissionTests extends ESTestCase {
         for (IndexMetadata index : failureIndices) {
             builder.put(index, false);
         }
-        var metadata = builder.build().getProject();
+        var metadata = builder.build();
         FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
 
         for (var privilege : List.of(IndexPrivilege.READ)) {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RolesBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RolesBackwardsCompatibilityIT.java
@@ -382,6 +382,7 @@ public class RolesBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
     private static RoleDescriptor randomRoleDescriptor(boolean includeDescription, boolean includeManageRoles) {
         final Set<String> excludedPrivileges = Set.of(
             "read_failure_store",
+            "manage_failure_store",
             "cross_cluster_replication",
             "cross_cluster_replication_internal",
             "manage_data_stream_lifecycle"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Failure Store Access Authorization (#123986)](https://github.com/elastic/elasticsearch/pull/123986)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)