### PR TITLE
[9.0] [docs] update release note template language and titles (#125548)

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -1,19 +1,20 @@
 ---
-navigation_title: "Elasticsearch"
+navigation_title: "Breaking changes"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes.html
 ---
 
 # Elasticsearch breaking changes [elasticsearch-breaking-changes]
-Before you upgrade, carefully review the Elasticsearch breaking changes and take the necessary steps to mitigate any issues. 
+
+Breaking changes can impact your Elastic applications, potentially disrupting normal operations. Before you upgrade, carefully review the Elasticsearch breaking changes and take the necessary steps to mitigate any issues.
+
+If you are migrating from a version prior to version 9.0, you must first upgrade to the last 8.x version available. To learn how to upgrade, check out [Upgrade](docs-content://deploy-manage/upgrade.md).
 
 To learn how to upgrade, check out <uprade docs>.
 
 % ## Next version [elasticsearch-nextversion-breaking-changes]
-% **Release date:** Month day, year
 
 ## 9.0.0 [elasticsearch-900-breaking-changes]
-**Release date:** March 25, 2025
 
 Allocation
 :   * Increase minimum threshold in shard balancer [#115831](https://github.com/elastic/elasticsearch/pull/115831)

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -1,11 +1,12 @@
 ---
-navigation_title: "Elasticsearch"
+navigation_title: "Deprecations"
 ---
 
 # {{es}} deprecations [elasticsearch-deprecations]
-Review the deprecated functionality for your {{es}} version. While deprecations have no immediate impact, we strongly encourage you update your implementation after you upgrade.
 
-To learn how to upgrade, check out <uprade docs>.
+Over time, certain Elastic functionality becomes outdated and is replaced or removed. To help with the transition, Elastic deprecates functionality for a period before removal, giving you time to update your applications.
+
+Review the deprecated functionality for Elasticsearch. While deprecations have no immediate impact, we strongly encourage you update your implementation after you upgrade. To learn how to upgrade, check out [Upgrade](docs-content://deploy-manage/upgrade.md).
 
 To give you insight into what deprecated features you’re using, {{es}}:
 
@@ -14,10 +15,8 @@ To give you insight into what deprecated features you’re using, {{es}}:
 * [Provides a deprecation info API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-migration-deprecations) that scans a cluster’s configuration and mappings for deprecated functionality.
 
 % ## Next version
-% **Release date:** Month day, year
 
 ## 9.0.0 [elasticsearch-900-deprecations]
-**Release date:** March 25, 2025
 
 Ingest Node
 :   * Fix `_type` deprecation on simulate pipeline API [#116259](https://github.com/elastic/elasticsearch/pull/116259)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -15,8 +15,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 % Release notes include only features, enhancements, and fixes. Add breaking changes, deprecations, and known issues to the applicable release notes sections.
 
-% ## version.next [felasticsearch-next-release-notes]
-% **Release date:** Month day, year
+% ## version.next [elasticsearch-next-release-notes]
 
 % ### Features and enhancements [elasticsearch-next-features-enhancements]
 % *
@@ -25,7 +24,6 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % *
 
 ## 9.0.0 [elasticsearch-900-release-notes]
-**Release date:** March 25, 2025
 
 ### Features and enhancements [elasticsearch-900-features-enhancements]
 Allocation

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -1,8 +1,7 @@
 ---
+navigation_title: "Known issues"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/es-connectors-known-issues.html
-
-navigation_title: "Elasticsearch"
 ---
 
 # Elasticsearch known issues


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[docs] update release note template language and titles (#125548)](https://github.com/elastic/elasticsearch/pull/125548)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)