### PR TITLE
Fix entitlement test failures on Java 17

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -484,7 +484,11 @@ public class EntitlementInitialization {
      * transformed and undergo verification. In order to avoid circularity errors as much as possible, we force a partial order.
      */
     private static void ensureClassesSensitiveToVerificationAreInitialized() {
-        var classesToInitialize = Set.of("sun.net.www.protocol.http.HttpURLConnection");
+        var classesToInitialize = Set.of(
+            "sun.net.www.protocol.http.HttpURLConnection",
+            "sun.nio.ch.SocketChannelImpl",
+            "java.net.ProxySelector"
+        );
         for (String className : classesToInitialize) {
             try {
                 Class.forName(className);


### PR DESCRIPTION
Fixes a number of integration test failures when running on Java 17 as a side effect of #125226. We get some strange behvavior in our instrumentation when also doing bytecode verification since the verification requires loading referenced classes itself. This introduces awkward ordering problems which we have to explicitly account for. This fix here was to add some of our instrumented class to the list of classes we eagerly load early.

Closes #125271
Closes #125270
Closes #125269
Closes #125268 
Closes #125267