### PR TITLE
[9.0] Minor-Fixes Support 7x segments as archive in 8x / 9x  (#125666)

### DIFF
--- a/docs/changelog/125666.yaml
+++ b/docs/changelog/125666.yaml
@@ -1,0 +1,5 @@
+pr: 125666
+summary: Minor-Fixes Support 7x segments as archive in 8x / 9x
+area: Search
+type: bug
+issues: []

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/BWCCodec.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/BWCCodec.java
@@ -29,7 +29,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Version;
 import org.elasticsearch.core.UpdateForV10;
-import org.elasticsearch.xpack.lucene.bwc.codecs.lucene70.BWCLucene70Codec;
 import org.elasticsearch.xpack.lucene.bwc.codecs.lucene80.BWCLucene80Codec;
 import org.elasticsearch.xpack.lucene.bwc.codecs.lucene84.BWCLucene84Codec;
 import org.elasticsearch.xpack.lucene.bwc.codecs.lucene86.BWCLucene86Codec;
@@ -229,7 +228,6 @@ public abstract class BWCCodec extends Codec {
         if (codec == null) return null;
 
         return switch (codec.getClass().getSimpleName()) {
-            case "Lucene70Codec" -> new BWCLucene70Codec();
             case "Lucene80Codec" -> new BWCLucene80Codec();
             case "Lucene84Codec" -> new BWCLucene84Codec();
             case "Lucene86Codec" -> new BWCLucene86Codec();


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Minor-Fixes Support 7x segments as archive in 8x / 9x  (#125666)