### PR TITLE
Fix vector-tile tests when run on non-snapshot builds

### DIFF
--- a/x-pack/plugin/vector-tile/build.gradle
+++ b/x-pack/plugin/vector-tile/build.gradle
@@ -38,7 +38,6 @@ dependencies {
   clusterModules project(':modules:analysis-common')
   clusterModules project(':modules:legacy-geo')
   clusterModules project(':modules:lang-painless')
-  clusterModules project(':test:external-modules:test-error-query')
 }
 
 tasks.named("thirdPartyAudit").configure {

--- a/x-pack/plugin/vector-tile/build.gradle
+++ b/x-pack/plugin/vector-tile/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   clusterModules project(':modules:analysis-common')
   clusterModules project(':modules:legacy-geo')
   clusterModules project(':modules:lang-painless')
+  clusterModules project(':test:external-modules:test-error-query')
 }
 
 tasks.named("thirdPartyAudit").configure {

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -52,7 +52,6 @@ public class VectorTileRestIT extends ESRestTestCase {
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("vector-tile")
-        .module("test-error-query")
         .setting("xpack.license.self_generated.type", "trial")
         .build();
 

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -50,10 +50,19 @@ import java.util.List;
 public class VectorTileRestIT extends ESRestTestCase {
 
     @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .module("vector-tile")
-        .setting("xpack.license.self_generated.type", "trial")
-        .build();
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    private static ElasticsearchCluster buildCluster() {
+        var builder = ElasticsearchCluster.local().module("vector-tile").setting("xpack.license.self_generated.type", "trial");
+
+        if (Build.current().isSnapshot()) {
+            // This module is not available in non-snapshot builds
+            // The tests below that use it are disabled in non-snapshot builds
+            builder.module("test-error-query");
+        }
+
+        return builder.build();
+    }
 
     private static final String INDEX_POINTS = "index-points";
     private static final String INDEX_POLYGON = "index-polygon";

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -50,19 +50,11 @@ import java.util.List;
 public class VectorTileRestIT extends ESRestTestCase {
 
     @ClassRule
-    public static ElasticsearchCluster cluster = buildCluster();
-
-    private static ElasticsearchCluster buildCluster() {
-        var builder = ElasticsearchCluster.local().module("vector-tile").setting("xpack.license.self_generated.type", "trial");
-
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("vector-tile").apply(c -> {
         if (Build.current().isSnapshot()) {
-            // This module is not available in non-snapshot builds
-            // The tests below that use it are disabled in non-snapshot builds
-            builder.module("test-error-query");
+            c.module("test-error-query");
         }
-
-        return builder.build();
-    }
+    }).setting("xpack.license.self_generated.type", "trial").build();
 
     private static final String INDEX_POINTS = "index-points";
     private static final String INDEX_POLYGON = "index-polygon";


### PR DESCRIPTION
`test-error-query` module looks like it was mistakenly added in #125874 and is causing the tests to fail in non-snapshot builds.

Fixes #126086