### PR TITLE
Fix ignores malformed testcase

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -399,9 +399,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.ReservedClusterStateServiceTests
   method: testProcessMultipleChunks
   issue: https://github.com/elastic/elasticsearch/issues/125305
-- class: org.elasticsearch.index.mapper.NativeArrayIntegrationTestCase
-  method: testSynthesizeArrayRandomIgnoresMalformed
-  issue: https://github.com/elastic/elasticsearch/issues/125319
 
 # Examples:
 #

--- a/server/src/test/java/org/elasticsearch/index/mapper/NativeArrayIntegrationTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NativeArrayIntegrationTestCase.java
@@ -83,10 +83,10 @@ public abstract class NativeArrayIntegrationTestCase extends ESSingleNodeTestCas
             var expectedDocument = jsonBuilder().startObject();
             var inputDocument = jsonBuilder().startObject();
 
-            boolean expectedContainsArray = values.length > 0 || malformed.length > 1;
-            if (expectedContainsArray) {
+            boolean expectedIsArray = values.length != 0 || malformed.length != 1;
+            if (expectedIsArray) {
                 expectedDocument.startArray("field");
-            } else if (malformed.length > 0) {
+            } else {
                 expectedDocument.field("field");
             }
             inputDocument.startArray("field");
@@ -113,7 +113,7 @@ public abstract class NativeArrayIntegrationTestCase extends ESSingleNodeTestCas
                 }
             }
 
-            if (expectedContainsArray) {
+            if (expectedIsArray) {
                 expectedDocument.endArray();
             }
             expectedDocument.endObject();


### PR DESCRIPTION
Fixed a bug in the construction of the expected source when the value and malformed value counts were both zero.

Closes #125319