### PR TITLE
Support serialization of aggregate metric double literal

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -50,7 +50,6 @@ import java.util.Set;
 import java.util.function.IntFunction;
 
 import static java.util.Map.entry;
-import static org.elasticsearch.TransportVersions.V_8_11_X;
 
 /**
  * A stream from another node to this node. Technically, it can also be streamed from a byte array but that is mostly for testing.
@@ -813,13 +812,10 @@ public abstract class StreamOutput extends OutputStream {
         entry(GenericNamedWriteable.class, (o, v) -> {
             // Note that we do not rely on the checks in VersionCheckingStreamOutput because that only applies to CCS
             final var genericNamedWriteable = (GenericNamedWriteable) v;
-            TransportVersion minSupportedVersion = genericNamedWriteable.getMinimalSupportedVersion();
-            assert minSupportedVersion.onOrAfter(V_8_11_X) : "[GenericNamedWriteable] requires [" + V_8_11_X + "]";
-            if (o.getTransportVersion().before(minSupportedVersion)) {
+            if (genericNamedWriteable.supportsVersion(o.getTransportVersion()) == false) {
                 final var message = Strings.format(
-                    "[%s] requires minimal transport version [%s] and cannot be sent using transport version [%s]",
+                    "[%s] doesn't support serialization with transport version [%s]",
                     genericNamedWriteable.getWriteableName(),
-                    minSupportedVersion,
                     o.getTransportVersion()
                 );
                 assert false : message;

--- a/server/src/test/java/org/elasticsearch/search/geo/GeoBoundsGenericWriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/search/geo/GeoBoundsGenericWriteableTests.java
@@ -85,7 +85,7 @@ public class GeoBoundsGenericWriteableTests extends AbstractWireTestCase<Generic
             output.setTransportVersion(older);
             assertThat(
                 expectThrows(Throwable.class, () -> output.writeGenericValue(testInstance)).getMessage(),
-                containsString("[GeoBoundingBox] requires minimal transport version")
+                containsString("[GeoBoundingBox] doesn't support serialization with transport version")
             );
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockBuilder.java
@@ -200,9 +200,14 @@ public class AggregateMetricDoubleBlockBuilder extends AbstractBlockBuilder impl
         }
 
         @Override
-        public TransportVersion getMinimalSupportedVersion() {
-            return TransportVersions.ESQL_AGGREGATE_METRIC_DOUBLE_LITERAL;
+        public boolean supportsVersion(TransportVersion version) {
+            return version.onOrAfter(TransportVersions.ESQL_AGGREGATE_METRIC_DOUBLE_LITERAL);
         }
 
+        @Override
+        public TransportVersion getMinimalSupportedVersion() {
+            assert false : "must not be called when overriding supportsVersion";
+            throw new UnsupportedOperationException("must not be called when overriding supportsVersion");
+        }
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValuesGenericWriteableTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValuesGenericWriteableTests.java
@@ -73,7 +73,7 @@ public abstract class ShapeValuesGenericWriteableTests<T extends ShapeValues.Sha
             output.setTransportVersion(older);
             assertThat(
                 expectThrows(Throwable.class, () -> output.writeGenericValue(testInstance)).getMessage(),
-                containsString("[" + shapeValueName() + "] requires minimal transport version")
+                containsString("[" + shapeValueName() + "] doesn't support serialization with transport version")
             );
         }
     }


### PR DESCRIPTION
To backport the newly introduced AggregateMetricDoubleLiteral to 8.x, we need to override the supportsVersion method instead of getMinimalSupportedVersion.