### PR TITLE
Fix inference plugin name in entitlements warning suppression

### DIFF
--- a/x-pack/plugin/inference/src/main/config/log4j2.properties
+++ b/x-pack/plugin/inference/src/main/config/log4j2.properties
@@ -1,3 +1,3 @@
-logger.entitlements_inference.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.inference.software.amazon.awssdk.profiles
+logger.entitlements_inference.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.x-pack-inference.software.amazon.awssdk.profiles
 logger.entitlements_inference.level = error
 


### PR DESCRIPTION
In #124883 I used the name `inference` but it's actually `x-pack-inference`.