### PR TITLE
Convert `:test` projects to new testing framework

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -36,12 +36,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":qa:remote-clusters");
         map.put(LegacyRestTestBasePlugin.class, ":qa:repository-multi-version");
         map.put(LegacyRestTestBasePlugin.class, ":qa:rolling-upgrade-legacy");
-        map.put(LegacyRestTestBasePlugin.class, ":test:external-modules:test-apm-integration");
-        map.put(LegacyRestTestBasePlugin.class, ":test:external-modules:test-delayed-aggs");
-        map.put(LegacyRestTestBasePlugin.class, ":test:external-modules:test-die-with-dignity");
-        map.put(LegacyRestTestBasePlugin.class, ":test:external-modules:test-error-query");
-        map.put(LegacyRestTestBasePlugin.class, ":test:external-modules:test-latency-simulating-directory");
-        map.put(LegacyRestTestBasePlugin.class, ":test:yaml-rest-runner");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:core");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ent-search");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:fleet");
@@ -60,8 +54,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:smoke-test-plugins-ssl");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:smoke-test-security-with-mustache");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:xpack-prefix-rest-compat");
-        map.put(LegacyRestTestBasePlugin.class, ":modules:ingest-geoip:qa:file-based-update");
-        map.put(LegacyRestTestBasePlugin.class, ":plugins:discovery-gce:qa:gce");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:multi-cluster-search-security:legacy-with-basic-license");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:multi-cluster-search-security:legacy-with-full-license");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:multi-cluster-search-security:legacy-with-restricted-trust");

--- a/test/external-modules/delayed-aggs/build.gradle
+++ b/test/external-modules/delayed-aggs/build.gradle
@@ -7,11 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
-
-tasks.named('yamlRestTest').configure {
-  it.onlyIf("snapshot build") { buildParams.snapshotBuild }
-}
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 esplugin {
   description = 'A test module that allows to delay aggregations on shards with a configurable time'
@@ -22,4 +18,9 @@ restResources {
   restApi {
     include '_common', 'indices', 'index', 'cluster', 'search'
   }
+}
+
+tasks.named('yamlRestTest') {
+  def isSnapshot = buildParams.snapshotBuild
+  it.onlyIf("snapshot build") { isSnapshot }
 }

--- a/test/external-modules/delayed-aggs/src/yamlRestTest/java/org/elasticsearch/search/aggregations/DelayedShardAggregationClientYamlTestSuiteIT.java
+++ b/test/external-modules/delayed-aggs/src/yamlRestTest/java/org/elasticsearch/search/aggregations/DelayedShardAggregationClientYamlTestSuiteIT.java
@@ -12,10 +12,18 @@ package org.elasticsearch.search.aggregations;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
 
 public class DelayedShardAggregationClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .module("test-delayed-aggs")
+        .build();
+
     public DelayedShardAggregationClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
     }
@@ -23,5 +31,10 @@ public class DelayedShardAggregationClientYamlTestSuiteIT extends ESClientYamlSu
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return ESClientYamlSuiteTestCase.createParameters();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 }

--- a/test/external-modules/delayed-aggs/src/yamlRestTest/java/org/elasticsearch/search/aggregations/DelayedShardAggregationClientYamlTestSuiteIT.java
+++ b/test/external-modules/delayed-aggs/src/yamlRestTest/java/org/elasticsearch/search/aggregations/DelayedShardAggregationClientYamlTestSuiteIT.java
@@ -20,9 +20,7 @@ import org.junit.ClassRule;
 public class DelayedShardAggregationClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .module("test-delayed-aggs")
-        .build();
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("test-delayed-aggs").build();
 
     public DelayedShardAggregationClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);

--- a/test/external-modules/error-query/build.gradle
+++ b/test/external-modules/error-query/build.gradle
@@ -7,17 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.internal-java-rest-test'
-
-tasks.named('javaRestTest') {
-  usesDefaultDistribution("to be triaged")
-  it.onlyIf("snapshot build") { buildParams.snapshotBuild }
-}
-
-tasks.named('yamlRestTest').configure {
-  it.onlyIf("snapshot build") { buildParams.snapshotBuild }
-}
 
 esplugin {
   description = 'A test module that exposes a way to simulate search shard failures and warnings'
@@ -28,4 +21,15 @@ restResources {
   restApi {
     include '_common', 'indices', 'index', 'cluster', 'search'
   }
+}
+
+dependencies {
+  clusterModules project(':x-pack:plugin:esql')
+  clusterModules project(':x-pack:plugin:autoscaling')
+  clusterModules project(':x-pack:plugin:ilm')
+}
+
+tasks.withType(StandaloneRestIntegTestTask) {
+  def isSnapshot = buildParams.snapshotBuild
+  onlyIf("snapshot build") { isSnapshot }
 }

--- a/test/external-modules/error-query/src/javaRestTest/java/org/elasticsearch/test/esql/EsqlPartialResultsIT.java
+++ b/test/external-modules/error-query/src/javaRestTest/java/org/elasticsearch/test/esql/EsqlPartialResultsIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.ClassRule;
 
@@ -35,8 +34,9 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 public class EsqlPartialResultsIT extends ESRestTestCase {
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .distribution(DistributionType.DEFAULT)
         .module("test-error-query")
+        .module("x-pack-esql")
+        .module("x-pack-ilm")
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
         .setting("esql.query.allow_partial_results", "true")

--- a/test/external-modules/error-query/src/yamlRestTest/java/org/elasticsearch/search/query/ErrorQueryClientYamlTestSuiteIT.java
+++ b/test/external-modules/error-query/src/yamlRestTest/java/org/elasticsearch/search/query/ErrorQueryClientYamlTestSuiteIT.java
@@ -12,10 +12,16 @@ package org.elasticsearch.search.query;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
 
 public class ErrorQueryClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("test-error-query").build();
+
     public ErrorQueryClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
     }
@@ -23,5 +29,10 @@ public class ErrorQueryClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return ESClientYamlSuiteTestCase.createParameters();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
@@ -41,7 +41,7 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
     public static final AtomicInteger NEXT_DEBUG_PORT = new AtomicInteger(5007);
 
     private static final Logger LOGGER = LogManager.getLogger(DefaultLocalClusterHandle.class);
-    private static final Duration CLUSTER_UP_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration CLUSTER_UP_TIMEOUT = Duration.ofMinutes(1);
 
     public final ForkJoinPool executor = new ForkJoinPool(
         Math.max(Runtime.getRuntime().availableProcessors(), 4),

--- a/test/yaml-rest-runner/build.gradle
+++ b/test/yaml-rest-runner/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'elasticsearch.build'
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
-apply plugin: 'elasticsearch.legacy-yaml-rest-compat-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
+apply plugin: 'elasticsearch.yaml-rest-compat-test'
 
 dependencies {
   api project(':test:framework')

--- a/test/yaml-rest-runner/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseFailLogIT.java
+++ b/test/yaml-rest-runner/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseFailLogIT.java
@@ -13,11 +13,16 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.logging.log4j.Level;
 import org.elasticsearch.test.MockLog;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 
 public class ESClientYamlSuiteTestCaseFailLogIT extends ESClientYamlSuiteTestCase {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().build();
 
     public ESClientYamlSuiteTestCaseFailLogIT(final ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -64,5 +69,10 @@ public class ESClientYamlSuiteTestCaseFailLogIT extends ESClientYamlSuiteTestCas
 
             mockLog.assertAllExpectationsMatched();
         }
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 }


### PR DESCRIPTION
Converts the last remaining projects under `test` to use the new testing framework.