### PR TITLE
[8.x] ES-125727 Fix for [CI] ReindexDataStreamTransportActionIT testAlreadyUpToDateDataStream failing (#126123)

### DIFF
--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamTransportActionIT.java
@@ -69,10 +69,7 @@ public class ReindexDataStreamTransportActionIT extends ESIntegTestCase {
             dataStreamName
         );
         final int backingIndexCount = createDataStream(dataStreamName);
-        AcknowledgedResponse response = client().execute(
-            new ActionType<AcknowledgedResponse>(ReindexDataStreamAction.NAME),
-            reindexDataStreamRequest
-        ).actionGet();
+        client().execute(new ActionType<AcknowledgedResponse>(ReindexDataStreamAction.NAME), reindexDataStreamRequest).actionGet();
         String persistentTaskId = "reindex-data-stream-" + dataStreamName;
         AtomicReference<ReindexDataStreamTask> runningTask = new AtomicReference<>();
         for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
@@ -91,12 +88,14 @@ public class ReindexDataStreamTransportActionIT extends ESIntegTestCase {
             );
         }
         ReindexDataStreamTask task = runningTask.get();
-        assertNotNull(task);
-        assertThat(task.getStatus().complete(), equalTo(true));
-        assertNull(task.getStatus().exception());
-        assertThat(task.getStatus().pending(), equalTo(0));
-        assertThat(task.getStatus().inProgress(), equalTo(Set.of()));
-        assertThat(task.getStatus().errors().size(), equalTo(0));
+        assertBusy(() -> {
+            assertNotNull(task);
+            assertThat(task.getStatus().complete(), equalTo(true));
+            assertNull(task.getStatus().exception());
+            assertThat(task.getStatus().pending(), equalTo(0));
+            assertThat(task.getStatus().inProgress(), equalTo(Set.of()));
+            assertThat(task.getStatus().errors().size(), equalTo(0));
+        });
 
         assertBusy(() -> {
             GetMigrationReindexStatusAction.Response statusResponse = client().execute(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [ES-125727 Fix for [CI] ReindexDataStreamTransportActionIT testAlreadyUpToDateDataStream failing (#126123)](https://github.com/elastic/elasticsearch/pull/126123)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)