### PR TITLE
[8.x] ESQL: make `AttributeMap` and `AttributeSet` immutable (#125938)

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Attribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Attribute.java
@@ -66,7 +66,7 @@ public abstract class Attribute extends NamedExpression {
 
     @Override
     public AttributeSet references() {
-        return new AttributeSet(this);
+        return AttributeSet.of(this);
     }
 
     public Attribute withLocation(Source source) {

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/AttributeSet.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/AttributeSet.java
@@ -26,22 +26,6 @@ public class AttributeSet implements Set<Attribute> {
 
     private final AttributeMap<Object> delegate;
 
-    public AttributeSet() {
-        delegate = new AttributeMap<>();
-    }
-
-    public AttributeSet(Attribute attr) {
-        delegate = new AttributeMap<>(attr, PRESENT);
-    }
-
-    public AttributeSet(Collection<? extends Attribute> attr) {
-        delegate = new AttributeMap<>();
-
-        for (Attribute a : attr) {
-            delegate.add(a, PRESENT);
-        }
-    }
-
     private AttributeSet(AttributeMap<Object> delegate) {
         this.delegate = delegate;
     }
@@ -113,44 +97,32 @@ public class AttributeSet implements Set<Attribute> {
 
     @Override
     public boolean add(Attribute e) {
-        return delegate.put(e, PRESENT) == null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean remove(Object o) {
-        return delegate.remove(o) != null;
-    }
-
-    public void addAll(AttributeSet other) {
-        delegate.addAll(other.delegate);
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean addAll(Collection<? extends Attribute> c) {
-        int size = delegate.size();
-        for (var e : c) {
-            delegate.put(e, PRESENT);
-        }
-        return delegate.size() != size;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean retainAll(Collection<?> c) {
-        return delegate.keySet().removeIf(e -> c.contains(e) == false);
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean removeAll(Collection<?> c) {
-        int size = delegate.size();
-        for (var e : c) {
-            delegate.remove(e);
-        }
-        return delegate.size() != size;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void clear() {
-        delegate.clear();
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -160,7 +132,7 @@ public class AttributeSet implements Set<Attribute> {
 
     @Override
     public boolean removeIf(Predicate<? super Attribute> filter) {
-        return delegate.keySet().removeIf(filter);
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -190,5 +162,77 @@ public class AttributeSet implements Set<Attribute> {
     @Override
     public String toString() {
         return delegate.keySet().toString();
+    }
+
+    public Builder asBuilder() {
+        return new Builder().addAll(this);
+    }
+
+    public static AttributeSet of(Attribute... attrs) {
+        final AttributeMap.Builder<Object> mapBuilder = AttributeMap.builder();
+        for (var a : attrs) {
+            mapBuilder.put(a, PRESENT);
+        }
+        return new AttributeSet(mapBuilder.build());
+    }
+
+    public static AttributeSet of(Collection<? extends Attribute> c) {
+        final AttributeMap.Builder<Object> mapBuilder = AttributeMap.builder();
+        for (var a : c) {
+            mapBuilder.put(a, PRESENT);
+        }
+        return new AttributeSet(mapBuilder.build());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final AttributeMap.Builder<Object> mapBuilder = AttributeMap.builder();
+
+        private Builder() {}
+
+        public Builder add(Attribute attr) {
+            mapBuilder.put(attr, PRESENT);
+            return this;
+        }
+
+        public boolean remove(Object o) {
+            return mapBuilder.remove(o) != null;
+        }
+
+        public Builder addAll(AttributeSet other) {
+            mapBuilder.putAll(other.delegate);
+            return this;
+        }
+
+        public Builder addAll(Builder other) {
+            mapBuilder.putAll(other.mapBuilder.build());
+            return this;
+        }
+
+        public Builder addAll(Collection<? extends Attribute> c) {
+            for (var e : c) {
+                mapBuilder.put(e, PRESENT);
+            }
+            return this;
+        }
+
+        public boolean removeIf(Predicate<? super Attribute> filter) {
+            return mapBuilder.keySet().removeIf(filter);
+        }
+
+        public boolean contains(Object o) {
+            return mapBuilder.containsKey(o);
+        }
+
+        public boolean isEmpty() {
+            return mapBuilder.isEmpty();
+        }
+
+        public AttributeSet build() {
+            return new AttributeSet(mapBuilder.build());
+        }
     }
 }

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expressions.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/Expressions.java
@@ -40,11 +40,11 @@ public final class Expressions {
             return AttributeMap.emptyAttributeMap();
         }
 
-        AttributeMap<Expression> map = new AttributeMap<>();
+        AttributeMap.Builder<Expression> mapBuilder = AttributeMap.builder();
         for (NamedExpression exp : named) {
-            map.add(exp.toAttribute(), exp);
+            mapBuilder.put(exp.toAttribute(), exp);
         }
-        return map;
+        return mapBuilder.build();
     }
 
     public static boolean anyMatch(List<? extends Expression> exps, Predicate<? super Expression> predicate) {
@@ -121,11 +121,11 @@ public final class Expressions {
             return AttributeSet.EMPTY;
         }
 
-        AttributeSet set = new AttributeSet();
+        var setBuilder = AttributeSet.builder();
         for (Expression exp : exps) {
-            set.addAll(exp.references());
+            setBuilder.addAll(exp.references());
         }
-        return set;
+        return setBuilder.build();
     }
 
     public static String name(Expression e) {

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/AttributeMapTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/AttributeMapTests.java
@@ -130,7 +130,7 @@ public class AttributeMapTests extends ESTestCase {
     }
 
     public void testEmptyConstructor() {
-        AttributeMap<Object> m = new AttributeMap<>();
+        AttributeMap<Object> m = AttributeMap.builder().build();
         assertThat(m.size(), is(0));
         assertThat(m.isEmpty(), is(true));
     }
@@ -156,7 +156,7 @@ public class AttributeMapTests extends ESTestCase {
 
     public void testSingleItemConstructor() {
         Attribute one = a("one");
-        AttributeMap<String> m = new AttributeMap<>(one, "one");
+        AttributeMap<String> m = AttributeMap.of(one, "one");
         assertThat(m.size(), is(1));
         assertThat(m.isEmpty(), is(false));
 
@@ -168,8 +168,8 @@ public class AttributeMapTests extends ESTestCase {
 
     public void testSubtract() {
         AttributeMap<String> m = threeMap();
-        AttributeMap<String> mo = new AttributeMap<>(m.keySet().iterator().next(), "one");
-        AttributeMap<String> empty = new AttributeMap<>();
+        AttributeMap<String> mo = AttributeMap.of(m.keySet().iterator().next(), "one");
+        AttributeMap<String> empty = AttributeMap.emptyAttributeMap();
 
         assertThat(m.subtract(empty), is(m));
         assertThat(m.subtract(m), is(empty));
@@ -184,7 +184,7 @@ public class AttributeMapTests extends ESTestCase {
     public void testIntersect() {
         AttributeMap<String> m = threeMap();
         AttributeMap<String> mo = new AttributeMap<>(m.keySet().iterator().next(), "one");
-        AttributeMap<String> empty = new AttributeMap<>();
+        AttributeMap<String> empty = AttributeMap.emptyAttributeMap();
 
         assertThat(m.intersect(empty), is(empty));
         assertThat(m.intersect(m), is(m));
@@ -194,7 +194,7 @@ public class AttributeMapTests extends ESTestCase {
     public void testSubsetOf() {
         AttributeMap<String> m = threeMap();
         AttributeMap<String> mo = new AttributeMap<>(m.keySet().iterator().next(), "one");
-        AttributeMap<String> empty = new AttributeMap<>();
+        AttributeMap<String> empty = AttributeMap.emptyAttributeMap();
 
         assertThat(m.subsetOf(empty), is(false));
         assertThat(m.subsetOf(m), is(true));
@@ -254,36 +254,48 @@ public class AttributeMapTests extends ESTestCase {
 
     public void testEmptyMapIsImmutable() {
         var empty = AttributeMap.emptyAttributeMap();
-        var ex = expectThrows(UnsupportedOperationException.class, () -> empty.add(a("one"), new Object()));
+        expectThrows(UnsupportedOperationException.class, () -> empty.put(a("one"), new Object()));
+    }
+
+    public void testMapIsImmutable() {
+        var map = threeMap();
+        expectThrows(UnsupportedOperationException.class, () -> map.put(a("one"), "one"));
+        expectThrows(UnsupportedOperationException.class, () -> map.putAll(threeMap()));
+        expectThrows(UnsupportedOperationException.class, () -> map.remove(a("one")));
+        expectThrows(UnsupportedOperationException.class, map::clear);
     }
 
     public void testAddPutEntriesIntoMap() {
-        var map = new AttributeMap<String>();
+        var builder = AttributeMap.builder();
         var one = a("one");
         var two = a("two");
         var three = a("three");
 
         for (var i : asList(one, two, three)) {
-            map.add(i, i.name());
+            builder.put(i, i.name());
         }
+
+        var map = builder.build();
 
         assertThat(map.size(), is(3));
 
-        assertThat(map.remove(one), is("one"));
-        assertThat(map.remove(two), is("two"));
+        assertThat(builder.remove(one), is("one"));
+        assertThat(builder.remove(two), is("two"));
 
         assertThat(map.size(), is(1));
     }
 
     public void testKeyIteratorRemoval() {
-        var map = new AttributeMap<String>();
+        var builder = AttributeMap.builder();
         var one = a("one");
         var two = a("two");
         var three = a("three");
 
         for (var i : asList(one, two, three)) {
-            map.add(i, i.name());
+            builder.put(i, i.name());
         }
+
+        var map = builder.build();
 
         assertThat(map.attributeNames(), contains("one", "two", "three"));
         assertThat(map.size(), is(3));
@@ -305,14 +317,16 @@ public class AttributeMapTests extends ESTestCase {
     }
 
     public void testValuesIteratorRemoval() {
-        var map = new AttributeMap<String>();
+        AttributeMap.Builder<String> builder = AttributeMap.builder();
         var one = a("one");
         var two = a("two");
         var three = a("three");
 
         for (var i : asList(one, two, three)) {
-            map.add(i, i.name());
+            builder.put(i, i.name());
         }
+
+        var map = builder.build();
 
         assertThat(map.values(), contains("one", "two", "three"));
 

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/AttributeSetTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/AttributeSetTests.java
@@ -8,8 +8,6 @@ package org.elasticsearch.xpack.esql.core.expression;
 
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.List;
-
 import static org.elasticsearch.xpack.esql.core.expression.AttributeMapTests.a;
 
 public class AttributeSetTests extends ESTestCase {
@@ -18,25 +16,38 @@ public class AttributeSetTests extends ESTestCase {
         Attribute a1 = a("1");
         Attribute a2 = a("2");
 
-        AttributeSet first = new AttributeSet(List.of(a1, a2));
+        AttributeSet first = AttributeSet.of(a1, a2);
         assertEquals(first, first);
 
-        AttributeSet second = new AttributeSet();
-        second.add(a1);
-        second.add(a2);
+        var secondBuilder = AttributeSet.builder();
+        secondBuilder.add(a1);
+        secondBuilder.add(a2);
 
+        var second = secondBuilder.build();
         assertEquals(first, second);
         assertEquals(second, first);
 
-        AttributeSet third = new AttributeSet();
-        third.add(a("1"));
-        third.add(a("2"));
+        var thirdBuilder = AttributeSet.builder();
+        thirdBuilder.add(a("1"));
+        thirdBuilder.add(a("2"));
 
+        AttributeSet third = thirdBuilder.build();
         assertNotEquals(first, third);
         assertNotEquals(third, first);
 
         assertEquals(AttributeSet.EMPTY, AttributeSet.EMPTY);
         assertEquals(AttributeSet.EMPTY, first.intersect(third));
         assertEquals(third.intersect(first), AttributeSet.EMPTY);
+    }
+
+    public void testSetIsImmutable() {
+        AttributeSet set = AttributeSet.of(a("1"), a("2"));
+        expectThrows(UnsupportedOperationException.class, () -> set.add(a("3")));
+        expectThrows(UnsupportedOperationException.class, () -> set.remove(a("1")));
+        expectThrows(UnsupportedOperationException.class, () -> set.addAll(set));
+        expectThrows(UnsupportedOperationException.class, () -> set.retainAll(set));
+        expectThrows(UnsupportedOperationException.class, () -> set.removeAll(set));
+        expectThrows(UnsupportedOperationException.class, set::clear);
+        expectThrows(UnsupportedOperationException.class, () -> set.removeIf((x -> true)));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
@@ -96,7 +96,7 @@ public final class CombineProjections extends OptimizerRules.OptimizerRule<Unary
         List<? extends NamedExpression> upperProjection,
         List<? extends NamedExpression> lowerAggregations
     ) {
-        AttributeSet seen = new AttributeSet();
+        AttributeSet.Builder seen = AttributeSet.builder();
         for (NamedExpression upper : upperProjection) {
             Expression unwrapped = Alias.unwrap(upper);
             // projection contains an inner alias (point to an existing fields inside the projection)
@@ -117,20 +117,21 @@ public final class CombineProjections extends OptimizerRules.OptimizerRule<Unary
     private static List<NamedExpression> combineProjections(List<? extends NamedExpression> upper, List<? extends NamedExpression> lower) {
 
         // collect named expressions declaration in the lower list
-        AttributeMap<NamedExpression> namedExpressions = new AttributeMap<>();
+        AttributeMap.Builder<NamedExpression> namedExpressionsBuilder = AttributeMap.builder();
         // while also collecting the alias map for resolving the source (f1 = 1, f2 = f1, etc..)
-        AttributeMap<Expression> aliases = new AttributeMap<>();
+        AttributeMap.Builder<Expression> aliasesBuilder = AttributeMap.builder();
         for (NamedExpression ne : lower) {
             // record the alias
-            aliases.put(ne.toAttribute(), Alias.unwrap(ne));
+            aliasesBuilder.put(ne.toAttribute(), Alias.unwrap(ne));
 
             // record named expression as is
             if (ne instanceof Alias as) {
                 Expression child = as.child();
-                namedExpressions.put(ne.toAttribute(), as.replaceChild(aliases.resolve(child, child)));
+                namedExpressionsBuilder.put(ne.toAttribute(), as.replaceChild(aliasesBuilder.build().resolve(child, child)));
             }
         }
         List<NamedExpression> replaced = new ArrayList<>();
+        var namedExpressions = namedExpressionsBuilder.build();
 
         // replace any matching attribute with a lower alias (if there's a match)
         // but clean-up non-top aliases at the end
@@ -149,12 +150,13 @@ public final class CombineProjections extends OptimizerRules.OptimizerRule<Unary
             || upperGroupings.stream().anyMatch(group -> group.anyMatch(expr -> expr instanceof Categorize)) == false
             : "CombineProjections only tested with a single CATEGORIZE with no additional groups";
         // Collect the alias map for resolving the source (f1 = 1, f2 = f1, etc..)
-        AttributeMap<Attribute> aliases = new AttributeMap<>();
+        AttributeMap.Builder<Attribute> aliasesBuilder = AttributeMap.builder();
         for (NamedExpression ne : lowerProjections) {
             // Record the aliases.
             // Projections are just aliases for attributes, so casting is safe.
-            aliases.put(ne.toAttribute(), (Attribute) Alias.unwrap(ne));
+            aliasesBuilder.put(ne.toAttribute(), (Attribute) Alias.unwrap(ne));
         }
+        var aliases = aliasesBuilder.build();
 
         // Propagate any renames from the lower projection into the upper groupings.
         // This can lead to duplicates: e.g.
@@ -180,18 +182,19 @@ public final class CombineProjections extends OptimizerRules.OptimizerRule<Unary
         List<? extends NamedExpression> oldAggs,
         List<? extends NamedExpression> newAggs
     ) {
-        AttributeMap<Expression> removedAliases = new AttributeMap<>();
-        AttributeSet currentAliases = new AttributeSet(Expressions.asAttributes(newAggs));
+        AttributeMap.Builder<Expression> removedAliasesBuilder = AttributeMap.builder();
+        AttributeSet currentAliases = AttributeSet.of(Expressions.asAttributes(newAggs));
 
         // record only removed aliases
         for (NamedExpression ne : oldAggs) {
             if (ne instanceof Alias alias) {
                 var attr = ne.toAttribute();
                 if (currentAliases.contains(attr) == false) {
-                    removedAliases.put(attr, alias.child());
+                    removedAliasesBuilder.put(attr, alias.child());
                 }
             }
         }
+        var removedAliases = removedAliasesBuilder.build();
 
         if (removedAliases.isEmpty()) {
             return groupings;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEvalFoldables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEvalFoldables.java
@@ -26,9 +26,9 @@ public final class PropagateEvalFoldables extends ParameterizedRule<LogicalPlan,
 
     @Override
     public LogicalPlan apply(LogicalPlan plan, LogicalOptimizerContext ctx) {
-        var collectRefs = new AttributeMap<Expression>();
+        AttributeMap.Builder<Expression> collectRefsBuilder = AttributeMap.builder();
 
-        java.util.function.Function<ReferenceAttribute, Expression> replaceReference = r -> collectRefs.resolve(r, r);
+        java.util.function.Function<ReferenceAttribute, Expression> replaceReference = r -> collectRefsBuilder.build().resolve(r, r);
 
         // collect aliases bottom-up
         plan.forEachExpressionUp(Alias.class, a -> {
@@ -40,10 +40,10 @@ public final class PropagateEvalFoldables extends ParameterizedRule<LogicalPlan,
                 shouldCollect = c.foldable();
             }
             if (shouldCollect) {
-                collectRefs.put(a.toAttribute(), Literal.of(ctx.foldCtx(), c));
+                collectRefsBuilder.put(a.toAttribute(), Literal.of(ctx.foldCtx(), c));
             }
         });
-        if (collectRefs.isEmpty()) {
+        if (collectRefsBuilder.isEmpty()) {
             return plan;
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -35,7 +35,7 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
     @Override
     public LogicalPlan apply(LogicalPlan plan) {
         // track used references
-        var used = plan.outputSet();
+        var used = plan.outputSet().asBuilder();
         // while going top-to-bottom (upstream)
         var pl = plan.transformDown(p -> {
             // Note: It is NOT required to do anything special for binary plans like JOINs. It is perfectly fine that transformDown descends
@@ -126,7 +126,7 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
      * Prunes attributes from the list not found in the given set.
      * Returns null if no changed occurred.
      */
-    private static <N extends NamedExpression> List<N> removeUnused(List<N> named, AttributeSet used) {
+    private static <N extends NamedExpression> List<N> removeUnused(List<N> named, AttributeSet.Builder used) {
         var clone = new ArrayList<>(named);
         var it = clone.listIterator(clone.size());
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFilters.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFilters.java
@@ -68,11 +68,11 @@ public final class PushDownAndCombineFilters extends OptimizerRules.OptimizerRul
             plan = maybePushDownPastUnary(filter, eval, evalAliases::containsKey, resolveRenames);
         } else if (child instanceof RegexExtract re) {
             // Push down filters that do not rely on attributes created by RegexExtract
-            var attributes = new AttributeSet(Expressions.asAttributes(re.extractedFields()));
+            var attributes = AttributeSet.of(Expressions.asAttributes(re.extractedFields()));
             plan = maybePushDownPastUnary(filter, re, attributes::contains, NO_OP);
         } else if (child instanceof Enrich enrich) {
             // Push down filters that do not rely on attributes created by Enrich
-            var attributes = new AttributeSet(Expressions.asAttributes(enrich.enrichFields()));
+            var attributes = AttributeSet.of(Expressions.asAttributes(enrich.enrichFields()));
             plan = maybePushDownPastUnary(filter, enrich, attributes::contains, NO_OP);
         } else if (child instanceof Project) {
             return PushDownUtils.pushDownPastProject(filter);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownUtils.java
@@ -149,13 +149,13 @@ class PushDownUtils {
         Set<String> attributeNamesToRename,
         List<? extends Expression> expressions
     ) {
-        AttributeMap<Alias> aliasesForReplacedAttributes = new AttributeMap<>();
+        AttributeMap.Builder<Alias> aliasesForReplacedAttributesBuilder = AttributeMap.builder();
         List<Expression> rewrittenExpressions = new ArrayList<>();
 
         for (Expression expr : expressions) {
             rewrittenExpressions.add(expr.transformUp(Attribute.class, attr -> {
                 if (attributeNamesToRename.contains(attr.name())) {
-                    Alias renamedAttribute = aliasesForReplacedAttributes.computeIfAbsent(attr, a -> {
+                    Alias renamedAttribute = aliasesForReplacedAttributesBuilder.computeIfAbsent(attr, a -> {
                         String tempName = TemporaryNameUtils.locallyUniqueTemporaryName(a.name(), "temp_name");
                         return new Alias(a.source(), tempName, a, null, true);
                     });
@@ -166,7 +166,7 @@ class PushDownUtils {
             }));
         }
 
-        return new AttributeReplacement(rewrittenExpressions, aliasesForReplacedAttributes);
+        return new AttributeReplacement(rewrittenExpressions, aliasesForReplacedAttributesBuilder.build());
     }
 
     private static Map<String, String> newNamesForConflictingAttributes(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAggregateAggExpressionWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAggregateAggExpressionWithEval.java
@@ -51,8 +51,9 @@ public final class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.
     @Override
     protected LogicalPlan rule(Aggregate aggregate) {
         // build alias map
-        AttributeMap<Expression> aliases = new AttributeMap<>();
-        aggregate.forEachExpressionUp(Alias.class, a -> aliases.put(a.toAttribute(), a.child()));
+        AttributeMap.Builder<Expression> aliasesBuilder = AttributeMap.builder();
+        aggregate.forEachExpressionUp(Alias.class, a -> aliasesBuilder.put(a.toAttribute(), a.child()));
+        var aliases = aliasesBuilder.build();
 
         // Build Categorize grouping functions map.
         // Functions like BUCKET() shouldn't reach this point,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateMetricsAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateMetricsAggregate.java
@@ -215,7 +215,7 @@ public final class TranslateMetricsAggregate extends OptimizerRules.OptimizerRul
 
     private static Aggregate toStandardAggregate(Aggregate metrics) {
         final LogicalPlan child = metrics.child().transformDown(EsRelation.class, r -> {
-            var attributes = new ArrayList<>(new AttributeSet(metrics.inputSet()));
+            var attributes = new ArrayList<>(AttributeSet.of(metrics.inputSet()));
             attributes.removeIf(a -> a.name().equals(MetadataAttribute.TSID_FIELD));
             if (attributes.stream().noneMatch(a -> a.name().equals(MetadataAttribute.TIMESTAMP_FIELD))) {
                 attributes.removeIf(a -> a.name().equals(MetadataAttribute.TIMESTAMP_FIELD));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/InferIsNotNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/InferIsNotNull.java
@@ -47,17 +47,17 @@ public class InferIsNotNull extends Rule<LogicalPlan, LogicalPlan> {
     @Override
     public LogicalPlan apply(LogicalPlan plan) {
         // the alias map is shared across the whole plan
-        AttributeMap<Expression> aliases = new AttributeMap<>();
+        AttributeMap.Builder<Expression> aliasesBuilder = AttributeMap.builder();
         // traverse bottom-up to pick up the aliases as we go
-        plan = plan.transformUp(p -> inspectPlan(p, aliases));
+        plan = plan.transformUp(p -> inspectPlan(p, aliasesBuilder));
         return plan;
     }
 
-    private LogicalPlan inspectPlan(LogicalPlan plan, AttributeMap<Expression> aliases) {
+    private LogicalPlan inspectPlan(LogicalPlan plan, AttributeMap.Builder<Expression> aliasesBuilder) {
         // inspect just this plan properties
-        plan.forEachExpression(Alias.class, a -> aliases.put(a.toAttribute(), a.child()));
+        plan.forEachExpression(Alias.class, a -> aliasesBuilder.put(a.toAttribute(), a.child()));
         // now go about finding isNull/isNotNull
-        LogicalPlan newPlan = plan.transformExpressionsOnlyUp(IsNotNull.class, inn -> inferNotNullable(inn, aliases));
+        LogicalPlan newPlan = plan.transformExpressionsOnlyUp(IsNotNull.class, inn -> inferNotNullable(inn, aliasesBuilder.build()));
         return newPlan;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToSource.java
@@ -74,13 +74,13 @@ public class PushStatsToSource extends PhysicalOptimizerRules.ParameterizedOptim
         AggregateExec aggregate,
         LocalPhysicalOptimizerContext context
     ) {
-        AttributeMap<EsStatsQueryExec.Stat> stats = new AttributeMap<>();
+        AttributeMap.Builder<EsStatsQueryExec.Stat> statsBuilder = AttributeMap.builder();
         Tuple<List<Attribute>, List<EsStatsQueryExec.Stat>> tuple = new Tuple<>(new ArrayList<>(), new ArrayList<>());
 
         if (aggregate.groupings().isEmpty()) {
             for (NamedExpression agg : aggregate.aggregates()) {
                 var attribute = agg.toAttribute();
-                EsStatsQueryExec.Stat stat = stats.computeIfAbsent(attribute, a -> {
+                EsStatsQueryExec.Stat stat = statsBuilder.computeIfAbsent(attribute, a -> {
                     if (agg instanceof Alias as) {
                         Expression child = as.child();
                         if (child instanceof Count count) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QueryPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QueryPlan.java
@@ -41,7 +41,7 @@ public abstract class QueryPlan<PlanType extends QueryPlan<PlanType>> extends No
 
     public AttributeSet outputSet() {
         if (lazyOutputSet == null) {
-            lazyOutputSet = new AttributeSet(output());
+            lazyOutputSet = AttributeSet.of(output());
         }
         return lazyOutputSet;
     }
@@ -52,7 +52,7 @@ public abstract class QueryPlan<PlanType extends QueryPlan<PlanType>> extends No
             for (PlanType child : children()) {
                 attrs.addAll(child.output());
             }
-            lazyInputSet = new AttributeSet(attrs);
+            lazyInputSet = AttributeSet.of(attrs);
         }
         return lazyInputSet;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
@@ -82,7 +82,7 @@ public class Eval extends UnaryPlan implements GeneratingPlan<Eval>, PostAnalysi
     }
 
     public static AttributeSet computeReferences(List<Alias> fields) {
-        AttributeSet generated = new AttributeSet(asAttributes(fields));
+        AttributeSet generated = AttributeSet.of(asAttributes(fields));
         return Expressions.references(fields).subtract(generated);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnaryPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnaryPlan.java
@@ -44,12 +44,18 @@ public abstract class UnaryPlan extends LogicalPlan {
         return child.output();
     }
 
+    @Override
     public AttributeSet outputSet() {
         if (lazyOutputSet == null) {
             List<Attribute> output = output();
-            lazyOutputSet = (output == child.output() ? child.outputSet() : new AttributeSet(output));
+            lazyOutputSet = output == child.output() ? child.outputSet() : AttributeSet.of(output);
         }
         return lazyOutputSet;
+    }
+
+    @Override
+    public AttributeSet inputSet() {
+        return child.outputSet();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/Join.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/Join.java
@@ -136,7 +136,7 @@ public class Join extends BinaryPlan implements PostAnalysisVerificationAware, S
         // TODO: make the other side nullable
         if (LEFT.equals(joinType)) {
             // right side becomes nullable and overrides left except for join keys, which we preserve from the left
-            AttributeSet rightKeys = new AttributeSet(config.rightFields());
+            AttributeSet rightKeys = AttributeSet.of(config.rightFields());
             List<Attribute> rightOutputWithoutMatchFields = rightOutput.stream().filter(attr -> rightKeys.contains(attr) == false).toList();
             output = mergeOutputAttributes(rightOutputWithoutMatchFields, leftOutput);
         } else {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/AggregateExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/AggregateExec.java
@@ -185,8 +185,8 @@ public class AggregateExec extends UnaryExec implements EstimatesRowSize {
     @Override
     protected AttributeSet computeReferences() {
         return mode.isInputPartial()
-            ? new AttributeSet(intermediateAttributes)
-            : Aggregate.computeReferences(aggregates, groupings).subtract(new AttributeSet(ordinalAttributes()));
+            ? AttributeSet.of(intermediateAttributes)
+            : Aggregate.computeReferences(aggregates, groupings).subtract(AttributeSet.of(ordinalAttributes()));
     }
 
     /** Returns the attributes that can be loaded from ordinals -- no explicit extraction is needed */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
@@ -108,7 +108,7 @@ public class FieldExtractExec extends UnaryExec implements EstimatesRowSize {
 
     @Override
     protected AttributeSet computeReferences() {
-        return sourceAttribute != null ? new AttributeSet(sourceAttribute) : AttributeSet.EMPTY;
+        return sourceAttribute != null ? AttributeSet.of(sourceAttribute) : AttributeSet.EMPTY;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/HashJoinExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/HashJoinExec.java
@@ -91,8 +91,8 @@ public class HashJoinExec extends BinaryExec implements EstimatesRowSize {
 
     public Set<Attribute> addedFields() {
         if (lazyAddedFields == null) {
-            lazyAddedFields = new AttributeSet(output());
-            lazyAddedFields.removeAll(left().output());
+            var outputSet = AttributeSet.of(output());
+            lazyAddedFields = outputSet.subtract(AttributeSet.of(left().output()));
         }
         return lazyAddedFields;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/UnaryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/UnaryExec.java
@@ -45,10 +45,15 @@ public abstract class UnaryExec extends PhysicalPlan {
     public AttributeSet outputSet() {
         if (lazyOutputSet == null) {
             List<Attribute> output = output();
-            lazyOutputSet = (output == child.output() ? child.outputSet() : new AttributeSet(output));
+            lazyOutputSet = output == child.output() ? child.outputSet() : AttributeSet.of(output);
             return lazyOutputSet;
         }
         return lazyOutputSet;
+    }
+
+    @Override
+    public AttributeSet inputSet() {
+        return child.outputSet();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -53,9 +53,9 @@ final class AggregateMapper {
     }
 
     private List<NamedExpression> doMapping(List<? extends NamedExpression> aggregates, boolean grouping) {
-        AttributeMap<NamedExpression> attrToExpressions = new AttributeMap<>();
-        aggregates.stream().flatMap(ne -> map(ne, grouping)).forEach(ne -> attrToExpressions.put(ne.toAttribute(), ne));
-        return attrToExpressions.values().stream().toList();
+        AttributeMap.Builder<NamedExpression> attrToExpressionsBuilder = AttributeMap.builder();
+        aggregates.stream().flatMap(ne -> map(ne, grouping)).forEach(ne -> attrToExpressionsBuilder.put(ne.toAttribute(), ne));
+        return attrToExpressionsBuilder.build().values().stream().toList();
     }
 
     public List<NamedExpression> mapGrouping(NamedExpression aggregate) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -209,12 +209,12 @@ public class PlannerUtils {
                     var conjunctions = Predicates.splitAnd(f.condition());
                     // look only at expressions that contain literals and the target field
                     for (var exp : conjunctions) {
-                        var refs = new AttributeSet(exp.references());
+                        var refsBuilder = AttributeSet.builder().addAll(exp.references());
                         // remove literals or attributes that match by name
-                        boolean matchesField = refs.removeIf(e -> fieldName.test(e.name()));
+                        boolean matchesField = refsBuilder.removeIf(e -> fieldName.test(e.name()));
                         // the expression only contains the target reference
                         // and the expression is pushable (functions can be fully translated)
-                        if (matchesField && refs.isEmpty() && canPushToSource(exp)) {
+                        if (matchesField && refsBuilder.isEmpty() && canPushToSource(exp)) {
                             matches.add(exp);
                         }
                     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -560,55 +560,55 @@ public class EsqlSession {
             return result.withFieldNames(IndexResolver.ALL_FIELDS);
         }
 
-        AttributeSet references = new AttributeSet();
+        var referencesBuilder = AttributeSet.builder();
         // "keep" attributes are special whenever a wildcard is used in their name
         // ie "from test | eval lang = languages + 1 | keep *l" should consider both "languages" and "*l" as valid fields to ask for
-        AttributeSet keepCommandReferences = new AttributeSet();
-        AttributeSet keepJoinReferences = new AttributeSet();
+        var keepCommandRefsBuilder = AttributeSet.builder();
+        var keepJoinRefsBuilder = AttributeSet.builder();
         Set<String> wildcardJoinIndices = new java.util.HashSet<>();
 
         parsed.forEachDown(p -> {// go over each plan top-down
             if (p instanceof RegexExtract re) { // for Grok and Dissect
                 // remove other down-the-tree references to the extracted fields
                 for (Attribute extracted : re.extractedFields()) {
-                    references.removeIf(attr -> matchByName(attr, extracted.name(), false));
+                    referencesBuilder.removeIf(attr -> matchByName(attr, extracted.name(), false));
                 }
                 // but keep the inputs needed by Grok/Dissect
-                references.addAll(re.input().references());
+                referencesBuilder.addAll(re.input().references());
             } else if (p instanceof Enrich enrich) {
-                AttributeSet enrichRefs = Expressions.references(enrich.enrichFields());
-                enrichRefs = enrichRefs.combine(enrich.matchField().references());
+                AttributeSet enrichFieldRefs = Expressions.references(enrich.enrichFields());
+                AttributeSet.Builder enrichRefs = enrichFieldRefs.combine(enrich.matchField().references()).asBuilder();
                 // Enrich adds an EmptyAttribute if no match field is specified
                 // The exact name of the field will be added later as part of enrichPolicyMatchFields Set
                 enrichRefs.removeIf(attr -> attr instanceof EmptyAttribute);
-                references.addAll(enrichRefs);
+                referencesBuilder.addAll(enrichRefs);
             } else if (p instanceof LookupJoin join) {
                 if (join.config().type() instanceof JoinTypes.UsingJoinType usingJoinType) {
-                    keepJoinReferences.addAll(usingJoinType.columns());
+                    keepJoinRefsBuilder.addAll(usingJoinType.columns());
                 }
-                if (keepCommandReferences.isEmpty()) {
+                if (keepCommandRefsBuilder.isEmpty()) {
                     // No KEEP commands after the JOIN, so we need to mark this index for "*" field resolution
                     wildcardJoinIndices.add(((UnresolvedRelation) join.right()).indexPattern().indexPattern());
                 } else {
                     // Keep commands can reference the join columns with names that shadow aliases, so we block their removal
-                    keepJoinReferences.addAll(keepCommandReferences);
+                    keepJoinRefsBuilder.addAll(keepCommandRefsBuilder);
                 }
             } else {
-                references.addAll(p.references());
+                referencesBuilder.addAll(p.references());
                 if (p instanceof UnresolvedRelation ur && ur.indexMode() == IndexMode.TIME_SERIES) {
                     // METRICS aggs generally rely on @timestamp without the user having to mention it.
-                    references.add(new UnresolvedAttribute(ur.source(), MetadataAttribute.TIMESTAMP_FIELD));
+                    referencesBuilder.add(new UnresolvedAttribute(ur.source(), MetadataAttribute.TIMESTAMP_FIELD));
                 }
                 // special handling for UnresolvedPattern (which is not an UnresolvedAttribute)
                 p.forEachExpression(UnresolvedNamePattern.class, up -> {
                     var ua = new UnresolvedAttribute(up.source(), up.name());
-                    references.add(ua);
+                    referencesBuilder.add(ua);
                     if (p instanceof Keep) {
-                        keepCommandReferences.add(ua);
+                        keepCommandRefsBuilder.add(ua);
                     }
                 });
                 if (p instanceof Keep) {
-                    keepCommandReferences.addAll(p.references());
+                    keepCommandRefsBuilder.addAll(p.references());
                 }
             }
 
@@ -623,11 +623,11 @@ public class EsqlSession {
                 if (fieldNames.contains(alias.name())) {
                     return;
                 }
-                references.removeIf(attr -> matchByName(attr, alias.name(), keepCommandReferences.contains(attr)));
+                referencesBuilder.removeIf(attr -> matchByName(attr, alias.name(), keepCommandRefsBuilder.contains(attr)));
             });
         });
         // Add JOIN ON column references afterward to avoid Alias removal
-        references.addAll(keepJoinReferences);
+        referencesBuilder.addAll(keepJoinRefsBuilder);
         // If any JOIN commands need wildcard field-caps calls, persist the index names
         if (wildcardJoinIndices.isEmpty() == false) {
             result = result.withWildcardJoinIndices(wildcardJoinIndices);
@@ -635,8 +635,8 @@ public class EsqlSession {
 
         // remove valid metadata attributes because they will be filtered out by the IndexResolver anyway
         // otherwise, in some edge cases, we will fail to ask for "*" (all fields) instead
-        references.removeIf(a -> a instanceof MetadataAttribute || MetadataAttribute.isSupported(a.name()));
-        Set<String> fieldNames = references.names();
+        referencesBuilder.removeIf(a -> a instanceof MetadataAttribute || MetadataAttribute.isSupported(a.name()));
+        Set<String> fieldNames = referencesBuilder.build().names();
 
         if (fieldNames.isEmpty() && enrichPolicyMatchFields.isEmpty()) {
             // there cannot be an empty list of fields, we'll ask the simplest and lightest one instead: _index

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -5389,11 +5389,11 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
                 renamingEval = as(enrich.child(), Eval.class);
             }
 
-            AttributeSet attributesCreatedInEval = new AttributeSet();
+            var attributesCreatedInEval = AttributeSet.builder();
             for (Alias field : renamingEval.fields()) {
                 attributesCreatedInEval.add(field.toAttribute());
             }
-            assertThat(attributesCreatedInEval, allOf(hasItem(renamed_emp_no), hasItem(renamed_salary), hasItem(renamed_emp_no2)));
+            assertThat(attributesCreatedInEval.build(), allOf(hasItem(renamed_emp_no), hasItem(renamed_salary), hasItem(renamed_emp_no2)));
 
             assertThat(renamingEval.fields().size(), anyOf(equalTo(2), equalTo(4))); // 4 for EVAL, 3 for the other overwritingCommands
             // emp_no ASC nulls first


### PR DESCRIPTION
This will allow reusing them in the plan analysis and skip recreating them in UnaryPlan/UnaryExec when not needed. Introduce/adjust builders for them, which are now the only way to use a modifiable map/set.

Related #124395

(cherry picked from commit 2b512bc58a240f58f5b19af5d497b9b6502d64d4)
