### PR TITLE
[9.0] Load FieldInfos from store if not yet initialised through a refresh on IndexShard (#125650)

### DIFF
--- a/docs/changelog/125650.yaml
+++ b/docs/changelog/125650.yaml
@@ -1,0 +1,7 @@
+pr: 125650
+summary: Load `FieldInfos` from store if not yet initialised through a refresh on
+  `IndexShard`
+area: Search
+type: bug
+issues:
+ - 125483

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsSearchIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsSearchIntegTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.searchablesnapshots;
 
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchType;
@@ -125,5 +126,9 @@ public class SearchableSnapshotsSearchIntegTests extends BaseFrozenSearchableSna
             assertThat(searchResponse.getTotalShards(), equalTo(20));
             assertThat(searchResponse.getHits().getTotalHits().value(), equalTo(4L));
         });
+
+        // check that field_caps empty field filtering works as well
+        FieldCapabilitiesResponse response = client().prepareFieldCaps(mountedIndices).setFields("*").setincludeEmptyFields(false).get();
+        assertNotNull(response.getField("keyword"));
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Load FieldInfos from store if not yet initialised through a refresh on IndexShard (#125650)