### PR TITLE
[Profiling] Don't use synthetic source for symbolization queues

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-executables.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-executables.json
@@ -7,12 +7,7 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "refresh_interval": "10s",
-        "hidden": true,
-        "mapping": {
-          "source": {
-            "mode": "synthetic"
-          }
-        }
+        "hidden": true
       }
     },
     "mappings": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-leafframes.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-leafframes.json
@@ -7,12 +7,7 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "refresh_interval": "10s",
-        "hidden": true,
-        "mapping": {
-          "source": {
-            "mode": "synthetic"
-          }
-        }
+        "hidden": true
       }
     },
     "mappings": {


### PR DESCRIPTION
Using synthetic source for the ephemeral symbolization queue indices `profiling-sq-leafframes` and `profiling-sq-executables` isn't needed, and even consumes CPU cycles unnecessarily when reading data.

A secondary issue is a side-effect of using synthetic source: in responses, the field names inside `_source` are "nested". If synthetic source is disabled, these field names are "dotted".
Since ES 8.17, synthetic source is automatically disabled outside enterprise subscriptions. 
This forces us to maintain two code pathes when parsing responses.
Switching away from using synthetic source allows having only one code path for parsing.
