### PR TITLE
Fix SearchServiceSingleNodeTests testSlicingBehaviourForParallelCollection

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -345,9 +345,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_stats/Test get transform stats with timeout}
   issue: https://github.com/elastic/elasticsearch/issues/125975
-- class: org.elasticsearch.search.SearchServiceSingleNodeTests
-  method: testSlicingBehaviourForParallelCollection
-  issue: https://github.com/elastic/elasticsearch/issues/125899
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test021InstallPlugin
   issue: https://github.com/elastic/elasticsearch/issues/116147

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -416,12 +416,12 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
         enableQueryPhaseParallelCollection = QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.get(settings);
         if (BATCHED_QUERY_PHASE_FEATURE_FLAG) {
-            clusterService.getClusterSettings()
-                .addSettingsUpdateConsumer(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED, this::setEnableQueryPhaseParallelCollection);
             batchQueryPhase = BATCHED_QUERY_PHASE.get(settings);
         } else {
             batchQueryPhase = false;
         }
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED, this::setEnableQueryPhaseParallelCollection);
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(BATCHED_QUERY_PHASE, bulkExecuteQueryPhase -> this.batchQueryPhase = bulkExecuteQueryPhase);
         memoryAccountingBufferSize = MEMORY_ACCOUNTING_BUFFER_SIZE.get(settings).getBytes();


### PR DESCRIPTION
We need to register the settings update consumer for the 
QUERY_PHASE_PARALLEL_COLLECTION_ENABLED setting 
regardless of the BATCHED_QUERY_PHASE_FEATURE_FLAG feature flag.

Closes #125899
