### PR TITLE
Doc: Update links to logstash plugin docs (#125675) to 9.0

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -21,6 +21,7 @@ cross_links:
   - go-elasticsearch
   - kibana
   - logstash
+  - logstash-docs-md
 toc:
   - toc: reference/elasticsearch
   - toc: reference/community-contributed

--- a/docs/reference/elasticsearch-plugins/integrations.md
+++ b/docs/reference/elasticsearch-plugins/integrations.md
@@ -20,10 +20,10 @@ Integrations are not plugins, but are external tools or modules that make it eas
 
 ### Supported by Elastic: [_supported_by_elastic]
 
-* [Logstash output to Elasticsearch](logstash://reference/plugins-outputs-elasticsearch.md): The Logstash `elasticsearch` output plugin.
-* [Elasticsearch input to Logstash](logstash://reference/plugins-inputs-elasticsearch.md) The Logstash `elasticsearch` input plugin.
-* [Elasticsearch event filtering in Logstash](logstash://reference/plugins-filters-elasticsearch.md) The Logstash `elasticsearch` filter plugin.
-* [Elasticsearch bulk codec](logstash://reference/plugins-codecs-es_bulk.md) The Logstash `es_bulk` plugin decodes the Elasticsearch bulk format into individual events.
+* [Logstash output to Elasticsearch](logstash-docs-md://lsr//plugins-outputs-elasticsearch.md): The Logstash `elasticsearch` output plugin.
+* [Elasticsearch input to Logstash](logstash-docs-md://lsr/plugins-inputs-elasticsearch.md) The Logstash `elasticsearch` input plugin.
+* [Elasticsearch event filtering in Logstash](logstash-docs-md://lsr/plugins-filters-elasticsearch.md) The Logstash `elasticsearch` filter plugin.
+* [Elasticsearch bulk codec](logstash-docs-md://lsr//plugins-codecs-es_bulk.md) The Logstash `es_bulk` plugin decodes the Elasticsearch bulk format into individual events.
 
 
 ### Supported by the community: [_supported_by_the_community_2]


### PR DESCRIPTION
Backports #125675 to 9.0
Related: https://github.com/elastic/logstash-docs-md/issues/7

Logstash plugin docs have moved.
Update links to point to new location.