### PR TITLE
Remove unused parameter from SiblingPipelineAggregator.doReduce

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -578,15 +578,11 @@ public class AggregatorFactories {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            if (aggregationBuilders != null) {
-                for (AggregationBuilder subAgg : aggregationBuilders) {
-                    subAgg.toXContent(builder, params);
-                }
+            for (AggregationBuilder subAgg : aggregationBuilders) {
+                subAgg.toXContent(builder, params);
             }
-            if (pipelineAggregatorBuilders != null) {
-                for (PipelineAggregationBuilder subAgg : pipelineAggregatorBuilders) {
-                    subAgg.toXContent(builder, params);
-                }
+            for (PipelineAggregationBuilder subAgg : pipelineAggregatorBuilders) {
+                subAgg.toXContent(builder, params);
             }
             builder.endObject();
             return builder;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -199,7 +199,7 @@ public final class InternalAggregations implements Iterable<InternalAggregation>
 
             for (PipelineAggregator pipelineAggregator : context.pipelineTreeRoot().aggregators()) {
                 SiblingPipelineAggregator sib = (SiblingPipelineAggregator) pipelineAggregator;
-                InternalAggregation newAgg = sib.doReduce(from(reducedInternalAggs), context);
+                InternalAggregation newAgg = sib.doReduce(from(reducedInternalAggs));
                 reducedInternalAggs.add(newAgg);
             }
             return from(reducedInternalAggs);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipelineAggregator.java
@@ -12,7 +12,6 @@ package org.elasticsearch.search.aggregations.pipeline;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
-import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -47,7 +46,7 @@ public abstract class BucketMetricsPipelineAggregator extends SiblingPipelineAgg
     }
 
     @Override
-    public final InternalAggregation doReduce(InternalAggregations aggregations, AggregationReduceContext context) {
+    public final InternalAggregation doReduce(InternalAggregations aggregations) {
         preCollection();
         List<AggregationPath.PathElement> parsedPath = AggregationPath.parse(bucketsPaths()[0]).getPathElements();
         for (Aggregation aggregation : aggregations) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SiblingPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SiblingPipelineAggregator.java
@@ -25,10 +25,10 @@ public abstract class SiblingPipelineAggregator extends PipelineAggregator {
     public InternalAggregation reduce(InternalAggregation aggregation, AggregationReduceContext reduceContext) {
         return aggregation.copyWithRewritenBuckets(
             aggregations -> InternalAggregations.from(
-                CollectionUtils.appendToCopyNoNullElements(aggregations.copyResults(), doReduce(aggregations, reduceContext))
+                CollectionUtils.appendToCopyNoNullElements(aggregations.copyResults(), doReduce(aggregations))
             )
         );
     }
 
-    public abstract InternalAggregation doReduce(InternalAggregations aggregations, AggregationReduceContext context);
+    public abstract InternalAggregation doReduce(InternalAggregations aggregations);
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/AvgBucketAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/AvgBucketAggregatorTests.java
@@ -125,7 +125,7 @@ public class AvgBucketAggregatorTests extends AggregatorTestCase {
             reducedAggs.add(histogramResult);
             reducedAggs.add(avgResult);
             InternalAggregations aggregations = InternalAggregations.from(reducedAggs);
-            InternalAggregation pipelineResult = ((AvgBucketPipelineAggregator) avgBucketAgg).doReduce(aggregations, null);
+            InternalAggregation pipelineResult = ((AvgBucketPipelineAggregator) avgBucketAgg).doReduce(aggregations);
             assertNotNull(pipelineResult);
         }
     }
@@ -178,7 +178,7 @@ public class AvgBucketAggregatorTests extends AggregatorTestCase {
 
             reducedAggs.add(filterResult);
             InternalAggregations aggregations = InternalAggregations.from(reducedAggs);
-            InternalAggregation pipelineResult = ((AvgBucketPipelineAggregator) avgBucketAgg).doReduce(aggregations, null);
+            InternalAggregation pipelineResult = ((AvgBucketPipelineAggregator) avgBucketAgg).doReduce(aggregations);
             assertNotNull(pipelineResult);
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregator.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.ml.aggs.changepoint;
 
-import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers;
@@ -27,7 +26,7 @@ public class ChangePointAggregator extends SiblingPipelineAggregator {
     }
 
     @Override
-    public InternalAggregation doReduce(InternalAggregations aggregations, AggregationReduceContext context) {
+    public InternalAggregation doReduce(InternalAggregations aggregations) {
         Optional<MlAggsHelper.DoubleBucketValues> maybeBucketValues = extractDoubleBucketedValues(
             bucketsPaths()[0],
             aggregations,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/correlation/BucketCorrelationAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/correlation/BucketCorrelationAggregator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.ml.aggs.correlation;
 
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.pipeline.InternalSimpleValue;
@@ -33,7 +32,7 @@ public class BucketCorrelationAggregator extends SiblingPipelineAggregator {
     }
 
     @Override
-    public InternalAggregation doReduce(InternalAggregations aggregations, AggregationReduceContext context) {
+    public InternalAggregation doReduce(InternalAggregations aggregations) {
         CountCorrelationIndicator bucketPathValue = MlAggsHelper.extractDoubleBucketedValues(bucketsPaths()[0], aggregations)
             .map(
                 doubleBucketValues -> new CountCorrelationIndicator(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/BucketCountKSTestAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/BucketCountKSTestAggregator.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
-import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.pipeline.SiblingPipelineAggregator;
@@ -224,7 +223,7 @@ public class BucketCountKSTestAggregator extends SiblingPipelineAggregator {
     }
 
     @Override
-    public InternalAggregation doReduce(InternalAggregations aggregations, AggregationReduceContext context) {
+    public InternalAggregation doReduce(InternalAggregations aggregations) {
         Optional<MlAggsHelper.DoubleBucketValues> maybeBucketsValue = extractDoubleBucketedValues(bucketsPaths()[0], aggregations).map(
             bucketValue -> {
                 double[] values = new double[bucketValue.getValues().length + 1];


### PR DESCRIPTION
Couple more random finds from going through this code:

The context isn't used by any impl -> remove it.
Also, remove unnecessary null checks in one spot, the fields are final and non-null via the initializer.
