### PR TITLE
[8.x] ESQL: Align `RENAME` behavior with `EVAL` for sequential processing (#122250)

### DIFF
--- a/docs/changelog/122250.yaml
+++ b/docs/changelog/122250.yaml
@@ -1,0 +1,6 @@
+pr: 122250
+summary: "ESQL: Align `RENAME` behavior with `EVAL` for sequential processing"
+area: ES|QL
+type: enhancement
+issues:
+  - 121739

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/rename.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/rename.csv-spec
@@ -214,3 +214,85 @@ x:keyword
 Facello
 Simmel
 ;
+
+swappingNames
+required_capability: rename_sequential_processing
+FROM employees
+| SORT emp_no ASC
+| KEEP first_name, last_name
+| RENAME first_name AS last_name, last_name AS first_name, first_name as name
+| LIMIT 2
+;
+
+name:keyword
+Georgi
+Bezalel
+;
+
+complexSwappingNames
+required_capability: rename_sequential_processing
+FROM employees
+| SORT emp_no ASC
+| KEEP first_name, last_name, emp_no
+| RENAME first_name AS last_name, last_name AS first_name, first_name as emp_no, emp_no AS first_name
+| LIMIT 2
+;
+
+first_name:keyword
+Georgi
+Bezalel
+;
+
+
+reuseRenamedAlias
+required_capability: rename_sequential_processing
+FROM employees
+| SORT emp_no ASC
+| KEEP first_name, last_name
+| LIMIT 2
+| RENAME first_name AS x, x AS y, last_name as x
+;
+
+y:keyword   | x:keyword
+Georgi      | Facello
+Bezalel     | Simmel
+;
+
+
+multipleRenamesToSameAliasLastOnePrevails
+required_capability: rename_sequential_processing
+FROM employees
+| SORT emp_no ASC
+| KEEP first_name, last_name
+| LIMIT 2
+| RENAME first_name AS x, last_name as x
+;
+
+x:keyword
+Facello
+Simmel
+;
+
+
+swapNames
+required_capability: rename_sequential_processing
+ROW a="keyword", b=5
+| RENAME a AS temp, b AS a, temp AS b
+;
+
+b:keyword | a:integer
+keyword   | 5
+;
+
+
+multipleRenames
+required_capability: rename_sequential_processing
+ROW a="keyword", b=5, c=null
+| RENAME a AS c, b AS a
+| RENAME c AS b
+| RENAME a AS b, b AS a
+;
+
+a:integer
+5
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -270,7 +270,9 @@ public class EsqlCapabilities {
 
         /**
          * Execute `RENAME` operations sequentially from left to right,
-         * see <a href="https://github.com/elastic/elasticsearch/issues/122250"> ESQL: Align RENAME behavior with EVAL for sequential processing #122250 </a>
+         * see <a href="https://github.com/elastic/elasticsearch/issues/122250">
+         *     ESQL: Align RENAME behavior with EVAL for sequential processing #122250
+         * </a>
          */
         RENAME_SEQUENTIAL_PROCESSING,
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -269,6 +269,12 @@ public class EsqlCapabilities {
         UNION_TYPES_FIX_RENAME_RESOLUTION,
 
         /**
+         * Execute `RENAME` operations sequentially from left to right,
+         * see <a href="https://github.com/elastic/elasticsearch/issues/122250"> ESQL: Align RENAME behavior with EVAL for sequential processing #122250 </a>
+         */
+        RENAME_SEQUENTIAL_PROCESSING,
+
+        /**
          * Fix for union-types when some indexes are missing the required field. Done in #111932.
          */
         UNION_TYPES_MISSING_FIELD,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -856,6 +856,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 if (alias.child() instanceof UnresolvedAttribute ua && alias.name().equals(ua.name()) == false) {
                     // remove attributes overwritten by a renaming: `| keep a, b, c | rename a as b`
                     projections.removeIf(x -> x.name().equals(alias.name()));
+                    childrenOutput.removeIf(x -> x.name().equals(alias.name()));
 
                     var resolved = maybeResolveAttribute(ua, childrenOutput, logger);
                     if (resolved instanceof UnsupportedAttribute || resolved.resolved()) {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Align `RENAME` behavior with `EVAL` for sequential processing (#122250)