### PR TITLE
Fix some ILM tests for searchable snapshots

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -368,9 +368,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test010Install
   issue: https://github.com/elastic/elasticsearch/issues/125680
-- class: org.elasticsearch.xpack.ilm.actions.SearchableSnapshotActionIT
-  method: testSearchableSnapshotsInHotPhasePinnedToHotNodes
-  issue: https://github.com/elastic/elasticsearch/issues/125683
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=cat.allocation/10_basic/Node forecasts}
   issue: https://github.com/elastic/elasticsearch/issues/125711


### PR DESCRIPTION
These tests are very prone to the "quiet test cluster syndrome" and sometimes need a little push by means of some artificial cluster state updates. To hopefully be done with these test failures once and for all (famous last words), I've updated all tests in this class to trigger cluster state updates where necessary.

This is basically a follow-up of #108162.

Fixes #125683
Fixes #125789
Fixes #125911