### PR TITLE
Put the not-entitled message in the log

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -572,7 +572,7 @@ public class PolicyManager {
         var exception = new NotEntitledException(message);
         // Don't emit a log for muted classes, e.g. classes containing self tests
         if (mutedClasses.contains(callerClass) == false) {
-            entitlements.logger().warn("Not entitled:", exception);
+            entitlements.logger().warn("Not entitled: {}", message, exception);
         }
         throw exception;
     }


### PR DESCRIPTION
The not-entitled message text appears as the message in the `NotEntitledException`, so to avoid redundancy, I removed it from the log message [here](https://github.com/elastic/elasticsearch/pull/124895/commits/1082cf1d7bac6742d384a92fd1b84256d512f9aa). However, this makes it awkward to generate concise alert messages.

Let's put the not-entitled message back in the log, redundant though that may be, to help us compose good alert messages.

See ES-10968.