### PR TITLE
Accumulate compute() calls and iterations between convergences in `DesiredBalanceComputer`

### DIFF
--- a/docs/changelog/126008.yaml
+++ b/docs/changelog/126008.yaml
@@ -1,0 +1,6 @@
+pr: 126008
+summary: Accumulate compute() calls and iterations between convergences
+area: Allocation
+type: enhancement
+issues:
+ - 100850


### PR DESCRIPTION
Add tracking of the number of compute() calls and total iterations between convergences in the DesiredBalanceComputer, along with the time since the last convergence.  These are included in the log message when the computer doesn't converge.

Closes #100850.