### PR TITLE
Fix some `yamlRestTestV7CompatTest` tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -426,29 +426,17 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
   issue: https://github.com/elastic/elasticsearch/issues/122755
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=data_stream/80_resolve_index_data_streams/Resolve index with hidden and closed indices}
-  issue: https://github.com/elastic/elasticsearch/issues/123081
 - class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
   method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
   issue: https://github.com/elastic/elasticsearch/issues/121625
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=data_stream/140_data_stream_aliases/Create data stream alias}
-  issue: https://github.com/elastic/elasticsearch/issues/122226
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/120148
 - class: org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeToCharProcessorTests
   issue: https://github.com/elastic/elasticsearch/issues/120575
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=deprecation/10_basic/Test Deprecations}
-  issue: https://github.com/elastic/elasticsearch/issues/123147
 - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
   method: testChildrenTasksCancelledOnTimeout
   issue: https://github.com/elastic/elasticsearch/issues/123568
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=data_stream/140_data_stream_aliases/Fix IndexNotFoundException error when handling remove alias action}
-  issue: https://github.com/elastic/elasticsearch/issues/121501
 - class: org.elasticsearch.xpack.inference.mapper.SemanticInferenceMetadataFieldsRecoveryTests
   method: testSnapshotRecovery {p0=false p1=false}
   issue: https://github.com/elastic/elasticsearch/issues/124385

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -224,3 +224,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
   task.skipTest("esql/40_unsupported_types/unsupported", "TODO: support for subset of metric fields")
   task.skipTest("esql/40_unsupported_types/unsupported with sort", "TODO: support for subset of metric fields")
 })
+
+tasks.named('yamlRestTestV7CompatTest').configure {
+  systemProperty 'es.queryable_built_in_roles_enabled', 'false'
+}


### PR DESCRIPTION
The V7 REST compat tests shouldn't run with queryable built-in roles enabled.

Relates #120323

Fixes #121501
Fixes #122226
Fixes #122687
Fixes #123081
Fixes #123147