### PR TITLE
[8.18] [Docs] ES|QL in Kibana 8.18 changes + fixes (#125346)

### DIFF
--- a/docs/reference/esql/esql-kibana.asciidoc
+++ b/docs/reference/esql/esql-kibana.asciidoc
@@ -37,7 +37,7 @@ To get started with {esql} in Discover, open the main menu and select
 [[esql-kibana-query-bar]]
 === The query bar
 
-After switching to {esql} mode, the query bar shows a sample query. For example:
+After switching to {esql} mode, the query bar shows your previous KQL or Lucene query converted into {esql}. If the query was empty, it shows a sample query. For example:
 
 [source,esql]
 ----

--- a/docs/reference/esql/esql-lookup-join.asciidoc
+++ b/docs/reference/esql/esql-lookup-join.asciidoc
@@ -38,7 +38,7 @@ you
 
 [discrete]
 [[esql-how-lookup-join-works]]
-==== How the `LOOKUP JOIN` command works ++[++esql-how-lookup-join-works++]++
+==== How the `LOOKUP JOIN` command works
 
 The `LOOKUP JOIN` command adds new columns to a table, with data from
 {es} indices.
@@ -134,8 +134,7 @@ FROM employees
 ====
 `LOOKUP JOIN` does not guarantee the output to be in
 any particular order. If a certain order is required, users should use a
-link:/reference/query-languages/esql/esql-commands.md#esql-sort[`SORT`]
-somewhere after the `LOOKUP JOIN`.
+<<esql-sort,`SORT`>> somewhere after the `LOOKUP JOIN`.
 ====
 
 [discrete]
@@ -157,9 +156,7 @@ with `double` (all represented as `double`)
 join only if they have a `.keyword` subfield
 
 For a complete list of supported data types and their internal
-representations, see the
-link:/reference/query-languages/esql/limitations.md#_supported_types[Supported
-Field Types documentation].
+representations, see the <<esql-supported-types,Supported Field Types documentation>>.
 
 [discrete]
 [[esql-lookup-join-limitations]]
@@ -171,9 +168,7 @@ The following are the current limitations with `LOOKUP JOIN`
 is a `KEYWORD` type. If the main index's join field is `TEXT` type, it
 must have an exact `.keyword` subfield that can be matched with the
 lookup index's `KEYWORD` field.
-* Indices in
-link:/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting[lookup]
-mode are always single-sharded.
+* Indices in <<index-mode-setting,lookup>> mode are always single-sharded.
 * Cross cluster search is unsupported. Both source and lookup indices
 must be local.
 * `LOOKUP JOIN` can only use a single match field and a single index.

--- a/docs/reference/esql/processing-commands/lookup.asciidoc
+++ b/docs/reference/esql/processing-commands/lookup.asciidoc
@@ -7,10 +7,10 @@
 This functionality is in technical preview and may be
 changed or removed in a future release. Elastic will work to fix any
 issues, but features in technical preview are not subject to the support
-SLA of official GA features. ::::
+SLA of official GA features.
 ====
 `LOOKUP JOIN` enables you to add data from another index, AKA a 'lookup'
-index, to your ++{{++esql}} query results, simplifying data enrichment
+index, to your {esql} query results, simplifying data enrichment
 and analysis workflows.
 
 *Syntax*
@@ -41,7 +41,7 @@ contains multi-valued entries, those entries will not match anything
 
 *Description*
 
-The `LOOKUP JOIN` command adds new columns to your ++{++esql} query
+The `LOOKUP JOIN` command adds new columns to your {esql} query
 results table by finding documents in a lookup index that share the same
 join field value as your result rows.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[Docs] ES|QL in Kibana 8.18 changes + fixes (#125346)](https://github.com/elastic/elasticsearch/pull/125346)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)