### PR TITLE
Field API path syntax support in IngestDocument

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -344,7 +344,7 @@ public final class IngestDocument {
 
     @Nullable
     private WriteField getWriteField(String path) {
-        if ((path.startsWith("$('") && path.endsWith("')") ) || (path.startsWith("$(\"") && path.endsWith("\")"))) {
+        if ((path.startsWith("$('") && path.endsWith("')")) || (path.startsWith("$(\"") && path.endsWith("\")"))) {
             return new WriteField(path.substring(3, path.length() - 2), this::getCtxMap);
         }
         return null;

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -344,6 +344,9 @@ public final class IngestDocument {
 
     @Nullable
     private WriteField getWriteField(String path) {
+        if (path == null) {
+            return null;
+        }
         if ((path.startsWith("$('") && path.endsWith("')")) || (path.startsWith("$(\"") && path.endsWith("\")"))) {
             return new WriteField(path.substring(3, path.length() - 2), this::getCtxMap);
         }


### PR DESCRIPTION
A POC for allowing a field api syntax for ingest pipeline field references.

This doesn't require any changes to `WriteField` or the field api itself. It just exposes the existing functionality in the context of ingest pipeline field references.

Example:
```json
{
  "processors": [
    {
      "rename": {
        "field": "$('attributes.foo.bar')",
        "target_field": "$('attributes.bar.foo')"
      }
    }
  ]
}
```