### PR TITLE
Simplify attribute map

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/AttributeMap.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/AttributeMap.java
@@ -375,32 +375,4 @@ public final class AttributeMap<E> implements Map<Attribute, E> {
     public String toString() {
         return delegate.toString();
     }
-
-    public static <E> Builder<E> builder() {
-        return new Builder<>();
-    }
-
-    public static <E> Builder<E> builder(AttributeMap<E> map) {
-        return new Builder<E>().putAll(map);
-    }
-
-    public static class Builder<E> {
-        private AttributeMap<E> map = new AttributeMap<>();
-
-        private Builder() {}
-
-        public Builder<E> put(Attribute attr, E value) {
-            map.add(attr, value);
-            return this;
-        }
-
-        public Builder<E> putAll(AttributeMap<E> m) {
-            map.addAll(m);
-            return this;
-        }
-
-        public AttributeMap<E> build() {
-            return map;
-        }
-    }
 }

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/AttributeMapTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/AttributeMapTests.java
@@ -35,12 +35,11 @@ public class AttributeMapTests extends ESTestCase {
     }
 
     private static AttributeMap<String> threeMap() {
-        AttributeMap.Builder<String> builder = AttributeMap.builder();
+        var builder = new AttributeMap<String>();
         builder.put(a("one"), "one");
         builder.put(a("two"), "two");
         builder.put(a("three"), "three");
-
-        return builder.build();
+        return builder;
     }
 
     public void testAttributeMapWithSameAliasesCanResolveAttributes() {
@@ -54,11 +53,10 @@ public class AttributeMapTests extends ESTestCase {
         assertTrue(param1.toAttribute().equals(param2.toAttribute()));
         assertFalse(param1.toAttribute().semanticEquals(param2.toAttribute()));
 
-        AttributeMap.Builder<Expression> mapBuilder = AttributeMap.builder();
+        var newAttributeMap = new AttributeMap<Expression>();
         for (Alias a : List.of(param1, param2)) {
-            mapBuilder.put(a.toAttribute(), a.child());
+            newAttributeMap.put(a.toAttribute(), a.child());
         }
-        AttributeMap<Expression> newAttributeMap = mapBuilder.build();
 
         assertTrue(newAttributeMap.containsKey(param1.toAttribute()));
         assertTrue(newAttributeMap.get(param1.toAttribute()) == param1.child());
@@ -67,18 +65,17 @@ public class AttributeMapTests extends ESTestCase {
     }
 
     public void testResolve() {
-        AttributeMap.Builder<Object> builder = AttributeMap.builder();
+        var map = new AttributeMap<Object>();
         Attribute one = a("one");
         Attribute two = fieldAttribute("two", DataType.INTEGER);
         Attribute three = fieldAttribute("three", DataType.INTEGER);
         Alias threeAlias = new Alias(Source.EMPTY, "three_alias", three);
         Alias threeAliasAlias = new Alias(Source.EMPTY, "three_alias_alias", threeAlias);
-        builder.put(one, of("one"));
-        builder.put(two, "two");
-        builder.put(three, of("three"));
-        builder.put(threeAlias.toAttribute(), threeAlias.child());
-        builder.put(threeAliasAlias.toAttribute(), threeAliasAlias.child());
-        AttributeMap<Object> map = builder.build();
+        map.put(one, of("one"));
+        map.put(two, "two");
+        map.put(three, of("three"));
+        map.put(threeAlias.toAttribute(), threeAlias.child());
+        map.put(threeAliasAlias.toAttribute(), threeAliasAlias.child());
 
         assertEquals(of("one"), map.resolve(one));
         assertEquals("two", map.resolve(two));
@@ -93,12 +90,11 @@ public class AttributeMapTests extends ESTestCase {
     }
 
     public void testResolveOneHopCycle() {
-        AttributeMap.Builder<Object> builder = AttributeMap.builder();
+        var map = new AttributeMap<Object>();
         Attribute a = fieldAttribute("a", DataType.INTEGER);
         Attribute b = fieldAttribute("b", DataType.INTEGER);
-        builder.put(a, a);
-        builder.put(b, a);
-        AttributeMap<Object> map = builder.build();
+        map.put(a, a);
+        map.put(b, a);
 
         assertEquals(a, map.resolve(a, "default"));
         assertEquals(a, map.resolve(b, "default"));
@@ -106,16 +102,15 @@ public class AttributeMapTests extends ESTestCase {
     }
 
     public void testResolveMultiHopCycle() {
-        AttributeMap.Builder<Object> builder = AttributeMap.builder();
+        var map = new AttributeMap<>();
         Attribute a = fieldAttribute("a", DataType.INTEGER);
         Attribute b = fieldAttribute("b", DataType.INTEGER);
         Attribute c = fieldAttribute("c", DataType.INTEGER);
         Attribute d = fieldAttribute("d", DataType.INTEGER);
-        builder.put(a, b);
-        builder.put(b, c);
-        builder.put(c, d);
-        builder.put(d, a);
-        AttributeMap<Object> map = builder.build();
+        map.put(a, b);
+        map.put(b, c);
+        map.put(c, d);
+        map.put(d, a);
 
         // note: multi hop cycles should not happen, unless we have a
         // bug in the code that populates the AttributeMaps
@@ -136,12 +131,11 @@ public class AttributeMapTests extends ESTestCase {
     }
 
     public void testBuilder() {
-        AttributeMap.Builder<String> builder = AttributeMap.builder();
-        builder.put(a("one"), "one");
-        builder.put(a("two"), "two");
-        builder.put(a("three"), "three");
+        var m = new AttributeMap<>();
+        m.put(a("one"), "one");
+        m.put(a("two"), "two");
+        m.put(a("three"), "three");
 
-        AttributeMap<String> m = builder.build();
         assertThat(m.size(), is(3));
         assertThat(m.isEmpty(), is(false));
 
@@ -247,7 +241,8 @@ public class AttributeMapTests extends ESTestCase {
 
     public void testCopy() {
         AttributeMap<String> m = threeMap();
-        AttributeMap<String> copy = AttributeMap.<String>builder().putAll(m).build();
+        AttributeMap<String> copy = new AttributeMap<>();
+        copy.putAll(m);
 
         assertThat(m, is(copy));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFilters.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFilters.java
@@ -49,11 +49,10 @@ public final class PushDownAndCombineFilters extends OptimizerRules.OptimizerRul
         } else if (child instanceof Eval eval) {
             // Don't push if Filter (still) contains references to Eval's fields.
             // Account for simple aliases in the Eval, though - these shouldn't stop us.
-            AttributeMap.Builder<Expression> aliasesBuilder = AttributeMap.builder();
+            var evalAliases = new AttributeMap<Expression>();
             for (Alias alias : eval.fields()) {
-                aliasesBuilder.put(alias.toAttribute(), alias.child());
+                evalAliases.put(alias.toAttribute(), alias.child());
             }
-            AttributeMap<Expression> evalAliases = aliasesBuilder.build();
 
             Function<Expression, Expression> resolveRenames = expr -> expr.transformDown(ReferenceAttribute.class, r -> {
                 Expression resolved = evalAliases.resolve(r, null);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownUtils.java
@@ -199,9 +199,8 @@ class PushDownUtils {
     }
 
     private static UnaryPlan resolveRenamesFromProject(UnaryPlan plan, Project project) {
-        AttributeMap.Builder<Expression> aliasBuilder = AttributeMap.builder();
-        project.forEachExpression(Alias.class, a -> aliasBuilder.put(a.toAttribute(), a.child()));
-        var aliases = aliasBuilder.build();
+        var aliases = new AttributeMap<Expression>();
+        project.forEachExpression(Alias.class, a -> aliases.put(a.toAttribute(), a.child()));
 
         return (UnaryPlan) plan.transformExpressionsOnly(ReferenceAttribute.class, r -> aliases.resolve(r, r));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
@@ -80,13 +80,13 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
     }
 
     static AttributeMap<Attribute> getAliasReplacedBy(EvalExec evalExec) {
-        AttributeMap.Builder<Attribute> aliasReplacedByBuilder = AttributeMap.builder();
+        var aliasReplacedByBuilder = new AttributeMap<Attribute>();
         evalExec.fields().forEach(alias -> {
             if (alias.child() instanceof Attribute attr) {
                 aliasReplacedByBuilder.put(alias.toAttribute(), attr);
             }
         });
-        return aliasReplacedByBuilder.build();
+        return aliasReplacedByBuilder;
     }
 
     private static PhysicalPlan rewrite(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSource.java
@@ -138,16 +138,15 @@ public class PushTopNToSource extends PhysicalOptimizerRules.ParameterizedOptimi
             List<Order> orders = topNExec.order();
             List<Alias> fields = evalExec.fields();
             LinkedHashMap<NameId, StDistance> distances = new LinkedHashMap<>();
-            AttributeMap.Builder<Attribute> aliasReplacedByBuilder = AttributeMap.builder();
+            var aliasReplacedBy = new AttributeMap<Attribute>();
             fields.forEach(alias -> {
                 // TODO: can we support CARTESIAN also?
                 if (alias.child() instanceof StDistance distance && distance.crsType() == BinarySpatialFunction.SpatialCrsType.GEO) {
                     distances.put(alias.id(), distance);
                 } else if (alias.child() instanceof Attribute attr) {
-                    aliasReplacedByBuilder.put(alias.toAttribute(), attr.toAttribute());
+                    aliasReplacedBy.put(alias.toAttribute(), attr.toAttribute());
                 }
             });
-            AttributeMap<Attribute> aliasReplacedBy = aliasReplacedByBuilder.build();
 
             List<EsQueryExec.Sort> pushableSorts = new ArrayList<>();
             for (Order order : orders) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
@@ -99,7 +99,7 @@ public class Eval extends UnaryPlan implements GeneratingPlan<Eval>, PostAnalysi
     }
 
     private List<Alias> renameAliases(List<Alias> originalAttributes, List<String> newNames) {
-        AttributeMap.Builder<Attribute> aliasReplacedByBuilder = AttributeMap.builder();
+        var aliasReplacedBy = new AttributeMap<Attribute>();
         List<Alias> newFields = new ArrayList<>(originalAttributes.size());
         for (int i = 0; i < originalAttributes.size(); i++) {
             Alias field = originalAttributes.get(i);
@@ -109,10 +109,9 @@ public class Eval extends UnaryPlan implements GeneratingPlan<Eval>, PostAnalysi
             } else {
                 Alias newField = new Alias(field.source(), newName, field.child(), new NameId(), field.synthetic());
                 newFields.add(newField);
-                aliasReplacedByBuilder.put(field.toAttribute(), newField.toAttribute());
+                aliasReplacedBy.put(field.toAttribute(), newField.toAttribute());
             }
         }
-        AttributeMap<Attribute> aliasReplacedBy = aliasReplacedByBuilder.build();
 
         // We need to also update any references to the old attributes in the new attributes; e.g.
         // EVAL x = 1, y = x + 1


### PR DESCRIPTION
We have AttributeMap#builder that is effectively not needed as the data structure is immutable.
This change removes it.