### PR TITLE
[9.0] Using a consistent index template name to avoid undefined behavior (#125624)

### DIFF
--- a/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
@@ -840,9 +840,9 @@ setup:
 
   - do:
       allowed_warnings:
-        - "index template [test-composable-1] has index patterns [foo*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test-composable-1] will take precedence during new index creation"
+        - "index template [foo_index_template] has index patterns [foo*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [foo_index_template] will take precedence during new index creation"
       indices.put_index_template:
-        name: test-composable-1
+        name: foo_index_template
         body:
           index_patterns:
             - foo*


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Using a consistent index template name to avoid undefined behavior (#125624)