### PR TITLE
[Failure Store] Prevent explicit selectors in role index name patterns

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/RoleDescriptorRequestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/RoleDescriptorRequestValidator.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.security.action.role;
 
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilege;
 import org.elasticsearch.xpack.core.security.authz.privilege.ClusterPrivilegeResolver;
@@ -52,6 +53,15 @@ public class RoleDescriptorRequestValidator {
                     IndexPrivilege.resolveBySelectorAccess(Set.of(idp.getPrivileges()));
                 } catch (IllegalArgumentException ile) {
                     validationException = addValidationError(ile.getMessage(), validationException);
+                }
+                for (final String indexName : idp.getIndices()) {
+                    if (IndexNameExpressionResolver.hasSelectorSuffix(indexName)) {
+                        validationException = addValidationError(
+                            IndexNameExpressionResolver.SelectorResolver.SELECTOR_SEPARATOR
+                                + " selectors are not allowed in the index name expression",
+                            validationException
+                        );
+                    }
                 }
             }
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/RoleDescriptorRequestValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/RoleDescriptorRequestValidatorTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.role;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor.IndicesPrivileges;
+import org.elasticsearch.xpack.core.security.authz.privilege.IndexPrivilege;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class RoleDescriptorRequestValidatorTests extends ESTestCase {
+
+    public void testSelectorsValidation() {
+        String[] invalidIndexNames = {
+            "index::failures",
+            ".fs-*::failures",
+            ".ds-*::data",
+            "*::failures",
+            "*::",
+            "?::?",
+            "test?-*::data",
+            "test-*::*", // actual selector is not relevant and not validated
+            "test::irrelevant",
+            "::test",
+            "test::",
+            "::",
+            ":: ",
+            " ::",
+            ":::",
+            "::::",
+            randomAlphaOfLengthBetween(5, 10) + "\u003a\u003afailures",
+            randomAlphaOfLengthBetween(5, 10) + "\072\072failures" };
+        for (String indexName : invalidIndexNames) {
+            validateAndAssertSelectorNotAllowed(indexName);
+        }
+
+        // these are not necessarily valid index names, but they should not trigger the selector validation
+        String[] validIndexNames = {
+            "index:failures", // single colon is allowed
+            ":failures",
+            "no double colon",
+            ":",
+            ": :",
+            "",
+            " ",
+            ":\n:",
+            null,
+            "a:",
+            ":b:",
+            "*",
+            "c?-*",
+            "d-*e",
+            "f:g:h",
+            "/[a-b]*test:[a-b]*:failures/", // while this regex can match test::failures, it is not rejected - doing so would be too complex
+            randomIntBetween(-10, 10) + "",
+            randomAlphaOfLengthBetween(1, 10),
+            randomAlphanumericOfLength(10) };
+        for (String indexName : validIndexNames) {
+            validateAndAssertNoException(indexName);
+        }
+    }
+
+    private static void validateAndAssertSelectorNotAllowed(String indexName) {
+        var validationException = RoleDescriptorRequestValidator.validate(roleWithIndexPrivileges(indexName));
+        assertThat("expected validation exception for " + indexName, validationException, notNullValue());
+        assertThat(validationException.validationErrors(), containsInAnyOrder(":: selectors are not allowed in the index name expression"));
+    }
+
+    private static void validateAndAssertNoException(String indexName) {
+        var validationException = RoleDescriptorRequestValidator.validate(roleWithIndexPrivileges(indexName));
+        assertThat("expected no validation exception for " + indexName, validationException, nullValue());
+    }
+
+    private static RoleDescriptor roleWithIndexPrivileges(String... indices) {
+        return new RoleDescriptor(
+            "test-role",
+            null,
+            new IndicesPrivileges[] {
+                IndicesPrivileges.builder()
+                    .allowRestrictedIndices(randomBoolean())
+                    .indices(indices)
+                    .privileges(randomSubsetOf(randomIntBetween(1, IndexPrivilege.names().size()), IndexPrivilege.names()))
+                    .build() },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/RoleDescriptorRequestValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/RoleDescriptorRequestValidatorTests.java
@@ -7,10 +7,14 @@
 
 package org.elasticsearch.xpack.core.security.action.role;
 
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor.IndicesPrivileges;
 import org.elasticsearch.xpack.core.security.authz.privilege.IndexPrivilege;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
@@ -19,6 +23,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class RoleDescriptorRequestValidatorTests extends ESTestCase {
 
     public void testSelectorsValidation() {
+        assumeTrue("failure store feature flag must be enabled", DataStream.isFailureStoreFeatureFlagEnabled());
         String[] invalidIndexNames = {
             "index::failures",
             ".fs-*::failures",
@@ -39,7 +44,8 @@ public class RoleDescriptorRequestValidatorTests extends ESTestCase {
             randomAlphaOfLengthBetween(5, 10) + "\u003a\u003afailures",
             randomAlphaOfLengthBetween(5, 10) + "\072\072failures" };
         for (String indexName : invalidIndexNames) {
-            validateAndAssertSelectorNotAllowed(indexName);
+            validateAndAssertSelectorNotAllowed(roleWithIndexPrivileges(indexName), indexName);
+            validateAndAssertSelectorNotAllowed(roleWithRemoteIndexPrivileges(indexName), indexName);
         }
 
         // these are not necessarily valid index names, but they should not trigger the selector validation
@@ -64,18 +70,22 @@ public class RoleDescriptorRequestValidatorTests extends ESTestCase {
             randomAlphaOfLengthBetween(1, 10),
             randomAlphanumericOfLength(10) };
         for (String indexName : validIndexNames) {
-            validateAndAssertNoException(indexName);
+            validateAndAssertNoException(roleWithIndexPrivileges(indexName), indexName);
+            validateAndAssertNoException(roleWithRemoteIndexPrivileges(indexName), indexName);
         }
     }
 
-    private static void validateAndAssertSelectorNotAllowed(String indexName) {
-        var validationException = RoleDescriptorRequestValidator.validate(roleWithIndexPrivileges(indexName));
+    private static void validateAndAssertSelectorNotAllowed(RoleDescriptor roleDescriptor, String indexName) {
+        var validationException = RoleDescriptorRequestValidator.validate(roleDescriptor);
         assertThat("expected validation exception for " + indexName, validationException, notNullValue());
-        assertThat(validationException.validationErrors(), containsInAnyOrder(":: selectors are not allowed in the index name expression"));
+        assertThat(
+            validationException.validationErrors(),
+            containsInAnyOrder("selectors [::] are not allowed in the index name expression [" + indexName + "]")
+        );
     }
 
-    private static void validateAndAssertNoException(String indexName) {
-        var validationException = RoleDescriptorRequestValidator.validate(roleWithIndexPrivileges(indexName));
+    private static void validateAndAssertNoException(RoleDescriptor roleDescriptor, String indexName) {
+        var validationException = RoleDescriptorRequestValidator.validate(roleDescriptor);
         assertThat("expected no validation exception for " + indexName, validationException, nullValue());
     }
 
@@ -95,6 +105,35 @@ public class RoleDescriptorRequestValidatorTests extends ESTestCase {
             null,
             null,
             null,
+            null,
+            null,
+            null
+        );
+    }
+
+    private static RoleDescriptor roleWithRemoteIndexPrivileges(String... indices) {
+        Set<String> privileges = IndexPrivilege.names()
+            .stream()
+            .filter(p -> false == (p.equals("read_failure_store") || p.equals("manage_failure_store")))
+            .collect(Collectors.toSet());
+        return new RoleDescriptor(
+            "remote-test-role",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            new RoleDescriptor.RemoteIndicesPrivileges[] {
+                new RoleDescriptor.RemoteIndicesPrivileges(
+                    IndicesPrivileges.builder()
+                        .allowRestrictedIndices(randomBoolean())
+                        .indices(indices)
+                        .privileges(randomSubsetOf(randomIntBetween(1, privileges.size()), privileges))
+                        .build(),
+                    "my-remote-cluster"
+                ) },
             null,
             null,
             null

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
@@ -915,6 +915,19 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
         );
         assertThat(bulkFailedError.getMessage(), containsString("selectors [::] are not allowed in the index name expression"));
 
+        expectThrowsSelectorsNotAllowed(() -> createApiKey("user", Strings.format("""
+            {
+                "role": {
+                    "cluster": ["all"],
+                    "indices": [
+                        {
+                            "names": ["%s"],
+                            "privileges": ["%s"]
+                        }
+                    ]
+                }
+            }""", randomFrom("*::failures", "test1::failures", "test1::data", "*::data"), randomFrom("read", "read_failure_store"))));
+
     }
 
     public void testFailureStoreAccess() throws Exception {


### PR DESCRIPTION
Adding basic validation to prevent using `::` selectors when defining index permissions.
Index names do not allow colon character (`:`), hence the index name patterns that
would include double colon (`::`), would never match any of the index names. 
To avoid confusion, we are preventing using `::` in role index name patterns.  

For example, the `test-*::failures` will be rejected during `test-role` validation:

```
PUT /_security/role/test-role
{
    "indices": [
        {
            "names": ["test-*::failures"],
            "privileges": ["read"]
        }
    ]
}
```
