### PR TITLE
Tweak tolerance in EWMR tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -311,9 +311,6 @@ tests:
 - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=search.vectors/41_knn_search_byte_quantized/kNN search plus query}
   issue: https://github.com/elastic/elasticsearch/issues/124687
-- class: org.elasticsearch.common.metrics.ExponentiallyWeightedMovingRateTests
-  method: testEwmr_threadSafe
-  issue: https://github.com/elastic/elasticsearch/issues/124692
 - class: org.elasticsearch.packaging.test.BootstrapCheckTests
   method: test20RunWithBootstrapChecks
   issue: https://github.com/elastic/elasticsearch/issues/124940

--- a/server/src/test/java/org/elasticsearch/common/metrics/ExponentiallyWeightedMovingRateTests.java
+++ b/server/src/test/java/org/elasticsearch/common/metrics/ExponentiallyWeightedMovingRateTests.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ExponentiallyWeightedMovingRateTests extends ESTestCase {
 
-    private static final double TOLERANCE = 1.0e-13;
+    private static final double TOLERANCE = 2.0e-13;
     private static final double HALF_LIFE_MILLIS = 1.0e6; // Half-life of used by many tests
     private static final double LAMBDA = Math.log(2.0) / HALF_LIFE_MILLIS; // Equivalent value of lambda
     public static final int START_TIME_IN_MILLIS = 1234567;


### PR DESCRIPTION
We have seen occasional failures with the existing tolerance, in `testEwmr_threadSafe` which contains some randomness. We were asserting the result of a lot of f.p. operations with a tolerance of 1.0e-13. The highest error I saw in any of the reported failures was less than 1.2e-13. This PR increases the tolerance to 2.0e-13 which should allow all those to pass.

Fixes #124692
