### PR TITLE
ESQL - Lower logging level

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/Range.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/Range.java
@@ -230,7 +230,7 @@ public class Range extends ScalarFunction implements TranslationAware.SingleValu
         String format = null;
 
         DataType dataType = value.dataType();
-        logger.warn(
+        logger.trace(
             "Translating Range into lucene query.  dataType is [{}] upper is [{}<{}>]  lower is [{}<{}>]",
             dataType,
             lower,
@@ -278,7 +278,7 @@ public class Range extends ScalarFunction implements TranslationAware.SingleValu
                 u = unsignedLongAsNumber(ul);
             }
         }
-        logger.warn("Building range query with format string [{}]", format);
+        logger.trace("Building range query with format string [{}]", format);
         return new RangeQuery(source(), handler.nameOf(value), l, includeLower(), u, includeUpper(), format, zoneId);
     }
 


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/125595 I accidentally left some logging at `WARN` level; this PR corrects that to `TRACE`.