### PR TITLE
[9.0] Mark semantic text as GA in docs (#124669)

### DIFF
--- a/docs/changelog/124669.yaml
+++ b/docs/changelog/124669.yaml
@@ -1,0 +1,10 @@
+pr: 124669
+summary: Release semantic_text as a GA feature
+area: Mapping
+type: feature
+issues: []
+highlight:
+  title: Release semantic_text as a GA feature
+  body: semantic_text is now an official GA (generally available) feature!
+        This field type allows you to easily set up and perform semantic search with minimal ramp up time.
+  notable: true

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -6,12 +6,6 @@ mapped_pages:
 
 # Semantic text field type [semantic-text]
 
-
-::::{warning}
-This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
-::::
-
-
 The `semantic_text` field type automatically generates embeddings for text content using an inference endpoint. Long passages are [automatically chunked](#auto-text-chunking) to smaller sections to enable the processing of larger corpuses of text.
 
 The `semantic_text` field type specifies an inference endpoint identifier that will be used to generate embeddings. You can create the inference endpoint by using the [Create {{infer}} API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put). This field type and the [`semantic` query](/reference/query-languages/query-dsl/query-dsl-semantic-query.md) type make it simpler to perform semantic search on your data. The `semantic_text` field type may also be queried with [match](/reference/query-languages/query-dsl/query-dsl-match-query.md), [sparse_vector](/reference/query-languages/query-dsl/query-dsl-sparse-vector-query.md) or [knn](/reference/query-languages/query-dsl/query-dsl-knn-query.md) queries.

--- a/docs/reference/query-languages/query-dsl/query-dsl-semantic-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-semantic-query.md
@@ -6,12 +6,6 @@ mapped_pages:
 
 # Semantic query [query-dsl-semantic-query]
 
-
-::::{warning}
-This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
-::::
-
-
 The `semantic` query type enables you to perform [semantic search](docs-content://solutions/search/semantic-search.md) on data stored in a [`semantic_text`](/reference/elasticsearch/mapping-reference/semantic-text.md) field.
 
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Mark semantic text as GA in docs (#124669)