### PR TITLE
Using a consistent index template name to avoid undefined behavior

### DIFF
--- a/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
@@ -840,9 +840,9 @@ setup:
 
   - do:
       allowed_warnings:
-        - "index template [test-composable-1] has index patterns [foo*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test-composable-1] will take precedence during new index creation"
+        - "index template [foo_index_template] has index patterns [foo*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [foo_index_template] will take precedence during new index creation"
       indices.put_index_template:
-        name: test-composable-1
+        name: foo_index_template
         body:
           index_patterns:
             - foo*


### PR DESCRIPTION
In `Test ingest simulate with index template substitutions` we created an index template with one name, and then provided an index template substitution with another name that matches the same pattern with the same priority (no priority). The behavior when you do this is undefined, and just depends on the order that a hash map returns them. In the old test framework, the same things were always in that hash map, so the same index template came out first, and it just happened to be the one that made the test work. @mark-vieira is changing out the test framework, and with that change the _other_ index template always happens to come out first, so the test always fails. This change just uses a single index template name so that we avoid this undefined behavior.