### PR TITLE
[ES|QL] Add supportsVersion to AggMetricDoubleLiteral

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockBuilder.java
@@ -201,8 +201,13 @@ public class AggregateMetricDoubleBlockBuilder extends AbstractBlockBuilder impl
 
         @Override
         public TransportVersion getMinimalSupportedVersion() {
-            return TransportVersions.ESQL_AGGREGATE_METRIC_DOUBLE_LITERAL;
+            assert false : "must not be called when overriding supportsVersion";
+            throw new UnsupportedOperationException("must not be called when overriding supportsVersion");
         }
 
+        @Override
+        public boolean supportsVersion(TransportVersion version) {
+            return version.onOrAfter(TransportVersions.ESQL_AGGREGATE_METRIC_DOUBLE_LITERAL);
+        }
     }
 }


### PR DESCRIPTION
This commit adds an implementation for supportsVersion() to the
AggregateMetricDoubleLiteral type in order to support backporting for
serialization of this type.
