### PR TITLE
[docs] nested knn only supports score_mode max

### DIFF
--- a/docs/reference/query-languages/query-dsl/query-dsl-knn-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-knn-query.md
@@ -206,7 +206,7 @@ POST my-image-index/_search
 
 A sample query can look like below:
 
-```js
+```json
 {
   "query" : {
     "nested" : {
@@ -226,6 +226,7 @@ A sample query can look like below:
 }
 ```
 
+Note that nested `knn` only supports `score_mode=max`.
 
 ## Knn query with aggregations [knn-query-aggregations]
 

--- a/docs/reference/query-languages/query-dsl/query-dsl-nested-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-nested-query.md
@@ -71,7 +71,7 @@ See [Multi-level nested queries](#multi-level-nested-query-ex) for an example.
 
 
 `score_mode`
-:   (Optional, string) Indicates how scores for matching child objects affect the root parent document’s [relevance score](/reference/query-languages/query-dsl/query-filter-context.md#relevance-scores). Valid values are:
+:   (Optional, string) Indicates how scores for matching child objects affect the root parent document’s [relevance score](/reference/query-languages/query-dsl/query-filter-context.md#relevance-scores). Default is `avg`, but nested `knn` queries only support `score_mode=max`. Valid values are:
 
 `avg` (Default)
 :   Use the mean relevance score of all matching child objects.


### PR DESCRIPTION
docs need to mention that nested `knn` queries only support `score_mode=max`.
see https://github.com/elastic/elasticsearch/issues/122625