### PR TITLE
Add shard routing and state transitions logging to testFilterCacheStats

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -287,9 +287,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testWatcherWithApiKey {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/124159
-- class: org.elasticsearch.indices.stats.IndexStatsIT
-  method: testFilterCacheStats
-  issue: https://github.com/elastic/elasticsearch/issues/124447
 - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=data_stream/190_failure_store_redirection/Redirect ingest failure in data stream to failure store}
   issue: https://github.com/elastic/elasticsearch/issues/124518

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -58,6 +58,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
@@ -1082,6 +1083,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertEquals(total, shardTotal);
     }
 
+    @TestLogging(value = "org.elasticsearch.cluster.service:TRACE", reason = "https://github.com/elastic/elasticsearch/issues/124447")
     public void testFilterCacheStats() throws Exception {
         Settings settings = Settings.builder()
             .put(indexSettings())
@@ -1356,7 +1358,11 @@ public class IndexStatsIT extends ESIntegTestCase {
             for (IndexService indexService : indexServices) {
                 for (IndexShard indexShard : indexService) {
                     indexShard.sync();
-                    assertThat(indexShard.getLastSyncedGlobalCheckpoint(), equalTo(indexShard.getLastKnownGlobalCheckpoint()));
+                    assertThat(
+                        "Routing entry for shard " + indexShard.routingEntry().toString(),
+                        indexShard.getLastSyncedGlobalCheckpoint(),
+                        equalTo(indexShard.getLastKnownGlobalCheckpoint())
+                    );
                 }
             }
         }


### PR DESCRIPTION
This unmutes and adds extra logging for the testFilterCacheStats test.

The test sporadically fails on 
```
assertThat(
                        indexShard.getLastSyncedGlobalCheckpoint(),
                        equalTo(indexShard.getLastKnownGlobalCheckpoint())
                    );
```
whenever the index under test has a high primary shards count (8). 

We'd want to monitor the cluster state transitions and the shard routing
when this test fails again. 


Relates to https://github.com/elastic/elasticsearch/issues/124447