### PR TITLE
ESQL: Hide some "extras" from docs (#124763)

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/examples/bucket.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/bucket.md
@@ -14,7 +14,6 @@ For example, asking for at most 20 buckets over a year results in monthly bucket
 FROM employees
 | WHERE hire_date >= "1985-01-01T00:00:00Z" AND hire_date < "1986-01-01T00:00:00Z"
 | STATS hire_date = MV_SORT(VALUES(hire_date)) BY month = BUCKET(hire_date, 20, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
-| SORT hire_date
 ```
 
 | hire_date:date | month:date |
@@ -61,7 +60,6 @@ For example, asking for at most 100 buckets in a year results in weekly buckets:
 FROM employees
 | WHERE hire_date >= "1985-01-01T00:00:00Z" AND hire_date < "1986-01-01T00:00:00Z"
 | STATS hires_per_week = COUNT(*) BY week = BUCKET(hire_date, 100, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
-| SORT week
 ```
 
 | hires_per_week:long | week:date |
@@ -169,7 +167,6 @@ Create monthly buckets for the year 1985, and calculate the average salary by hi
 FROM employees
 | WHERE hire_date >= "1985-01-01T00:00:00Z" AND hire_date < "1986-01-01T00:00:00Z"
 | STATS AVG(salary) BY bucket = BUCKET(hire_date, 20, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
-| SORT bucket
 ```
 
 | AVG(salary):double | bucket:date |
@@ -218,8 +215,6 @@ inserting a negative offset of `1 hour` to buckets of `1 year` looks like this:
 FROM employees
 | STATS dates = MV_SORT(VALUES(birth_date)) BY b = BUCKET(birth_date + 1 HOUR, 1 YEAR) - 1 HOUR
 | EVAL d_count = MV_COUNT(dates)
-| SORT d_count, b
-| LIMIT 3
 ```
 
 | dates:date | b:date | d_count:integer |

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/kql.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/kql.md
@@ -5,9 +5,6 @@
 ```esql
 FROM books
 | WHERE KQL("author: Faulkner")
-| KEEP book_no, author
-| SORT book_no
-| LIMIT 5
 ```
 
 | book_no:keyword | author:text |

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/left.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/left.md
@@ -6,8 +6,6 @@
 FROM employees
 | KEEP last_name
 | EVAL left = LEFT(last_name, 3)
-| SORT last_name ASC
-| LIMIT 5
 ```
 
 | last_name:keyword | left:keyword |

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/match.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/match.md
@@ -5,9 +5,6 @@
 ```esql
 FROM books
 | WHERE MATCH(author, "Faulkner")
-| KEEP book_no, author
-| SORT book_no
-| LIMIT 5
 ```
 
 | book_no:keyword | author:text |

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/qstr.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/qstr.md
@@ -5,9 +5,6 @@
 ```esql
 FROM books
 | WHERE QSTR("author: Faulkner")
-| KEEP book_no, author
-| SORT book_no
-| LIMIT 5
 ```
 
 | book_no:keyword | author:text |
@@ -21,9 +18,6 @@ FROM books
 ```esql
 FROM books
 | WHERE QSTR("title: Hobbjt~", {"fuzziness": 2})
-| KEEP book_no, title
-| SORT book_no
-| LIMIT 5
 ```
 
 | book_no:keyword | title:text |

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/right.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/right.md
@@ -6,8 +6,6 @@
 FROM employees
 | KEEP last_name
 | EVAL right = RIGHT(last_name, 3)
-| SORT last_name ASC
-| LIMIT 5
 ```
 
 | last_name:keyword | right:keyword |

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/term.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/term.md
@@ -5,8 +5,6 @@
 ```esql
 FROM books
 | WHERE TERM(author, "gabriel")
-| KEEP book_no, title
-| LIMIT 3
 ```
 
 | book_no:keyword | title:text |

--- a/docs/reference/query-languages/esql/_snippets/operators/examples/is_null.md
+++ b/docs/reference/query-languages/esql/_snippets/operators/examples/is_null.md
@@ -5,9 +5,6 @@
 ```esql
 FROM employees
 | WHERE birth_date IS NULL
-| KEEP first_name, last_name
-| SORT first_name
-| LIMIT 3
 ```
 
 | first_name:keyword | last_name:keyword |

--- a/docs/reference/query-languages/esql/_snippets/operators/examples/match_operator.md
+++ b/docs/reference/query-languages/esql/_snippets/operators/examples/match_operator.md
@@ -5,9 +5,6 @@
 ```esql
 FROM books
 | WHERE MATCH(author, "Faulkner")
-| KEEP book_no, author
-| SORT book_no
-| LIMIT 5
 ```
 
 | book_no:keyword | author:text |

--- a/docs/reference/query-languages/esql/_snippets/operators/examples/predicates.md
+++ b/docs/reference/query-languages/esql/_snippets/operators/examples/predicates.md
@@ -5,9 +5,6 @@
 ```esql
 FROM employees
 | WHERE birth_date IS NULL
-| KEEP first_name, last_name
-| SORT first_name
-| LIMIT 3
 ```
 
 | first_name:keyword | last_name:keyword |

--- a/docs/reference/query-languages/esql/kibana/definition/functions/bucket.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/bucket.json
@@ -1590,16 +1590,16 @@
     }
   ],
   "examples" : [
-    "FROM employees\n| WHERE hire_date >= \"1985-01-01T00:00:00Z\" AND hire_date < \"1986-01-01T00:00:00Z\"\n| STATS hire_date = MV_SORT(VALUES(hire_date)) BY month = BUCKET(hire_date, 20, \"1985-01-01T00:00:00Z\", \"1986-01-01T00:00:00Z\")\n| SORT hire_date",
+    "FROM employees\n| WHERE hire_date >= \"1985-01-01T00:00:00Z\" AND hire_date < \"1986-01-01T00:00:00Z\"\n| STATS hire_date = MV_SORT(VALUES(hire_date)) BY month = BUCKET(hire_date, 20, \"1985-01-01T00:00:00Z\", \"1986-01-01T00:00:00Z\")",
     "FROM employees\n| WHERE hire_date >= \"1985-01-01T00:00:00Z\" AND hire_date < \"1986-01-01T00:00:00Z\"\n| STATS hires_per_month = COUNT(*) BY month = BUCKET(hire_date, 20, \"1985-01-01T00:00:00Z\", \"1986-01-01T00:00:00Z\")\n| SORT month",
-    "FROM employees\n| WHERE hire_date >= \"1985-01-01T00:00:00Z\" AND hire_date < \"1986-01-01T00:00:00Z\"\n| STATS hires_per_week = COUNT(*) BY week = BUCKET(hire_date, 100, \"1985-01-01T00:00:00Z\", \"1986-01-01T00:00:00Z\")\n| SORT week",
+    "FROM employees\n| WHERE hire_date >= \"1985-01-01T00:00:00Z\" AND hire_date < \"1986-01-01T00:00:00Z\"\n| STATS hires_per_week = COUNT(*) BY week = BUCKET(hire_date, 100, \"1985-01-01T00:00:00Z\", \"1986-01-01T00:00:00Z\")",
     "FROM employees\n| WHERE hire_date >= \"1985-01-01T00:00:00Z\" AND hire_date < \"1986-01-01T00:00:00Z\"\n| STATS hires_per_week = COUNT(*) BY week = BUCKET(hire_date, 1 week)\n| SORT week",
     "FROM employees\n| STATS COUNT(*) by bs = BUCKET(salary, 20, 25324, 74999)\n| SORT bs",
     "FROM employees\n| WHERE hire_date >= \"1985-01-01T00:00:00Z\" AND hire_date < \"1986-01-01T00:00:00Z\"\n| STATS c = COUNT(1) BY b = BUCKET(salary, 5000.)\n| SORT b",
     "FROM sample_data\n| WHERE @timestamp >= NOW() - 1 day and @timestamp < NOW()\n| STATS COUNT(*) BY bucket = BUCKET(@timestamp, 25, NOW() - 1 day, NOW())",
-    "FROM employees\n| WHERE hire_date >= \"1985-01-01T00:00:00Z\" AND hire_date < \"1986-01-01T00:00:00Z\"\n| STATS AVG(salary) BY bucket = BUCKET(hire_date, 20, \"1985-01-01T00:00:00Z\", \"1986-01-01T00:00:00Z\")\n| SORT bucket",
+    "FROM employees\n| WHERE hire_date >= \"1985-01-01T00:00:00Z\" AND hire_date < \"1986-01-01T00:00:00Z\"\n| STATS AVG(salary) BY bucket = BUCKET(hire_date, 20, \"1985-01-01T00:00:00Z\", \"1986-01-01T00:00:00Z\")",
     "FROM employees\n| STATS s1 = b1 + 1, s2 = BUCKET(salary / 1000 + 999, 50.) + 2 BY b1 = BUCKET(salary / 100 + 99, 50.), b2 = BUCKET(salary / 1000 + 999, 50.)\n| SORT b1, b2\n| KEEP s1, b1, s2, b2",
-    "FROM employees\n| STATS dates = MV_SORT(VALUES(birth_date)) BY b = BUCKET(birth_date + 1 HOUR, 1 YEAR) - 1 HOUR\n| EVAL d_count = MV_COUNT(dates)\n| SORT d_count, b\n| LIMIT 3"
+    "FROM employees\n| STATS dates = MV_SORT(VALUES(birth_date)) BY b = BUCKET(birth_date + 1 HOUR, 1 YEAR) - 1 HOUR\n| EVAL d_count = MV_COUNT(dates)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/functions/kql.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/kql.json
@@ -30,7 +30,7 @@
     }
   ],
   "examples" : [
-    "FROM books\n| WHERE KQL(\"author: Faulkner\")\n| KEEP book_no, author\n| SORT book_no\n| LIMIT 5"
+    "FROM books\n| WHERE KQL(\"author: Faulkner\")"
   ],
   "preview" : true,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/functions/left.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/left.json
