### PR TITLE
Un-flake some flaky tests recently introduced by #122250

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Rename.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Rename.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.UnsupportedAttribute;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -47,7 +48,8 @@ public class Rename extends UnaryPlan implements TelemetryAware, SortAgnostic {
     @Override
     public List<Attribute> output() {
         // Normally shouldn't reach here, as Rename only exists before resolution.
-        List<NamedExpression> projectionsAfterResolution = ResolveRefs.projectionsForRename(this, this.child().output(), null);
+        var childOutput = new ArrayList<>(this.child().output());
+        List<NamedExpression> projectionsAfterResolution = ResolveRefs.projectionsForRename(this, childOutput, null);
 
         return Expressions.asAttributes(projectionsAfterResolution);
     }


### PR DESCRIPTION
The PR at https://github.com/elastic/elasticsearch/pull/122250 seems to have created a flaky test failure in `EsqlNodeSubclassTests`. Local runs with `-Dtests.iters=100` lead to about two dozen failures in over 70k tests run. This is not a high failure rate, but still requires addressing.

The single line added to the Analyzer by that PR causes an `UnsupportedOperationException` on attempting to mutate an immutable collection when running `EsqlNodeSubclassTests`. It turns out that this code path comes from `Rename.output()` which is only called in test scenarios. So a quick fix is to copy the child output into a mutable collection.