### PR TITLE
Update missed documentation change for new watcher index settings

### DIFF
--- a/docs/reference/rest-api/watcher/update-settings.asciidoc
+++ b/docs/reference/rest-api/watcher/update-settings.asciidoc
@@ -11,10 +11,17 @@
 For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{watcher} APIs].
 --
 
-This API allows a user to modify the settings for the Watcher internal index (`.watches`). Only a subset of settings are allowed to by modified. This includes:
+This API allows a user to modify the settings for the Watcher internal index (`.watches`). Only a subset of settings
+are allowed to by modified. This includes:
 
 - `index.auto_expand_replicas`
 - `index.number_of_replicas`
+- Any setting with the prefix `index.routing.allocation.exclude.`
+- Any setting with the prefix `index.routing.allocation.include.`
+- Any setting with the prefix `index.routing.allocation.require.`
+
+Modification of `index.routing.allocation.include._tier_preference` is an exception and is not allowed as the Watcher
+shards must always be in the `data_content` tier.
 
 An example of modifying the Watcher settings:
 

--- a/docs/reference/rest-api/watcher/update-settings.asciidoc
+++ b/docs/reference/rest-api/watcher/update-settings.asciidoc
@@ -12,7 +12,7 @@ For the most up-to-date API details, refer to {api-es}/group/endpoint-watcher[{w
 --
 
 This API allows a user to modify the settings for the Watcher internal index (`.watches`). Only a subset of settings
-are allowed to by modified. This includes:
+are allowed to be modified. This includes:
 
 - `index.auto_expand_replicas`
 - `index.number_of_replicas`


### PR DESCRIPTION
This PR adds a documentation change to the 8.x branches that was missed when merging  https://github.com/elastic/elasticsearch/pull/115251.

9.x documentation is handled in the new elasticsearch-spec docs system via https://github.com/elastic/elasticsearch-specification/pull/4141