### PR TITLE
[8.16] [CI] Trigger FIPS PR tests when test-fips label is present (#126332)

### DIFF
--- a/.buildkite/pipelines/pull-request/part-1-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-1-fips.yml
@@ -1,5 +1,7 @@
 config:
-  allow-labels: "Team:Security"
+  allow-labels:
+    - Team:Security
+    - test-fips
 steps:
   - label: part-1-fips
     command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.fips.enabled=true checkPart1

--- a/.buildkite/pipelines/pull-request/part-2-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-2-fips.yml
@@ -1,5 +1,7 @@
 config:
-  allow-labels: "Team:Security"
+  allow-labels:
+    - Team:Security
+    - test-fips
 steps:
   - label: part-2-fips
     command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.fips.enabled=true checkPart2

--- a/.buildkite/pipelines/pull-request/part-3-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-3-fips.yml
@@ -1,5 +1,7 @@
 config:
-  allow-labels: "Team:Security"
+  allow-labels:
+    - Team:Security
+    - test-fips
 steps:
   - label: part-3-fips
     command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.fips.enabled=true checkPart3

--- a/.buildkite/pipelines/pull-request/part-4-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-4-fips.yml
@@ -1,5 +1,7 @@
 config:
-  allow-labels: "Team:Security"
+  allow-labels:
+    - Team:Security
+    - test-fips
 steps:
   - label: part-4-fips
     command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.fips.enabled=true checkPart4

--- a/.buildkite/pipelines/pull-request/part-5-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-5-fips.yml
@@ -1,5 +1,7 @@
 config:
-  allow-labels: "Team:Security"
+  allow-labels:
+    - Team:Security
+    - test-fips
 steps:
   - label: part-5-fips
     command: .ci/scripts/run-gradle.sh -Dignore.tests.seed -Dtests.fips.enabled=true checkPart5


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[CI] Trigger FIPS PR tests when test-fips label is present (#126332)](https://github.com/elastic/elasticsearch/pull/126332)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)