### PR TITLE
[8.x] Fix `p0=deprecation/10_basic/Test Deprecations` (#125687)

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/RestDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/RestDeprecationInfoAction.java
@@ -17,10 +17,13 @@ import org.elasticsearch.xpack.deprecation.DeprecationInfoAction.Request;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestDeprecationInfoAction extends BaseRestHandler {
+
+    private static final Set<String> SUPPORTED_CAPABILITIES = Set.of("data_streams", "ilm_policies", "templates");
 
     @Override
     public List<Route> routes() {
@@ -52,5 +55,10 @@ public class RestDeprecationInfoAction extends BaseRestHandler {
             Strings.splitStringByCommaToArray(request.param("index"))
         );
         return channel -> client.execute(DeprecationInfoAction.INSTANCE, infoRequest, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public Set<String> supportedCapabilities() {
+        return SUPPORTED_CAPABILITIES;
     }
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/deprecation/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/deprecation/10_basic.yml
@@ -11,9 +11,11 @@ setup:
         - method: GET
           path: /_migration/deprecations
           capabilities: [ data_streams, ilm_policies, templates ]
-      test_runner_features: capabilities
+      test_runner_features: [capabilities, allowed_warnings]
       reason: "Support for data streams, ILM policies and templates"
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.security-7], but in a future major version, direct access to system indices will be prevented by default"
       migration.deprecations:
         index: "*"
   - length: { cluster_settings: 0 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix `p0=deprecation/10_basic/Test Deprecations` (#125687)