### PR TITLE
Handle patch from 8.19 about introducing data stream lifecycle template

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -152,6 +152,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_FAILURE_FROM_REMOTE_8_19 = def(8_841_0_11);
     public static final TransportVersion ESQL_AGGREGATE_METRIC_DOUBLE_LITERAL_8_19 = def(8_841_0_12);
     public static final TransportVersion INFERENCE_MODEL_REGISTRY_METADATA_8_19 = def(8_841_0_13);
+    public static final TransportVersion INTRODUCE_LIFECYCLE_TEMPLATE_8_19 = def(8_841_0_14);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0 = def(9_000_0_00);
     public static final TransportVersion REMOVE_SNAPSHOT_FAILURES_90 = def(9_000_0_01);
     public static final TransportVersion TRANSPORT_STATS_HANDLING_TIME_REQUIRED_90 = def(9_000_0_02);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -279,7 +279,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)) {
-            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)
+                || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE_8_19)) {
                 out.writeOptionalTimeValue(dataRetention);
             } else {
                 writeLegacyOptionalValue(dataRetention, out, StreamOutput::writeTimeValue);
@@ -287,7 +288,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
 
         }
         if (out.getTransportVersion().onOrAfter(ADDED_ENABLED_FLAG_VERSION)) {
-            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)
+                || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE_8_19)) {
                 out.writeOptionalCollection(downsampling);
             } else {
                 writeLegacyOptionalValue(downsampling, out, StreamOutput::writeCollection);
@@ -298,7 +300,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
 
     public DataStreamLifecycle(StreamInput in) throws IOException {
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)) {
-            if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)) {
+            if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)
+                || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE_8_19)) {
                 dataRetention = in.readOptionalTimeValue();
             } else {
                 dataRetention = readLegacyOptionalValue(in, StreamInput::readTimeValue);
@@ -307,7 +310,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
             dataRetention = null;
         }
         if (in.getTransportVersion().onOrAfter(ADDED_ENABLED_FLAG_VERSION)) {
-            if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)) {
+            if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)
+                || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE_8_19)) {
                 downsampling = in.readOptionalCollectionAsList(DownsamplingRound::read);
             } else {
                 downsampling = readLegacyOptionalValue(in, is -> is.readCollectionAsList(DownsamplingRound::read));
@@ -600,14 +604,16 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
         public void writeTo(StreamOutput out) throws IOException {
             // The order of the fields is like this for bwc reasons
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)) {
-                if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)) {
+                if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)
+                    || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE_8_19)) {
                     ResettableValue.write(out, dataRetention, StreamOutput::writeTimeValue);
                 } else {
                     writeLegacyValue(out, dataRetention, StreamOutput::writeTimeValue);
                 }
             }
             if (out.getTransportVersion().onOrAfter(ADDED_ENABLED_FLAG_VERSION)) {
-                if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)) {
+                if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)
+                    || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE_8_19)) {
                     ResettableValue.write(out, downsampling, StreamOutput::writeCollection);
                 } else {
                     writeLegacyValue(out, downsampling, StreamOutput::writeCollection);
@@ -657,14 +663,16 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
 
             // The order of the fields is like this for bwc reasons
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)) {
-                if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)) {
+                if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)
+                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE_8_19)) {
                     dataRetention = ResettableValue.read(in, StreamInput::readTimeValue);
                 } else {
                     dataRetention = readLegacyValues(in, StreamInput::readTimeValue);
                 }
             }
             if (in.getTransportVersion().onOrAfter(ADDED_ENABLED_FLAG_VERSION)) {
-                if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)) {
+                if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE)
+                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_LIFECYCLE_TEMPLATE_8_19)) {
                     downsampling = ResettableValue.read(in, i -> i.readCollectionAsList(DownsamplingRound::read));
                 } else {
                     downsampling = readLegacyValues(in, i -> i.readCollectionAsList(DownsamplingRound::read));


### PR DESCRIPTION
Update `TransportVersions` with the patched version from `8.19.0`:
- `main`: https://github.com/elastic/elasticsearch/pull/124593
- `8.19.0`: https://github.com/elastic/elasticsearch/pull/125199