### PR TITLE
[DOCS] Clarify regex character range case insensitivity limitations

### DIFF
--- a/docs/reference/query-dsl/regexp-syntax.asciidoc
+++ b/docs/reference/query-dsl/regexp-syntax.asciidoc
@@ -181,6 +181,15 @@ example:
 [^-abc]     # matches any character except '-', 'a', 'b', or 'c'
 [^abc\-]    # matches any character except 'a', 'b', 'c', or '-'
 ....
+
+[NOTE]
+====
+Character range classes such as `[a-c]` do not behave as expected when using `case_insensitive: true` — they remain case sensitive.
+For example, `[a-c]+` with `case_insensitive: true` will match strings containing only the characters 'a', 'b', and 'c', but not 'A', 'B', or 'C'. 
+Use `[a-zA-Z]` to match both uppercase and lowercase characters.
+This is due to a known limitation in Lucene's regular expression engine.
+See https://github.com/apache/lucene/issues/14378[Lucene issue #14378] for details.
+====
 --
 
 [discrete]


### PR DESCRIPTION
Flagged by @dadoonet in Slack:

>  There's an interesting discussion [on discuss](https://discuss.elastic.co/t/case-insensitive-regex-query-with-character-range/376136/9?u=dadoonet) about [Lucene regex](https://lucene.apache.org/core/10_1_0/core/org/apache/lucene/util/automaton/RegExp.html) support.  
> Our [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/regexp-syntax.html#regexp-standard-operators) says things like:  
> 
> - `[a-c] # matches 'a', 'b', or 'c'`
> - `[^a-c] # matches any character except 'a', 'b', or 'c'`
> 
> Which is correct unless you use as well `case_insensitive: true` option. In which case you would expect `B` to match `[a-c]`. But it does not work that way and it's a known limitation as Robert answered in [https://github.com/apache/lucene/issues/14378#issuecomment-2740658343](https://github.com/apache/lucene/issues/14378#issuecomment-2740658343).  
> 
