### PR TITLE
[8.x] [ML] Fix ModelRegistryMetadataTests intermittent failures (#125883)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -489,9 +489,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DebPreservationTests
   method: test40RestartOnUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/125821
-- class: org.elasticsearch.xpack.inference.registry.ModelRegistryMetadataTests
-  method: testAlreadyUpgraded
-  issue: https://github.com/elastic/elasticsearch/issues/125585
 - class: org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT
   method: testHFEmbeddings {upgradedNodes=2}
   issue: https://github.com/elastic/elasticsearch/issues/125551

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -468,9 +468,6 @@ tests:
 - class: org.elasticsearch.qa.verify_version_constants.VerifyVersionConstantsIT
   method: testLuceneVersionConstant
   issue: https://github.com/elastic/elasticsearch/issues/125638
-- class: org.elasticsearch.xpack.inference.registry.ModelRegistryMetadataTests
-  method: testUpgrade
-  issue: https://github.com/elastic/elasticsearch/issues/125554
 - class: org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT
   method: testElser {upgradedNodes=2}
   issue: https://github.com/elastic/elasticsearch/issues/125550

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistryMetadata.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistryMetadata.java
@@ -47,7 +47,8 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 public class ModelRegistryMetadata implements Metadata.Custom {
     public static final String TYPE = "model_registry";
 
-    public static final ModelRegistryMetadata EMPTY = new ModelRegistryMetadata(ImmutableOpenMap.of(), Set.of());
+    public static final ModelRegistryMetadata EMPTY_NOT_UPGRADED = new ModelRegistryMetadata(ImmutableOpenMap.of(), Set.of());
+    public static final ModelRegistryMetadata EMPTY_UPGRADED = new ModelRegistryMetadata(ImmutableOpenMap.of());
 
     private static final ParseField UPGRADED_FIELD = new ParseField("upgraded");
     private static final ParseField MODELS_FIELD = new ParseField("models");
@@ -83,7 +84,7 @@ public class ModelRegistryMetadata implements Metadata.Custom {
 
     public static ModelRegistryMetadata fromState(Metadata metadata) {
         ModelRegistryMetadata resp = metadata.custom(TYPE);
-        return resp != null ? resp : EMPTY;
+        return resp != null ? resp : EMPTY_NOT_UPGRADED;
     }
 
     public ModelRegistryMetadata withAddedModel(String inferenceEntityId, MinimalServiceSettings settings) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryMetadataTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryMetadataTests.java
@@ -22,16 +22,17 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ModelRegistryMetadataTests extends AbstractChunkedSerializingTestCase<ModelRegistryMetadata> {
     public static ModelRegistryMetadata randomInstance() {
-        return randomInstance(randomBoolean());
+        return randomInstance(randomBoolean(), true);
     }
 
-    public static ModelRegistryMetadata randomInstance(boolean isUpgraded) {
-        if (rarely() && isUpgraded == false) {
-            return ModelRegistryMetadata.EMPTY;
+    public static ModelRegistryMetadata randomInstance(boolean isUpgraded, boolean acceptsEmpty) {
+        if (rarely() && acceptsEmpty) {
+            return isUpgraded ? ModelRegistryMetadata.EMPTY_UPGRADED : ModelRegistryMetadata.EMPTY_NOT_UPGRADED;
         }
         int size = randomIntBetween(1, 5);
 
@@ -82,7 +83,7 @@ public class ModelRegistryMetadataTests extends AbstractChunkedSerializingTestCa
     }
 
     public void testUpgrade() {
-        var metadata = randomInstance(false);
+        var metadata = randomInstance(false, false);
         var metadataWithTombstones = metadata.withRemovedModel(Set.of(randomFrom(metadata.getModelMap().keySet())));
 
         var indexMetadata = metadata.withAddedModel(randomAlphanumericOfLength(10), MinimalServiceSettingsTests.randomInstance());
@@ -99,9 +100,10 @@ public class ModelRegistryMetadataTests extends AbstractChunkedSerializingTestCa
     }
 
     public void testAlreadyUpgraded() {
-        var metadata = randomInstance(true);
-        var indexMetadata = randomInstance(true);
+        var metadata = randomInstance(true, true);
+        var indexMetadata = randomInstance(true, true);
 
         var exc = expectThrows(IllegalArgumentException.class, () -> metadata.withUpgradedModels(indexMetadata.getModelMap()));
+        assertThat(exc.getMessage(), containsString("upgraded"));
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ML] Fix ModelRegistryMetadataTests intermittent failures (#125883)](https://github.com/elastic/elasticsearch/pull/125883)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)