### PR TITLE
[8.17] The histogram field type does not support `time_series_metric` attribute (#125366)

### DIFF
--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -130,7 +130,6 @@ To mark a field as a metric, you must specify a metric type using the
 `time_series_metric` parameter:
 
 * <<aggregate-metric-double,`aggregate_metric_double`>>
-* <<histogram,`histogram`>>
 * All <<number,numeric field types>>
 
 Accepted metric types vary based on the field type:


### PR DESCRIPTION
Backports the following commits to 8.17:
 - The histogram field type does not support `time_series_metric` attribute (#125366)