### PR TITLE
ESQL: Fail with 500 not 400 for ValueExtractor bugs

### DIFF
--- a/docs/changelog/126296.yaml
+++ b/docs/changelog/126296.yaml
@@ -1,0 +1,5 @@
+pr: 126296
+summary: Fail with 500 not 400 for `ValueExtractor` bugs
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
@@ -27,7 +27,10 @@ interface ValueExtractor {
 
     static ValueExtractor extractorFor(ElementType elementType, TopNEncoder encoder, boolean inKey, Block block) {
         if (false == (elementType == block.elementType() || ElementType.NULL == block.elementType())) {
-            throw new IllegalArgumentException("Expected [" + elementType + "] but was [" + block.elementType() + "]");
+            // While this maybe should be an IllegalArgumentException, it's important to throw an exception that causes a 500 response.
+            // If we reach here, that's a bug. Arguably, the operators are in an illegal state because the layout doesn't match the
+            // actual pages.
+            throw new IllegalStateException("Expected [" + elementType + "] but was [" + block.elementType() + "]");
         }
         return switch (block.elementType()) {
             case BOOLEAN -> ValueExtractorForBoolean.extractorFor(encoder, inKey, (BooleanBlock) block);


### PR DESCRIPTION
Fix [#126198](https://github.com/elastic/elasticsearch/issues/126198)

In case of wrong layouts of ESQL's operators, it can happen that `ValueExtractor.extractorFor` encounters a data type mismatch. Currently, this throws `IllegalArgumentException`, which is treated like a user exception and triggers a 400 response.

We need to return a 500 status code for such errors; this is also important for observability of ES clusters, which can normally use 500 responses as an indicator of a bug.

Throw `IllegalStateException` instead, it's close enough.