### PR TITLE
[8.x] ESQL: Fail with 500 not 400 for ValueExtractor bugs (#126296)

### DIFF
--- a/docs/changelog/126296.yaml
+++ b/docs/changelog/126296.yaml
@@ -1,0 +1,5 @@
+pr: 126296
+summary: Fail with 500 not 400 for `ValueExtractor` bugs
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
@@ -26,7 +26,10 @@ interface ValueExtractor {
 
     static ValueExtractor extractorFor(ElementType elementType, TopNEncoder encoder, boolean inKey, Block block) {
         if (false == (elementType == block.elementType() || ElementType.NULL == block.elementType())) {
-            throw new IllegalArgumentException("Expected [" + elementType + "] but was [" + block.elementType() + "]");
+            // While this maybe should be an IllegalArgumentException, it's important to throw an exception that causes a 500 response.
+            // If we reach here, that's a bug. Arguably, the operators are in an illegal state because the layout doesn't match the
+            // actual pages.
+            throw new IllegalStateException("Expected [" + elementType + "] but was [" + block.elementType() + "]");
         }
         return switch (block.elementType()) {
             case BOOLEAN -> ValueExtractorForBoolean.extractorFor(encoder, inKey, (BooleanBlock) block);


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Fail with 500 not 400 for ValueExtractor bugs (#126296)