### PR TITLE
Fix a RemoveProcessor test that never ran

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorTests.java
@@ -139,7 +139,7 @@ public class RemoveProcessorTests extends ESTestCase {
         assertTrue(document.hasField("_version_type"));
     }
 
-    public void testShouldKeep(String a, String b) {
+    public void testShouldKeep() {
         Map<String, Object> address = new HashMap<>();
         address.put("street", "Ipiranga Street");
         address.put("number", 123);

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorTests.java
@@ -127,6 +127,7 @@ public class RemoveProcessorTests extends ESTestCase {
 
         Processor processor = new RemoveProcessor(null, null, List.of(), templates("name", "address.street"), false);
         processor.execute(document);
+
         assertTrue(document.hasField("name"));
         assertTrue(document.hasField("address"));
         assertTrue(document.hasField("address.street"));
@@ -150,21 +151,13 @@ public class RemoveProcessorTests extends ESTestCase {
         IngestDocument document = RandomDocumentPicks.randomIngestDocument(random(), source);
 
         assertTrue(shouldKeep("name", templates("name"), document));
-
         assertTrue(shouldKeep("age", templates("age"), document));
-
         assertFalse(shouldKeep("name", templates("age"), document));
-
         assertTrue(shouldKeep("address", templates("address.street"), document));
-
         assertTrue(shouldKeep("address", templates("address.number"), document));
-
         assertTrue(shouldKeep("address.street", templates("address"), document));
-
         assertTrue(shouldKeep("address.number", templates("address"), document));
-
         assertTrue(shouldKeep("address", templates("address"), document));
-
         assertFalse(shouldKeep("address.street", templates("address.number"), document));
     }
 


### PR DESCRIPTION
The important bit is the change to the signature of `testShouldKeep` which makes the test actually run. 😬