### PR TITLE
Introduce `TestBlobContainerBuilder`

### DIFF
--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -111,6 +111,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         final @Nullable Integer maxRetries,
         final @Nullable TimeValue readTimeout,
         final @Nullable Boolean disableChunkedEncoding,
+        final @Nullable Integer maxConnections,
         final @Nullable ByteSizeValue bufferSize,
         final @Nullable Integer maxBulkDeletes,
         final @Nullable BlobPath blobContainerPath
@@ -176,7 +177,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         final int maxRetries = randomIntBetween(2, 10);
         final AtomicInteger countDown = new AtomicInteger(maxRetries);
 
-        final BlobContainer blobContainer = createBlobContainer(maxRetries, null, null, null, null, null);
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(maxRetries).build();
 
         // SDK reads in 2 MB chunks so we use twice that to simulate 2 chunks
         final byte[] bytes = randomBytes(1 << 22);
@@ -205,7 +206,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         final int maxRetries = randomIntBetween(2, 10);
         final CountDown countDown = new CountDown(maxRetries);
 
-        final BlobContainer blobContainer = createBlobContainer(maxRetries, null, null, null, null, null);
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(maxRetries).build();
         final byte[] bytes = randomBlobContent();
         httpServer.createContext("/upload/storage/v1/b/bucket/o", safeHandler(exchange -> {
             assertThat(exchange.getRequestURI().getQuery(), containsString("uploadType=multipart"));
@@ -247,7 +248,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
     public void testWriteBlobWithReadTimeouts() {
         final byte[] bytes = randomByteArrayOfLength(randomIntBetween(10, 128));
         final TimeValue readTimeout = TimeValue.timeValueMillis(randomIntBetween(100, 500));
-        final BlobContainer blobContainer = createBlobContainer(1, readTimeout, null, null, null, null);
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(1).readTimeout(readTimeout).build();
 
         // HTTP server does not send a response
         httpServer.createContext("/upload/storage/v1/b/bucket/o", exchange -> {
@@ -300,7 +301,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         logger.debug("starting with resumable upload id [{}]", sessionUploadId.get());
 
         final TimeValue readTimeout = allowReadTimeout.get() ? TimeValue.timeValueSeconds(3) : null;
-        final BlobContainer blobContainer = createBlobContainer(nbErrors + 1, readTimeout, null, null, null, null);
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(nbErrors + 1).readTimeout(readTimeout).build();
 
         httpServer.createContext("/upload/storage/v1/b/bucket/o", safeHandler(exchange -> {
             final BytesReference requestBody = Streams.readFully(exchange.getRequestBody());
@@ -440,7 +441,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
                 return Integer.toString(totalDeletesSent++);
             }
         };
-        final BlobContainer blobContainer = createBlobContainer(1, null, null, null, null, null);
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(1).build();
         httpServer.createContext("/batch/storage/v1", safeHandler(exchange -> {
             assert pendingDeletes.get() <= MAX_DELETES_PER_BATCH;
 

--- a/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/URLBlobContainerRetriesTests.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/URLBlobContainerRetriesTests.java
@@ -77,6 +77,7 @@ public class URLBlobContainerRetriesTests extends AbstractBlobContainerRetriesTe
         Integer maxRetries,
         TimeValue readTimeout,
         Boolean disableChunkedEncoding,
+        Integer maxConnections,
         ByteSizeValue bufferSize,
         Integer maxBulkDeletes,
         BlobPath blobContainerPath

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -79,22 +79,13 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
 
     protected abstract Class<? extends Exception> unresponsiveExceptionType();
 
-    protected abstract BlobContainer createBlobContainer(
-        @Nullable Integer maxRetries,
-        @Nullable TimeValue readTimeout,
-        @Nullable Boolean disableChunkedEncoding,
-        @Nullable ByteSizeValue bufferSize,
-        @Nullable Integer maxBulkDeletes,
-        @Nullable BlobPath blobContainerPath
-    );
-
     protected org.hamcrest.Matcher<Object> readTimeoutExceptionMatcher() {
         return either(instanceOf(SocketTimeoutException.class)).or(instanceOf(ConnectionClosedException.class))
             .or(instanceOf(RuntimeException.class));
     }
 
     public void testReadNonexistentBlobThrowsNoSuchFileException() {
-        final BlobContainer blobContainer = createBlobContainer(between(1, 5), null, null, null, null, null);
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(between(1, 5)).build();
         final long position = randomLongBetween(0, MAX_RANGE_VAL);
         final int length = randomIntBetween(1, Math.toIntExact(Math.min(Integer.MAX_VALUE, MAX_RANGE_VAL - position)));
         final Exception exception = expectThrows(NoSuchFileException.class, () -> {
@@ -121,7 +112,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
 
         final byte[] bytes = randomBlobContent();
         final TimeValue readTimeout = TimeValue.timeValueSeconds(between(1, 3));
-        final BlobContainer blobContainer = createBlobContainer(maxRetries, readTimeout, null, null, null, null);
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(maxRetries).readTimeout(readTimeout).build();
         httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_max_retries"), exchange -> {
             Streams.readFully(exchange.getRequestBody());
             if (countDown.countDown()) {
@@ -178,7 +169,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         final CountDown countDown = new CountDown(maxRetries + 1);
 
         final TimeValue readTimeout = TimeValue.timeValueSeconds(between(5, 10));
-        final BlobContainer blobContainer = createBlobContainer(maxRetries, readTimeout, null, null, null, null);
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(maxRetries).readTimeout(readTimeout).build();
         final byte[] bytes = randomBlobContent();
         httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_range_blob_max_retries"), exchange -> {
             Streams.readFully(exchange.getRequestBody());
@@ -250,7 +241,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
     public void testReadBlobWithReadTimeouts() {
         final int maxRetries = randomInt(5);
         final TimeValue readTimeout = TimeValue.timeValueMillis(between(100, 200));
-        final BlobContainer blobContainer = createBlobContainer(maxRetries, readTimeout, null, null, null, null);
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(maxRetries).readTimeout(readTimeout).build();
 
         // HTTP server does not send a response
         httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_unresponsive"), exchange -> {});
@@ -307,7 +298,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
 
     public void testReadBlobWithNoHttpResponse() {
         final TimeValue readTimeout = TimeValue.timeValueMillis(between(100, 200));
-        final BlobContainer blobContainer = createBlobContainer(randomInt(5), readTimeout, null, null, null, null);
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(randomInt(5)).readTimeout(readTimeout).build();
 
         // HTTP server closes connection immediately
         httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_no_response"), HttpExchange::close);
@@ -327,7 +318,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
 
     public void testReadBlobWithPrematureConnectionClose() {
         final int maxRetries = randomInt(20);
-        final BlobContainer blobContainer = createBlobContainer(maxRetries, null, null, null, null, null);
+        final BlobContainer blobContainer = blobContainerBuilder().maxRetries(maxRetries).build();
 
         final boolean alwaysFlushBody = randomBoolean();
 
@@ -503,5 +494,90 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
                 throw new IOException("Stream closed");
             }
         }
+    }
+
+    /**
+     * Method for subclasses to define how to create a {@link BlobContainer} with the given (optional) parameters. Callers should use
+     * {@link #blobContainerBuilder} to obtain a builder to construct the arguments to this method rather than calling it directly.
+     */
+    protected abstract BlobContainer createBlobContainer(
+        @Nullable Integer maxRetries,
+        @Nullable TimeValue readTimeout,
+        @Nullable Boolean disableChunkedEncoding,
+        @Nullable Integer maxConnections,
+        @Nullable ByteSizeValue bufferSize,
+        @Nullable Integer maxBulkDeletes,
+        @Nullable BlobPath blobContainerPath
+    );
+
+    protected final class TestBlobContainerBuilder {
+        @Nullable
+        private Integer maxRetries;
+        @Nullable
+        private TimeValue readTimeout;
+        @Nullable
+        private Boolean disableChunkedEncoding;
+        @Nullable
+        private Integer maxConnections;
+        @Nullable
+        private ByteSizeValue bufferSize;
+        @Nullable
+        private Integer maxBulkDeletes;
+        @Nullable
+        private BlobPath blobContainerPath;
+
+        public TestBlobContainerBuilder maxRetries(@Nullable Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public TestBlobContainerBuilder readTimeout(@Nullable TimeValue readTimeout) {
+            this.readTimeout = readTimeout;
+            return this;
+        }
+
+        public TestBlobContainerBuilder disableChunkedEncoding(@Nullable Boolean disableChunkedEncoding) {
+            this.disableChunkedEncoding = disableChunkedEncoding;
+            return this;
+        }
+
+        public TestBlobContainerBuilder maxConnections(@Nullable Integer maxConnections) {
+            this.maxConnections = maxConnections;
+            return this;
+        }
+
+        public TestBlobContainerBuilder bufferSize(@Nullable ByteSizeValue bufferSize) {
+            this.bufferSize = bufferSize;
+            return this;
+        }
+
+        public TestBlobContainerBuilder maxBulkDeletes(@Nullable Integer maxBulkDeletes) {
+            this.maxBulkDeletes = maxBulkDeletes;
+            return this;
+        }
+
+        public TestBlobContainerBuilder blobContainerPath(@Nullable BlobPath blobContainerPath) {
+            this.blobContainerPath = blobContainerPath;
+            return this;
+        }
+
+        public BlobContainer build() {
+            return createBlobContainer(
+                maxRetries,
+                readTimeout,
+                disableChunkedEncoding,
+                maxConnections,
+                bufferSize,
+                maxBulkDeletes,
+                blobContainerPath
+            );
+        }
+    }
+
+    /**
+     * @return a {@link TestBlobContainerBuilder} to construct the arguments with which to call {@link #createBlobContainer}.
+     */
+    protected final TestBlobContainerBuilder blobContainerBuilder() {
+        return new TestBlobContainerBuilder();
     }
 }


### PR DESCRIPTION
The mostly-optional parameters to `createBlobContainer` are getting
rather numerous in this test harness which makes the tests hard to read.
This commit introduces a builder to help name the provided parameters
and skip the omitted ones. It also adds a `maxConnections` override.

Backport of #126445 and #126435 to `8.x`

Co-authored-by: Dianna Hohensee <dianna.hohensee@elastic.co>