### PR TITLE
[8.18] Fix entitlement test failures on Java 17 (#125344)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -484,7 +484,11 @@ public class EntitlementInitialization {
      * transformed and undergo verification. In order to avoid circularity errors as much as possible, we force a partial order.
      */
     private static void ensureClassesSensitiveToVerificationAreInitialized() {
-        var classesToInitialize = Set.of("sun.net.www.protocol.http.HttpURLConnection");
+        var classesToInitialize = Set.of(
+            "sun.net.www.protocol.http.HttpURLConnection",
+            "sun.nio.ch.SocketChannelImpl",
+            "java.net.ProxySelector"
+        );
         for (String className : classesToInitialize) {
             try {
                 Class.forName(className);


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix entitlement test failures on Java 17 (#125344)