### PR TITLE
Convert TransportMessage to an interface

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportMessage.java
@@ -12,20 +12,15 @@ package org.elasticsearch.transport;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.RefCounted;
 
-public abstract class TransportMessage implements Writeable, RefCounted {
-
-    /**
-     * Constructs a new empty transport message
-     */
-    public TransportMessage() {}
+public interface TransportMessage extends Writeable, RefCounted {
 
     @Override
-    public void incRef() {
+    default void incRef() {
         // noop, override to manage the life-cycle of resources held by a transport message
     }
 
     @Override
-    public boolean tryIncRef() {
+    default boolean tryIncRef() {
         // noop, override to manage the life-cycle of resources held by a transport message
         return true;
     }
@@ -38,13 +33,13 @@ public abstract class TransportMessage implements Writeable, RefCounted {
      * layer in a manner that might end up nesting too deeply. When in doubt, dispatch any further work onto a separate thread.
      */
     @Override
-    public boolean decRef() {
+    default boolean decRef() {
         // noop, override to manage the life-cycle of resources held by a transport message
         return false;
     }
 
     @Override
-    public boolean hasReferences() {
+    default boolean hasReferences() {
         // noop, override to manage the life-cycle of resources held by a transport message
         return true;
     }

--- a/server/src/main/java/org/elasticsearch/transport/TransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportRequest.java
@@ -18,7 +18,7 @@ import org.elasticsearch.tasks.TaskId;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-public abstract class TransportRequest extends TransportMessage implements TaskAwareRequest {
+public abstract class TransportRequest implements TransportMessage, TaskAwareRequest {
 
     @Nullable // set by the transport service on inbound messages; unset on outbound messages
     private InetSocketAddress remoteAddress;

--- a/server/src/main/java/org/elasticsearch/transport/TransportResponse.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportResponse.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public abstract class TransportResponse extends TransportMessage {
+public abstract class TransportResponse implements TransportMessage {
 
     /**
      * Constructs a new empty transport response


### PR DESCRIPTION
TransportMessage is unnecessarily an abstract class, which is more rigid when trying to refactor due to only being able to extend a single class. This commit makes TransportMessage an interface with default methods.