### PR TITLE
Return null from transformer when not transforming (#125961)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/Transformer.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/Transformer.java
@@ -46,7 +46,7 @@ public class Transformer implements ClassFileTransformer {
             return instrumenter.instrumentClass(className, classfileBuffer, verifyClasses);
         } else {
             // System.out.println("Not transforming " + className);
-            return classfileBuffer;
+            return null;
         }
     }
 


### PR DESCRIPTION
The transform API for instrumentation should return null when no transformation occurs. This commit fixes our entitlement transformer to return null instead of the original buffer.