### PR TITLE
ES-10037 Persist recent write load in index metadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -195,6 +195,7 @@ public class TransportVersions {
     public static final TransportVersion INTRODUCE_LIFECYCLE_TEMPLATE = def(9_033_0_00);
     public static final TransportVersion INDEXING_STATS_INCLUDES_RECENT_WRITE_LOAD = def(9_034_0_00);
     public static final TransportVersion ESQL_AGGREGATE_METRIC_DOUBLE_LITERAL = def(9_035_0_00);
+    public static final TransportVersion INDEX_METADATA_INCLUDES_RECENT_WRITE_LOAD = def(9_036_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingService.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingService.java
@@ -322,6 +322,17 @@ public class DataStreamAutoShardingService {
 
     // Visible for testing
     static long computeOptimalNumberOfShards(int minNumberWriteThreads, int maxNumberWriteThreads, double indexingLoad) {
+        /*
+         * Define:
+         *  - shardsByMaxThreads = number of shards required to ensure no more than 50% utilization with max number of threads per shard
+         *  - shardsByMaxThreads = number of shards required to ensure no more than 50% utilization with min number of threads per shard
+         * Note that shardsByMaxThreads <= shardsByMinThreads.
+         * This returns:
+         *  - shardsByMaxThreads if shardsByMaxThreads > 3
+         *  - 3 if shardsByMaxThreads <= 3 and shardsByMinThreads > 3
+         *  - shardsByMinThreads if 0 < shardsByMinThreads <= 3
+         *  - 1 if shardsByMinThreads == 0
+         */
         return Math.max(
             Math.max(
                 Math.min(roundUp(indexingLoad / (minNumberWriteThreads / 2.0)), 3),

--- a/server/src/main/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingService.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingService.java
@@ -325,7 +325,7 @@ public class DataStreamAutoShardingService {
         /*
          * Define:
          *  - shardsByMaxThreads = number of shards required to ensure no more than 50% utilization with max number of threads per shard
-         *  - shardsByMaxThreads = number of shards required to ensure no more than 50% utilization with min number of threads per shard
+         *  - shardsByMinThreads = number of shards required to ensure no more than 50% utilization with min number of threads per shard
          * Note that shardsByMaxThreads <= shardsByMinThreads.
          * This returns:
          *  - shardsByMaxThreads if shardsByMaxThreads > 3

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadataStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadataStats.java
@@ -108,6 +108,7 @@ public record IndexMetadataStats(IndexWriteLoad indexWriteLoad, AverageShardSize
             indexWriteLoadBuilder.withShardWriteLoad(
                 shardStats.getShardRouting().id(),
                 indexingShardStats.getWriteLoad(),
+                indexingShardStats.getRecentWriteLoad(),
                 indexingShardStats.getTotalActiveTimeInMillis()
             );
             totalSizeInBytes += commonStats.getDocs().getTotalSizeInBytes();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexWriteLoad.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexWriteLoad.java
@@ -53,7 +53,7 @@ public class IndexWriteLoad implements Writeable, ToXContentFragment {
         @Nullable List<Double> shardsRecentWriteLoad
     ) {
         if (shardsWriteLoad.size() != shardsUptimeInMillis.size()) {
-            assert false;
+            assert false : "IndexWriteLoad.create() was called with non-matched lengths for shardWriteLoad and shardUptimeInMillis";
             throw new IllegalArgumentException(
                 "The same number of shard write loads and shard uptimes should be provided, but "
                     + shardsWriteLoad
@@ -64,12 +64,13 @@ public class IndexWriteLoad implements Writeable, ToXContentFragment {
         }
 
         if (shardsWriteLoad.isEmpty()) {
-            assert false;
+            assert false : "IndexWriteLoad.create() was called with empty shardsRecentWriteLoad";
+            ;
             throw new IllegalArgumentException("At least one shard write load and uptime should be provided, but none was provided");
         }
 
         if (shardsRecentWriteLoad != null && shardsRecentWriteLoad.size() != shardsUptimeInMillis.size()) {
-            assert false;
+            assert false : "IndexWriteLoad.create() was called with non-matched lengths for shardsRecentWriteLoad and shardUptimeInMillis";
             throw new IllegalArgumentException(
                 "The same number of shard write loads and shard uptimes should be provided, but "
                     + shardsWriteLoad
@@ -91,11 +92,13 @@ public class IndexWriteLoad implements Writeable, ToXContentFragment {
     private final double[] shardRecentWriteLoad;
 
     private IndexWriteLoad(double[] shardWriteLoad, long[] shardUptimeInMillis, @Nullable double[] shardRecentWriteLoad) {
-        assert shardWriteLoad.length == shardUptimeInMillis.length;
+        assert shardWriteLoad.length == shardUptimeInMillis.length
+            : "IndexWriteLoad constructor was called with non-matched lengths for shardWriteLoad and shardUptimeInMillis";
         this.shardWriteLoad = shardWriteLoad;
         this.shardUptimeInMillis = shardUptimeInMillis;
         if (shardRecentWriteLoad != null) {
-            assert shardRecentWriteLoad.length == shardUptimeInMillis.length;
+            assert shardRecentWriteLoad.length == shardUptimeInMillis.length
+                : "IndexWriteLoad constructor was called with non-matched lengths for shardRecentWriteLoad and shardUptimeInMillis";
             this.shardRecentWriteLoad = shardRecentWriteLoad;
         } else {
             this.shardRecentWriteLoad = new double[shardUptimeInMillis.length];

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -298,7 +298,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final RefreshFieldHasValueListener refreshFieldHasValueListener;
     private volatile boolean useRetentionLeasesInPeerRecovery;
     private final LongSupplier relativeTimeInNanosSupplier;
-    private volatile long startedRelativeTimeInNanos;
+    private volatile long startedRelativeTimeInNanos = -1L; // use -1 to indicate this has not yet been set to its true value
     private volatile long indexingTimeBeforeShardStartedInNanos;
     private volatile double recentIndexingLoadAtShardStarted;
     private final SubscribableListener<Void> waitForEngineOrClosedShardListeners = new SubscribableListener<>();
@@ -557,7 +557,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     : "a primary relocation is completed by the master, but primary mode is not active " + currentRouting;
 
                 changeState(IndexShardState.STARTED, "global state is [" + newRouting.state() + "]");
-                startedRelativeTimeInNanos = getRelativeTimeInNanos();
+                long relativeTimeInNanos = getRelativeTimeInNanos();
+                // We use -1 to indicate that startedRelativeTimeInNanos has yet not been set to its true value. So in the vanishingly
+                // unlikely case that getRelativeTimeInNanos() returns exactly -1, we advance by 1ns to avoid that special value.
+                startedRelativeTimeInNanos = (relativeTimeInNanos != -1L) ? relativeTimeInNanos : 0L;
                 indexingTimeBeforeShardStartedInNanos = internalIndexingStats.totalIndexingTimeInNanos();
                 recentIndexingLoadAtShardStarted = internalIndexingStats.recentIndexingLoad(startedRelativeTimeInNanos);
             } else if (currentRouting.primary()
@@ -1370,11 +1373,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
 
         long currentTimeInNanos = getRelativeTimeInNanos();
+        // We use -1 to indicate that startedRelativeTimeInNanos has yet not been set to its true value, i.e the shard has not started.
+        // In that case, we set timeSinceShardStartedInNanos to zero (which will result in all load metrics definitely being zero).
+        long timeSinceShardStartedInNanos = (startedRelativeTimeInNanos != -1L) ? (currentTimeInNanos - startedRelativeTimeInNanos) : 0L;
         return internalIndexingStats.stats(
             throttled,
             throttleTimeInMillis,
             indexingTimeBeforeShardStartedInNanos,
-            currentTimeInNanos - startedRelativeTimeInNanos,
+            timeSinceShardStartedInNanos,
             currentTimeInNanos,
             recentIndexingLoadAtShardStarted
         );

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexingStatsSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexingStatsSettings.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -22,8 +21,9 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class IndexingStatsSettings {
 
-    // TODO: Change this default to something sensible:
-    static final TimeValue RECENT_WRITE_LOAD_HALF_LIFE_DEFAULT = new TimeValue(10000, TimeUnit.DAYS);
+    static final TimeValue RECENT_WRITE_LOAD_HALF_LIFE_DEFAULT = TimeValue.timeValueMinutes(5); // Aligns with the interval between DSL runs
+    static final TimeValue RECENT_WRITE_LOAD_HALF_LIFE_MIN = TimeValue.timeValueSeconds(1); // A sub-second half-life makes no sense
+    static final TimeValue RECENT_WRITE_LOAD_HALF_LIFE_MAX = TimeValue.timeValueDays(100_000); // Long.MAX_VALUE nanos, rounded down
 
     /**
      * A cluster setting giving the half-life, in seconds, to use for the Exponentially Weighted Moving Rate calculation used for the
@@ -34,7 +34,8 @@ public class IndexingStatsSettings {
     public static final Setting<TimeValue> RECENT_WRITE_LOAD_HALF_LIFE_SETTING = Setting.timeSetting(
         "indices.stats.recent_write_load.half_life",
         RECENT_WRITE_LOAD_HALF_LIFE_DEFAULT,
-        TimeValue.ZERO,
+        RECENT_WRITE_LOAD_HALF_LIFE_MIN,
+        RECENT_WRITE_LOAD_HALF_LIFE_MAX,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );

--- a/server/src/test/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingServiceTests.java
@@ -100,7 +100,7 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
             1,
             now,
             List.of(now - 3000, now - 2000, now - 1000),
-            getWriteLoad(1, 2.0),
+            getWriteLoad(1, 2.0, 9999.0),
             null
         );
         builder.put(dataStream);
@@ -141,7 +141,7 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
                 1,
                 now,
                 List.of(now - 10_000, now - 7000, now - 5000, now - 2000, now - 1000),
-                getWriteLoad(1, 2.0),
+                getWriteLoad(1, 2.0, 9999.0),
                 autoShardingEvent
             );
 
@@ -170,7 +170,7 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
                 1,
                 now,
                 List.of(now - 10_000, now - 7000, now - 5000, now - 2000, now - 1000),
-                getWriteLoad(1, 2.0),
+                getWriteLoad(1, 2.0, 9999.0),
                 autoShardingEvent
             );
 
@@ -202,7 +202,7 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
                 1,
                 now,
                 List.of(now - 10_000_000, now - 7_000_000, now - 2_000_000, now - 1_000_000, now - 1000),
-                getWriteLoad(1, 2.0),
+                getWriteLoad(1, 2.0, 9999.0),
                 autoShardingEvent
             );
 
@@ -237,7 +237,7 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
                 3,
                 now,
                 List.of(now - 10_000, now - 7000, now - 5000, now - 2000, now - 1000),
-                getWriteLoad(3, 0.25),
+                getWriteLoad(3, 0.25, 9999.0),
                 autoShardingEvent
             );
 
@@ -271,7 +271,7 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
                     now - TimeValue.timeValueDays(2).getMillis(),
                     now - 1000
                 ),
-                getWriteLoad(3, 0.333),
+                getWriteLoad(3, 0.333, 9999.0),
                 autoShardingEvent
             );
 
@@ -306,7 +306,7 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
                     now - TimeValue.timeValueDays(2).getMillis(),
                     now - 1000
                 ),
-                getWriteLoad(3, 0.333),
+                getWriteLoad(3, 0.333, 9999.0),
                 autoShardingEvent
             );
 
@@ -346,7 +346,7 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
                     now - TimeValue.timeValueDays(1).getMillis(),
                     now - 1000
                 ),
-                getWriteLoad(3, 0.25),
+                getWriteLoad(3, 0.25, 9999.0),
                 autoShardingEvent
             );
 
@@ -386,7 +386,7 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
                     now - TimeValue.timeValueDays(2).getMillis(),
                     now - 1000
                 ),
-                getWriteLoad(3, 1.333),
+                getWriteLoad(3, 1.333, 9999.0),
                 autoShardingEvent
             );
 
@@ -479,7 +479,7 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
             IndexMetadata indexMetadata = createIndexMetadata(
                 DataStream.getDefaultBackingIndexName(dataStreamName, backingIndices.size(), creationDate),
                 1,
-                getWriteLoad(1, 999.0),
+                getWriteLoad(1, 999.0, 9999.0),
                 creationDate
             );
 
@@ -487,7 +487,7 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
                 indexMetadata = createIndexMetadata(
                     DataStream.getDefaultBackingIndexName(dataStreamName, backingIndices.size(), creationDate),
                     1,
-                    getWriteLoad(1, 1.0),
+                    getWriteLoad(1, 1.0, 9999.0),
                     creationDate
                 );
             }
@@ -502,14 +502,14 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
                 indexMetadata = createIndexMetadata(
                     DataStream.getDefaultBackingIndexName(dataStreamName, backingIndices.size(), createdAt),
                     3,
-                    getWriteLoad(3, 5.0), // max write index within cooling period
+                    getWriteLoad(3, 5.0, 9999.0), // max write index within cooling period
                     createdAt
                 );
             } else {
                 indexMetadata = createIndexMetadata(
                     DataStream.getDefaultBackingIndexName(dataStreamName, backingIndices.size(), createdAt),
                     3,
-                    getWriteLoad(3, 3.0), // each backing index has a write load of 3.0
+                    getWriteLoad(3, 3.0, 9999.0), // each backing index has a write load of 3.0
                     createdAt
                 );
             }
@@ -518,7 +518,12 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
         }
 
         final String writeIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, backingIndices.size());
-        final IndexMetadata writeIndexMetadata = createIndexMetadata(writeIndexName, 3, getWriteLoad(3, 1.0), System.currentTimeMillis());
+        final IndexMetadata writeIndexMetadata = createIndexMetadata(
+            writeIndexName,
+            3,
+            getWriteLoad(3, 1.0, 9999.0),
+            System.currentTimeMillis()
+        );
         backingIndices.add(writeIndexMetadata.getIndex());
         metadataBuilder.put(writeIndexMetadata, false);
 
@@ -558,9 +563,9 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
             IndexWriteLoad.Builder builder = IndexWriteLoad.builder(3);
             for (int shardId = 0; shardId < 3; shardId++) {
                 switch (shardId) {
-                    case 0 -> builder.withShardWriteLoad(shardId, 0.5, 40);
-                    case 1 -> builder.withShardWriteLoad(shardId, 3.0, 10);
-                    case 2 -> builder.withShardWriteLoad(shardId, 0.3333, 150);
+                    case 0 -> builder.withShardWriteLoad(shardId, 0.5, 9999.0, 40);
+                    case 1 -> builder.withShardWriteLoad(shardId, 3.0, 9999.0, 10);
+                    case 2 -> builder.withShardWriteLoad(shardId, 0.3333, 9999.0, 150);
                 }
             }
             indexMetadata = createIndexMetadata(
@@ -574,7 +579,12 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
         }
 
         final String writeIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, backingIndices.size());
-        final IndexMetadata writeIndexMetadata = createIndexMetadata(writeIndexName, 3, getWriteLoad(3, 0.1), System.currentTimeMillis());
+        final IndexMetadata writeIndexMetadata = createIndexMetadata(
+            writeIndexName,
+            3,
+            getWriteLoad(3, 0.1, 9999.0),
+            System.currentTimeMillis()
+        );
         backingIndices.add(writeIndexMetadata.getIndex());
         metadataBuilder.put(writeIndexMetadata, false);
 
@@ -694,12 +704,11 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
             .build();
     }
 
-    private IndexWriteLoad getWriteLoad(int numberOfShards, double shardWriteLoad) {
+    private IndexWriteLoad getWriteLoad(int numberOfShards, double shardWriteLoad, double shardRecentWriteLoad) {
         IndexWriteLoad.Builder builder = IndexWriteLoad.builder(numberOfShards);
         for (int shardId = 0; shardId < numberOfShards; shardId++) {
-            builder.withShardWriteLoad(shardId, shardWriteLoad, 1);
+            builder.withShardWriteLoad(shardId, shardWriteLoad, shardRecentWriteLoad, 1);
         }
         return builder.build();
     }
-
 }

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -1069,7 +1069,8 @@ public class ClusterStateTests extends ESTestCase {
                                 "stats": {
                                     "write_load": {
                                       "loads": [-1.0],
-                                      "uptimes": [-1]
+                                      "uptimes": [-1],
+                                      "recent_loads": [-1.0]
                                     },
                                     "avg_size": {
                                         "total_size_in_bytes": 120,
@@ -1343,6 +1344,9 @@ public class ClusterStateTests extends ESTestCase {
                                 ],
                                 "uptimes" : [
                                   -1
+                                ],
+                                "recent_loads" : [
+                                  -1.0
                                 ]
                               },
                               "avg_size" : {
@@ -1623,6 +1627,9 @@ public class ClusterStateTests extends ESTestCase {
                                 ],
                                 "uptimes" : [
                                   -1
+                                ],
+                                "recent_loads" : [
+                                  -1.0
                                 ]
                               },
                               "avg_size" : {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -2138,7 +2138,12 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
     private IndexWriteLoad randomIndexWriteLoad(int numberOfShards) {
         IndexWriteLoad.Builder builder = IndexWriteLoad.builder(numberOfShards);
         for (int shardId = 0; shardId < numberOfShards; shardId++) {
-            builder.withShardWriteLoad(shardId, randomDoubleBetween(0, 64, true), randomLongBetween(1, 10));
+            builder.withShardWriteLoad(
+                shardId,
+                randomDoubleBetween(0, 64, true),
+                randomDoubleBetween(0, 64, true),
+                randomLongBetween(1, 10)
+            );
         }
         return builder.build();
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsSerializationTests.java
@@ -32,7 +32,12 @@ public class IndexMetadataStatsSerializationTests extends AbstractXContentSerial
         final int numberOfShards = randomIntBetween(1, 10);
         final var indexWriteLoad = IndexWriteLoad.builder(numberOfShards);
         for (int i = 0; i < numberOfShards; i++) {
-            indexWriteLoad.withShardWriteLoad(i, randomDoubleBetween(1, 10, true), randomLongBetween(1, 1000));
+            indexWriteLoad.withShardWriteLoad(
+                i,
+                randomDoubleBetween(1, 10, true),
+                randomDoubleBetween(1, 10, true),
+                randomLongBetween(1, 1000)
+            );
         }
         return new IndexMetadataStats(indexWriteLoad.build(), randomLongBetween(1024, 10240), randomIntBetween(1, 4));
     }
@@ -53,10 +58,13 @@ public class IndexMetadataStatsSerializationTests extends AbstractXContentSerial
             double shardLoad = existingShard && randomBoolean()
                 ? originalWriteLoad.getWriteLoadForShard(i).getAsDouble()
                 : randomDoubleBetween(0, 128, true);
+            double recentShardLoad = existingShard && randomBoolean()
+                ? originalWriteLoad.getRecentWriteLoadForShard(i).getAsDouble()
+                : randomDoubleBetween(0, 128, true);
             long uptimeInMillis = existingShard && randomBoolean()
                 ? originalWriteLoad.getUptimeInMillisForShard(i).getAsLong()
                 : randomNonNegativeLong();
-            indexWriteLoad.withShardWriteLoad(i, shardLoad, uptimeInMillis);
+            indexWriteLoad.withShardWriteLoad(i, shardLoad, recentShardLoad, uptimeInMillis);
         }
         return new IndexMetadataStats(indexWriteLoad.build(), randomLongBetween(1024, 10240), randomIntBetween(1, 4));
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
@@ -735,7 +735,12 @@ public class IndexMetadataTests extends ESTestCase {
         IndexWriteLoad.Builder indexWriteLoadBuilder = IndexWriteLoad.builder(numberOfShards);
         int numberOfPopulatedWriteLoads = randomIntBetween(0, numberOfShards);
         for (int i = 0; i < numberOfPopulatedWriteLoads; i++) {
-            indexWriteLoadBuilder.withShardWriteLoad(i, randomDoubleBetween(0.0, 128.0, true), randomNonNegativeLong());
+            indexWriteLoadBuilder.withShardWriteLoad(
+                i,
+                randomDoubleBetween(0.0, 128.0, true),
+                randomDoubleBetween(0.0, 128.0, true),
+                randomNonNegativeLong()
+            );
         }
         return new IndexMetadataStats(indexWriteLoadBuilder.build(), randomLongBetween(100, 1024), randomIntBetween(1, 2));
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexWriteLoadTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexWriteLoadTests.java
@@ -10,9 +10,17 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
 
+import java.io.IOException;
+import java.util.OptionalDouble;
+import java.util.OptionalLong;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 public class IndexWriteLoadTests extends ESTestCase {
 
@@ -22,26 +30,71 @@ public class IndexWriteLoadTests extends ESTestCase {
         final IndexWriteLoad.Builder indexWriteLoadBuilder = IndexWriteLoad.builder(numberOfShards);
 
         final double[] populatedShardWriteLoads = new double[numberOfPopulatedShards];
+        final double[] populatedShardRecentWriteLoads = new double[numberOfPopulatedShards];
         final long[] populatedShardUptimes = new long[numberOfPopulatedShards];
         for (int shardId = 0; shardId < numberOfPopulatedShards; shardId++) {
             double writeLoad = randomDoubleBetween(1, 128, true);
+            double recentWriteLoad = randomDoubleBetween(1, 128, true);
             long uptimeInMillis = randomNonNegativeLong();
             populatedShardWriteLoads[shardId] = writeLoad;
+            populatedShardRecentWriteLoads[shardId] = recentWriteLoad;
             populatedShardUptimes[shardId] = uptimeInMillis;
-            indexWriteLoadBuilder.withShardWriteLoad(shardId, writeLoad, uptimeInMillis);
+            indexWriteLoadBuilder.withShardWriteLoad(shardId, writeLoad, recentWriteLoad, uptimeInMillis);
         }
 
         final IndexWriteLoad indexWriteLoad = indexWriteLoadBuilder.build();
         for (int shardId = 0; shardId < numberOfShards; shardId++) {
             if (shardId < numberOfPopulatedShards) {
-                assertThat(indexWriteLoad.getWriteLoadForShard(shardId).isPresent(), is(equalTo(true)));
-                assertThat(indexWriteLoad.getWriteLoadForShard(shardId).getAsDouble(), is(equalTo(populatedShardWriteLoads[shardId])));
-                assertThat(indexWriteLoad.getUptimeInMillisForShard(shardId).isPresent(), is(equalTo(true)));
-                assertThat(indexWriteLoad.getUptimeInMillisForShard(shardId).getAsLong(), is(equalTo(populatedShardUptimes[shardId])));
+                assertThat(indexWriteLoad.getWriteLoadForShard(shardId), equalTo(OptionalDouble.of(populatedShardWriteLoads[shardId])));
+                assertThat(
+                    indexWriteLoad.getRecentWriteLoadForShard(shardId),
+                    equalTo(OptionalDouble.of(populatedShardRecentWriteLoads[shardId]))
+                );
+                assertThat(indexWriteLoad.getUptimeInMillisForShard(shardId), equalTo(OptionalLong.of(populatedShardUptimes[shardId])));
             } else {
-                assertThat(indexWriteLoad.getWriteLoadForShard(shardId).isPresent(), is(false));
-                assertThat(indexWriteLoad.getUptimeInMillisForShard(shardId).isPresent(), is(false));
+                assertThat(indexWriteLoad.getWriteLoadForShard(shardId), equalTo(OptionalDouble.empty()));
+                assertThat(indexWriteLoad.getRecentWriteLoadForShard(shardId), equalTo(OptionalDouble.empty()));
+                assertThat(indexWriteLoad.getUptimeInMillisForShard(shardId), equalTo(OptionalLong.empty()));
             }
         }
+    }
+
+    public void testXContent_roundTrips() throws IOException {
+        IndexWriteLoad original = randomIndexWriteLoad();
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().value(original).endObject();
+        IndexWriteLoad roundTripped = IndexWriteLoad.fromXContent(createParser(xContentBuilder));
+        assertThat(roundTripped, equalTo(original));
+    }
+
+    public void testXContent_missingRecentWriteLoad() throws IOException {
+        // Simulate a JSON serialization from before we added recent write load:
+        IndexWriteLoad original = randomIndexWriteLoad();
+        XContentBuilder builder = XContentBuilder.builder(
+            XContentType.JSON,
+            emptySet(),
+            singleton(IndexWriteLoad.SHARDS_RECENT_WRITE_LOAD_FIELD.getPreferredName())
+        ).startObject().value(original).endObject();
+        // Deserialize, and assert that it matches the original except the recent write loads are all missing:
+        IndexWriteLoad roundTripped = IndexWriteLoad.fromXContent(createParser(builder));
+        for (int i = 0; i < original.numberOfShards(); i++) {
+            assertThat(roundTripped.getUptimeInMillisForShard(i), equalTo(original.getUptimeInMillisForShard(i)));
+            assertThat(roundTripped.getWriteLoadForShard(i), equalTo(original.getWriteLoadForShard(i)));
+            assertThat(roundTripped.getRecentWriteLoadForShard(i), equalTo(OptionalDouble.empty()));
+        }
+    }
+
+    private static IndexWriteLoad randomIndexWriteLoad() {
+        int numberOfPopulatedShards = 10;
+        int numberOfShards = randomIntBetween(numberOfPopulatedShards, 20);
+        IndexWriteLoad.Builder builder = IndexWriteLoad.builder(numberOfShards);
+        for (int shardId = 0; shardId < numberOfPopulatedShards; shardId++) {
+            builder.withShardWriteLoad(
+                shardId,
+                randomDoubleBetween(1, 128, true),
+                randomDoubleBetween(1, 128, true),
+                randomNonNegativeLong()
+            );
+        }
+        return builder.build();
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexingStatsSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexingStatsSettingsTests.java
@@ -14,9 +14,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-
 import static org.hamcrest.Matchers.equalTo;
 
 public class IndexingStatsSettingsTests extends ESTestCase {
@@ -42,61 +39,5 @@ public class IndexingStatsSettingsTests extends ESTestCase {
             Settings.builder().put(IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_SETTING.getKey(), "90m").build()
         );
         assertThat(settings.getRecentWriteLoadHalfLifeForNewShards(), equalTo(TimeValue.timeValueMinutes(90)));
-    }
-
-    public void testRecentWriteLoadHalfLife_minValue() {
-        IndexingStatsSettings settings = new IndexingStatsSettings(
-            ClusterSettings.createBuiltInClusterSettings(
-                Settings.builder()
-                    .put(
-                        IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_SETTING.getKey(),
-                        IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_MIN.toString()
-                    )
-                    .build()
-            )
-        );
-        assertThat(settings.getRecentWriteLoadHalfLifeForNewShards(), equalTo(IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_MIN));
-    }
-
-    public void testRecentWriteLoadHalfLife_valueTooSmall() {
-        long tooFewMillis = IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_MIN.getMillis() / 2;
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new IndexingStatsSettings(
-                ClusterSettings.createBuiltInClusterSettings(
-                    Settings.builder().put(IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_SETTING.getKey(), tooFewMillis + "ms").build()
-                )
-            )
-        );
-    }
-
-    public void testRecentWriteLoadHalfLife_maxValue() {
-        IndexingStatsSettings settings = new IndexingStatsSettings(
-            ClusterSettings.createBuiltInClusterSettings(
-                Settings.builder()
-                    .put(
-                        IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_SETTING.getKey(),
-                        IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_MAX.toString()
-                    )
-                    .build()
-            )
-        );
-        assertThat(settings.getRecentWriteLoadHalfLifeForNewShards(), equalTo(IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_MAX));
-    }
-
-    public void testRecentWriteLoadHalfLife_valueTooLarge() {
-        int tooManyDays = BigDecimal.valueOf(Long.MAX_VALUE)
-            .add(BigDecimal.ONE)
-            .divide(BigDecimal.valueOf(24 * 60 * 60 * 1_000_000_000L), RoundingMode.UP)
-            .setScale(0, RoundingMode.UP)
-            .intValueExact();
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new IndexingStatsSettings(
-                ClusterSettings.createBuiltInClusterSettings(
-                    Settings.builder().put(IndexingStatsSettings.RECENT_WRITE_LOAD_HALF_LIFE_SETTING.getKey(), tooManyDays + "d").build()
-                )
-            )
-        );
     }
 }

--- a/x-pack/plugin/write-load-forecaster/src/test/java/org/elasticsearch/xpack/writeloadforecaster/LicensedWriteLoadForecasterTests.java
+++ b/x-pack/plugin/write-load-forecaster/src/test/java/org/elasticsearch/xpack/writeloadforecaster/LicensedWriteLoadForecasterTests.java
@@ -128,11 +128,11 @@ public class LicensedWriteLoadForecasterTests extends ESTestCase {
             DataStream.getDefaultBackingIndexName(dataStreamName, 0),
             numberOfShards,
             IndexWriteLoad.builder(numberOfShards)
-                .withShardWriteLoad(0, 12, 80)
-                .withShardWriteLoad(1, 24, 5)
-                .withShardWriteLoad(2, 24, 5)
-                .withShardWriteLoad(3, 24, 5)
-                .withShardWriteLoad(4, 24, 5)
+                .withShardWriteLoad(0, 12, 999, 80)
+                .withShardWriteLoad(1, 24, 999, 5)
+                .withShardWriteLoad(2, 24, 999, 5)
+                .withShardWriteLoad(3, 24, 999, 5)
+                .withShardWriteLoad(4, 24, 999, 5)
                 .build(),
             System.currentTimeMillis() - (maxIndexAge.millis() / 2)
         );
@@ -234,7 +234,7 @@ public class LicensedWriteLoadForecasterTests extends ESTestCase {
 
         {
             OptionalDouble writeLoadForecast = forecastIndexWriteLoad(
-                List.of(IndexWriteLoad.builder(1).withShardWriteLoad(0, 12, 100).build())
+                List.of(IndexWriteLoad.builder(1).withShardWriteLoad(0, 12, 999, 100).build())
             );
             assertThat(writeLoadForecast.isPresent(), is(true));
             assertThat(writeLoadForecast.getAsDouble(), is(equalTo(12.0)));
@@ -244,11 +244,11 @@ public class LicensedWriteLoadForecasterTests extends ESTestCase {
             OptionalDouble writeLoadForecast = forecastIndexWriteLoad(
                 List.of(
                     IndexWriteLoad.builder(5)
-                        .withShardWriteLoad(0, 12, 80)
-                        .withShardWriteLoad(1, 24, 5)
-                        .withShardWriteLoad(2, 24, 5)
-                        .withShardWriteLoad(3, 24, 5)
-                        .withShardWriteLoad(4, 24, 5)
+                        .withShardWriteLoad(0, 12, 999, 80)
+                        .withShardWriteLoad(1, 24, 999, 5)
+                        .withShardWriteLoad(2, 24, 999, 5)
+                        .withShardWriteLoad(3, 24, 999, 5)
+                        .withShardWriteLoad(4, 24, 999, 5)
                         .build()
                 )
             );
@@ -260,14 +260,14 @@ public class LicensedWriteLoadForecasterTests extends ESTestCase {
             OptionalDouble writeLoadForecast = forecastIndexWriteLoad(
                 List.of(
                     IndexWriteLoad.builder(5)
-                        .withShardWriteLoad(0, 12, 80)
-                        .withShardWriteLoad(1, 24, 5)
-                        .withShardWriteLoad(2, 24, 5)
-                        .withShardWriteLoad(3, 24, 5)
-                        .withShardWriteLoad(4, 24, 4)
+                        .withShardWriteLoad(0, 12, 999, 80)
+                        .withShardWriteLoad(1, 24, 999, 5)
+                        .withShardWriteLoad(2, 24, 999, 5)
+                        .withShardWriteLoad(3, 24, 999, 5)
+                        .withShardWriteLoad(4, 24, 999, 4)
                         .build(),
                     // Since this shard uptime is really low, it doesn't add much to the avg
-                    IndexWriteLoad.builder(1).withShardWriteLoad(0, 120, 1).build()
+                    IndexWriteLoad.builder(1).withShardWriteLoad(0, 120, 999, 1).build()
                 )
             );
             assertThat(writeLoadForecast.isPresent(), is(true));
@@ -277,9 +277,9 @@ public class LicensedWriteLoadForecasterTests extends ESTestCase {
         {
             OptionalDouble writeLoadForecast = forecastIndexWriteLoad(
                 List.of(
-                    IndexWriteLoad.builder(2).withShardWriteLoad(0, 12, 25).withShardWriteLoad(1, 12, 25).build(),
+                    IndexWriteLoad.builder(2).withShardWriteLoad(0, 12, 999, 25).withShardWriteLoad(1, 12, 999, 25).build(),
 
-                    IndexWriteLoad.builder(1).withShardWriteLoad(0, 12, 50).build()
+                    IndexWriteLoad.builder(1).withShardWriteLoad(0, 12, 999, 50).build()
                 )
             );
             assertThat(writeLoadForecast.isPresent(), is(true));
@@ -291,14 +291,14 @@ public class LicensedWriteLoadForecasterTests extends ESTestCase {
             OptionalDouble writeLoadForecast = forecastIndexWriteLoad(
                 List.of(
                     IndexWriteLoad.builder(3)
-                        .withShardWriteLoad(0, 25, 1)
-                        .withShardWriteLoad(1, 18, 1)
-                        .withShardWriteLoad(2, 23, 1)
+                        .withShardWriteLoad(0, 25, 999, 1)
+                        .withShardWriteLoad(1, 18, 999, 1)
+                        .withShardWriteLoad(2, 23, 999, 1)
                         .build(),
 
-                    IndexWriteLoad.builder(2).withShardWriteLoad(0, 6, 1).withShardWriteLoad(1, 8, 1).build(),
+                    IndexWriteLoad.builder(2).withShardWriteLoad(0, 6, 999, 1).withShardWriteLoad(1, 8, 999, 1).build(),
 
-                    IndexWriteLoad.builder(1).withShardWriteLoad(0, 15, 1).build()
+                    IndexWriteLoad.builder(1).withShardWriteLoad(0, 15, 999, 1).build()
                 )
             );
             assertThat(writeLoadForecast.isPresent(), is(true));
@@ -309,7 +309,12 @@ public class LicensedWriteLoadForecasterTests extends ESTestCase {
     private IndexWriteLoad randomIndexWriteLoad(int numberOfShards) {
         IndexWriteLoad.Builder builder = IndexWriteLoad.builder(numberOfShards);
         for (int shardId = 0; shardId < numberOfShards; shardId++) {
-            builder.withShardWriteLoad(shardId, randomDoubleBetween(0, 64, true), randomLongBetween(1, 10));
+            builder.withShardWriteLoad(
+                shardId,
+                randomDoubleBetween(0, 64, true),
+                randomDoubleBetween(0, 64, true),
+                randomLongBetween(1, 10)
+            );
         }
         return builder.build();
     }


### PR DESCRIPTION
This changes the default value for the Exponentially Weighted Moving Rate calculation used for the 'recent write load' metric in indexing stats to 5 minutes (as agreed over Slack) and persists the value in the index metadata alongside the existing write load metric.

The value is still not used in the data stream autosharding calculation, that will be yet one more PR.

There are a couple of drive-by changes in this PR:
 - It adds a comment to `DataStreamAutoShardingService.computeOptimalNumberOfShards`, because the nested `min` and `max` calls are quite hard to understand at a glance.
 - It changes `IndexShard.indexingStats()` so that, if it is called before the shard has entered the started state, it uses a `timeSinceShardStartedInNanos` value of zero when calling `InternalIndexingStats.stats()`. Previously, it would have passed the current relative time in nanos as `timeSinceShardStartedInNanos` (because `startedRelativeTimeInNanos` would be zero) which is arbitrary and incorrect (since the zero point of `System.nanoTime()` is arbitrary). This didn't actually matter, since `InternalIndexingStats.postIndex` would not increment the metrics while in recovery, so the numerator used to calculate the write load would be zero if the shard has not started, so it doesn't matter if the denominator is incorrect. However, it is good defensive coding not to rely on that, and to pass a correct value instead.