### PR TITLE
[8.x] Use `Sets.newHashSetWithExpectedSize`  (#125327)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -34,6 +34,7 @@ import org.elasticsearch.action.search.TransportSearchShardsAction;
 import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.seqno.RetentionLeaseActions;
 import org.elasticsearch.xpack.core.ccr.action.ForgetFollowerAction;
@@ -452,8 +453,8 @@ public final class IndexPrivilege extends Privilege {
         Collection<String> actions,
         IndexComponentSelectorPredicate selectorPredicate
     ) {
-        final Set<Automaton> automata = new HashSet<>(privileges.size() + actions.size());
-        final Set<String> names = new HashSet<>(privileges.size() + actions.size());
+        final Set<Automaton> automata = Sets.newHashSetWithExpectedSize(privileges.size() + actions.size());
+        final Set<String> names = Sets.newHashSetWithExpectedSize(privileges.size() + actions.size());
         for (IndexPrivilege privilege : privileges) {
             names.addAll(privilege.name());
             automata.add(privilege.automaton);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Use &#x60;Sets.newHashSetWithExpectedSize&#x60;  (#125327)](https://github.com/elastic/elasticsearch/pull/125327)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)