### PR TITLE
[8.16] [8.x][DOCS] Fixes typo on built-in role page. (#126211)

### DIFF
--- a/docs/reference/security/authorization/built-in-roles.asciidoc
+++ b/docs/reference/security/authorization/built-in-roles.asciidoc
@@ -75,7 +75,7 @@ use of the {inference} APIs. Grants the `manage_inference` cluster privilege.
 
 [[built-in-roles-inference-user]] `inference_user`::
 Provides the minimum privileges required to view {inference} configurations
-and perform inference. Grants the `monintor_inference` cluster privilege.
+and perform inference. Grants the `monitor_inference` cluster privilege.
 
 [[built-in-roles-ingest-user]] `ingest_admin` ::
 Grants access to manage *all* index templates and *all* ingest pipeline configurations.


### PR DESCRIPTION
Backports the following commits to 8.16:
 - [8.x][DOCS] Fixes typo on built-in role page. (#126211)