### PR TITLE
Fix data stream retrieval in `ExplainDataStreamLifecycleIT`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -336,12 +336,6 @@ tests:
 - class: org.elasticsearch.xpack.ilm.DataStreamAndIndexLifecycleMixingTests
   method: testUpdateIndexTemplateFromILMtoBothILMAndDataStreamLifecycle
   issue: https://github.com/elastic/elasticsearch/issues/124850
-- class: org.elasticsearch.datastreams.lifecycle.ExplainDataStreamLifecycleIT
-  method: testExplainLifecycle
-  issue: https://github.com/elastic/elasticsearch/issues/124882
-- class: org.elasticsearch.datastreams.lifecycle.ExplainDataStreamLifecycleIT
-  method: testSystemExplainLifecycle
-  issue: https://github.com/elastic/elasticsearch/issues/124885
 - class: org.elasticsearch.xpack.ilm.DataStreamAndIndexLifecycleMixingTests
   method: testIndexTemplateSwapsILMForDataStreamLifecycle
   issue: https://github.com/elastic/elasticsearch/issues/124886


### PR DESCRIPTION
These tests had the potential to fail when two consecutive GET data streams requests would hit two different nodes, where one node already had the cluster state that contained the new backing index and the other node didn't yet.

Additionally, we remove a few usages of `DataStream#getDefaultBackingIndexName`, so also relates #123376.

Caused by #122852

Fixes #124882
Fixes #124885