### PR TITLE
[9.0] Remove fixed test from muted-tests.yml (#124088)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -128,8 +128,6 @@ tests:
 - class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
   method: testShardChangesNoOperation
   issue: https://github.com/elastic/elasticsearch/issues/118800
-- class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectoryRunAsIT
-  issue: https://github.com/elastic/elasticsearch/issues/115727
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
   issue: https://github.com/elastic/elasticsearch/issues/119508


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Remove fixed test from muted-tests.yml (#124088)