### PR TITLE
ESQL: Fix EsqlNodeSubclassTest failure from mutating

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -454,6 +454,8 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             }
             final List<Attribute> childrenOutput = new ArrayList<>();
 
+            // Gather all the children's output in case of non-unary plans; even for unaries, we need to copy because we may mutate this to
+            // simplify resolution of e.g. RENAME.
             for (LogicalPlan child : plan.children()) {
                 var output = child.output();
                 childrenOutput.addAll(output);
@@ -939,7 +941,6 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
         }
 
         private LogicalPlan resolveDrop(Drop drop, List<Attribute> childOutput) {
-            // Make a copy of childOutput because we may mutate this to simplify resolution of e.g. RENAME.
             List<NamedExpression> resolvedProjections = new ArrayList<>(childOutput);
 
             for (var ne : drop.removals()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -939,6 +939,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
         }
 
         private LogicalPlan resolveDrop(Drop drop, List<Attribute> childOutput) {
+            // Make a copy of childOutput because we may mutate this to simplify resolution of e.g. RENAME.
             List<NamedExpression> resolvedProjections = new ArrayList<>(childOutput);
 
             for (var ne : drop.removals()) {
@@ -974,6 +975,10 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             return new EsqlProject(rename.source(), rename.child(), projections);
         }
 
+        /**
+         * This will turn a {@link Rename} into an equivalent {@link Project}.
+         * Can mutate {@code childrenOutput}; hand this a copy if you want to avoid mutation.
+         */
         public static List<NamedExpression> projectionsForRename(Rename rename, List<Attribute> childrenOutput, Logger logger) {
             List<NamedExpression> projections = new ArrayList<>(childrenOutput);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Rename.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Rename.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.UnsupportedAttribute;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -47,7 +48,11 @@ public class Rename extends UnaryPlan implements TelemetryAware, SortAgnostic {
     @Override
     public List<Attribute> output() {
         // Normally shouldn't reach here, as Rename only exists before resolution.
-        List<NamedExpression> projectionsAfterResolution = ResolveRefs.projectionsForRename(this, this.child().output(), null);
+        List<NamedExpression> projectionsAfterResolution = ResolveRefs.projectionsForRename(
+            this,
+            new ArrayList<>(this.child().output()),
+            null
+        );
 
         return Expressions.asAttributes(projectionsAfterResolution);
     }


### PR DESCRIPTION
We shouldn't mutate LogicalPlan.child().output() (or just LogicalPlan.output()); we did so in RENAME, but only in EsqlNodeSubclassTest, making them flaky.

>The PR at https://github.com/elastic/elasticsearch/pull/122250 seems to have created a flaky test failure in `EsqlNodeSubclassTests`. Local runs with `-Dtests.iters=100` lead to about two dozen failures in over 70k tests run. This is not a high failure rate, but still requires addressing.
>
>The single line added to the Analyzer by that PR causes an `UnsupportedOperationException` on attempting to mutate an immutable collection when running `EsqlNodeSubclassTests`. It turns out that this code path comes from `Rename.output()` which is only called in test scenarios. So a quick fix is to copy the child output into a mutable collection.