### PR TITLE
Hack to set write load to zero when balancing search nodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -1239,7 +1239,9 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             index.assertMatch(shard);
             indices.computeIfAbsent(index, t -> new ModelIndex()).addShard(shard);
             IndexMetadata indexMetadata = metadata.getProject(index.project).index(shard.index());
-            writeLoad += writeLoadForecaster.getForecastedWriteLoad(indexMetadata).orElse(0.0);
+            if (shard.role() != ShardRouting.Role.SEARCH_ONLY) {
+                writeLoad += writeLoadForecaster.getForecastedWriteLoad(indexMetadata).orElse(0.0);
+            }
             diskUsageInBytes += Balancer.getShardDiskUsageInBytes(shard, indexMetadata, clusterInfo);
             numShards++;
         }
@@ -1253,7 +1255,9 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                 }
             }
             IndexMetadata indexMetadata = metadata.getProject(projectIndex.project).index(shard.index());
-            writeLoad -= writeLoadForecaster.getForecastedWriteLoad(indexMetadata).orElse(0.0);
+            if (shard.role() != ShardRouting.Role.SEARCH_ONLY) {
+                writeLoad -= writeLoadForecaster.getForecastedWriteLoad(indexMetadata).orElse(0.0);
+            }
             diskUsageInBytes -= Balancer.getShardDiskUsageInBytes(shard, indexMetadata, clusterInfo);
             numShards--;
         }


### PR DESCRIPTION
Not for merging, just an attempt at a simple hack that should remove write load from search nodes when balancing.

It'd probably be better to be able to set the `writeLoadBalance` weight to zero for the `WeightFunction` used on search-only nodes, that way the node weight could go to zero on search nodes, but doing it this way should at least remove the benefit of any search-only shard movements purely for write load reasons. And it's a very simple POC.

It's not clear to me what effect this will have. The "average write load" should be reduced because the search nodes won't contribute to it, and the search node weights will probably remain persistently non-zero because there will always be the non-zero `theta2 * (0 - avgWriteLoadPerNode)` component.

Relates: ES-11367