### PR TITLE
Improve log message of upgrade of primary job snapshots.

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpgradeJobModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpgradeJobModelSnapshotAction.java
@@ -211,7 +211,8 @@ public class TransportUpgradeJobModelSnapshotAction extends TransportMasterNodeA
                 && (JobState.CLOSED.equals(MlTasks.getJobState(request.getJobId(), customMetadata)) == false)) {
                 listener.onFailure(
                     ExceptionsHelper.conflictStatusException(
-                        "Cannot upgrade snapshot [{}] for job [{}] as it is the current primary job snapshot and the job's state is [{}]",
+                        "Cannot upgrade snapshot [{}] for job [{}] as it is the current primary job snapshot and the job's state is [{}]. "
+                            + "Please close the job before upgrading the snapshot.",
                         request.getSnapshotId(),
                         request.getJobId(),
                         MlTasks.getJobState(request.getJobId(), customMetadata)


### PR DESCRIPTION
Instruct users to close the job to proceed with upgrading primary snapshots.