### PR TITLE
Fix Semantic Text 8.x Upgrade Bug

### DIFF
--- a/docs/changelog/125446.yaml
+++ b/docs/changelog/125446.yaml
@@ -1,0 +1,5 @@
+pr: 125446
+summary: Fix Semantic Text 8.x Upgrade Bug
+area: Relevance
+type: bug
+issues: []

--- a/docs/changelog/125446.yaml
+++ b/docs/changelog/125446.yaml
@@ -1,5 +1,5 @@
 pr: 125446
 summary: Fix Semantic Text 8.x Upgrade Bug
-area: Relevance
+area: Mapping
 type: bug
 issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/InferenceMetadataFieldsMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/InferenceMetadataFieldsMapper.java
@@ -93,7 +93,9 @@ public abstract class InferenceMetadataFieldsMapper extends MetadataFieldMapper 
         var version = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(settings);
         if ((version.before(IndexVersions.INFERENCE_METADATA_FIELDS)
             && version.between(IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT, IndexVersions.UPGRADE_TO_LUCENE_10_0_0) == false)
-            || (version.before(USE_NEW_SEMANTIC_TEXT_FORMAT_BY_DEFAULT) && USE_LEGACY_SEMANTIC_TEXT_FORMAT.exists(settings) == false)) {
+            || (version.onOrAfter(IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
+                && version.before(USE_NEW_SEMANTIC_TEXT_FORMAT_BY_DEFAULT)
+                && USE_LEGACY_SEMANTIC_TEXT_FORMAT.exists(settings) == false)) {
             return false;
         }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
@@ -71,6 +71,20 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
             )
             .build();
         assertTrue(InferenceMetadataFieldsMapper.isEnabled(settings));
+
+        // Test upgrades from 8.x
+        settings = Settings.builder()
+            .put(
+                IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
+                IndexVersionUtils.getPreviousVersion(IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT)
+            )
+            .build();
+        assertFalse(InferenceMetadataFieldsMapper.isEnabled(settings));
+
+        settings = Settings.builder()
+            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT)
+            .build();
+        assertTrue(InferenceMetadataFieldsMapper.isEnabled(settings));
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
@@ -76,13 +76,20 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
         settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
-                IndexVersionUtils.getPreviousVersion(IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT)
+                IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT)
             )
             .build();
         assertFalse(InferenceMetadataFieldsMapper.isEnabled(settings));
 
         settings = Settings.builder()
-            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT)
+            .put(
+                IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
+                IndexVersionUtils.randomVersionBetween(
+                    random(),
+                    IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT,
+                    IndexVersionUtils.getPreviousVersion(IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
+                )
+            )
             .build();
         assertTrue(InferenceMetadataFieldsMapper.isEnabled(settings));
     }


### PR DESCRIPTION
Fix a bug where 8.x -> 9.0 upgrades would revert `semantic_text` fields to the legacy format