### PR TITLE
[9.0] [Gradle] Wire java toolchain plugin into integration tests (#125347)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleInternalPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleInternalPluginFuncTest.groovy
@@ -20,6 +20,22 @@ abstract class AbstractGradleInternalPluginFuncTest extends AbstractJavaGradleFu
         plugins {
             id 'elasticsearch.java-toolchain'
         }
+
+        toolchainManagement {
+          jvm {
+            javaRepositories {
+              repository('bundledOracleOpendJdk') {
+                resolverClass = org.elasticsearch.gradle.internal.toolchain.OracleOpenJdkToolchainResolver
+              }
+              repository('adoptiumJdks') {
+                resolverClass = org.elasticsearch.gradle.internal.toolchain.AdoptiumJdkToolchainResolver
+              }
+              repository('archivedOracleJdks') {
+                resolverClass = org.elasticsearch.gradle.internal.toolchain.ArchivedOracleJdkToolchainResolver
+              }
+            }
+          }
+        }
         """ + settingsFile.text
 
         buildFile << """


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [Gradle] Wire java toolchain plugin into integration tests (#125347)