### PR TITLE
[8.18] Ensure the tsdb doc values codec is used in ES87TSDBDocValuesFormatTests (#125420)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormatTests.java
@@ -59,6 +59,7 @@ public class ES87TSDBDocValuesFormatTests extends BaseDocValuesFormatTestCase {
         try (Directory directory = newDirectory()) {
             Analyzer analyzer = new MockAnalyzer(random());
             IndexWriterConfig conf = newIndexWriterConfig(analyzer);
+            conf.setCodec(getCodec());
             conf.setMergePolicy(newLogMergePolicy());
             try (RandomIndexWriter iwriter = new RandomIndexWriter(random(), directory, conf)) {
                 for (int i = 0; i < NUM_DOCS; i++) {
@@ -95,6 +96,7 @@ public class ES87TSDBDocValuesFormatTests extends BaseDocValuesFormatTestCase {
         try (Directory directory = newDirectory()) {
             Analyzer analyzer = new MockAnalyzer(random());
             IndexWriterConfig conf = newIndexWriterConfig(analyzer);
+            conf.setCodec(getCodec());
             conf.setMergePolicy(newLogMergePolicy());
             try (RandomIndexWriter iwriter = new RandomIndexWriter(random(), directory, conf)) {
                 for (int i = 0; i < NUM_DOCS; i++) {
@@ -134,6 +136,7 @@ public class ES87TSDBDocValuesFormatTests extends BaseDocValuesFormatTestCase {
 
     public void testOneDocManyValues() throws Exception {
         IndexWriterConfig config = new IndexWriterConfig();
+        config.setCodec(getCodec());
         try (Directory dir = newDirectory(); IndexWriter writer = new IndexWriter(dir, config)) {
             int numValues = 128 + random().nextInt(1024); // > 2^7 to require two blocks
             Document d = new Document();
@@ -161,6 +164,7 @@ public class ES87TSDBDocValuesFormatTests extends BaseDocValuesFormatTestCase {
         final Map<String, long[]> sortedNumbers = new HashMap<>(); // key -> numbers
         try (Directory directory = newDirectory()) {
             IndexWriterConfig conf = newIndexWriterConfig();
+            conf.setCodec(getCodec());
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), directory, conf)) {
                 for (int i = 0; i < numDocs; i++) {
                     Document doc = new Document();


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Ensure the tsdb doc values codec is used in ES87TSDBDocValuesFormatTests (#125420)