### PR TITLE
Data stream lifecycle does not record error in failure store rollover

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
@@ -11,8 +11,10 @@ package org.elasticsearch.datastreams.lifecycle;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.rollover.Condition;
+import org.elasticsearch.action.admin.indices.rollover.RolloverAction;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConditions;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
+import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -23,7 +25,10 @@ import org.elasticsearch.action.datastreams.lifecycle.ExplainIndexDataStreamLife
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.DataStreamFailureStore;
 import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
+import org.elasticsearch.cluster.metadata.DataStreamOptions;
+import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -31,6 +36,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -45,6 +51,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.backingIndexEqualTo;
+import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.dataStreamIndexEqualTo;
 import static org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.DEFAULT_TIMESTAMP_FIELD;
 import static org.elasticsearch.datastreams.lifecycle.DataStreamLifecycleServiceIT.TestSystemDataStreamPlugin.SYSTEM_DATA_STREAM_NAME;
 import static org.elasticsearch.datastreams.lifecycle.DataStreamLifecycleServiceIT.TestSystemDataStreamPlugin.SYSTEM_DATA_STREAM_RETENTION_DAYS;
@@ -64,7 +71,8 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
         return List.of(
             DataStreamsPlugin.class,
             MockTransportService.TestPlugin.class,
-            DataStreamLifecycleServiceIT.TestSystemDataStreamPlugin.class
+            DataStreamLifecycleServiceIT.TestSystemDataStreamPlugin.class,
+            MapperExtrasPlugin.class
         );
     }
 
@@ -238,12 +246,27 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
         }
     }
 
