### PR TITLE
[8.18] Adjusting 41_knn_search_bbq_hnsw tests to have explicit refresh (#125255)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -358,9 +358,6 @@ tests:
 - class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
   method: testRandomDirectoryIOExceptions
   issue: https://github.com/elastic/elasticsearch/issues/118733
-- class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
-  method: test {p0=search.vectors/41_knn_search_bbq_hnsw/Vector rescoring has same scoring as exact search for kNN section}
-  issue: https://github.com/elastic/elasticsearch/issues/120441
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=logsdb/10_settings/missing hostname field}
   issue: https://github.com/elastic/elasticsearch/issues/120476

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_bbq_hnsw.yml
@@ -78,6 +78,9 @@ setup:
       indices.forcemerge:
         index: bbq_hnsw
         max_num_segments: 1
+
+  - do:
+      indices.refresh: { }
 ---
 "Test knn search":
   - requires:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Adjusting 41_knn_search_bbq_hnsw tests to have explicit refresh (#125255)](https://github.com/elastic/elasticsearch/pull/125255)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)