### PR TITLE
[8.x] Fix vector-tile tests when run on non-snapshot builds (#126251)

### DIFF
--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -50,11 +50,11 @@ import java.util.List;
 public class VectorTileRestIT extends ESRestTestCase {
 
     @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .module("vector-tile")
-        .module("test-error-query")
-        .setting("xpack.license.self_generated.type", "trial")
-        .build();
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("vector-tile").apply(c -> {
+        if (Build.current().isSnapshot()) {
+            c.module("test-error-query");
+        }
+    }).setting("xpack.license.self_generated.type", "trial").build();
 
     private static final String INDEX_POINTS = "index-points";
     private static final String INDEX_POLYGON = "index-polygon";


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix vector-tile tests when run on non-snapshot builds (#126251)](https://github.com/elastic/elasticsearch/pull/126251)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)