### PR TITLE
Support explicit Z/M coordinate values in WKT parsing for GeoPoint

### DIFF
--- a/libs/geo/src/main/java/org/elasticsearch/geometry/Point.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/Point.java
@@ -16,6 +16,8 @@ import org.elasticsearch.geometry.utils.WellKnownText;
  */
 public class Point implements Geometry {
     public static final Point EMPTY = new Point();
+    public static final String Z = "Z";
+    public static final String M = "M";
 
     private final double y;
     private final double x;


### PR DESCRIPTION
#123111 

This PR enhances the WKT parser to support explicit dimensionality declarations ("Z" and "M") as specified in the OGC Simple Features standard. Previously, Elasticsearch allowed a third dimension in WKT but did not explicitly support declaring that dimension as Z or M.

**Changes**

- Added support for "POINT Z" and "POINT M" syntax in the WKT parser
- Both formats require exactly three coordinates
- Added validation to ensure three coordinates are provided when Z or M is specified
- Added constants for Z and M in the Point class
- Added comprehensive test cases for all supported and unsupported formats
- Improved error messages for invalid input formats
- The _search API returns documents containing Z/M coordinates exactly as they were indexed, without any code modifications

**Not supported**

- The "ZM" dimensionality declaration (four dimensions) is not supported, as specified in the ticket.