### PR TITLE
[8.x] Adjusting 41_knn_search_bbq_hnsw tests to have explicit refresh (#125255)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -498,9 +498,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DebPreservationTests
   method: test40RestartOnUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/125821
-- class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
-  method: test {p0=search.vectors/41_knn_search_bbq_hnsw/Vector rescoring has same scoring as exact search for kNN section}
-  issue: https://github.com/elastic/elasticsearch/issues/125822
 - class: org.elasticsearch.xpack.inference.registry.ModelRegistryMetadataTests
   method: testAlreadyUpgraded
   issue: https://github.com/elastic/elasticsearch/issues/125585

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
@@ -78,6 +78,9 @@ setup:
       indices.forcemerge:
         index: bbq_hnsw
         max_num_segments: 1
+
+  - do:
+      indices.refresh: { }
 ---
 "Test knn search":
   - requires:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Adjusting 41_knn_search_bbq_hnsw tests to have explicit refresh (#125255)](https://github.com/elastic/elasticsearch/pull/125255)

<!--- Backport version: 9.4.1 -->

closes: https://github.com/elastic/elasticsearch/issues/125822

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)