### PR TITLE
[8.x] Preventing ConcurrentModificationException when updating settings for more than one index (#126077)

### DIFF
--- a/docs/changelog/126077.yaml
+++ b/docs/changelog/126077.yaml
@@ -1,0 +1,6 @@
+pr: 126077
+summary: Preventing `ConcurrentModificationException` when updating settings for more
+  than one index
+area: Indices APIs
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsServiceIT.java
@@ -39,7 +39,8 @@ public class MetadataUpdateSettingsServiceIT extends ESIntegTestCase {
          * This test makes sure that when non-dynamic settings are updated that they actually take effect (as opposed to just being set
          * in the cluster state).
          */
-        createIndex("test", Settings.EMPTY);
+        createIndex("test-1", Settings.EMPTY);
+        createIndex("test-2", Settings.EMPTY);
         MetadataUpdateSettingsService metadataUpdateSettingsService = internalCluster().getCurrentMasterNodeInstance(
             MetadataUpdateSettingsService.class
         );

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -219,7 +219,7 @@ public class MetadataUpdateSettingsService {
                         allocationService.getShardRoutingRoleStrategy(),
                         currentState.routingTable()
                     );
-                    for (Index index : openIndices) {
+                    for (Index index : new HashSet<>(openIndices)) {
                         // We only want to take on the expense of reopening all shards for an index if the setting is really changing
                         Settings existingSettings = currentState.getMetadata().index(index).getSettings();
                         boolean needToReopenIndex = false;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Preventing ConcurrentModificationException when updating settings for more than one index (#126077)](https://github.com/elastic/elasticsearch/pull/126077)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)