### PR TITLE
[8.x] [ML] Add logging for ModelRegistry cluster state update failure (#125401)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistry.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistry.java
@@ -725,6 +725,10 @@ public class ModelRegistry implements ClusterStateListener {
 
             @Override
             public void onFailure(Exception exc) {
+                logger.warn(
+                    format("Failed to add inference endpoint [%s] minimal service settings to cluster state", inferenceEntityId),
+                    exc
+                );
                 deleteModel(inferenceEntityId, ActionListener.running(() -> {
                     listener.onFailure(
                         new ElasticsearchStatusException(


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Add logging for ModelRegistry cluster state update failure (#125401)