### PR TITLE
Replace `region` with `regionSupplier` in all AWS tests

### DIFF
--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3BasicCredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3BasicCredentialsRestIT.java
@@ -20,6 +20,7 @@ import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+import static fixture.aws.AwsCredentialsUtils.ANY_REGION;
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
 
 @ThreadLeakFilters(filters = { TestContainersThreadFilter.class })
@@ -33,7 +34,7 @@ public class RepositoryS3BasicCredentialsRestIT extends AbstractRepositoryS3Rest
     private static final String SECRET_KEY = PREFIX + "secret-key";
     private static final String CLIENT = "basic_credentials_client";
 
-    private static final S3HttpFixture s3Fixture = new S3HttpFixture(true, BUCKET, BASE_PATH, fixedAccessKey(ACCESS_KEY, "*", "s3"));
+    private static final S3HttpFixture s3Fixture = new S3HttpFixture(true, BUCKET, BASE_PATH, fixedAccessKey(ACCESS_KEY, ANY_REGION, "s3"));
 
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("repository-s3")

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestReloadCredentialsIT.java
@@ -25,6 +25,7 @@ import org.junit.rules.TestRule;
 
 import java.io.IOException;
 
+import static fixture.aws.AwsCredentialsUtils.ANY_REGION;
 import static fixture.aws.AwsCredentialsUtils.mutableAccessKey;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.allOf;
@@ -42,7 +43,7 @@ public class RepositoryS3RestReloadCredentialsIT extends ESRestTestCase {
         true,
         BUCKET,
         BASE_PATH,
-        mutableAccessKey(() -> repositoryAccessKey, "*", "s3")
+        mutableAccessKey(() -> repositoryAccessKey, ANY_REGION, "s3")
     );
 
     private static final MutableSettingsProvider keystoreSettings = new MutableSettingsProvider();

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3SessionCredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3SessionCredentialsRestIT.java
@@ -20,6 +20,7 @@ import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+import static fixture.aws.AwsCredentialsUtils.ANY_REGION;
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKeyAndToken;
 
 @ThreadLeakFilters(filters = { TestContainersThreadFilter.class })
@@ -38,7 +39,7 @@ public class RepositoryS3SessionCredentialsRestIT extends AbstractRepositoryS3Re
         true,
         BUCKET,
         BASE_PATH,
-        fixedAccessKeyAndToken(ACCESS_KEY, SESSION_TOKEN, "*", "s3")
+        fixedAccessKeyAndToken(ACCESS_KEY, SESSION_TOKEN, ANY_REGION, "s3")
     );
 
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()

--- a/modules/repository-s3/src/yamlRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ClientYamlTestSuiteIT.java
+++ b/modules/repository-s3/src/yamlRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ClientYamlTestSuiteIT.java
@@ -23,6 +23,7 @@ import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+import static fixture.aws.AwsCredentialsUtils.ANY_REGION;
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
 
 @ThreadLeakFilters(filters = { TestContainersThreadFilter.class })
@@ -36,7 +37,7 @@ public class RepositoryS3ClientYamlTestSuiteIT extends AbstractRepositoryS3Clien
         true,
         "bucket",
         "base_path_integration_tests",
-        fixedAccessKey(ACCESS_KEY, "*", "s3")
+        fixedAccessKey(ACCESS_KEY, ANY_REGION, "s3")
     );
 
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()

--- a/plugins/discovery-ec2/src/javaRestTest/java/org/elasticsearch/discovery/ec2/DiscoveryEc2EnvironmentVariableCredentialsIT.java
+++ b/plugins/discovery-ec2/src/javaRestTest/java/org/elasticsearch/discovery/ec2/DiscoveryEc2EnvironmentVariableCredentialsIT.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.discovery.ec2;
 
+import fixture.aws.DynamicRegionSupplier;
 import fixture.aws.ec2.AwsEc2HttpFixture;
 
 import org.elasticsearch.discovery.DiscoveryModule;
