### PR TITLE
[9.0] Let random_score yaml test explicitly fail on _id field (#125230)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -258,9 +258,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
   method: testDeploymentSurvivesRestart {cluster=OLD}
   issue: https://github.com/elastic/elasticsearch/issues/124160
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search/610_function_score/Random}
-  issue: https://github.com/elastic/elasticsearch/issues/125010
 
 # Examples:
 #

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/610_function_score.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/610_function_score.yml
@@ -82,7 +82,7 @@
 ---
 "No field only runs on 9.x":
   - requires:
-      cluster_features: [ "gte_v9.0.0" ]
+      cluster_features: [ "gte_v8.20.0" ]
       reason: "empty field works seamlessly (relying on _seqno since 9.x)"
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/610_function_score.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/610_function_score.yml
@@ -71,13 +71,55 @@
                 }
               },
               "random_score": {
-                "seed": 10
+                "seed": 10,
+                "field": "uuid"
               }
             }
 
   - length: { hits.hits: 2 }
   - match: { hits.total.value: 2 }
 
+---
+"No field only runs on 9.x":
+  - requires:
+      cluster_features: [ "gte_v9.0.0" ]
+      reason: "empty field works seamlessly (relying on _seqno since 9.x)"
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              text:
+                type: text
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        body: { text: "foo bar", uuid: 1234 }
+
+  - do:
+      index:
+        index: test
+        id: "2"
+        body: { text: "high bar", uuid: 5678 }
+
+  - do:
+      index:
+        index: test
+        id: "3"
+        body: { text: "raise bar", uuid: 9012 }
+
+  - do:
+      index:
+        index: test
+        id: "3"
+        body: { text: "raise hands", uuid: 3456 }
+
+  - do:
+      indices.refresh:
+        index: [ test ]
   - do:
       search:
         index: test
@@ -91,10 +133,8 @@
                 }
               },
               "random_score": {
-                "seed": 10,
-                "field": "uuid"
+                "seed": 10
               }
             }
-
   - length: { hits.hits: 2 }
   - match: { hits.total.value: 2 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Let random_score yaml test explicitly fail on _id field (#125230)](https://github.com/elastic/elasticsearch/pull/125230)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)