### PR TITLE
[8.x] Generalize `S3HttpHandler` request matching (#125670)

### DIFF
--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -149,7 +149,7 @@ public class S3HttpHandler implements HttpHandler {
                 exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
                 exchange.getResponseBody().write(response);
 
-            } else if (Regex.simpleMatch("PUT /" + path + "/*?uploadId=*&partNumber=*", request)) {
+            } else if (isUploadPartRequest(request)) {
                 final Map<String, String> params = new HashMap<>();
                 RestUtils.decodeQueryString(request, request.indexOf('?') + 1, params);
 
@@ -212,7 +212,7 @@ public class S3HttpHandler implements HttpHandler {
                 exchange.getResponseHeaders().add("ETag", blob.v1());
                 exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
 
-            } else if (Regex.simpleMatch("GET /" + bucket + "/?prefix=*", request)) {
+            } else if (isListObjectsRequest(request)) {
                 final Map<String, String> params = new HashMap<>();
                 RestUtils.decodeQueryString(request, request.indexOf('?') + 1, params);
                 if (params.get("list-type") != null) {
@@ -319,7 +319,7 @@ public class S3HttpHandler implements HttpHandler {
                 }
                 exchange.sendResponseHeaders((deletions > 0 ? RestStatus.OK : RestStatus.NO_CONTENT).getStatus(), -1);
 
-            } else if (Regex.simpleMatch("POST /" + bucket + "/?delete", request)) {
+            } else if (isMultiObjectDeleteRequest(request)) {
                 final String requestBody = Streams.copyToString(new InputStreamReader(exchange.getRequestBody(), UTF_8));
 
                 final StringBuilder deletes = new StringBuilder();
@@ -341,16 +341,36 @@ public class S3HttpHandler implements HttpHandler {
                 exchange.getResponseBody().write(response);
 
             } else {
+                logger.error("unknown request: {}", request);
                 exchange.sendResponseHeaders(RestStatus.INTERNAL_SERVER_ERROR.getStatus(), -1);
             }
+        } catch (Exception e) {
+            logger.error("exception in request " + request, e);
+            throw e;
         } finally {
             exchange.close();
         }
     }
 
+    private boolean isUploadPartRequest(String request) {
+        return Regex.simpleMatch("PUT /" + path + "/*?uploadId=*&partNumber=*", request)
+            || Regex.simpleMatch("PUT /" + path + "/*?partNumber=*&uploadId=*", request);
+    }
+
     private boolean isListMultipartUploadsRequest(String request) {
         return Regex.simpleMatch("GET /" + bucket + "/?uploads&prefix=*", request)
-            || Regex.simpleMatch("GET /" + bucket + "/?uploads&max-uploads=*&prefix=*", request);
+            || Regex.simpleMatch("GET /" + bucket + "/?uploads&max-uploads=*&prefix=*", request)
+            || Regex.simpleMatch("GET /" + bucket + "?uploads&prefix=*", request)
+            || Regex.simpleMatch("GET /" + bucket + "?uploads&max-uploads=*&prefix=*", request);
+    }
+
+    private boolean isListObjectsRequest(String request) {
+        return Regex.simpleMatch("GET /" + bucket + "/?prefix=*", request)
+            || Regex.simpleMatch("GET /" + bucket + "?list-type=2&*prefix=*", request);
+    }
+
+    private boolean isMultiObjectDeleteRequest(String request) {
+        return request.equals("POST /" + bucket + "/?delete") || request.equals("POST /" + bucket + "?delete");
     }
 
     public Map<String, BytesReference> blobs() {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Generalize `S3HttpHandler` request matching (#125670)