@@ -19,17 +20,18 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
 
 public class DiscoveryEc2EnvironmentVariableCredentialsIT extends DiscoveryEc2ClusterFormationTestCase {
 
     private static final String PREFIX = getIdentifierPrefix("DiscoveryEc2EnvironmentVariableCredentialsIT");
-    private static final String REGION = PREFIX + "-region";
     private static final String ACCESS_KEY = PREFIX + "-access-key";
 
+    private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     private static final AwsEc2HttpFixture ec2ApiFixture = new AwsEc2HttpFixture(
-        fixedAccessKey(ACCESS_KEY, REGION, "ec2"),
+        fixedAccessKey(ACCESS_KEY, regionSupplier, "ec2"),
         DiscoveryEc2EnvironmentVariableCredentialsIT::getAvailableTransportEndpoints
     );
 
@@ -39,7 +41,7 @@ public class DiscoveryEc2EnvironmentVariableCredentialsIT extends DiscoveryEc2Cl
         .setting(DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), Ec2DiscoveryPlugin.EC2_SEED_HOSTS_PROVIDER_NAME)
         .setting("logger." + AwsEc2SeedHostsProvider.class.getCanonicalName(), "DEBUG")
         .setting(Ec2ClientSettings.ENDPOINT_SETTING.getKey(), ec2ApiFixture::getAddress)
-        .environment("AWS_REGION", REGION)
+        .environment("AWS_REGION", regionSupplier)
         .environment("AWS_ACCESS_KEY_ID", ACCESS_KEY)
         .environment("AWS_SECRET_ACCESS_KEY", ESTestCase::randomSecretKey)
         .build();

--- a/plugins/discovery-ec2/src/javaRestTest/java/org/elasticsearch/discovery/ec2/DiscoveryEc2KeystoreCredentialsIT.java
+++ b/plugins/discovery-ec2/src/javaRestTest/java/org/elasticsearch/discovery/ec2/DiscoveryEc2KeystoreCredentialsIT.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.discovery.ec2;
 
+import fixture.aws.DynamicRegionSupplier;
 import fixture.aws.ec2.AwsEc2HttpFixture;
 
 import org.elasticsearch.discovery.DiscoveryModule;
@@ -19,17 +20,18 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
 
 public class DiscoveryEc2KeystoreCredentialsIT extends DiscoveryEc2ClusterFormationTestCase {
 
     private static final String PREFIX = getIdentifierPrefix("DiscoveryEc2KeystoreCredentialsIT");
-    private static final String REGION = PREFIX + "-region";
     private static final String ACCESS_KEY = PREFIX + "-access-key";
 
+    private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     private static final AwsEc2HttpFixture ec2ApiFixture = new AwsEc2HttpFixture(
-        fixedAccessKey(ACCESS_KEY, REGION, "ec2"),
+        fixedAccessKey(ACCESS_KEY, regionSupplier, "ec2"),
         DiscoveryEc2KeystoreCredentialsIT::getAvailableTransportEndpoints
     );
 
@@ -39,7 +41,7 @@ public class DiscoveryEc2KeystoreCredentialsIT extends DiscoveryEc2ClusterFormat
         .setting(DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), Ec2DiscoveryPlugin.EC2_SEED_HOSTS_PROVIDER_NAME)
         .setting("logger." + AwsEc2SeedHostsProvider.class.getCanonicalName(), "DEBUG")
         .setting(Ec2ClientSettings.ENDPOINT_SETTING.getKey(), ec2ApiFixture::getAddress)
-        .environment("AWS_REGION", REGION)
+        .environment("AWS_REGION", regionSupplier)
         .keystore("discovery.ec2.access_key", ACCESS_KEY)
         .keystore("discovery.ec2.secret_key", ESTestCase::randomSecretKey)
         .build();

--- a/plugins/discovery-ec2/src/javaRestTest/java/org/elasticsearch/discovery/ec2/DiscoveryEc2KeystoreSessionCredentialsIT.java
+++ b/plugins/discovery-ec2/src/javaRestTest/java/org/elasticsearch/discovery/ec2/DiscoveryEc2KeystoreSessionCredentialsIT.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.discovery.ec2;
 
+import fixture.aws.DynamicRegionSupplier;
 import fixture.aws.ec2.AwsEc2HttpFixture;
 
 import org.elasticsearch.discovery.DiscoveryModule;
