### PR TITLE
[8.x] [ML] Fix ModelRegistryMetadataTests  (#125756)

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryMetadataTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryMetadataTests.java
@@ -30,7 +30,7 @@ public class ModelRegistryMetadataTests extends AbstractChunkedSerializingTestCa
     }
 
     public static ModelRegistryMetadata randomInstance(boolean isUpgraded) {
-        if (rarely()) {
+        if (rarely() && isUpgraded == false) {
             return ModelRegistryMetadata.EMPTY;
         }
         int size = randomIntBetween(1, 5);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ML] Fix ModelRegistryMetadataTests  (#125756)](https://github.com/elastic/elasticsearch/pull/125756)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)