### PR TITLE
[8.17] ESQL: ESQL: Fix ReplaceMissingFieldsWithNull (#125764)

### DIFF
--- a/docs/changelog/125764.yaml
+++ b/docs/changelog/125764.yaml
@@ -1,0 +1,8 @@
+pr: 125764
+summary: Fix `ReplaceMissingFieldsWithNull`
+area: ES|QL
+type: bug
+issues:
+ - 126036
+ - 121754
+ - 126030

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -64,6 +64,7 @@ import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.parser.QueryParam;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
@@ -132,6 +133,7 @@ import static org.elasticsearch.xpack.esql.parser.ParserUtils.ParamClassificatio
 import static org.elasticsearch.xpack.esql.parser.ParserUtils.ParamClassification.PATTERN;
 import static org.elasticsearch.xpack.esql.parser.ParserUtils.ParamClassification.VALUE;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -391,6 +393,14 @@ public final class EsqlTestUtils {
     public static <T> T as(Object node, Class<T> type) {
         Assert.assertThat(node, instanceOf(type));
         return type.cast(node);
+    }
+
+    public static Limit asLimit(Object node, Integer limitLiteral) {
+        Limit limit = as(node, Limit.class);
+        if (limitLiteral != null) {
+            assertEquals(as(limit.limit(), Literal.class).value(), limitLiteral);
+        }
+        return limit;
     }
 
     public static Map<String, EsField> loadMapping(String name) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -644,3 +644,21 @@ FROM airports
 abbrev:k  |  city_name:k  |  city_location:geo_point |  country:k  |  location:geo_point                       |  name:text                    |  region:text  |  boundary_wkt_length:i
 IDR       |  Indore       |  POINT(75.8472 22.7167)  |  India      |  POINT(75.8092915005895 22.727749187571)  |  Devi Ahilyabai Holkar Int'l  |  Indore City  |  231
 ;
+
+// Regression test for https://github.com/elastic/elasticsearch/issues/126030
+// We had wrong layouts from ReplaceMissingFieldsWithNull in case of indices that had relevant fields for the query,
+// but were **missing the field we enrich on**.
+fieldsInOtherIndicesBug
+required_capability: enrich_load
+required_capability: fix_replace_missing_field_with_null_duplicate_name_id_in_layout
+
+from *
+| keep author.keyword, book_no, scalerank, street, bytes_in, @timestamp, abbrev, city_location, distance, description, birth_date, language_code, intersects, client_ip, event_duration, version
+| enrich languages_policy on author.keyword
+| sort book_no
+| limit 1
+;
+
+author.keyword:keyword|book_no:keyword|scalerank:integer|street:keyword|bytes_in:ul|@timestamp:unsupported|abbrev:keyword|city_location:geo_point|distance:double|description:unsupported|birth_date:date|language_code:integer|intersects:boolean|client_ip:unsupported|event_duration:long|version:version|language_name:keyword
+Fyodor Dostoevsky     |1211           |null             |null          |null       |null                  |null          |null                   |null           |null                   |null           |null                 |null              |null                 |null               |null           |null
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -659,6 +659,6 @@ from *
 | limit 1
 ;
 
-author.keyword:keyword|book_no:keyword|scalerank:integer|street:keyword|bytes_in:ul|@timestamp:unsupported|abbrev:keyword|city_location:geo_point|distance:double|description:unsupported|birth_date:date|language_code:integer|intersects:boolean|client_ip:unsupported|event_duration:long|version:version|language_name:keyword
-Fyodor Dostoevsky     |1211           |null             |null          |null       |null                  |null          |null                   |null           |null                   |null           |null                 |null              |null                 |null               |null           |null
+author.keyword:keyword|book_no:keyword|scalerank:integer|street:keyword|bytes_in:ul|@timestamp:null|abbrev:keyword|city_location:geo_point|distance:double|description:null|birth_date:date|language_code:keyword|intersects:boolean|client_ip:null|event_duration:long|version:version|language_name:keyword
+Fyodor Dostoevsky     |1211           |null             |null          |null       |null           |null          |null                   |null           |null            |null           |null                 |null              |null          |null               |null           |null
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -524,7 +524,12 @@ public class EsqlCapabilities {
         /**
          * Fix for regex folding with case-insensitive pattern https://github.com/elastic/elasticsearch/issues/118371
          */
-        FIXED_REGEX_FOLD;
+        FIXED_REGEX_FOLD,
+
+        /**
+         * Avoid duplicated channels with the same name id when executing ESQL queries.
+         */
+        FIX_REPLACE_MISSING_FIELD_WITH_NULL_DUPLICATE_NAME_ID_IN_LAYOUT;
 
         private final boolean enabled;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Layout.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Layout.java
@@ -109,12 +109,11 @@ public interface Layout {
             for (ChannelSet set : channels) {
                 int channel = numberOfChannels++;
                 for (NameId id : set.nameIds) {
+                    // Duplicate name ids would mean that have 2 channels that are declared under the same id. That makes no sense - which
+                    // channel should subsequent operators use, then, when they want to refer to this id?
+                    assert (layout.containsKey(id) == false) : "Duplicate name ids are not allowed in layouts";
                     ChannelAndType next = new ChannelAndType(channel, set.type);
-                    ChannelAndType prev = layout.put(id, next);
-                    // Do allow multiple name to point to the same channel - see https://github.com/elastic/elasticsearch/pull/100238
-                    // if (prev != null) {
-                    // throw new IllegalArgumentException("Name [" + id + "] is on two channels [" + prev + "] and [" + next + "]");
-                    // }
+                    layout.put(id, next);
                 }
             }
             return new DefaultLayout(Collections.unmodifiableMap(layout), numberOfChannels);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -281,7 +281,6 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/110150")
     public void testMissingFieldInNewCommand() {
         var testStats = statsForMissingField("last_name");
         localPlan(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
-import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.core.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -65,6 +64,7 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.THREE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TWO;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.asLimit;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getFieldAttribute;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.greaterThanOf;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.loadMapping;
@@ -73,9 +73,9 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.statsForMissingField;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning;
 import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 //@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "debug")
@@ -139,7 +139,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Project[[last_name{r}#6]]
+     * Project[[last_name{f}#6]]
      * \_Eval[[null[KEYWORD] AS last_name]]
      *  \_Limit[10000[INTEGER]]
      *   \_EsRelation[test][_meta_field{f}#8, emp_no{f}#2, first_name{f}#3, gen..]
@@ -156,7 +156,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         var project = as(localPlan, Project.class);
         var projections = project.projections();
         assertThat(Expressions.names(projections), contains("last_name"));
-        as(projections.get(0), ReferenceAttribute.class);
+        as(projections.get(0), FieldAttribute.class);
         var eval = as(project.child(), Eval.class);
         assertThat(Expressions.names(eval.fields()), contains("last_name"));
         var alias = as(eval.fields().get(0), Alias.class);
@@ -166,6 +166,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
 
         var limit = as(eval.child(), Limit.class);
         var source = as(limit.child(), EsRelation.class);
+        assertThat(Expressions.names(source.output()), not(contains("last_name")));
     }
 
     /**
@@ -190,14 +191,18 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
 
         var limit = as(project.child(), Limit.class);
         var source = as(limit.child(), EsRelation.class);
+        assertThat(Expressions.names(source.output()), not(contains("last_name")));
     }
 
     /**
      * Expects
-     * EsqlProject[[first_name{f}#9, last_name{r}#18]]
-     * \_MvExpand[last_name{f}#12,last_name{r}#18,1000]
-     *   \_Limit[1000[INTEGER]]
-     *     \_EsRelation[test][_meta_field{f}#14, emp_no{f}#8, first_name{f}#9, ge..]
+     * EsqlProject[[first_name{f}#7, last_name{r}#16]]
+     * \_MvExpand[last_name{f}#10,last_name{r}#16,1000]
+     *   \_Project[[_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, gender{f}#8, job{f}#13, job.raw{f}#14, languages{f}#9, last_
+     * name{r}#10, long_noidx{f}#15, salary{f}#11]]
+     *     \_Eval[[null[KEYWORD] AS last_name]]
+     *       \_Limit[1000[INTEGER]]
+     *         \_EsRelation[test][_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, ge..]
      */
     public void testMissingFieldInMvExpand() {
         var plan = plan("""
@@ -209,14 +214,23 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         var testStats = statsForMissingField("last_name");
         var localPlan = localPlan(plan, testStats);
 
+        // It'd be much better if this project was pushed down past the MvExpand, because MvExpand's cost scales with the number of
+        // involved attributes/columns.
         var project = as(localPlan, EsqlProject.class);
         var projections = project.projections();
         assertThat(Expressions.names(projections), contains("first_name", "last_name"));
 
         var mvExpand = as(project.child(), MvExpand.class);
-        assertThat(mvExpand.limit(), equalTo(1000));
-        var limit2 = as(mvExpand.child(), Limit.class);
-        as(limit2.child(), EsRelation.class);
+        assertEquals(1000, (int) mvExpand.limit());
+        var project2 = as(mvExpand.child(), Project.class);
+        var eval = as(project2.child(), Eval.class);
+        assertEquals(eval.fields().size(), 1);
+        var lastName = eval.fields().get(0);
+        assertEquals(lastName.name(), "last_name");
+        assertEquals(lastName.child(), new Literal(EMPTY, null, DataType.KEYWORD));
+        var limit = asLimit(eval.child(), 1000);
+        var relation = as(limit.child(), EsRelation.class);
+        assertThat(Expressions.names(relation.output()), not(contains("last_name")));
     }
 
     public static class MockFieldAttributeCommand extends UnaryPlan {
@@ -278,6 +292,39 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
             ),
             testStats
         );
+
+        var plan = plan("""
+              from test
+            """);
+        var initialRelation = plan.collectLeaves().get(0);
+        FieldAttribute lastName = null;
+        for (Attribute attr : initialRelation.output()) {
+            if (attr.name().equals("last_name")) {
+                lastName = (FieldAttribute) attr;
+            }
+        }
+
+        // Expects
+        // MockFieldAttributeCommand[last_name{f}#7]
+        // \_Project[[_meta_field{f}#9, emp_no{f}#3, first_name{f}#4, gender{f}#5, hire_date{f}#10, job{f}#11, job.raw{f}#12, langu
+        // ages{f}#6, last_name{r}#7, long_noidx{f}#13, salary{f}#8]]
+        // \_Eval[[null[KEYWORD] AS last_name]]
+        // \_Limit[1000[INTEGER],false]
+        // \_EsRelation[test][_meta_field{f}#9, emp_no{f}#3, first_name{f}#4, gen..]
+        LogicalPlan localPlan = localPlan(new MockFieldAttributeCommand(EMPTY, plan, lastName), testStats);
+
+        var mockCommand = as(localPlan, MockFieldAttributeCommand.class);
+        var project = as(mockCommand.child(), Project.class);
+        var eval = as(project.child(), Eval.class);
+        var limit = asLimit(eval.child(), 1000);
+        var relation = as(limit.child(), EsRelation.class);
+
+        assertThat(Expressions.names(eval.fields()), contains("last_name"));
+        var literal = as(eval.fields().get(0), Alias.class);
+        assertEquals(literal.child(), new Literal(EMPTY, null, DataType.KEYWORD));
+        assertThat(Expressions.names(relation.output()), not(contains("last_name")));
+
+        assertEquals(Expressions.names(initialRelation.output()), Expressions.names(project.output()));
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -31,7 +31,7 @@ import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
 import org.elasticsearch.xpack.esql.analysis.Verifier;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
-import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
@@ -1082,9 +1082,9 @@ public class LocalPhysicalPlanOptimizerTests extends MapperServiceTestCase {
             contains("_meta_field", "emp_no", "first_name", "gender", "job", "job.raw", "languages", "last_name", "long_noidx", "salary")
         );
         // emp_no
-        assertThat(projections.get(1), instanceOf(ReferenceAttribute.class));
+        assertThat(projections.get(1), instanceOf(FieldAttribute.class));
         // first_name
-        assertThat(projections.get(2), instanceOf(ReferenceAttribute.class));
+        assertThat(projections.get(2), instanceOf(FieldAttribute.class));
 
         // last_name --> first_name
         var nullAlias = Alias.unwrap(projections.get(7));


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.18` to `8.17`:
 - [[8.18] ESQL: ESQL: Fix ReplaceMissingFieldsWithNull (#125764) (#126166)](https://github.com/elastic/elasticsearch/pull/126166)

(Backporting from 8.18 rather than the main commit https://github.com/elastic/elasticsearch/pull/125764 as the former already has more resolved conflicts.)