@@ -19,18 +20,19 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKeyAndToken;
 
 public class DiscoveryEc2KeystoreSessionCredentialsIT extends DiscoveryEc2ClusterFormationTestCase {
 
     private static final String PREFIX = getIdentifierPrefix("DiscoveryEc2KeystoreSessionCredentialsIT");
-    private static final String REGION = PREFIX + "-region";
     private static final String ACCESS_KEY = PREFIX + "-access-key";
     private static final String SESSION_TOKEN = PREFIX + "-session-token";
 
+    private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     private static final AwsEc2HttpFixture ec2ApiFixture = new AwsEc2HttpFixture(
-        fixedAccessKeyAndToken(ACCESS_KEY, SESSION_TOKEN, REGION, "ec2"),
+        fixedAccessKeyAndToken(ACCESS_KEY, SESSION_TOKEN, regionSupplier, "ec2"),
         DiscoveryEc2KeystoreSessionCredentialsIT::getAvailableTransportEndpoints
     );
 
@@ -40,7 +42,7 @@ public class DiscoveryEc2KeystoreSessionCredentialsIT extends DiscoveryEc2Cluste
         .setting(DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), Ec2DiscoveryPlugin.EC2_SEED_HOSTS_PROVIDER_NAME)
         .setting("logger." + AwsEc2SeedHostsProvider.class.getCanonicalName(), "DEBUG")
         .setting(Ec2ClientSettings.ENDPOINT_SETTING.getKey(), ec2ApiFixture::getAddress)
-        .environment("AWS_REGION", REGION)
+        .environment("AWS_REGION", regionSupplier)
         .keystore("discovery.ec2.access_key", ACCESS_KEY)
         .keystore("discovery.ec2.secret_key", ESTestCase::randomSecretKey)
         .keystore("discovery.ec2.session_token", SESSION_TOKEN)

--- a/plugins/discovery-ec2/src/javaRestTest/java/org/elasticsearch/discovery/ec2/DiscoveryEc2SystemPropertyCredentialsIT.java
+++ b/plugins/discovery-ec2/src/javaRestTest/java/org/elasticsearch/discovery/ec2/DiscoveryEc2SystemPropertyCredentialsIT.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.discovery.ec2;
 
+import fixture.aws.DynamicRegionSupplier;
 import fixture.aws.ec2.AwsEc2HttpFixture;
 
 import org.elasticsearch.discovery.DiscoveryModule;
@@ -19,17 +20,18 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
 
 public class DiscoveryEc2SystemPropertyCredentialsIT extends DiscoveryEc2ClusterFormationTestCase {
 
     private static final String PREFIX = getIdentifierPrefix("DiscoveryEc2SystemPropertyCredentialsIT");
-    private static final String REGION = PREFIX + "-region";
     private static final String ACCESS_KEY = PREFIX + "-access-key";
 
+    private static final Supplier<String> regionSupplier = new DynamicRegionSupplier();
     private static final AwsEc2HttpFixture ec2ApiFixture = new AwsEc2HttpFixture(
-        fixedAccessKey(ACCESS_KEY, REGION, "ec2"),
+        fixedAccessKey(ACCESS_KEY, regionSupplier, "ec2"),
         DiscoveryEc2SystemPropertyCredentialsIT::getAvailableTransportEndpoints
     );
 
@@ -39,7 +41,7 @@ public class DiscoveryEc2SystemPropertyCredentialsIT extends DiscoveryEc2Cluster
         .setting(DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), Ec2DiscoveryPlugin.EC2_SEED_HOSTS_PROVIDER_NAME)
         .setting("logger." + AwsEc2SeedHostsProvider.class.getCanonicalName(), "DEBUG")
         .setting(Ec2ClientSettings.ENDPOINT_SETTING.getKey(), ec2ApiFixture::getAddress)
-        .environment("AWS_REGION", REGION)
+        .environment("AWS_REGION", regionSupplier)
         .systemProperty("aws.accessKeyId", ACCESS_KEY)
         .systemProperty("aws.secretAccessKey", ESTestCase::randomSecretKey)
         .build();

