### PR TITLE
Fix TsdbDocValueBwcTests test failure.

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/TsdbDocValueBwcTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/TsdbDocValueBwcTests.java
@@ -235,8 +235,7 @@ public class TsdbDocValueBwcTests extends ESTestCase {
 
     // A hacky way to figure out whether doc values format is written in what version. Need to use reflection, because
     // PerFieldDocValuesFormat hides the doc values formats it wraps.
-    private void assertOldDocValuesFormatVersion(DirectoryReader reader) throws NoSuchFieldException, IllegalAccessException,
-        IOException {
+    private void assertOldDocValuesFormatVersion(DirectoryReader reader) throws NoSuchFieldException, IllegalAccessException, IOException {
         if (System.getSecurityManager() != null) {
             // With jvm version 24 entitlements are used and security manager is nog longer used.
             // Making this assertion work with security manager requires granting the entire test codebase privileges to use
@@ -256,8 +255,8 @@ public class TsdbDocValueBwcTests extends ESTestCase {
         }
     }
 
-    private void assertNewDocValuesFormatVersion(DirectoryReader reader) throws NoSuchFieldException, IllegalAccessException,
-        IOException, ClassNotFoundException {
+    private void assertNewDocValuesFormatVersion(DirectoryReader reader) throws NoSuchFieldException, IllegalAccessException, IOException,
+        ClassNotFoundException {
         if (System.getSecurityManager() != null) {
             // With jvm version 24 entitlements are used and security manager is nog longer used.
             // Making this assertion work with security manager requires granting the entire test codebase privileges to use

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/TsdbDocValueBwcTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/TsdbDocValueBwcTests.java
@@ -235,8 +235,16 @@ public class TsdbDocValueBwcTests extends ESTestCase {
 
     // A hacky way to figure out whether doc values format is written in what version. Need to use reflection, because
     // PerFieldDocValuesFormat hides the doc values formats it wraps.
-    private static void assertOldDocValuesFormatVersion(DirectoryReader reader) throws NoSuchFieldException, IllegalAccessException,
+    private void assertOldDocValuesFormatVersion(DirectoryReader reader) throws NoSuchFieldException, IllegalAccessException,
         IOException {
+        if (System.getSecurityManager() != null) {
+            // With jvm version 24 entitlements are used and security manager is nog longer used.
+            // Making this assertion work with security manager requires granting the entire test codebase privileges to use
+            // suppressAccessChecks and accessDeclaredMembers. This is undesired from a security manager perspective.
+            logger.info("not asserting doc values format version, because security manager is used");
+            return;
+        }
+
         for (var leafReaderContext : reader.leaves()) {
             var leaf = (SegmentReader) leafReaderContext.reader();
             var dvReader = leaf.getDocValuesReader();
@@ -248,8 +256,16 @@ public class TsdbDocValueBwcTests extends ESTestCase {
         }
     }
 
-    private static void assertNewDocValuesFormatVersion(DirectoryReader reader) throws NoSuchFieldException, IllegalAccessException,
+    private void assertNewDocValuesFormatVersion(DirectoryReader reader) throws NoSuchFieldException, IllegalAccessException,
         IOException, ClassNotFoundException {
+        if (System.getSecurityManager() != null) {
+            // With jvm version 24 entitlements are used and security manager is nog longer used.
+            // Making this assertion work with security manager requires granting the entire test codebase privileges to use
+            // suppressAccessChecks and suppressAccessChecks. This is undesired from a security manager perspective.
+            logger.info("not asserting doc values format version, because security manager is used");
+            return;
+        }
+
         for (var leafReaderContext : reader.leaves()) {
             var leaf = (SegmentReader) leafReaderContext.reader();
             var dvReader = leaf.getDocValuesReader();


### PR DESCRIPTION
Don't perform version check assertion in TsdbDocValueBwcTests if security manager is active.

By default, with jvm version 24 entitlements are used instead security manager and assertOldDocValuesFormatVersion() / assertNewDocValuesFormatVersion() work as expected.

Making these methods work with security manager would require granting the server entire test codebase suppressAccessChecks and suppressAccessChecks privileges. This is undesired from a security manager perspective. Instead, only assert doc values format checks if security manager isn't active, which is always the case jvm version 24 or higher is used.

Closes #126174