### PR TITLE
[8.19] Throw nicer exception in SpanBooleanQueryRewriteWithMaxClause (#126387)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/search/SpanBooleanQueryRewriteWithMaxClause.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/SpanBooleanQueryRewriteWithMaxClause.java
@@ -24,7 +24,9 @@ import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.lucene.queries.SpanMatchNoDocsQuery;
+import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -94,13 +96,14 @@ public class SpanBooleanQueryRewriteWithMaxClause extends SpanMultiTermQueryWrap
                     while ((bytes = termsEnum.next()) != null) {
                         if (queries.size() >= maxExpansions) {
                             if (hardLimit) {
-                                throw new RuntimeException(
+                                throw new ElasticsearchStatusException(
                                     "["
                                         + query.toString()
                                         + " ] "
                                         + "exceeds maxClauseCount [ Boolean maxClauseCount is set to "
-                                        + BooleanQuery.getMaxClauseCount()
-                                        + "]"
+                                        + IndexSearcher.getMaxClauseCount()
+                                        + "]",
+                                    RestStatus.BAD_REQUEST
                                 );
                             } else {
                                 return queries;

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/SpanBooleanQueryRewriteWithMaxClause.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/SpanBooleanQueryRewriteWithMaxClause.java
@@ -101,7 +101,7 @@ public class SpanBooleanQueryRewriteWithMaxClause extends SpanMultiTermQueryWrap
                                         + query.toString()
                                         + " ] "
                                         + "exceeds maxClauseCount [ Boolean maxClauseCount is set to "
-                                        + IndexSearcher.getMaxClauseCount()
+                                        + BooleanQuery.getMaxClauseCount()
                                         + "]",
                                     RestStatus.BAD_REQUEST
                                 );


### PR DESCRIPTION
Throw an ElasticsearchStatusException with a RestStatus.BAD_REQUEST code instead of a generic RuntimeException. 