@@ -42,7 +42,7 @@
     }
   ],
   "examples" : [
-    "FROM employees\n| KEEP last_name\n| EVAL left = LEFT(last_name, 3)\n| SORT last_name ASC\n| LIMIT 5"
+    "FROM employees\n| KEEP last_name\n| EVAL left = LEFT(last_name, 3)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/functions/match.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/match.json
@@ -731,7 +731,7 @@
     }
   ],
   "examples" : [
-    "FROM books\n| WHERE MATCH(author, \"Faulkner\")\n| KEEP book_no, author\n| SORT book_no\n| LIMIT 5",
+    "FROM books\n| WHERE MATCH(author, \"Faulkner\")",
     "FROM books\n| WHERE MATCH(title, \"Hobbit Back Again\", {\"operator\": \"AND\"})\n| KEEP title;"
   ],
   "preview" : true,

--- a/docs/reference/query-languages/esql/kibana/definition/functions/qstr.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/qstr.json
@@ -44,8 +44,8 @@
     }
   ],
   "examples" : [
-    "FROM books\n| WHERE QSTR(\"author: Faulkner\")\n| KEEP book_no, author\n| SORT book_no\n| LIMIT 5",
-    "FROM books\n| WHERE QSTR(\"title: Hobbjt~\", {\"fuzziness\": 2})\n| KEEP book_no, title\n| SORT book_no\n| LIMIT 5"
+    "FROM books\n| WHERE QSTR(\"author: Faulkner\")",
+    "FROM books\n| WHERE QSTR(\"title: Hobbjt~\", {\"fuzziness\": 2})"
   ],
   "preview" : true,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/functions/right.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/right.json
