### PR TITLE
Backport docs-content#962

### DIFF
--- a/docs/reference/data-streams/logs.asciidoc
+++ b/docs/reference/data-streams/logs.asciidoc
@@ -14,7 +14,7 @@ stream. The exact impact varies by data set.
 [[how-to-use-logsds]]
 === Create a logs data stream
 
-IMPORTANT: Fleet integrations use <<index-templates,index templates>> managed by Elastic. To modify thsee backing templates, update their {observability-guide}/logs-index-template.html#custom-logs-template-edit[composite `custom` templates].
+IMPORTANT: Fleet integrations use <<index-templates,index templates>> managed by Elastic. To modify these backing templates, update their {observability-guide}/logs-index-template.html#custom-logs-template-edit[composite `custom` templates].
 
 To create a logs data stream, set your <<index-templates,template>> `index.mode` to `logsdb`:
 

--- a/docs/reference/data-streams/logs.asciidoc
+++ b/docs/reference/data-streams/logs.asciidoc
@@ -14,13 +14,15 @@ stream. The exact impact varies by data set.
 [[how-to-use-logsds]]
 === Create a logs data stream
 
+IMPORTANT: Fleet integrations use <<index-templates,index templates>> managed by Elastic. To modify thsee backing templates, update their https://www.elastic.co/guide/en/observability/current/logs-index-template.html#custom-logs-template-edit[composite `custom` templates].
+
 To create a logs data stream, set your <<index-templates,template>> `index.mode` to `logsdb`:
 
 [source,console]
 ----
 PUT _index_template/my-index-template
 {
-  "index_patterns": ["logs-*"],
+  "index_patterns": ["my-datastream-*"],
   "data_stream": { },
   "template": {
      "settings": {

--- a/docs/reference/data-streams/logs.asciidoc
+++ b/docs/reference/data-streams/logs.asciidoc
@@ -14,7 +14,7 @@ stream. The exact impact varies by data set.
 [[how-to-use-logsds]]
 === Create a logs data stream
 
-IMPORTANT: Fleet integrations use <<index-templates,index templates>> managed by Elastic. To modify thsee backing templates, update their https://www.elastic.co/guide/en/observability/current/logs-index-template.html#custom-logs-template-edit[composite `custom` templates].
+IMPORTANT: Fleet integrations use <<index-templates,index templates>> managed by Elastic. To modify thsee backing templates, update their {observability-guide}/logs-index-template.html#custom-logs-template-edit[composite `custom` templates].
 
 To create a logs data stream, set your <<index-templates,template>> `index.mode` to `logsdb`:
 


### PR DESCRIPTION
👋🏽 howdy, team! 

This backports https://github.com/elastic/docs-content/pull/962 into v8.x docs (future tracked in https://github.com/elastic/integrations/issues/12298). 

🙏 In the Asciidocs>Markdown translation I need help knowing how to reference the Observability docs. cc: @lcawl 