### PR TITLE
Record action name for all outbound messages

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.network.HandlingTimeTracker;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.transport.NetworkExceptionHelper;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -114,6 +113,7 @@ public final class OutboundHandler {
         assert assertValidTransportVersion(transportVersion);
         sendMessage(
             channel,
+            MessageDirection.REQUEST,
             action,
             request,
             requestId,
@@ -146,7 +146,8 @@ public final class OutboundHandler {
         try {
             sendMessage(
                 channel,
-                null,
+                MessageDirection.RESPONSE,
+                action,
                 response,
                 requestId,
                 isHandshake,
@@ -188,7 +189,8 @@ public final class OutboundHandler {
         try {
             sendMessage(
                 channel,
-                null,
+                MessageDirection.RESPONSE_ERROR,
+                action,
                 msg,
                 requestId,
                 false,
@@ -204,29 +206,36 @@ public final class OutboundHandler {
         }
     }
 
+    public enum MessageDirection {
+        REQUEST,
+        RESPONSE,
+        RESPONSE_ERROR
+    }
+
     private void sendMessage(
         TcpChannel channel,
-        @Nullable String requestAction,
+        MessageDirection messageDirection,
+        String action,
         Writeable writeable,
         long requestId,
         boolean isHandshake,
-        Compression.Scheme compressionScheme,
+        Compression.Scheme possibleCompressionScheme,
         TransportVersion version,
         ResponseStatsConsumer responseStatsConsumer,
         Releasable onAfter
     ) throws IOException {
-        compressionScheme = writeable instanceof BytesTransportRequest ? null : compressionScheme;
+        assert action != null;
+        final var compressionScheme = writeable instanceof BytesTransportRequest ? null : possibleCompressionScheme;
         final BytesReference message;
         boolean serializeSuccess = false;
-        final boolean isError = writeable instanceof RemoteTransportException;
         final RecyclerBytesStreamOutput byteStreamOutput = new RecyclerBytesStreamOutput(recycler);
         try {
             message = serialize(
-                requestAction,
+                messageDirection,
+                action,
                 requestId,
                 isHandshake,
                 version,
-                isError,
                 compressionScheme,
                 writeable,
                 threadPool.getThreadContext(),
@@ -242,14 +251,23 @@ public final class OutboundHandler {
             }
         }
         responseStatsConsumer.addResponseStats(message.length());
-        final var responseType = writeable.getClass();
-        final boolean compress = compressionScheme != null;
+        final var messageType = writeable.getClass();
         internalSend(
             channel,
             message,
-            requestAction == null
-                ? () -> "Response{" + requestId + "}{" + isError + "}{" + compress + "}{" + isHandshake + "}{" + responseType + "}"
-                : () -> "Request{" + requestAction + "}{" + requestId + "}{" + isError + "}{" + compress + "}{" + isHandshake + "}",
+            () -> (messageDirection == MessageDirection.REQUEST ? "Request{" : "Response{")
+                + action
+                + "}{id="
+                + requestId
+                + "}{err="
+                + (messageDirection == MessageDirection.RESPONSE_ERROR)
+                + "}{cs="
+                + compressionScheme
+                + "}{hs="
+                + isHandshake
+                + "}{t="
+                + messageType
+                + "}",
             ActionListener.releasing(
                 message instanceof ReleasableBytesReference r
                     ? Releasables.wrap(byteStreamOutput, onAfter, r)
@@ -260,11 +278,11 @@ public final class OutboundHandler {
 
     // public for tests
     public static BytesReference serialize(
-        @Nullable String requestAction,
+        MessageDirection messageDirection,
+        String action,
         long requestId,
         boolean isHandshake,
         TransportVersion version,
-        boolean isError,
         Compression.Scheme compressionScheme,
         Writeable writeable,
         ThreadContext threadContext,
@@ -273,6 +291,7 @@ public final class OutboundHandler {
         compressionScheme = compressionScheme == Compression.Scheme.LZ4 && version.before(Compression.Scheme.LZ4_VERSION)
             ? null
             : compressionScheme;
+        assert action != null;
         assert byteStreamOutput.position() == 0;
         byteStreamOutput.setTransportVersion(version);
         final int headerSize = TcpHeader.headerSize(version);
@@ -280,12 +299,12 @@ public final class OutboundHandler {
         final int variableHeaderLength;
         if (version.onOrAfter(TcpHeader.VERSION_WITH_HEADER_SIZE)) {
             threadContext.writeTo(byteStreamOutput);
-            if (requestAction != null) {
+            if (messageDirection == MessageDirection.REQUEST) {
                 if (version.before(TransportVersions.V_8_0_0)) {
                     // empty features array
                     byteStreamOutput.writeStringArray(Strings.EMPTY_ARRAY);
                 }
-                byteStreamOutput.writeString(requestAction);
+                byteStreamOutput.writeString(action);
             }
             variableHeaderLength = Math.toIntExact(byteStreamOutput.position() - headerSize);
         } else {
@@ -298,16 +317,16 @@ public final class OutboundHandler {
             byteStreamOutput,
             variableHeaderLength,
             threadContext,
-            requestAction
+            action
         );
         byte status = 0;
-        if (requestAction == null) {
+        if (messageDirection != MessageDirection.REQUEST) {
             status = TransportStatus.setResponse(status);
         }
         if (isHandshake) {
             status = TransportStatus.setHandshake(status);
         }
-        if (isError) {
+        if (messageDirection == MessageDirection.RESPONSE_ERROR) {
             status = TransportStatus.setError(status);
         }
         if (compressionScheme != null) {
@@ -340,6 +359,8 @@ public final class OutboundHandler {
                 }
             }
             if (writeable instanceof BytesTransportRequest bRequest) {
+                assert stream == byteStreamOutput;
+                assert compressionScheme == null;
                 bRequest.writeThin(stream);
                 zeroCopyBuffer = bRequest.bytes;
             } else if (writeable instanceof RemoteTransportException remoteTransportException) {

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -311,6 +311,7 @@ public final class OutboundHandler {
             variableHeaderLength = -1;
         }
         BytesReference message = serializeMessageBody(
+            messageDirection,
             writeable,
             compressionScheme,
             version,
@@ -338,6 +339,7 @@ public final class OutboundHandler {
     }
 
     private static BytesReference serializeMessageBody(
+        MessageDirection messageDirection,
         Writeable writeable,
         Compression.Scheme compressionScheme,
         TransportVersion version,
@@ -353,7 +355,7 @@ public final class OutboundHandler {
             stream.setTransportVersion(version);
             if (variableHeaderLength == -1) {
                 threadContext.writeTo(stream);
-                if (requestAction != null) {
+                if (messageDirection == MessageDirection.REQUEST) {
                     stream.writeStringArray(Strings.EMPTY_ARRAY);
                     stream.writeString(requestAction);
                 }

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -56,32 +56,17 @@ public class InboundDecoderTests extends ESTestCase {
         }
 
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
-            final BytesReference totalBytes;
-            if (isRequest) {
-                totalBytes = OutboundHandler.serialize(
-                    action,
-                    requestId,
-                    false,
-                    TransportVersion.current(),
-                    false,
-                    null,
-                    new TestRequest(randomAlphaOfLength(100)),
-                    threadContext,
-                    os
-                );
-            } else {
-                totalBytes = OutboundHandler.serialize(
-                    null,
-                    requestId,
-                    false,
-                    TransportVersion.current(),
-                    false,
-                    null,
-                    new TestResponse(randomAlphaOfLength(100)),
-                    threadContext,
-                    os
-                );
-            }
+            final BytesReference totalBytes = OutboundHandler.serialize(
+                isRequest ? OutboundHandler.MessageDirection.REQUEST : OutboundHandler.MessageDirection.RESPONSE,
+                action,
+                requestId,
+                false,
+                TransportVersion.current(),
+                null,
+                isRequest ? new TestRequest(randomAlphaOfLength(100)) : new TestResponse(randomAlphaOfLength(100)),
+                threadContext,
+                os
+            );
             int totalHeaderSize = TcpHeader.headerSize(TransportVersion.current()) + totalBytes.getInt(
                 TcpHeader.VARIABLE_HEADER_SIZE_POSITION
             );
@@ -138,11 +123,11 @@ public class InboundDecoderTests extends ESTestCase {
         // 8.0 is only compatible with handshakes on a pre-variable int version
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference totalBytes = OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 action,
                 requestId,
                 true,
                 preHeaderVariableInt,
-                false,
                 compressionScheme,
                 new TestRequest(contentValue),
                 threadContext,
@@ -195,11 +180,11 @@ public class InboundDecoderTests extends ESTestCase {
         TransportVersion handshakeCompat = TransportHandshaker.V7_HANDSHAKE_VERSION;
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             BytesReference bytes = OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 action,
                 requestId,
                 true,
                 handshakeCompat,
-                false,
                 null,
                 new TestRequest(randomAlphaOfLength(100)),
                 threadContext,
@@ -247,11 +232,11 @@ public class InboundDecoderTests extends ESTestCase {
         int totalHeaderSize = TcpHeader.headerSize(transportVersion);
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference bytes = OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 action,
                 requestId,
                 true,
                 transportVersion,
-                false,
                 compressionScheme,
                 new TestRequest(randomAlphaOfLength(100)),
                 threadContext,
@@ -298,11 +283,11 @@ public class InboundDecoderTests extends ESTestCase {
 
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference bytes = OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 action,
                 requestId,
                 isHandshake,
                 version,
-                false,
                 randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4, null),
                 new TestRequest(randomAlphaOfLength(100)),
                 threadContext,
@@ -348,11 +333,11 @@ public class InboundDecoderTests extends ESTestCase {
 
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference bytes = OutboundHandler.serialize(
-                null,
+                OutboundHandler.MessageDirection.RESPONSE,
+                "test:action",
                 requestId,
                 isHandshake,
                 version,
-                false,
                 randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4, null),
                 new TestRequest(randomAlphaOfLength(100)),
                 threadContext,
@@ -388,38 +373,23 @@ public class InboundDecoderTests extends ESTestCase {
         } else {
             threadContext.addResponseHeader(headerKey, headerValue);
         }
-        final BytesReference totalBytes;
-        TransportMessage transportMessage;
         Compression.Scheme scheme = randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4);
 
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
-            if (isRequest) {
-                transportMessage = new TestRequest(randomAlphaOfLength(100));
-                totalBytes = OutboundHandler.serialize(
-                    action,
-                    requestId,
-                    false,
-                    TransportVersion.current(),
-                    false,
-                    scheme,
-                    transportMessage,
-                    threadContext,
-                    os
-                );
-            } else {
-                transportMessage = new TestResponse(randomAlphaOfLength(100));
-                totalBytes = OutboundHandler.serialize(
-                    null,
-                    requestId,
-                    false,
-                    TransportVersion.current(),
-                    false,
-                    scheme,
-                    transportMessage,
-                    threadContext,
-                    os
-                );
-            }
+            final TransportMessage transportMessage = isRequest
+                ? new TestRequest(randomAlphaOfLength(100))
+                : new TestResponse(randomAlphaOfLength(100));
+            final BytesReference totalBytes = OutboundHandler.serialize(
+                isRequest ? OutboundHandler.MessageDirection.REQUEST : OutboundHandler.MessageDirection.RESPONSE,
+                action,
+                requestId,
+                false,
+                TransportVersion.current(),
+                scheme,
+                transportMessage,
+                threadContext,
+                os
+            );
             final BytesStreamOutput out = new BytesStreamOutput();
             transportMessage.writeTo(out);
             final BytesReference uncompressedBytes = out.bytes();
@@ -479,11 +449,11 @@ public class InboundDecoderTests extends ESTestCase {
         TransportVersion handshakeCompat = TransportHandshaker.V7_HANDSHAKE_VERSION;
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference bytes = OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 action,
                 requestId,
                 true,
                 handshakeCompat,
-                false,
                 Compression.Scheme.DEFLATE,
                 new TestRequest(randomAlphaOfLength(100)),
                 threadContext,
@@ -517,11 +487,11 @@ public class InboundDecoderTests extends ESTestCase {
         final ReleasableBytesReference releasable1;
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference bytes = OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 action,
                 requestId,
                 false,
                 incompatibleVersion,
-                false,
                 Compression.Scheme.DEFLATE,
                 new TestRequest(randomAlphaOfLength(100)),
                 threadContext,

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -173,11 +173,11 @@ public class InboundHandlerTests extends ESTestCase {
         String requestValue = randomAlphaOfLength(10);
         BytesRefRecycler recycler = new BytesRefRecycler(PageCacheRecycler.NON_RECYCLING_INSTANCE);
         BytesReference fullRequestBytes = OutboundHandler.serialize(
+            OutboundHandler.MessageDirection.REQUEST,
             action,
             requestId,
             false,
             TransportVersion.current(),
-            false,
             null,
             new TestRequest(requestValue),
             threadPool.getThreadContext(),

--- a/server/src/test/java/org/elasticsearch/transport/InboundPipelineTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundPipelineTests.java
@@ -114,11 +114,11 @@ public class InboundPipelineTests extends ESTestCase {
                             if (rarely()) {
                                 messageData = new MessageData(version, requestId, true, compressionScheme, breakThisAction, null);
                                 message = OutboundHandler.serialize(
+                                    OutboundHandler.MessageDirection.REQUEST,
                                     breakThisAction,
                                     requestId,
                                     false,
                                     version,
-                                    false,
                                     compressionScheme,
                                     new TestRequest(value),
                                     threadContext,
@@ -128,11 +128,11 @@ public class InboundPipelineTests extends ESTestCase {
                             } else {
                                 messageData = new MessageData(version, requestId, true, compressionScheme, actionName, value);
                                 message = OutboundHandler.serialize(
+                                    OutboundHandler.MessageDirection.REQUEST,
                                     actionName,
                                     requestId,
                                     false,
                                     version,
-                                    false,
                                     compressionScheme,
                                     new TestRequest(value),
                                     threadContext,
@@ -142,11 +142,11 @@ public class InboundPipelineTests extends ESTestCase {
                         } else {
                             messageData = new MessageData(version, requestId, false, compressionScheme, null, value);
                             message = OutboundHandler.serialize(
-                                null,
+                                OutboundHandler.MessageDirection.RESPONSE,
+                                actionName,
                                 requestId,
                                 false,
                                 version,
-                                false,
                                 compressionScheme,
                                 new TestResponse(value),
                                 threadContext,
@@ -228,32 +228,17 @@ public class InboundPipelineTests extends ESTestCase {
             final boolean isRequest = randomBoolean();
             final long requestId = randomNonNegativeLong();
 
-            BytesReference message;
-            if (isRequest) {
-                message = OutboundHandler.serialize(
-                    actionName,
-                    requestId,
-                    false,
-                    invalidVersion,
-                    false,
-                    null,
-                    new TestRequest(value),
-                    threadContext,
-                    streamOutput
-                );
-            } else {
-                message = OutboundHandler.serialize(
-                    null,
-                    requestId,
-                    false,
-                    invalidVersion,
-                    false,
-                    null,
-                    new TestResponse(value),
-                    threadContext,
-                    streamOutput
-                );
-            }
+            final BytesReference message = OutboundHandler.serialize(
+                isRequest ? OutboundHandler.MessageDirection.REQUEST : OutboundHandler.MessageDirection.RESPONSE,
+                actionName,
+                requestId,
+                false,
+                invalidVersion,
+                null,
+                isRequest ? new TestRequest(value) : new TestResponse(value),
+                threadContext,
+                streamOutput
+            );
 
             try (ReleasableBytesReference releasable = ReleasableBytesReference.wrap(message)) {
                 expectThrows(IllegalStateException.class, () -> pipeline.handleBytes(new FakeTcpChannel(), releasable));
@@ -284,32 +269,17 @@ public class InboundPipelineTests extends ESTestCase {
             final boolean isRequest = randomBoolean();
             final long requestId = randomNonNegativeLong();
 
-            final BytesReference reference;
-            if (isRequest) {
-                reference = OutboundHandler.serialize(
-                    actionName,
-                    requestId,
-                    false,
-                    version,
-                    false,
-                    null,
-                    new TestRequest(value),
-                    threadContext,
-                    streamOutput
-                );
-            } else {
-                reference = OutboundHandler.serialize(
-                    null,
-                    requestId,
-                    false,
-                    version,
-                    false,
-                    null,
-                    new TestResponse(value),
-                    threadContext,
-                    streamOutput
-                );
-            }
+            final BytesReference reference = OutboundHandler.serialize(
+                isRequest ? OutboundHandler.MessageDirection.REQUEST : OutboundHandler.MessageDirection.RESPONSE,
+                actionName,
+                requestId,
+                false,
+                version,
+                null,
+                isRequest ? new TestRequest(value) : new TestResponse(value),
+                threadContext,
+                streamOutput
+            );
 
             final int fixedHeaderSize = TcpHeader.headerSize(TransportVersion.current());
             final int variableHeaderSize = reference.getInt(fixedHeaderSize - 4);

--- a/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
@@ -71,11 +71,11 @@ public class TransportLoggerTests extends ESTestCase {
         Compression.Scheme compress = randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4, null);
         try (RecyclerBytesStreamOutput bytesStreamOutput = new RecyclerBytesStreamOutput(recycler)) {
             return OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 "internal:test",
                 randomInt(30),
                 false,
                 TransportVersion.current(),
-                false,
                 compress,
                 new EmptyRequest(),
                 new ThreadContext(Settings.EMPTY),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
@@ -334,11 +334,11 @@ public class SecurityNetty4ServerTransportAuthenticationTests extends ESTestCase
             Recycler<BytesRef> recycler = new BytesRefRecycler(PageCacheRecycler.NON_RECYCLING_INSTANCE);
             RecyclerBytesStreamOutput out = new RecyclerBytesStreamOutput(recycler);
             BytesReference bytesReference = OutboundHandler.serialize(
+                OutboundHandler.MessageDirection.REQUEST,
                 "internal:whatever",
                 randomNonNegativeLong(),
                 false,
                 TransportVersion.current(),
-                false,
                 randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4, null),
                 new EmptyRequest(),
                 threadPool.getThreadContext(),


### PR DESCRIPTION
On outbound messages we know the action name whether it's a request or
response, so we can report it in logs rather than just relying on the
payload's type.

Backport of #125399 to `8.x`