--- a/test/fixtures/aws-fixture-utils/src/main/java/fixture/aws/AwsCredentialsUtils.java
+++ b/test/fixtures/aws-fixture-utils/src/main/java/fixture/aws/AwsCredentialsUtils.java
@@ -24,23 +24,34 @@ public enum AwsCredentialsUtils {
     ;
 
     /**
+     * Region supplier which matches any region.
+     */
+    public static final Supplier<String> ANY_REGION = () -> "*";
+
+    /**
      * @return an authorization predicate that ensures the authorization header matches the given access key, region and service name.
      * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html">AWS v4 Signatures</a>
-     * @param region the name of the AWS region used to sign the request, or {@code *} to skip validation of the region parameter
+     * @param regionSupplier supplies the name of the AWS region used to sign the request, or {@code *} to skip validation of the region
+     *                       parameter
      */
-    public static BiPredicate<String, String> fixedAccessKey(String accessKey, String region, String serviceName) {
-        return mutableAccessKey(() -> accessKey, region, serviceName);
+    public static BiPredicate<String, String> fixedAccessKey(String accessKey, Supplier<String> regionSupplier, String serviceName) {
+        return mutableAccessKey(() -> accessKey, regionSupplier, serviceName);
     }
 
     /**
      * @return an authorization predicate that ensures the authorization header matches the access key supplied by the given supplier,
      *         and also matches the given region and service name.
      * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html">AWS v4 Signatures</a>
-     * @param region the name of the AWS region used to sign the request, or {@code *} to skip validation of the region parameter
+     * @param regionSupplier supplies the name of the AWS region used to sign the request, or {@code *} to skip validation of the region
+     *                       parameter
      */
-    public static BiPredicate<String, String> mutableAccessKey(Supplier<String> accessKeySupplier, String region, String serviceName) {
+    public static BiPredicate<String, String> mutableAccessKey(
+        Supplier<String> accessKeySupplier,
+        Supplier<String> regionSupplier,
+        String serviceName
+    ) {
         return (authorizationHeader, sessionTokenHeader) -> authorizationHeader != null
-            && isValidAwsV4SignedAuthorizationHeader(accessKeySupplier.get(), region, serviceName, authorizationHeader);
+            && isValidAwsV4SignedAuthorizationHeader(accessKeySupplier.get(), regionSupplier.get(), serviceName, authorizationHeader);
     }
 
     /**
@@ -72,16 +83,17 @@ public enum AwsCredentialsUtils {
     /**
      * @return an authorization predicate that ensures the access key, session token, region and service name all match the given values.
      * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html">AWS v4 Signatures</a>
-     * @param region the name of the AWS region used to sign the request, or {@code *} to skip validation of the region parameter
+     * @param regionSupplier supplies the name of the AWS region used to sign the request, or {@code *} to skip validation of the region
+     *                       parameter
      */
     public static BiPredicate<String, String> fixedAccessKeyAndToken(
         String accessKey,
         String sessionToken,
-        String region,
+        Supplier<String> regionSupplier,
         String serviceName
     ) {
         Objects.requireNonNull(sessionToken);
-        final var accessKeyPredicate = fixedAccessKey(accessKey, region, serviceName);
+        final var accessKeyPredicate = fixedAccessKey(accessKey, regionSupplier, serviceName);
         return (authorizationHeader, sessionTokenHeader) -> accessKeyPredicate.test(authorizationHeader, sessionTokenHeader)
             && sessionToken.equals(sessionTokenHeader);
     }

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpFixture.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpFixture.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.function.BiPredicate;
 
+import static fixture.aws.AwsCredentialsUtils.ANY_REGION;
 import static fixture.aws.AwsCredentialsUtils.checkAuthorization;
 import static fixture.aws.AwsCredentialsUtils.fixedAccessKey;
 import static fixture.aws.AwsFixtureUtils.getLocalFixtureAddress;
@@ -33,7 +34,7 @@ public class S3HttpFixture extends ExternalResource {
     private final BiPredicate<String, String> authorizationPredicate;
 
     public S3HttpFixture(boolean enabled) {
-        this(enabled, "bucket", "base_path_integration_tests", fixedAccessKey("s3_test_access_key", "*", "s3"));
+        this(enabled, "bucket", "base_path_integration_tests", fixedAccessKey("s3_test_access_key", ANY_REGION, "s3"));
     }
 
     public S3HttpFixture(boolean enabled, String bucket, String basePath, BiPredicate<String, String> authorizationPredicate) {

--- a/x-pack/plugin/searchable-snapshots/qa/s3/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/s3/S3SearchableSnapshotsCredentialsReloadIT.java
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/s3/S3SearchableSnapshotsCredentialsReloadIT.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.function.UnaryOperator;
 
+import static fixture.aws.AwsCredentialsUtils.ANY_REGION;
 import static fixture.aws.AwsCredentialsUtils.mutableAccessKey;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.allOf;
@@ -50,7 +51,7 @@ public class S3SearchableSnapshotsCredentialsReloadIT extends ESRestTestCase {
         true,
         BUCKET,
         BASE_PATH,
-        mutableAccessKey(() -> repositoryAccessKey, "*", "s3")
+        mutableAccessKey(() -> repositoryAccessKey, ANY_REGION, "s3")
     );
 
     private static final MutableSettingsProvider keystoreSettings = new MutableSettingsProvider();


### PR DESCRIPTION
Rather than hard-coding a region name we should always auto-generate it
randomly during test execution. This commit replaces the remaining fixed
`String` arguments with a `Supplier<String>` argument to enable this.