### PR TITLE
[9.0] Return null from transformer when not transforming (#125961)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/Transformer.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/Transformer.java
@@ -46,7 +46,7 @@ public class Transformer implements ClassFileTransformer {
             return instrumenter.instrumentClass(className, classfileBuffer, verifyClasses);
         } else {
             // System.out.println("Not transforming " + className);
-            return classfileBuffer;
+            return null;
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Return null from transformer when not transforming (#125961)