### PR TITLE
Fork per-node query action to search_coordination pool

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -559,7 +559,7 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
         final int searchPoolMax = threadPool.info(ThreadPool.Names.SEARCH).getMax();
         transportService.registerRequestHandler(
             NODE_SEARCH_ACTION_NAME,
-            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
             NodeQueryRequest::new,
             (request, channel, task) -> {
                 final CancellableTask cancellableTask = (CancellableTask) task;


### PR DESCRIPTION
The runtime of this action can heavily depend on the number of shards queried, how quickly queries execute and how likely the can_match we execute during the query phase is to return `false`. As we shouldn't have O(n) cost tasks that may run unpredictably long, let's fork this to search_coordination like we do for can_match and field_caps which both have similar runtime cost.