### PR TITLE
ESQL: Speed up TO_IP (#126338)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -82,19 +82,21 @@ To get realistic results, you should exercise care when running benchmarks. Here
 NOTE: Linux only. Sorry Mac and Windows.
 
 Disassembling is fun! Maybe not always useful, but always fun! Generally, you'll want to install `perf` and the JDK's `hsdis`.
-`perf` is generally available via `apg-get install perf` or `pacman -S perf`. `hsdis` you'll want to compile from source. is a little more involved. This worked
+`perf` is generally available via `apg-get install perf` or `pacman -S perf linux-tools`. `hsdis` you'll want to compile from source. is a little more involved. This worked
 on 2020-08-01:
 
 ```
 git clone git@github.com:openjdk/jdk.git
 cd jdk
-git checkout jdk-17-ga
-cd src/utils/hsdis
+git checkout jdk-24-ga
 # Get a known good binutils
 wget https://ftp.gnu.org/gnu/binutils/binutils-2.35.tar.gz
 tar xf binutils-2.35.tar.gz
-make BINUTILS=binutils-2.35 ARCH=amd64
-sudo cp build/linux-amd64/hsdis-amd64.so /usr/lib/jvm/java-17-openjdk/lib/server/
+bash configure --with-hsdis=binutils --with-binutils-src=binutils-2.35 \
+    --with-boot-jdk=~/.gradle/jdks/oracle_corporation-24-amd64-linux.2
+make build-hsdis
+cp ./build/linux-x86_64-server-release/jdk/lib/hsdis-amd64.so \
+    ~/.gradle/jdks/oracle_corporation-24-amd64-linux.2/lib/hsdis.so
 ```
 
 If you want to disassemble a single method do something like this:
@@ -104,6 +106,30 @@ gradlew -p benchmarks run --args ' MemoryStatsBenchmark -jvmArgs "-XX:+UnlockDia
 ```
 
 If you want `perf` to find the hot methods for you, then do add `-prof perfasm`.
+
+NOTE: `perfasm` will need more access:
+```
+sudo bash
+echo -1 > /proc/sys/kernel/perf_event_paranoid
+exit
+```
+
+If you get warnings like:
+```
+The perf event count is suspiciously low (0).
+```
+then check if you are bumping into [this](https://man.archlinux.org/man/perf-stat.1.en#INTEL_HYBRID_SUPPORT)
+by running:
+```
+perf stat -B dd if=/dev/zero of=/dev/null count=1000000
+```
+
+If you see lines like:
+```
+         765019980      cpu_atom/cycles/                 #    1.728 GHz                         (0.60%)
+        2258845959      cpu_core/cycles/                 #    5.103 GHz                         (99.18%)
+```
+then `perf` is just not going to work for you.
 
 ## Async Profiler
 

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ParseIpBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ParseIpBenchmark.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.compute.operator;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ParseIp;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.net.InetAddress;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5)
+@Measurement(iterations = 7)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+public class ParseIpBenchmark {
+    private final BytesRef ip = new BytesRef("192.168.0.1");
+    private final BreakingBytesRefBuilder scratch = ParseIp.buildScratch(new NoopCircuitBreaker("request"));
+
+    @Benchmark
+    public BytesRef leadingZerosRejected() {
+        return ParseIp.leadingZerosRejected(ip, scratch);
+    }
+
+    @Benchmark
+    public BytesRef leadingZerosAreDecimal() {
+        return ParseIp.leadingZerosAreDecimal(ip, scratch);
+    }
+
+    @Benchmark
+    public BytesRef leadingZerosAreOctal() {
+        return ParseIp.leadingZerosAreOctal(ip, scratch);
+    }
+
+    @Benchmark
+    public BytesRef original() {
+        InetAddress inetAddress = InetAddresses.forString(ip.utf8ToString());
+        return new BytesRef(InetAddressPoint.encode(inetAddress));
+    }
+}

--- a/docs/changelog/126338.yaml
+++ b/docs/changelog/126338.yaml
@@ -1,0 +1,5 @@
+pr: 126338
+summary: Speed up TO_IP
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorFunctionSupplierImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorFunctionSupplierImplementer.java
@@ -34,6 +34,7 @@ import static org.elasticsearch.compute.gen.Types.DRIVER_CONTEXT;
 import static org.elasticsearch.compute.gen.Types.LIST_AGG_FUNC_DESC;
 import static org.elasticsearch.compute.gen.Types.LIST_INTEGER;
 import static org.elasticsearch.compute.gen.Types.STRING;
+import static org.elasticsearch.compute.gen.Types.WARNINGS;
 
 /**
  * Implements "AggregationFunctionSupplier" from a class annotated with both
@@ -161,8 +162,9 @@ public class AggregatorFunctionSupplierImplementer {
 
         if (hasWarnings) {
             builder.addStatement(
-                "var warnings = Warnings.createWarnings(driverContext.warningsMode(), "
-                    + "warningsLineNumber, warningsColumnNumber, warningsSourceText)"
+                "var warnings = $T.createWarnings(driverContext.warningsMode(), "
+                    + "warningsLineNumber, warningsColumnNumber, warningsSourceText)",
+                WARNINGS
             );
         }
 
@@ -187,8 +189,9 @@ public class AggregatorFunctionSupplierImplementer {
 
         if (hasWarnings) {
             builder.addStatement(
-                "var warnings = Warnings.createWarnings(driverContext.warningsMode(), "
-                    + "warningsLineNumber, warningsColumnNumber, warningsSourceText)"
+                "var warnings = $T.createWarnings(driverContext.warningsMode(), "
+                    + "warningsLineNumber, warningsColumnNumber, warningsSourceText)",
+                WARNINGS
             );
         }
 

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/ConsumeProcessor.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/ConsumeProcessor.java
@@ -42,6 +42,7 @@ public class ConsumeProcessor implements Processor {
             "org.elasticsearch.xpack.esql.expression.function.MapParam",
             "org.elasticsearch.rest.ServerlessScope",
             "org.elasticsearch.xcontent.ParserConstructor",
+            "org.elasticsearch.core.UpdateForV9",
             Fixed.class.getName()
         );
     }

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorImplementer.java
@@ -21,6 +21,7 @@ import org.elasticsearch.compute.ann.Fixed.Scope;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -33,7 +34,6 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 
-import static org.elasticsearch.compute.gen.Methods.appendMethod;
 import static org.elasticsearch.compute.gen.Methods.buildFromFactory;
 import static org.elasticsearch.compute.gen.Methods.getMethod;
 import static org.elasticsearch.compute.gen.Types.BLOCK;
@@ -71,7 +71,7 @@ public class EvaluatorImplementer {
         List<TypeMirror> warnExceptions
     ) {
         this.declarationType = (TypeElement) processFunction.getEnclosingElement();
-        this.processFunction = new ProcessFunction(elements, types, processFunction, warnExceptions);
+        this.processFunction = new ProcessFunction(types, processFunction, warnExceptions);
 
         this.implementation = ClassName.get(
             elements.getPackageOf(declarationType).toString(),
@@ -99,7 +99,7 @@ public class EvaluatorImplementer {
         builder.addType(factory());
 
         builder.addField(SOURCE, "source", Modifier.PRIVATE, Modifier.FINAL);
-        processFunction.args.stream().forEach(a -> a.declareField(builder));
+        processFunction.args.forEach(a -> a.declareField(builder));
         builder.addField(DRIVER_CONTEXT, "driverContext", Modifier.PRIVATE, Modifier.FINAL);
 
         builder.addField(WARNINGS, "warnings", Modifier.PRIVATE);
@@ -117,8 +117,8 @@ public class EvaluatorImplementer {
             }
             builder.addMethod(realEval(false));
         }
-        builder.addMethod(toStringMethod());
-        builder.addMethod(close());
+        builder.addMethod(processFunction.toStringMethod(implementation));
+        builder.addMethod(processFunction.close());
         builder.addMethod(warnings());
         return builder.build();
     }
@@ -238,7 +238,7 @@ public class EvaluatorImplementer {
                 String builtPattern;
                 if (processFunction.builderArg == null) {
                     builtPattern = vectorize ? "result.$L(p, " + pattern + ")" : "result.$L(" + pattern + ")";
-                    args.add(0, appendMethod(resultDataType));
+                    args.add(0, processFunction.appendMethod());
                 } else {
                     builtPattern = pattern.toString();
                 }
@@ -290,35 +290,6 @@ public class EvaluatorImplementer {
         builder.endControlFlow();
     }
 
-    private MethodSpec toStringMethod() {
-        MethodSpec.Builder builder = MethodSpec.methodBuilder("toString").addAnnotation(Override.class);
-        builder.addModifiers(Modifier.PUBLIC).returns(String.class);
-
-        StringBuilder pattern = new StringBuilder();
-        List<Object> args = new ArrayList<>();
-        pattern.append("return $S");
-        args.add(implementation.simpleName() + "[");
-        processFunction.args.stream().forEach(a -> a.buildToStringInvocation(pattern, args, args.size() > 2 ? ", " : ""));
-        pattern.append(" + $S");
-        args.add("]");
-        builder.addStatement(pattern.toString(), args.toArray());
-        return builder.build();
-    }
-
-    private MethodSpec close() {
-        MethodSpec.Builder builder = MethodSpec.methodBuilder("close").addAnnotation(Override.class);
-        builder.addModifiers(Modifier.PUBLIC);
-
-        List<String> invocations = processFunction.args.stream().map(ProcessFunctionArg::closeInvocation).filter(s -> s != null).toList();
-        if (invocations.isEmpty() == false) {
-            builder.addStatement(
-                "$T.closeExpectNoException(" + invocations.stream().collect(Collectors.joining(", ")) + ")",
-                Types.RELEASABLES
-            );
-        }
-        return builder.build();
-    }
-
     static MethodSpec warnings() {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("warnings");
         builder.addModifiers(Modifier.PRIVATE).returns(WARNINGS);
@@ -343,42 +314,14 @@ public class EvaluatorImplementer {
         builder.addField(SOURCE, "source", Modifier.PRIVATE, Modifier.FINAL);
         processFunction.args.stream().forEach(a -> a.declareFactoryField(builder));
 
-        builder.addMethod(factoryCtor());
-        builder.addMethod(factoryGet());
-        builder.addMethod(toStringMethod());
+        builder.addMethod(processFunction.factoryCtor());
+        builder.addMethod(processFunction.factoryGet(implementation));
+        builder.addMethod(processFunction.toStringMethod(implementation));
 
         return builder.build();
     }
 
-    private MethodSpec factoryCtor() {
-        MethodSpec.Builder builder = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC);
-        builder.addParameter(SOURCE, "source");
-        builder.addStatement("this.source = source");
-        processFunction.args.stream().forEach(a -> a.implementFactoryCtor(builder));
-
-        return builder.build();
-    }
-
-    private MethodSpec factoryGet() {
-        MethodSpec.Builder builder = MethodSpec.methodBuilder("get").addAnnotation(Override.class);
-        builder.addModifiers(Modifier.PUBLIC);
-        builder.addParameter(DRIVER_CONTEXT, "context");
-        builder.returns(implementation);
-
-        List<String> args = new ArrayList<>();
-        args.add("source");
-        for (ProcessFunctionArg arg : processFunction.args) {
-            String invocation = arg.factoryInvocation(builder);
-            if (invocation != null) {
-                args.add(invocation);
-            }
-        }
-        args.add("context");
-        builder.addStatement("return new $T($L)", implementation, args.stream().collect(Collectors.joining(", ")));
-        return builder.build();
-    }
-
-    private interface ProcessFunctionArg {
+    interface ProcessFunctionArg {
         /**
          * Type containing the actual data for a page of values for this field. Usually a
          * Block or Vector, but for fixed fields will be the original fixed type.
@@ -470,7 +413,7 @@ public class EvaluatorImplementer {
         String closeInvocation();
     }
 
-    private record StandardProcessFunctionArg(TypeName type, String name) implements ProcessFunctionArg {
+    record StandardProcessFunctionArg(TypeName type, String name) implements ProcessFunctionArg {
         @Override
         public TypeName dataType(boolean blockStyle) {
             if (blockStyle) {
@@ -726,7 +669,7 @@ public class EvaluatorImplementer {
         }
     }
 
-    private record FixedProcessFunctionArg(TypeName type, String name, boolean includeInToString, Scope scope, boolean releasable)
+    record FixedProcessFunctionArg(TypeName type, String name, boolean includeInToString, Scope scope, boolean releasable)
         implements
             ProcessFunctionArg {
         @Override
@@ -999,20 +942,15 @@ public class EvaluatorImplementer {
         }
     }
 
-    private static class ProcessFunction {
-        private final ExecutableElement function;
-        private final List<ProcessFunctionArg> args;
+    static class ProcessFunction {
+        final ExecutableElement function;
+        final List<ProcessFunctionArg> args;
         private final BuilderProcessFunctionArg builderArg;
         private final List<TypeMirror> warnExceptions;
 
         private boolean hasBlockType;
 
-        private ProcessFunction(
-            Elements elements,
-            javax.lang.model.util.Types types,
-            ExecutableElement function,
-            List<TypeMirror> warnExceptions
-        ) {
+        ProcessFunction(javax.lang.model.util.Types types, ExecutableElement function, List<TypeMirror> warnExceptions) {
             this.function = function;
             args = new ArrayList<>();
             BuilderProcessFunctionArg builderArg = null;
@@ -1063,12 +1001,89 @@ public class EvaluatorImplementer {
             this.warnExceptions = warnExceptions;
         }
 
-        private ClassName resultDataType(boolean blockStyle) {
+        TypeName returnType() {
+            return TypeName.get(function.getReturnType());
+        }
+
+        ClassName resultDataType(boolean blockStyle) {
             if (builderArg != null) {
                 return builderArg.type.enclosingClassName();
             }
             boolean useBlockStyle = blockStyle || warnExceptions.isEmpty() == false;
-            return useBlockStyle ? blockType(TypeName.get(function.getReturnType())) : vectorType(TypeName.get(function.getReturnType()));
+            return useBlockStyle ? blockType(returnType()) : vectorType(returnType());
+        }
+
+        String appendMethod() {
+            return Methods.appendMethod(returnType());
+        }
+
+        @Override
+        public String toString() {
+            return "ProcessFunction{"
+                + "function="
+                + function
+                + ", args="
+                + args
+                + ", builderArg="
+                + builderArg
+                + ", warnExceptions="
+                + warnExceptions
+                + ", hasBlockType="
+                + hasBlockType
+                + '}';
+        }
+
+        MethodSpec toStringMethod(ClassName implementation) {
+            MethodSpec.Builder builder = MethodSpec.methodBuilder("toString").addAnnotation(Override.class);
+            builder.addModifiers(Modifier.PUBLIC).returns(String.class);
+
+            StringBuilder pattern = new StringBuilder();
+            List<Object> args = new ArrayList<>();
+            pattern.append("return $S");
+            args.add(implementation.simpleName() + "[");
+            this.args.forEach(a -> a.buildToStringInvocation(pattern, args, args.size() > 2 ? ", " : ""));
+            pattern.append(" + $S");
+            args.add("]");
+            builder.addStatement(pattern.toString(), args.toArray());
+            return builder.build();
+        }
+
+        MethodSpec factoryCtor() {
+            MethodSpec.Builder builder = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC);
+            builder.addParameter(SOURCE, "source");
+            builder.addStatement("this.source = source");
+            args.stream().forEach(a -> a.implementFactoryCtor(builder));
+            return builder.build();
+        }
+
+        MethodSpec factoryGet(ClassName implementation) {
+            MethodSpec.Builder builder = MethodSpec.methodBuilder("get").addAnnotation(Override.class);
+            builder.addModifiers(Modifier.PUBLIC);
+            builder.addParameter(DRIVER_CONTEXT, "context");
+            builder.returns(implementation);
+
+            List<String> args = new ArrayList<>();
+            args.add("source");
+            for (ProcessFunctionArg arg : this.args) {
+                String invocation = arg.factoryInvocation(builder);
+                if (invocation != null) {
+                    args.add(invocation);
+                }
+            }
+            args.add("context");
+            builder.addStatement("return new $T($L)", implementation, String.join(", ", args));
+            return builder.build();
+        }
+
+        MethodSpec close() {
+            MethodSpec.Builder builder = MethodSpec.methodBuilder("close").addAnnotation(Override.class);
+            builder.addModifiers(Modifier.PUBLIC);
+
+            List<String> invocations = args.stream().map(ProcessFunctionArg::closeInvocation).filter(Objects::nonNull).toList();
+            if (invocations.isEmpty() == false) {
+                builder.addStatement("$T.closeExpectNoException(" + String.join(", ", invocations) + ")", Types.RELEASABLES);
+            }
+            return builder.build();
         }
     }
 

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorProcessor.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorProcessor.java
@@ -121,6 +121,7 @@ public class EvaluatorProcessor implements Processor {
                             "evaluator",
                             new ConvertEvaluatorImplementer(
                                 env.getElementUtils(),
+                                env.getTypeUtils(),
                                 (ExecutableElement) evaluatorMethod,
                                 convertEvaluatorAnn.extraName(),
                                 warnExceptionsTypes

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIpLeadingZerosAreDecimalEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIpLeadingZerosAreDecimalEvaluator.java
@@ -4,34 +4,41 @@
 // 2.0.
 package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 
+import java.lang.IllegalArgumentException;
 import java.lang.Override;
 import java.lang.String;
+import java.util.function.Function;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
- * {@link EvalOperator.ExpressionEvaluator} implementation for {@link ToString}.
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link ParseIp}.
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
-public final class ToStringFromCartesianPointEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  private final EvalOperator.ExpressionEvaluator wkb;
+public final class ParseIpLeadingZerosAreDecimalEvaluator extends AbstractConvertFunction.AbstractEvaluator {
+  private final EvalOperator.ExpressionEvaluator string;
 
-  public ToStringFromCartesianPointEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
+  private final BreakingBytesRefBuilder scratch;
+
+  public ParseIpLeadingZerosAreDecimalEvaluator(Source source,
+      EvalOperator.ExpressionEvaluator string, BreakingBytesRefBuilder scratch,
       DriverContext driverContext) {
     super(driverContext, source);
-    this.wkb = wkb;
+    this.string = string;
+    this.scratch = scratch;
   }
 
   @Override
   public EvalOperator.ExpressionEvaluator next() {
-    return wkb;
+    return string;
   }
 
   @Override
@@ -40,11 +47,21 @@ public final class ToStringFromCartesianPointEvaluator extends AbstractConvertFu
     int positionCount = v.getPositionCount();
     BytesRef scratchPad = new BytesRef();
     if (vector.isConstant()) {
-      return driverContext.blockFactory().newConstantBytesRefBlockWith(evalValue(vector, 0, scratchPad), positionCount);
+      try {
+        return driverContext.blockFactory().newConstantBytesRefBlockWith(evalValue(vector, 0, scratchPad), positionCount);
+      } catch (IllegalArgumentException  e) {
+        registerException(e);
+        return driverContext.blockFactory().newConstantNullBlock(positionCount);
+      }
     }
     try (BytesRefBlock.Builder builder = driverContext.blockFactory().newBytesRefBlockBuilder(positionCount)) {
       for (int p = 0; p < positionCount; p++) {
-        builder.appendBytesRef(evalValue(vector, p, scratchPad));
+        try {
+          builder.appendBytesRef(evalValue(vector, p, scratchPad));
+        } catch (IllegalArgumentException  e) {
+          registerException(e);
+          builder.appendNull();
+        }
       }
       return builder.build();
     }
@@ -52,7 +69,7 @@ public final class ToStringFromCartesianPointEvaluator extends AbstractConvertFu
 
   private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
-    return ToString.fromCartesianPoint(value);
+    return ParseIp.leadingZerosAreDecimal(value, this.scratch);
   }
 
   @Override
@@ -68,13 +85,17 @@ public final class ToStringFromCartesianPointEvaluator extends AbstractConvertFu
         boolean positionOpened = false;
         boolean valuesAppended = false;
         for (int i = start; i < end; i++) {
-          BytesRef value = evalValue(block, i, scratchPad);
-          if (positionOpened == false && valueCount > 1) {
-            builder.beginPositionEntry();
-            positionOpened = true;
+          try {
+            BytesRef value = evalValue(block, i, scratchPad);
+            if (positionOpened == false && valueCount > 1) {
+              builder.beginPositionEntry();
+              positionOpened = true;
+            }
+            builder.appendBytesRef(value);
+            valuesAppended = true;
+          } catch (IllegalArgumentException  e) {
+            registerException(e);
           }
-          builder.appendBytesRef(value);
-          valuesAppended = true;
         }
         if (valuesAppended == false) {
           builder.appendNull();
@@ -88,37 +109,41 @@ public final class ToStringFromCartesianPointEvaluator extends AbstractConvertFu
 
   private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
-    return ToString.fromCartesianPoint(value);
+    return ParseIp.leadingZerosAreDecimal(value, this.scratch);
   }
 
   @Override
   public String toString() {
-    return "ToStringFromCartesianPointEvaluator[" + "wkb=" + wkb + "]";
+    return "ParseIpLeadingZerosAreDecimalEvaluator[" + "string=" + string + "]";
   }
 
   @Override
   public void close() {
-    Releasables.closeExpectNoException(wkb);
+    Releasables.closeExpectNoException(string, scratch);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory wkb;
+    private final EvalOperator.ExpressionEvaluator.Factory string;
 
-    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
+    private final Function<DriverContext, BreakingBytesRefBuilder> scratch;
+
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory string,
+        Function<DriverContext, BreakingBytesRefBuilder> scratch) {
       this.source = source;
-      this.wkb = wkb;
+      this.string = string;
+      this.scratch = scratch;
     }
 
     @Override
-    public ToStringFromCartesianPointEvaluator get(DriverContext context) {
-      return new ToStringFromCartesianPointEvaluator(source, wkb.get(context), context);
+    public ParseIpLeadingZerosAreDecimalEvaluator get(DriverContext context) {
+      return new ParseIpLeadingZerosAreDecimalEvaluator(source, string.get(context), scratch.apply(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromCartesianPointEvaluator[" + "wkb=" + wkb + "]";
+      return "ParseIpLeadingZerosAreDecimalEvaluator[" + "string=" + string + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanFromDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanFromDoubleEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToBooleanFromDoubleEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToBooleanFromDoubleEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator d;
+
+  public ToBooleanFromDoubleEvaluator(Source source, EvalOperator.ExpressionEvaluator d,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.d = d;
   }
 
   @Override
-  public String name() {
-    return "ToBooleanFromDouble";
+  public EvalOperator.ExpressionEvaluator next() {
+    return d;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToBooleanFromDoubleEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static boolean evalValue(DoubleVector container, int index) {
+  private boolean evalValue(DoubleVector container, int index) {
     double value = container.getDouble(index);
     return ToBoolean.fromDouble(value);
   }
@@ -80,29 +84,39 @@ public final class ToBooleanFromDoubleEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static boolean evalValue(DoubleBlock container, int index) {
+  private boolean evalValue(DoubleBlock container, int index) {
     double value = container.getDouble(index);
     return ToBoolean.fromDouble(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToBooleanFromDoubleEvaluator[" + "d=" + d + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(d);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory d;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory d) {
       this.source = source;
+      this.d = d;
     }
 
     @Override
     public ToBooleanFromDoubleEvaluator get(DriverContext context) {
-      return new ToBooleanFromDoubleEvaluator(field.get(context), source, context);
+      return new ToBooleanFromDoubleEvaluator(source, d.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToBooleanFromDoubleEvaluator[field=" + field + "]";
+      return "ToBooleanFromDoubleEvaluator[" + "d=" + d + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanFromIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanFromIntEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToBooleanFromIntEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToBooleanFromIntEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator i;
+
+  public ToBooleanFromIntEvaluator(Source source, EvalOperator.ExpressionEvaluator i,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.i = i;
   }
 
   @Override
-  public String name() {
-    return "ToBooleanFromInt";
+  public EvalOperator.ExpressionEvaluator next() {
+    return i;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToBooleanFromIntEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static boolean evalValue(IntVector container, int index) {
+  private boolean evalValue(IntVector container, int index) {
     int value = container.getInt(index);
     return ToBoolean.fromInt(value);
   }
@@ -80,29 +84,39 @@ public final class ToBooleanFromIntEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static boolean evalValue(IntBlock container, int index) {
+  private boolean evalValue(IntBlock container, int index) {
     int value = container.getInt(index);
     return ToBoolean.fromInt(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToBooleanFromIntEvaluator[" + "i=" + i + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(i);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory i;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory i) {
       this.source = source;
+      this.i = i;
     }
 
     @Override
     public ToBooleanFromIntEvaluator get(DriverContext context) {
-      return new ToBooleanFromIntEvaluator(field.get(context), source, context);
+      return new ToBooleanFromIntEvaluator(source, i.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToBooleanFromIntEvaluator[field=" + field + "]";
+      return "ToBooleanFromIntEvaluator[" + "i=" + i + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanFromLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanFromLongEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToBooleanFromLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToBooleanFromLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator l;
+
+  public ToBooleanFromLongEvaluator(Source source, EvalOperator.ExpressionEvaluator l,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.l = l;
   }
 
   @Override
-  public String name() {
-    return "ToBooleanFromLong";
+  public EvalOperator.ExpressionEvaluator next() {
+    return l;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToBooleanFromLongEvaluator extends AbstractConvertFunction.Ab
     }
   }
 
-  private static boolean evalValue(LongVector container, int index) {
+  private boolean evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToBoolean.fromLong(value);
   }
@@ -80,29 +84,39 @@ public final class ToBooleanFromLongEvaluator extends AbstractConvertFunction.Ab
     }
   }
 
-  private static boolean evalValue(LongBlock container, int index) {
+  private boolean evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToBoolean.fromLong(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToBooleanFromLongEvaluator[" + "l=" + l + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(l);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory l;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory l) {
       this.source = source;
+      this.l = l;
     }
 
     @Override
     public ToBooleanFromLongEvaluator get(DriverContext context) {
-      return new ToBooleanFromLongEvaluator(field.get(context), source, context);
+      return new ToBooleanFromLongEvaluator(source, l.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToBooleanFromLongEvaluator[field=" + field + "]";
+      return "ToBooleanFromLongEvaluator[" + "l=" + l + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanFromStringEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToBooleanFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToBooleanFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator keyword;
+
+  public ToBooleanFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator keyword,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.keyword = keyword;
   }
 
   @Override
-  public String name() {
-    return "ToBooleanFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return keyword;
   }
 
   @Override
@@ -47,7 +51,7 @@ public final class ToBooleanFromStringEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static boolean evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private boolean evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToBoolean.fromKeyword(value);
   }
@@ -83,29 +87,39 @@ public final class ToBooleanFromStringEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static boolean evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private boolean evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToBoolean.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToBooleanFromStringEvaluator[" + "keyword=" + keyword + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(keyword);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory keyword;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory keyword) {
       this.source = source;
+      this.keyword = keyword;
     }
 
     @Override
     public ToBooleanFromStringEvaluator get(DriverContext context) {
-      return new ToBooleanFromStringEvaluator(field.get(context), source, context);
+      return new ToBooleanFromStringEvaluator(source, keyword.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToBooleanFromStringEvaluator[field=" + field + "]";
+      return "ToBooleanFromStringEvaluator[" + "keyword=" + keyword + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanFromUnsignedLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanFromUnsignedLongEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToBooleanFromUnsignedLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToBooleanFromUnsignedLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator ul;
+
+  public ToBooleanFromUnsignedLongEvaluator(Source source, EvalOperator.ExpressionEvaluator ul,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.ul = ul;
   }
 
   @Override
-  public String name() {
-    return "ToBooleanFromUnsignedLong";
+  public EvalOperator.ExpressionEvaluator next() {
+    return ul;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToBooleanFromUnsignedLongEvaluator extends AbstractConvertFun
     }
   }
 
-  private static boolean evalValue(LongVector container, int index) {
+  private boolean evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToBoolean.fromUnsignedLong(value);
   }
@@ -80,29 +84,39 @@ public final class ToBooleanFromUnsignedLongEvaluator extends AbstractConvertFun
     }
   }
 
-  private static boolean evalValue(LongBlock container, int index) {
+  private boolean evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToBoolean.fromUnsignedLong(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToBooleanFromUnsignedLongEvaluator[" + "ul=" + ul + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(ul);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory ul;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory ul) {
       this.source = source;
+      this.ul = ul;
     }
 
     @Override
     public ToBooleanFromUnsignedLongEvaluator get(DriverContext context) {
-      return new ToBooleanFromUnsignedLongEvaluator(field.get(context), source, context);
+      return new ToBooleanFromUnsignedLongEvaluator(source, ul.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToBooleanFromUnsignedLongEvaluator[field=" + field + "]";
+      return "ToBooleanFromUnsignedLongEvaluator[" + "ul=" + ul + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointFromStringEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToCartesianPointFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToCartesianPointFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToCartesianPointFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToCartesianPointFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -57,7 +61,7 @@ public final class ToCartesianPointFromStringEvaluator extends AbstractConvertFu
     }
   }
 
-  private static BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToCartesianPoint.fromKeyword(value);
   }
@@ -97,29 +101,39 @@ public final class ToCartesianPointFromStringEvaluator extends AbstractConvertFu
     }
   }
 
-  private static BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToCartesianPoint.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToCartesianPointFromStringEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToCartesianPointFromStringEvaluator get(DriverContext context) {
-      return new ToCartesianPointFromStringEvaluator(field.get(context), source, context);
+      return new ToCartesianPointFromStringEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToCartesianPointFromStringEvaluator[field=" + field + "]";
+      return "ToCartesianPointFromStringEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeFromStringEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToCartesianShapeFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToCartesianShapeFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToCartesianShapeFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToCartesianShapeFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -57,7 +61,7 @@ public final class ToCartesianShapeFromStringEvaluator extends AbstractConvertFu
     }
   }
 
-  private static BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToCartesianShape.fromKeyword(value);
   }
@@ -97,29 +101,39 @@ public final class ToCartesianShapeFromStringEvaluator extends AbstractConvertFu
     }
   }
 
-  private static BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToCartesianShape.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToCartesianShapeFromStringEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToCartesianShapeFromStringEvaluator get(DriverContext context) {
-      return new ToCartesianShapeFromStringEvaluator(field.get(context), source, context);
+      return new ToCartesianShapeFromStringEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToCartesianShapeFromStringEvaluator[field=" + field + "]";
+      return "ToCartesianShapeFromStringEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosFromDatetimeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosFromDatetimeEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDateNanosFromDatetimeEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDateNanosFromDatetimeEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToDateNanosFromDatetimeEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToDateNanosFromDatetime";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -55,7 +59,7 @@ public final class ToDateNanosFromDatetimeEvaluator extends AbstractConvertFunct
     }
   }
 
-  private static long evalValue(LongVector container, int index) {
+  private long evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToDateNanos.fromDatetime(value);
   }
@@ -94,29 +98,39 @@ public final class ToDateNanosFromDatetimeEvaluator extends AbstractConvertFunct
     }
   }
 
-  private static long evalValue(LongBlock container, int index) {
+  private long evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToDateNanos.fromDatetime(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDateNanosFromDatetimeEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToDateNanosFromDatetimeEvaluator get(DriverContext context) {
-      return new ToDateNanosFromDatetimeEvaluator(field.get(context), source, context);
+      return new ToDateNanosFromDatetimeEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDateNanosFromDatetimeEvaluator[field=" + field + "]";
+      return "ToDateNanosFromDatetimeEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosFromDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosFromDoubleEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -22,14 +23,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDateNanosFromDoubleEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDateNanosFromDoubleEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToDateNanosFromDoubleEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToDateNanosFromDouble";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -57,7 +61,7 @@ public final class ToDateNanosFromDoubleEvaluator extends AbstractConvertFunctio
     }
   }
 
-  private static long evalValue(DoubleVector container, int index) {
+  private long evalValue(DoubleVector container, int index) {
     double value = container.getDouble(index);
     return ToDateNanos.fromDouble(value);
   }
@@ -96,29 +100,39 @@ public final class ToDateNanosFromDoubleEvaluator extends AbstractConvertFunctio
     }
   }
 
-  private static long evalValue(DoubleBlock container, int index) {
+  private long evalValue(DoubleBlock container, int index) {
     double value = container.getDouble(index);
     return ToDateNanos.fromDouble(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDateNanosFromDoubleEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToDateNanosFromDoubleEvaluator get(DriverContext context) {
-      return new ToDateNanosFromDoubleEvaluator(field.get(context), source, context);
+      return new ToDateNanosFromDoubleEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDateNanosFromDoubleEvaluator[field=" + field + "]";
+      return "ToDateNanosFromDoubleEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosFromLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosFromLongEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDateNanosFromLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDateNanosFromLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToDateNanosFromLongEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToDateNanosFromLong";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -55,7 +59,7 @@ public final class ToDateNanosFromLongEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static long evalValue(LongVector container, int index) {
+  private long evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToDateNanos.fromLong(value);
   }
@@ -94,29 +98,39 @@ public final class ToDateNanosFromLongEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static long evalValue(LongBlock container, int index) {
+  private long evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToDateNanos.fromLong(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDateNanosFromLongEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToDateNanosFromLongEvaluator get(DriverContext context) {
-      return new ToDateNanosFromLongEvaluator(field.get(context), source, context);
+      return new ToDateNanosFromLongEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDateNanosFromLongEvaluator[field=" + field + "]";
+      return "ToDateNanosFromLongEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosFromStringEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -22,14 +23,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDateNanosFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDateNanosFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToDateNanosFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToDateNanosFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -58,7 +62,7 @@ public final class ToDateNanosFromStringEvaluator extends AbstractConvertFunctio
     }
   }
 
-  private static long evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private long evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToDateNanos.fromKeyword(value);
   }
@@ -98,29 +102,39 @@ public final class ToDateNanosFromStringEvaluator extends AbstractConvertFunctio
     }
   }
 
-  private static long evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private long evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToDateNanos.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDateNanosFromStringEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToDateNanosFromStringEvaluator get(DriverContext context) {
-      return new ToDateNanosFromStringEvaluator(field.get(context), source, context);
+      return new ToDateNanosFromStringEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDateNanosFromStringEvaluator[field=" + field + "]";
+      return "ToDateNanosFromStringEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeFromDateNanosEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeFromDateNanosEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDatetimeFromDateNanosEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDatetimeFromDateNanosEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToDatetimeFromDateNanosEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToDatetimeFromDateNanos";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -55,7 +59,7 @@ public final class ToDatetimeFromDateNanosEvaluator extends AbstractConvertFunct
     }
   }
 
-  private static long evalValue(LongVector container, int index) {
+  private long evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToDatetime.fromDatenanos(value);
   }
@@ -94,29 +98,39 @@ public final class ToDatetimeFromDateNanosEvaluator extends AbstractConvertFunct
     }
   }
 
-  private static long evalValue(LongBlock container, int index) {
+  private long evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToDatetime.fromDatenanos(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDatetimeFromDateNanosEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToDatetimeFromDateNanosEvaluator get(DriverContext context) {
-      return new ToDatetimeFromDateNanosEvaluator(field.get(context), source, context);
+      return new ToDatetimeFromDateNanosEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDatetimeFromDateNanosEvaluator[field=" + field + "]";
+      return "ToDatetimeFromDateNanosEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeFromStringEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -22,14 +23,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDatetimeFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDatetimeFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToDatetimeFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToDatetimeFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -58,7 +62,7 @@ public final class ToDatetimeFromStringEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static long evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private long evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToDatetime.fromKeyword(value);
   }
@@ -98,29 +102,39 @@ public final class ToDatetimeFromStringEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static long evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private long evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToDatetime.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDatetimeFromStringEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToDatetimeFromStringEvaluator get(DriverContext context) {
-      return new ToDatetimeFromStringEvaluator(field.get(context), source, context);
+      return new ToDatetimeFromStringEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDatetimeFromStringEvaluator[field=" + field + "]";
+      return "ToDatetimeFromStringEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegreesEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegreesEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDegreesEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDegreesEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator deg;
+
+  public ToDegreesEvaluator(Source source, EvalOperator.ExpressionEvaluator deg,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.deg = deg;
   }
 
   @Override
-  public String name() {
-    return "ToDegrees";
+  public EvalOperator.ExpressionEvaluator next() {
+    return deg;
   }
 
   @Override
@@ -55,7 +59,7 @@ public final class ToDegreesEvaluator extends AbstractConvertFunction.AbstractEv
     }
   }
 
-  private static double evalValue(DoubleVector container, int index) {
+  private double evalValue(DoubleVector container, int index) {
     double value = container.getDouble(index);
     return ToDegrees.process(value);
   }
@@ -94,29 +98,39 @@ public final class ToDegreesEvaluator extends AbstractConvertFunction.AbstractEv
     }
   }
 
-  private static double evalValue(DoubleBlock container, int index) {
+  private double evalValue(DoubleBlock container, int index) {
     double value = container.getDouble(index);
     return ToDegrees.process(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDegreesEvaluator[" + "deg=" + deg + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(deg);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory deg;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory deg) {
       this.source = source;
+      this.deg = deg;
     }
 
     @Override
     public ToDegreesEvaluator get(DriverContext context) {
-      return new ToDegreesEvaluator(field.get(context), source, context);
+      return new ToDegreesEvaluator(source, deg.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDegreesEvaluator[field=" + field + "]";
+      return "ToDegreesEvaluator[" + "deg=" + deg + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleFromBooleanEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleFromBooleanEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDoubleFromBooleanEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDoubleFromBooleanEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator bool;
+
+  public ToDoubleFromBooleanEvaluator(Source source, EvalOperator.ExpressionEvaluator bool,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.bool = bool;
   }
 
   @Override
-  public String name() {
-    return "ToDoubleFromBoolean";
+  public EvalOperator.ExpressionEvaluator next() {
+    return bool;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToDoubleFromBooleanEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static double evalValue(BooleanVector container, int index) {
+  private double evalValue(BooleanVector container, int index) {
     boolean value = container.getBoolean(index);
     return ToDouble.fromBoolean(value);
   }
@@ -80,29 +84,39 @@ public final class ToDoubleFromBooleanEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static double evalValue(BooleanBlock container, int index) {
+  private double evalValue(BooleanBlock container, int index) {
     boolean value = container.getBoolean(index);
     return ToDouble.fromBoolean(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDoubleFromBooleanEvaluator[" + "bool=" + bool + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(bool);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory bool;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory bool) {
       this.source = source;
+      this.bool = bool;
     }
 
     @Override
     public ToDoubleFromBooleanEvaluator get(DriverContext context) {
-      return new ToDoubleFromBooleanEvaluator(field.get(context), source, context);
+      return new ToDoubleFromBooleanEvaluator(source, bool.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDoubleFromBooleanEvaluator[field=" + field + "]";
+      return "ToDoubleFromBooleanEvaluator[" + "bool=" + bool + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleFromIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleFromIntEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDoubleFromIntEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDoubleFromIntEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator i;
+
+  public ToDoubleFromIntEvaluator(Source source, EvalOperator.ExpressionEvaluator i,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.i = i;
   }
 
   @Override
-  public String name() {
-    return "ToDoubleFromInt";
+  public EvalOperator.ExpressionEvaluator next() {
+    return i;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToDoubleFromIntEvaluator extends AbstractConvertFunction.Abst
     }
   }
 
-  private static double evalValue(IntVector container, int index) {
+  private double evalValue(IntVector container, int index) {
     int value = container.getInt(index);
     return ToDouble.fromInt(value);
   }
@@ -80,29 +84,39 @@ public final class ToDoubleFromIntEvaluator extends AbstractConvertFunction.Abst
     }
   }
 
-  private static double evalValue(IntBlock container, int index) {
+  private double evalValue(IntBlock container, int index) {
     int value = container.getInt(index);
     return ToDouble.fromInt(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDoubleFromIntEvaluator[" + "i=" + i + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(i);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory i;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory i) {
       this.source = source;
+      this.i = i;
     }
 
     @Override
     public ToDoubleFromIntEvaluator get(DriverContext context) {
-      return new ToDoubleFromIntEvaluator(field.get(context), source, context);
+      return new ToDoubleFromIntEvaluator(source, i.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDoubleFromIntEvaluator[field=" + field + "]";
+      return "ToDoubleFromIntEvaluator[" + "i=" + i + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleFromLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleFromLongEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDoubleFromLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDoubleFromLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator l;
+
+  public ToDoubleFromLongEvaluator(Source source, EvalOperator.ExpressionEvaluator l,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.l = l;
   }
 
   @Override
-  public String name() {
-    return "ToDoubleFromLong";
+  public EvalOperator.ExpressionEvaluator next() {
+    return l;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToDoubleFromLongEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static double evalValue(LongVector container, int index) {
+  private double evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToDouble.fromLong(value);
   }
@@ -80,29 +84,39 @@ public final class ToDoubleFromLongEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static double evalValue(LongBlock container, int index) {
+  private double evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToDouble.fromLong(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDoubleFromLongEvaluator[" + "l=" + l + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(l);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory l;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory l) {
       this.source = source;
+      this.l = l;
     }
 
     @Override
     public ToDoubleFromLongEvaluator get(DriverContext context) {
-      return new ToDoubleFromLongEvaluator(field.get(context), source, context);
+      return new ToDoubleFromLongEvaluator(source, l.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDoubleFromLongEvaluator[field=" + field + "]";
+      return "ToDoubleFromLongEvaluator[" + "l=" + l + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleFromStringEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -22,14 +23,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDoubleFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDoubleFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToDoubleFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToDoubleFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -58,7 +62,7 @@ public final class ToDoubleFromStringEvaluator extends AbstractConvertFunction.A
     }
   }
 
-  private static double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToDouble.fromKeyword(value);
   }
@@ -98,29 +102,39 @@ public final class ToDoubleFromStringEvaluator extends AbstractConvertFunction.A
     }
   }
 
-  private static double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToDouble.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDoubleFromStringEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToDoubleFromStringEvaluator get(DriverContext context) {
-      return new ToDoubleFromStringEvaluator(field.get(context), source, context);
+      return new ToDoubleFromStringEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDoubleFromStringEvaluator[field=" + field + "]";
+      return "ToDoubleFromStringEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleFromUnsignedLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleFromUnsignedLongEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToDoubleFromUnsignedLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToDoubleFromUnsignedLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator l;
+
+  public ToDoubleFromUnsignedLongEvaluator(Source source, EvalOperator.ExpressionEvaluator l,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.l = l;
   }
 
   @Override
-  public String name() {
-    return "ToDoubleFromUnsignedLong";
+  public EvalOperator.ExpressionEvaluator next() {
+    return l;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToDoubleFromUnsignedLongEvaluator extends AbstractConvertFunc
     }
   }
 
-  private static double evalValue(LongVector container, int index) {
+  private double evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToDouble.fromUnsignedLong(value);
   }
@@ -80,29 +84,39 @@ public final class ToDoubleFromUnsignedLongEvaluator extends AbstractConvertFunc
     }
   }
 
-  private static double evalValue(LongBlock container, int index) {
+  private double evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToDouble.fromUnsignedLong(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToDoubleFromUnsignedLongEvaluator[" + "l=" + l + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(l);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory l;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory l) {
       this.source = source;
+      this.l = l;
     }
 
     @Override
     public ToDoubleFromUnsignedLongEvaluator get(DriverContext context) {
-      return new ToDoubleFromUnsignedLongEvaluator(field.get(context), source, context);
+      return new ToDoubleFromUnsignedLongEvaluator(source, l.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToDoubleFromUnsignedLongEvaluator[field=" + field + "]";
+      return "ToDoubleFromUnsignedLongEvaluator[" + "l=" + l + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointFromStringEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToGeoPointFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToGeoPointFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToGeoPointFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToGeoPointFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -57,7 +61,7 @@ public final class ToGeoPointFromStringEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToGeoPoint.fromKeyword(value);
   }
@@ -97,29 +101,39 @@ public final class ToGeoPointFromStringEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToGeoPoint.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToGeoPointFromStringEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToGeoPointFromStringEvaluator get(DriverContext context) {
-      return new ToGeoPointFromStringEvaluator(field.get(context), source, context);
+      return new ToGeoPointFromStringEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToGeoPointFromStringEvaluator[field=" + field + "]";
+      return "ToGeoPointFromStringEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShapeFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShapeFromStringEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToGeoShapeFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToGeoShapeFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToGeoShapeFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToGeoShapeFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -57,7 +61,7 @@ public final class ToGeoShapeFromStringEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToGeoShape.fromKeyword(value);
   }
@@ -97,29 +101,39 @@ public final class ToGeoShapeFromStringEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToGeoShape.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToGeoShapeFromStringEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToGeoShapeFromStringEvaluator get(DriverContext context) {
-      return new ToGeoShapeFromStringEvaluator(field.get(context), source, context);
+      return new ToGeoShapeFromStringEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToGeoShapeFromStringEvaluator[field=" + field + "]";
+      return "ToGeoShapeFromStringEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerFromBooleanEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerFromBooleanEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToIntegerFromBooleanEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToIntegerFromBooleanEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator bool;
+
+  public ToIntegerFromBooleanEvaluator(Source source, EvalOperator.ExpressionEvaluator bool,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.bool = bool;
   }
 
   @Override
-  public String name() {
-    return "ToIntegerFromBoolean";
+  public EvalOperator.ExpressionEvaluator next() {
+    return bool;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToIntegerFromBooleanEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static int evalValue(BooleanVector container, int index) {
+  private int evalValue(BooleanVector container, int index) {
     boolean value = container.getBoolean(index);
     return ToInteger.fromBoolean(value);
   }
@@ -80,29 +84,39 @@ public final class ToIntegerFromBooleanEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static int evalValue(BooleanBlock container, int index) {
+  private int evalValue(BooleanBlock container, int index) {
     boolean value = container.getBoolean(index);
     return ToInteger.fromBoolean(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToIntegerFromBooleanEvaluator[" + "bool=" + bool + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(bool);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory bool;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory bool) {
       this.source = source;
+      this.bool = bool;
     }
 
     @Override
     public ToIntegerFromBooleanEvaluator get(DriverContext context) {
-      return new ToIntegerFromBooleanEvaluator(field.get(context), source, context);
+      return new ToIntegerFromBooleanEvaluator(source, bool.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToIntegerFromBooleanEvaluator[field=" + field + "]";
+      return "ToIntegerFromBooleanEvaluator[" + "bool=" + bool + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerFromDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerFromDoubleEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToIntegerFromDoubleEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToIntegerFromDoubleEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator dbl;
+
+  public ToIntegerFromDoubleEvaluator(Source source, EvalOperator.ExpressionEvaluator dbl,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.dbl = dbl;
   }
 
   @Override
-  public String name() {
-    return "ToIntegerFromDouble";
+  public EvalOperator.ExpressionEvaluator next() {
+    return dbl;
   }
 
   @Override
@@ -56,7 +60,7 @@ public final class ToIntegerFromDoubleEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static int evalValue(DoubleVector container, int index) {
+  private int evalValue(DoubleVector container, int index) {
     double value = container.getDouble(index);
     return ToInteger.fromDouble(value);
   }
@@ -95,29 +99,39 @@ public final class ToIntegerFromDoubleEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static int evalValue(DoubleBlock container, int index) {
+  private int evalValue(DoubleBlock container, int index) {
     double value = container.getDouble(index);
     return ToInteger.fromDouble(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToIntegerFromDoubleEvaluator[" + "dbl=" + dbl + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(dbl);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory dbl;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory dbl) {
       this.source = source;
+      this.dbl = dbl;
     }
 
     @Override
     public ToIntegerFromDoubleEvaluator get(DriverContext context) {
-      return new ToIntegerFromDoubleEvaluator(field.get(context), source, context);
+      return new ToIntegerFromDoubleEvaluator(source, dbl.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToIntegerFromDoubleEvaluator[field=" + field + "]";
+      return "ToIntegerFromDoubleEvaluator[" + "dbl=" + dbl + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerFromLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerFromLongEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToIntegerFromLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToIntegerFromLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator lng;
+
+  public ToIntegerFromLongEvaluator(Source source, EvalOperator.ExpressionEvaluator lng,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.lng = lng;
   }
 
   @Override
-  public String name() {
-    return "ToIntegerFromLong";
+  public EvalOperator.ExpressionEvaluator next() {
+    return lng;
   }
 
   @Override
@@ -56,7 +60,7 @@ public final class ToIntegerFromLongEvaluator extends AbstractConvertFunction.Ab
     }
   }
 
-  private static int evalValue(LongVector container, int index) {
+  private int evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToInteger.fromLong(value);
   }
@@ -95,29 +99,39 @@ public final class ToIntegerFromLongEvaluator extends AbstractConvertFunction.Ab
     }
   }
 
-  private static int evalValue(LongBlock container, int index) {
+  private int evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToInteger.fromLong(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToIntegerFromLongEvaluator[" + "lng=" + lng + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(lng);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory lng;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory lng) {
       this.source = source;
+      this.lng = lng;
     }
 
     @Override
     public ToIntegerFromLongEvaluator get(DriverContext context) {
-      return new ToIntegerFromLongEvaluator(field.get(context), source, context);
+      return new ToIntegerFromLongEvaluator(source, lng.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToIntegerFromLongEvaluator[field=" + field + "]";
+      return "ToIntegerFromLongEvaluator[" + "lng=" + lng + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerFromStringEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -22,14 +23,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToIntegerFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToIntegerFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToIntegerFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToIntegerFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -58,7 +62,7 @@ public final class ToIntegerFromStringEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static int evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private int evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToInteger.fromKeyword(value);
   }
@@ -98,29 +102,39 @@ public final class ToIntegerFromStringEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static int evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private int evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToInteger.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToIntegerFromStringEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToIntegerFromStringEvaluator get(DriverContext context) {
-      return new ToIntegerFromStringEvaluator(field.get(context), source, context);
+      return new ToIntegerFromStringEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToIntegerFromStringEvaluator[field=" + field + "]";
+      return "ToIntegerFromStringEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerFromUnsignedLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerFromUnsignedLongEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToIntegerFromUnsignedLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToIntegerFromUnsignedLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator ul;
+
+  public ToIntegerFromUnsignedLongEvaluator(Source source, EvalOperator.ExpressionEvaluator ul,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.ul = ul;
   }
 
   @Override
-  public String name() {
-    return "ToIntegerFromUnsignedLong";
+  public EvalOperator.ExpressionEvaluator next() {
+    return ul;
   }
 
   @Override
@@ -56,7 +60,7 @@ public final class ToIntegerFromUnsignedLongEvaluator extends AbstractConvertFun
     }
   }
 
-  private static int evalValue(LongVector container, int index) {
+  private int evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToInteger.fromUnsignedLong(value);
   }
@@ -95,29 +99,39 @@ public final class ToIntegerFromUnsignedLongEvaluator extends AbstractConvertFun
     }
   }
 
-  private static int evalValue(LongBlock container, int index) {
+  private int evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToInteger.fromUnsignedLong(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToIntegerFromUnsignedLongEvaluator[" + "ul=" + ul + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(ul);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory ul;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory ul) {
       this.source = source;
+      this.ul = ul;
     }
 
     @Override
     public ToIntegerFromUnsignedLongEvaluator get(DriverContext context) {
-      return new ToIntegerFromUnsignedLongEvaluator(field.get(context), source, context);
+      return new ToIntegerFromUnsignedLongEvaluator(source, ul.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToIntegerFromUnsignedLongEvaluator[field=" + field + "]";
+      return "ToIntegerFromUnsignedLongEvaluator[" + "ul=" + ul + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromBooleanEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromBooleanEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToLongFromBooleanEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToLongFromBooleanEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator bool;
+
+  public ToLongFromBooleanEvaluator(Source source, EvalOperator.ExpressionEvaluator bool,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.bool = bool;
   }
 
   @Override
-  public String name() {
-    return "ToLongFromBoolean";
+  public EvalOperator.ExpressionEvaluator next() {
+    return bool;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToLongFromBooleanEvaluator extends AbstractConvertFunction.Ab
     }
   }
 
-  private static long evalValue(BooleanVector container, int index) {
+  private long evalValue(BooleanVector container, int index) {
     boolean value = container.getBoolean(index);
     return ToLong.fromBoolean(value);
   }
@@ -80,29 +84,39 @@ public final class ToLongFromBooleanEvaluator extends AbstractConvertFunction.Ab
     }
   }
 
-  private static long evalValue(BooleanBlock container, int index) {
+  private long evalValue(BooleanBlock container, int index) {
     boolean value = container.getBoolean(index);
     return ToLong.fromBoolean(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToLongFromBooleanEvaluator[" + "bool=" + bool + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(bool);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory bool;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory bool) {
       this.source = source;
+      this.bool = bool;
     }
 
     @Override
     public ToLongFromBooleanEvaluator get(DriverContext context) {
-      return new ToLongFromBooleanEvaluator(field.get(context), source, context);
+      return new ToLongFromBooleanEvaluator(source, bool.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToLongFromBooleanEvaluator[field=" + field + "]";
+      return "ToLongFromBooleanEvaluator[" + "bool=" + bool + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromDoubleEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToLongFromDoubleEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToLongFromDoubleEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator dbl;
+
+  public ToLongFromDoubleEvaluator(Source source, EvalOperator.ExpressionEvaluator dbl,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.dbl = dbl;
   }
 
   @Override
-  public String name() {
-    return "ToLongFromDouble";
+  public EvalOperator.ExpressionEvaluator next() {
+    return dbl;
   }
 
   @Override
@@ -56,7 +60,7 @@ public final class ToLongFromDoubleEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static long evalValue(DoubleVector container, int index) {
+  private long evalValue(DoubleVector container, int index) {
     double value = container.getDouble(index);
     return ToLong.fromDouble(value);
   }
@@ -95,29 +99,39 @@ public final class ToLongFromDoubleEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static long evalValue(DoubleBlock container, int index) {
+  private long evalValue(DoubleBlock container, int index) {
     double value = container.getDouble(index);
     return ToLong.fromDouble(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToLongFromDoubleEvaluator[" + "dbl=" + dbl + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(dbl);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory dbl;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory dbl) {
       this.source = source;
+      this.dbl = dbl;
     }
 
     @Override
     public ToLongFromDoubleEvaluator get(DriverContext context) {
-      return new ToLongFromDoubleEvaluator(field.get(context), source, context);
+      return new ToLongFromDoubleEvaluator(source, dbl.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToLongFromDoubleEvaluator[field=" + field + "]";
+      return "ToLongFromDoubleEvaluator[" + "dbl=" + dbl + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromIntEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToLongFromIntEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToLongFromIntEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator i;
+
+  public ToLongFromIntEvaluator(Source source, EvalOperator.ExpressionEvaluator i,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.i = i;
   }
 
   @Override
-  public String name() {
-    return "ToLongFromInt";
+  public EvalOperator.ExpressionEvaluator next() {
+    return i;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToLongFromIntEvaluator extends AbstractConvertFunction.Abstra
     }
   }
 
-  private static long evalValue(IntVector container, int index) {
+  private long evalValue(IntVector container, int index) {
     int value = container.getInt(index);
     return ToLong.fromInt(value);
   }
@@ -80,29 +84,39 @@ public final class ToLongFromIntEvaluator extends AbstractConvertFunction.Abstra
     }
   }
 
-  private static long evalValue(IntBlock container, int index) {
+  private long evalValue(IntBlock container, int index) {
     int value = container.getInt(index);
     return ToLong.fromInt(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToLongFromIntEvaluator[" + "i=" + i + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(i);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory i;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory i) {
       this.source = source;
+      this.i = i;
     }
 
     @Override
     public ToLongFromIntEvaluator get(DriverContext context) {
-      return new ToLongFromIntEvaluator(field.get(context), source, context);
+      return new ToLongFromIntEvaluator(source, i.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToLongFromIntEvaluator[field=" + field + "]";
+      return "ToLongFromIntEvaluator[" + "i=" + i + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromStringEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -22,14 +23,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToLongFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToLongFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToLongFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToLongFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -58,7 +62,7 @@ public final class ToLongFromStringEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static long evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private long evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToLong.fromKeyword(value);
   }
@@ -98,29 +102,39 @@ public final class ToLongFromStringEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static long evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private long evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToLong.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToLongFromStringEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToLongFromStringEvaluator get(DriverContext context) {
-      return new ToLongFromStringEvaluator(field.get(context), source, context);
+      return new ToLongFromStringEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToLongFromStringEvaluator[field=" + field + "]";
+      return "ToLongFromStringEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromUnsignedLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromUnsignedLongEvaluator.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToLongFromUnsignedLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToLongFromUnsignedLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator ul;
+
+  public ToLongFromUnsignedLongEvaluator(Source source, EvalOperator.ExpressionEvaluator ul,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.ul = ul;
   }
 
   @Override
-  public String name() {
-    return "ToLongFromUnsignedLong";
+  public EvalOperator.ExpressionEvaluator next() {
+    return ul;
   }
 
   @Override
@@ -55,7 +59,7 @@ public final class ToLongFromUnsignedLongEvaluator extends AbstractConvertFuncti
     }
   }
 
-  private static long evalValue(LongVector container, int index) {
+  private long evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToLong.fromUnsignedLong(value);
   }
@@ -94,29 +98,39 @@ public final class ToLongFromUnsignedLongEvaluator extends AbstractConvertFuncti
     }
   }
 
-  private static long evalValue(LongBlock container, int index) {
+  private long evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToLong.fromUnsignedLong(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToLongFromUnsignedLongEvaluator[" + "ul=" + ul + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(ul);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory ul;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory ul) {
       this.source = source;
+      this.ul = ul;
     }
 
     @Override
     public ToLongFromUnsignedLongEvaluator get(DriverContext context) {
-      return new ToLongFromUnsignedLongEvaluator(field.get(context), source, context);
+      return new ToLongFromUnsignedLongEvaluator(source, ul.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToLongFromUnsignedLongEvaluator[field=" + field + "]";
+      return "ToLongFromUnsignedLongEvaluator[" + "ul=" + ul + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadiansEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadiansEvaluator.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -19,14 +20,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToRadiansEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToRadiansEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator deg;
+
+  public ToRadiansEvaluator(Source source, EvalOperator.ExpressionEvaluator deg,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.deg = deg;
   }
 
   @Override
-  public String name() {
-    return "ToRadians";
+  public EvalOperator.ExpressionEvaluator next() {
+    return deg;
   }
 
   @Override
@@ -44,7 +48,7 @@ public final class ToRadiansEvaluator extends AbstractConvertFunction.AbstractEv
     }
   }
 
-  private static double evalValue(DoubleVector container, int index) {
+  private double evalValue(DoubleVector container, int index) {
     double value = container.getDouble(index);
     return ToRadians.process(value);
   }
@@ -79,29 +83,39 @@ public final class ToRadiansEvaluator extends AbstractConvertFunction.AbstractEv
     }
   }
 
-  private static double evalValue(DoubleBlock container, int index) {
+  private double evalValue(DoubleBlock container, int index) {
     double value = container.getDouble(index);
     return ToRadians.process(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToRadiansEvaluator[" + "deg=" + deg + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(deg);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory deg;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory deg) {
       this.source = source;
+      this.deg = deg;
     }
 
     @Override
     public ToRadiansEvaluator get(DriverContext context) {
-      return new ToRadiansEvaluator(field.get(context), source, context);
+      return new ToRadiansEvaluator(source, deg.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToRadiansEvaluator[field=" + field + "]";
+      return "ToRadiansEvaluator[" + "deg=" + deg + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromBooleanEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromBooleanEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromBooleanEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromBooleanEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator bool;
+
+  public ToStringFromBooleanEvaluator(Source source, EvalOperator.ExpressionEvaluator bool,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.bool = bool;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromBoolean";
+  public EvalOperator.ExpressionEvaluator next() {
+    return bool;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromBooleanEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static BytesRef evalValue(BooleanVector container, int index) {
+  private BytesRef evalValue(BooleanVector container, int index) {
     boolean value = container.getBoolean(index);
     return ToString.fromBoolean(value);
   }
@@ -81,29 +85,39 @@ public final class ToStringFromBooleanEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static BytesRef evalValue(BooleanBlock container, int index) {
+  private BytesRef evalValue(BooleanBlock container, int index) {
     boolean value = container.getBoolean(index);
     return ToString.fromBoolean(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromBooleanEvaluator[" + "bool=" + bool + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(bool);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory bool;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory bool) {
       this.source = source;
+      this.bool = bool;
     }
 
     @Override
     public ToStringFromBooleanEvaluator get(DriverContext context) {
-      return new ToStringFromBooleanEvaluator(field.get(context), source, context);
+      return new ToStringFromBooleanEvaluator(source, bool.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromBooleanEvaluator[field=" + field + "]";
+      return "ToStringFromBooleanEvaluator[" + "bool=" + bool + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromCartesianShapeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromCartesianShapeEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromCartesianShapeEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromCartesianShapeEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public ToStringFromCartesianShapeEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromCartesianShape";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromCartesianShapeEvaluator extends AbstractConvertFu
     }
   }
 
-  private static BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToString.fromCartesianShape(value);
   }
@@ -82,29 +86,39 @@ public final class ToStringFromCartesianShapeEvaluator extends AbstractConvertFu
     }
   }
 
-  private static BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToString.fromCartesianShape(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromCartesianShapeEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public ToStringFromCartesianShapeEvaluator get(DriverContext context) {
-      return new ToStringFromCartesianShapeEvaluator(field.get(context), source, context);
+      return new ToStringFromCartesianShapeEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromCartesianShapeEvaluator[field=" + field + "]";
+      return "ToStringFromCartesianShapeEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromDateNanosEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromDateNanosEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromDateNanosEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromDateNanosEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator datetime;
+
+  public ToStringFromDateNanosEvaluator(Source source, EvalOperator.ExpressionEvaluator datetime,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.datetime = datetime;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromDateNanos";
+  public EvalOperator.ExpressionEvaluator next() {
+    return datetime;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromDateNanosEvaluator extends AbstractConvertFunctio
     }
   }
 
-  private static BytesRef evalValue(LongVector container, int index) {
+  private BytesRef evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToString.fromDateNanos(value);
   }
@@ -81,29 +85,39 @@ public final class ToStringFromDateNanosEvaluator extends AbstractConvertFunctio
     }
   }
 
-  private static BytesRef evalValue(LongBlock container, int index) {
+  private BytesRef evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToString.fromDateNanos(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromDateNanosEvaluator[" + "datetime=" + datetime + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(datetime);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory datetime;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory datetime) {
       this.source = source;
+      this.datetime = datetime;
     }
 
     @Override
     public ToStringFromDateNanosEvaluator get(DriverContext context) {
-      return new ToStringFromDateNanosEvaluator(field.get(context), source, context);
+      return new ToStringFromDateNanosEvaluator(source, datetime.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromDateNanosEvaluator[field=" + field + "]";
+      return "ToStringFromDateNanosEvaluator[" + "datetime=" + datetime + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromDatetimeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromDatetimeEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromDatetimeEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromDatetimeEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator datetime;
+
+  public ToStringFromDatetimeEvaluator(Source source, EvalOperator.ExpressionEvaluator datetime,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.datetime = datetime;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromDatetime";
+  public EvalOperator.ExpressionEvaluator next() {
+    return datetime;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromDatetimeEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(LongVector container, int index) {
+  private BytesRef evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToString.fromDatetime(value);
   }
@@ -81,29 +85,39 @@ public final class ToStringFromDatetimeEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(LongBlock container, int index) {
+  private BytesRef evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToString.fromDatetime(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromDatetimeEvaluator[" + "datetime=" + datetime + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(datetime);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory datetime;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory datetime) {
       this.source = source;
+      this.datetime = datetime;
     }
 
     @Override
     public ToStringFromDatetimeEvaluator get(DriverContext context) {
-      return new ToStringFromDatetimeEvaluator(field.get(context), source, context);
+      return new ToStringFromDatetimeEvaluator(source, datetime.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromDatetimeEvaluator[field=" + field + "]";
+      return "ToStringFromDatetimeEvaluator[" + "datetime=" + datetime + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromDoubleEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromDoubleEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromDoubleEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator dbl;
+
+  public ToStringFromDoubleEvaluator(Source source, EvalOperator.ExpressionEvaluator dbl,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.dbl = dbl;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromDouble";
+  public EvalOperator.ExpressionEvaluator next() {
+    return dbl;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromDoubleEvaluator extends AbstractConvertFunction.A
     }
   }
 
-  private static BytesRef evalValue(DoubleVector container, int index) {
+  private BytesRef evalValue(DoubleVector container, int index) {
     double value = container.getDouble(index);
     return ToString.fromDouble(value);
   }
@@ -81,29 +85,39 @@ public final class ToStringFromDoubleEvaluator extends AbstractConvertFunction.A
     }
   }
 
-  private static BytesRef evalValue(DoubleBlock container, int index) {
+  private BytesRef evalValue(DoubleBlock container, int index) {
     double value = container.getDouble(index);
     return ToString.fromDouble(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromDoubleEvaluator[" + "dbl=" + dbl + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(dbl);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory dbl;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory dbl) {
       this.source = source;
+      this.dbl = dbl;
     }
 
     @Override
     public ToStringFromDoubleEvaluator get(DriverContext context) {
-      return new ToStringFromDoubleEvaluator(field.get(context), source, context);
+      return new ToStringFromDoubleEvaluator(source, dbl.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromDoubleEvaluator[field=" + field + "]";
+      return "ToStringFromDoubleEvaluator[" + "dbl=" + dbl + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromGeoPointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromGeoPointEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromGeoPointEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromGeoPointEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public ToStringFromGeoPointEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromGeoPoint";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromGeoPointEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToString.fromGeoPoint(value);
   }
@@ -82,29 +86,39 @@ public final class ToStringFromGeoPointEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToString.fromGeoPoint(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromGeoPointEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public ToStringFromGeoPointEvaluator get(DriverContext context) {
-      return new ToStringFromGeoPointEvaluator(field.get(context), source, context);
+      return new ToStringFromGeoPointEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromGeoPointEvaluator[field=" + field + "]";
+      return "ToStringFromGeoPointEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromGeoShapeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromGeoShapeEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromGeoShapeEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromGeoShapeEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public ToStringFromGeoShapeEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromGeoShape";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromGeoShapeEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToString.fromGeoShape(value);
   }
@@ -82,29 +86,39 @@ public final class ToStringFromGeoShapeEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToString.fromGeoShape(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromGeoShapeEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public ToStringFromGeoShapeEvaluator get(DriverContext context) {
-      return new ToStringFromGeoShapeEvaluator(field.get(context), source, context);
+      return new ToStringFromGeoShapeEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromGeoShapeEvaluator[field=" + field + "]";
+      return "ToStringFromGeoShapeEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromIPEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromIPEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromIPEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromIPEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator ip;
+
+  public ToStringFromIPEvaluator(Source source, EvalOperator.ExpressionEvaluator ip,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.ip = ip;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromIP";
+  public EvalOperator.ExpressionEvaluator next() {
+    return ip;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromIPEvaluator extends AbstractConvertFunction.Abstr
     }
   }
 
-  private static BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToString.fromIP(value);
   }
@@ -82,29 +86,39 @@ public final class ToStringFromIPEvaluator extends AbstractConvertFunction.Abstr
     }
   }
 
-  private static BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToString.fromIP(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromIPEvaluator[" + "ip=" + ip + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(ip);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory ip;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory ip) {
       this.source = source;
+      this.ip = ip;
     }
 
     @Override
     public ToStringFromIPEvaluator get(DriverContext context) {
-      return new ToStringFromIPEvaluator(field.get(context), source, context);
+      return new ToStringFromIPEvaluator(source, ip.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromIPEvaluator[field=" + field + "]";
+      return "ToStringFromIPEvaluator[" + "ip=" + ip + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromIntEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromIntEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromIntEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator integer;
+
+  public ToStringFromIntEvaluator(Source source, EvalOperator.ExpressionEvaluator integer,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.integer = integer;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromInt";
+  public EvalOperator.ExpressionEvaluator next() {
+    return integer;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromIntEvaluator extends AbstractConvertFunction.Abst
     }
   }
 
-  private static BytesRef evalValue(IntVector container, int index) {
+  private BytesRef evalValue(IntVector container, int index) {
     int value = container.getInt(index);
     return ToString.fromDouble(value);
   }
@@ -81,29 +85,39 @@ public final class ToStringFromIntEvaluator extends AbstractConvertFunction.Abst
     }
   }
 
-  private static BytesRef evalValue(IntBlock container, int index) {
+  private BytesRef evalValue(IntBlock container, int index) {
     int value = container.getInt(index);
     return ToString.fromDouble(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromIntEvaluator[" + "integer=" + integer + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(integer);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory integer;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory integer) {
       this.source = source;
+      this.integer = integer;
     }
 
     @Override
     public ToStringFromIntEvaluator get(DriverContext context) {
-      return new ToStringFromIntEvaluator(field.get(context), source, context);
+      return new ToStringFromIntEvaluator(source, integer.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromIntEvaluator[field=" + field + "]";
+      return "ToStringFromIntEvaluator[" + "integer=" + integer + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromLongEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator lng;
+
+  public ToStringFromLongEvaluator(Source source, EvalOperator.ExpressionEvaluator lng,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.lng = lng;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromLong";
+  public EvalOperator.ExpressionEvaluator next() {
+    return lng;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromLongEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static BytesRef evalValue(LongVector container, int index) {
+  private BytesRef evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToString.fromDouble(value);
   }
@@ -81,29 +85,39 @@ public final class ToStringFromLongEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static BytesRef evalValue(LongBlock container, int index) {
+  private BytesRef evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToString.fromDouble(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromLongEvaluator[" + "lng=" + lng + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(lng);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory lng;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory lng) {
       this.source = source;
+      this.lng = lng;
     }
 
     @Override
     public ToStringFromLongEvaluator get(DriverContext context) {
-      return new ToStringFromLongEvaluator(field.get(context), source, context);
+      return new ToStringFromLongEvaluator(source, lng.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromLongEvaluator[field=" + field + "]";
+      return "ToStringFromLongEvaluator[" + "lng=" + lng + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromUnsignedLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromUnsignedLongEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromUnsignedLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromUnsignedLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator lng;
+
+  public ToStringFromUnsignedLongEvaluator(Source source, EvalOperator.ExpressionEvaluator lng,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.lng = lng;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromUnsignedLong";
+  public EvalOperator.ExpressionEvaluator next() {
+    return lng;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromUnsignedLongEvaluator extends AbstractConvertFunc
     }
   }
 
-  private static BytesRef evalValue(LongVector container, int index) {
+  private BytesRef evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToString.fromUnsignedLong(value);
   }
@@ -81,29 +85,39 @@ public final class ToStringFromUnsignedLongEvaluator extends AbstractConvertFunc
     }
   }
 
-  private static BytesRef evalValue(LongBlock container, int index) {
+  private BytesRef evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToString.fromUnsignedLong(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromUnsignedLongEvaluator[" + "lng=" + lng + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(lng);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory lng;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory lng) {
       this.source = source;
+      this.lng = lng;
     }
 
     @Override
     public ToStringFromUnsignedLongEvaluator get(DriverContext context) {
-      return new ToStringFromUnsignedLongEvaluator(field.get(context), source, context);
+      return new ToStringFromUnsignedLongEvaluator(source, lng.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromUnsignedLongEvaluator[field=" + field + "]";
+      return "ToStringFromUnsignedLongEvaluator[" + "lng=" + lng + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromVersionEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromVersionEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToStringFromVersionEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToStringFromVersionEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator version;
+
+  public ToStringFromVersionEvaluator(Source source, EvalOperator.ExpressionEvaluator version,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.version = version;
   }
 
   @Override
-  public String name() {
-    return "ToStringFromVersion";
+  public EvalOperator.ExpressionEvaluator next() {
+    return version;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToStringFromVersionEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToString.fromVersion(value);
   }
@@ -82,29 +86,39 @@ public final class ToStringFromVersionEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToString.fromVersion(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToStringFromVersionEvaluator[" + "version=" + version + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(version);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory version;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory version) {
       this.source = source;
+      this.version = version;
     }
 
     @Override
     public ToStringFromVersionEvaluator get(DriverContext context) {
-      return new ToStringFromVersionEvaluator(field.get(context), source, context);
+      return new ToStringFromVersionEvaluator(source, version.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToStringFromVersionEvaluator[field=" + field + "]";
+      return "ToStringFromVersionEvaluator[" + "version=" + version + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromBooleanEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromBooleanEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToUnsignedLongFromBooleanEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToUnsignedLongFromBooleanEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator bool;
+
+  public ToUnsignedLongFromBooleanEvaluator(Source source, EvalOperator.ExpressionEvaluator bool,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.bool = bool;
   }
 
   @Override
-  public String name() {
-    return "ToUnsignedLongFromBoolean";
+  public EvalOperator.ExpressionEvaluator next() {
+    return bool;
   }
 
   @Override
@@ -45,7 +49,7 @@ public final class ToUnsignedLongFromBooleanEvaluator extends AbstractConvertFun
     }
   }
 
-  private static long evalValue(BooleanVector container, int index) {
+  private long evalValue(BooleanVector container, int index) {
     boolean value = container.getBoolean(index);
     return ToUnsignedLong.fromBoolean(value);
   }
@@ -80,29 +84,39 @@ public final class ToUnsignedLongFromBooleanEvaluator extends AbstractConvertFun
     }
   }
 
-  private static long evalValue(BooleanBlock container, int index) {
+  private long evalValue(BooleanBlock container, int index) {
     boolean value = container.getBoolean(index);
     return ToUnsignedLong.fromBoolean(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToUnsignedLongFromBooleanEvaluator[" + "bool=" + bool + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(bool);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory bool;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory bool) {
       this.source = source;
+      this.bool = bool;
     }
 
     @Override
     public ToUnsignedLongFromBooleanEvaluator get(DriverContext context) {
-      return new ToUnsignedLongFromBooleanEvaluator(field.get(context), source, context);
+      return new ToUnsignedLongFromBooleanEvaluator(source, bool.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToUnsignedLongFromBooleanEvaluator[field=" + field + "]";
+      return "ToUnsignedLongFromBooleanEvaluator[" + "bool=" + bool + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromDoubleEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToUnsignedLongFromDoubleEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToUnsignedLongFromDoubleEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator dbl;
+
+  public ToUnsignedLongFromDoubleEvaluator(Source source, EvalOperator.ExpressionEvaluator dbl,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.dbl = dbl;
   }
 
   @Override
-  public String name() {
-    return "ToUnsignedLongFromDouble";
+  public EvalOperator.ExpressionEvaluator next() {
+    return dbl;
   }
 
   @Override
@@ -56,7 +60,7 @@ public final class ToUnsignedLongFromDoubleEvaluator extends AbstractConvertFunc
     }
   }
 
-  private static long evalValue(DoubleVector container, int index) {
+  private long evalValue(DoubleVector container, int index) {
     double value = container.getDouble(index);
     return ToUnsignedLong.fromDouble(value);
   }
@@ -95,29 +99,39 @@ public final class ToUnsignedLongFromDoubleEvaluator extends AbstractConvertFunc
     }
   }
 
-  private static long evalValue(DoubleBlock container, int index) {
+  private long evalValue(DoubleBlock container, int index) {
     double value = container.getDouble(index);
     return ToUnsignedLong.fromDouble(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToUnsignedLongFromDoubleEvaluator[" + "dbl=" + dbl + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(dbl);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory dbl;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory dbl) {
       this.source = source;
+      this.dbl = dbl;
     }
 
     @Override
     public ToUnsignedLongFromDoubleEvaluator get(DriverContext context) {
-      return new ToUnsignedLongFromDoubleEvaluator(field.get(context), source, context);
+      return new ToUnsignedLongFromDoubleEvaluator(source, dbl.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToUnsignedLongFromDoubleEvaluator[field=" + field + "]";
+      return "ToUnsignedLongFromDoubleEvaluator[" + "dbl=" + dbl + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromIntEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -21,14 +22,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToUnsignedLongFromIntEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToUnsignedLongFromIntEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator i;
+
+  public ToUnsignedLongFromIntEvaluator(Source source, EvalOperator.ExpressionEvaluator i,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.i = i;
   }
 
   @Override
-  public String name() {
-    return "ToUnsignedLongFromInt";
+  public EvalOperator.ExpressionEvaluator next() {
+    return i;
   }
 
   @Override
@@ -56,7 +60,7 @@ public final class ToUnsignedLongFromIntEvaluator extends AbstractConvertFunctio
     }
   }
 
-  private static long evalValue(IntVector container, int index) {
+  private long evalValue(IntVector container, int index) {
     int value = container.getInt(index);
     return ToUnsignedLong.fromInt(value);
   }
@@ -95,29 +99,39 @@ public final class ToUnsignedLongFromIntEvaluator extends AbstractConvertFunctio
     }
   }
 
-  private static long evalValue(IntBlock container, int index) {
+  private long evalValue(IntBlock container, int index) {
     int value = container.getInt(index);
     return ToUnsignedLong.fromInt(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToUnsignedLongFromIntEvaluator[" + "i=" + i + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(i);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory i;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory i) {
       this.source = source;
+      this.i = i;
     }
 
     @Override
     public ToUnsignedLongFromIntEvaluator get(DriverContext context) {
-      return new ToUnsignedLongFromIntEvaluator(field.get(context), source, context);
+      return new ToUnsignedLongFromIntEvaluator(source, i.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToUnsignedLongFromIntEvaluator[field=" + field + "]";
+      return "ToUnsignedLongFromIntEvaluator[" + "i=" + i + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromLongEvaluator.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToUnsignedLongFromLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToUnsignedLongFromLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator lng;
+
+  public ToUnsignedLongFromLongEvaluator(Source source, EvalOperator.ExpressionEvaluator lng,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.lng = lng;
   }
 
   @Override
-  public String name() {
-    return "ToUnsignedLongFromLong";
+  public EvalOperator.ExpressionEvaluator next() {
+    return lng;
   }
 
   @Override
@@ -55,7 +59,7 @@ public final class ToUnsignedLongFromLongEvaluator extends AbstractConvertFuncti
     }
   }
 
-  private static long evalValue(LongVector container, int index) {
+  private long evalValue(LongVector container, int index) {
     long value = container.getLong(index);
     return ToUnsignedLong.fromLong(value);
   }
@@ -94,29 +98,39 @@ public final class ToUnsignedLongFromLongEvaluator extends AbstractConvertFuncti
     }
   }
 
-  private static long evalValue(LongBlock container, int index) {
+  private long evalValue(LongBlock container, int index) {
     long value = container.getLong(index);
     return ToUnsignedLong.fromLong(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToUnsignedLongFromLongEvaluator[" + "lng=" + lng + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(lng);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory lng;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory lng) {
       this.source = source;
+      this.lng = lng;
     }
 
     @Override
     public ToUnsignedLongFromLongEvaluator get(DriverContext context) {
-      return new ToUnsignedLongFromLongEvaluator(field.get(context), source, context);
+      return new ToUnsignedLongFromLongEvaluator(source, lng.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToUnsignedLongFromLongEvaluator[field=" + field + "]";
+      return "ToUnsignedLongFromLongEvaluator[" + "lng=" + lng + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromStringEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
@@ -23,14 +24,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToUnsignedLongFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToUnsignedLongFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public ToUnsignedLongFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "ToUnsignedLongFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -59,7 +63,7 @@ public final class ToUnsignedLongFromStringEvaluator extends AbstractConvertFunc
     }
   }
 
-  private static long evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private long evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToUnsignedLong.fromKeyword(value);
   }
@@ -99,29 +103,39 @@ public final class ToUnsignedLongFromStringEvaluator extends AbstractConvertFunc
     }
   }
 
-  private static long evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private long evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToUnsignedLong.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToUnsignedLongFromStringEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public ToUnsignedLongFromStringEvaluator get(DriverContext context) {
-      return new ToUnsignedLongFromStringEvaluator(field.get(context), source, context);
+      return new ToUnsignedLongFromStringEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToUnsignedLongFromStringEvaluator[field=" + field + "]";
+      return "ToUnsignedLongFromStringEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionFromStringEvaluator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
@@ -20,14 +21,17 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class ToVersionFromStringEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public ToVersionFromStringEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator asString;
+
+  public ToVersionFromStringEvaluator(Source source, EvalOperator.ExpressionEvaluator asString,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.asString = asString;
   }
 
   @Override
-  public String name() {
-    return "ToVersionFromString";
+  public EvalOperator.ExpressionEvaluator next() {
+    return asString;
   }
 
   @Override
@@ -46,7 +50,7 @@ public final class ToVersionFromStringEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToVersion.fromKeyword(value);
   }
@@ -82,29 +86,39 @@ public final class ToVersionFromStringEvaluator extends AbstractConvertFunction.
     }
   }
 
-  private static BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToVersion.fromKeyword(value);
+  }
+
+  @Override
+  public String toString() {
+    return "ToVersionFromStringEvaluator[" + "asString=" + asString + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(asString);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory asString;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory asString) {
       this.source = source;
+      this.asString = asString;
     }
 
     @Override
     public ToVersionFromStringEvaluator get(DriverContext context) {
-      return new ToVersionFromStringEvaluator(field.get(context), source, context);
+      return new ToVersionFromStringEvaluator(source, asString.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "ToVersionFromStringEvaluator[field=" + field + "]";
+      return "ToVersionFromStringEvaluator[" + "asString=" + asString + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StEnvelopeFromWKBGeoEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StEnvelopeFromWKBGeoEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 
@@ -22,14 +23,17 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class StEnvelopeFromWKBGeoEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public StEnvelopeFromWKBGeoEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public StEnvelopeFromWKBGeoEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "StEnvelopeFromWKBGeo";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -58,7 +62,7 @@ public final class StEnvelopeFromWKBGeoEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StEnvelope.fromWellKnownBinaryGeo(value);
   }
@@ -98,29 +102,39 @@ public final class StEnvelopeFromWKBGeoEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private BytesRef evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StEnvelope.fromWellKnownBinaryGeo(value);
+  }
+
+  @Override
+  public String toString() {
+    return "StEnvelopeFromWKBGeoEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public StEnvelopeFromWKBGeoEvaluator get(DriverContext context) {
-      return new StEnvelopeFromWKBGeoEvaluator(field.get(context), source, context);
+      return new StEnvelopeFromWKBGeoEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "StEnvelopeFromWKBGeoEvaluator[field=" + field + "]";
+      return "StEnvelopeFromWKBGeoEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXFromWKBEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXFromWKBEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 
@@ -23,14 +24,17 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class StXFromWKBEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public StXFromWKBEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public StXFromWKBEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "StXFromWKB";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -59,7 +63,7 @@ public final class StXFromWKBEvaluator extends AbstractConvertFunction.AbstractE
     }
   }
 
-  private static double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StX.fromWellKnownBinary(value);
   }
@@ -99,29 +103,39 @@ public final class StXFromWKBEvaluator extends AbstractConvertFunction.AbstractE
     }
   }
 
-  private static double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StX.fromWellKnownBinary(value);
+  }
+
+  @Override
+  public String toString() {
+    return "StXFromWKBEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public StXFromWKBEvaluator get(DriverContext context) {
-      return new StXFromWKBEvaluator(field.get(context), source, context);
+      return new StXFromWKBEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "StXFromWKBEvaluator[field=" + field + "]";
+      return "StXFromWKBEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMaxFromWKBEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMaxFromWKBEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 
@@ -23,14 +24,17 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class StXMaxFromWKBEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public StXMaxFromWKBEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public StXMaxFromWKBEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "StXMaxFromWKB";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -59,7 +63,7 @@ public final class StXMaxFromWKBEvaluator extends AbstractConvertFunction.Abstra
     }
   }
 
-  private static double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StXMax.fromWellKnownBinary(value);
   }
@@ -99,29 +103,39 @@ public final class StXMaxFromWKBEvaluator extends AbstractConvertFunction.Abstra
     }
   }
 
-  private static double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StXMax.fromWellKnownBinary(value);
+  }
+
+  @Override
+  public String toString() {
+    return "StXMaxFromWKBEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public StXMaxFromWKBEvaluator get(DriverContext context) {
-      return new StXMaxFromWKBEvaluator(field.get(context), source, context);
+      return new StXMaxFromWKBEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "StXMaxFromWKBEvaluator[field=" + field + "]";
+      return "StXMaxFromWKBEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMaxFromWKBGeoEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMaxFromWKBGeoEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 
@@ -23,14 +24,17 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class StXMaxFromWKBGeoEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public StXMaxFromWKBGeoEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public StXMaxFromWKBGeoEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "StXMaxFromWKBGeo";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -59,7 +63,7 @@ public final class StXMaxFromWKBGeoEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StXMax.fromWellKnownBinaryGeo(value);
   }
@@ -99,29 +103,39 @@ public final class StXMaxFromWKBGeoEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StXMax.fromWellKnownBinaryGeo(value);
+  }
+
+  @Override
+  public String toString() {
+    return "StXMaxFromWKBGeoEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public StXMaxFromWKBGeoEvaluator get(DriverContext context) {
-      return new StXMaxFromWKBGeoEvaluator(field.get(context), source, context);
+      return new StXMaxFromWKBGeoEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "StXMaxFromWKBGeoEvaluator[field=" + field + "]";
+      return "StXMaxFromWKBGeoEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMinFromWKBEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMinFromWKBEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 
@@ -23,14 +24,17 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class StXMinFromWKBEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public StXMinFromWKBEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public StXMinFromWKBEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "StXMinFromWKB";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -59,7 +63,7 @@ public final class StXMinFromWKBEvaluator extends AbstractConvertFunction.Abstra
     }
   }
 
-  private static double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StXMin.fromWellKnownBinary(value);
   }
@@ -99,29 +103,39 @@ public final class StXMinFromWKBEvaluator extends AbstractConvertFunction.Abstra
     }
   }
 
-  private static double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StXMin.fromWellKnownBinary(value);
+  }
+
+  @Override
+  public String toString() {
+    return "StXMinFromWKBEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public StXMinFromWKBEvaluator get(DriverContext context) {
-      return new StXMinFromWKBEvaluator(field.get(context), source, context);
+      return new StXMinFromWKBEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "StXMinFromWKBEvaluator[field=" + field + "]";
+      return "StXMinFromWKBEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMinFromWKBGeoEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMinFromWKBGeoEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 
@@ -23,14 +24,17 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class StXMinFromWKBGeoEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public StXMinFromWKBGeoEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public StXMinFromWKBGeoEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "StXMinFromWKBGeo";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -59,7 +63,7 @@ public final class StXMinFromWKBGeoEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StXMin.fromWellKnownBinaryGeo(value);
   }
@@ -99,29 +103,39 @@ public final class StXMinFromWKBGeoEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StXMin.fromWellKnownBinaryGeo(value);
+  }
+
+  @Override
+  public String toString() {
+    return "StXMinFromWKBGeoEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public StXMinFromWKBGeoEvaluator get(DriverContext context) {
-      return new StXMinFromWKBGeoEvaluator(field.get(context), source, context);
+      return new StXMinFromWKBGeoEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "StXMinFromWKBGeoEvaluator[field=" + field + "]";
+      return "StXMinFromWKBGeoEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYFromWKBEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYFromWKBEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 
@@ -23,14 +24,17 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class StYFromWKBEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public StYFromWKBEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator in;
+
+  public StYFromWKBEvaluator(Source source, EvalOperator.ExpressionEvaluator in,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.in = in;
   }
 
   @Override
-  public String name() {
-    return "StYFromWKB";
+  public EvalOperator.ExpressionEvaluator next() {
+    return in;
   }
 
   @Override
@@ -59,7 +63,7 @@ public final class StYFromWKBEvaluator extends AbstractConvertFunction.AbstractE
     }
   }
 
-  private static double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StY.fromWellKnownBinary(value);
   }
@@ -99,29 +103,39 @@ public final class StYFromWKBEvaluator extends AbstractConvertFunction.AbstractE
     }
   }
 
-  private static double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StY.fromWellKnownBinary(value);
+  }
+
+  @Override
+  public String toString() {
+    return "StYFromWKBEvaluator[" + "in=" + in + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(in);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory in;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory in) {
       this.source = source;
+      this.in = in;
     }
 
     @Override
     public StYFromWKBEvaluator get(DriverContext context) {
-      return new StYFromWKBEvaluator(field.get(context), source, context);
+      return new StYFromWKBEvaluator(source, in.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "StYFromWKBEvaluator[field=" + field + "]";
+      return "StYFromWKBEvaluator[" + "in=" + in + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMaxFromWKBEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMaxFromWKBEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 
@@ -23,14 +24,17 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class StYMaxFromWKBEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public StYMaxFromWKBEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public StYMaxFromWKBEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "StYMaxFromWKB";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -59,7 +63,7 @@ public final class StYMaxFromWKBEvaluator extends AbstractConvertFunction.Abstra
     }
   }
 
-  private static double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StYMax.fromWellKnownBinary(value);
   }
@@ -99,29 +103,39 @@ public final class StYMaxFromWKBEvaluator extends AbstractConvertFunction.Abstra
     }
   }
 
-  private static double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StYMax.fromWellKnownBinary(value);
+  }
+
+  @Override
+  public String toString() {
+    return "StYMaxFromWKBEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public StYMaxFromWKBEvaluator get(DriverContext context) {
-      return new StYMaxFromWKBEvaluator(field.get(context), source, context);
+      return new StYMaxFromWKBEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "StYMaxFromWKBEvaluator[field=" + field + "]";
+      return "StYMaxFromWKBEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMaxFromWKBGeoEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMaxFromWKBGeoEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 
@@ -23,14 +24,17 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class StYMaxFromWKBGeoEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public StYMaxFromWKBGeoEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public StYMaxFromWKBGeoEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "StYMaxFromWKBGeo";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -59,7 +63,7 @@ public final class StYMaxFromWKBGeoEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StYMax.fromWellKnownBinaryGeo(value);
   }
@@ -99,29 +103,39 @@ public final class StYMaxFromWKBGeoEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StYMax.fromWellKnownBinaryGeo(value);
+  }
+
+  @Override
+  public String toString() {
+    return "StYMaxFromWKBGeoEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public StYMaxFromWKBGeoEvaluator get(DriverContext context) {
-      return new StYMaxFromWKBGeoEvaluator(field.get(context), source, context);
+      return new StYMaxFromWKBGeoEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "StYMaxFromWKBGeoEvaluator[field=" + field + "]";
+      return "StYMaxFromWKBGeoEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMinFromWKBEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMinFromWKBEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 
@@ -23,14 +24,17 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class StYMinFromWKBEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public StYMinFromWKBEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public StYMinFromWKBEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "StYMinFromWKB";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -59,7 +63,7 @@ public final class StYMinFromWKBEvaluator extends AbstractConvertFunction.Abstra
     }
   }
 
-  private static double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StYMin.fromWellKnownBinary(value);
   }
@@ -99,29 +103,39 @@ public final class StYMinFromWKBEvaluator extends AbstractConvertFunction.Abstra
     }
   }
 
-  private static double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StYMin.fromWellKnownBinary(value);
+  }
+
+  @Override
+  public String toString() {
+    return "StYMinFromWKBEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public StYMinFromWKBEvaluator get(DriverContext context) {
-      return new StYMinFromWKBEvaluator(field.get(context), source, context);
+      return new StYMinFromWKBEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "StYMinFromWKBEvaluator[field=" + field + "]";
+      return "StYMinFromWKBEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMinFromWKBGeoEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMinFromWKBGeoEvaluator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 
@@ -23,14 +24,17 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
  * This class is generated. Edit {@code ConvertEvaluatorImplementer} instead.
  */
 public final class StYMinFromWKBGeoEvaluator extends AbstractConvertFunction.AbstractEvaluator {
-  public StYMinFromWKBGeoEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+  private final EvalOperator.ExpressionEvaluator wkb;
+
+  public StYMinFromWKBGeoEvaluator(Source source, EvalOperator.ExpressionEvaluator wkb,
       DriverContext driverContext) {
-    super(driverContext, field, source);
+    super(driverContext, source);
+    this.wkb = wkb;
   }
 
   @Override
-  public String name() {
-    return "StYMinFromWKBGeo";
+  public EvalOperator.ExpressionEvaluator next() {
+    return wkb;
   }
 
   @Override
@@ -59,7 +63,7 @@ public final class StYMinFromWKBGeoEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StYMin.fromWellKnownBinaryGeo(value);
   }
@@ -99,29 +103,39 @@ public final class StYMinFromWKBGeoEvaluator extends AbstractConvertFunction.Abs
     }
   }
 
-  private static double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private double evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return StYMin.fromWellKnownBinaryGeo(value);
+  }
+
+  @Override
+  public String toString() {
+    return "StYMinFromWKBGeoEvaluator[" + "wkb=" + wkb + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(wkb);
   }
 
   public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
     private final Source source;
 
-    private final EvalOperator.ExpressionEvaluator.Factory field;
+    private final EvalOperator.ExpressionEvaluator.Factory wkb;
 
-    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
-      this.field = field;
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory wkb) {
       this.source = source;
+      this.wkb = wkb;
     }
 
     @Override
     public StYMinFromWKBGeoEvaluator get(DriverContext context) {
-      return new StYMinFromWKBGeoEvaluator(field.get(context), source, context);
+      return new StYMinFromWKBGeoEvaluator(source, wkb.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "StYMinFromWKBGeoEvaluator[field=" + field + "]";
+      return "StYMinFromWKBGeoEvaluator[" + "wkb=" + wkb + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 
 import joptsimple.internal.Strings;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.Page;
@@ -17,9 +19,6 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.Warnings;
-import org.elasticsearch.core.Releasables;
-import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -66,7 +65,7 @@ public abstract class AbstractConvertFunction extends UnaryScalarFunction {
         if (factory == null) {
             throw EsqlIllegalArgumentException.illegalDataType(sourceType);
         }
-        return factory.build(fieldEval, source());
+        return factory.build(source(), fieldEval);
     }
 
     @Override
@@ -101,7 +100,7 @@ public abstract class AbstractConvertFunction extends UnaryScalarFunction {
 
     @FunctionalInterface
     interface BuildFactory {
-        ExpressionEvaluator.Factory build(ExpressionEvaluator.Factory field, Source source);
+        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field);
     }
 
     /**
@@ -128,15 +127,13 @@ public abstract class AbstractConvertFunction extends UnaryScalarFunction {
 
     public abstract static class AbstractEvaluator implements EvalOperator.ExpressionEvaluator {
 
-        private static final Logger logger = LogManager.getLogger(AbstractEvaluator.class);
+        private static final Log logger = LogFactory.getLog(AbstractEvaluator.class);
 
         protected final DriverContext driverContext;
-        private final EvalOperator.ExpressionEvaluator fieldEvaluator;
         private final Warnings warnings;
 
-        protected AbstractEvaluator(DriverContext driverContext, EvalOperator.ExpressionEvaluator field, Source source) {
+        protected AbstractEvaluator(DriverContext driverContext, Source source) {
             this.driverContext = driverContext;
-            this.fieldEvaluator = field;
             this.warnings = Warnings.createWarnings(
                 driverContext.warningsMode(),
                 source.source().getLineNumber(),
@@ -145,7 +142,7 @@ public abstract class AbstractConvertFunction extends UnaryScalarFunction {
             );
         }
 
-        protected abstract String name();
+        protected abstract ExpressionEvaluator next();
 
         /**
          * Called when evaluating a {@link Block} that contains null values.
@@ -161,7 +158,7 @@ public abstract class AbstractConvertFunction extends UnaryScalarFunction {
 
         @Override
         public final Block eval(Page page) {
-            try (Block block = fieldEvaluator.eval(page)) {
+            try (Block block = next().eval(page)) {
                 Vector vector = block.asVector();
                 return vector == null ? evalBlock(block) : evalVector(vector);
             }
@@ -170,17 +167,6 @@ public abstract class AbstractConvertFunction extends UnaryScalarFunction {
         protected final void registerException(Exception exception) {
             logger.trace("conversion failure", exception);
             warnings.registerException(exception);
-        }
-
-        @Override
-        public final String toString() {
-            return name() + "Evaluator[field=" + fieldEvaluator + "]";
-        }
-
-        @Override
-        public void close() {
-            // TODO toString allocates - we should probably check breakers there too
-            Releasables.closeExpectNoException(fieldEvaluator);
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIp.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIp.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.compute.operator.EvalOperator;
+
+import java.net.InetAddress;
+
+/**
+ * Fast IP parsing suitable for embedding in an {@link EvalOperator.ExpressionEvaluator}
+ * because they don't allocate memory on every run. Instead, it converts directly from
+ * utf-8 encoded strings into {@link InetAddressPoint} encoded ips.
+ * <p>
+ *     This contains three parsing methods to handle the three ways ipv4 addresses
+ *     have historically handled leading 0s, namely, {@link #leadingZerosRejected reject} them,
+ *     treat them as {@link #leadingZerosAreDecimal decimal} numbers, and treat them as
+ *     {@link #leadingZerosAreOctal} numbers.
+ * </p>
+ * <p>
+ *     Note: We say "directly from utf-8" but, really, all of the digits in an ip are
+ *     in the traditional 7-bit ascii range where utf-8 overlaps. So we just treat everything
+ *     as 7-bit ascii. Anything that isn't in the range is an invalid ip anyway. Much love
+ *     for the designers of utf-8 for making it this way.
+ * </p>
+ */
+public class ParseIp {
+    private static final byte[] IPV4_PREFIX = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, -1 };
+
+    static final AbstractConvertFunction.BuildFactory FROM_KEYWORD_LEADING_ZEROS_REJECTED = (source, field) -> {
+        return new ParseIpLeadingZerosRejectedEvaluator.Factory(source, field, driverContext -> buildScratch(driverContext.breaker()));
+    };
+
+    public static BreakingBytesRefBuilder buildScratch(CircuitBreaker breaker) {
+        BreakingBytesRefBuilder scratch = new BreakingBytesRefBuilder(breaker, "to_ip", 16);
+        scratch.setLength(InetAddressPoint.BYTES);
+        return scratch;
+    }
+
+    /**
+     * Parse an IP address, rejecting v4 addresses with leading 0s. This aligns
+     * exactly with {@link InetAddresses#forString(String)}.
+     * <ul>
+     *     <li>192.168.1.1 : valid</li>
+     *     <li>192.168.0.1 : valid</li>
+     *     <li>192.168.01.1 : invalid</li>
+     * </ul>
+     * @param scratch A "scratch" memory space build by {@link #buildScratch}
+     */
+    @ConvertEvaluator(extraName = "LeadingZerosRejected", warnExceptions = { IllegalArgumentException.class })
+    public static BytesRef leadingZerosRejected(
+        BytesRef string,
+        @Fixed(includeInToString = false, scope = Fixed.Scope.THREAD_LOCAL) BreakingBytesRefBuilder scratch
+    ) {
+        /*
+         * If this is an ipv6 address then delegate to InetAddresses.forString
+         * because we don't have anything nice for parsing those.
+         */
+        int end = string.offset + string.length;
+        if (isV6(string, end)) {
+            InetAddress inetAddress = InetAddresses.forString(string.utf8ToString());
+            return new BytesRef(InetAddressPoint.encode(inetAddress));
+        }
+
+        System.arraycopy(IPV4_PREFIX, 0, scratch.bytes(), 0, IPV4_PREFIX.length);
+        int offset = string.offset;
+        for (int dest = IPV4_PREFIX.length; dest < InetAddressPoint.BYTES; dest++) {
+            if (offset >= end) {
+                throw invalid(string);
+            }
+            if (string.bytes[offset] == '0') {
+                // Lone zeros are just 0, but a 0 with numbers after it are invalid
+                offset++;
+                if (offset == end || string.bytes[offset] == '.') {
+                    scratch.bytes()[dest] = (byte) 0;
+                    offset++;
+                    continue;
+                }
+                throw invalid(string);
+            }
+            int v = digit(string, offset++);
+            while (offset < end && string.bytes[offset] != '.') {
+                v = v * 10 + digit(string, offset++);
+            }
+            offset++;
+            if (v > 255) {
+                throw invalid(string);
+            }
+            scratch.bytes()[dest] = (byte) v;
+        }
+        return scratch.bytesRefView();
+    }
+
+    /**
+     * Parse an IP address, interpreting v4 addresses with leading 0s as
+     * <strong>decimal</strong> numbers.
+     * <ul>
+     *     <li>192.168.1.1 : valid</li>
+     *     <li>192.168.0.1 : valid</li>
+     *     <li>192.168.01.1 : valid</li>
+     *     <li>192.168.09.1 : valid</li>
+     *     <li>192.168.010.1 : valid</li>
+     * </ul>
+     * @param scratch A "scratch" memory space build by {@link #buildScratch}
+     */
+    @ConvertEvaluator(extraName = "LeadingZerosAreDecimal", warnExceptions = { IllegalArgumentException.class })
+    public static BytesRef leadingZerosAreDecimal(
+        BytesRef string,
+        @Fixed(includeInToString = false, scope = Fixed.Scope.THREAD_LOCAL) BreakingBytesRefBuilder scratch
+    ) {
+        /*
+         * If this is an ipv6 address then delegate to InetAddresses.forString
+         * because we don't have anything nice for parsing those.
+         */
+        int end = string.offset + string.length;
+        if (isV6(string, end)) {
+            InetAddress inetAddress = InetAddresses.forString(string.utf8ToString());
+            return new BytesRef(InetAddressPoint.encode(inetAddress));
+        }
+
+        System.arraycopy(IPV4_PREFIX, 0, scratch.bytes(), 0, IPV4_PREFIX.length);
+        int offset = string.offset;
+        for (int dest = IPV4_PREFIX.length; dest < InetAddressPoint.BYTES; dest++) {
+            if (offset >= end) {
+                throw invalid(string);
+            }
+            int v = digit(string, offset++);
+            while (offset < end && string.bytes[offset] != '.') {
+                v = v * 10 + digit(string, offset++);
+            }
+            offset++;
+            if (v > 255) {
+                throw invalid(string);
+            }
+            scratch.bytes()[dest] = (byte) v;
+        }
+        return scratch.bytesRefView();
+    }
+
+    /**
+     * Parse an IP address, interpreting v4 addresses with leading 0s as
+     * <strong>octal</strong> numbers.
+     * <ul>
+     *     <li>192.168.1.1 : valid</li>
+     *     <li>192.168.0.1 : valid</li>
+     *     <li>192.168.01.1 : valid</li>
+     *     <li>192.168.09.1 : invalid</li>
+     *     <li>192.168.010.1 : valid but would print as 192.168.8.1</li>
+     * </ul>
+     * @param scratch A "scratch" memory space build by {@link #buildScratch}
+     */
+    @ConvertEvaluator(extraName = "LeadingZerosAreOctal", warnExceptions = { IllegalArgumentException.class })
+    public static BytesRef leadingZerosAreOctal(
+        BytesRef string,
+        @Fixed(includeInToString = false, scope = Fixed.Scope.THREAD_LOCAL) BreakingBytesRefBuilder scratch
+    ) {
+        /*
+         * If this is an ipv6 address then delegate to InetAddresses.forString
+         * because we don't have anything nice for parsing those.
+         */
+        int end = string.offset + string.length;
+        if (isV6(string, end)) {
+            InetAddress inetAddress = InetAddresses.forString(string.utf8ToString());
+            return new BytesRef(InetAddressPoint.encode(inetAddress));
+        }
+
+        System.arraycopy(IPV4_PREFIX, 0, scratch.bytes(), 0, IPV4_PREFIX.length);
+        int offset = string.offset;
+        for (int dest = IPV4_PREFIX.length; dest < InetAddressPoint.BYTES; dest++) {
+            if (offset >= end) {
+                throw invalid(string);
+            }
+            int v;
+            if (string.bytes[offset] == '0') {
+                // Octal
+                offset++;
+                v = 0;
+                while (offset < end && string.bytes[offset] != '.') {
+                    v = v * 8 + octalDigit(string, offset++);
+                }
+                offset++;
+            } else {
+                // Decimal
+                v = digit(string, offset++);
+                while (offset < end && string.bytes[offset] != '.') {
+                    v = v * 10 + digit(string, offset++);
+                }
+                offset++;
+            }
+            scratch.bytes()[dest] = (byte) v;
+        }
+        return scratch.bytesRefView();
+    }
+
+    private static int digit(BytesRef string, int offset) {
+        if (string.bytes[offset] < '0' && '9' < string.bytes[offset]) {
+            throw invalid(string);
+        }
+        return string.bytes[offset] - '0';
+    }
+
+    private static int octalDigit(BytesRef string, int offset) {
+        if (string.bytes[offset] < '0' && '7' < string.bytes[offset]) {
+            throw invalid(string);
+        }
+        return string.bytes[offset] - '0';
+    }
+
+    private static IllegalArgumentException invalid(BytesRef string) {
+        return new IllegalArgumentException("'" + string.utf8ToString() + "' is not an IP string literal.");
+    }
+
+    private static boolean isV6(BytesRef string, int end) {
+        for (int i = string.offset; i < end; i++) {
+            if (string.bytes[i] == ':') {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBoolean.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBoolean.java
@@ -42,7 +42,7 @@ public class ToBoolean extends AbstractConvertFunction {
     );
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(BOOLEAN, (field, source) -> field),
+        Map.entry(BOOLEAN, (source, field) -> field),
         Map.entry(KEYWORD, ToBooleanFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToBooleanFromStringEvaluator.Factory::new),
         Map.entry(SEMANTIC_TEXT, ToBooleanFromStringEvaluator.Factory::new),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPoint.java
@@ -37,7 +37,7 @@ public class ToCartesianPoint extends AbstractConvertFunction {
     );
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(CARTESIAN_POINT, (fieldEval, source) -> fieldEval),
+        Map.entry(CARTESIAN_POINT, (source, fieldEval) -> fieldEval),
         Map.entry(KEYWORD, ToCartesianPointFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToCartesianPointFromStringEvaluator.Factory::new),
         Map.entry(SEMANTIC_TEXT, ToCartesianPointFromStringEvaluator.Factory::new)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShape.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShape.java
@@ -38,8 +38,8 @@ public class ToCartesianShape extends AbstractConvertFunction {
     );
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(CARTESIAN_POINT, (fieldEval, source) -> fieldEval),
-        Map.entry(CARTESIAN_SHAPE, (fieldEval, source) -> fieldEval),
+        Map.entry(CARTESIAN_POINT, (source, fieldEval) -> fieldEval),
+        Map.entry(CARTESIAN_SHAPE, (source, fieldEval) -> fieldEval),
         Map.entry(KEYWORD, ToCartesianShapeFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToCartesianShapeFromStringEvaluator.Factory::new),
         Map.entry(SEMANTIC_TEXT, ToCartesianShapeFromStringEvaluator.Factory::new)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanos.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanos.java
@@ -47,7 +47,7 @@ public class ToDateNanos extends AbstractConvertFunction {
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
         Map.entry(DATETIME, ToDateNanosFromDatetimeEvaluator.Factory::new),
-        Map.entry(DATE_NANOS, (field, source) -> field),
+        Map.entry(DATE_NANOS, (source, field) -> field),
         Map.entry(LONG, ToDateNanosFromLongEvaluator.Factory::new),
         Map.entry(KEYWORD, ToDateNanosFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToDateNanosFromStringEvaluator.Factory::new),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetime.java
@@ -43,9 +43,9 @@ public class ToDatetime extends AbstractConvertFunction {
     );
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(DATETIME, (field, source) -> field),
+        Map.entry(DATETIME, (source, field) -> field),
         Map.entry(DATE_NANOS, ToDatetimeFromDateNanosEvaluator.Factory::new),
-        Map.entry(LONG, (field, source) -> field),
+        Map.entry(LONG, (source, field) -> field),
         Map.entry(KEYWORD, ToDatetimeFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToDatetimeFromStringEvaluator.Factory::new),
         Map.entry(SEMANTIC_TEXT, ToDatetimeFromStringEvaluator.Factory::new),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegrees.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegrees.java
@@ -42,11 +42,11 @@ public class ToDegrees extends AbstractConvertFunction implements EvaluatorMappe
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
         Map.entry(DOUBLE, ToDegreesEvaluator.Factory::new),
-        Map.entry(INTEGER, (field, source) -> new ToDegreesEvaluator.Factory(new ToDoubleFromIntEvaluator.Factory(field, source), source)),
-        Map.entry(LONG, (field, source) -> new ToDegreesEvaluator.Factory(new ToDoubleFromLongEvaluator.Factory(field, source), source)),
+        Map.entry(INTEGER, (source, field) -> new ToDegreesEvaluator.Factory(source, new ToDoubleFromIntEvaluator.Factory(source, field))),
+        Map.entry(LONG, (source, field) -> new ToDegreesEvaluator.Factory(source, new ToDoubleFromLongEvaluator.Factory(source, field))),
         Map.entry(
             UNSIGNED_LONG,
-            (field, source) -> new ToDegreesEvaluator.Factory(new ToDoubleFromUnsignedLongEvaluator.Factory(field, source), source)
+            (source, field) -> new ToDegreesEvaluator.Factory(source, new ToDoubleFromUnsignedLongEvaluator.Factory(source, field))
         )
     );
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDouble.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDouble.java
@@ -40,7 +40,7 @@ public class ToDouble extends AbstractConvertFunction {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "ToDouble", ToDouble::new);
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(DOUBLE, (fieldEval, source) -> fieldEval),
+        Map.entry(DOUBLE, (source, fieldEval) -> fieldEval),
         Map.entry(BOOLEAN, ToDoubleFromBooleanEvaluator.Factory::new),
         Map.entry(DATETIME, ToDoubleFromLongEvaluator.Factory::new), // CastLongToDoubleEvaluator would be a candidate, but not MV'd
         Map.entry(KEYWORD, ToDoubleFromStringEvaluator.Factory::new),
@@ -49,7 +49,7 @@ public class ToDouble extends AbstractConvertFunction {
         Map.entry(UNSIGNED_LONG, ToDoubleFromUnsignedLongEvaluator.Factory::new),
         Map.entry(LONG, ToDoubleFromLongEvaluator.Factory::new), // CastLongToDoubleEvaluator would be a candidate, but not MV'd
         Map.entry(INTEGER, ToDoubleFromIntEvaluator.Factory::new), // CastIntToDoubleEvaluator would be a candidate, but not MV'd
-        Map.entry(DataType.COUNTER_DOUBLE, (field, source) -> field),
+        Map.entry(DataType.COUNTER_DOUBLE, (source, field) -> field),
         Map.entry(DataType.COUNTER_INTEGER, ToDoubleFromIntEvaluator.Factory::new),
         Map.entry(DataType.COUNTER_LONG, ToDoubleFromLongEvaluator.Factory::new)
     );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPoint.java
@@ -37,7 +37,7 @@ public class ToGeoPoint extends AbstractConvertFunction {
     );
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(GEO_POINT, (fieldEval, source) -> fieldEval),
+        Map.entry(GEO_POINT, (source, fieldEval) -> fieldEval),
         Map.entry(KEYWORD, ToGeoPointFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToGeoPointFromStringEvaluator.Factory::new),
         Map.entry(SEMANTIC_TEXT, ToGeoPointFromStringEvaluator.Factory::new)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShape.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShape.java
@@ -38,8 +38,8 @@ public class ToGeoShape extends AbstractConvertFunction {
     );
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(GEO_POINT, (fieldEval, source) -> fieldEval),
-        Map.entry(GEO_SHAPE, (fieldEval, source) -> fieldEval),
+        Map.entry(GEO_POINT, (source, fieldEval) -> fieldEval),
+        Map.entry(GEO_SHAPE, (source, fieldEval) -> fieldEval),
         Map.entry(KEYWORD, ToGeoShapeFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToGeoShapeFromStringEvaluator.Factory::new),
         Map.entry(SEMANTIC_TEXT, ToGeoShapeFromStringEvaluator.Factory::new)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIP.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIP.java
@@ -7,10 +7,8 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.compute.ann.ConvertEvaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -27,16 +25,16 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.IP;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.SEMANTIC_TEXT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
-import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToIP;
+import static org.elasticsearch.xpack.esql.expression.function.scalar.convert.ParseIp.FROM_KEYWORD_LEADING_ZEROS_REJECTED;
 
 public class ToIP extends AbstractConvertFunction {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "ToIP", ToIP::new);
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(IP, (field, source) -> field),
-        Map.entry(KEYWORD, ToIPFromStringEvaluator.Factory::new),
-        Map.entry(TEXT, ToIPFromStringEvaluator.Factory::new),
-        Map.entry(SEMANTIC_TEXT, ToIPFromStringEvaluator.Factory::new)
+        Map.entry(IP, (source, field) -> field),
+        Map.entry(KEYWORD, FROM_KEYWORD_LEADING_ZEROS_REJECTED),
+        Map.entry(TEXT, FROM_KEYWORD_LEADING_ZEROS_REJECTED),
+        Map.entry(SEMANTIC_TEXT, FROM_KEYWORD_LEADING_ZEROS_REJECTED)
     );
 
     @FunctionInfo(
@@ -91,10 +89,5 @@ public class ToIP extends AbstractConvertFunction {
     @Override
     protected NodeInfo<? extends Expression> info() {
         return NodeInfo.create(this, ToIP::new, field());
-    }
-
-    @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })
-    static BytesRef fromKeyword(BytesRef asString) {
-        return stringToIP(asString);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToInteger.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToInteger.java
@@ -46,7 +46,7 @@ public class ToInteger extends AbstractConvertFunction {
     );
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(INTEGER, (fieldEval, source) -> fieldEval),
+        Map.entry(INTEGER, (source, fieldEval) -> fieldEval),
         Map.entry(BOOLEAN, ToIntegerFromBooleanEvaluator.Factory::new),
         Map.entry(DATETIME, ToIntegerFromLongEvaluator.Factory::new),
         Map.entry(KEYWORD, ToIntegerFromStringEvaluator.Factory::new),
@@ -55,7 +55,7 @@ public class ToInteger extends AbstractConvertFunction {
         Map.entry(DOUBLE, ToIntegerFromDoubleEvaluator.Factory::new),
         Map.entry(UNSIGNED_LONG, ToIntegerFromUnsignedLongEvaluator.Factory::new),
         Map.entry(LONG, ToIntegerFromLongEvaluator.Factory::new),
-        Map.entry(COUNTER_INTEGER, (fieldEval, source) -> fieldEval)
+        Map.entry(COUNTER_INTEGER, (source, fieldEval) -> fieldEval)
     );
 
     @FunctionInfo(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLong.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLong.java
@@ -42,9 +42,9 @@ public class ToLong extends AbstractConvertFunction {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "ToLong", ToLong::new);
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(LONG, (fieldEval, source) -> fieldEval),
-        Map.entry(DATETIME, (fieldEval, source) -> fieldEval),
-        Map.entry(DATE_NANOS, (fieldEval, source) -> fieldEval),
+        Map.entry(LONG, (source, fieldEval) -> fieldEval),
+        Map.entry(DATETIME, (source, fieldEval) -> fieldEval),
+        Map.entry(DATE_NANOS, (source, fieldEval) -> fieldEval),
         Map.entry(BOOLEAN, ToLongFromBooleanEvaluator.Factory::new),
         Map.entry(KEYWORD, ToLongFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToLongFromStringEvaluator.Factory::new),
@@ -52,7 +52,7 @@ public class ToLong extends AbstractConvertFunction {
         Map.entry(DOUBLE, ToLongFromDoubleEvaluator.Factory::new),
         Map.entry(UNSIGNED_LONG, ToLongFromUnsignedLongEvaluator.Factory::new),
         Map.entry(INTEGER, ToLongFromIntEvaluator.Factory::new), // CastIntToLongEvaluator would be a candidate, but not MV'd
-        Map.entry(DataType.COUNTER_LONG, (field, source) -> field),
+        Map.entry(DataType.COUNTER_LONG, (source, field) -> field),
         Map.entry(DataType.COUNTER_INTEGER, ToLongFromIntEvaluator.Factory::new)
     );
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadians.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadians.java
@@ -41,11 +41,11 @@ public class ToRadians extends AbstractConvertFunction implements EvaluatorMappe
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
         Map.entry(DOUBLE, ToRadiansEvaluator.Factory::new),
-        Map.entry(INTEGER, (field, source) -> new ToRadiansEvaluator.Factory(new ToDoubleFromIntEvaluator.Factory(field, source), source)),
-        Map.entry(LONG, (field, source) -> new ToRadiansEvaluator.Factory(new ToDoubleFromLongEvaluator.Factory(field, source), source)),
+        Map.entry(INTEGER, (source, field) -> new ToRadiansEvaluator.Factory(source, new ToDoubleFromIntEvaluator.Factory(source, field))),
+        Map.entry(LONG, (source, field) -> new ToRadiansEvaluator.Factory(source, new ToDoubleFromLongEvaluator.Factory(source, field))),
         Map.entry(
             UNSIGNED_LONG,
-            (field, source) -> new ToRadiansEvaluator.Factory(new ToDoubleFromUnsignedLongEvaluator.Factory(field, source), source)
+            (source, field) -> new ToRadiansEvaluator.Factory(source, new ToDoubleFromUnsignedLongEvaluator.Factory(source, field))
         )
     );
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
@@ -52,7 +52,7 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "ToString", ToString::new);
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(KEYWORD, (fieldEval, source) -> fieldEval),
+        Map.entry(KEYWORD, (source, fieldEval) -> fieldEval),
         Map.entry(BOOLEAN, ToStringFromBooleanEvaluator.Factory::new),
         Map.entry(DATETIME, ToStringFromDatetimeEvaluator.Factory::new),
         Map.entry(DATE_NANOS, ToStringFromDateNanosEvaluator.Factory::new),
@@ -60,8 +60,8 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
         Map.entry(DOUBLE, ToStringFromDoubleEvaluator.Factory::new),
         Map.entry(LONG, ToStringFromLongEvaluator.Factory::new),
         Map.entry(INTEGER, ToStringFromIntEvaluator.Factory::new),
-        Map.entry(TEXT, (fieldEval, source) -> fieldEval),
-        Map.entry(SEMANTIC_TEXT, (fieldEval, source) -> fieldEval),
+        Map.entry(TEXT, (source, fieldEval) -> fieldEval),
+        Map.entry(SEMANTIC_TEXT, (source, fieldEval) -> fieldEval),
         Map.entry(VERSION, ToStringFromVersionEvaluator.Factory::new),
         Map.entry(UNSIGNED_LONG, ToStringFromUnsignedLongEvaluator.Factory::new),
         Map.entry(GEO_POINT, ToStringFromGeoPointEvaluator.Factory::new),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLong.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLong.java
@@ -47,7 +47,7 @@ public class ToUnsignedLong extends AbstractConvertFunction {
     );
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(UNSIGNED_LONG, (fieldEval, source) -> fieldEval),
+        Map.entry(UNSIGNED_LONG, (source, fieldEval) -> fieldEval),
         Map.entry(DATETIME, ToUnsignedLongFromLongEvaluator.Factory::new),
         Map.entry(BOOLEAN, ToUnsignedLongFromBooleanEvaluator.Factory::new),
         Map.entry(KEYWORD, ToUnsignedLongFromStringEvaluator.Factory::new),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersion.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersion.java
@@ -37,7 +37,7 @@ public class ToVersion extends AbstractConvertFunction {
     );
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
-        Map.entry(VERSION, (fieldEval, source) -> fieldEval),
+        Map.entry(VERSION, (source, fieldEval) -> fieldEval),
         Map.entry(KEYWORD, ToVersionFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToVersionFromStringEvaluator.Factory::new),
         Map.entry(SEMANTIC_TEXT, ToVersionFromStringEvaluator.Factory::new)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StEnvelope.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StEnvelope.java
@@ -91,9 +91,9 @@ public class StEnvelope extends UnaryScalarFunction {
     @Override
     public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         if (field().dataType() == GEO_POINT || field().dataType() == DataType.GEO_SHAPE) {
-            return new StEnvelopeFromWKBGeoEvaluator.Factory(toEvaluator.apply(field()), source());
+            return new StEnvelopeFromWKBGeoEvaluator.Factory(source(), toEvaluator.apply(field()));
         }
-        return new StEnvelopeFromWKBEvaluator.Factory(toEvaluator.apply(field()), source());
+        return new StEnvelopeFromWKBEvaluator.Factory(source(), toEvaluator.apply(field()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StX.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StX.java
@@ -72,7 +72,7 @@ public class StX extends UnaryScalarFunction {
 
     @Override
     public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
-        return new StXFromWKBEvaluator.Factory(toEvaluator.apply(field()), source());
+        return new StXFromWKBEvaluator.Factory(source(), toEvaluator.apply(field()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMax.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMax.java
@@ -76,9 +76,9 @@ public class StXMax extends UnaryScalarFunction {
     @Override
     public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         if (field().dataType() == GEO_POINT || field().dataType() == DataType.GEO_SHAPE) {
-            return new StXMaxFromWKBGeoEvaluator.Factory(toEvaluator.apply(field()), source());
+            return new StXMaxFromWKBGeoEvaluator.Factory(source(), toEvaluator.apply(field()));
         }
-        return new StXMaxFromWKBEvaluator.Factory(toEvaluator.apply(field()), source());
+        return new StXMaxFromWKBEvaluator.Factory(source(), toEvaluator.apply(field()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMin.java
@@ -76,9 +76,9 @@ public class StXMin extends UnaryScalarFunction {
     @Override
     public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         if (field().dataType() == GEO_POINT || field().dataType() == DataType.GEO_SHAPE) {
-            return new StXMinFromWKBGeoEvaluator.Factory(toEvaluator.apply(field()), source());
+            return new StXMinFromWKBGeoEvaluator.Factory(source(), toEvaluator.apply(field()));
         }
-        return new StXMinFromWKBEvaluator.Factory(toEvaluator.apply(field()), source());
+        return new StXMinFromWKBEvaluator.Factory(source(), toEvaluator.apply(field()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StY.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StY.java
@@ -72,7 +72,7 @@ public class StY extends UnaryScalarFunction {
 
     @Override
     public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
-        return new StYFromWKBEvaluator.Factory(toEvaluator.apply(field()), source());
+        return new StYFromWKBEvaluator.Factory(source(), toEvaluator.apply(field()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMax.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMax.java
@@ -76,9 +76,9 @@ public class StYMax extends UnaryScalarFunction {
     @Override
     public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         if (field().dataType() == GEO_POINT || field().dataType() == DataType.GEO_SHAPE) {
-            return new StYMaxFromWKBGeoEvaluator.Factory(toEvaluator.apply(field()), source());
+            return new StYMaxFromWKBGeoEvaluator.Factory(source(), toEvaluator.apply(field()));
         }
-        return new StYMaxFromWKBEvaluator.Factory(toEvaluator.apply(field()), source());
+        return new StYMaxFromWKBEvaluator.Factory(source(), toEvaluator.apply(field()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMin.java
@@ -76,9 +76,9 @@ public class StYMin extends UnaryScalarFunction {
     @Override
     public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         if (field().dataType() == GEO_POINT || field().dataType() == DataType.GEO_SHAPE) {
-            return new StYMinFromWKBGeoEvaluator.Factory(toEvaluator.apply(field()), source());
+            return new StYMinFromWKBGeoEvaluator.Factory(source(), toEvaluator.apply(field()));
         }
-        return new StYMinFromWKBEvaluator.Factory(toEvaluator.apply(field()), source());
+        return new StYMinFromWKBEvaluator.Factory(source(), toEvaluator.apply(field()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIpTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIpTests.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.network.NetworkAddress;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.test.ESTestCase;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ParseIpTests extends ESTestCase {
+    @ParametersFactory(argumentFormatting = "%s")
+    public static Iterable<Object[]> parameters() {
+        List<TestCase> strs = List.of(
+            new TestCase("192.168.1.1", true, true, true),
+            new TestCase("192.168.0.1", true, true, true),
+            new TestCase("255.255.255.255", true, true, true),
+            new TestCase("1.1.1.1", true, true, true),
+            new TestCase("0.0.0.0", true, true, true),
+
+            new TestCase("192.168.01.1", false, true, true),
+            new TestCase("192.168.0255.1", false, true, true),
+
+            new TestCase("1", false, false, false),
+            new TestCase("0", false, false, false),
+            new TestCase("255.1", false, false, false),
+            new TestCase("255.0", false, false, false),
+            new TestCase("255.255.1", false, false, false),
+            new TestCase("255.255.0", false, false, false),
+            new TestCase(new Supplier<>() {
+                @Override
+                public String get() {
+                    return NetworkAddress.format(randomIp(true));
+                }
+
+                @Override
+                public String toString() {
+                    return "v4";
+                }
+            }, true, true, true),
+            new TestCase(new Supplier<>() {
+                @Override
+                public String get() {
+                    return NetworkAddress.format(randomIp(false));
+                }
+
+                @Override
+                public String toString() {
+                    return "v6";
+                }
+            }, true, true, true)
+        );
+        return strs.stream().map(s -> new Object[] { s }).toList();
+    }
+
+    private record TestCase(
+        Supplier<String> str,
+        boolean validLeadingZerosRejected,
+        boolean validLeadingZerosAreDecimal,
+        boolean validLeadingZerosAreOctal
+    ) {
+        TestCase(String str, boolean validLeadingZerosRejected, boolean validLeadingZerosAreDecimal, boolean validLeadingZerosAreOctal) {
+            this(new Supplier<>() {
+                @Override
+                public String get() {
+                    return str;
+                }
+
+                @Override
+                public String toString() {
+                    return str;
+                }
+            }, validLeadingZerosRejected, validLeadingZerosAreDecimal, validLeadingZerosAreOctal);
+        }
+    }
+
+    private final TestCase testCase;
+    private final String str;
+
+    public ParseIpTests(TestCase testCase) {
+        this.testCase = testCase;
+        this.str = testCase.str.get();
+    }
+
+    public void testLeadingZerosRejecting() {
+        if (testCase.validLeadingZerosRejected) {
+            InetAddress inetAddress = InetAddresses.forString(str);
+            BytesRef expected = new BytesRef(InetAddressPoint.encode(inetAddress));
+            success(ParseIp::leadingZerosRejected, expected);
+        } else {
+            failure(ParseIp::leadingZerosRejected);
+        }
+    }
+
+    public void testLeadingZerosAreDecimal() {
+        if (testCase.validLeadingZerosAreDecimal) {
+            InetAddress inetAddress = InetAddresses.forString(leadingZerosAreDecimalToIp(str));
+            BytesRef expected = new BytesRef(InetAddressPoint.encode(inetAddress));
+            success(ParseIp::leadingZerosAreDecimal, expected);
+        } else {
+            failure(ParseIp::leadingZerosAreDecimal);
+        }
+    }
+
+    public void testLeadingZerosAreOctal() {
+        if (testCase.validLeadingZerosAreOctal) {
+            InetAddress inetAddress = InetAddresses.forString(leadingZerosAreOctalToIp(str));
+            BytesRef expected = new BytesRef(InetAddressPoint.encode(inetAddress));
+            success(ParseIp::leadingZerosAreOctal, expected);
+        } else {
+            failure(ParseIp::leadingZerosAreOctal);
+        }
+    }
+
+    private void success(BiFunction<BytesRef, BreakingBytesRefBuilder, BytesRef> fn, BytesRef expected) {
+        try (BreakingBytesRefBuilder scratch = ParseIp.buildScratch(new NoopCircuitBreaker("request"))) {
+            assertThat(fn.apply(new BytesRef(str), scratch), equalTo(expected));
+        }
+    }
+
+    private void failure(BiFunction<BytesRef, BreakingBytesRefBuilder, BytesRef> fn) {
+        try (BreakingBytesRefBuilder scratch = ParseIp.buildScratch(new NoopCircuitBreaker("request"))) {
+            Exception thrown = expectThrows(IllegalArgumentException.class, () -> fn.apply(new BytesRef(str), scratch));
+            assertThat(thrown.getMessage(), equalTo("'" + str + "' is not an IP string literal."));
+        }
+    }
+
+    public static String leadingZerosAreDecimalToIp(String ip) {
+        if (ip.contains(":")) {
+            // v6 ip, don't change it.
+            return ip;
+        }
+        StringBuilder b = new StringBuilder();
+        boolean lastWasBreak = true;
+        boolean lastWasZero = false;
+        for (int i = 0; i < ip.length(); i++) {
+            char c = ip.charAt(i);
+            if (lastWasBreak && c == '0') {
+                lastWasZero = true;
+                continue;
+            }
+            if (c == '.') {
+                if (lastWasZero) {
+                    b.append('0');
+                }
+                lastWasBreak = true;
+            } else {
+                lastWasBreak = false;
+            }
+            lastWasZero = false;
+            b.append(c);
+        }
+        if (lastWasZero) {
+            b.append('0');
+        }
+        return b.toString();
+    }
+
+    public static String leadingZerosAreOctalToIp(String ip) {
+        if (ip.contains(":")) {
+            // v6 ip, don't change it.
+            return ip;
+        }
+        StringBuilder b = new StringBuilder();
+        boolean lastWasBreak = true;
+        boolean octalMode = false;
+        int current = 0;
+        for (int i = 0; i < ip.length(); i++) {
+            char c = ip.charAt(i);
+            if (lastWasBreak && c == '0') {
+                octalMode = true;
+                continue;
+            }
+            if (c == '.') {
+                lastWasBreak = true;
+                b.append(current).append('.');
+                current = 0;
+                continue;
+            }
+            lastWasBreak = false;
+            if (octalMode) {
+                current = current * 8 + (c - '0');
+            } else {
+                current = current * 10 + (c - '0');
+            }
+        }
+        b.append(current);
+        return b.toString();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanTests.java
@@ -38,7 +38,7 @@ public class ToBooleanTests extends AbstractScalarFunctionTestCase {
 
         TestCaseSupplier.forUnaryInt(
             suppliers,
-            "ToBooleanFromIntEvaluator[field=" + read + "]",
+            "ToBooleanFromIntEvaluator[i=" + read + "]",
             DataType.BOOLEAN,
             i -> i != 0,
             Integer.MIN_VALUE,
@@ -47,7 +47,7 @@ public class ToBooleanTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            "ToBooleanFromLongEvaluator[field=" + read + "]",
+            "ToBooleanFromLongEvaluator[l=" + read + "]",
             DataType.BOOLEAN,
             l -> l != 0,
             Long.MIN_VALUE,
@@ -56,7 +56,7 @@ public class ToBooleanTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            "ToBooleanFromUnsignedLongEvaluator[field=" + read + "]",
+            "ToBooleanFromUnsignedLongEvaluator[ul=" + read + "]",
             DataType.BOOLEAN,
             ul -> ul.compareTo(BigInteger.ZERO) != 0,
             BigInteger.ZERO,
@@ -65,7 +65,7 @@ public class ToBooleanTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            "ToBooleanFromDoubleEvaluator[field=" + read + "]",
+            "ToBooleanFromDoubleEvaluator[d=" + read + "]",
             DataType.BOOLEAN,
             d -> d != 0d,
             Double.NEGATIVE_INFINITY,
@@ -74,7 +74,7 @@ public class ToBooleanTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryStrings(
             suppliers,
-            "ToBooleanFromStringEvaluator[field=" + read + "]",
+            "ToBooleanFromStringEvaluator[keyword=" + read + "]",
             DataType.BOOLEAN,
             bytesRef -> String.valueOf(bytesRef).toLowerCase(Locale.ROOT).equals("true"),
             emptyList()

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointTests.java
@@ -36,7 +36,7 @@ public class ToCartesianPointTests extends AbstractScalarFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         // TODO multivalue fields
         final String attribute = "Attribute[channel=0]";
-        final Function<String, String> evaluatorName = s -> "ToCartesianPoint" + s + "Evaluator[field=" + attribute + "]";
+        final Function<String, String> evaluatorName = s -> "ToCartesianPoint" + s + "Evaluator[in=" + attribute + "]";
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         TestCaseSupplier.forUnaryCartesianPoint(suppliers, attribute, DataType.CARTESIAN_POINT, v -> v, List.of());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeTests.java
@@ -36,7 +36,7 @@ public class ToCartesianShapeTests extends AbstractScalarFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         // TODO multivalue fields
         final String attribute = "Attribute[channel=0]";
-        final Function<String, String> evaluatorName = s -> "ToCartesianShape" + s + "Evaluator[field=" + attribute + "]";
+        final Function<String, String> evaluatorName = s -> "ToCartesianShape" + s + "Evaluator[in=" + attribute + "]";
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         TestCaseSupplier.forUnaryCartesianPoint(suppliers, attribute, DataType.CARTESIAN_SHAPE, v -> v, List.of());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosTests.java
@@ -47,7 +47,7 @@ public class ToDateNanosTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.unary(
             suppliers,
-            "ToDateNanosFromDatetimeEvaluator[field=" + read + "]",
+            "ToDateNanosFromDatetimeEvaluator[in=" + read + "]",
             TestCaseSupplier.dateCases(0, DateUtils.MAX_NANOSECOND_INSTANT.toEpochMilli()),
             DataType.DATE_NANOS,
             i -> DateUtils.toNanoSeconds(((Instant) i).toEpochMilli()),
@@ -55,7 +55,7 @@ public class ToDateNanosTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            "ToDateNanosFromLongEvaluator[field=" + read + "]",
+            "ToDateNanosFromLongEvaluator[in=" + read + "]",
             DataType.DATE_NANOS,
             l -> l,
             0,
@@ -64,7 +64,7 @@ public class ToDateNanosTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            "ToDateNanosFromLongEvaluator[field=" + read + "]",
+            "ToDateNanosFromLongEvaluator[in=" + read + "]",
             DataType.DATE_NANOS,
             l -> null,
             Long.MIN_VALUE,
@@ -76,7 +76,7 @@ public class ToDateNanosTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            "ToLongFromUnsignedLongEvaluator[field=" + read + "]",
+            "ToLongFromUnsignedLongEvaluator[ul=" + read + "]",
             DataType.DATE_NANOS,
             BigInteger::longValueExact,
             BigInteger.ZERO,
@@ -85,7 +85,7 @@ public class ToDateNanosTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            "ToLongFromUnsignedLongEvaluator[field=" + read + "]",
+            "ToLongFromUnsignedLongEvaluator[ul=" + read + "]",
             DataType.DATE_NANOS,
             bi -> null,
             BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.TWO),
@@ -97,7 +97,7 @@ public class ToDateNanosTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            "ToDateNanosFromDoubleEvaluator[field=" + read + "]",
+            "ToDateNanosFromDoubleEvaluator[in=" + read + "]",
             DataType.DATE_NANOS,
             d -> null,
             Double.NEGATIVE_INFINITY,
@@ -109,7 +109,7 @@ public class ToDateNanosTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            "ToDateNanosFromDoubleEvaluator[field=" + read + "]",
+            "ToDateNanosFromDoubleEvaluator[in=" + read + "]",
             DataType.DATE_NANOS,
             d -> null,
             9.223372036854777E18, // a "convenient" value larger than `(double) Long.MAX_VALUE` (== ...776E18)
@@ -121,7 +121,7 @@ public class ToDateNanosTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryStrings(
             suppliers,
-            "ToDateNanosFromStringEvaluator[field=" + read + "]",
+            "ToDateNanosFromStringEvaluator[in=" + read + "]",
             DataType.DATE_NANOS,
             bytesRef -> null,
             bytesRef -> List.of(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeTests.java
@@ -47,7 +47,7 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.unary(
             suppliers,
-            "ToDatetimeFromDateNanosEvaluator[field=" + read + "]",
+            "ToDatetimeFromDateNanosEvaluator[in=" + read + "]",
             TestCaseSupplier.dateNanosCases(),
             DataType.DATETIME,
             i -> DateUtils.toMilliSeconds(DateUtils.toLong((Instant) i)),
@@ -56,7 +56,7 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
 
         TestCaseSupplier.forUnaryInt(
             suppliers,
-            "ToLongFromIntEvaluator[field=" + read + "]",
+            "ToLongFromIntEvaluator[i=" + read + "]",
             DataType.DATETIME,
             i -> ((Integer) i).longValue(),
             Integer.MIN_VALUE,
@@ -66,7 +66,7 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
         TestCaseSupplier.forUnaryLong(suppliers, read, DataType.DATETIME, l -> l, Long.MIN_VALUE, Long.MAX_VALUE, emptyList());
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            "ToLongFromUnsignedLongEvaluator[field=" + read + "]",
+            "ToLongFromUnsignedLongEvaluator[ul=" + read + "]",
             DataType.DATETIME,
             BigInteger::longValueExact,
             BigInteger.ZERO,
@@ -75,7 +75,7 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            "ToLongFromUnsignedLongEvaluator[field=" + read + "]",
+            "ToLongFromUnsignedLongEvaluator[ul=" + read + "]",
             DataType.DATETIME,
             bi -> null,
             BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.TWO),
@@ -87,7 +87,7 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            "ToLongFromDoubleEvaluator[field=" + read + "]",
+            "ToLongFromDoubleEvaluator[dbl=" + read + "]",
             DataType.DATETIME,
             d -> null,
             Double.NEGATIVE_INFINITY,
@@ -99,7 +99,7 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            "ToLongFromDoubleEvaluator[field=" + read + "]",
+            "ToLongFromDoubleEvaluator[dbl=" + read + "]",
             DataType.DATETIME,
             d -> null,
             9.223372036854777E18, // a "convenient" value larger than `(double) Long.MAX_VALUE` (== ...776E18)
@@ -111,7 +111,7 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryStrings(
             suppliers,
-            "ToDatetimeFromStringEvaluator[field=" + read + "]",
+            "ToDatetimeFromStringEvaluator[in=" + read + "]",
             DataType.DATETIME,
             bytesRef -> null,
             bytesRef -> List.of(
@@ -124,7 +124,7 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.unary(
             suppliers,
-            "ToDatetimeFromStringEvaluator[field=" + read + "]",
+            "ToDatetimeFromStringEvaluator[in=" + read + "]",
             List.of(
                 new TestCaseSupplier.TypedDataSupplier(
                     "<date string>",
@@ -139,7 +139,7 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.unary(
             suppliers,
-            "ToDatetimeFromStringEvaluator[field=" + read + "]",
+            "ToDatetimeFromStringEvaluator[in=" + read + "]",
             List.of(
                 new TestCaseSupplier.TypedDataSupplier(
                     "<date string before -9999-12-31T23:59:59.999Z>",
@@ -159,7 +159,7 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.unary(
             suppliers,
-            "ToDatetimeFromStringEvaluator[field=" + read + "]",
+            "ToDatetimeFromStringEvaluator[in=" + read + "]",
             List.of(
                 new TestCaseSupplier.TypedDataSupplier(
                     "<date string after 9999-12-31T23:59:59.999Z>",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegreesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegreesTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 public class ToDegreesTests extends AbstractScalarFunctionTestCase {
@@ -30,12 +30,16 @@ public class ToDegreesTests extends AbstractScalarFunctionTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
         // TODO multivalue fields
-        Function<String, String> evaluatorName = eval -> "ToDegreesEvaluator[field=" + eval + "[field=Attribute[channel=0]]]";
+        BiFunction<String, String, String> evaluatorName = (eval, f) -> "ToDegreesEvaluator[deg="
+            + eval
+            + "["
+            + f
+            + "=Attribute[channel=0]]]";
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         TestCaseSupplier.forUnaryInt(
             suppliers,
-            evaluatorName.apply("ToDoubleFromIntEvaluator"),
+            evaluatorName.apply("ToDoubleFromIntEvaluator", "i"),
             DataType.DOUBLE,
             Math::toDegrees,
             Integer.MIN_VALUE,
@@ -44,7 +48,7 @@ public class ToDegreesTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            evaluatorName.apply("ToDoubleFromLongEvaluator"),
+            evaluatorName.apply("ToDoubleFromLongEvaluator", "l"),
             DataType.DOUBLE,
             Math::toDegrees,
             Long.MIN_VALUE,
@@ -53,14 +57,14 @@ public class ToDegreesTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            evaluatorName.apply("ToDoubleFromUnsignedLongEvaluator"),
+            evaluatorName.apply("ToDoubleFromUnsignedLongEvaluator", "l"),
             DataType.DOUBLE,
             ul -> Math.toDegrees(ul.doubleValue()),
             BigInteger.ZERO,
             UNSIGNED_LONG_MAX,
             List.of()
         );
-        TestCaseSupplier.forUnaryDouble(suppliers, "ToDegreesEvaluator[field=Attribute[channel=0]]", DataType.DOUBLE, d -> {
+        TestCaseSupplier.forUnaryDouble(suppliers, "ToDegreesEvaluator[deg=Attribute[channel=0]]", DataType.DOUBLE, d -> {
             double deg = Math.toDegrees(d);
             return Double.isNaN(deg) || Double.isInfinite(deg) ? null : deg;
         }, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, d -> {
@@ -74,7 +78,7 @@ public class ToDegreesTests extends AbstractScalarFunctionTestCase {
         });
         TestCaseSupplier.unary(
             suppliers,
-            "ToDegreesEvaluator[field=Attribute[channel=0]]",
+            "ToDegreesEvaluator[deg=Attribute[channel=0]]",
             List.of(
                 new TestCaseSupplier.TypedDataSupplier("Double.MAX_VALUE", () -> Double.MAX_VALUE, DataType.DOUBLE),
                 new TestCaseSupplier.TypedDataSupplier("-Double.MAX_VALUE", () -> -Double.MAX_VALUE, DataType.DOUBLE),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleTests.java
@@ -24,7 +24,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 public class ToDoubleTests extends AbstractScalarFunctionTestCase {
@@ -36,7 +36,7 @@ public class ToDoubleTests extends AbstractScalarFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         // TODO multivalue fields
         String read = "Attribute[channel=0]";
-        Function<String, String> evaluatorName = s -> "ToDoubleFrom" + s + "Evaluator[field=" + read + "]";
+        BiFunction<String, String, String> evaluatorName = (s, f) -> "ToDoubleFrom" + s + "Evaluator[" + f + "=" + read + "]";
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         TestCaseSupplier.forUnaryDouble(
@@ -49,17 +49,17 @@ public class ToDoubleTests extends AbstractScalarFunctionTestCase {
             List.of()
         );
 
-        TestCaseSupplier.forUnaryBoolean(suppliers, evaluatorName.apply("Boolean"), DataType.DOUBLE, b -> b ? 1d : 0d, List.of());
+        TestCaseSupplier.forUnaryBoolean(suppliers, evaluatorName.apply("Boolean", "bool"), DataType.DOUBLE, b -> b ? 1d : 0d, List.of());
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("Long"),
+            evaluatorName.apply("Long", "l"),
             TestCaseSupplier.dateCases(),
             DataType.DOUBLE,
             i -> (double) ((Instant) i).toEpochMilli(),
             List.of()
         );
         // random strings that don't look like a double
-        TestCaseSupplier.forUnaryStrings(suppliers, evaluatorName.apply("String"), DataType.DOUBLE, bytesRef -> null, bytesRef -> {
+        TestCaseSupplier.forUnaryStrings(suppliers, evaluatorName.apply("String", "in"), DataType.DOUBLE, bytesRef -> null, bytesRef -> {
             var exception = expectThrows(
                 InvalidArgumentException.class,
                 () -> EsqlDataTypeConverter.stringToDouble(bytesRef.utf8ToString())
@@ -71,7 +71,7 @@ public class ToDoubleTests extends AbstractScalarFunctionTestCase {
         });
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            evaluatorName.apply("UnsignedLong"),
+            evaluatorName.apply("UnsignedLong", "l"),
             DataType.DOUBLE,
             BigInteger::doubleValue,
             BigInteger.ZERO,
@@ -80,7 +80,7 @@ public class ToDoubleTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            evaluatorName.apply("Long"),
+            evaluatorName.apply("Long", "l"),
             DataType.DOUBLE,
             l -> (double) l,
             Long.MIN_VALUE,
@@ -89,7 +89,7 @@ public class ToDoubleTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryInt(
             suppliers,
-            evaluatorName.apply("Int"),
+            evaluatorName.apply("Int", "i"),
             DataType.DOUBLE,
             i -> (double) i,
             Integer.MIN_VALUE,
@@ -100,7 +100,7 @@ public class ToDoubleTests extends AbstractScalarFunctionTestCase {
         // strings of random numbers
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.castToDoubleSuppliersFromRange(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY)
                 .stream()
                 .map(
@@ -126,7 +126,7 @@ public class ToDoubleTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("Int"),
+            evaluatorName.apply("Int", "i"),
             List.of(new TestCaseSupplier.TypedDataSupplier("counter", () -> randomInt(1000), DataType.COUNTER_INTEGER)),
             DataType.DOUBLE,
             l -> ((Integer) l).doubleValue(),
@@ -134,7 +134,7 @@ public class ToDoubleTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("Long"),
+            evaluatorName.apply("Long", "l"),
             List.of(new TestCaseSupplier.TypedDataSupplier("counter", () -> randomLongBetween(1, 1000), DataType.COUNTER_LONG)),
             DataType.DOUBLE,
             l -> ((Long) l).doubleValue(),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointTests.java
@@ -36,7 +36,7 @@ public class ToGeoPointTests extends AbstractScalarFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         // TODO multivalue fields
         final String attribute = "Attribute[channel=0]";
-        final Function<String, String> evaluatorName = s -> "ToGeoPoint" + s + "Evaluator[field=" + attribute + "]";
+        final Function<String, String> evaluatorName = s -> "ToGeoPoint" + s + "Evaluator[in=" + attribute + "]";
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         TestCaseSupplier.forUnaryGeoPoint(suppliers, attribute, DataType.GEO_POINT, v -> v, List.of());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShapeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShapeTests.java
@@ -36,7 +36,7 @@ public class ToGeoShapeTests extends AbstractScalarFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         // TODO multivalue fields
         final String attribute = "Attribute[channel=0]";
-        final Function<String, String> evaluatorName = s -> "ToGeoShape" + s + "Evaluator[field=" + attribute + "]";
+        final Function<String, String> evaluatorName = s -> "ToGeoShape" + s + "Evaluator[in=" + attribute + "]";
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         TestCaseSupplier.forUnaryGeoPoint(suppliers, attribute, DataType.GEO_SHAPE, v -> v, List.of());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIPTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIPTests.java
@@ -34,7 +34,7 @@ public class ToIPTests extends AbstractScalarFunctionTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
         String read = "Attribute[channel=0]";
-        String stringEvaluator = "ToIPFromStringEvaluator[field=" + read + "]";
+        String stringEvaluator = "ParseIpLeadingZerosRejectedEvaluator[string=" + read + "]";
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         // convert from IP to IP

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerTests.java
@@ -22,7 +22,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.esql.core.type.DataTypeConverter.safeToInt;
@@ -36,17 +36,17 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         // TODO multivalue fields
         String read = "Attribute[channel=0]";
-        Function<String, String> evaluatorName = s -> "ToIntegerFrom" + s + "Evaluator[field=" + read + "]";
+        BiFunction<String, String, String> evaluatorName = (s, f) -> "ToIntegerFrom" + s + "Evaluator[" + f + "=" + read + "]";
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         TestCaseSupplier.forUnaryInt(suppliers, read, DataType.INTEGER, i -> i, Integer.MIN_VALUE, Integer.MAX_VALUE, List.of());
 
-        TestCaseSupplier.forUnaryBoolean(suppliers, evaluatorName.apply("Boolean"), DataType.INTEGER, b -> b ? 1 : 0, List.of());
+        TestCaseSupplier.forUnaryBoolean(suppliers, evaluatorName.apply("Boolean", "bool"), DataType.INTEGER, b -> b ? 1 : 0, List.of());
 
         // datetimes that fall within Integer's range
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("Long"),
+            evaluatorName.apply("Long", "lng"),
             dateCases(0, Integer.MAX_VALUE),
             DataType.INTEGER,
             l -> Long.valueOf(((Instant) l).toEpochMilli()).intValue(),
@@ -55,7 +55,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // datetimes that fall outside Integer's range
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("Long"),
+            evaluatorName.apply("Long", "lng"),
             dateCases(Integer.MAX_VALUE + 1L, Long.MAX_VALUE),
             DataType.INTEGER,
             l -> null,
@@ -69,7 +69,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // random strings that don't look like an Integer
         TestCaseSupplier.forUnaryStrings(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             DataType.INTEGER,
             bytesRef -> null,
             bytesRef -> List.of(
@@ -82,7 +82,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // from doubles within Integer's range
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            evaluatorName.apply("Double"),
+            evaluatorName.apply("Double", "dbl"),
             DataType.INTEGER,
             d -> safeToInt(Math.round(d)),
             Integer.MIN_VALUE,
@@ -92,7 +92,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // from doubles outside Integer's range, negative
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            evaluatorName.apply("Double"),
+            evaluatorName.apply("Double", "dbl"),
             DataType.INTEGER,
             d -> null,
             Double.NEGATIVE_INFINITY,
@@ -105,7 +105,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // from doubles outside Integer's range, positive
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            evaluatorName.apply("Double"),
+            evaluatorName.apply("Double", "dbl"),
             DataType.INTEGER,
             d -> null,
             Integer.MAX_VALUE + 1d,
@@ -119,7 +119,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // from unsigned_long within Integer's range
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            evaluatorName.apply("UnsignedLong"),
+            evaluatorName.apply("UnsignedLong", "ul"),
             DataType.INTEGER,
             BigInteger::intValue,
             BigInteger.ZERO,
@@ -129,7 +129,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // from unsigned_long outside Integer's range
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            evaluatorName.apply("UnsignedLong"),
+            evaluatorName.apply("UnsignedLong", "ul"),
             DataType.INTEGER,
             ul -> null,
             BigInteger.valueOf(Integer.MAX_VALUE).add(BigInteger.ONE),
@@ -144,7 +144,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // from long, within Integer's range
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            evaluatorName.apply("Long"),
+            evaluatorName.apply("Long", "lng"),
             DataType.INTEGER,
             l -> (int) l,
             Integer.MIN_VALUE,
@@ -154,7 +154,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // from long, outside Integer's range, negative
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            evaluatorName.apply("Long"),
+            evaluatorName.apply("Long", "lng"),
             DataType.INTEGER,
             l -> null,
             Long.MIN_VALUE,
@@ -168,7 +168,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // from long, outside Integer's range, positive
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            evaluatorName.apply("Long"),
+            evaluatorName.apply("Long", "lng"),
             DataType.INTEGER,
             l -> null,
             Integer.MAX_VALUE + 1L,
@@ -182,7 +182,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // strings of random ints within Integer's range
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.intCases(Integer.MIN_VALUE, Integer.MAX_VALUE, true)
                 .stream()
                 .map(
@@ -200,7 +200,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // strings of random doubles within Integer's range
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.doubleCases(Integer.MIN_VALUE, Integer.MAX_VALUE, true)
                 .stream()
                 .map(
@@ -218,7 +218,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // strings of random doubles outside Integer's range, negative
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.doubleCases(Double.NEGATIVE_INFINITY, Integer.MIN_VALUE - 1d, true)
                 .stream()
                 .map(
@@ -241,7 +241,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
         // strings of random doubles outside Integer's range, positive
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.doubleCases(Integer.MAX_VALUE + 1d, Double.POSITIVE_INFINITY, true)
                 .stream()
                 .map(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongTests.java
@@ -23,7 +23,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 public class ToLongTests extends AbstractScalarFunctionTestCase {
@@ -35,12 +35,12 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         // TODO multivalue fields
         String read = "Attribute[channel=0]";
-        Function<String, String> evaluatorName = s -> "ToLongFrom" + s + "Evaluator[field=" + read + "]";
+        BiFunction<String, String, String> evaluatorName = (s, f) -> "ToLongFrom" + s + "Evaluator[" + f + "=" + read + "]";
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         TestCaseSupplier.forUnaryLong(suppliers, read, DataType.LONG, l -> l, Long.MIN_VALUE, Long.MAX_VALUE, List.of());
 
-        TestCaseSupplier.forUnaryBoolean(suppliers, evaluatorName.apply("Boolean"), DataType.LONG, b -> b ? 1L : 0L, List.of());
+        TestCaseSupplier.forUnaryBoolean(suppliers, evaluatorName.apply("Boolean", "bool"), DataType.LONG, b -> b ? 1L : 0L, List.of());
 
         // datetimes
         TestCaseSupplier.unary(
@@ -62,7 +62,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         // random strings that don't look like a long
         TestCaseSupplier.forUnaryStrings(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             DataType.LONG,
             bytesRef -> null,
             bytesRef -> List.of(
@@ -75,7 +75,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         // from doubles within long's range
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            evaluatorName.apply("Double"),
+            evaluatorName.apply("Double", "dbl"),
             DataType.LONG,
             Math::round,
             Long.MIN_VALUE,
@@ -85,7 +85,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         // from doubles outside long's range, negative
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            evaluatorName.apply("Double"),
+            evaluatorName.apply("Double", "dbl"),
             DataType.LONG,
             d -> null,
             Double.NEGATIVE_INFINITY,
@@ -98,7 +98,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         // from doubles outside long's range, positive
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            evaluatorName.apply("Double"),
+            evaluatorName.apply("Double", "dbl"),
             DataType.LONG,
             d -> null,
             Long.MAX_VALUE + 1d,
@@ -112,7 +112,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         // from unsigned_long within long's range
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            evaluatorName.apply("UnsignedLong"),
+            evaluatorName.apply("UnsignedLong", "ul"),
             DataType.LONG,
             BigInteger::longValue,
             BigInteger.ZERO,
@@ -121,7 +121,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            evaluatorName.apply("UnsignedLong"),
+            evaluatorName.apply("UnsignedLong", "ul"),
             DataType.LONG,
             ul -> null,
             BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE),
@@ -136,7 +136,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         // from integer
         TestCaseSupplier.forUnaryInt(
             suppliers,
-            evaluatorName.apply("Int"),
+            evaluatorName.apply("Int", "i"),
             DataType.LONG,
             l -> (long) l,
             Integer.MIN_VALUE,
@@ -147,7 +147,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         // strings of random longs
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.longCases(Long.MIN_VALUE, Long.MAX_VALUE, true)
                 .stream()
                 .map(
@@ -165,7 +165,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         // strings of random doubles within long's range
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.doubleCases(Long.MIN_VALUE, Long.MAX_VALUE, true)
                 .stream()
                 .map(
@@ -183,7 +183,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         // strings of random doubles outside integer's range, negative
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.doubleCases(Double.NEGATIVE_INFINITY, Long.MIN_VALUE - 1d, true)
                 .stream()
                 .map(
@@ -206,7 +206,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         // strings of random doubles outside integer's range, positive
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.doubleCases(Long.MAX_VALUE + 1d, Double.POSITIVE_INFINITY, true)
                 .stream()
                 .map(
@@ -237,7 +237,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("Int"),
+            evaluatorName.apply("Int", "i"),
             List.of(new TestCaseSupplier.TypedDataSupplier("counter", ESTestCase::randomInt, DataType.COUNTER_INTEGER)),
             DataType.LONG,
             l -> ((Integer) l).longValue(),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadiansTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadiansTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 public class ToRadiansTests extends AbstractScalarFunctionTestCase {
@@ -30,12 +30,16 @@ public class ToRadiansTests extends AbstractScalarFunctionTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
         // TODO multivalue fields
-        Function<String, String> evaluatorName = eval -> "ToRadiansEvaluator[field=" + eval + "[field=Attribute[channel=0]]]";
+        BiFunction<String, String, String> evaluatorName = (eval, f) -> "ToRadiansEvaluator[deg="
+            + eval
+            + "["
+            + f
+            + "=Attribute[channel=0]]]";
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         TestCaseSupplier.forUnaryInt(
             suppliers,
-            evaluatorName.apply("ToDoubleFromIntEvaluator"),
+            evaluatorName.apply("ToDoubleFromIntEvaluator", "i"),
             DataType.DOUBLE,
             Math::toRadians,
             Integer.MIN_VALUE,
@@ -44,7 +48,7 @@ public class ToRadiansTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            evaluatorName.apply("ToDoubleFromLongEvaluator"),
+            evaluatorName.apply("ToDoubleFromLongEvaluator", "l"),
             DataType.DOUBLE,
             Math::toRadians,
             Long.MIN_VALUE,
@@ -53,7 +57,7 @@ public class ToRadiansTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            evaluatorName.apply("ToDoubleFromUnsignedLongEvaluator"),
+            evaluatorName.apply("ToDoubleFromUnsignedLongEvaluator", "l"),
             DataType.DOUBLE,
             ul -> Math.toRadians(ul.doubleValue()),
             BigInteger.ZERO,
@@ -62,7 +66,7 @@ public class ToRadiansTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            "ToRadiansEvaluator[field=Attribute[channel=0]]",
+            "ToRadiansEvaluator[deg=Attribute[channel=0]]",
             DataType.DOUBLE,
             Math::toRadians,
             Double.NEGATIVE_INFINITY,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
@@ -41,7 +41,7 @@ public class ToStringTests extends AbstractScalarFunctionTestCase {
         List<TestCaseSupplier> suppliers = new ArrayList<>();
         TestCaseSupplier.forUnaryInt(
             suppliers,
-            "ToStringFromIntEvaluator[field=" + read + "]",
+            "ToStringFromIntEvaluator[integer=" + read + "]",
             DataType.KEYWORD,
             i -> new BytesRef(Integer.toString(i)),
             Integer.MIN_VALUE,
@@ -50,7 +50,7 @@ public class ToStringTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            "ToStringFromLongEvaluator[field=" + read + "]",
+            "ToStringFromLongEvaluator[lng=" + read + "]",
             DataType.KEYWORD,
             l -> new BytesRef(Long.toString(l)),
             Long.MIN_VALUE,
@@ -59,7 +59,7 @@ public class ToStringTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
-            "ToStringFromUnsignedLongEvaluator[field=" + read + "]",
+            "ToStringFromUnsignedLongEvaluator[lng=" + read + "]",
             DataType.KEYWORD,
             ul -> new BytesRef(ul.toString()),
             BigInteger.ZERO,
@@ -68,7 +68,7 @@ public class ToStringTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            "ToStringFromDoubleEvaluator[field=" + read + "]",
+            "ToStringFromDoubleEvaluator[dbl=" + read + "]",
             DataType.KEYWORD,
             d -> new BytesRef(Double.toString(d)),
             Double.NEGATIVE_INFINITY,
@@ -77,14 +77,14 @@ public class ToStringTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryBoolean(
             suppliers,
-            "ToStringFromBooleanEvaluator[field=" + read + "]",
+            "ToStringFromBooleanEvaluator[bool=" + read + "]",
             DataType.KEYWORD,
             b -> new BytesRef(b.toString()),
             List.of()
         );
         TestCaseSupplier.unary(
             suppliers,
-            "ToStringFromDatetimeEvaluator[field=" + read + "]",
+            "ToStringFromDatetimeEvaluator[datetime=" + read + "]",
             TestCaseSupplier.dateCases(),
             DataType.KEYWORD,
             i -> new BytesRef(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(DateUtils.toLongMillis((Instant) i))),
@@ -92,7 +92,7 @@ public class ToStringTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.unary(
             suppliers,
-            "ToStringFromDateNanosEvaluator[field=" + read + "]",
+            "ToStringFromDateNanosEvaluator[datetime=" + read + "]",
             TestCaseSupplier.dateNanosCases(),
             DataType.KEYWORD,
             i -> new BytesRef(DateFieldMapper.DEFAULT_DATE_TIME_NANOS_FORMATTER.formatNanos(DateUtils.toLong((Instant) i))),
@@ -100,35 +100,35 @@ public class ToStringTests extends AbstractScalarFunctionTestCase {
         );
         TestCaseSupplier.forUnaryGeoPoint(
             suppliers,
-            "ToStringFromGeoPointEvaluator[field=" + read + "]",
+            "ToStringFromGeoPointEvaluator[wkb=" + read + "]",
             DataType.KEYWORD,
             wkb -> new BytesRef(GEO.wkbToWkt(wkb)),
             List.of()
         );
         TestCaseSupplier.forUnaryCartesianPoint(
             suppliers,
-            "ToStringFromCartesianPointEvaluator[field=" + read + "]",
+            "ToStringFromCartesianPointEvaluator[wkb=" + read + "]",
             DataType.KEYWORD,
             wkb -> new BytesRef(CARTESIAN.wkbToWkt(wkb)),
             List.of()
         );
         TestCaseSupplier.forUnaryGeoShape(
             suppliers,
-            "ToStringFromGeoShapeEvaluator[field=" + read + "]",
+            "ToStringFromGeoShapeEvaluator[wkb=" + read + "]",
             DataType.KEYWORD,
             wkb -> new BytesRef(GEO.wkbToWkt(wkb)),
             List.of()
         );
         TestCaseSupplier.forUnaryCartesianShape(
             suppliers,
-            "ToStringFromCartesianShapeEvaluator[field=" + read + "]",
+            "ToStringFromCartesianShapeEvaluator[wkb=" + read + "]",
             DataType.KEYWORD,
             wkb -> new BytesRef(CARTESIAN.wkbToWkt(wkb)),
             List.of()
         );
         TestCaseSupplier.forUnaryIp(
             suppliers,
-            "ToStringFromIPEvaluator[field=" + read + "]",
+            "ToStringFromIPEvaluator[ip=" + read + "]",
             DataType.KEYWORD,
             ip -> new BytesRef(DocValueFormat.IP.format(ip)),
             List.of()
@@ -136,7 +136,7 @@ public class ToStringTests extends AbstractScalarFunctionTestCase {
         TestCaseSupplier.forUnaryStrings(suppliers, read, DataType.KEYWORD, bytesRef -> bytesRef, List.of());
         TestCaseSupplier.forUnaryVersion(
             suppliers,
-            "ToStringFromVersionEvaluator[field=" + read + "]",
+            "ToStringFromVersionEvaluator[version=" + read + "]",
             DataType.KEYWORD,
             v -> new BytesRef(v.toString()),
             List.of()

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongTests.java
@@ -22,7 +22,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.esql.core.type.DataTypeConverter.safeToUnsignedLong;
@@ -37,7 +37,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         // TODO multivalue fields
         String read = "Attribute[channel=0]";
-        Function<String, String> evaluatorName = s -> "ToUnsignedLongFrom" + s + "Evaluator[field=" + read + "]";
+        BiFunction<String, String, String> evaluatorName = (s, f) -> "ToUnsignedLongFrom" + s + "Evaluator[" + f + "=" + read + "]";
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         TestCaseSupplier.forUnaryUnsignedLong(
@@ -52,7 +52,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
 
         TestCaseSupplier.forUnaryBoolean(
             suppliers,
-            evaluatorName.apply("Boolean"),
+            evaluatorName.apply("Boolean", "bool"),
             DataType.UNSIGNED_LONG,
             b -> b ? BigInteger.ONE : BigInteger.ZERO,
             List.of()
@@ -61,27 +61,33 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         // datetimes
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("Long"),
+            evaluatorName.apply("Long", "lng"),
             TestCaseSupplier.dateCases(),
             DataType.UNSIGNED_LONG,
             instant -> BigInteger.valueOf(((Instant) instant).toEpochMilli()),
             List.of()
         );
         // random strings that don't look like an unsigned_long
-        TestCaseSupplier.forUnaryStrings(suppliers, evaluatorName.apply("String"), DataType.UNSIGNED_LONG, bytesRef -> null, bytesRef -> {
-            // BigDecimal, used to parse unsigned_longs will throw NFEs with different messages depending on empty string, first
-            // non-number character after a number-looking like prefix, or string starting with "e", maybe others -- safer to take
-            // this shortcut here.
-            Exception e = expectThrows(NumberFormatException.class, () -> new BigDecimal(bytesRef.utf8ToString()));
-            return List.of(
-                "Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.",
-                "Line 1:1: java.lang.NumberFormatException: " + e.getMessage()
-            );
-        });
+        TestCaseSupplier.forUnaryStrings(
+            suppliers,
+            evaluatorName.apply("String", "in"),
+            DataType.UNSIGNED_LONG,
+            bytesRef -> null,
+            bytesRef -> {
+                // BigDecimal, used to parse unsigned_longs will throw NFEs with different messages depending on empty string, first
+                // non-number character after a number-looking like prefix, or string starting with "e", maybe others -- safer to take
+                // this shortcut here.
+                Exception e = expectThrows(NumberFormatException.class, () -> new BigDecimal(bytesRef.utf8ToString()));
+                return List.of(
+                    "Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.",
+                    "Line 1:1: java.lang.NumberFormatException: " + e.getMessage()
+                );
+            }
+        );
         // from doubles within unsigned_long's range
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            evaluatorName.apply("Double"),
+            evaluatorName.apply("Double", "dbl"),
             DataType.UNSIGNED_LONG,
             d -> BigDecimal.valueOf(d).toBigInteger(), // note: not: new BigDecimal(d).toBigInteger
             0d,
@@ -91,7 +97,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         // from doubles outside unsigned_long's range, negative
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            evaluatorName.apply("Double"),
+            evaluatorName.apply("Double", "dbl"),
             DataType.UNSIGNED_LONG,
             d -> null,
             Double.NEGATIVE_INFINITY,
@@ -104,7 +110,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         // from doubles outside Long's range, positive
         TestCaseSupplier.forUnaryDouble(
             suppliers,
-            evaluatorName.apply("Double"),
+            evaluatorName.apply("Double", "dbl"),
             DataType.UNSIGNED_LONG,
             d -> null,
             UNSIGNED_LONG_MAX_AS_DOUBLE + 10e5,
@@ -118,7 +124,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         // from long within unsigned_long's range
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            evaluatorName.apply("Long"),
+            evaluatorName.apply("Long", "lng"),
             DataType.UNSIGNED_LONG,
             BigInteger::valueOf,
             0L,
@@ -128,7 +134,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         // from long outside unsigned_long's range
         TestCaseSupplier.forUnaryLong(
             suppliers,
-            evaluatorName.apply("Long"),
+            evaluatorName.apply("Long", "lng"),
             DataType.UNSIGNED_LONG,
             unused -> null,
             Long.MIN_VALUE,
@@ -142,7 +148,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         // from int within unsigned_long's range
         TestCaseSupplier.forUnaryInt(
             suppliers,
-            evaluatorName.apply("Int"),
+            evaluatorName.apply("Int", "i"),
             DataType.UNSIGNED_LONG,
             BigInteger::valueOf,
             0,
@@ -152,7 +158,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         // from int outside unsigned_long's range
         TestCaseSupplier.forUnaryInt(
             suppliers,
-            evaluatorName.apply("Int"),
+            evaluatorName.apply("Int", "i"),
             DataType.UNSIGNED_LONG,
             unused -> null,
             Integer.MIN_VALUE,
@@ -166,7 +172,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         // strings of random unsigned_longs
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.ulongCases(BigInteger.ZERO, UNSIGNED_LONG_MAX, true)
                 .stream()
                 .map(
@@ -184,7 +190,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         // strings of random doubles within unsigned_long's range
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.doubleCases(0, UNSIGNED_LONG_MAX_AS_DOUBLE, true)
                 .stream()
                 .map(
@@ -202,7 +208,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         // strings of random doubles outside unsigned_long's range, negative
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.doubleCases(Double.NEGATIVE_INFINITY, -1d, true)
                 .stream()
                 .map(
@@ -225,7 +231,7 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         // strings of random doubles outside Integer's range, positive
         TestCaseSupplier.unary(
             suppliers,
-            evaluatorName.apply("String"),
+            evaluatorName.apply("String", "in"),
             TestCaseSupplier.doubleCases(UNSIGNED_LONG_MAX_AS_DOUBLE + 10e5, Double.POSITIVE_INFINITY, true)
                 .stream()
                 .map(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionTests.java
@@ -31,7 +31,7 @@ public class ToVersionTests extends AbstractScalarFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         // TODO multivalue fields
         String read = "Attribute[channel=0]";
-        String stringEvaluator = "ToVersionFromStringEvaluator[field=" + read + "]";
+        String stringEvaluator = "ToVersionFromStringEvaluator[asString=" + read + "]";
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         // Converting and IP to an IP doesn't change anything. Everything should succeed.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StEnvelopeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StEnvelopeTests.java
@@ -36,8 +36,8 @@ public class StEnvelopeTests extends AbstractScalarFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        String expectedGeo = "StEnvelopeFromWKBGeoEvaluator[field=Attribute[channel=0]]";
-        String expectedCartesian = "StEnvelopeFromWKBEvaluator[field=Attribute[channel=0]]";
+        String expectedGeo = "StEnvelopeFromWKBGeoEvaluator[wkb=Attribute[channel=0]]";
+        String expectedCartesian = "StEnvelopeFromWKBEvaluator[wkb=Attribute[channel=0]]";
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
         TestCaseSupplier.forUnaryGeoPoint(suppliers, expectedGeo, GEO_SHAPE, StEnvelopeTests::valueOfGeo, List.of());
         TestCaseSupplier.forUnaryCartesianPoint(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMaxTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMaxTests.java
@@ -35,8 +35,8 @@ public class StXMaxTests extends AbstractScalarFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        String expectedGeo = "StXMaxFromWKBGeoEvaluator[field=Attribute[channel=0]]";
-        String expectedCartesian = "StXMaxFromWKBEvaluator[field=Attribute[channel=0]]";
+        String expectedGeo = "StXMaxFromWKBGeoEvaluator[wkb=Attribute[channel=0]]";
+        String expectedCartesian = "StXMaxFromWKBEvaluator[wkb=Attribute[channel=0]]";
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
         TestCaseSupplier.forUnaryGeoPoint(suppliers, expectedGeo, DOUBLE, StXMaxTests::valueOfGeo, List.of());
         TestCaseSupplier.forUnaryCartesianPoint(suppliers, expectedCartesian, DOUBLE, StXMaxTests::valueOfCartesian, List.of());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXMinTests.java
@@ -35,8 +35,8 @@ public class StXMinTests extends AbstractScalarFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        String expectedGeo = "StXMinFromWKBGeoEvaluator[field=Attribute[channel=0]]";
-        String expectedCartesian = "StXMinFromWKBEvaluator[field=Attribute[channel=0]]";
+        String expectedGeo = "StXMinFromWKBGeoEvaluator[wkb=Attribute[channel=0]]";
+        String expectedCartesian = "StXMinFromWKBEvaluator[wkb=Attribute[channel=0]]";
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
         TestCaseSupplier.forUnaryGeoPoint(suppliers, expectedGeo, DOUBLE, StXMinTests::valueOfGeo, List.of());
         TestCaseSupplier.forUnaryCartesianPoint(suppliers, expectedCartesian, DOUBLE, StXMinTests::valueOfCartesian, List.of());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXTests.java
@@ -32,7 +32,7 @@ public class StXTests extends AbstractScalarFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        String expectedEvaluator = "StXFromWKBEvaluator[field=Attribute[channel=0]]";
+        String expectedEvaluator = "StXFromWKBEvaluator[in=Attribute[channel=0]]";
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
         TestCaseSupplier.forUnaryGeoPoint(suppliers, expectedEvaluator, DOUBLE, StXTests::valueOf, List.of());
         TestCaseSupplier.forUnaryCartesianPoint(suppliers, expectedEvaluator, DOUBLE, StXTests::valueOf, List.of());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMaxTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMaxTests.java
@@ -35,8 +35,8 @@ public class StYMaxTests extends AbstractScalarFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        String expectedGeo = "StYMaxFromWKBGeoEvaluator[field=Attribute[channel=0]]";
-        String expectedCartesian = "StYMaxFromWKBEvaluator[field=Attribute[channel=0]]";
+        String expectedGeo = "StYMaxFromWKBGeoEvaluator[wkb=Attribute[channel=0]]";
+        String expectedCartesian = "StYMaxFromWKBEvaluator[wkb=Attribute[channel=0]]";
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
         TestCaseSupplier.forUnaryGeoPoint(suppliers, expectedGeo, DOUBLE, StYMaxTests::valueOfGeo, List.of());
         TestCaseSupplier.forUnaryCartesianPoint(suppliers, expectedCartesian, DOUBLE, StYMaxTests::valueOfCartesian, List.of());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYMinTests.java
@@ -35,8 +35,8 @@ public class StYMinTests extends AbstractScalarFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        String expectedGeo = "StYMinFromWKBGeoEvaluator[field=Attribute[channel=0]]";
-        String expectedCartesian = "StYMinFromWKBEvaluator[field=Attribute[channel=0]]";
+        String expectedGeo = "StYMinFromWKBGeoEvaluator[wkb=Attribute[channel=0]]";
+        String expectedCartesian = "StYMinFromWKBEvaluator[wkb=Attribute[channel=0]]";
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
         TestCaseSupplier.forUnaryGeoPoint(suppliers, expectedGeo, DOUBLE, StYMinTests::valueOfGeo, List.of());
         TestCaseSupplier.forUnaryCartesianPoint(suppliers, expectedCartesian, DOUBLE, StYMinTests::valueOfCartesian, List.of());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYTests.java
@@ -32,7 +32,7 @@ public class StYTests extends AbstractScalarFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        String expectedEvaluator = "StYFromWKBEvaluator[field=Attribute[channel=0]]";
+        String expectedEvaluator = "StYFromWKBEvaluator[in=Attribute[channel=0]]";
         final List<TestCaseSupplier> suppliers = new ArrayList<>();
         TestCaseSupplier.forUnaryGeoPoint(suppliers, expectedEvaluator, DOUBLE, StYTests::valueOf, List.of());
         TestCaseSupplier.forUnaryCartesianPoint(suppliers, expectedEvaluator, DOUBLE, StYTests::valueOf, List.of());


### PR DESCRIPTION
Speed up the TO_IP method by converting directly from utf-8 encoded strings to the ip encoding. Previously we did:
```
utf-8 -> String -> INetAddress -> ip encoding
```

In a step towards solving #125460 this creates three IP parsing functions, one the rejects leading zeros, one that interprets leading zeros as decimal numbers, and one the interprets leading zeros as octal numbers. IPs have historically been parsed in all three of those ways.

This plugs the "rejects leading zeros" parser into `TO_IP` because that's the behavior it had before.

Here is the performance:
```
Benchmark               Score    Error  Units
leadingZerosAreDecimal  14.007 ± 0.093  ns/op
leadingZerosAreOctal    15.020 ± 0.373  ns/op
leadingZerosRejected    14.176 ± 3.861  ns/op
original                32.950 ± 1.062  ns/op
```

So this is roughly 45% faster than what we had.

This includes a big chunk of #124676 - but not the behavior change - just the code that allowed it.
