### PR TITLE
Remove `testWriteBlobWithExceptionThrownAtClosingTime`

### DIFF
--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -22,8 +22,6 @@ import com.sun.net.httpserver.HttpHandler;
 
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.Level;
-import org.apache.lucene.index.CorruptIndexException;
-import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.BackoffPolicy;
@@ -85,7 +83,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntConsumer;
 import java.util.regex.Pattern;
 
@@ -341,57 +338,6 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
 
         assertThat(exception.getCause().getCause(), instanceOf(SocketTimeoutException.class));
         assertThat(exception.getCause().getCause().getMessage().toLowerCase(Locale.ROOT), containsString("read timed out"));
-    }
-
-    /**
-     * This test shows that the AWS SDKv1 defers the closing of the InputStream used to upload a blob after the HTTP request has been sent
-     * to S3, swallowing any exception thrown at closing time.
-     */
-    public void testWriteBlobWithExceptionThrownAtClosingTime() throws Exception {
-        var maxRetries = randomInt(3);
-        var blobLength = randomIntBetween(1, 4096 * 3);
-        var blobName = getTestName().toLowerCase(Locale.ROOT);
-        var blobContainer = createBlobContainer(maxRetries, null, true, null, null);
-
-        var uploadedBytes = new AtomicReference<BytesReference>();
-        httpServer.createContext(downloadStorageEndpoint(blobContainer, blobName), exchange -> {
-            var requestComponents = parseRequest(exchange);
-            if (requestComponents.isPutObjectRequest()) {
-                var body = Streams.readFully(exchange.getRequestBody());
-                if (uploadedBytes.compareAndSet(null, body)) {
-                    exchange.sendResponseHeaders(HttpStatus.SC_OK, -1);
-                    exchange.close();
-                    return;
-                }
-            }
-            exchange.sendResponseHeaders(HttpStatus.SC_BAD_REQUEST, -1);
-            exchange.close();
-        });
-
-        final byte[] bytes = randomByteArrayOfLength(blobLength);
-
-        var exceptionThrown = new AtomicBoolean();
-        blobContainer.writeBlobAtomic(randomPurpose(), blobName, new FilterInputStream(new ByteArrayInputStream(bytes)) {
-            @Override
-            public void close() throws IOException {
-                if (exceptionThrown.compareAndSet(false, true)) {
-                    switch (randomInt(3)) {
-                        case 0:
-                            throw new CorruptIndexException("simulated", blobName);
-                        case 1:
-                            throw new AlreadyClosedException("simulated");
-                        case 2:
-                            throw new RuntimeException("simulated");
-                        case 3:
-                        default:
-                            throw new IOException("simulated");
-                    }
-                }
-            }
-        }, blobLength, true);
-
-        assertThat(exceptionThrown.get(), is(true));
-        assertArrayEquals(bytes, BytesReference.toBytes(uploadedBytes.get()));
     }
 
     public void testWriteLargeBlob() throws Exception {


### PR DESCRIPTION
Reverts the test added in #123505 - this is not behaviour on which we
rely any more, and it does not apply with SDKv2 anyway.