### PR TITLE
[8.x] Exercise multi-part uploads in S3 repo analysis tests (#125669)

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/qa/s3/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/S3RepositoryAnalysisRestIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/s3/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/S3RepositoryAnalysisRestIT.java
@@ -9,6 +9,7 @@ package org.elasticsearch.repositories.blobstore.testkit.analyze;
 import fixture.s3.S3HttpFixture;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.junit.ClassRule;
@@ -59,6 +60,7 @@ public class S3RepositoryAnalysisRestIT extends AbstractRepositoryAnalysisRestTe
             .put("bucket", bucket)
             .put("base_path", basePath)
             .put("delete_objects_max_size", between(1, 1000))
+            .put("buffer_size", ByteSizeValue.ofMb(5)) // so some uploads are multipart ones
             .build();
     }
 }

--- a/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/analyze/AbstractRepositoryAnalysisRestTestCase.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/analyze/AbstractRepositoryAnalysisRestTestCase.java
@@ -29,7 +29,7 @@ public abstract class AbstractRepositoryAnalysisRestTestCase extends ESRestTestC
         final Request request = new Request(HttpPost.METHOD_NAME, "/_snapshot/" + repository + "/_analyze");
         request.addParameter("blob_count", "10");
         request.addParameter("concurrency", "4");
-        request.addParameter("max_blob_size", "1mb");
+        request.addParameter("max_blob_size", randomFrom("1mb", "10mb"));
         request.addParameter("timeout", "120s");
         request.addParameter("seed", Long.toString(randomLong()));
         assertOK(client().performRequest(request));


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Exercise multi-part uploads in S3 repo analysis tests (#125669)