### PR TITLE
Throttling reindex requests per node from reindex data stream api

### DIFF
--- a/docs/changelog/125353.yaml
+++ b/docs/changelog/125353.yaml
@@ -1,0 +1,5 @@
+pr: 125353
+summary: Throttling reindex requests per node from reindex data stream api
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportAction.java
@@ -128,7 +128,7 @@ public class ReindexDataStreamIndexTransportAction extends HandledTransportActio
      * the unit test doesn't fail if it rolls over Integer.MAX_VALUE (since the node selected is the same for Integer.MAX_VALUE and
      * Integer.MAX_VALUE + 1).
      */
-    private final AtomicInteger ingestNodeOffsetGenerator = new AtomicInteger(Randomness.get().nextInt(2 ^ 30));
+    private final AtomicInteger ingestNodeOffsetGenerator = new AtomicInteger(Randomness.get().nextInt((int) Math.pow(2, 30)));
     /*
      * This maps nodeId to a semaphore for that node, controlling the number of concurrent reindex requests we send to that node.
      */


### PR DESCRIPTION
NOTE: This is currently a draft, created so that we can discuss whether the added complexity is worth the benefit we get from it. It is not ready for review.

We allow users to configure the number of indices we reindex in parallel from the reindex data stream API. It is possible that a user could set this to a very high value, and then swamp the cluster with reindex requests. This change makes it so that we send no more than 10 reindex requests to any node at a time. It builds on the work done in #125171.