### PR TITLE
[DOCS] Clarify negative scores returned by Elastic Rerank

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -626,7 +626,7 @@ score = ln(score), if score < 0
 `min_score`
 :   (Optional, `float`)
 
-    Sets a minimum threshold score for including documents in the re-ranked results. Documents with similarity scores below this threshold will be excluded. Note that score calculations vary depending on the model used.
+    Sets a minimum threshold score for including documents in the re-ranked results. Documents with similarity scores below this threshold will be excluded. Note that score calculations vary depending on the model used and can result in negative values.
 
 
 `filter`
@@ -670,6 +670,10 @@ Follow these steps:
 
 2. Define a `text_similarity_rerank` retriever:
 
+    ::::{note}
+    The relevance scores produced during reranking depend on the text similarity model used and can include negative values.
+    ::::
+
     ```console
     POST _search
     {
@@ -692,8 +696,6 @@ Follow these steps:
       }
     }
     ```
-
-
 
 ### Example: Cohere Rerank [text-similarity-reranker-retriever-example-cohere]
 

--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -687,8 +687,7 @@ Follow these steps:
           "field": "text",
           "inference_id": "my-elastic-rerank",
           "inference_text": "How often does the moon hide the sun?",
-          "rank_window_size": 100,
-          "min_score": 0.5
+          "rank_window_size": 100
         }
       }
     }


### PR DESCRIPTION
- Added a note clarifying that relevance scores produced during reranking can include negative values.
- Removed "min_score": 0.5 from the example to avoid confusion, as users might incorrectly assume scores are always positive.
Based on https://github.com/elastic/search-docs-team/issues/234