@@ -42,7 +42,7 @@
     }
   ],
   "examples" : [
-    "FROM employees\n| KEEP last_name\n| EVAL right = RIGHT(last_name, 3)\n| SORT last_name ASC\n| LIMIT 5"
+    "FROM employees\n| KEEP last_name\n| EVAL right = RIGHT(last_name, 3)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/functions/term.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/term.json
@@ -78,7 +78,7 @@
     }
   ],
   "examples" : [
-    "FROM books\n| WHERE TERM(author, \"gabriel\")\n| KEEP book_no, title\n| LIMIT 3"
+    "FROM books\n| WHERE TERM(author, \"gabriel\")"
   ],
   "preview" : true,
   "snapshot_only" : true

--- a/docs/reference/query-languages/esql/kibana/definition/operators/is_null.json
+++ b/docs/reference/query-languages/esql/kibana/definition/operators/is_null.json
@@ -187,7 +187,7 @@
     }
   ],
   "examples" : [
-    "FROM employees\n| WHERE birth_date IS NULL\n| KEEP first_name, last_name\n| SORT first_name\n| LIMIT 3"
+    "FROM employees\n| WHERE birth_date IS NULL"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/operators/match_operator.json
+++ b/docs/reference/query-languages/esql/kibana/definition/operators/match_operator.json
@@ -529,7 +529,7 @@
     }
   ],
   "examples" : [
-    "FROM books\n| WHERE MATCH(author, \"Faulkner\")\n| KEEP book_no, author\n| SORT book_no\n| LIMIT 5"
+    "FROM books\n| WHERE MATCH(author, \"Faulkner\")"
   ],
   "preview" : true,
   "snapshot_only" : false

