### PR TITLE
Add time bucket to time-series rate aggregation

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.operator;
 
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.aggregation.GroupingAggregator;
@@ -23,6 +24,7 @@ import static java.util.stream.Collectors.joining;
 public class TimeSeriesAggregationOperator extends HashAggregationOperator {
 
     public record Factory(
+        Rounding.Prepared timeBucket,
         List<BlockHash.GroupSpec> groups,
         AggregatorMode aggregatorMode,
         List<GroupingAggregator.Factory> aggregators,
@@ -32,6 +34,7 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         public Operator get(DriverContext driverContext) {
             // TODO: use TimeSeriesBlockHash when possible
             return new TimeSeriesAggregationOperator(
+                timeBucket,
                 aggregators,
                 () -> BlockHash.build(
                     groups,
@@ -53,11 +56,15 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         }
     }
 
+    private final Rounding.Prepared timeBucket;
+
     public TimeSeriesAggregationOperator(
+        Rounding.Prepared timeBucket,
         List<GroupingAggregator.Factory> aggregators,
         Supplier<BlockHash> blockHash,
         DriverContext driverContext
     ) {
         super(aggregators, blockHash, driverContext);
+        this.timeBucket = timeBucket;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorFactories.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorFactories.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.operator;
 
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.aggregation.GroupingAggregator;
@@ -46,6 +47,7 @@ public final class TimeSeriesAggregationOperatorFactories {
     public record Initial(
         int tsHashChannel,
         int timeBucketChannel,
+        Rounding.Prepared timeBucket,
         List<BlockHash.GroupSpec> groupings,
         List<SupplierWithChannels> rates,
         List<SupplierWithChannels> nonRates,
@@ -62,6 +64,7 @@ public final class TimeSeriesAggregationOperatorFactories {
             }
             aggregators.addAll(valuesAggregatorForGroupings(groupings, timeBucketChannel));
             return new TimeSeriesAggregationOperator(
+                timeBucket,
                 aggregators,
                 () -> new TimeSeriesBlockHash(tsHashChannel, timeBucketChannel, driverContext.blockFactory()),
                 driverContext
@@ -77,6 +80,7 @@ public final class TimeSeriesAggregationOperatorFactories {
     public record Intermediate(
         int tsHashChannel,
         int timeBucketChannel,
+        Rounding.Prepared timeBucket,
         List<BlockHash.GroupSpec> groupings,
         List<SupplierWithChannels> rates,
         List<SupplierWithChannels> nonRates,
@@ -97,6 +101,7 @@ public final class TimeSeriesAggregationOperatorFactories {
                 new BlockHash.GroupSpec(timeBucketChannel, ElementType.LONG)
             );
             return new TimeSeriesAggregationOperator(
+                timeBucket,
                 aggregators,
                 () -> BlockHash.build(hashGroups, driverContext.blockFactory(), maxPageSize, true),
                 driverContext

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
@@ -270,6 +270,7 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
         Operator intialAgg = new TimeSeriesAggregationOperatorFactories.Initial(
             1,
             3,
+            rounding,
             IntStream.range(0, nonBucketGroupings.size()).mapToObj(n -> new BlockHash.GroupSpec(5 + n, ElementType.BYTES_REF)).toList(),
             List.of(new SupplierWithChannels(new RateLongAggregatorFunctionSupplier(unitInMillis), List.of(4, 2))),
             List.of(),
@@ -280,6 +281,7 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
         Operator intermediateAgg = new TimeSeriesAggregationOperatorFactories.Intermediate(
             0,
             1,
+            rounding,
             IntStream.range(0, nonBucketGroupings.size()).mapToObj(n -> new BlockHash.GroupSpec(5 + n, ElementType.BYTES_REF)).toList(),
             List.of(new SupplierWithChannels(new RateLongAggregatorFunctionSupplier(unitInMillis), List.of(2, 3, 4))),
             List.of(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
@@ -262,16 +262,7 @@ public class Bucket extends GroupingFunction implements PostOptimizationVerifica
     @Override
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         if (field.dataType() == DataType.DATETIME || field.dataType() == DataType.DATE_NANOS) {
-            Rounding.Prepared preparedRounding;
-            if (buckets.dataType().isWholeNumber()) {
-                int b = ((Number) buckets.fold(toEvaluator.foldCtx())).intValue();
-                long f = foldToLong(toEvaluator.foldCtx(), from);
-                long t = foldToLong(toEvaluator.foldCtx(), to);
-                preparedRounding = new DateRoundingPicker(b, f, t).pickRounding().prepareForUnknown();
-            } else {
-                assert DataType.isTemporalAmount(buckets.dataType()) : "Unexpected span data type [" + buckets.dataType() + "]";
-                preparedRounding = DateTrunc.createRounding(buckets.fold(toEvaluator.foldCtx()), DEFAULT_TZ);
-            }
+            Rounding.Prepared preparedRounding = getDateRounding(toEvaluator.foldCtx());
             return DateTrunc.evaluator(field.dataType(), source(), toEvaluator.apply(field), preparedRounding);
         }
         if (field.dataType().isNumeric()) {
@@ -293,6 +284,30 @@ public class Bucket extends GroupingFunction implements PostOptimizationVerifica
             return toEvaluator.apply(mul);
         }
         throw EsqlIllegalArgumentException.illegalDataType(field.dataType());
+    }
+
+    /**
+     * Returns the date rounding from this bucket function if the target field is a date type; otherwise, returns null.
+     */
+    public Rounding.Prepared getDateRoundingOrNull(FoldContext foldCtx) {
+        if (field.dataType() == DataType.DATETIME || field.dataType() == DataType.DATE_NANOS) {
+            return getDateRounding(foldCtx);
+        } else {
+            return null;
+        }
+    }
+
+    private Rounding.Prepared getDateRounding(FoldContext foldContext) {
+        assert field.dataType() == DataType.DATETIME || field.dataType() == DataType.DATE_NANOS : "expected date type; got " + field;
+        if (buckets.dataType().isWholeNumber()) {
+            int b = ((Number) buckets.fold(foldContext)).intValue();
+            long f = foldToLong(foldContext, from);
+            long t = foldToLong(foldContext, to);
+            return new DateRoundingPicker(b, f, t).pickRounding().prepareForUnknown();
+        } else {
+            assert DataType.isTemporalAmount(buckets.dataType()) : "Unexpected span data type [" + buckets.dataType() + "]";
+            return DateTrunc.createRounding(buckets.fold(foldContext), DEFAULT_TZ);
+        }
     }
 
     private record DateRoundingPicker(int buckets, long from, long to) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
@@ -123,7 +123,7 @@ public final class TranslateTimeSeriesAggregate extends OptimizerRules.Optimizer
 
     @Override
     protected LogicalPlan rule(Aggregate aggregate) {
-        if (aggregate instanceof TimeSeriesAggregate ts) {
+        if (aggregate instanceof TimeSeriesAggregate ts && ts.timeBucket() == null) {
             return translate(ts);
         } else {
             return aggregate;
@@ -226,7 +226,8 @@ public final class TranslateTimeSeriesAggregate extends OptimizerRules.Optimizer
             newChild.source(),
             newChild,
             firstPassGroupings,
-            mergeExpressions(firstPassAggs, firstPassGroupings)
+            mergeExpressions(firstPassAggs, firstPassGroupings),
+            (Bucket) Alias.unwrap(timeBucket)
         );
         return new Aggregate(firstPhase.source(), firstPhase, secondPassGroupings, mergeExpressions(secondPassAggs, secondPassGroupings));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -315,7 +315,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
         final Stats stats = stats(source(ctx), ctx.grouping, ctx.stats);
         return input -> {
             if (input.anyMatch(p -> p instanceof UnresolvedRelation ur && ur.indexMode() == IndexMode.TIME_SERIES)) {
-                return new TimeSeriesAggregate(source(ctx), input, stats.groupings, stats.aggregates);
+                return new TimeSeriesAggregate(source(ctx), input, stats.groupings, stats.aggregates, null);
             } else {
                 return new Aggregate(source(ctx), input, stats.groupings, stats.aggregates);
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TimeSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TimeSeriesAggregate.java
@@ -9,10 +9,12 @@ package org.elasticsearch.xpack.esql.plan.logical;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
 
 import java.io.IOException;
 import java.util.List;
@@ -28,17 +30,28 @@ public class TimeSeriesAggregate extends Aggregate {
         TimeSeriesAggregate::new
     );
 
-    public TimeSeriesAggregate(Source source, LogicalPlan child, List<Expression> groupings, List<? extends NamedExpression> aggregates) {
+    private final Bucket timeBucket;
+
+    public TimeSeriesAggregate(
+        Source source,
+        LogicalPlan child,
+        List<Expression> groupings,
+        List<? extends NamedExpression> aggregates,
+        Bucket timeBucket
+    ) {
         super(source, child, groupings, aggregates);
+        this.timeBucket = timeBucket;
     }
 
     public TimeSeriesAggregate(StreamInput in) throws IOException {
         super(in);
+        this.timeBucket = in.readOptionalWriteable(inp -> (Bucket) Bucket.ENTRY.reader.read(inp));
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        out.writeOptionalWriteable(timeBucket);
     }
 
     @Override
@@ -48,16 +61,21 @@ public class TimeSeriesAggregate extends Aggregate {
 
     @Override
     protected NodeInfo<Aggregate> info() {
-        return NodeInfo.create(this, TimeSeriesAggregate::new, child(), groupings, aggregates);
+        return NodeInfo.create(this, TimeSeriesAggregate::new, child(), groupings, aggregates, timeBucket);
     }
 
     @Override
     public TimeSeriesAggregate replaceChild(LogicalPlan newChild) {
-        return new TimeSeriesAggregate(source(), newChild, groupings, aggregates);
+        return new TimeSeriesAggregate(source(), newChild, groupings, aggregates, timeBucket);
     }
 
     @Override
     public TimeSeriesAggregate with(LogicalPlan child, List<Expression> newGroupings, List<? extends NamedExpression> newAggregates) {
-        return new TimeSeriesAggregate(source(), child, newGroupings, newAggregates);
+        return new TimeSeriesAggregate(source(), child, newGroupings, newAggregates, timeBucket);
+    }
+
+    @Nullable
+    public Bucket timeBucket() {
+        return timeBucket;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -174,8 +174,9 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
                 s -> aggregatorFactories.add(s.supplier.groupingAggregatorFactory(s.mode, s.channels))
             );
             // time-series aggregation
-            if (aggregateExec instanceof TimeSeriesAggregateExec) {
+            if (aggregateExec instanceof TimeSeriesAggregateExec ts) {
                 operatorFactory = new TimeSeriesAggregationOperator.Factory(
+                    ts.timeBucketRounding(context.foldCtx()),
                     groupSpecs.stream().map(GroupSpec::toHashGroupSpec).toList(),
                     aggregatorMode,
                     aggregatorFactories,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/MapperUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/MapperUtils.java
@@ -131,7 +131,7 @@ class MapperUtils {
     }
 
     static AggregateExec aggExec(Aggregate aggregate, PhysicalPlan child, AggregatorMode aggMode, List<Attribute> intermediateAttributes) {
-        if (aggregate instanceof TimeSeriesAggregate) {
+        if (aggregate instanceof TimeSeriesAggregate ts) {
             return new TimeSeriesAggregateExec(
                 aggregate.source(),
                 child,
@@ -139,7 +139,8 @@ class MapperUtils {
                 aggregate.aggregates(),
                 aggMode,
                 intermediateAttributes,
-                null
+                null,
+                ts.timeBucket()
             );
         } else {
             return new AggregateExec(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -2332,7 +2332,11 @@ public class StatementParserTests extends AbstractStatementParserTests {
                 EMPTY,
                 unresolvedTSRelation("foo"),
                 List.of(attribute("ts")),
-                List.of(new Alias(EMPTY, "load", new UnresolvedFunction(EMPTY, "avg", DEFAULT, List.of(attribute("cpu")))), attribute("ts"))
+                List.of(
+                    new Alias(EMPTY, "load", new UnresolvedFunction(EMPTY, "avg", DEFAULT, List.of(attribute("cpu")))),
+                    attribute("ts")
+                ),
+                null
             )
         );
         assertStatement(
@@ -2341,7 +2345,11 @@ public class StatementParserTests extends AbstractStatementParserTests {
                 EMPTY,
                 unresolvedTSRelation("foo,bar"),
                 List.of(attribute("ts")),
-                List.of(new Alias(EMPTY, "load", new UnresolvedFunction(EMPTY, "avg", DEFAULT, List.of(attribute("cpu")))), attribute("ts"))
+                List.of(
+                    new Alias(EMPTY, "load", new UnresolvedFunction(EMPTY, "avg", DEFAULT, List.of(attribute("cpu")))),
+                    attribute("ts")
+                ),
+                null
             )
         );
         assertStatement(
@@ -2363,7 +2371,8 @@ public class StatementParserTests extends AbstractStatementParserTests {
                         )
                     ),
                     attribute("ts")
-                )
+                ),
+                null
             )
         );
         assertStatement(
@@ -2372,7 +2381,8 @@ public class StatementParserTests extends AbstractStatementParserTests {
                 EMPTY,
                 unresolvedTSRelation("foo*"),
                 List.of(),
-                List.of(new Alias(EMPTY, "count(errors)", new UnresolvedFunction(EMPTY, "count", DEFAULT, List.of(attribute("errors")))))
+                List.of(new Alias(EMPTY, "count(errors)", new UnresolvedFunction(EMPTY, "count", DEFAULT, List.of(attribute("errors"))))),
+                null
             )
         );
         assertStatement(
@@ -2381,7 +2391,8 @@ public class StatementParserTests extends AbstractStatementParserTests {
                 EMPTY,
                 unresolvedTSRelation("foo*"),
                 List.of(),
-                List.of(new Alias(EMPTY, "a(b)", new UnresolvedFunction(EMPTY, "a", DEFAULT, List.of(attribute("b")))))
+                List.of(new Alias(EMPTY, "a(b)", new UnresolvedFunction(EMPTY, "a", DEFAULT, List.of(attribute("b"))))),
+                null
             )
         );
         assertStatement(
@@ -2390,7 +2401,8 @@ public class StatementParserTests extends AbstractStatementParserTests {
                 EMPTY,
                 unresolvedTSRelation("foo*"),
                 List.of(),
-                List.of(new Alias(EMPTY, "a(b)", new UnresolvedFunction(EMPTY, "a", DEFAULT, List.of(attribute("b")))))
+                List.of(new Alias(EMPTY, "a(b)", new UnresolvedFunction(EMPTY, "a", DEFAULT, List.of(attribute("b"))))),
+                null
             )
         );
         assertStatement(
@@ -2399,7 +2411,8 @@ public class StatementParserTests extends AbstractStatementParserTests {
                 EMPTY,
                 unresolvedTSRelation("foo*"),
                 List.of(),
-                List.of(new Alias(EMPTY, "a1(b2)", new UnresolvedFunction(EMPTY, "a1", DEFAULT, List.of(attribute("b2")))))
+                List.of(new Alias(EMPTY, "a1(b2)", new UnresolvedFunction(EMPTY, "a1", DEFAULT, List.of(attribute("b2"))))),
+                null
             )
         );
         assertStatement(
@@ -2412,7 +2425,8 @@ public class StatementParserTests extends AbstractStatementParserTests {
                     new Alias(EMPTY, "b", new UnresolvedFunction(EMPTY, "min", DEFAULT, List.of(attribute("a")))),
                     attribute("c"),
                     attribute("d.e")
-                )
+                ),
+                null
             )
         );
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AggregateSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AggregateSerializationTests.java
@@ -35,7 +35,7 @@ public class AggregateSerializationTests extends AbstractLogicalPlanSerializatio
         if (randomBoolean()) {
             return new Aggregate(source, child, groupings, aggregates);
         } else {
-            return new TimeSeriesAggregate(source, child, groupings, aggregates);
+            return new TimeSeriesAggregate(source, child, groupings, aggregates, null);
         }
     }
 
@@ -76,7 +76,7 @@ public class AggregateSerializationTests extends AbstractLogicalPlanSerializatio
             case 2 -> aggregates = randomValueOtherThan(aggregates, AggregateSerializationTests::randomAggregates);
         }
         if (instance instanceof TimeSeriesAggregate) {
-            return new TimeSeriesAggregate(instance.source(), child, groupings, aggregates);
+            return new TimeSeriesAggregate(instance.source(), child, groupings, aggregates, null);
         } else {
             return new Aggregate(instance.source(), child, groupings, aggregates);
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AggregateExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AggregateExecSerializationTests.java
@@ -31,7 +31,7 @@ public class AggregateExecSerializationTests extends AbstractPhysicalPlanSeriali
         if (randomBoolean()) {
             return new AggregateExec(source, child, groupings, aggregates, mode, intermediateAttributes, estimatedRowSize);
         } else {
-            return new TimeSeriesAggregateExec(source, child, groupings, aggregates, mode, intermediateAttributes, estimatedRowSize);
+            return new TimeSeriesAggregateExec(source, child, groupings, aggregates, mode, intermediateAttributes, estimatedRowSize, null);
         }
     }
 
@@ -68,7 +68,8 @@ public class AggregateExecSerializationTests extends AbstractPhysicalPlanSeriali
                 aggregates,
                 mode,
                 intermediateAttributes,
-                estimatedRowSize
+                estimatedRowSize,
+                null
             );
         } else {
             return new AggregateExec(instance.source(), child, groupings, aggregates, mode, intermediateAttributes, estimatedRowSize);


### PR DESCRIPTION
We need the bucket interval within the rate function to perform extrapolation. With this change, along with #26089, we will be able to pass the grouping range interval to rate aggregations.