### PR TITLE
Optimize slicing ReleasableBytesReference to avoid needless retention  of unused pages

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
@@ -121,9 +121,7 @@ public class InboundDecoder implements Releasable {
                 bytesConsumedThisDecode += maxBytesToConsume;
                 bytesConsumed += maxBytesToConsume;
                 if (maxBytesToConsume == remainingToConsume) {
-                    try (ReleasableBytesReference retained = reference.retainedSlice(0, maxBytesToConsume)) {
-                        fragmentConsumer.accept(retained);
-                    }
+                    fragmentConsumer.accept(reference.slice(0, maxBytesToConsume));
                 } else {
                     fragmentConsumer.accept(reference);
                 }


### PR DESCRIPTION
We can make slicing things like search hits where we cut many small buffers out of a large composite reference a lot more efficient in some cases by making the slice of a releasable reference itself releasable. This fixes the current situation where we could have composite buffer of many MB that is made up of e.g. 16k chunks but that we would retain in full if we were to slice even a single byte out of it in any position.

