### PR TITLE
[8.x] Unify template builders for data stream options, failure store and data stream lifecycle (#125293)

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -1372,7 +1372,7 @@ public class DataStreamIT extends ESIntegTestCase {
 
     public void testGetDataStream() throws Exception {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, maximumNumberOfReplicas() + 2).build();
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder().dataRetention(randomPositiveTimeValue()).build();
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.builder().dataRetention(randomPositiveTimeValue()).buildTemplate();
         putComposableIndexTemplate("template_for_foo", null, List.of("metrics-foo*"), settings, null, null, lifecycle, false);
         int numDocsFoo = randomIntBetween(2, 16);
         indexDocs("metrics-foo", numDocsFoo);

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
@@ -226,7 +226,7 @@ public class CrudDataStreamLifecycleIT extends ESIntegTestCase {
     }
 
     public void testDeleteLifecycle() throws Exception {
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder().dataRetention(randomPositiveTimeValue()).build();
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.builder().dataRetention(randomPositiveTimeValue()).buildTemplate();
         putComposableIndexTemplate("id1", null, List.of("with-lifecycle*"), null, null, lifecycle);
         putComposableIndexTemplate("id2", null, List.of("without-lifecycle*"), null, null, null);
         {

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudSystemDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudSystemDataStreamLifecycleIT.java
@@ -204,7 +204,7 @@ public class CrudSystemDataStreamLifecycleIT extends ESIntegTestCase {
                                 Template.builder()
                                     .settings(Settings.EMPTY)
                                     .mappings(mappings)
-                                    .lifecycle(DataStreamLifecycle.Template.builder().dataRetention(randomPositiveTimeValue()).build())
+                                    .lifecycle(DataStreamLifecycle.builder().dataRetention(randomPositiveTimeValue()))
                             )
                             .dataStreamTemplate(new DataStreamTemplate())
                             .build(),

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
@@ -178,7 +178,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
     }
 
     public void testRolloverAndRetention() throws Exception {
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder().dataRetention(TimeValue.ZERO).build();
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.builder().dataRetention(TimeValue.ZERO).buildTemplate();
 
         putComposableIndexTemplate("id1", null, List.of("metrics-foo*"), null, null, lifecycle, false);
 
@@ -321,7 +321,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
          * days ago, and one with an origination date 1 day ago. After data stream lifecycle runs, we expect the one with the old
          * origination date to have been deleted, and the one with the newer origination date to remain.
          */
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder().dataRetention(TimeValue.timeValueDays(7)).build();
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.builder().dataRetention(TimeValue.timeValueDays(7)).buildTemplate();
 
         putComposableIndexTemplate("id1", null, List.of("metrics-foo*"), null, null, lifecycle, false);
 
@@ -970,7 +970,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
 
     public void testReenableDataStreamLifecycle() throws Exception {
         // start with a lifecycle that's not enabled
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder().enabled(false).build();
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.builder().enabled(false).buildTemplate();
 
         putComposableIndexTemplate("id1", null, List.of("metrics-foo*"), null, null, lifecycle, false);
         String dataStreamName = "metrics-foo";
@@ -1029,7 +1029,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
 
     public void testLifecycleAppliedToFailureStore() throws Exception {
         // We configure a lifecycle with downsampling to ensure it doesn't fail
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder()
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.builder()
             .dataRetention(TimeValue.timeValueSeconds(20))
             .downsampling(
                 List.of(
@@ -1039,7 +1039,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
                     )
                 )
             )
-            .build();
+            .buildTemplate();
 
         putComposableIndexTemplate("id1", """
             {
@@ -1263,8 +1263,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
                             Template.builder()
                                 .settings(Settings.EMPTY)
                                 .lifecycle(
-                                    DataStreamLifecycle.Template.builder()
-                                        .dataRetention(TimeValue.timeValueDays(SYSTEM_DATA_STREAM_RETENTION_DAYS))
+                                    DataStreamLifecycle.builder().dataRetention(TimeValue.timeValueDays(SYSTEM_DATA_STREAM_RETENTION_DAYS))
                                 )
                         )
                         .build(),

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
@@ -374,7 +374,7 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
             List.of("metrics-foo*"),
             null,
             null,
-            DataStreamLifecycle.Template.builder().enabled(false).build()
+            DataStreamLifecycle.builder().enabled(false).buildTemplate()
         );
         CreateDataStreamAction.Request createDataStreamRequest = new CreateDataStreamAction.Request(
             TEST_REQUEST_TIMEOUT,

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/MetadataIndexTemplateServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/MetadataIndexTemplateServiceTests.java
@@ -145,12 +145,9 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         }
         // One lifecycle results to this lifecycle as the final
         {
-            DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder()
-                .dataRetention(randomRetention())
-                .downsampling(randomDownsampling())
-                .build();
+            DataStreamLifecycle.Template lifecycle = new DataStreamLifecycle.Template(true, randomRetention(), randomDownsampling());
             List<DataStreamLifecycle.Template> lifecycles = List.of(lifecycle);
-            DataStreamLifecycle result = composeDataLifecycles(lifecycles).toDataStreamLifecycle();
+            DataStreamLifecycle result = composeDataLifecycles(lifecycles).build();
             // Defaults to true
             assertThat(result.enabled(), equalTo(true));
             assertThat(result.dataRetention(), equalTo(lifecycle.dataRetention().get()));
@@ -159,31 +156,19 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         // If the last lifecycle is missing a property (apart from enabled) we keep the latest from the previous ones
         // Enabled is always true unless it's explicitly set to false
         {
-            DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder()
-                .enabled(false)
-                .dataRetention(randomPositiveTimeValue())
-                .downsampling(randomRounds())
-                .build();
+            DataStreamLifecycle.Template lifecycle = new DataStreamLifecycle.Template(false, randomPositiveTimeValue(), randomRounds());
             List<DataStreamLifecycle.Template> lifecycles = List.of(lifecycle, DataStreamLifecycle.Template.DEFAULT);
-            DataStreamLifecycle result = composeDataLifecycles(lifecycles).toDataStreamLifecycle();
+            DataStreamLifecycle result = composeDataLifecycles(lifecycles).build();
             assertThat(result.enabled(), equalTo(true));
             assertThat(result.dataRetention(), equalTo(lifecycle.dataRetention().get()));
             assertThat(result.downsampling(), equalTo(lifecycle.downsampling().get()));
         }
         // If both lifecycle have all properties, then the latest one overwrites all the others
         {
-            DataStreamLifecycle.Template lifecycle1 = DataStreamLifecycle.Template.builder()
-                .enabled(false)
-                .dataRetention(randomPositiveTimeValue())
-                .downsampling(randomRounds())
-                .build();
-            DataStreamLifecycle.Template lifecycle2 = DataStreamLifecycle.Template.builder()
-                .enabled(true)
-                .dataRetention(randomPositiveTimeValue())
-                .downsampling(randomRounds())
-                .build();
+            DataStreamLifecycle.Template lifecycle1 = new DataStreamLifecycle.Template(false, randomPositiveTimeValue(), randomRounds());
+            DataStreamLifecycle.Template lifecycle2 = new DataStreamLifecycle.Template(true, randomPositiveTimeValue(), randomRounds());
             List<DataStreamLifecycle.Template> lifecycles = List.of(lifecycle1, lifecycle2);
-            DataStreamLifecycle result = composeDataLifecycles(lifecycles).toDataStreamLifecycle();
+            DataStreamLifecycle result = composeDataLifecycles(lifecycles).build();
             assertThat(result.enabled(), equalTo(lifecycle2.enabled()));
             assertThat(result.dataRetention(), equalTo(lifecycle2.dataRetention().get()));
             assertThat(result.downsampling(), equalTo(lifecycle2.downsampling().get()));

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleFixtures.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleFixtures.java
@@ -129,11 +129,11 @@ public class DataStreamLifecycleFixtures {
     }
 
     static DataStreamLifecycle.Template randomLifecycleTemplate() {
-        return DataStreamLifecycle.Template.builder()
-            .dataRetention(randomResettable(ESTestCase::randomTimeValue))
-            .downsampling(randomResettable(DataStreamLifecycleFixtures::randomDownsamplingRounds))
-            .enabled(frequently())
-            .build();
+        return new DataStreamLifecycle.Template(
+            frequently(),
+            randomResettable(ESTestCase::randomTimeValue),
+            randomResettable(DataStreamLifecycleFixtures::randomDownsamplingRounds)
+        );
     }
 
     private static <T> ResettableValue<T> randomResettable(Supplier<T> supplier) {

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
@@ -213,7 +213,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
             numBackingIndices,
             2,
             settings(IndexVersion.current()),
-            DataStreamLifecycle.builder().dataRetention(0).build(),
+            DataStreamLifecycle.builder().dataRetention(TimeValue.ZERO).build(),
             now
         );
         builder.put(dataStream);
@@ -309,7 +309,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
             dataStream.copy()
                 .setName(dataStreamName)
                 .setGeneration(dataStream.getGeneration() + 1)
-                .setLifecycle(DataStreamLifecycle.builder().dataRetention(0L).build())
+                .setLifecycle(DataStreamLifecycle.builder().dataRetention(TimeValue.ZERO).build())
                 .build()
         );
         clusterState = ClusterState.builder(clusterState).metadata(builder).build();
@@ -458,7 +458,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
             Settings.builder()
                 .put(IndexMetadata.LIFECYCLE_NAME, "ILM_policy")
                 .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()),
-            DataStreamLifecycle.builder().dataRetention(0).build(),
+            DataStreamLifecycle.builder().dataRetention(TimeValue.ZERO).build(),
             now
         );
         builder.put(dataStream);
@@ -1526,7 +1526,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
             numBackingIndices,
             2,
             settings(IndexVersion.current()),
-            DataStreamLifecycle.builder().dataRetention(0).build(),
+            DataStreamLifecycle.builder().dataRetention(TimeValue.ZERO).build(),
             now
         ).copy().setDataStreamOptions(DataStreamOptions.FAILURE_STORE_DISABLED).build(); // failure store is managed even when disabled
         builder.put(dataStream);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
+import org.elasticsearch.cluster.metadata.DataStreamOptions;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
@@ -342,16 +343,18 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
         );
 
         Settings settings = Settings.builder().put(additionalSettings.build()).put(templateSettings).build();
-        DataStreamLifecycle.Template lifecycle = resolveLifecycle(simulatedState.metadata(), matchingTemplate);
+        DataStreamLifecycle.Builder lifecycleBuilder = resolveLifecycle(simulatedState.metadata(), matchingTemplate);
+        DataStreamLifecycle.Template lifecycle = lifecycleBuilder == null ? null : lifecycleBuilder.buildTemplate();
         if (template.getDataStreamTemplate() != null && lifecycle == null && isDslOnlyMode) {
             lifecycle = DataStreamLifecycle.Template.DEFAULT;
         }
+        DataStreamOptions.Builder optionsBuilder = resolveDataStreamOptions(simulatedState.metadata(), matchingTemplate);
         return new Template(
             settings,
             mergedMapping,
             aliasesByName,
             lifecycle,
-            resolveDataStreamOptions(simulatedState.metadata(), matchingTemplate)
+            optionsBuilder == null ? null : optionsBuilder.buildTemplate()
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -667,12 +667,12 @@ public class TransportBulkAction extends TransportAbstractBulkAction {
             ComposableIndexTemplate composableIndexTemplate = metadata.templatesV2().get(template);
             if (composableIndexTemplate.getDataStreamTemplate() != null) {
                 // Check if the data stream has the failure store enabled
-                DataStreamOptions dataStreamOptions = MetadataIndexTemplateService.resolveDataStreamOptions(
+                DataStreamOptions.Builder dataStreamOptionsBuilder = MetadataIndexTemplateService.resolveDataStreamOptions(
                     composableIndexTemplate,
                     metadata.componentTemplates()
-                ).mapAndGet(DataStreamOptions.Template::toDataStreamOptions);
+                );
                 return DataStream.isFailureStoreEffectivelyEnabled(
-                    dataStreamOptions,
+                    dataStreamOptionsBuilder == null ? null : dataStreamOptionsBuilder.build(),
                     dataStreamFailureStoreSettings,
                     IndexNameExpressionResolver.resolveDateMathExpression(indexName, epochMillis),
                     systemIndices

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -430,57 +430,6 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
         return new DelegatingMapParams(INCLUDE_EFFECTIVE_RETENTION_PARAMS, params);
     }
 
-    public static Builder builder(DataStreamLifecycle lifecycle) {
-        return new Builder(lifecycle);
-    }
-
-    public static Builder builder() {
-        return new Builder(null);
-    }
-
-    /**
-     * This builder helps during the composition of the data stream lifecycle templates.
-     */
-    public static class Builder {
-        private boolean enabled = true;
-        @Nullable
-        private TimeValue dataRetention = null;
-        @Nullable
-        private List<DownsamplingRound> downsampling = null;
-
-        private Builder(@Nullable DataStreamLifecycle lifecycle) {
-            if (lifecycle != null) {
-                enabled = lifecycle.enabled;
-                dataRetention = lifecycle.dataRetention;
-                downsampling = lifecycle.downsampling;
-            }
-        }
-
-        public Builder enabled(boolean value) {
-            enabled = value;
-            return this;
-        }
-
-        public Builder dataRetention(@Nullable TimeValue value) {
-            dataRetention = value;
-            return this;
-        }
-
-        public Builder dataRetention(long value) {
-            dataRetention = TimeValue.timeValueMillis(value);
-            return this;
-        }
-
-        public Builder downsampling(@Nullable List<DownsamplingRound> rounds) {
-            downsampling = rounds;
-            return this;
-        }
-
-        public DataStreamLifecycle build() {
-            return new DataStreamLifecycle(enabled, dataRetention, downsampling);
-        }
-    }
-
     /**
      * This enum represents all configuration sources that can influence the retention of a data stream.
      */
@@ -602,6 +551,10 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
         ResettableValue<TimeValue> dataRetention,
         ResettableValue<List<DataStreamLifecycle.DownsamplingRound>> downsampling
     ) implements ToXContentObject, Writeable {
+
+        public Template(boolean enabled, TimeValue dataRetention, List<DataStreamLifecycle.DownsamplingRound> downsampling) {
+            this(enabled, ResettableValue.create(dataRetention), ResettableValue.create(downsampling));
+        }
 
         public Template {
             if (downsampling.isDefined() && downsampling.get() != null) {
@@ -761,57 +714,6 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
             return builder;
         }
 
-        public static Builder builder(DataStreamLifecycle.Template template) {
-            return new Builder(template);
-        }
-
-        public static Builder builder() {
-            return new Builder(null);
-        }
-
-        public static class Builder {
-            private boolean enabled = true;
-            private ResettableValue<TimeValue> dataRetention = ResettableValue.undefined();
-            private ResettableValue<List<DownsamplingRound>> downsampling = ResettableValue.undefined();
-
-            private Builder(Template template) {
-                if (template != null) {
-                    enabled = template.enabled();
-                    dataRetention = template.dataRetention();
-                    downsampling = template.downsampling();
-                }
-            }
-
-            public Builder enabled(boolean enabled) {
-                this.enabled = enabled;
-                return this;
-            }
-
-            public Builder dataRetention(ResettableValue<TimeValue> dataRetention) {
-                this.dataRetention = dataRetention;
-                return this;
-            }
-
-            public Builder dataRetention(@Nullable TimeValue dataRetention) {
-                this.dataRetention = ResettableValue.create(dataRetention);
-                return this;
-            }
-
-            public Builder downsampling(ResettableValue<List<DownsamplingRound>> downsampling) {
-                this.downsampling = downsampling;
-                return this;
-            }
-
-            public Builder downsampling(@Nullable List<DownsamplingRound> downsampling) {
-                this.downsampling = ResettableValue.create(downsampling);
-                return this;
-            }
-
-            public Template build() {
-                return new Template(enabled, dataRetention, downsampling);
-            }
-        }
-
         public DataStreamLifecycle toDataStreamLifecycle() {
             return new DataStreamLifecycle(enabled, dataRetention.get(), downsampling.get());
         }
@@ -819,6 +721,89 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
         @Override
         public String toString() {
             return Strings.toString(this, true, true);
+        }
+    }
+
+    public static Builder builder(DataStreamLifecycle lifecycle) {
+        return new Builder(lifecycle);
+    }
+
+    public static Builder builder(Template template) {
+        return new Builder(template);
+    }
+
+    public static Builder builder() {
+        return new Builder((DataStreamLifecycle) null);
+    }
+
+    /**
+     * Builds and composes the data stream lifecycle or the respective template.
+     */
+    public static class Builder {
+        private boolean enabled = true;
+        @Nullable
+        private TimeValue dataRetention = null;
+        @Nullable
+        private List<DownsamplingRound> downsampling = null;
+
+        private Builder(DataStreamLifecycle.Template template) {
+            if (template != null) {
+                enabled = template.enabled();
+                dataRetention = template.dataRetention().get();
+                downsampling = template.downsampling().get();
+            }
+        }
+
+        private Builder(DataStreamLifecycle lifecycle) {
+            if (lifecycle != null) {
+                enabled = lifecycle.enabled();
+                dataRetention = lifecycle.dataRetention();
+                downsampling = lifecycle.downsampling();
+            }
+        }
+
+        public Builder composeTemplate(DataStreamLifecycle.Template template) {
+            enabled(template.enabled());
+            dataRetention(template.dataRetention());
+            downsampling(template.downsampling());
+            return this;
+        }
+
+        public Builder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder dataRetention(ResettableValue<TimeValue> dataRetention) {
+            if (dataRetention.isDefined()) {
+                this.dataRetention = dataRetention.get();
+            }
+            return this;
+        }
+
+        public Builder dataRetention(@Nullable TimeValue dataRetention) {
+            this.dataRetention = dataRetention;
+            return this;
+        }
+
+        public Builder downsampling(ResettableValue<List<DownsamplingRound>> downsampling) {
+            if (downsampling.isDefined()) {
+                this.downsampling = downsampling.get();
+            }
+            return this;
+        }
+
+        public Builder downsampling(@Nullable List<DownsamplingRound> downsampling) {
+            this.downsampling = downsampling;
+            return this;
+        }
+
+        public DataStreamLifecycle build() {
+            return new DataStreamLifecycle(enabled, dataRetention, downsampling);
+        }
+
+        public Template buildTemplate() {
+            return new Template(enabled, dataRetention, downsampling);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -478,26 +478,26 @@ public class MetadataCreateDataStreamService {
     }
 
     private static DataStreamOptions resolveDataStreamOptions(
-        Metadata project,
+        Metadata metadata,
         SystemDataStreamDescriptor systemDataStreamDescriptor,
         ComposableIndexTemplate template,
         boolean isSystem
     ) {
         DataStreamOptions.Builder builder = isSystem
             ? MetadataIndexTemplateService.resolveDataStreamOptions(template, systemDataStreamDescriptor.getComponentTemplates())
-            : MetadataIndexTemplateService.resolveDataStreamOptions(template, project.componentTemplates());
+            : MetadataIndexTemplateService.resolveDataStreamOptions(template, metadata.componentTemplates());
         return builder == null ? null : builder.build();
     }
 
     private static DataStreamLifecycle resolveDataStreamLifecycle(
-        Metadata project,
+        Metadata metadata,
         SystemDataStreamDescriptor systemDataStreamDescriptor,
         ComposableIndexTemplate template,
         boolean isSystem
     ) {
         DataStreamLifecycle.Builder builder = isSystem
             ? MetadataIndexTemplateService.resolveLifecycle(template, systemDataStreamDescriptor.getComponentTemplates())
-            : MetadataIndexTemplateService.resolveLifecycle(template, project.componentTemplates());
+            : MetadataIndexTemplateService.resolveLifecycle(template, metadata.componentTemplates());
         return builder == null ? null : builder.build();
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -262,10 +262,7 @@ public class MetadataCreateDataStreamService {
         // This is not a problem as both have different prefixes (`.ds-` vs `.fs-`) and both will be using the same `generation` field
         // when rolling over in the future.
         final long initialGeneration = 1;
-        ResettableValue<DataStreamOptions.Template> dataStreamOptionsTemplate = isSystem
-            ? MetadataIndexTemplateService.resolveDataStreamOptions(template, systemDataStreamDescriptor.getComponentTemplates())
-            : MetadataIndexTemplateService.resolveDataStreamOptions(template, metadata.componentTemplates());
-        final DataStreamOptions dataStreamOptions = dataStreamOptionsTemplate.mapAndGet(DataStreamOptions.Template::toDataStreamOptions);
+        final DataStreamOptions dataStreamOptions = resolveDataStreamOptions(metadata, systemDataStreamDescriptor, template, isSystem);
 
         // If we need to create a failure store, do so first. Do not reroute during the creation since we will do
         // that as part of creating the backing index if required. N.B. This is done if initializeFailureStore,
@@ -320,10 +317,7 @@ public class MetadataCreateDataStreamService {
         dsBackingIndices.add(writeIndex.getIndex());
         boolean hidden = isSystem || template.getDataStreamTemplate().isHidden();
         final IndexMode indexMode = metadata.retrieveIndexModeFromTemplate(template);
-        final DataStreamLifecycle.Template lifecycleTemplate = isSystem
-            ? MetadataIndexTemplateService.resolveLifecycle(template, systemDataStreamDescriptor.getComponentTemplates())
-            : MetadataIndexTemplateService.resolveLifecycle(template, metadata.componentTemplates());
-        final DataStreamLifecycle lifecycle = lifecycleTemplate == null ? null : lifecycleTemplate.toDataStreamLifecycle();
+        final DataStreamLifecycle lifecycle = resolveDataStreamLifecycle(metadata, systemDataStreamDescriptor, template, isSystem);
         List<Index> failureIndices = failureStoreIndex == null ? List.of() : List.of(failureStoreIndex.getIndex());
         DataStream newDataStream = new DataStream(
             dataStreamName,
@@ -481,5 +475,29 @@ public class MetadataCreateDataStreamService {
         }
         // Sanity check (this validation logic should already have been executed when merging mappings):
         fieldMapper.validate(mappingLookup);
+    }
+
+    private static DataStreamOptions resolveDataStreamOptions(
+        Metadata project,
+        SystemDataStreamDescriptor systemDataStreamDescriptor,
+        ComposableIndexTemplate template,
+        boolean isSystem
+    ) {
+        DataStreamOptions.Builder builder = isSystem
+            ? MetadataIndexTemplateService.resolveDataStreamOptions(template, systemDataStreamDescriptor.getComponentTemplates())
+            : MetadataIndexTemplateService.resolveDataStreamOptions(template, project.componentTemplates());
+        return builder == null ? null : builder.build();
+    }
+
+    private static DataStreamLifecycle resolveDataStreamLifecycle(
+        Metadata project,
+        SystemDataStreamDescriptor systemDataStreamDescriptor,
+        ComposableIndexTemplate template,
+        boolean isSystem
+    ) {
+        DataStreamLifecycle.Builder builder = isSystem
+            ? MetadataIndexTemplateService.resolveLifecycle(template, systemDataStreamDescriptor.getComponentTemplates())
+            : MetadataIndexTemplateService.resolveLifecycle(template, project.componentTemplates());
+        return builder == null ? null : builder.build();
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -802,8 +802,8 @@ public class MetadataIndexTemplateService {
         ComposableIndexTemplate template,
         @Nullable DataStreamGlobalRetention globalRetention
     ) {
-        DataStreamLifecycle.Template lifecycle = resolveLifecycle(template, metadata.componentTemplates());
-        if (lifecycle != null) {
+        DataStreamLifecycle.Builder builder = resolveLifecycle(template, metadata.componentTemplates());
+        if (builder != null) {
             if (template.getDataStreamTemplate() == null) {
                 throw new IllegalArgumentException(
                     "index template ["
@@ -815,15 +815,15 @@ public class MetadataIndexTemplateService {
                 // We cannot know for sure if the template will apply to internal data streams, so we use a simpler heuristic:
                 // If all the index patterns start with a dot, we consider that all the connected data streams are internal.
                 boolean isInternalDataStream = template.indexPatterns().stream().allMatch(indexPattern -> indexPattern.charAt(0) == '.');
-                lifecycle.toDataStreamLifecycle().addWarningHeaderIfDataRetentionNotEffective(globalRetention, isInternalDataStream);
+                builder.build().addWarningHeaderIfDataRetentionNotEffective(globalRetention, isInternalDataStream);
             }
         }
     }
 
     // Visible for testing
     static void validateDataStreamOptions(Metadata metadata, String indexTemplateName, ComposableIndexTemplate template) {
-        ResettableValue<DataStreamOptions.Template> dataStreamOptions = resolveDataStreamOptions(template, metadata.componentTemplates());
-        if (dataStreamOptions.get() != null) {
+        DataStreamOptions.Builder dataStreamOptionsBuilder = resolveDataStreamOptions(template, metadata.componentTemplates());
+        if (dataStreamOptionsBuilder != null) {
             if (template.getDataStreamTemplate() == null) {
                 throw new IllegalArgumentException(
                     "index template ["
@@ -1573,7 +1573,7 @@ public class MetadataIndexTemplateService {
      * Resolve the given v2 template into a {@link DataStreamLifecycle} object
      */
     @Nullable
-    public static DataStreamLifecycle.Template resolveLifecycle(final Metadata metadata, final String templateName) {
+    public static DataStreamLifecycle.Builder resolveLifecycle(final Metadata metadata, final String templateName) {
         final ComposableIndexTemplate template = metadata.templatesV2().get(templateName);
         assert template != null
             : "attempted to resolve lifecycle for a template [" + templateName + "] that did not exist in the cluster state";
@@ -1587,7 +1587,7 @@ public class MetadataIndexTemplateService {
      * Resolve the provided v2 template and component templates into a {@link DataStreamLifecycle} object
      */
     @Nullable
-    public static DataStreamLifecycle.Template resolveLifecycle(
+    public static DataStreamLifecycle.Builder resolveLifecycle(
         ComposableIndexTemplate template,
         Map<String, ComponentTemplate> componentTemplates
     ) {
@@ -1647,44 +1647,42 @@ public class MetadataIndexTemplateService {
      * The result will be { "lifecycle": { "enabled": true, "data_retention" : "10d"} } because the latest lifecycle does not have any
      * information on retention.
      * @param lifecycles a sorted list of lifecycles in the order that they will be composed
-     * @return the final lifecycle
+     * @return the builder that will build the final lifecycle or the template
      */
     @Nullable
-    public static DataStreamLifecycle.Template composeDataLifecycles(List<DataStreamLifecycle.Template> lifecycles) {
-        DataStreamLifecycle.Template.Builder builder = null;
+    public static DataStreamLifecycle.Builder composeDataLifecycles(List<DataStreamLifecycle.Template> lifecycles) {
+        DataStreamLifecycle.Builder builder = null;
         for (DataStreamLifecycle.Template current : lifecycles) {
             if (builder == null) {
-                builder = DataStreamLifecycle.Template.builder(current);
+                builder = DataStreamLifecycle.builder(current);
             } else {
-                builder.enabled(current.enabled());
-                if (current.dataRetention().isDefined()) {
-                    builder.dataRetention(current.dataRetention());
-                }
-                if (current.downsampling().isDefined()) {
-                    builder.downsampling(current.downsampling());
-                }
+                builder.composeTemplate(current);
             }
         }
-        return builder == null ? null : builder.build();
+        return builder;
     }
 
     /**
-     * Resolve the given v2 template into a {@link ResettableValue<DataStreamOptions>} object
+     * Resolve the given v2 template into a {@link DataStreamOptions.Builder} object that can be built to either a
+     * {@link DataStreamOptions} or the equivalent {@link DataStreamOptions.Template}.
      */
-    public static ResettableValue<DataStreamOptions.Template> resolveDataStreamOptions(final Metadata metadata, final String templateName) {
+    @Nullable
+    public static DataStreamOptions.Builder resolveDataStreamOptions(final Metadata metadata, final String templateName) {
         final ComposableIndexTemplate template = metadata.templatesV2().get(templateName);
         assert template != null
             : "attempted to resolve data stream options for a template [" + templateName + "] that did not exist in the cluster state";
         if (template == null) {
-            return ResettableValue.undefined();
+            return null;
         }
         return resolveDataStreamOptions(template, metadata.componentTemplates());
     }
 
     /**
-     * Resolve the provided v2 template and component templates into a {@link ResettableValue<DataStreamOptions>} object
+     * Resolve the provided v2 template and component templates into a {@link DataStreamOptions.Builder} object that can be built to
+     * either a {@link DataStreamOptions} or the equivalent {@link DataStreamOptions.Template}.
      */
-    public static ResettableValue<DataStreamOptions.Template> resolveDataStreamOptions(
+    @Nullable
+    public static DataStreamOptions.Builder resolveDataStreamOptions(
         ComposableIndexTemplate template,
         Map<String, ComponentTemplate> componentTemplates
     ) {
@@ -1711,19 +1709,18 @@ public class MetadataIndexTemplateService {
     }
 
     /**
-     * This method composes a series of data streams options to a final one. Since currently the data stream options
-     * contains only the failure store configuration which also contains only one field, the composition is a bit trivial.
-     * But we introduce the mechanics that will help extend it really easily.
+     * This method composes a series of data streams options to a final one.
      * @param dataStreamOptionsList a sorted list of data stream options in the order that they will be composed
      * @return the final data stream option configuration
      */
-    public static ResettableValue<DataStreamOptions.Template> composeDataStreamOptions(
+    @Nullable
+    public static DataStreamOptions.Builder composeDataStreamOptions(
         List<ResettableValue<DataStreamOptions.Template>> dataStreamOptionsList
     ) {
         if (dataStreamOptionsList.isEmpty()) {
-            return ResettableValue.undefined();
+            return null;
         }
-        DataStreamOptions.Template.Builder builder = null;
+        DataStreamOptions.Builder builder = null;
         for (ResettableValue<DataStreamOptions.Template> current : dataStreamOptionsList) {
             if (current.isDefined() == false) {
                 continue;
@@ -1733,14 +1730,13 @@ public class MetadataIndexTemplateService {
             } else {
                 DataStreamOptions.Template currentTemplate = current.get();
                 if (builder == null) {
-                    builder = DataStreamOptions.Template.builder(currentTemplate);
+                    builder = DataStreamOptions.builder(currentTemplate);
                 } else {
-                    // Currently failure store has only one field that needs to be defined so the composing of the failure store is trivial
-                    builder.updateFailureStore(currentTemplate.failureStore());
+                    builder.composeTemplate(currentTemplate);
                 }
             }
         }
-        return builder == null ? ResettableValue.undefined() : ResettableValue.create(builder.build());
+        return builder;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ResettableValue.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ResettableValue.java
@@ -19,7 +19,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -152,23 +151,6 @@ public class ResettableValue<T> {
             return reset();
         }
         return ResettableValue.create(mapper.apply(value));
-    }
-
-    /**
-     * Ιt merges the values of the ResettableValue's when they are defined using the provided mergeFunction.
-     */
-    public static <T> ResettableValue<T> merge(ResettableValue<T> initial, ResettableValue<T> update, BiFunction<T, T, T> mergeFunction) {
-        if (update.shouldReset()) {
-            return undefined();
-        }
-        if (update.isDefined() == false) {
-            return initial;
-        }
-        if (initial.isDefined() == false || initial.shouldReset()) {
-            return update;
-        }
-        // Because we checked that's defined and not in reset state, we can directly apply the merge function.
-        return ResettableValue.create(mergeFunction.apply(initial.value, update.value));
     }
 
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params, String field) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
@@ -61,6 +61,7 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
             a[4] == null ? ResettableValue.undefined() : (ResettableValue<DataStreamOptions.Template>) a[4]
         )
     );
+    public static final DataStreamLifecycle.Template DISABLED_LIFECYCLE = DataStreamLifecycle.builder().enabled(false).buildTemplate();
 
     static {
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> Settings.fromXContent(p), SETTINGS);
@@ -127,6 +128,20 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
         this.dataStreamOptions = dataStreamOptions;
     }
 
+    public Template(
+        @Nullable Settings settings,
+        @Nullable CompressedXContent mappings,
+        @Nullable Map<String, AliasMetadata> aliases,
+        @Nullable DataStreamLifecycle.Template lifecycle,
+        @Nullable DataStreamOptions.Template dataStreamOptions
+    ) {
+        this.settings = settings;
+        this.mappings = mappings;
+        this.aliases = aliases;
+        this.lifecycle = lifecycle;
+        this.dataStreamOptions = ResettableValue.create(dataStreamOptions);
+    }
+
     public Template(@Nullable Settings settings, @Nullable CompressedXContent mappings, @Nullable Map<String, AliasMetadata> aliases) {
         this(settings, mappings, aliases, null, ResettableValue.undefined());
     }
@@ -152,7 +167,7 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
         } else if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)) {
             boolean isExplicitNull = in.readBoolean();
             if (isExplicitNull) {
-                this.lifecycle = DataStreamLifecycle.Template.builder().enabled(false).build();
+                this.lifecycle = DISABLED_LIFECYCLE;
             } else {
                 this.lifecycle = in.readOptionalWriteable(DataStreamLifecycle.Template::read);
             }
@@ -387,8 +402,8 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
             return this;
         }
 
-        public Builder lifecycle(DataStreamLifecycle.Template.Builder lifecycle) {
-            this.lifecycle = lifecycle.build();
+        public Builder lifecycle(DataStreamLifecycle.Builder lifecycle) {
+            this.lifecycle = lifecycle.buildTemplate();
             return this;
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreTemplateTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
-import static org.elasticsearch.cluster.metadata.DataStreamFailureStore.Template.merge;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -42,7 +41,7 @@ public class DataStreamFailureStoreTemplateTests extends AbstractXContentSeriali
     }
 
     static DataStreamFailureStore.Template randomFailureStoreTemplate() {
-        return new DataStreamFailureStore.Template(ResettableValue.create(randomBoolean()));
+        return new DataStreamFailureStore.Template(randomBoolean());
     }
 
     public void testInvalidEmptyConfiguration() {
@@ -53,13 +52,15 @@ public class DataStreamFailureStoreTemplateTests extends AbstractXContentSeriali
         assertThat(exception.getMessage(), containsString("at least one non-null configuration value"));
     }
 
-    public void testMerging() {
-        DataStreamFailureStore.Template template = randomFailureStoreTemplate();
-        DataStreamFailureStore.Template result = merge(template, template);
+    public void testTemplateComposition() {
+        boolean enabled = randomBoolean();
+        DataStreamFailureStore.Template template = new DataStreamFailureStore.Template(enabled);
+        DataStreamFailureStore.Template result = DataStreamFailureStore.builder(template).composeTemplate(template).buildTemplate();
         assertThat(result, equalTo(template));
 
-        DataStreamFailureStore.Template negatedTemplate = mutateInstance(template);
-        result = merge(template, negatedTemplate);
+        DataStreamFailureStore.Template negatedTemplate = new DataStreamFailureStore.Template(enabled == false);
+        result = DataStreamFailureStore.builder(template).composeTemplate(negatedTemplate).buildTemplate();
+        ;
         assertThat(result, equalTo(negatedTemplate));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTemplateTests.java
@@ -45,7 +45,7 @@ public class DataStreamLifecycleTemplateTests extends AbstractXContentSerializin
             case 2 -> downsampling = randomValueOtherThan(downsampling, DataStreamLifecycleTemplateTests::randomDownsampling);
             default -> throw new AssertionError("Illegal randomisation branch");
         }
-        return DataStreamLifecycle.Template.builder().dataRetention(retention).downsampling(downsampling).enabled(enabled).build();
+        return new DataStreamLifecycle.Template(enabled, retention, downsampling);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class DataStreamLifecycleTemplateTests extends AbstractXContentSerializin
         {
             IllegalArgumentException exception = expectThrows(
                 IllegalArgumentException.class,
-                () -> DataStreamLifecycle.Template.builder()
+                () -> DataStreamLifecycle.builder()
                     .downsampling(
                         List.of(
                             new DataStreamLifecycle.DownsamplingRound(
@@ -70,7 +70,7 @@ public class DataStreamLifecycleTemplateTests extends AbstractXContentSerializin
                             )
                         )
                     )
-                    .build()
+                    .buildTemplate()
             );
             assertThat(
                 exception.getMessage(),
@@ -80,7 +80,7 @@ public class DataStreamLifecycleTemplateTests extends AbstractXContentSerializin
         {
             IllegalArgumentException exception = expectThrows(
                 IllegalArgumentException.class,
-                () -> DataStreamLifecycle.Template.builder()
+                () -> DataStreamLifecycle.builder()
                     .downsampling(
                         List.of(
                             new DataStreamLifecycle.DownsamplingRound(
@@ -93,14 +93,14 @@ public class DataStreamLifecycleTemplateTests extends AbstractXContentSerializin
                             )
                         )
                     )
-                    .build()
+                    .buildTemplate()
             );
             assertThat(exception.getMessage(), equalTo("Downsampling interval [2h] must be greater than the source index interval [2h]."));
         }
         {
             IllegalArgumentException exception = expectThrows(
                 IllegalArgumentException.class,
-                () -> DataStreamLifecycle.Template.builder()
+                () -> DataStreamLifecycle.builder()
                     .downsampling(
                         List.of(
                             new DataStreamLifecycle.DownsamplingRound(
@@ -113,21 +113,21 @@ public class DataStreamLifecycleTemplateTests extends AbstractXContentSerializin
                             )
                         )
                     )
-                    .build()
+                    .buildTemplate()
             );
             assertThat(exception.getMessage(), equalTo("Downsampling interval [3h] must be a multiple of the source index interval [2h]."));
         }
         {
             IllegalArgumentException exception = expectThrows(
                 IllegalArgumentException.class,
-                () -> DataStreamLifecycle.Template.builder().downsampling((List.of())).build()
+                () -> DataStreamLifecycle.builder().downsampling((List.of())).buildTemplate()
             );
             assertThat(exception.getMessage(), equalTo("Downsampling configuration should have at least one round configured."));
         }
         {
             IllegalArgumentException exception = expectThrows(
                 IllegalArgumentException.class,
-                () -> DataStreamLifecycle.Template.builder()
+                () -> DataStreamLifecycle.builder()
                     .downsampling(
                         Stream.iterate(1, i -> i * 2)
                             .limit(12)
@@ -139,7 +139,7 @@ public class DataStreamLifecycleTemplateTests extends AbstractXContentSerializin
                             )
                             .toList()
                     )
-                    .build()
+                    .buildTemplate()
             );
             assertThat(exception.getMessage(), equalTo("Downsampling configuration supports maximum 10 configured rounds. Found: 12"));
         }
@@ -147,7 +147,7 @@ public class DataStreamLifecycleTemplateTests extends AbstractXContentSerializin
         {
             IllegalArgumentException exception = expectThrows(
                 IllegalArgumentException.class,
-                () -> DataStreamLifecycle.Template.builder()
+                () -> DataStreamLifecycle.builder()
                     .downsampling(
                         List.of(
                             new DataStreamLifecycle.DownsamplingRound(
@@ -156,7 +156,7 @@ public class DataStreamLifecycleTemplateTests extends AbstractXContentSerializin
                             )
                         )
                     )
-                    .build()
+                    .buildTemplate()
             );
             assertThat(
                 exception.getMessage(),
@@ -166,11 +166,7 @@ public class DataStreamLifecycleTemplateTests extends AbstractXContentSerializin
     }
 
     public static DataStreamLifecycle.Template randomLifecycleTemplate() {
-        return DataStreamLifecycle.Template.builder()
-            .enabled(randomBoolean())
-            .dataRetention(randomRetention())
-            .downsampling(randomDownsampling())
-            .build();
+        return new DataStreamLifecycle.Template(randomBoolean(), randomRetention(), randomDownsampling());
     }
 
     private static ResettableValue<TimeValue> randomRetention() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleWithRetentionWarningsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleWithRetentionWarningsTests.java
@@ -218,9 +218,7 @@ public class DataStreamLifecycleWithRetentionWarningsTests extends ESTestCase {
                         "component-template",
                         new ComponentTemplate(
                             Template.builder()
-                                .lifecycle(
-                                    DataStreamLifecycle.Template.builder().dataRetention(randomTimeValue(2, 100, TimeUnit.DAYS)).build()
-                                )
+                                .lifecycle(DataStreamLifecycle.builder().dataRetention(randomTimeValue(2, 100, TimeUnit.DAYS)))
                                 .build(),
                             null,
                             null

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -139,7 +139,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
                 : randomValueOtherThan(indexMode, () -> randomFrom(IndexMode.values()));
             case 9 -> lifecycle = randomBoolean() && lifecycle != null
                 ? null
-                : DataStreamLifecycle.builder().dataRetention(randomMillisUpToYear9999()).build();
+                : DataStreamLifecycle.builder().dataRetention(randomPositiveTimeValue()).build();
             case 10 -> failureIndices = randomValueOtherThan(failureIndices, DataStreamTestHelper::randomIndexInstances);
             case 11 -> dataStreamOptions = dataStreamOptions.isEmpty() ? new DataStreamOptions(new DataStreamFailureStore(randomBoolean()))
                 : randomBoolean() ? DataStreamOptions.EMPTY
@@ -1472,7 +1472,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
                 dataStreamName,
                 creationAndRolloverTimes,
                 settings(IndexVersion.current()),
-                DataStreamLifecycle.builder().dataRetention(0).build()
+                DataStreamLifecycle.builder().dataRetention(TimeValue.ZERO).build()
             );
             Metadata metadata = builder.build();
 
@@ -1511,7 +1511,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
                 Settings.builder()
                     .put(IndexMetadata.LIFECYCLE_NAME, "ILM_policy")
                     .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()),
-                DataStreamLifecycle.builder().dataRetention(0).build()
+                DataStreamLifecycle.builder().dataRetention(TimeValue.ZERO).build()
             );
             Metadata metadata = builder.build();
 
@@ -1763,7 +1763,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
             dataStreamName,
             creationAndRolloverTimes,
             settings(IndexVersion.current()),
-            DataStreamLifecycle.builder().dataRetention(0).build()
+            DataStreamLifecycle.builder().dataRetention(TimeValue.ZERO).build()
         );
         Metadata metadata = builder.build();
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsServiceTests.java
@@ -466,7 +466,7 @@ public class MetadataDataStreamsServiceTests extends MapperServiceTestCase {
 
     public void testUpdateLifecycle() {
         String dataStream = randomAlphaOfLength(5);
-        DataStreamLifecycle lifecycle = DataStreamLifecycle.builder().dataRetention(randomMillisUpToYear9999()).build();
+        DataStreamLifecycle lifecycle = DataStreamLifecycle.builder().dataRetention(randomPositiveTimeValue()).build();
         ClusterState before = DataStreamTestHelper.getClusterStateWithDataStreams(List.of(new Tuple<>(dataStream, 2)), List.of());
         MetadataDataStreamsService service = new MetadataDataStreamsService(
             mock(ClusterService.class),

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ResettableValueTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ResettableValueTests.java
@@ -33,41 +33,6 @@ public class ResettableValueTests extends ESTestCase {
         assertThat(ResettableValue.create(null), equalTo(ResettableValue.undefined()));
     }
 
-    public void testMerge() {
-        // Initial state: undefined
-        {
-            ResettableValue<Integer> initial = ResettableValue.undefined();
-            assertThat(ResettableValue.merge(initial, ResettableValue.reset(), Integer::sum), equalTo(ResettableValue.undefined()));
-
-            assertThat(ResettableValue.merge(initial, ResettableValue.undefined(), Integer::sum), equalTo(ResettableValue.undefined()));
-
-            ResettableValue<Integer> update = ResettableValue.create(randomInt());
-            assertThat(ResettableValue.merge(initial, update, Integer::sum), equalTo(update));
-        }
-
-        // Initial state: reset
-        {
-            ResettableValue<Integer> initial = ResettableValue.reset();
-            assertThat(ResettableValue.merge(initial, ResettableValue.reset(), Integer::sum), equalTo(ResettableValue.undefined()));
-
-            assertThat(ResettableValue.merge(initial, ResettableValue.undefined(), Integer::sum), equalTo(initial));
-
-            ResettableValue<Integer> update = ResettableValue.create(randomInt());
-            assertThat(ResettableValue.merge(ResettableValue.undefined(), update, Integer::sum), equalTo(update));
-        }
-
-        // Initial state: value
-        {
-            ResettableValue<Integer> initial = ResettableValue.create(randomIntBetween(1, 200));
-            assertThat(ResettableValue.merge(initial, ResettableValue.reset(), Integer::sum), equalTo(ResettableValue.undefined()));
-
-            assertThat(ResettableValue.merge(initial, ResettableValue.undefined(), Integer::sum), equalTo(initial));
-
-            ResettableValue<Integer> update = ResettableValue.create(randomIntBetween(1, 200));
-            assertThat(ResettableValue.merge(initial, update, Integer::sum).get(), equalTo(initial.get() + update.get()));
-        }
-    }
-
     public void testMap() {
         Function<Integer, Integer> increment = x -> x + 1;
         assertThat(ResettableValue.<Integer>undefined().map(increment), equalTo(ResettableValue.undefined()));

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -80,6 +80,7 @@ import static org.elasticsearch.test.ESTestCase.randomFrom;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.elasticsearch.test.ESTestCase.randomMap;
 import static org.elasticsearch.test.ESTestCase.randomMillisUpToYear9999;
+import static org.elasticsearch.test.ESTestCase.randomPositiveTimeValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -369,7 +370,7 @@ public final class DataStreamTestHelper {
             timeProvider,
             randomBoolean(),
             randomBoolean() ? IndexMode.STANDARD : null, // IndexMode.TIME_SERIES triggers validation that many unit tests doesn't pass
-            randomBoolean() ? DataStreamLifecycle.builder().dataRetention(randomMillisUpToYear9999()).build() : null,
+            randomBoolean() ? DataStreamLifecycle.builder().dataRetention(randomPositiveTimeValue()).build() : null,
             failureStore ? DataStreamOptions.FAILURE_STORE_ENABLED : DataStreamOptions.EMPTY,
             DataStream.DataStreamIndices.backingIndicesBuilder(indices)
                 .setRolloverOnWrite(replicated == false && randomBoolean())

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
@@ -157,7 +157,10 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
                             }
                             atLeastOne = true;
                         }
-                        lifecycle = DataStreamLifecycle.builder().dataRetention(retentionMillis).enabled(isEnabled).build();
+                        lifecycle = DataStreamLifecycle.builder()
+                            .dataRetention(TimeValue.timeValueMillis(retentionMillis))
+                            .enabled(isEnabled)
+                            .build();
                     }
                 } else {
                     lifecycle = null;

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleDisruptionIT.java
@@ -64,7 +64,7 @@ public class DataStreamLifecycleDownsampleDisruptionIT extends ESIntegTestCase {
         ensureGreen();
 
         final String dataStreamName = "metrics-foo";
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder()
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.builder()
             .downsampling(
                 List.of(
                     new DataStreamLifecycle.DownsamplingRound(
@@ -73,7 +73,7 @@ public class DataStreamLifecycleDownsampleDisruptionIT extends ESIntegTestCase {
                     )
                 )
             )
-            .build();
+            .buildTemplate();
         DataStreamLifecycleDriver.setupTSDBDataStreamAndIngestDocs(
             client(),
             dataStreamName,

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleIT.java
@@ -54,7 +54,7 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
     public void testDownsampling() throws Exception {
         String dataStreamName = "metrics-foo";
 
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder()
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.builder()
             .downsampling(
                 List.of(
                     new DataStreamLifecycle.DownsamplingRound(
@@ -67,7 +67,7 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
                     )
                 )
             )
-            .build();
+            .buildTemplate();
 
         DataStreamLifecycleDriver.setupTSDBDataStreamAndIngestDocs(
             client(),
@@ -127,7 +127,7 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
     public void testDownsamplingOnlyExecutesTheLastMatchingRound() throws Exception {
         String dataStreamName = "metrics-bar";
 
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder()
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.builder()
             .downsampling(
                 List.of(
                     new DataStreamLifecycle.DownsamplingRound(
@@ -142,7 +142,7 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
                     )
                 )
             )
-            .build();
+            .buildTemplate();
         DataStreamLifecycleDriver.setupTSDBDataStreamAndIngestDocs(
             client(),
             dataStreamName,
@@ -195,7 +195,7 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
         // we expect the earlier round to be ignored
         String dataStreamName = "metrics-baz";
 
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder()
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.builder()
             .downsampling(
                 List.of(
                     new DataStreamLifecycle.DownsamplingRound(
@@ -210,7 +210,7 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
                     )
                 )
             )
-            .build();
+            .buildTemplate();
 
         DataStreamLifecycleDriver.setupTSDBDataStreamAndIngestDocs(
             client(),

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataStreamAndIndexLifecycleMixingTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataStreamAndIndexLifecycleMixingTests.java
@@ -170,9 +170,9 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
 
         // we'll rollover the data stream by indexing 2 documents (like ILM expects) and assert that the rollover happens once so the
         // data stream has 3 backing indices, two managed by ILM and one will be managed by the data stream lifecycle
-        DataStreamLifecycle.Template customLifecycle = DataStreamLifecycle.Template.builder()
+        DataStreamLifecycle.Template customLifecycle = DataStreamLifecycle.builder()
             .dataRetention(randomPositiveTimeValue())
-            .build();
+            .buildTemplate();
         putComposableIndexTemplate(indexTemplateName, null, List.of(dataStreamName + "*"), Settings.EMPTY, null, customLifecycle);
 
         indexDocs(dataStreamName, 2);
@@ -564,9 +564,9 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
 
         // we'll rollover the data stream by indexing 2 documents (like ILM expects) and assert that the rollover happens once so the
         // data stream has 3 backing indices, 2 managed by ILM and 1 by the default data stream lifecycle
-        DataStreamLifecycle.Template customLifecycle = DataStreamLifecycle.Template.builder()
+        DataStreamLifecycle.Template customLifecycle = DataStreamLifecycle.builder()
             .dataRetention(randomPositiveTimeValue())
-            .build();
+            .buildTemplate();
         putComposableIndexTemplate(
             indexTemplateName,
             null,

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataStreamLifecycleDownsamplingSecurityIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataStreamLifecycleDownsamplingSecurityIT.java
@@ -119,7 +119,7 @@ public class DataStreamLifecycleDownsamplingSecurityIT extends SecurityIntegTest
     public void testDownsamplingAuthorized() throws Exception {
         String dataStreamName = "metrics-foo";
 
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.builder()
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.builder()
             .downsampling(
                 List.of(
                     new DataStreamLifecycle.DownsamplingRound(
@@ -132,7 +132,7 @@ public class DataStreamLifecycleDownsamplingSecurityIT extends SecurityIntegTest
                     )
                 )
             )
-            .build();
+            .buildTemplate();
 
         setupDataStreamAndIngestDocs(
             client(),
@@ -409,7 +409,7 @@ public class DataStreamLifecycleDownsamplingSecurityIT extends SecurityIntegTest
 
     public static class SystemDataStreamWithDownsamplingConfigurationPlugin extends Plugin implements SystemIndexPlugin {
 
-        public static final DataStreamLifecycle.Template LIFECYCLE = DataStreamLifecycle.Template.builder()
+        public static final DataStreamLifecycle.Template LIFECYCLE = DataStreamLifecycle.builder()
             .downsampling(
                 List.of(
                     new DataStreamLifecycle.DownsamplingRound(
@@ -422,7 +422,7 @@ public class DataStreamLifecycleDownsamplingSecurityIT extends SecurityIntegTest
                     )
                 )
             )
-            .build();
+            .buildTemplate();
         static final String SYSTEM_DATA_STREAM_NAME = ".fleet-actions-results";
 
         @Override

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataStreamLifecycleServiceRuntimeSecurityIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataStreamLifecycleServiceRuntimeSecurityIT.java
@@ -117,7 +117,7 @@ public class DataStreamLifecycleServiceRuntimeSecurityIT extends SecurityIntegTe
 
     public void testRolloverAndRetentionAuthorized() throws Exception {
         String dataStreamName = randomDataStreamName();
-        prepareDataStreamAndIndex(dataStreamName, DataStreamLifecycle.Template.builder().dataRetention(TimeValue.ZERO).build());
+        prepareDataStreamAndIndex(dataStreamName, DataStreamLifecycle.builder().dataRetention(TimeValue.ZERO).buildTemplate());
 
         assertBusy(() -> {
             assertNoAuthzErrors();
@@ -272,7 +272,7 @@ public class DataStreamLifecycleServiceRuntimeSecurityIT extends SecurityIntegTe
                     SystemDataStreamDescriptor.Type.EXTERNAL,
                     ComposableIndexTemplate.builder()
                         .indexPatterns(List.of(SYSTEM_DATA_STREAM_NAME))
-                        .template(Template.builder().lifecycle(DataStreamLifecycle.Template.builder().dataRetention(TimeValue.ZERO)))
+                        .template(Template.builder().lifecycle(DataStreamLifecycle.builder().dataRetention(TimeValue.ZERO)))
                         .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
                         .build(),
                     Map.of(),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Unify template builders for data stream options, failure store and data stream lifecycle (#125293)](https://github.com/elastic/elasticsearch/pull/125293)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)