### PR TITLE
[8.18] Fix some `yamlRestTestV7CompatTest` tests (#125682)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -224,3 +224,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
   task.skipTest("esql/40_unsupported_types/unsupported", "TODO: support for subset of metric fields")
   task.skipTest("esql/40_unsupported_types/unsupported with sort", "TODO: support for subset of metric fields")
 })
+
+tasks.named('yamlRestTestV7CompatTest').configure {
+  systemProperty 'es.queryable_built_in_roles_enabled', 'false'
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [Fix some &#x60;yamlRestTestV7CompatTest&#x60; tests (#125682)](https://github.com/elastic/elasticsearch/pull/125949)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)