### PR TITLE
Remove redundant `consumeAll` call on  in QueryPhaseResultConsumer

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -385,7 +385,6 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
             result.consumeAll();
             next.run();
         } else if (result.isNull()) {
-            result.consumeAll();
             SearchShardTarget target = result.getSearchShardTarget();
             SearchShard searchShard = new SearchShard(target.getClusterAlias(), target.getShardId());
             synchronized (this) {


### PR DESCRIPTION
This is redundant, no need to call this for a null response which has none of the fields that `consumeAll` nulls out set in the first place.
