### PR TITLE
[9.0]  Clarify regex character range case insensitivity limitations (#125413)

### DIFF
--- a/docs/reference/query-languages/query-dsl/regexp-syntax.md
+++ b/docs/reference/query-languages/query-dsl/regexp-syntax.md
@@ -138,6 +138,13 @@ A `^` before a character in the brackets negates the character or range. For exa
 [^abc\-]    # matches any character except 'a', 'b', 'c', or '-'
 ```
 
+:::{note}
+Character range classes such as `[a-c]` do not behave as expected when using `case_insensitive: true` — they remain case sensitive. For example, `[a-c]+` with `case_insensitive: true` will match strings containing only the characters 'a', 'b', and 'c', but not 'A', 'B', or 'C'. Use `[a-zA-Z]` to match both uppercase and lowercase characters.
+
+This is due to a known limitation in Lucene's regular expression engine.
+See [Lucene issue #14378](https://github.com/apache/lucene/issues/14378) for details.
+:::
+
 
 ## Optional operators [regexp-optional-operators]
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 -  Clarify regex character range case insensitivity limitations (#125413)