### PR TITLE
[9.0] Adjusting 41_knn_search_bbq_hnsw tests to have explicit refresh (#125255)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
@@ -75,6 +75,9 @@ setup:
       indices.forcemerge:
         index: bbq_hnsw
         max_num_segments: 1
+
+  - do:
+      indices.refresh: { }
 ---
 "Test knn search":
   - requires:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Adjusting 41_knn_search_bbq_hnsw tests to have explicit refresh (#125255)](https://github.com/elastic/elasticsearch/pull/125255)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)