### PR TITLE
[9.0] Unmute ThreadContextTests testDropWarningsExceedingMaxSettings (#123629)

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
@@ -639,7 +639,6 @@ public class ThreadContextTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/112256")
     public void testDropWarningsExceedingMaxSettings() {
         Settings settings = Settings.builder()
             .put(HttpTransportSettings.SETTING_HTTP_MAX_WARNING_HEADER_COUNT.getKey(), 1)


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Unmute ThreadContextTests testDropWarningsExceedingMaxSettings (#123629)