### PR TITLE
Convert ingest-geoip file based update tests to new testing framework

### DIFF
--- a/modules/ingest-geoip/qa/file-based-update/build.gradle
+++ b/modules/ingest-geoip/qa/file-based-update/build.gradle
@@ -7,20 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-apply plugin: 'elasticsearch.legacy-java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
-testClusters.configureEach {
-  testDistribution = 'DEFAULT'
-  setting 'resource.reload.interval.high', '100ms'
-  setting 'xpack.security.enabled', 'true'
-  user username: 'admin', password: 'admin-password', role: 'superuser'
-}
-
-tasks.named("javaRestTest").configure {
-  systemProperty 'tests.security.manager', 'false' // Allows the test the add databases to config directory.
-  nonInputProperties.systemProperty 'tests.config.dir', testClusters.named("javaRestTest").map(c -> c.singleNode().getConfigDir())
-}
-
-tasks.named("forbiddenPatterns").configure {
-  exclude '**/*.mmdb'
+dependencies {
+  clusterModules project(':modules:ingest-geoip')
 }

--- a/modules/ingest-geoip/qa/file-based-update/src/javaRestTest/java/org/elasticsearch/ingest/geoip/UpdateDatabasesIT.java
+++ b/modules/ingest-geoip/qa/file-based-update/src/javaRestTest/java/org/elasticsearch/ingest/geoip/UpdateDatabasesIT.java
@@ -9,12 +9,12 @@
 package org.elasticsearch.ingest.geoip;
 
 import org.elasticsearch.client.Request;
-import org.elasticsearch.common.settings.SecureString;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.PathUtils;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.ObjectPath;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -29,6 +29,15 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class UpdateDatabasesIT extends ESRestTestCase {
+    public static TemporaryFolder configDir = new TemporaryFolder();
+
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .module("ingest-geoip")
+        .withConfigDir(() -> configDir.getRoot().toPath())
+        .build();
+
+    @ClassRule
+    public static RuleChain ruleChain = RuleChain.outerRule(configDir).around(cluster);
 
     public void test() throws Exception {
         String body = """
@@ -51,7 +60,7 @@ public class UpdateDatabasesIT extends ESRestTestCase {
             assertThat(stats, nullValue());
         }
 
-        Path configPath = PathUtils.get(System.getProperty("tests.config.dir"));
+        Path configPath = configDir.getRoot().toPath();
         assertThat(Files.exists(configPath), is(true));
         Path ingestGeoipDatabaseDir = configPath.resolve("ingest-geoip");
         Files.createDirectory(ingestGeoipDatabaseDir);
@@ -82,9 +91,7 @@ public class UpdateDatabasesIT extends ESRestTestCase {
     }
 
     @Override
-    protected Settings restClientSettings() {
-        String token = basicAuthHeaderValue("admin", new SecureString("admin-password".toCharArray()));
-        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
-
 }

--- a/modules/ingest-geoip/qa/file-based-update/src/javaRestTest/java/org/elasticsearch/ingest/geoip/UpdateDatabasesIT.java
+++ b/modules/ingest-geoip/qa/file-based-update/src/javaRestTest/java/org/elasticsearch/ingest/geoip/UpdateDatabasesIT.java
@@ -34,6 +34,7 @@ public class UpdateDatabasesIT extends ESRestTestCase {
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("ingest-geoip")
         .withConfigDir(() -> configDir.getRoot().toPath())
+        .setting("resource.reload.interval.high", "100ms")
         .build();
 
     @ClassRule


### PR DESCRIPTION
This QA project was still using legacy test clusters.