### PR TITLE
[8.18] Handle long overflow in dates (#124048)

### DIFF
--- a/docs/changelog/124048.yaml
+++ b/docs/changelog/124048.yaml
@@ -1,0 +1,6 @@
+pr: 124048
+summary: Handle long overflow in dates
+area: Search
+type: bug
+issues:
+ - 112483

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
@@ -149,3 +149,39 @@ setup:
                 to: 2023
                 include_lower: false
                 include_upper: false
+
+---
+"test bad dates in range - past":
+  - requires:
+      cluster_features: [ "mapper.range.invalid_date_fix" ]
+      reason: "Fix for invalid date required"
+  - do:
+      catch: /illegal_argument_exception/
+      search:
+        index: dates
+        body:
+          sort: field
+          query:
+            range:
+              date:
+                gte: -522000000
+                lte: 2023
+                format: date_optional_time
+
+---
+"test bad dates in range - future":
+  - requires:
+      cluster_features: [ "mapper.range.invalid_date_fix" ]
+      reason: "Fix for invalid date required"
+  - do:
+      catch: /illegal_argument_exception/
+      search:
+        index: dates
+        body:
+          sort: field
+          query:
+            range:
+              date:
+                gte: 2020
+                lte: 522000000
+                format: date_optional_time

--- a/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
@@ -191,7 +191,7 @@ public class DateUtils {
 
     /**
      * convert a java time instant to a long value which is stored in lucene
-     * the long value resembles the nanoseconds since the epoch
+     * the long value represents the nanoseconds since the epoch
      *
      * @param instant the instant to convert
      * @return        the nano seconds and seconds as a single long
@@ -211,9 +211,34 @@ public class DateUtils {
     }
 
     /**
+     * Convert a java time instant to a long value which is stored in lucene,
+     * the long value represents the milliseconds since epoch
+     *
+     * @param instant the instant to convert
+     * @return        the total milliseconds as a single long
+     */
+    public static long toLongMillis(Instant instant) {
+        try {
+            return instant.toEpochMilli();
+        } catch (ArithmeticException e) {
+            if (instant.isAfter(Instant.now())) {
+                throw new IllegalArgumentException(
+                    "date[" + instant + "] is too far in the future to be represented in a long milliseconds variable",
+                    e
+                );
+            } else {
+                throw new IllegalArgumentException(
+                    "date[" + instant + "] is too far in the past to be represented in a long milliseconds variable",
+                    e
+                );
+            }
+        }
+    }
+
+    /**
      * Returns an instant that is with valid nanosecond resolution. If
      * the parameter is before the valid nanosecond range then this returns
-     * the minimum {@linkplain Instant} valid for nanosecond resultion. If
+     * the minimum {@linkplain Instant} valid for nanosecond resolution. If
      * the parameter is after the valid nanosecond range then this returns
      * the maximum {@linkplain Instant} valid for nanosecond resolution.
      * <p>

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fielddata.FieldDataContext;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -74,6 +74,7 @@ import java.util.function.Function;
 import java.util.function.LongSupplier;
 
 import static org.elasticsearch.common.time.DateUtils.toLong;
+import static org.elasticsearch.common.time.DateUtils.toLongMillis;
 
 /** A {@link FieldMapper} for dates. */
 public final class DateFieldMapper extends FieldMapper {
@@ -93,12 +94,13 @@ public final class DateFieldMapper extends FieldMapper {
     private static final DateMathParser EPOCH_MILLIS_PARSER = DateFormatter.forPattern("epoch_millis")
         .withLocale(DEFAULT_LOCALE)
         .toDateMathParser();
+    public static final NodeFeature INVALID_DATE_FIX = new NodeFeature("mapper.range.invalid_date_fix");
 
     public enum Resolution {
         MILLISECONDS(CONTENT_TYPE, NumericType.DATE, DateMillisDocValuesField::new) {
             @Override
             public long convert(Instant instant) {
-                return instant.toEpochMilli();
+                return toLongMillis(instant);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -79,7 +79,8 @@ public class MapperFeatures implements FeatureSpecification {
             SORT_FIELDS_CHECK_FOR_NESTED_OBJECT_FIX,
             COUNTED_KEYWORD_SYNTHETIC_SOURCE_NATIVE_SUPPORT,
             SourceFieldMapper.SYNTHETIC_RECOVERY_SOURCE,
-            ObjectMapper.SUBOBJECTS_FALSE_MAPPING_UPDATE_FIX
+            ObjectMapper.SUBOBJECTS_FALSE_MAPPING_UPDATE_FIX,
+            DateFieldMapper.INVALID_DATE_FIX
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -152,7 +152,8 @@ public class DateFieldMapperTests extends MapperTestCase {
         return List.of(
             exampleMalformedValue("2016-03-99").mapping(mappingWithFormat("strict_date_optional_time||epoch_millis"))
                 .errorMatches("failed to parse date field [2016-03-99] with format [strict_date_optional_time||epoch_millis]"),
-            exampleMalformedValue("-522000000").mapping(mappingWithFormat("date_optional_time")).errorMatches("long overflow"),
+            exampleMalformedValue("-522000000").mapping(mappingWithFormat("date_optional_time")).errorMatches("too far in the past"),
+            exampleMalformedValue("522000000").mapping(mappingWithFormat("date_optional_time")).errorMatches("too far in the future"),
             exampleMalformedValue("2020").mapping(mappingWithFormat("strict_date"))
                 .errorMatches("failed to parse date field [2020] with format [strict_date]"),
             exampleMalformedValue("hello world").mapping(mappingWithFormat("strict_date_optional_time"))

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeTests.java
@@ -42,7 +42,7 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
             read,
             TestCaseSupplier.dateCases(),
             DataType.DATETIME,
-            v -> ((Instant) v).toEpochMilli(),
+            v -> DateUtils.toLongMillis((Instant) v),
             emptyList()
         );
         TestCaseSupplier.unary(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongTests.java
@@ -43,7 +43,14 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         TestCaseSupplier.forUnaryBoolean(suppliers, evaluatorName.apply("Boolean"), DataType.LONG, b -> b ? 1L : 0L, List.of());
 
         // datetimes
-        TestCaseSupplier.unary(suppliers, read, TestCaseSupplier.dateCases(), DataType.LONG, v -> ((Instant) v).toEpochMilli(), List.of());
+        TestCaseSupplier.unary(
+            suppliers,
+            read,
+            TestCaseSupplier.dateCases(),
+            DataType.LONG,
+            v -> DateUtils.toLongMillis((Instant) v),
+            List.of()
+        );
         TestCaseSupplier.unary(
             suppliers,
             read,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
@@ -87,7 +87,7 @@ public class ToStringTests extends AbstractScalarFunctionTestCase {
             "ToStringFromDatetimeEvaluator[field=" + read + "]",
             TestCaseSupplier.dateCases(),
             DataType.KEYWORD,
-            i -> new BytesRef(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(((Instant) i).toEpochMilli())),
+            i -> new BytesRef(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(DateUtils.toLongMillis((Instant) i))),
             List.of()
         );
         TestCaseSupplier.unary(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Handle long overflow in dates (#124048)](https://github.com/elastic/elasticsearch/pull/124048)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)