### PR TITLE
Unmute already fixed test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -332,9 +332,6 @@ tests:
 - class: org.elasticsearch.xpack.ilm.actions.SearchableSnapshotActionIT
   method: testSearchableSnapshotsInHotPhasePinnedToHotNodes
   issue: https://github.com/elastic/elasticsearch/issues/125683
-- class: org.elasticsearch.xpack.esql.spatial.SpatialExtentAggregationNoLicenseIT
-  method: testStExtentAggregationWithPoints
-  issue: https://github.com/elastic/elasticsearch/issues/125735
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
   issue: https://github.com/elastic/elasticsearch/issues/120720


### PR DESCRIPTION
This was fixed last week in https://github.com/elastic/elasticsearch/pull/125802. It seems this report was from the day before the fix, but the PR was based on main without the mute, so a timing issue. I'll make a PR that simply unmutes the test.

Fixes #125735
