### PR TITLE
[9.0] SQL: Docs: Drop examples of LIKE/RLIKE vs QUERY/MATCH equivalence (#125673)

### DIFF
--- a/docs/reference/query-languages/sql/sql-like-rlike-operators.md
+++ b/docs/reference/query-languages/sql/sql-like-rlike-operators.md
@@ -90,6 +90,7 @@ Even though `RLIKE` is a valid option when searching or filtering in Elasticsear
 
 When using `LIKE`/`RLIKE`, do consider using [full-text search predicates](/reference/query-languages/sql/sql-functions-search.md) which are faster, much more powerful and offer the option of sorting by relevancy (results can be returned based on how well they matched).
 
+<!--
 For example:
 
 |     |     |
@@ -101,5 +102,4 @@ For example:
 | ``foo LIKE 'bar' AND tar LIKE 'goo'`` | ``QUERY('foo: bar AND tar: goo')`` |
 | ``foo RLIKE 'ba.*'`` | ``MATCH(foo, 'ba', 'fuzziness=AUTO:1,5')`` |
 | ``foo RLIKE 'b.{{1}}r'`` | ``MATCH(foo, 'br', 'fuzziness=1')`` |
-
-
+-->


### PR DESCRIPTION
Backports the following commits to 9.0:
 - SQL: Docs: Drop examples of LIKE/RLIKE vs QUERY/MATCH equivalence (#125673)