### PR TITLE
[8.x] Set the level for zstd best speed to 1 (#125375)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/zstd/Zstd814StoredFieldsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/zstd/Zstd814StoredFieldsFormat.java
@@ -48,7 +48,7 @@ public final class Zstd814StoredFieldsFormat extends Lucene90CompressingStoredFi
     public static final String MODE_KEY = Zstd814StoredFieldsFormat.class.getSimpleName() + ".mode";
 
     public enum Mode {
-        BEST_SPEED(0, BEST_SPEED_BLOCK_SIZE, 128),
+        BEST_SPEED(1, BEST_SPEED_BLOCK_SIZE, 128),
         BEST_COMPRESSION(3, BEST_COMPRESSION_BLOCK_SIZE, 2048);
 
         final int level, blockSizeInBytes, blockDocCount;

--- a/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
@@ -57,7 +57,7 @@ public class CodecTests extends ESTestCase {
         assumeTrue("Only when zstd_stored_fields feature flag is enabled", CodecService.ZSTD_STORED_FIELDS_FEATURE_FLAG.isEnabled());
         Codec codec = createCodecService().codec("default");
         assertEquals(
-            "Zstd814StoredFieldsFormat(compressionMode=ZSTD(level=0), chunkSize=14336, maxDocsPerChunk=128, blockShift=10)",
+            "Zstd814StoredFieldsFormat(compressionMode=ZSTD(level=1), chunkSize=14336, maxDocsPerChunk=128, blockShift=10)",
             codec.storedFieldsFormat().toString()
         );
     }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Set the level for zstd best speed to 1 (#125375)