### PR TITLE
[8.x] Improve error handling during index expressions resolving (#126018)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
@@ -83,7 +83,7 @@ public enum IndexComponentSelector implements Writeable {
         }
         IndexComponentSelector selector = getByKey(key);
         if (selector == null) {
-            throw new IllegalArgumentException(
+            throw new InvalidSelectorException(
                 "Unknown key of index component selector [" + key + "], available options are: " + KEY_REGISTRY.keySet()
             );
         }
@@ -105,7 +105,7 @@ public enum IndexComponentSelector implements Writeable {
     static IndexComponentSelector getById(byte id) {
         IndexComponentSelector indexComponentSelector = ID_REGISTRY.get(id);
         if (indexComponentSelector == null) {
-            throw new IllegalArgumentException(
+            throw new InvalidSelectorException(
                 "Unknown id of index component selector [" + id + "], available options are: " + ID_REGISTRY
             );
         }

--- a/server/src/main/java/org/elasticsearch/action/support/InvalidSelectorException.java
+++ b/server/src/main/java/org/elasticsearch/action/support/InvalidSelectorException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.support;
+
+/**
+ * Exception thrown when a :: selector is invalid.
+ */
+public class InvalidSelectorException extends IllegalArgumentException {
+
+    public InvalidSelectorException(String message) {
+        super(message);
+    }
+
+    public InvalidSelectorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/action/support/UnsupportedSelectorException.java
+++ b/server/src/main/java/org/elasticsearch/action/support/UnsupportedSelectorException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.support;
+
+/**
+ * Exception thrown when a :: selector is not supported.
+ */
+public class UnsupportedSelectorException extends IllegalArgumentException {
+
+    public UnsupportedSelectorException(String expression) {
+        super("Index component selectors are not supported in this context but found selector in expression [" + expression + "]");
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolver.java
@@ -11,6 +11,7 @@ package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.UnsupportedSelectorException;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
@@ -57,11 +58,7 @@ public class IndexAbstractionResolver {
             Tuple<String, String> expressionAndSelector = IndexNameExpressionResolver.splitSelectorExpression(indexAbstraction);
             String selectorString = expressionAndSelector.v2();
             if (indicesOptions.allowSelectors() == false && selectorString != null) {
-                throw new IllegalArgumentException(
-                    "Index component selectors are not supported in this context but found selector in expression ["
-                        + indexAbstraction
-                        + "]"
-                );
+                throw new UnsupportedSelectorException(indexAbstraction);
             }
             indexAbstraction = expressionAndSelector.v1();
             IndexComponentSelector selector = IndexComponentSelector.getByKeyOrThrow(selectorString);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.UnsupportedSelectorException;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexAbstraction.Type;
 import org.elasticsearch.common.Strings;
@@ -2156,13 +2157,11 @@ public class IndexNameExpressionResolver {
          * Checks the selectors that have been returned from splitting an expression and throws an exception if any were present.
          * @param expression Original expression
          * @param selector Selectors to validate
-         * @throws IllegalArgumentException if selectors are present
+         * @throws UnsupportedSelectorException if selectors are present
          */
         private static void ensureNoSelectorsProvided(String expression, IndexComponentSelector selector) {
             if (selector != null) {
-                throw new IllegalArgumentException(
-                    "Index component selectors are not supported in this context but found selector in expression [" + expression + "]"
-                );
+                throw new UnsupportedSelectorException(expression);
             }
         }
 

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityFailureStoreRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityFailureStoreRestIT.java
@@ -170,7 +170,7 @@ abstract class AbstractRemoteClusterSecurityFailureStoreRestIT extends AbstractR
     }
 
     protected static void assertSelectorsNotSupported(ResponseException exception) {
-        assertThat(exception.getResponse().getStatusLine().getStatusCode(), equalTo(403));
+        assertThat(exception.getResponse().getStatusLine().getStatusCode(), equalTo(400));
         assertThat(exception.getMessage(), containsString("Selectors are not yet supported on remote cluster patterns"));
     }
 

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
@@ -1817,7 +1817,11 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
         expectThrows(() -> deleteDataStream(MANAGE_FAILURE_STORE_ACCESS, dataIndexName), 403);
 
         expectThrows(() -> deleteDataStream(MANAGE_FAILURE_STORE_ACCESS, "test1"), 403);
-        expectThrows(() -> deleteDataStream(MANAGE_FAILURE_STORE_ACCESS, "test1::failures"), 403);
+        // selectors aren't supported for deletes so we get a 403
+        expectThrowsBadRequest(
+            () -> deleteDataStream(MANAGE_FAILURE_STORE_ACCESS, "test1::failures"),
+            containsString("Index component selectors are not supported in this context but found selector in expression [test1::failures]")
+        );
 
         // manage user can delete data stream
         deleteDataStream(MANAGE_ACCESS, "test1");
@@ -2269,6 +2273,12 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
     private static void expectThrows(ThrowingRunnable runnable, int statusCode) {
         var ex = expectThrows(ResponseException.class, runnable);
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(statusCode));
+    }
+
+    private void expectThrowsBadRequest(ThrowingRunnable runnable, Matcher<String> errorMatcher) {
+        ResponseException ex = expectThrows(ResponseException.class, runnable);
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+        assertThat(ex.getMessage(), errorMatcher);
     }
 
     private void expectThrowsUnauthorized(String user, Search search, Matcher<String> errorMatcher) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -29,7 +29,6 @@ import org.elasticsearch.action.index.TransportIndexAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.InvalidSelectorException;
-import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.UnsupportedSelectorException;
 import org.elasticsearch.action.support.replication.TransportReplicationAction.ConcreteShardRequest;
 import org.elasticsearch.action.update.TransportUpdateAction;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -28,6 +28,9 @@ import org.elasticsearch.action.delete.TransportDeleteAction;
 import org.elasticsearch.action.index.TransportIndexAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.GroupedActionListener;
+import org.elasticsearch.action.support.InvalidSelectorException;
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.action.support.UnsupportedSelectorException;
 import org.elasticsearch.action.support.replication.TransportReplicationAction.ConcreteShardRequest;
 import org.elasticsearch.action.update.TransportUpdateAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -42,6 +45,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportActionProxy;
@@ -496,6 +500,21 @@ public class AuthorizationService {
                                 indicesAndAliasesResolver.resolve(action, request, metadata, authorizedIndices)
                             ),
                             e -> {
+                                if (e instanceof InvalidIndexNameException
+                                    || e instanceof InvalidSelectorException
+                                    || e instanceof UnsupportedSelectorException) {
+                                    logger.debug(
+                                        () -> Strings.format(
+                                            "failed [%s] action authorization for [%s] due to [%s] exception",
+                                            action,
+                                            authentication,
+                                            e.getClass().getSimpleName()
+                                        ),
+                                        e
+                                    );
+                                    listener.onFailure(e);
+                                    return;
+                                }
                                 auditTrail.accessDenied(requestId, authentication, action, request, authzInfo);
                                 if (e instanceof IndexNotFoundException) {
                                     listener.onFailure(e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.search.SearchContextId;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndexComponentSelector;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.UnsupportedSelectorException;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexAbstractionResolver;
@@ -314,11 +315,7 @@ class IndicesAndAliasesResolver {
                 // First, if a selector is present, check to make sure that selectors are even allowed here
                 if (indicesOptions.allowSelectors() == false && allIndicesPatternSelector != null) {
                     String originalIndexExpression = indicesRequest.indices()[0];
-                    throw new IllegalArgumentException(
-                        "Index component selectors are not supported in this context but found selector in expression ["
-                            + originalIndexExpression
-                            + "]"
-                    );
+                    throw new UnsupportedSelectorException(originalIndexExpression);
                 }
                 if (indicesOptions.expandWildcardExpressions()) {
                     IndexComponentSelector selector = IndexComponentSelector.getByKeyOrThrow(allIndicesPatternSelector);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Improve error handling during index expressions resolving (#126018)](https://github.com/elastic/elasticsearch/pull/126018)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)