### PR TITLE
[8.x] Add missing test security policies (#126309)

### DIFF
--- a/modules/repository-s3/qa/insecure-credentials/src/test/resources/plugin-security.policy
+++ b/modules/repository-s3/qa/insecure-credentials/src/test/resources/plugin-security.policy
@@ -1,0 +1,3 @@
+grant {
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+};

--- a/modules/repository-s3/qa/web-identity-token/src/test/resources/plugin-security.policy
+++ b/modules/repository-s3/qa/web-identity-token/src/test/resources/plugin-security.policy
@@ -1,0 +1,3 @@
+grant {
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+};


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add missing test security policies (#126309)