### PR TITLE
[8.18] Backport docs-content#962 (#126242)

### DIFF
--- a/docs/reference/data-streams/logs.asciidoc
+++ b/docs/reference/data-streams/logs.asciidoc
@@ -14,13 +14,15 @@ stream. The exact impact varies by data set.
 [[how-to-use-logsds]]
 === Create a logs data stream
 
+IMPORTANT: Fleet integrations use <<index-templates,index templates>> managed by Elastic. To modify these backing templates, update their {observability-guide}/logs-index-template.html#custom-logs-template-edit[composite `custom` templates].
+
 To create a logs data stream, set your <<index-templates,template>> `index.mode` to `logsdb`:
 
 [source,console]
 ----
 PUT _index_template/my-index-template
 {
-  "index_patterns": ["logs-*"],
+  "index_patterns": ["my-datastream-*"],
   "data_stream": { },
   "template": {
      "settings": {


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Backport docs-content#962 (#126242)