### PR TITLE
Resolve bwc dependencies for packer cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,7 +295,16 @@ allprojects {
   tasks.register('resolveAllDependencies', ResolveAllDependencies) {
     def ignoredPrefixes = [DistributionDownloadPlugin.ES_DISTRO_CONFIG_PREFIX, "jdbcDriver"]
     configs = project.configurations.matching { config -> ignoredPrefixes.any { config.name.startsWith(it) } == false }
-    resolveJavaToolChain = true
+    if(project.path == ':') {
+      resolveJavaToolChain = true
+
+      // ensure we have best possible caching of bwc builds
+      dependsOn ":distribution:bwc:bugfix:buildBwcLinuxTar"
+      dependsOn ":distribution:bwc:bugfix2:buildBwcLinuxTar"
+      dependsOn ":distribution:bwc:minor:buildBwcLinuxTar"
+      dependsOn ":distribution:bwc:staged:buildBwcLinuxTar"
+      dependsOn ":distribution:bwc:staged2:buildBwcLinuxTar"
+    }
     if (project.path.contains("fixture")) {
       dependsOn tasks.withType(ComposePull)
     }
@@ -306,6 +315,7 @@ allprojects {
       // ensure we resolve p2 dependencies for the spotless eclipse formatter
       dependsOn "spotlessJavaCheck"
     }
+
   }
 
   ext.withReleaseBuild = { Closure config ->

--- a/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
+++ b/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
@@ -19,6 +19,14 @@ public final class MinioTestContainer extends DockerEnvironmentAwareTestContaine
     public static final String DOCKER_BASE_IMAGE = "minio/minio:RELEASE.2024-12-18T13-15-44Z";
     private final boolean enabled;
 
+    /**
+     * for packer caching only
+     * see CacheCacheableTestFixtures.
+     * */
+    protected MinioTestContainer() {
+        this(true, "minio", "minio123", "test-bucket");
+    }
+
     public MinioTestContainer(boolean enabled, String accessKey, String secretKey, String bucketName) {
         super(
             new ImageFromDockerfile("es-minio-testfixture").withDockerfileFromBuilder(


### PR DESCRIPTION
bwc builds are built against an empty Gradle userhome by now and this results in
- downloading the gradle distro for each first bwc build
- downloading build dependency on each fresh bwc build resulting in >1gb of dependencies resolved
- downloading java toolchains not resolved otherwise on the first bwc build.

Requiring less downloads on every ci build also results in more stable builds with less transient download errors like: https://gradle-enterprise.elastic.co/s/wcp3lfhkkhrqg/console-log/task/:distribution:bwc:staged:buildBwcLinuxTar?anchor=744&page=1