### PR TITLE
Adding a cleanup method to EnterpriseGeoIpDownloaderIT

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/EnterpriseGeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/EnterpriseGeoIpDownloaderIT.java
@@ -127,7 +127,6 @@ public class EnterpriseGeoIpDownloaderIT extends ESIntegTestCase {
          * We know that the databases index has been populated (because we waited around, :wink:), but we don't know for sure that
          * the databases have been pulled down and made available on all nodes. So we run these ingest-and-check steps in assertBusy blocks.
          */
-
         assertBusy(() -> {
             logger.info("Ingesting a test document");
             String documentId = ingestDocument(indexName, geoipPipelineName, sourceField, "89.160.20.128");


### PR DESCRIPTION
EnterpriseGeoIpDownloaderIT fails, but rarely (see https://github.com/elastic/elasticsearch/issues/115163). We're currently unable to run the test repeatedly to attempt to reproduce failure using `-Dtests.iters`. This test cleans up the database configurations after the test completes so that it is in a state that can run again. I also suspect that this change might fix the failures (I don't have any direct evidence of that, but I was able to reproduce the failure in that ticket when I artificially ran this test without properly cleaning up).