### PR TITLE
Record action name for all outbound messages

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.network.HandlingTimeTracker;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.transport.NetworkExceptionHelper;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -116,6 +116,7 @@ public final class OutboundHandler {
         assert assertValidTransportVersion(transportVersion);
         sendMessage(
             channel,
+            MessageDirection.REQUEST,
             action,
             request,
             requestId,
@@ -148,7 +149,8 @@ public final class OutboundHandler {
         try {
             sendMessage(
                 channel,
-                null,
+                MessageDirection.RESPONSE,
+                action,
                 response,
                 requestId,
                 isHandshake,
@@ -190,7 +192,8 @@ public final class OutboundHandler {
         try {
             sendMessage(
                 channel,
-                null,
+                MessageDirection.RESPONSE_ERROR,
+                action,
                 msg,
                 requestId,
                 false,
@@ -206,29 +209,36 @@ public final class OutboundHandler {
         }
     }
 
+    public enum MessageDirection {
+        REQUEST,
+        RESPONSE,
+        RESPONSE_ERROR
+    }
+
     private void sendMessage(
         TcpChannel channel,
-        @Nullable String requestAction,
+        MessageDirection messageDirection,
+        String action,
         Writeable writeable,
         long requestId,
         boolean isHandshake,
-        Compression.Scheme compressionScheme,
+        Compression.Scheme possibleCompressionScheme,
         TransportVersion version,
         ResponseStatsConsumer responseStatsConsumer,
         Releasable onAfter
     ) throws IOException {
-        compressionScheme = writeable instanceof BytesTransportRequest ? null : compressionScheme;
+        assert action != null;
+        final var compressionScheme = writeable instanceof BytesTransportRequest ? null : possibleCompressionScheme;
         final BytesReference message;
         boolean serializeSuccess = false;
-        final boolean isError = writeable instanceof RemoteTransportException;
         final RecyclerBytesStreamOutput byteStreamOutput = new RecyclerBytesStreamOutput(recycler);
         try {
             message = serialize(
-                requestAction,
+                messageDirection,
+                action,
                 requestId,
                 isHandshake,
                 version,
-                isError,
                 compressionScheme,
                 writeable,
                 threadPool.getThreadContext(),
@@ -244,14 +254,23 @@ public final class OutboundHandler {
             }
         }
         responseStatsConsumer.addResponseStats(message.length());
-        final var responseType = writeable.getClass();
-        final boolean compress = compressionScheme != null;
+        final var messageType = writeable.getClass();
         internalSend(
             channel,
             message,
-            requestAction == null
-                ? () -> "Response{" + requestId + "}{" + isError + "}{" + compress + "}{" + isHandshake + "}{" + responseType + "}"
-                : () -> "Request{" + requestAction + "}{" + requestId + "}{" + isError + "}{" + compress + "}{" + isHandshake + "}",
+            () -> (messageDirection == MessageDirection.REQUEST ? "Request{" : "Response{")
+                + action
+                + "}{id="
+                + requestId
+                + "}{err="
+                + (messageDirection == MessageDirection.RESPONSE_ERROR)
+                + "}{cs="
+                + compressionScheme
+                + "}{hs="
+                + isHandshake
+                + "}{t="
+                + messageType
+                + "}",
             ActionListener.releasing(
                 message instanceof ReleasableBytesReference r
                     ? Releasables.wrap(byteStreamOutput, onAfter, r)
@@ -262,38 +281,39 @@ public final class OutboundHandler {
 
     // public for tests
     public static BytesReference serialize(
-        @Nullable String requestAction,
+        MessageDirection messageDirection,
+        String action,
         long requestId,
         boolean isHandshake,
         TransportVersion version,
-        boolean isError,
         Compression.Scheme compressionScheme,
         Writeable writeable,
         ThreadContext threadContext,
         RecyclerBytesStreamOutput byteStreamOutput
     ) throws IOException {
+        assert action != null;
         assert byteStreamOutput.position() == 0;
         byteStreamOutput.setTransportVersion(version);
         byteStreamOutput.skip(TcpHeader.HEADER_SIZE);
         threadContext.writeTo(byteStreamOutput);
-        if (requestAction != null) {
+        if (messageDirection == MessageDirection.REQUEST) {
             if (version.before(TransportVersions.V_8_0_0)) {
                 // empty features array
                 byteStreamOutput.writeStringArray(Strings.EMPTY_ARRAY);
             }
-            byteStreamOutput.writeString(requestAction);
+            byteStreamOutput.writeString(action);
         }
 
         final int variableHeaderLength = Math.toIntExact(byteStreamOutput.position() - TcpHeader.HEADER_SIZE);
         BytesReference message = serializeMessageBody(writeable, compressionScheme, version, byteStreamOutput);
         byte status = 0;
-        if (requestAction == null) {
+        if (messageDirection != MessageDirection.REQUEST) {
             status = TransportStatus.setResponse(status);
         }
         if (isHandshake) {
             status = TransportStatus.setHandshake(status);
         }
-        if (isError) {
+        if (messageDirection == MessageDirection.RESPONSE_ERROR) {
             status = TransportStatus.setError(status);
         }
         if (compressionScheme != null) {
@@ -316,6 +336,8 @@ public final class OutboundHandler {
         try {
             stream.setTransportVersion(version);
             if (writeable instanceof BytesTransportRequest bRequest) {
+                assert stream == byteStreamOutput;
+                assert compressionScheme == null;
                 bRequest.writeThin(stream);
                 zeroCopyBuffer = bRequest.bytes;
             } else if (writeable instanceof RemoteTransportException remoteTransportException) {

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -59,11 +59,11 @@ public class InboundDecoderTests extends ESTestCase {
             final BytesReference totalBytes;
             if (isRequest) {
                 totalBytes = OutboundHandler.serialize(
+                    isRequest ? OutboundHandler.MessageDirection.REQUEST : OutboundHandler.MessageDirection.RESPONSE,
                     action,
                     requestId,
                     false,
                     TransportVersion.current(),
-                    false,
                     null,
                     new TestRequest(randomAlphaOfLength(100)),
                     threadContext,
@@ -71,11 +71,11 @@ public class InboundDecoderTests extends ESTestCase {
                 );
             } else {
                 totalBytes = OutboundHandler.serialize(
-                    null,
+                    isRequest ? OutboundHandler.MessageDirection.REQUEST : OutboundHandler.MessageDirection.RESPONSE,
+                    action,
                     requestId,
                     false,
                     TransportVersion.current(),
-                    false,
                     null,
                     new TestResponse(randomAlphaOfLength(100)),
                     threadContext,
@@ -144,11 +144,11 @@ public class InboundDecoderTests extends ESTestCase {
 
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference bytes = OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 action,
                 requestId,
                 true,
                 transportVersion,
-                false,
                 compressionScheme,
                 new TestRequest(randomAlphaOfLength(100)),
                 threadContext,
@@ -195,11 +195,11 @@ public class InboundDecoderTests extends ESTestCase {
 
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference bytes = OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 action,
                 requestId,
                 isHandshake,
                 version,
-                false,
                 randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4, null),
                 new TestRequest(randomAlphaOfLength(100)),
                 threadContext,
@@ -243,11 +243,11 @@ public class InboundDecoderTests extends ESTestCase {
 
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference bytes = OutboundHandler.serialize(
-                null,
+                OutboundHandler.MessageDirection.RESPONSE,
+                "test:action",
                 requestId,
                 isHandshake,
                 version,
-                false,
                 randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4, null),
                 new TestRequest(randomAlphaOfLength(100)),
                 threadContext,
@@ -281,38 +281,23 @@ public class InboundDecoderTests extends ESTestCase {
         } else {
             threadContext.addResponseHeader(headerKey, headerValue);
         }
-        final BytesReference totalBytes;
-        TransportMessage transportMessage;
         Compression.Scheme scheme = randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4);
 
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
-            if (isRequest) {
-                transportMessage = new TestRequest(randomAlphaOfLength(100));
-                totalBytes = OutboundHandler.serialize(
-                    action,
-                    requestId,
-                    false,
-                    TransportVersion.current(),
-                    false,
-                    scheme,
-                    transportMessage,
-                    threadContext,
-                    os
-                );
-            } else {
-                transportMessage = new TestResponse(randomAlphaOfLength(100));
-                totalBytes = OutboundHandler.serialize(
-                    null,
-                    requestId,
-                    false,
-                    TransportVersion.current(),
-                    false,
-                    scheme,
-                    transportMessage,
-                    threadContext,
-                    os
-                );
-            }
+            final TransportMessage transportMessage = isRequest
+                ? new TestRequest(randomAlphaOfLength(100))
+                : new TestResponse(randomAlphaOfLength(100));
+            final BytesReference totalBytes = OutboundHandler.serialize(
+                isRequest ? OutboundHandler.MessageDirection.REQUEST : OutboundHandler.MessageDirection.RESPONSE,
+                action,
+                requestId,
+                false,
+                TransportVersion.current(),
+                scheme,
+                transportMessage,
+                threadContext,
+                os
+            );
             final BytesStreamOutput out = new BytesStreamOutput();
             transportMessage.writeTo(out);
             final BytesReference uncompressedBytes = out.bytes();
@@ -373,11 +358,11 @@ public class InboundDecoderTests extends ESTestCase {
         final ReleasableBytesReference releasable1;
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference bytes = OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 action,
                 requestId,
                 false,
                 incompatibleVersion,
-                false,
                 Compression.Scheme.DEFLATE,
                 new TestRequest(randomAlphaOfLength(100)),
                 threadContext,

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -56,32 +56,17 @@ public class InboundDecoderTests extends ESTestCase {
         }
 
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
-            final BytesReference totalBytes;
-            if (isRequest) {
-                totalBytes = OutboundHandler.serialize(
-                    isRequest ? OutboundHandler.MessageDirection.REQUEST : OutboundHandler.MessageDirection.RESPONSE,
-                    action,
-                    requestId,
-                    false,
-                    TransportVersion.current(),
-                    null,
-                    new TestRequest(randomAlphaOfLength(100)),
-                    threadContext,
-                    os
-                );
-            } else {
-                totalBytes = OutboundHandler.serialize(
-                    isRequest ? OutboundHandler.MessageDirection.REQUEST : OutboundHandler.MessageDirection.RESPONSE,
-                    action,
-                    requestId,
-                    false,
-                    TransportVersion.current(),
-                    null,
-                    new TestResponse(randomAlphaOfLength(100)),
-                    threadContext,
-                    os
-                );
-            }
+            final BytesReference totalBytes = OutboundHandler.serialize(
+                isRequest ? OutboundHandler.MessageDirection.REQUEST : OutboundHandler.MessageDirection.RESPONSE,
+                action,
+                requestId,
+                false,
+                TransportVersion.current(),
+                null,
+                isRequest ? new TestRequest(randomAlphaOfLength(100)) : new TestResponse(randomAlphaOfLength(100)),
+                threadContext,
+                os
+            );
             int totalHeaderSize = TcpHeader.HEADER_SIZE + totalBytes.getInt(TcpHeader.VARIABLE_HEADER_SIZE_POSITION);
             final BytesReference messageBytes = totalBytes.slice(totalHeaderSize, totalBytes.length() - totalHeaderSize);
 

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -172,11 +172,11 @@ public class InboundHandlerTests extends ESTestCase {
         String requestValue = randomAlphaOfLength(10);
         BytesRefRecycler recycler = new BytesRefRecycler(PageCacheRecycler.NON_RECYCLING_INSTANCE);
         BytesReference fullRequestBytes = OutboundHandler.serialize(
+            OutboundHandler.MessageDirection.REQUEST,
             action,
             requestId,
             false,
             TransportVersion.current(),
-            false,
             null,
             new TestRequest(requestValue),
             threadPool.getThreadContext(),

--- a/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
@@ -71,11 +71,11 @@ public class TransportLoggerTests extends ESTestCase {
         Compression.Scheme compress = randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4, null);
         try (RecyclerBytesStreamOutput bytesStreamOutput = new RecyclerBytesStreamOutput(recycler)) {
             return OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 "internal:test",
                 randomInt(30),
                 false,
                 TransportVersion.current(),
-                false,
                 compress,
                 new EmptyRequest(),
                 new ThreadContext(Settings.EMPTY),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
@@ -334,11 +334,11 @@ public class SecurityNetty4ServerTransportAuthenticationTests extends ESTestCase
             Recycler<BytesRef> recycler = new BytesRefRecycler(PageCacheRecycler.NON_RECYCLING_INSTANCE);
             RecyclerBytesStreamOutput out = new RecyclerBytesStreamOutput(recycler);
             BytesReference bytesReference = OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 "internal:whatever",
                 randomNonNegativeLong(),
                 false,
                 TransportVersion.current(),
-                false,
                 randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4, null),
                 new EmptyRequest(),
                 threadPool.getThreadContext(),


### PR DESCRIPTION
On outbound messages we know the action name whether it's a request or
response, so we can report it in logs rather than just relying on the
payload's type.