### PR TITLE
[8.x] Add Bounded Window to Inference Models for Rescoring to Ensure Positive Score Range  (#125694)

### DIFF
--- a/docs/changelog/125694.yaml
+++ b/docs/changelog/125694.yaml
@@ -1,0 +1,5 @@
+pr: 125694
+summary: LTR score bounding
+area: Ranking
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/BoundedInferenceModel.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/BoundedInferenceModel.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference;
+
+public interface BoundedInferenceModel extends InferenceModel {
+    double getMinPredictedValue();
+
+    double getMaxPredictedValue();
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/BoundedWindowInferenceModel.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/BoundedWindowInferenceModel.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference;
+
+import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.inference.InferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TargetType;
+
+import java.util.Map;
+
+public class BoundedWindowInferenceModel implements BoundedInferenceModel {
+    public static final double DEFAULT_MIN_PREDICTED_VALUE = 0;
+
+    private final BoundedInferenceModel model;
+    private final double minPredictedValue;
+    private final double maxPredictedValue;
+    private final double adjustmentValue;
+
+    public BoundedWindowInferenceModel(BoundedInferenceModel model) {
+        this.model = model;
+        this.minPredictedValue = model.getMinPredictedValue();
+        this.maxPredictedValue = model.getMaxPredictedValue();
+
+        if (this.minPredictedValue < DEFAULT_MIN_PREDICTED_VALUE) {
+            this.adjustmentValue = DEFAULT_MIN_PREDICTED_VALUE - this.minPredictedValue;
+        } else {
+            this.adjustmentValue = 0.0;
+        }
+    }
+
+    @Override
+    public String[] getFeatureNames() {
+        return model.getFeatureNames();
+    }
+
+    @Override
+    public TargetType targetType() {
+        return model.targetType();
+    }
+
+    @Override
+    public InferenceResults infer(Map<String, Object> fields, InferenceConfig config, Map<String, String> featureDecoderMap) {
+        return boundInferenceResultScores(model.infer(fields, config, featureDecoderMap));
+    }
+
+    @Override
+    public InferenceResults infer(double[] features, InferenceConfig config) {
+        return boundInferenceResultScores(model.infer(features, config));
+    }
+
+    @Override
+    public boolean supportsFeatureImportance() {
+        return model.supportsFeatureImportance();
+    }
+
+    @Override
+    public String getName() {
+        return "bounded_window[" + model.getName() + "]";
+    }
+
+    @Override
+    public void rewriteFeatureIndices(Map<String, Integer> newFeatureIndexMapping) {
+        model.rewriteFeatureIndices(newFeatureIndexMapping);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return model.ramBytesUsed();
+    }
+
+    @Override
+    public double getMinPredictedValue() {
+        return minPredictedValue;
+    }
+
+    @Override
+    public double getMaxPredictedValue() {
+        return maxPredictedValue;
+    }
+
+    private InferenceResults boundInferenceResultScores(InferenceResults inferenceResult) {
+        // if the min value < the default minimum, slide the values up by the adjustment value
+        if (inferenceResult instanceof RegressionInferenceResults regressionInferenceResults) {
+            double predictedValue = ((Number) regressionInferenceResults.predictedValue()).doubleValue();
+
+            predictedValue += this.adjustmentValue;
+
+            return new RegressionInferenceResults(
+                predictedValue,
+                inferenceResult.getResultsField(),
+                ((RegressionInferenceResults) inferenceResult).getFeatureImportance()
+            );
+        }
+
+        throw new IllegalStateException(
+            LoggerMessageFormat.format(
+                "Model used within a {} should return a {} but got {} instead",
+                BoundedWindowInferenceModel.class.getSimpleName(),
+                RegressionInferenceResults.class.getSimpleName(),
+                inferenceResult.getClass().getSimpleName()
+            )
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "BoundedWindowInferenceModel{"
+            + "model="
+            + model
+            + ", minPredictedValue="
+            + getMinPredictedValue()
+            + ", maxPredictedValue="
+            + getMaxPredictedValue()
+            + '}';
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/BoundedWindowInferenceModelTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/BoundedWindowInferenceModelTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.inference.results.SingleValueInferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TargetType;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.Tree;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.TreeNode;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference.InferenceModelTestUtils.deserializeFromTrainedModel;
+import static org.hamcrest.Matchers.equalTo;
+
+public class BoundedWindowInferenceModelTests extends ESTestCase {
+
+    private static final List<String> featureNames = Arrays.asList("foo", "bar");
+
+    public void testBoundsSetting() throws IOException {
+        BoundedWindowInferenceModel testModel = getModel(-2.0, 5.2, 10.5);
+        assertThat(testModel.getMinPredictedValue(), equalTo(-2.0));
+        assertThat(testModel.getMaxPredictedValue(), equalTo(10.5));
+    }
+
+    public void testInferenceScoresWithoutAdjustment() throws IOException {
+        BoundedWindowInferenceModel testModel = getModel(1.0, 5.2, 10.5);
+
+        List<Double> featureVector = Arrays.asList(0.4, 0.0);
+        Map<String, Object> featureMap = zipObjMap(featureNames, featureVector);
+        Double lowResultValue = ((SingleValueInferenceResults) testModel.infer(
+            featureMap,
+            RegressionConfig.EMPTY_PARAMS,
+            Collections.emptyMap()
+        )).value();
+        assertThat(lowResultValue, equalTo(1.0));
+
+        featureVector = Arrays.asList(12.0, 0.0);
+        featureMap = zipObjMap(featureNames, featureVector);
+        Double highResultValue = ((SingleValueInferenceResults) testModel.infer(
+            featureMap,
+            RegressionConfig.EMPTY_PARAMS,
+            Collections.emptyMap()
+        )).value();
+        assertThat(highResultValue, equalTo(10.5));
+
+        double[] featureArray = new double[2];
+        featureArray[0] = 12.0;
+        featureArray[1] = 0.0;
+        Double highResultValueFromFeatures = ((SingleValueInferenceResults) testModel.infer(featureArray, RegressionConfig.EMPTY_PARAMS))
+            .value();
+        assertThat(highResultValueFromFeatures, equalTo(10.5));
+    }
+
+    public void testInferenceScoresWithAdjustment() throws IOException {
+        BoundedWindowInferenceModel testModel = getModel(-5.0, 1.2, 6.5);
+
+        List<Double> featureVector = Arrays.asList(-10.0, 0.0);
+        Map<String, Object> featureMap = zipObjMap(featureNames, featureVector);
+        Double lowResultValue = ((SingleValueInferenceResults) testModel.infer(
+            featureMap,
+            RegressionConfig.EMPTY_PARAMS,
+            Collections.emptyMap()
+        )).value();
+        assertThat(lowResultValue, equalTo(0.0));
+
+        featureVector = Arrays.asList(12.0, 0.0);
+        featureMap = zipObjMap(featureNames, featureVector);
+        Double highResultValue = ((SingleValueInferenceResults) testModel.infer(
+            featureMap,
+            RegressionConfig.EMPTY_PARAMS,
+            Collections.emptyMap()
+        )).value();
+        assertThat(highResultValue, equalTo(11.5));
+
+        double[] featureArray = new double[2];
+        featureArray[0] = 12.0;
+        featureArray[1] = 0.0;
+        Double highResultValueFromFeatures = ((SingleValueInferenceResults) testModel.infer(featureArray, RegressionConfig.EMPTY_PARAMS))
+            .value();
+        assertThat(highResultValueFromFeatures, equalTo(11.5));
+    }
+
+    private BoundedWindowInferenceModel getModel(double lowerBoundValue, double midValue, double upperBoundValue) throws IOException {
+        Tree.Builder builder = Tree.builder().setTargetType(TargetType.REGRESSION);
+        TreeNode.Builder rootNode = builder.addJunction(0, 0, true, 0.5);
+        builder.addLeaf(rootNode.getRightChild(), upperBoundValue);
+        TreeNode.Builder leftChildNode = builder.addJunction(rootNode.getLeftChild(), 1, true, 0.8);
+        builder.addLeaf(leftChildNode.getLeftChild(), lowerBoundValue);
+        builder.addLeaf(leftChildNode.getRightChild(), midValue);
+
+        List<String> featureNames = Arrays.asList("foo", "bar");
+        Tree treeObject = builder.setFeatureNames(featureNames).build();
+        TreeInferenceModel tree = deserializeFromTrainedModel(treeObject, xContentRegistry(), TreeInferenceModel::fromXContent);
+        tree.rewriteFeatureIndices(Collections.emptyMap());
+
+        return new BoundedWindowInferenceModel(tree);
+    }
+
+    private static Map<String, Object> zipObjMap(List<String> keys, List<Double> values) {
+        return IntStream.range(0, keys.size()).boxed().collect(Collectors.toMap(keys::get, values::get));
+    }
+
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add Bounded Window to Inference Models for Rescoring to Ensure Positive Score Range  (#125694)](https://github.com/elastic/elasticsearch/pull/125694)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)