### PR TITLE
Acquire searcher in field caps only when needed

### DIFF
--- a/docs/changelog/126137.yaml
+++ b/docs/changelog/126137.yaml
@@ -1,0 +1,5 @@
+pr: 126137
+summary: Acquire searcher in field caps only when needed
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
+import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.plugins.internal.rewriter.QueryRewriteInterceptor;
@@ -465,4 +466,22 @@ public class QueryRewriteContext {
         this.queryRewriteInterceptor = queryRewriteInterceptor;
     }
 
+    public boolean isMetadataField(String field) {
+        return mapperService.isMetadataField(field);
+    }
+
+    public boolean isMultiField(String field) {
+        if (runtimeMappings.containsKey(field)) {
+            return false;
+        }
+        return mapperService.isMultiField(field);
+    }
+
+    public NestedLookup nestedLookup() {
+        return mappingLookup.nestedLookup();
+    }
+
+    public boolean hasMappings() {
+        return mappingLookup.hasMappings();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -43,7 +43,6 @@ import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.MappingParserContext;
-import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.SourceToParse;
@@ -372,30 +371,11 @@ public class SearchExecutionContext extends QueryRewriteContext {
         return mapperService.documentParser().parseDocument(source, mappingLookup);
     }
 
-    public NestedLookup nestedLookup() {
-        return mappingLookup.nestedLookup();
-    }
-
-    public boolean hasMappings() {
-        return mappingLookup.hasMappings();
-    }
-
     /**
      * Returns true if the field identified by the provided name is mapped, false otherwise
      */
     public boolean isFieldMapped(String name) {
         return fieldType(name) != null;
-    }
-
-    public boolean isMetadataField(String field) {
-        return mapperService.isMetadataField(field);
-    }
-
-    public boolean isMultiField(String field) {
-        if (runtimeMappings.containsKey(field)) {
-            return false;
-        }
-        return mapperService.isMultiField(field);
     }
 
     public Iterable<MappedFieldType> dimensionFields() {


### PR DESCRIPTION
FieldCapabilitiesFetcher acquires a searcher to perform basic checks that don't actually require a searcher to be performed, as they are purely mappings driven. Instead, we can reuse the existing QueryRewriteContext to perform such checks and entirely avoid acquiring a searcher.