### PR TITLE
Fix data stream retrieval in `TimeSeriesDataStreamsIT`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -363,9 +363,6 @@ tests:
 - class: org.elasticsearch.packaging.test.BootstrapCheckTests
   method: test10Install
   issue: https://github.com/elastic/elasticsearch/issues/124957
-- class: org.elasticsearch.xpack.ilm.TimeSeriesDataStreamsIT
-  method: testRolloverAction
-  issue: https://github.com/elastic/elasticsearch/issues/124987
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test011SecurityEnabledStatus
   issue: https://github.com/elastic/elasticsearch/issues/124990

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
@@ -83,9 +83,6 @@ public class TimeSeriesDataStreamsIT extends ESRestTestCase {
             final var backingIndices = getDataStreamBackingIndexNames(dataStream);
             assertEquals(2, backingIndices.size());
             assertTrue(Boolean.parseBoolean((String) getIndexSettingsAsMap(backingIndices.getLast()).get("index.hidden")));
-        });
-        assertBusy(() -> {
-            final var backingIndices = getDataStreamBackingIndexNames(dataStream);
             assertEquals(PhaseCompleteStep.finalStep("hot").getKey(), getStepKeyForIndex(client(), backingIndices.getFirst()));
         });
     }


### PR DESCRIPTION
This test had the potential to fail when two consecutive GET data streams requests would hit two different nodes, where one node already had the cluster state that contained the new backing index and the other node didn't yet.

Caused by #122852

Fixes #124987