### PR TITLE
[8.x] Remove spurious `NOMERGE` comment (#126231)

### DIFF
--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2ClientSettings.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2ClientSettings.java
@@ -69,7 +69,6 @@ final class Ec2ClientSettings {
         Property.NodeScope,
         Property.Deprecated
     );
-    // NOMERGE should we now reject this if set to `http` or just silently ignore it?
 
     /** The username of a proxy to connect to EC2 through. */
     static final Setting<SecureString> PROXY_USERNAME_SETTING = SecureSetting.secureString("discovery.ec2.proxy.username", null);


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Remove spurious `NOMERGE` comment (#126231)