--- a/docs/reference/query-languages/esql/kibana/definition/operators/predicates.json
+++ b/docs/reference/query-languages/esql/kibana/definition/operators/predicates.json
@@ -187,7 +187,7 @@
     }
   ],
   "examples" : [
-    "FROM employees\n| WHERE birth_date IS NULL\n| KEEP first_name, last_name\n| SORT first_name\n| LIMIT 3",
+    "FROM employees\n| WHERE birth_date IS NULL",
     "FROM employees\n| WHERE is_rehired IS NOT NULL\n| STATS COUNT(emp_no)"
   ],
   "preview" : false,

--- a/docs/reference/query-languages/esql/kibana/docs/functions/bucket.md
+++ b/docs/reference/query-languages/esql/kibana/docs/functions/bucket.md
@@ -10,5 +10,4 @@ The size of the buckets can either be provided directly, or chosen based on a re
 FROM employees
 | WHERE hire_date >= "1985-01-01T00:00:00Z" AND hire_date < "1986-01-01T00:00:00Z"
 | STATS hire_date = MV_SORT(VALUES(hire_date)) BY month = BUCKET(hire_date, 20, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
-| SORT hire_date
 ```

--- a/docs/reference/query-languages/esql/kibana/docs/functions/kql.md
+++ b/docs/reference/query-languages/esql/kibana/docs/functions/kql.md
@@ -8,7 +8,4 @@ Performs a KQL query. Returns true if the provided KQL query string matches the 
 ```esql
 FROM books
 | WHERE KQL("author: Faulkner")
-| KEEP book_no, author
-| SORT book_no
-| LIMIT 5
 ```

--- a/docs/reference/query-languages/esql/kibana/docs/functions/left.md
+++ b/docs/reference/query-languages/esql/kibana/docs/functions/left.md
@@ -9,6 +9,4 @@ Returns the substring that extracts *length* chars from *string* starting from t
 FROM employees
 | KEEP last_name
 | EVAL left = LEFT(last_name, 3)
-| SORT last_name ASC
-| LIMIT 5
 ```

--- a/docs/reference/query-languages/esql/kibana/docs/functions/match.md
+++ b/docs/reference/query-languages/esql/kibana/docs/functions/match.md
@@ -19,7 +19,4 @@ For a simplified syntax, you can use the [match operator](https://www.elastic.co
 ```esql
 FROM books
 | WHERE MATCH(author, "Faulkner")
-| KEEP book_no, author
-| SORT book_no
-| LIMIT 5
 ```

--- a/docs/reference/query-languages/esql/kibana/docs/functions/qstr.md
+++ b/docs/reference/query-languages/esql/kibana/docs/functions/qstr.md
@@ -8,7 +8,4 @@ Performs a [query string query](https://www.elastic.co/docs/reference/elasticsea
 ```esql
 FROM books
 | WHERE QSTR("author: Faulkner")
-| KEEP book_no, author
-| SORT book_no
-| LIMIT 5
 ```

--- a/docs/reference/query-languages/esql/kibana/docs/functions/right.md
+++ b/docs/reference/query-languages/esql/kibana/docs/functions/right.md
@@ -9,6 +9,4 @@ Return the substring that extracts *length* chars from *str* starting from the r
 FROM employees
 | KEEP last_name
 | EVAL right = RIGHT(last_name, 3)
-| SORT last_name ASC
-| LIMIT 5
 ```

--- a/docs/reference/query-languages/esql/kibana/docs/functions/term.md
+++ b/docs/reference/query-languages/esql/kibana/docs/functions/term.md
@@ -8,6 +8,4 @@ Performs a Term query on the specified field. Returns true if the provided term 
 ```esql
 FROM books
 | WHERE TERM(author, "gabriel")
-| KEEP book_no, title
-| LIMIT 3
 ```

--- a/docs/reference/query-languages/esql/kibana/docs/operators/is_null.md
+++ b/docs/reference/query-languages/esql/kibana/docs/operators/is_null.md
@@ -8,7 +8,4 @@ Use `IS NULL` to filter data based on whether the field exists or not.
 ```esql
 FROM employees
 | WHERE birth_date IS NULL
-| KEEP first_name, last_name
-| SORT first_name
-| LIMIT 3
 ```

--- a/docs/reference/query-languages/esql/kibana/docs/operators/match_operator.md
+++ b/docs/reference/query-languages/esql/kibana/docs/operators/match_operator.md
@@ -16,7 +16,4 @@ For using the function syntax, or adding [match query parameters](https://www.el
 ```esql
 FROM books
 | WHERE MATCH(author, "Faulkner")
-| KEEP book_no, author
-| SORT book_no
-| LIMIT 5
 ```

--- a/docs/reference/query-languages/esql/kibana/docs/operators/predicates.md
+++ b/docs/reference/query-languages/esql/kibana/docs/operators/predicates.md
@@ -8,7 +8,4 @@ For NULL comparison use the `IS NULL` and `IS NOT NULL` predicates.
 ```esql
 FROM employees
 | WHERE birth_date IS NULL
-| KEEP first_name, last_name
-| SORT first_name
-| LIMIT 3
 ```

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/bucket.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/bucket.csv-spec
@@ -130,8 +130,8 @@ bucketMonthInAgg#[skip:-8.13.99, reason:BUCKET renamed in 8.14]
 FROM employees
 | WHERE hire_date >= "1985-01-01T00:00:00Z" AND hire_date < "1986-01-01T00:00:00Z"
 | STATS AVG(salary) BY bucket = BUCKET(hire_date, 20, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
-| SORT bucket
 // end::bucket_in_agg[]
+| SORT bucket
 ;
 
 // tag::bucket_in_agg-result[]
@@ -150,9 +150,9 @@ bucketWithOffset#[skip:-8.13.99, reason:BUCKET renamed in 8.14]
 FROM employees
 | STATS dates = MV_SORT(VALUES(birth_date)) BY b = BUCKET(birth_date + 1 HOUR, 1 YEAR) - 1 HOUR
 | EVAL d_count = MV_COUNT(dates)
+// end::bucketWithOffset[]
 | SORT d_count, b
 | LIMIT 3
-// end::bucketWithOffset[]
 ;
 
 // tag::bucketWithOffset-result[]
@@ -168,8 +168,8 @@ docsBucketMonth#[skip:-8.13.99, reason:BUCKET renamed in 8.14]
 FROM employees
 | WHERE hire_date >= "1985-01-01T00:00:00Z" AND hire_date < "1986-01-01T00:00:00Z"
 | STATS hire_date = MV_SORT(VALUES(hire_date)) BY month = BUCKET(hire_date, 20, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
-| SORT hire_date
 //end::docsBucketMonth[]
+| SORT hire_date
 ;
 
 //tag::docsBucketMonth-result[]
@@ -208,8 +208,8 @@ docsBucketWeeklyHistogram#[skip:-8.13.99, reason:BUCKET renamed in 8.14]
 FROM employees
 | WHERE hire_date >= "1985-01-01T00:00:00Z" AND hire_date < "1986-01-01T00:00:00Z"
 | STATS hires_per_week = COUNT(*) BY week = BUCKET(hire_date, 100, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
-| SORT week
 //end::docsBucketWeeklyHistogram[]
+| SORT week
 ;
 
 //tag::docsBucketWeeklyHistogram-result[]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -9,9 +9,9 @@ FROM employees
 | KEEP emp_no, languages
 | INLINESTATS max_lang = MAX(languages) 
 | WHERE max_lang == languages
+// end::max-languages[]
 | SORT emp_no ASC
 | LIMIT 5
-// end::max-languages[]
 ;
 
 // tag::max-languages-result[]
@@ -78,9 +78,9 @@ FROM employees
 | KEEP emp_no, avg_worked_seconds, last_name
 | INLINESTATS max_avg_worked_seconds = MAX(avg_worked_seconds) BY SUBSTRING(last_name, 0, 1)
 | WHERE max_avg_worked_seconds == avg_worked_seconds
+// end::longest-tenured-by-first[]
 | SORT last_name ASC
 | LIMIT 5
-// end::longest-tenured-by-first[]
 ;
 
 // tag::longest-tenured-by-first-result[]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/kql-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/kql-function.csv-spec
@@ -8,10 +8,10 @@ required_capability: kql_function
 // tag::kql-with-field[]
 FROM books
 | WHERE KQL("author: Faulkner")
+// end::kql-with-field[]
 | KEEP book_no, author
 | SORT book_no
 | LIMIT 5
-// end::kql-with-field[]
 ;
 
 // tag::kql-with-field-result[]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
@@ -8,10 +8,10 @@ required_capability: match_function
 // tag::match-with-field[]
 FROM books
 | WHERE MATCH(author, "Faulkner")
+// end::match-with-field[]
 | KEEP book_no, author
 | SORT book_no
 | LIMIT 5
-// end::match-with-field[]
 ;
 
 // tag::match-with-field-result[]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
@@ -8,10 +8,10 @@ required_capability: match_operator_colon
 // tag::match-with-field[]
 FROM books 
 | WHERE author:"Faulkner"
+// end::match-with-field[]
 | KEEP book_no, author 
 | SORT book_no 
 | LIMIT 5
-// end::match-with-field[]
 ;
 
 // tag::match-with-field-result[]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/null.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/null.csv-spec
@@ -28,10 +28,10 @@ isNullForDocs
 // tag::is-null[]
 FROM employees
 | WHERE birth_date IS NULL
+// end::is-null[]
 | KEEP first_name, last_name
 | SORT first_name
 | LIMIT 3
-// end::is-null[]
 ;
 
 // tag::is-null-result[]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/qstr-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/qstr-function.csv-spec
@@ -8,10 +8,10 @@ required_capability: qstr_function
 // tag::qstr-with-field[]
 FROM books 
 | WHERE QSTR("author: Faulkner")
+// end::qstr-with-field[]
 | KEEP book_no, author 
 | SORT book_no 
 | LIMIT 5
-// end::qstr-with-field[]
 ;
 
 // tag::qstr-with-field-result[]
@@ -196,10 +196,10 @@ required_capability: query_string_function_options
 // tag::qstr-with-options[]
 FROM books 
 | WHERE QSTR("title: Hobbjt~", {"fuzziness": 2})
+// end::qstr-with-options[]
 | KEEP book_no, title 
 | SORT book_no 
 | LIMIT 5
-// end::qstr-with-options[]
 ;
 ignoreOrder: true
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1113,9 +1113,9 @@ left
 FROM employees
 | KEEP last_name
 | EVAL left = LEFT(last_name, 3)
+// end::left[]
 | SORT last_name ASC
 | LIMIT 5
-// end::left[]
 ;
 
 // tag::left-result[]
@@ -1133,9 +1133,9 @@ right
 FROM employees
 | KEEP last_name
 | EVAL right = RIGHT(last_name, 3)
+// end::right[]
 | SORT last_name ASC
 | LIMIT 5
-// end::right[]
 ;
 
 // tag::right-result[]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/term-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/term-function.csv-spec
@@ -8,9 +8,9 @@ required_capability: term_function
 // tag::term-with-field[]
 FROM books 
 | WHERE TERM(author, "gabriel")  
+// end::term-with-field[]
 | KEEP book_no, title
 | LIMIT 3
-// end::term-with-field[]
 ;
 ignoreOrder:true
 


### PR DESCRIPTION
Hides some of the "extra" lines from ESQL's documentation. These lines are required to make the documentation into nice tests which is important to make sure the docs don't get out of date. But readers don't need to see them.
