### PR TITLE
[8.16] Backport docs-content#962 (#126242)

### DIFF
--- a/docs/reference/data-streams/logs.asciidoc
+++ b/docs/reference/data-streams/logs.asciidoc
@@ -20,13 +20,15 @@ The following features are enabled in a logs data stream:
 [[how-to-use-logsds]]
 === Create a logs data stream
 
-To create a logs data stream, set your index template  `index.mode` to `logsdb`:
+IMPORTANT: Fleet integrations use <<index-templates,index templates>> managed by Elastic. To modify these backing templates, update their {observability-guide}/logs-index-template.html#custom-logs-template-edit[composite `custom` templates].
+
+To create a logs data stream, set your <<index-templates,template>> `index.mode` to `logsdb`:
 
 [source,console]
 ----
 PUT _index_template/my-index-template
 {
-  "index_patterns": ["logs-*"],
+  "index_patterns": ["my-datastream-*"],
   "data_stream": { },
   "template": {
      "settings": {


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.16`:
 - [Backport docs-content#962 (#126242)](https://github.com/elastic/elasticsearch/pull/126242)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)