### PR TITLE
[8.17] Fix some `yamlRestTestV7CompatTest` tests (#125682)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -211,3 +211,6 @@ tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
   task.skipTest("esql/61_enrich_ip/Invalid IP strings", "We switched from exceptions to null+warnings for ENRICH runtime errors")
 })
 
+tasks.named('yamlRestTestV7CompatTest').configure {
+  systemProperty 'es.queryable_built_in_roles_enabled', 'false'
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.17`:
 - [Fix some &#x60;yamlRestTestV7CompatTest&#x60; tests (#125682)](https://github.com/elastic/elasticsearch/pull/125949)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)