### PR TITLE
[DOCS] Clarify negative scores returned by Elastic Rerank

### DIFF
--- a/docs/reference/reranking/semantic-reranking.asciidoc
+++ b/docs/reference/reranking/semantic-reranking.asciidoc
@@ -103,6 +103,9 @@ The retriever syntax makes it simple to configure both the retrieval and re-rank
 [%collapsible]
 ==============
 The following example shows a search request that uses a semantic reranker to reorder the top-k documents based on their semantic similarity to the query.
+
+NOTE: The relevance scores produced during reranking depend on the text similarity model used and can include negative values.
+
 [source,console]
 ----
 POST _search
@@ -121,8 +124,7 @@ POST _search
       "field": "text",
       "inference_id": "elastic-rerank",
       "inference_text": "How often does the moon hide the sun?",
-      "rank_window_size": 100,
-      "min_score": 0.5
+      "rank_window_size": 100
     }
   }
 }

--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -602,7 +602,7 @@ Defaults to `10`.
 +
 Sets a minimum threshold score for including documents in the re-ranked results.
 Documents with similarity scores below this threshold will be excluded.
-Note that score calculations vary depending on the model used.
+Note that score calculations vary depending on the model used and can result in negative values.
 
 `filter`::
 (Optional, <<query-dsl, query object or list of query objects>>)
@@ -641,6 +641,8 @@ PUT _inference/rerank/my-elastic-rerank
 +
 . Define a `text_similarity_rerank` retriever:
 +
+NOTE: The relevance scores produced during reranking depend on the text similarity model used and can include negative values.
++
 [source,console]
 ----
 POST _search
@@ -659,8 +661,7 @@ POST _search
       "field": "text",
       "inference_id": "my-elastic-rerank",
       "inference_text": "How often does the moon hide the sun?",
-      "rank_window_size": 100,
-      "min_score": 0.5
+      "rank_window_size": 100
     }
   }
 }


### PR DESCRIPTION
- Added a note clarifying that relevance scores produced during reranking can include negative values.
- Removed "min_score": 0.5 from the example to avoid confusion, as users might incorrectly assume scores are always positive.
Based on https://github.com/elastic/search-docs-team/issues/234
