### PR TITLE
[9.0] add missing mapped pages (#126054)

### DIFF
--- a/docs/reference/search-connectors/es-postgresql-connector-client-tutorial.md
+++ b/docs/reference/search-connectors/es-postgresql-connector-client-tutorial.md
@@ -2,6 +2,7 @@
 navigation_title: "Tutorial"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/es-postgresql-connector-client-tutorial.html
+  - https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-appsearch.html
 ---
 
 # PostgreSQL self-managed connector tutorial [es-postgresql-connector-client-tutorial]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [add missing mapped pages (#126054)](https://github.com/elastic/elasticsearch/pull/126054)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)