### PR TITLE
[8.x] Resolve bwc dependencies for packer cache (#125625)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -298,7 +298,16 @@ allprojects {
   tasks.register('resolveAllDependencies', ResolveAllDependencies) {
     def ignoredPrefixes = [DistributionDownloadPlugin.ES_DISTRO_CONFIG_PREFIX, "jdbcDriver"]
     configs = project.configurations.matching { config -> ignoredPrefixes.any { config.name.startsWith(it) } == false }
-    resolveJavaToolChain = true
+    if(project.path == ':') {
+      resolveJavaToolChain = true
+
+      // ensure we have best possible caching of bwc builds
+      dependsOn ":distribution:bwc:bugfix:buildBwcLinuxTar"
+      dependsOn ":distribution:bwc:bugfix2:buildBwcLinuxTar"
+      dependsOn ":distribution:bwc:minor:buildBwcLinuxTar"
+      dependsOn ":distribution:bwc:staged:buildBwcLinuxTar"
+      dependsOn ":distribution:bwc:staged2:buildBwcLinuxTar"
+    }
     if (project.path.contains("fixture")) {
       dependsOn tasks.withType(ComposePull)
     }
@@ -309,6 +318,7 @@ allprojects {
       // ensure we resolve p2 dependencies for the spotless eclipse formatter
       dependsOn "spotlessJavaCheck"
     }
+
   }
 
   ext.withReleaseBuild = { Closure config ->

--- a/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
+++ b/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
@@ -19,6 +19,14 @@ public final class MinioTestContainer extends DockerEnvironmentAwareTestContaine
     public static final String DOCKER_BASE_IMAGE = "minio/minio:RELEASE.2024-12-18T13-15-44Z";
     private final boolean enabled;
 
+    /**
+     * for packer caching only
+     * see CacheCacheableTestFixtures.
+     * */
+    protected MinioTestContainer() {
+        this(true, "minio", "minio123", "test-bucket");
+    }
+
     public MinioTestContainer(boolean enabled, String accessKey, String secretKey, String bucketName) {
         super(
             new ImageFromDockerfile("es-minio-testfixture").withDockerfileFromBuilder(


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Resolve bwc dependencies for packer cache (#125625)