### PR TITLE
[9.0] ESQL: Fail in AggregateFunction when `LogicPlan` is not an `Aggregate`

### DIFF
--- a/docs/changelog/124446.yaml
+++ b/docs/changelog/124446.yaml
@@ -1,0 +1,6 @@
+pr: 124446
+summary: "ESQL: Fail in `AggregateFunction` when `LogicPlan` is not an `Aggregate`"
+area: ES|QL
+type: bug
+issues:
+  - 124311

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
@@ -24,8 +24,6 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.plan.GeneratingPlan;
 
@@ -179,14 +177,6 @@ public class Eval extends UnaryPlan implements GeneratingPlan<Eval>, PostAnalysi
                     )
                 );
             }
-            // check no aggregate functions are used
-            field.forEachDown(AggregateFunction.class, af -> {
-                if (af instanceof Rate) {
-                    failures.add(fail(af, "aggregate function [{}] not allowed outside METRICS command", af.sourceText()));
-                } else {
-                    failures.add(fail(af, "aggregate function [{}] not allowed outside STATS command", af.sourceText()));
-                }
-            });
         });
     }
 }


### PR DESCRIPTION
Manual 9.0 backport of https://github.com/elastic/elasticsearch/pull/124446, with support for Metrics aggs and removed Dedup support