### PR TITLE
Improve StatementParserTests error message

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -2714,6 +2714,20 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
+     * Checks a specific exception class with matched message is thrown by the given runnable, and returns it.
+     */
+    public static <T extends Throwable> T expectThrows(
+        String reason,
+        Class<T> expectedType,
+        Matcher<String> messageMatcher,
+        ThrowingRunnable runnable
+    ) {
+        var e = expectThrows(expectedType, reason, runnable);
+        assertThat(reason, e.getMessage(), messageMatcher);
+        return e;
+    }
+
+    /**
      * Same as {@link #runInParallel(int, IntConsumer)} but also attempts to start all tasks at the same time by blocking execution on a
      * barrier until all threads are started and ready to execute their task.
      */

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/IdentifierGenerator.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/IdentifierGenerator.java
@@ -90,8 +90,7 @@ public class IdentifierGenerator {
             var cluster = maybeQuote(randomIdentifier());
             pattern = maybeQuote(cluster + ":" + pattern);
         } else if (EsqlCapabilities.Cap.INDEX_COMPONENT_SELECTORS.isEnabled() && canAdd(Features.INDEX_SELECTOR, features)) {
-            var selector = ESTestCase.randomFrom(IndexComponentSelector.values());
-            pattern = maybeQuote(pattern + "::" + selector.getKey());
+            pattern = maybeQuote(pattern + "::" + randomFrom(IndexComponentSelector.values()).getKey());
         }
         return pattern;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/AbstractStatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/AbstractStatementParserTests.java
@@ -140,22 +140,30 @@ abstract class AbstractStatementParserTests extends ESTestCase {
     }
 
     void expectError(String query, String errorMessage) {
-        ParsingException e = expectThrows(ParsingException.class, "Expected syntax error for " + query, () -> statement(query));
-        assertThat(e.getMessage(), containsString(errorMessage));
-    }
-
-    void expectVerificationError(String query, String errorMessage) {
-        VerificationException e = expectThrows(VerificationException.class, "Expected syntax error for " + query, () -> statement(query));
-        assertThat(e.getMessage(), containsString(errorMessage));
+        expectThrows(
+            "Query [" + query + "] is expected to throw " + ParsingException.class + " with message [" + errorMessage + "]",
+            ParsingException.class,
+            containsString(errorMessage),
+            () -> parser.createStatement(query)
+        );
     }
 
     void expectError(String query, List<QueryParam> params, String errorMessage) {
-        ParsingException e = expectThrows(
+        expectThrows(
+            "Query [" + query + "] is expected to throw " + ParsingException.class + " with message [" + errorMessage + "]",
             ParsingException.class,
-            "Expected syntax error for " + query,
+            containsString(errorMessage),
             () -> statement(query, new QueryParams(params))
         );
-        assertThat(e.getMessage(), containsString(errorMessage));
+    }
+
+    void expectVerificationError(String query, String errorMessage) {
+        expectThrows(
+            "Query [" + query + "] is expected to throw " + VerificationException.class + " with message [" + errorMessage + "]",
+            VerificationException.class,
+            containsString(errorMessage),
+            () -> parser.createStatement(query)
+        );
     }
 
     void expectInvalidIndexNameErrorWithLineNumber(String query, String indexString, String lineNumber) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/AbstractStatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/AbstractStatementParserTests.java
@@ -140,12 +140,7 @@ abstract class AbstractStatementParserTests extends ESTestCase {
     }
 
     void expectError(String query, String errorMessage) {
-        expectThrows(
-            "Query [" + query + "] is expected to throw " + ParsingException.class + " with message [" + errorMessage + "]",
-            ParsingException.class,
-            containsString(errorMessage),
-            () -> parser.createStatement(query)
-        );
+        expectError(query, null, errorMessage);
     }
 
     void expectError(String query, List<QueryParam> params, String errorMessage) {


### PR DESCRIPTION
When validating ParsingException(s) the testing framework displays query only if exception is not thrown at all and not when the error message is different from the expected one. 

This change adds the query to both cases. 
It makes it much easier to troubleshot failures from tests that rely on a query generation and/or IdentifierGenerator. 