-    public void testExplainLifecycleForIndicesWithErrors() throws Exception {
-        // empty lifecycle contains the default rollover
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
-
-        putComposableIndexTemplate("id1", null, List.of("metrics-foo*"), null, null, lifecycle);
-
+    public void testExplainFailuresLifecycle() throws Exception {
+        // Failure indices are always managed unless explicitly disabled.
+        putComposableIndexTemplate(
+            "id1",
+            """
+                {
+                    "properties": {
+                      "@timestamp" : {
+                        "type": "date"
+                      },
+                      "count": {
+                        "type": "long"
+                      }
+                    }
+                }""",
+            List.of("metrics-foo*"),
+            null,
+            null,
+            DataStreamLifecycle.Template.DEFAULT,
+            new DataStreamOptions.Template(new DataStreamFailureStore.Template(true))
+        );
         String dataStreamName = "metrics-foo";
         CreateDataStreamAction.Request createDataStreamRequest = new CreateDataStreamAction.Request(
             TEST_REQUEST_TIMEOUT,
@@ -252,6 +275,142 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
         );
         client().execute(CreateDataStreamAction.INSTANCE, createDataStreamRequest).get();
 
+        indexFailedDocs(dataStreamName, 1);
+
+        List<String> failureIndices = waitForDataStreamIndices(dataStreamName, 1, true);
+        String firstGenerationIndex = failureIndices.get(0);
+        assertThat(firstGenerationIndex, DataStreamTestHelper.dataStreamIndexEqualTo(dataStreamName, 2, true));
+
+        indexFailedDocs(dataStreamName, 1);
+        failureIndices = waitForDataStreamIndices(dataStreamName, 2, true);
+        String secondGenerationIndex = failureIndices.get(1);
+        assertThat(secondGenerationIndex, DataStreamTestHelper.dataStreamIndexEqualTo(dataStreamName, 3, true));
+
+        {
+            ExplainDataStreamLifecycleAction.Request explainIndicesRequest = new ExplainDataStreamLifecycleAction.Request(
+                TEST_REQUEST_TIMEOUT,
+                new String[] { firstGenerationIndex, secondGenerationIndex }
+            );
+            ExplainDataStreamLifecycleAction.Response response = client().execute(
+                ExplainDataStreamLifecycleAction.INSTANCE,
+                explainIndicesRequest
+            ).actionGet();
+            assertThat(response.getIndices().size(), is(2));
+            // we requested the explain for indices with the default include_details=false
+            assertThat(response.getRolloverConfiguration(), nullValue());
+            for (ExplainIndexDataStreamLifecycle explainIndex : response.getIndices()) {
+                assertThat(explainIndex.isManagedByLifecycle(), is(true));
+                assertThat(explainIndex.getIndexCreationDate(), notNullValue());
+                assertThat(explainIndex.getLifecycle(), notNullValue());
+                assertThat(explainIndex.getLifecycle().dataRetention(), nullValue());
+                if (internalCluster().numDataNodes() > 1) {
+                    // If the number of nodes is 1 then the cluster will be yellow so forcemerge will report an error if it has run
+                    assertThat(explainIndex.getError(), nullValue());
+                }
+
+                if (explainIndex.getIndex().equals(firstGenerationIndex)) {
+                    // first generation index was rolled over
+                    assertThat(explainIndex.getRolloverDate(), notNullValue());
+                    assertThat(explainIndex.getTimeSinceRollover(System::currentTimeMillis), notNullValue());
+                    assertThat(explainIndex.getGenerationTime(System::currentTimeMillis), notNullValue());
+                } else {
+                    // the write index has not been rolled over yet
+                    assertThat(explainIndex.getRolloverDate(), nullValue());
+                    assertThat(explainIndex.getTimeSinceRollover(System::currentTimeMillis), nullValue());
+                    assertThat(explainIndex.getGenerationTime(System::currentTimeMillis), nullValue());
+                }
+            }
+        }
+
+        {
+            // let's also explain with include_defaults=true
+            ExplainDataStreamLifecycleAction.Request explainIndicesRequest = new ExplainDataStreamLifecycleAction.Request(
+                TEST_REQUEST_TIMEOUT,
+                new String[] { firstGenerationIndex },
+                true
+            );
+            ExplainDataStreamLifecycleAction.Response response = client().execute(
+                ExplainDataStreamLifecycleAction.INSTANCE,
+                explainIndicesRequest
+            ).actionGet();
+            assertThat(response.getIndices().size(), is(1));
+            RolloverConfiguration rolloverConfiguration = response.getRolloverConfiguration();
+            assertThat(rolloverConfiguration, notNullValue());
+            Map<String, Condition<?>> conditions = rolloverConfiguration.resolveRolloverConditions(null).getConditions();
+            assertThat(conditions.size(), is(2));
+            assertThat(conditions.get(RolloverConditions.MAX_DOCS_FIELD.getPreferredName()).value(), is(1L));
+            assertThat(conditions.get(RolloverConditions.MIN_DOCS_FIELD.getPreferredName()).value(), is(1L));
+        }
+
+        {
+            // Let's also explain using the data stream name
+            ExplainDataStreamLifecycleAction.Request explainIndicesRequest = new ExplainDataStreamLifecycleAction.Request(
+                TEST_REQUEST_TIMEOUT,
+                new String[] { dataStreamName }
+            );
+            ExplainDataStreamLifecycleAction.Response response = client().execute(
+                ExplainDataStreamLifecycleAction.INSTANCE,
+                explainIndicesRequest
+            ).actionGet();
+            assertThat(response.getIndices().size(), is(1));
+            for (ExplainIndexDataStreamLifecycle explainIndex : response.getIndices()) {
+                assertThat(explainIndex.isManagedByLifecycle(), is(true));
+                assertThat(explainIndex.getIndexCreationDate(), notNullValue());
+                assertThat(explainIndex.getLifecycle(), notNullValue());
+                assertThat(explainIndex.getLifecycle().dataRetention(), nullValue());
+
+                if (internalCluster().numDataNodes() > 1) {
+                    // If the number of nodes is 1 then the cluster will be yellow so forcemerge will report an error if it has run
+                    assertThat(explainIndex.getError(), nullValue());
+                }
+
+                if (explainIndex.getIndex().equals(firstGenerationIndex)) {
+                    // first generation index was rolled over
+                    assertThat(explainIndex.getRolloverDate(), notNullValue());
+                    assertThat(explainIndex.getTimeSinceRollover(System::currentTimeMillis), notNullValue());
+                    assertThat(explainIndex.getGenerationTime(System::currentTimeMillis), notNullValue());
+                } else {
+                    // the write index has not been rolled over yet
+                    assertThat(explainIndex.getRolloverDate(), nullValue());
+                    assertThat(explainIndex.getTimeSinceRollover(System::currentTimeMillis), nullValue());
+                    assertThat(explainIndex.getGenerationTime(System::currentTimeMillis), nullValue());
+                }
+            }
+        }
+    }
+
+    public void testExplainLifecycleForIndicesWithErrors() throws Exception {
+        // empty lifecycle contains the default rollover
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+
+        putComposableIndexTemplate(
+            "id1",
+            """
+                {
+                    "properties": {
+                      "@timestamp" : {
+                        "type": "date"
+                      },
+                      "count": {
+                        "type": "long"
+                      }
+                    }
+                }""",
+            List.of("metrics-foo*"),
+            null,
+            null,
+            lifecycle,
+            new DataStreamOptions.Template(new DataStreamFailureStore.Template(true))
+        );
+        String dataStreamName = "metrics-foo";
+        CreateDataStreamAction.Request createDataStreamRequest = new CreateDataStreamAction.Request(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            dataStreamName
+        );
+        safeGet(client().execute(CreateDataStreamAction.INSTANCE, createDataStreamRequest));
+        safeGet(client().execute(RolloverAction.INSTANCE, new RolloverRequest(dataStreamName + "::failures", null)));
+
         indexDocs(dataStreamName, 1);
 
         // let's allow one rollover to go through
@@ -259,39 +418,49 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
         String firstGenerationIndex = backingIndices.get(0);
         assertThat(firstGenerationIndex, backingIndexEqualTo(dataStreamName, 1));
         String secondGenerationIndex = backingIndices.get(1);
-        assertThat(secondGenerationIndex, backingIndexEqualTo(dataStreamName, 2));
+        assertThat(secondGenerationIndex, backingIndexEqualTo(dataStreamName, 3));
+        // let's ensure that the failure store is initialised
+        List<String> failureIndices = waitForDataStreamIndices(dataStreamName, 1, true);
+        String firstGenerationFailureIndex = failureIndices.get(0);
+        assertThat(firstGenerationFailureIndex, dataStreamIndexEqualTo(dataStreamName, 2, true));
 
         // prevent new indices from being created (ie. future rollovers)
         updateClusterSettings(Settings.builder().put(SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey(), 1));
 
         indexDocs(dataStreamName, 1);
+        indexFailedDocs(dataStreamName, 1);
 
         assertBusy(() -> {
             ExplainDataStreamLifecycleAction.Request explainIndicesRequest = new ExplainDataStreamLifecycleAction.Request(
                 TEST_REQUEST_TIMEOUT,
-                new String[] { secondGenerationIndex }
+                new String[] { secondGenerationIndex, firstGenerationFailureIndex }
             );
             ExplainDataStreamLifecycleAction.Response response = client().execute(
                 ExplainDataStreamLifecycleAction.INSTANCE,
                 explainIndicesRequest
             ).actionGet();
-            assertThat(response.getIndices().size(), is(1));
+            assertThat(response.getIndices().size(), is(2));
             // we requested the explain for indices with the default include_details=false
             assertThat(response.getRolloverConfiguration(), nullValue());
-            for (ExplainIndexDataStreamLifecycle explainIndex : response.getIndices()) {
-                assertThat(explainIndex.getIndex(), is(secondGenerationIndex));
-                assertThat(explainIndex.isManagedByLifecycle(), is(true));
-                assertThat(explainIndex.getIndexCreationDate(), notNullValue());
-                assertThat(explainIndex.getLifecycle(), notNullValue());
-                assertThat(explainIndex.getLifecycle().dataRetention(), nullValue());
-                assertThat(explainIndex.getRolloverDate(), nullValue());
-                assertThat(explainIndex.getTimeSinceRollover(System::currentTimeMillis), nullValue());
+            for (int i = 0; i < 2; i++) {
+                ExplainIndexDataStreamLifecycle explainIndex = response.getIndices().get(i);
+                if (i == 0) {
+                    assertThat(explainIndex.getIndex(), is(secondGenerationIndex));
+                } else {
+                    assertThat(explainIndex.getIndex(), is(firstGenerationFailureIndex));
+                }
+                assertThat(explainIndex.getIndex(), explainIndex.isManagedByLifecycle(), is(true));
+                assertThat(explainIndex.getIndex(), explainIndex.getIndexCreationDate(), notNullValue());
+                assertThat(explainIndex.getIndex(), explainIndex.getLifecycle(), notNullValue());
+                assertThat(explainIndex.getIndex(), explainIndex.getLifecycle().dataRetention(), nullValue());
+                assertThat(explainIndex.getIndex(), explainIndex.getRolloverDate(), nullValue());
+                assertThat(explainIndex.getIndex(), explainIndex.getTimeSinceRollover(System::currentTimeMillis), nullValue());
                 // index has not been rolled over yet
-                assertThat(explainIndex.getGenerationTime(System::currentTimeMillis), nullValue());
+                assertThat(explainIndex.getIndex(), explainIndex.getGenerationTime(System::currentTimeMillis), nullValue());
 
-                assertThat(explainIndex.getError(), notNullValue());
-                assertThat(explainIndex.getError().error(), containsString("maximum normal shards open"));
-                assertThat(explainIndex.getError().retryCount(), greaterThanOrEqualTo(1));
+                assertThat(explainIndex.getIndex(), explainIndex.getError(), notNullValue());
+                assertThat(explainIndex.getIndex(), explainIndex.getError().error(), containsString("maximum normal shards open"));
+                assertThat(explainIndex.getIndex(), explainIndex.getError().retryCount(), greaterThanOrEqualTo(1));
             }
         });
 
@@ -301,21 +470,23 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
         assertBusy(() -> {
             ExplainDataStreamLifecycleAction.Request explainIndicesRequest = new ExplainDataStreamLifecycleAction.Request(
                 TEST_REQUEST_TIMEOUT,
-                new String[] { secondGenerationIndex }
+                new String[] { secondGenerationIndex, firstGenerationFailureIndex }
             );
             ExplainDataStreamLifecycleAction.Response response = client().execute(
                 ExplainDataStreamLifecycleAction.INSTANCE,
                 explainIndicesRequest
             ).actionGet();
-            assertThat(response.getIndices().size(), is(1));
+            assertThat(response.getIndices().size(), is(2));
             if (internalCluster().numDataNodes() > 1) {
                 assertThat(response.getIndices().get(0).getError(), is(nullValue()));
+                assertThat(response.getIndices().get(1).getError(), is(nullValue()));
             } else {
                 /*
                  * If there is only one node in the cluster then the replica shard will never be allocated. So forcemerge will never
                  * succeed, and there will always be an error in the error store. This behavior is subject to change in the future.
                  */
                 assertThat(response.getIndices().get(0).getError(), is(notNullValue()));
+                assertThat(response.getIndices().get(1).getError(), is(nullValue()));
             }
         });
     }
@@ -390,6 +561,29 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
         indicesAdmin().refresh(new RefreshRequest(dataStream)).actionGet();
     }
 
+    private void indexFailedDocs(String dataStream, int numDocs) {
+        BulkRequest bulkRequest = new BulkRequest();
+        for (int i = 0; i < numDocs; i++) {
+            String value = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(System.currentTimeMillis());
+            bulkRequest.add(
+                new IndexRequest(dataStream).opType(DocWriteRequest.OpType.CREATE)
+                    .source(
+                        String.format(Locale.ROOT, "{\"%s\":\"%s\", \"count\":\"not-a-number\"}", DEFAULT_TIMESTAMP_FIELD, value),
+                        XContentType.JSON
+                    )
+            );
+        }
+        BulkResponse bulkResponse = safeGet(client().bulk(bulkRequest));
+        assertThat(bulkResponse.getItems().length, equalTo(numDocs));
+        String failureIndexPrefix = DataStream.FAILURE_STORE_PREFIX + dataStream;
+        for (BulkItemResponse itemResponse : bulkResponse) {
+            assertThat(itemResponse.getFailureMessage(), nullValue());
+            assertThat(itemResponse.status(), equalTo(RestStatus.CREATED));
+            assertThat(itemResponse.getIndex(), startsWith(failureIndexPrefix));
+        }
+        safeGet(indicesAdmin().refresh(new RefreshRequest(dataStream)));
+    }
+
     static void putComposableIndexTemplate(
         String id,
         @Nullable String mappings,
@@ -397,6 +591,18 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
         @Nullable Settings settings,
         @Nullable Map<String, Object> metadata,
         @Nullable DataStreamLifecycle.Template lifecycle
+    ) throws IOException {
+        putComposableIndexTemplate(id, mappings, patterns, settings, metadata, lifecycle, null);
+    }
+
+    static void putComposableIndexTemplate(
+        String id,
+        @Nullable String mappings,
+        List<String> patterns,
+        @Nullable Settings settings,
+        @Nullable Map<String, Object> metadata,
+        @Nullable DataStreamLifecycle.Template lifecycle,
+        @Nullable DataStreamOptions.Template options
     ) throws IOException {
         TransportPutComposableIndexTemplateAction.Request request = new TransportPutComposableIndexTemplateAction.Request(id);
         request.indexTemplate(
@@ -407,6 +613,7 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
                         .settings(settings)
                         .mappings(mappings == null ? null : CompressedXContent.fromJSON(mappings))
                         .lifecycle(lifecycle)
+                        .dataStreamOptions(options)
                 )
                 .metadata(metadata)
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
@@ -1080,7 +1080,8 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
             public void onFailure(Exception e) {
                 ProjectMetadata latestProject = clusterService.state().metadata().projects().get(projectId);
                 DataStream dataStream = latestProject == null ? null : latestProject.dataStreams().get(resolvedRolloverTarget.resource());
-                if (dataStream == null || dataStream.getWriteIndex().getName().equals(writeIndexName) == false) {
+                boolean targetsFailureStore = IndexComponentSelector.FAILURES == resolvedRolloverTarget.selector();
+                if (dataStream == null || Objects.equals(getWriteIndexName(dataStream, targetsFailureStore), writeIndexName) == false) {
                     // the data stream has another write index so no point in recording an error for the previous write index we were
                     // attempting to roll over
                     // if there are persistent issues with rolling over this data stream, the next data stream lifecycle run will attempt to
@@ -1093,6 +1094,17 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
                 }
             }
         });
+    }
+
+    @Nullable
+    private String getWriteIndexName(DataStream dataStream, boolean failureStore) {
+        if (dataStream == null) {
+            return null;
+        }
+        if (failureStore) {
+            return dataStream.getWriteFailureIndex() == null ? null : dataStream.getWriteFailureIndex().getName();
+        }
+        return dataStream.getWriteIndex().getName();
     }
 
     private void updateIndexSetting(ProjectId projectId, UpdateSettingsRequest updateSettingsRequest, ActionListener<Void> listener) {

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -71,6 +71,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.DataStream.BACKING_INDEX_PREFIX;
 import static org.elasticsearch.cluster.metadata.DataStream.DATE_FORMATTER;
+import static org.elasticsearch.cluster.metadata.DataStream.FAILURE_STORE_PREFIX;
 import static org.elasticsearch.cluster.metadata.DataStream.getDefaultBackingIndexName;
 import static org.elasticsearch.cluster.metadata.DataStream.getDefaultFailureStoreName;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
@@ -629,27 +630,50 @@ public final class DataStreamTestHelper {
         return String.format(Locale.ROOT, "\\.ds-%s-(\\d{4}\\.\\d{2}\\.\\d{2}-)?%06d", dataStreamName, generation);
     }
 
+    /**
+     * Checks if the index name provided starts with the prefix ".ds-", continues with the data stream name
+     * till the next `-`, and after the last `-` it ends with a number that matches the generation.
+     * @param dataStreamName
+     * @param generation
+     * @return the matcher
+     */
     public static Matcher<String> backingIndexEqualTo(String dataStreamName, int generation) {
+        return dataStreamIndexEqualTo(dataStreamName, generation, false);
+    }
+
+    /**
+     * Checks if the index name provided starts with the prefix ".ds-" when failure store is false and ".fs-" when true, continues with
+     * the data stream name till the next `-`, and after the last `-` it ends with a number that matches the generation.
+     * @param dataStreamName
+     * @param generation
+     * @param failureStore, determines the prefix, ".ds-" when failure store is false and ".fs-" when true
+     * @return the matcher
+     */
+    public static Matcher<String> dataStreamIndexEqualTo(String dataStreamName, int generation, boolean failureStore) {
         return new TypeSafeMatcher<>() {
+            private final String prefix = failureStore ? FAILURE_STORE_PREFIX : BACKING_INDEX_PREFIX;
 
             @Override
             protected boolean matchesSafely(String backingIndexName) {
                 if (backingIndexName == null) {
                     return false;
                 }
-
+                String actualPrefix = backingIndexName.substring(0, prefix.length());
                 int indexOfLastDash = backingIndexName.lastIndexOf('-');
-                String actualDataStreamName = parseDataStreamName(backingIndexName, indexOfLastDash);
+                String actualDataStreamName = parseDataStreamName(backingIndexName, prefix, indexOfLastDash);
                 int actualGeneration = parseGeneration(backingIndexName, indexOfLastDash);
-                return actualDataStreamName.equals(dataStreamName) && actualGeneration == generation;
+                return actualPrefix.equals(prefix) && actualDataStreamName.equals(dataStreamName) && actualGeneration == generation;
             }
 
             @Override
             protected void describeMismatchSafely(String backingIndexName, Description mismatchDescription) {
+                String actualPrefix = backingIndexName.substring(0, prefix.length());
                 int indexOfLastDash = backingIndexName.lastIndexOf('-');
-                String dataStreamName = parseDataStreamName(backingIndexName, indexOfLastDash);
+                String dataStreamName = parseDataStreamName(backingIndexName, prefix, indexOfLastDash);
                 int generation = parseGeneration(backingIndexName, indexOfLastDash);
-                mismatchDescription.appendText(" was data stream name ")
+                mismatchDescription.appendText(" was prefix ")
+                    .appendValue(actualPrefix)
+                    .appendText(", data stream name ")
                     .appendValue(dataStreamName)
                     .appendText(" and generation ")
                     .appendValue(generation);
@@ -657,14 +681,16 @@ public final class DataStreamTestHelper {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("expected data stream name ")
+                description.appendText("expected prefix ")
+                    .appendValue(prefix)
+                    .appendText(", expected data stream name ")
                     .appendValue(dataStreamName)
                     .appendText(" and expected generation ")
                     .appendValue(generation);
             }
 
-            private static String parseDataStreamName(String backingIndexName, int indexOfLastDash) {
-                return backingIndexName.substring(4, backingIndexName.lastIndexOf('-', indexOfLastDash - 1));
+            private static String parseDataStreamName(String backingIndexName, String prefix, int indexOfLastDash) {
+                return backingIndexName.substring(prefix.length(), backingIndexName.lastIndexOf('-', indexOfLastDash - 1));
             }
 
             private static int parseGeneration(String backingIndexName, int indexOfLastDash) {


### PR DESCRIPTION
**Issue**
The data stream lifecycle does not register correctly rollover errors for failure store.

**Observed bahaviour**
When data stream lifecycle encounters a rollover error it records it unless it sees that the current write index of this data stream doesn't match the source index of the request. However, the write index check does not use the failure write index but the write backing index, so the failure gets ignored

**Desired behaviour**
When data stream lifecycle encounters a rollover error it will check the relevant write index before it determines if it should be recorded or not.
