### PR TITLE
[9.0] Remove old InvalidateApiKeyRequest transport versions (#118290)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/InvalidateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/InvalidateApiKeyRequest.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.core.security.action.apikey;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.Strings;
@@ -41,19 +40,10 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
         super(in);
         realmName = textOrNull(in.readOptionalString());
         userName = textOrNull(in.readOptionalString());
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_7_10_0)) {
-            ids = in.readOptionalStringArray();
-        } else {
-            final String id = in.readOptionalString();
-            ids = Strings.hasText(id) ? new String[] { id } : null;
-        }
+        ids = in.readOptionalStringArray();
         validateIds(ids);
         name = textOrNull(in.readOptionalString());
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_7_4_0)) {
-            ownedByAuthenticatedUser = in.readOptionalBoolean();
-        } else {
-            ownedByAuthenticatedUser = false;
-        }
+        ownedByAuthenticatedUser = in.readOptionalBoolean();
     }
 
     public InvalidateApiKeyRequest(
@@ -209,23 +199,9 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
         super.writeTo(out);
         out.writeOptionalString(realmName);
         out.writeOptionalString(userName);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_10_0)) {
-            out.writeOptionalStringArray(ids);
-        } else {
-            if (ids != null) {
-                if (ids.length == 1) {
-                    out.writeOptionalString(ids[0]);
-                } else {
-                    throw new IllegalArgumentException("a request with multi-valued field [ids] cannot be sent to an older version");
-                }
-            } else {
-                out.writeOptionalString(null);
-            }
-        }
+        out.writeOptionalStringArray(ids);
         out.writeOptionalString(name);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_4_0)) {
-            out.writeOptionalBoolean(ownedByAuthenticatedUser);
-        }
+        out.writeOptionalBoolean(ownedByAuthenticatedUser);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/InvalidateApiKeyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/InvalidateApiKeyRequestTests.java
@@ -22,12 +22,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.function.Supplier;
 
-import static org.elasticsearch.test.TransportVersionUtils.getPreviousVersion;
 import static org.elasticsearch.test.TransportVersionUtils.randomVersionBetween;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class InvalidateApiKeyRequestTests extends ESTestCase {
@@ -120,14 +118,10 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
                 super.writeTo(out);
                 out.writeOptionalString(realm);
                 out.writeOptionalString(user);
-                if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_10_0)) {
-                    if (Strings.hasText(apiKeyId)) {
-                        out.writeOptionalStringArray(new String[] { apiKeyId });
-                    } else {
-                        out.writeOptionalStringArray(null);
-                    }
+                if (Strings.hasText(apiKeyId)) {
+                    out.writeOptionalStringArray(new String[] { apiKeyId });
                 } else {
-                    out.writeOptionalString(apiKeyId);
+                    out.writeOptionalStringArray(null);
                 }
                 out.writeOptionalString(apiKeyName);
                 out.writeOptionalBoolean(ownedByAuthenticatedUser);
@@ -160,20 +154,13 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
                 ByteArrayOutputStream bos = new ByteArrayOutputStream();
                 OutputStreamStreamOutput osso = new OutputStreamStreamOutput(bos)
             ) {
-                TransportVersion streamVersion = randomVersionBetween(
-                    random(),
-                    TransportVersions.V_7_4_0,
-                    getPreviousVersion(TransportVersions.V_7_10_0)
-                );
                 Dummy d = new Dummy(inputs[caseNo]);
-                osso.setTransportVersion(streamVersion);
                 d.writeTo(osso);
 
                 ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
                 InputStreamStreamInput issi = new InputStreamStreamInput(bis);
-                issi.setTransportVersion(streamVersion);
-
                 InvalidateApiKeyRequest request = new InvalidateApiKeyRequest(issi);
+
                 ActionRequestValidationException ve = request.validate();
                 assertNotNull(ve.getMessage(), ve);
                 assertEquals(expectedErrorMessages[caseNo].length, ve.validationErrors().size());
@@ -189,36 +176,6 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
         {
             ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
             OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
-            out.setTransportVersion(randomVersionBetween(random(), TransportVersions.V_7_0_0, TransportVersions.V_7_3_0));
-            invalidateApiKeyRequest.writeTo(out);
-
-            InputStreamStreamInput inputStreamStreamInput = new InputStreamStreamInput(new ByteArrayInputStream(outBuffer.toByteArray()));
-            inputStreamStreamInput.setTransportVersion(
-                randomVersionBetween(random(), TransportVersions.V_7_0_0, TransportVersions.V_7_3_0)
-            );
-            InvalidateApiKeyRequest requestFromInputStream = new InvalidateApiKeyRequest(inputStreamStreamInput);
-
-            assertThat(requestFromInputStream.getIds(), equalTo(invalidateApiKeyRequest.getIds()));
-            // old version so the default for `ownedByAuthenticatedUser` is false
-            assertThat(requestFromInputStream.ownedByAuthenticatedUser(), is(false));
-        }
-        {
-            ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
-            OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
-            out.setTransportVersion(randomVersionBetween(random(), TransportVersions.V_7_4_0, TransportVersions.V_7_9_0));
-            invalidateApiKeyRequest.writeTo(out);
-
-            InputStreamStreamInput inputStreamStreamInput = new InputStreamStreamInput(new ByteArrayInputStream(outBuffer.toByteArray()));
-            inputStreamStreamInput.setTransportVersion(
-                randomVersionBetween(random(), TransportVersions.V_7_4_0, TransportVersions.V_7_9_0)
-            );
-            InvalidateApiKeyRequest requestFromInputStream = new InvalidateApiKeyRequest(inputStreamStreamInput);
-
-            assertThat(requestFromInputStream, equalTo(invalidateApiKeyRequest));
-        }
-        {
-            ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
-            OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
             out.setTransportVersion(randomVersionBetween(random(), TransportVersions.V_7_10_0, TransportVersion.current()));
             invalidateApiKeyRequest.writeTo(out);
 
@@ -230,21 +187,6 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
 
             assertThat(requestFromInputStream, equalTo(invalidateApiKeyRequest));
         }
-    }
-
-    public void testSerializationWillThrowWhenMultipleIdsAndOldVersionStream() {
-        final InvalidateApiKeyRequest invalidateApiKeyRequest = new InvalidateApiKeyRequest(
-            randomFrom(randomNullOrEmptyString(), randomAlphaOfLength(8)),
-            randomFrom(randomNullOrEmptyString(), randomAlphaOfLength(8)),
-            randomFrom(randomNullOrEmptyString(), randomAlphaOfLength(8)),
-            false,
-            new String[] { randomAlphaOfLength(12), randomAlphaOfLength(12) }
-        );
-        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
-        OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
-        out.setTransportVersion(randomVersionBetween(random(), TransportVersions.V_7_4_0, getPreviousVersion(TransportVersions.V_7_10_0)));
-        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> invalidateApiKeyRequest.writeTo(out));
-        assertThat(e.getMessage(), containsString("a request with multi-valued field [ids] cannot be sent to an older version"));
     }
 
     private static String randomNullOrEmptyString() {


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Remove old InvalidateApiKeyRequest transport versions (#118290)