### PR TITLE
[8.x] Ensure sentence overlap is considered in SentenceBoundaryChunkingSettings equals/hashCode (#126250)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/chunking/SentenceBoundaryChunkingSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/chunking/SentenceBoundaryChunkingSettings.java
@@ -134,11 +134,11 @@ public class SentenceBoundaryChunkingSettings implements ChunkingSettings {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SentenceBoundaryChunkingSettings that = (SentenceBoundaryChunkingSettings) o;
-        return Objects.equals(maxChunkSize, that.maxChunkSize);
+        return Objects.equals(maxChunkSize, that.maxChunkSize) && Objects.equals(sentenceOverlap, that.sentenceOverlap);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxChunkSize);
+        return Objects.hash(maxChunkSize, sentenceOverlap);
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Ensure sentence overlap is considered in SentenceBoundaryChunkingSettings equals/hashCode (#126250)