### PR TITLE
Remove redundant `response` parameter to `onResponseSent()`

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -148,7 +148,7 @@ final class OutboundHandler {
         );
         assert response.hasReferences();
         try {
-            sendMessage(channel, message, responseStatsConsumer, () -> messageListener.onResponseSent(requestId, action, response));
+            sendMessage(channel, message, responseStatsConsumer, () -> messageListener.onResponseSent(requestId, action));
         } catch (Exception ex) {
             if (isHandshake) {
                 logger.error(

--- a/server/src/main/java/org/elasticsearch/transport/TransportMessageListener.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportMessageListener.java
@@ -27,9 +27,8 @@ public interface TransportMessageListener {
      * Called for every action response sent after the response has been passed to the underlying network implementation.
      * @param requestId the request ID (unique per client)
      * @param action the request action
-     * @param response the response send
      */
-    default void onResponseSent(long requestId, String action, TransportResponse response) {}
+    default void onResponseSent(long requestId, String action) {}
 
     /***
      * Called for every failed action response after the response has been passed to the underlying network implementation.

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1288,7 +1288,7 @@ public class TransportService extends AbstractLifecycleComponent
 
     /** called by the {@link Transport} implementation once a response was sent to calling node */
     @Override
-    public void onResponseSent(long requestId, String action, TransportResponse response) {
+    public void onResponseSent(long requestId, String action) {
         if (tracerLog.isTraceEnabled() && shouldTraceAction(action)) {
             tracerLog.trace("[{}][{}] sent response", requestId, action);
         }
@@ -1541,7 +1541,7 @@ public class TransportService extends AbstractLifecycleComponent
 
         @Override
         public void sendResponse(TransportResponse response) {
-            service.onResponseSent(requestId, action, response);
+            service.onResponseSent(requestId, action);
             try (var shutdownBlock = service.pendingDirectHandlers.withRef()) {
                 if (shutdownBlock == null) {
                     // already shutting down, the handler will be completed by sendRequestInternal or doStop

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -220,13 +220,11 @@ public class OutboundHandlerTests extends ESTestCase {
 
         AtomicLong requestIdRef = new AtomicLong();
         AtomicReference<String> actionRef = new AtomicReference<>();
-        AtomicReference<TransportResponse> responseRef = new AtomicReference<>();
         handler.setMessageListener(new TransportMessageListener() {
             @Override
-            public void onResponseSent(long requestId, String action, TransportResponse response) {
+            public void onResponseSent(long requestId, String action) {
                 requestIdRef.set(requestId);
                 actionRef.set(action);
-                responseRef.set(response);
             }
         });
         if (compress) {
@@ -244,7 +242,6 @@ public class OutboundHandlerTests extends ESTestCase {
         }
         assertEquals(requestId, requestIdRef.get());
         assertEquals(action, actionRef.get());
-        assertEquals(response, responseRef.get());
 
         pipeline.handleBytes(channel, new ReleasableBytesReference(reference, () -> {}));
         final Tuple<Header, BytesReference> tuple = message.get();
@@ -338,18 +335,15 @@ public class OutboundHandlerTests extends ESTestCase {
 
         AtomicLong requestIdRef = new AtomicLong();
         AtomicReference<String> actionRef = new AtomicReference<>();
-        AtomicReference<TransportResponse> responseRef = new AtomicReference<>();
         AtomicReference<Exception> exceptionRef = new AtomicReference<>();
         handler.setMessageListener(new TransportMessageListener() {
             @Override
-            public void onResponseSent(long requestId, String action, TransportResponse response) {
+            public void onResponseSent(long requestId, String action) {
                 assertNull(channel.getMessageCaptor().get());
                 assertThat(requestIdRef.get(), equalTo(0L));
                 requestIdRef.set(requestId);
                 assertNull(actionRef.get());
                 actionRef.set(action);
-                assertNull(responseRef.get());
-                responseRef.set(response);
             }
 
             @Override
@@ -374,7 +368,6 @@ public class OutboundHandlerTests extends ESTestCase {
         }
         assertEquals(requestId, requestIdRef.get());
         assertEquals(action, actionRef.get());
-        assertEquals(response, responseRef.get());
         assertThat(exceptionRef.get().getMessage(), equalTo("simulated cbe"));
         assertTrue(response.released.get());
         BytesReference reference = channel.getMessageCaptor().get();
@@ -400,18 +393,15 @@ public class OutboundHandlerTests extends ESTestCase {
         long requestId = randomLongBetween(0, 300);
         AtomicLong requestIdRef = new AtomicLong();
         AtomicReference<String> actionRef = new AtomicReference<>();
-        AtomicReference<TransportResponse> responseRef = new AtomicReference<>();
         AtomicReference<Exception> exceptionRef = new AtomicReference<>();
         handler.setMessageListener(new TransportMessageListener() {
             @Override
-            public void onResponseSent(long requestId, String action, TransportResponse response) {
+            public void onResponseSent(long requestId, String action) {
                 assertNull(channel.getMessageCaptor().get());
                 assertThat(requestIdRef.get(), equalTo(0L));
                 requestIdRef.set(requestId);
                 assertNull(actionRef.get());
                 actionRef.set(action);
-                assertNull(responseRef.get());
-                responseRef.set(response);
             }
 
             @Override
@@ -436,7 +426,6 @@ public class OutboundHandlerTests extends ESTestCase {
         }
         assertEquals(requestId, requestIdRef.get());
         assertEquals(action, actionRef.get());
-        assertEquals(response, responseRef.get());
         assertThat(exceptionRef.get().getMessage(), equalTo("simulated cbe"));
         assertTrue(response.released.get());
         assertNull(channel.getMessageCaptor().get());
@@ -457,17 +446,14 @@ public class OutboundHandlerTests extends ESTestCase {
 
         AtomicLong requestIdRef = new AtomicLong();
         AtomicReference<String> actionRef = new AtomicReference<>();
-        AtomicReference<TransportResponse> responseRef = new AtomicReference<>();
         handler.setMessageListener(new TransportMessageListener() {
             @Override
-            public void onResponseSent(long requestId, String action, TransportResponse response) {
+            public void onResponseSent(long requestId, String action) {
                 assertNull(channel.getMessageCaptor().get());
                 assertThat(requestIdRef.get(), equalTo(0L));
                 requestIdRef.set(requestId);
                 assertNull(actionRef.get());
                 actionRef.set(action);
-                assertNull(responseRef.get());
-                responseRef.set(response);
             }
 
             @Override
@@ -485,7 +471,6 @@ public class OutboundHandlerTests extends ESTestCase {
         assertNull(channel.getListenerCaptor().get());
         assertEquals(requestId, requestIdRef.get());
         assertEquals(action, actionRef.get());
-        assertEquals(response, responseRef.get());
         assertTrue(response.released.get());
         assertFalse(channel.isOpen());
     }
@@ -507,7 +492,7 @@ public class OutboundHandlerTests extends ESTestCase {
         AtomicReference<Exception> exceptionRef = new AtomicReference<>();
         handler.setMessageListener(new TransportMessageListener() {
             @Override
-            public void onResponseSent(long requestId, String action, TransportResponse response) {
+            public void onResponseSent(long requestId, String action) {
                 throw new AssertionError("must not be called");
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -60,7 +60,6 @@ import org.elasticsearch.transport.TransportInterceptor;
 import org.elasticsearch.transport.TransportMessageListener;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestOptions;
-import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.TransportSettings;
 import org.elasticsearch.transport.netty4.Netty4Transport;
@@ -845,9 +844,9 @@ public class MockTransportService extends TransportService {
     }
 
     @Override
-    public void onResponseSent(long requestId, String action, TransportResponse response) {
-        super.onResponseSent(requestId, action, response);
-        messageListener.onResponseSent(requestId, action, response);
+    public void onResponseSent(long requestId, String action) {
+        super.onResponseSent(requestId, action);
+        messageListener.onResponseSent(requestId, action);
     }
 
     @Override
@@ -876,9 +875,9 @@ public class MockTransportService extends TransportService {
         }
 
         @Override
-        public void onResponseSent(long requestId, String action, TransportResponse response) {
+        public void onResponseSent(long requestId, String action) {
             for (TransportMessageListener listener : listeners) {
-                listener.onResponseSent(requestId, action, response);
+                listener.onResponseSent(requestId, action);
             }
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -545,7 +545,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             }
 
             @Override
-            public void onResponseSent(long requestId, String action, TransportResponse response) {
+            public void onResponseSent(long requestId, String action) {
                 if (action.equals(ACTION)) {
                     responseSent.incrementAndGet();
                 }


### PR DESCRIPTION
Nobody uses this parameter (except some tests that simply verify the
otherwise-unused plumbing is connected). This commit removes it.

Relates #125163