### PR TITLE
[docs] More updates for docs-assembler

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,4 +1,5 @@
 project: 'Elasticsearch'
+max_toc_depth: 3
 exclude:
   - README.md
   - internal/*
@@ -22,15 +23,7 @@ cross_links:
   - kibana
   - logstash
 toc:
-  - toc: reference/elasticsearch
-  - toc: reference/community-contributed
-  - toc: reference/enrich-processor
-  - toc: reference/search-connectors
-  - toc: reference/elasticsearch-plugins
-  - toc: reference/query-languages
-  - toc: reference/scripting-languages
-  - toc: reference/text-analysis
-  - toc: reference/aggregations
+  - toc: reference
   - toc: release-notes
   - toc: extend
 subs:

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,5 +1,5 @@
 project: 'Elasticsearch'
-max_toc_depth: 3
+max_toc_depth: 2
 exclude:
   - README.md
   - internal/*

--- a/docs/reference/elasticsearch/index.md
+++ b/docs/reference/elasticsearch/index.md
@@ -1,1 +1,18 @@
 # Elasticsearch and index management
+
+% TO-DO: Add links to "Elasticsearch basics"%
+
+This section contains reference information for Elasticsearch and index management features, including:
+
+* Settings
+* Security roles and privileges
+* Index lifecycle actions
+* Mappings
+* Command line tools
+* Curator
+* Clients
+
+% TO-DO: Add links to "query language and scripting language sections"%
+
+Elasticsearch also provides REST APIs that are used by the UI components and can be called directly to configure and access Elasticsearch features.
+Refer to [Elasticsearch API](https://www.elastic.co/docs/api/doc/elasticsearch) and [Elasticsearch Serverless API](https://www.elastic.co/docs/api/doc/elasticsearch-serverless).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,1 @@
+# Reference

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -1,4 +1,5 @@
 toc:
+  - file: index.md
   - toc: elasticsearch
   - toc: community-contributed
   - toc: enrich-processor

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -1,0 +1,10 @@
+toc:
+  - toc: elasticsearch
+  - toc: community-contributed
+  - toc: enrich-processor
+  - toc: search-connectors
+  - toc: elasticsearch-plugins
+  - toc: query-languages
+  - toc: scripting-languages
+  - toc: text-analysis
+  - toc: aggregations


### PR DESCRIPTION
Adds a `reference/toc.yml` file, move individual reference toc entries from `docset.yml` to the new `reference/toc.yml` file. This also moves the intro content from `docs-content` to this repo so the intro can be at `elastic.co/docs/reference/elasticsearch/`.