### PR TITLE
Remove another outdated assertion from SearchQueryThenFetchAsyncActionTests (#122086)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -246,9 +246,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test151MachineDependentHeapWithSizeOverride
   issue: https://github.com/elastic/elasticsearch/issues/123437
-- class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
-  method: testBottomFieldSort
-  issue: https://github.com/elastic/elasticsearch/issues/122911
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/cat/nodes/line_361}
   issue: https://github.com/elastic/elasticsearch/issues/124103

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -219,12 +219,8 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
             if (withScroll) {
                 assertFalse(canReturnNullResponse.get());
                 assertThat(numWithTopDocs.get(), equalTo(0));
-            } else {
-                if (withCollapse) {
-                    assertThat(numWithTopDocs.get(), equalTo(0));
-                } else {
-                    assertThat(numWithTopDocs.get(), greaterThanOrEqualTo(1));
-                }
+            } else if (withCollapse) {
+                assertThat(numWithTopDocs.get(), equalTo(0));
             }
             SearchPhaseController.ReducedQueryPhase phase = action.results.reduce();
             assertThat(phase.numReducePhases(), greaterThanOrEqualTo(1));


### PR DESCRIPTION
Same reasoning as in 2b410c44eb8fc684d3986247a49f9696b44f2d4c, with the now weaker ordering guarantees from optimizations this assertion stopped being reliable.

back port of #122086 

closes https://github.com/elastic/elasticsearch/issues/122911