### PR TITLE
[docs] Remove reliance on temporary redirects

### DIFF
--- a/docs/reference/community-contributed/index.md
+++ b/docs/reference/community-contributed/index.md
@@ -11,7 +11,7 @@ This is a list of clients submitted by members of the Elastic community. Elastic
 If you'd like to add a new client to this list, please [open a pull request](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md).
 :::
 
-Besides the [officially supported Elasticsearch clients](docs-content://reference/elasticsearch/clients/index.md), there are
+Besides the [officially supported Elasticsearch clients](docs-content://reference/elasticsearch-clients/index.md), there are
 a number of clients that have been contributed by the community for various languages.
 
 ## B4J [b4j]

--- a/docs/reference/elasticsearch/configuration-reference/auding-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/auding-settings.md
@@ -12,7 +12,7 @@ applies_to:
 
 
 $$$auditing-settings-description$$$
-You can use [audit logging](docs-content://deploy-manage/monitor/logging-configuration/enabling-audit-logs.md) to record security-related events, such as authentication failures, refused connections, and data-access events. In addition, changes via the APIs to the security configuration, such as creating, updating and removing [native](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/native.md) and [built-in](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md) users, [roles](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-role), [role mappings](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-role-mapping) and [API keys](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key) are also recorded.
+You can use [audit logging](docs-content://deploy-manage/security/logging-configuration/enabling-audit-logs.md) to record security-related events, such as authentication failures, refused connections, and data-access events. In addition, changes via the APIs to the security configuration, such as creating, updating and removing [native](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/native.md) and [built-in](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md) users, [roles](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-role), [role mappings](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-role-mapping) and [API keys](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key) are also recorded.
 
 ::::{tip}
 Audit logs are only available on certain subscription levels. For more information, see [{{stack}} subscriptions](https://www.elastic.co/subscriptions).
@@ -48,7 +48,7 @@ $$$xpack-sa-lf-events-exclude$$$
 $$$xpack-sa-lf-events-emit-request$$$
 
 `xpack.security.audit.logfile.events.emit_request_body` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
-:   ([Dynamic](docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md#dynamic-cluster-setting)) Specifies whether to include the full request body from REST requests as an attribute of certain kinds of audit events. This setting can be used to [audit search queries](docs-content://deploy-manage/monitor/logging-configuration/auditing-search-queries.md).
+:   ([Dynamic](docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md#dynamic-cluster-setting)) Specifies whether to include the full request body from REST requests as an attribute of certain kinds of audit events. This setting can be used to [audit search queries](docs-content://deploy-manage/security/logging-configuration/auditing-search-queries.md).
 
     The default value is `false`, so request bodies are not printed.
 
@@ -83,7 +83,7 @@ $$$xpack-sa-lf-emit-node-id$$$
 
 ## Audit Logfile Event Ignore Policies [audit-event-ignore-policies]
 
-The following settings affect the [ignore policies](docs-content://deploy-manage/monitor/logging-configuration/logfile-audit-events-ignore-policies.md) that enable fine-grained control over which audit events are printed to the log file. All of the settings with the same policy name combine to form a single policy. If an event matches all the conditions of any policy, it is ignored and not printed. Most audit events are subject to the ignore policies. The sole exception are events of the `security_config_change` type, which cannot be filtered out, unless [excluded](#xpack-sa-lf-events-exclude) altogether.
+The following settings affect the [ignore policies](docs-content://deploy-manage/security/logging-configuration/logfile-audit-events-ignore-policies.md) that enable fine-grained control over which audit events are printed to the log file. All of the settings with the same policy name combine to form a single policy. If an event matches all the conditions of any policy, it is ignored and not printed. Most audit events are subject to the ignore policies. The sole exception are events of the `security_config_change` type, which cannot be filtered out, unless [excluded](#xpack-sa-lf-events-exclude) altogether.
 
 $$$xpack-sa-lf-events-ignore-users$$$
 

--- a/docs/reference/elasticsearch/configuration-reference/index-management-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/index-management-settings.md
@@ -29,7 +29,7 @@ $$$cluster-indices-close-enable$$$
     ::::{warning}
     For versions 7.1 and below, closed indices represent a data loss risk. Enable this setting only temporarily for these versions.
     ::::
-    
+
     ::::{note}
     Closed indices still consume a significant amount of disk space.
     ::::
@@ -38,7 +38,7 @@ $$$cluster-indices-close-enable$$$
 $$$stack-templates-enabled$$$
 
 `stack.templates.enabled`
-:   ([Dynamic](docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md#dynamic-cluster-setting)) If `true`, enables built-in index and component templates. [{{agent}}](docs-content://reference/ingestion-tools/fleet/index.md) uses these templates to create data streams. If `false`, {{es}} disables these index and component templates. Defaults to `true`.
+:   ([Dynamic](docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md#dynamic-cluster-setting)) If `true`, enables built-in index and component templates. [{{agent}}](docs-content://reference/fleet/index.md) uses these templates to create data streams. If `false`, {{es}} disables these index and component templates. Defaults to `true`.
 
 ::::{note}
 It is not recommended to disable the built-in stack templates, as some functionality of {{es}} or Kibana will not work correctly when disabled. Features like log and metric collection, as well as Kibana reporting, may malfunction without the built-in stack templates. Stack templates should only be disabled temporarily, if necessary, to resolve upgrade issues, then re-enabled after any issues have been resolved.
@@ -65,7 +65,7 @@ This setting also affects the following built-in component templates:
 * `synthetics@mapping`
 * `synthetics@settings`
 
-### Universal Profiling settings 
+### Universal Profiling settings
 
 The following settings for Elastic Universal Profiling are supported:
 

--- a/docs/reference/elasticsearch/elasticsearch-audit-events.md
+++ b/docs/reference/elasticsearch/elasticsearch-audit-events.md
@@ -16,11 +16,11 @@ This section provides detailed **reference information** for Elasticsearch audit
 Refer to [Security event audit logging](docs-content://deploy-manage/security/logging-configuration/security-event-audit-logging.md) in the **Deploy and manage** section for overview, getting started and conceptual information about audit logging.
 :::
 
-When you are [auditing security events](docs-content://deploy-manage/monitor/logging-configuration/enabling-audit-logs.md), a single client request might generate multiple audit events, across multiple cluster nodes. The common `request.id` attribute can be used to correlate the associated events.
+When you are [auditing security events](docs-content://deploy-manage/security/logging-configuration/enabling-audit-logs.md), a single client request might generate multiple audit events, across multiple cluster nodes. The common `request.id` attribute can be used to correlate the associated events.
 
 This document provides a reference for all types of audit events and their associated [attributes](#audit-event-attributes) in {{es}}. Use [audit event settings](./configuration-reference/auding-settings.md) options to control what gets logged.
 
-For more information and options about tuning audit logs, refer to [Configuring audit logs](docs-content://deploy-manage/monitor/logging-configuration/configuring-audit-logs.md).
+For more information and options about tuning audit logs, refer to [Configuring audit logs](docs-content://deploy-manage/security/logging-configuration/configuring-audit-logs.md).
 
 ::::{note}
 Certain audit events require the `security_config_change` event type to log the related event action. The event descriptions in this document indicate whether this requirement is applicable.
@@ -573,7 +573,7 @@ $$$event-tampered-request$$$
 
 ## Audit event attributes [audit-event-attributes]
 
-The audit events are formatted as JSON documents, and each event is printed on a separate line in the audit log. The entries themselves do not contain an end-of-line delimiter. For more details, see [Log entry format](docs-content://deploy-manage/monitor/logging-configuration/logfile-audit-output.md#audit-log-entry-format).
+The audit events are formatted as JSON documents, and each event is printed on a separate line in the audit log. The entries themselves do not contain an end-of-line delimiter. For more details, see [Log entry format](docs-content://deploy-manage/security/logging-configuration/logfile-audit-output.md#audit-log-entry-format).
 
 ### Common attributes
 

--- a/docs/reference/elasticsearch/index-lifecycle-actions/ilm-allocate.md
+++ b/docs/reference/elasticsearch/index-lifecycle-actions/ilm-allocate.md
@@ -11,7 +11,7 @@ Updates the index settings to change which nodes are allowed to host the index s
 
 The allocate action is not allowed in the hot phase. The initial allocation for the index must be done manually or via [index templates](docs-content://manage-data/data-store/templates.md).
 
-You can configure this action to modify both the allocation rules and number of replicas, only the allocation rules, or only the number of replicas. For more information about how {{es}} uses replicas for scaling, see [Get ready for production](docs-content://deploy-manage/production-guidance/getting-ready-for-production-elasticsearch.md). See [Index-level shard allocation filtering](/reference/elasticsearch/index-settings/shard-allocation.md) for more information about controlling where {{es}} allocates shards of a particular index.
+You can configure this action to modify both the allocation rules and number of replicas, only the allocation rules, or only the number of replicas. For more information about how {{es}} uses replicas for scaling, see [Get ready for production](docs-content://deploy-manage/production-guidance/elasticsearch-in-production-environments.md). See [Index-level shard allocation filtering](/reference/elasticsearch/index-settings/shard-allocation.md) for more information about controlling where {{es}} allocates shards of a particular index.
 
 ## Options [ilm-allocate-options]
 

--- a/docs/reference/elasticsearch/index-settings/slow-log.md
+++ b/docs/reference/elasticsearch/index-settings/slow-log.md
@@ -218,7 +218,7 @@ Slow log thresholds being met does not guarantee cluster performance issues. In 
 
 If you’re experiencing search performance issues, then you might also consider investigating searches flagged for their query durations using the [profile API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-profile.html). You can then use the profiled query to investigate optimization options using the [query profiler](docs-content://explore-analyze/query-filter/tools/search-profiler.md). This type of investigation should usually take place in a non-production environment.
 
-Slow logging checks each event against the reporting threshold when the event is complete. This means that it can’t report if events trigger [circuit breaker errors](docs-content://troubleshoot/elasticsearch/circuit-breaker-errors.md). If suspect circuit breaker errors, then you should also consider enabling [audit logging](docs-content://deploy-manage/monitor/logging-configuration/enabling-audit-logs.md), which logs events before they are executed.
+Slow logging checks each event against the reporting threshold when the event is complete. This means that it can’t report if events trigger [circuit breaker errors](docs-content://troubleshoot/elasticsearch/circuit-breaker-errors.md). If suspect circuit breaker errors, then you should also consider enabling [audit logging](docs-content://deploy-manage/security/logging-configuration/enabling-audit-logs.md), which logs events before they are executed.
 
 
 ## Learn more [_learn_more]

--- a/docs/reference/elasticsearch/rest-apis/paginate-search-results.md
+++ b/docs/reference/elasticsearch/rest-apis/paginate-search-results.md
@@ -114,7 +114,7 @@ GET twitter/_search
 }
 ```
 
-Repeat this process by updating the `search_after` array every time you retrieve a new page of results. If a [refresh](docs-content://solutions/search/search-approaches/near-real-time-search.md) occurs between these requests, the order of your results may change, causing inconsistent results across pages. To prevent this, you can create a [point in time (PIT)](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-open-point-in-time) to preserve the current index state over your searches.
+Repeat this process by updating the `search_after` array every time you retrieve a new page of results. If a [refresh](docs-content://manage-data/data-store/near-real-time-search.md) occurs between these requests, the order of your results may change, causing inconsistent results across pages. To prevent this, you can create a [point in time (PIT)](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-open-point-in-time) to preserve the current index state over your searches.
 
 ```console
 POST /my-index-000001/_pit?keep_alive=1m

--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -666,7 +666,7 @@ Follow these steps:
     }
     ```
 
-    1. [Adaptive allocations](docs-content://explore-analyze/machine-learning/nlp/ml-nlp-auto-scale.md#nlp-model-adaptive-allocations) will be enabled with the minimum of 1 and the maximum of 10 allocations.
+    1. [Adaptive allocations](docs-content://deploy-manage/autoscaling/trained-model-autoscaling.md#enabling-autoscaling-through-apis-adaptive-allocations) will be enabled with the minimum of 1 and the maximum of 10 allocations.
 
 2. Define a `text_similarity_rerank` retriever:
 

--- a/docs/reference/enrich-processor/reroute-processor.md
+++ b/docs/reference/enrich-processor/reroute-processor.md
@@ -11,9 +11,9 @@ The `reroute` processor allows to route a document to another target index or da
 
 When setting the `destination` option, the target is explicitly specified and the `dataset` and `namespace` options can’t be set.
 
-When the `destination` option is not set, this processor is in a data stream mode. Note that in this mode, the `reroute` processor can only be used on data streams that follow the [data stream naming scheme](docs-content://reference/ingestion-tools/fleet/data-streams.md#data-streams-naming-scheme). Trying to use this processor on a data stream with a non-compliant name will raise an exception.
+When the `destination` option is not set, this processor is in a data stream mode. Note that in this mode, the `reroute` processor can only be used on data streams that follow the [data stream naming scheme](docs-content://reference/fleet/data-streams.md#data-streams-naming-scheme). Trying to use this processor on a data stream with a non-compliant name will raise an exception.
 
-The name of a data stream consists of three parts: `<type>-<dataset>-<namespace>`. See the [data stream naming scheme](docs-content://reference/ingestion-tools/fleet/data-streams.md#data-streams-naming-scheme) documentation for more details.
+The name of a data stream consists of three parts: `<type>-<dataset>-<namespace>`. See the [data stream naming scheme](docs-content://reference/fleet/data-streams.md#data-streams-naming-scheme) documentation for more details.
 
 This processor can use both static values or reference fields from the document to determine the `dataset` and `namespace` components of the new target. See [Table 40](#reroute-options) for more details.
 

--- a/docs/reference/search-connectors/api-tutorial.md
+++ b/docs/reference/search-connectors/api-tutorial.md
@@ -48,7 +48,7 @@ docker run -p 9200:9200 -d --name elasticsearch \
 ```
 
 ::::{warning}
-This {{es}} setup is for development purposes only. Never use this configuration in production. Refer to [Set up {{es}}](docs-content://deploy-manage/deploy/self-managed/deploy-cluster.md) for production-grade installation instructions, including Docker.
+This {{es}} setup is for development purposes only. Never use this configuration in production. Refer to [Set up {{es}}](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md) for production-grade installation instructions, including Docker.
 
 ::::
 


### PR DESCRIPTION
Related to https://github.com/elastic/docs-content/pull/914
Loosely related to https://github.com/elastic/elasticsearch/pull/125663

Removes reliance on temporary redirects in the docs-content repo.

@leemthompo  can you help me with backport labels? I always get mixed up across repos.