### PR TITLE
[8.x] [DLM]Use default lifecycle instance instead of default constructor (#126461)

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
@@ -146,7 +146,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
 
     public void testRolloverLifecycle() throws Exception {
         // empty lifecycle contains the default rollover
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
 
         putComposableIndexTemplate("id1", null, List.of("metrics-foo*"), null, null, lifecycle, false);
         String dataStreamName = "metrics-foo";
@@ -393,7 +393,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
     }
 
     public void testUpdatingLifecycleAppliesToAllBackingIndices() throws Exception {
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
 
         putComposableIndexTemplate("id1", null, List.of("metrics-foo*"), null, null, lifecycle, false);
 
@@ -437,7 +437,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
          * because all necessary merging has already happened automatically. So in order to detect whether forcemerge has been called, we
          * use a SendRequestBehavior in the MockTransportService to detect it.
          */
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
         disableDataStreamLifecycle();
         String dataStreamName = "metrics-foo";
         putComposableIndexTemplate(
@@ -539,7 +539,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
 
     public void testErrorRecordingOnRollover() throws Exception {
         // empty lifecycle contains the default rollover
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
         /*
          * We set index.auto_expand_replicas to 0-1 so that if we get a single-node cluster it is not yellow. The cluster being yellow
          * could result in data stream lifecycle's automatic forcemerge failing, which would result in an unexpected error in the error
@@ -697,7 +697,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
     public void testErrorRecordingOnRetention() throws Exception {
         // starting with a lifecycle without retention so we can rollover the data stream and manipulate the second generation index such
         // that its retention execution fails
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
 
         /*
          * We set index.auto_expand_replicas to 0-1 so that if we get a single-node cluster it is not yellow. The cluster being yellow
@@ -871,7 +871,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
     }
 
     public void testDataLifecycleServiceConfiguresTheMergePolicy() throws Exception {
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
 
         putComposableIndexTemplate(
             "id1",

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
@@ -92,7 +92,7 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
 
     public void testExplainLifecycle() throws Exception {
         // empty lifecycle contains the default rollover
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
 
         putComposableIndexTemplate("id1", null, List.of("metrics-foo*"), null, null, lifecycle);
         String dataStreamName = "metrics-foo";
@@ -264,7 +264,7 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
             List.of("metrics-foo*"),
             null,
             null,
-            DataStreamLifecycle.Template.DEFAULT,
+            DataStreamLifecycle.Template.DATA_DEFAULT,
             new DataStreamOptions.Template(new DataStreamFailureStore.Template(true))
         );
         String dataStreamName = "metrics-foo";
@@ -381,7 +381,7 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
 
     public void testExplainLifecycleForIndicesWithErrors() throws Exception {
         // empty lifecycle contains the default rollover
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
 
         putComposableIndexTemplate(
             "id1",

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/MetadataIndexTemplateServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/MetadataIndexTemplateServiceTests.java
@@ -157,7 +157,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         // Enabled is always true unless it's explicitly set to false
         {
             DataStreamLifecycle.Template lifecycle = new DataStreamLifecycle.Template(false, randomPositiveTimeValue(), randomRounds());
-            List<DataStreamLifecycle.Template> lifecycles = List.of(lifecycle, DataStreamLifecycle.Template.DEFAULT);
+            List<DataStreamLifecycle.Template> lifecycles = List.of(lifecycle, DataStreamLifecycle.Template.DATA_DEFAULT);
             DataStreamLifecycle result = composeDataLifecycles(lifecycles).build();
             assertThat(result.enabled(), equalTo(true));
             assertThat(result.dataRetention(), equalTo(lifecycle.dataRetention().get()));

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsResponseTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsResponseTests.java
@@ -83,7 +83,7 @@ public class GetDataStreamsResponseTests extends AbstractWireSerializingTestCase
                 .setGeneration(3)
                 .setAllowCustomRouting(true)
                 .setIndexMode(IndexMode.STANDARD)
-                .setLifecycle(new DataStreamLifecycle())
+                .setLifecycle(DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE)
                 .setDataStreamOptions(DataStreamOptions.FAILURE_STORE_ENABLED)
                 .setFailureIndices(DataStream.DataStreamIndices.failureIndicesBuilder(failureStores).build())
                 .build();

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
@@ -254,7 +254,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
             dataStreamName,
             numBackingIndices,
             settings(IndexVersion.current()),
-            new DataStreamLifecycle(),
+            DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE,
             now
         );
         builder.put(dataStream);
@@ -498,7 +498,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
             dataStreamName,
             numBackingIndices,
             Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()),
-            new DataStreamLifecycle(),
+            DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE,
             now
         );
         builder.put(dataStream);
@@ -1496,7 +1496,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
             numBackingIndices,
             numFailureIndices,
             settings(IndexVersion.current()),
-            new DataStreamLifecycle(),
+            DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE,
             now
         ).copy().setDataStreamOptions(dataStreamOptions).build(); // failure store is managed even when disabled
         builder.put(dataStream);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -346,7 +346,7 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
         DataStreamLifecycle.Builder lifecycleBuilder = resolveLifecycle(simulatedState.metadata(), matchingTemplate);
         DataStreamLifecycle.Template lifecycle = lifecycleBuilder == null ? null : lifecycleBuilder.buildTemplate();
         if (template.getDataStreamTemplate() != null && lifecycle == null && isDslOnlyMode) {
-            lifecycle = DataStreamLifecycle.Template.DEFAULT;
+            lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
         }
         DataStreamOptions.Builder optionsBuilder = resolveDataStreamOptions(simulatedState.metadata(), matchingTemplate);
         return new Template(

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -86,7 +86,7 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
         Setting.Property.NodeScope
     );
 
-    public static final DataStreamLifecycle DEFAULT = new DataStreamLifecycle();
+    public static final DataStreamLifecycle DEFAULT_DATA_LIFECYCLE = new DataStreamLifecycle(null, null, null);
 
     public static final String DATA_STREAM_LIFECYCLE_ORIGIN = "data_stream_lifecycle";
 
@@ -131,10 +131,6 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
     private final TimeValue dataRetention;
     @Nullable
     private final List<DownsamplingRound> downsampling;
-
-    public DataStreamLifecycle() {
-        this(null, null, null);
-    }
 
     public DataStreamLifecycle(
         @Nullable Boolean enabled,
@@ -562,7 +558,7 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
             }
         }
 
-        public static final DataStreamLifecycle.Template DEFAULT = new DataStreamLifecycle.Template(
+        public static final DataStreamLifecycle.Template DATA_DEFAULT = new DataStreamLifecycle.Template(
             true,
             ResettableValue.undefined(),
             ResettableValue.undefined()

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -329,7 +329,7 @@ public class MetadataCreateDataStreamService {
             System::currentTimeMillis,
             template.getDataStreamTemplate().isAllowCustomRouting(),
             indexMode,
-            lifecycle == null && isDslOnlyMode ? DataStreamLifecycle.DEFAULT : lifecycle,
+            lifecycle == null && isDslOnlyMode ? DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE : lifecycle,
             dataStreamOptions,
             new DataStream.DataStreamIndices(DataStream.BACKING_INDEX_PREFIX, dsBackingIndices, false, null),
             // If the failure store shouldn't be initialized on data stream creation, we're marking it for "lazy rollover", which will

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateResponseTests.java
@@ -66,7 +66,7 @@ public class GetComponentTemplateResponseTests extends AbstractWireSerializingTe
         Settings settings = null;
         CompressedXContent mappings = null;
         Map<String, AliasMetadata> aliases = null;
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
         ResettableValue<DataStreamOptions.Template> dataStreamOptions = ResettableValue.undefined();
         if (randomBoolean()) {
             settings = randomSettings();

--- a/server/src/test/java/org/elasticsearch/action/datastreams/lifecycle/ExplainDataStreamLifecycleResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/datastreams/lifecycle/ExplainDataStreamLifecycleResponseTests.java
@@ -63,7 +63,7 @@ public class ExplainDataStreamLifecycleResponseTests extends AbstractWireSeriali
     @SuppressWarnings("unchecked")
     public void testToXContent() throws IOException {
         long now = System.currentTimeMillis();
-        DataStreamLifecycle lifecycle = new DataStreamLifecycle();
+        DataStreamLifecycle lifecycle = DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE;
         ExplainIndexDataStreamLifecycle explainIndex = createRandomIndexDataStreamLifecycleExplanation(now, lifecycle);
         explainIndex.setNowSupplier(() -> now);
         {
@@ -241,7 +241,7 @@ public class ExplainDataStreamLifecycleResponseTests extends AbstractWireSeriali
 
     public void testChunkCount() {
         long now = System.currentTimeMillis();
-        DataStreamLifecycle lifecycle = new DataStreamLifecycle();
+        DataStreamLifecycle lifecycle = DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE;
         Response response = new Response(
             List.of(
                 createRandomIndexDataStreamLifecycleExplanation(now, lifecycle),
@@ -298,7 +298,12 @@ public class ExplainDataStreamLifecycleResponseTests extends AbstractWireSeriali
 
     private Response randomResponse() {
         return new Response(
-            List.of(createRandomIndexDataStreamLifecycleExplanation(System.nanoTime(), randomBoolean() ? new DataStreamLifecycle() : null)),
+            List.of(
+                createRandomIndexDataStreamLifecycleExplanation(
+                    System.nanoTime(),
+                    randomBoolean() ? DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE : null
+                )
+            ),
             randomBoolean()
                 ? new RolloverConfiguration(
                     new RolloverConditions(

--- a/server/src/test/java/org/elasticsearch/action/datastreams/lifecycle/ExplainIndexDataStreamLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/action/datastreams/lifecycle/ExplainIndexDataStreamLifecycleTests.java
@@ -41,7 +41,7 @@ public class ExplainIndexDataStreamLifecycleTests extends AbstractWireSerializin
                 now,
                 randomBoolean() ? now + TimeValue.timeValueDays(1).getMillis() : null,
                 null,
-                new DataStreamLifecycle(),
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE,
                 randomBoolean()
                     ? new ErrorEntry(
                         System.currentTimeMillis(),
@@ -59,7 +59,7 @@ public class ExplainIndexDataStreamLifecycleTests extends AbstractWireSerializin
                 now,
                 randomBoolean() ? now + TimeValue.timeValueDays(1).getMillis() : null,
                 TimeValue.timeValueMillis(now + 100),
-                new DataStreamLifecycle(),
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE,
                 randomBoolean()
                     ? new ErrorEntry(
                         System.currentTimeMillis(),
@@ -95,7 +95,7 @@ public class ExplainIndexDataStreamLifecycleTests extends AbstractWireSerializin
                 now,
                 now + 80L, // rolled over in the future (clocks are funny that way)
                 TimeValue.timeValueMillis(now + 100L),
-                new DataStreamLifecycle(),
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE,
                 null
             );
             assertThat(indexDataStreamLifecycle.getGenerationTime(() -> now), is(TimeValue.ZERO));
@@ -107,7 +107,7 @@ public class ExplainIndexDataStreamLifecycleTests extends AbstractWireSerializin
         {
             ExplainIndexDataStreamLifecycle randomIndexDataStreamLifecycleExplanation = createManagedIndexDataStreamLifecycleExplanation(
                 now,
-                new DataStreamLifecycle()
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE
             );
             assertThat(
                 randomIndexDataStreamLifecycleExplanation.getTimeSinceIndexCreation(() -> now + 75L),
@@ -138,7 +138,7 @@ public class ExplainIndexDataStreamLifecycleTests extends AbstractWireSerializin
                 now + 80L, // created in the future (clocks are funny that way)
                 null,
                 null,
-                new DataStreamLifecycle(),
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE,
                 null
             );
             assertThat(indexDataStreamLifecycle.getTimeSinceIndexCreation(() -> now), is(TimeValue.ZERO));
@@ -150,7 +150,7 @@ public class ExplainIndexDataStreamLifecycleTests extends AbstractWireSerializin
         {
             ExplainIndexDataStreamLifecycle randomIndexDataStreamLifecycleExplanation = createManagedIndexDataStreamLifecycleExplanation(
                 now,
-                new DataStreamLifecycle()
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE
             );
             if (randomIndexDataStreamLifecycleExplanation.getRolloverDate() == null) {
                 // age calculated since creation date
@@ -188,7 +188,7 @@ public class ExplainIndexDataStreamLifecycleTests extends AbstractWireSerializin
                 now - 50L,
                 now + 100L, // rolled over in the future
                 TimeValue.timeValueMillis(now),
-                new DataStreamLifecycle(),
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE,
                 null
             );
             assertThat(indexDataStreamLifecycle.getTimeSinceRollover(() -> now), is(TimeValue.ZERO));
@@ -254,12 +254,18 @@ public class ExplainIndexDataStreamLifecycleTests extends AbstractWireSerializin
 
     @Override
     protected ExplainIndexDataStreamLifecycle createTestInstance() {
-        return createManagedIndexDataStreamLifecycleExplanation(System.nanoTime(), randomBoolean() ? new DataStreamLifecycle() : null);
+        return createManagedIndexDataStreamLifecycleExplanation(
+            System.nanoTime(),
+            randomBoolean() ? DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE : null
+        );
     }
 
     @Override
     protected ExplainIndexDataStreamLifecycle mutateInstance(ExplainIndexDataStreamLifecycle instance) throws IOException {
-        return createManagedIndexDataStreamLifecycleExplanation(System.nanoTime(), randomBoolean() ? new DataStreamLifecycle() : null);
+        return createManagedIndexDataStreamLifecycleExplanation(
+            System.nanoTime(),
+            randomBoolean() ? DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE : null
+        );
     }
 
     private static ExplainIndexDataStreamLifecycle createManagedIndexDataStreamLifecycleExplanation(

--- a/server/src/test/java/org/elasticsearch/action/datastreams/lifecycle/GetDataStreamLifecycleActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/datastreams/lifecycle/GetDataStreamLifecycleActionTests.java
@@ -35,7 +35,7 @@ public class GetDataStreamLifecycleActionTests extends ESTestCase {
     public void testDefaultLifecycleResponseToXContent() throws Exception {
         boolean isInternalDataStream = randomBoolean();
         GetDataStreamLifecycleAction.Response.DataStreamLifecycle dataStreamLifecycle = createDataStreamLifecycle(
-            DataStreamLifecycle.DEFAULT,
+            DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE,
             isInternalDataStream
         );
         GetDataStreamLifecycleAction.Response response = new GetDataStreamLifecycleAction.Response(List.of(dataStreamLifecycle));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateTests.java
@@ -286,7 +286,7 @@ public class ComponentTemplateTests extends SimpleDiffableSerializationTestCase<
         if (randomBoolean()) {
             dataStreamOptions = randomDataStreamOptionsTemplate();
         }
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
         ComponentTemplate template = new ComponentTemplate(
             new Template(settings, mappings, aliases, lifecycle, dataStreamOptions),
             randomNonNegativeLong(),

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
@@ -236,7 +236,7 @@ public class ComposableIndexTemplateTests extends SimpleDiffableSerializationTes
             dataStreamOptions = ComponentTemplateTests.randomDataStreamOptionsTemplate();
         }
         // We use the empty lifecycle so the global retention can be in effect
-        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
         Template template = new Template(settings, mappings, aliases, lifecycle, dataStreamOptions);
         ComposableIndexTemplate.builder()
             .indexPatterns(List.of(randomAlphaOfLength(4)))

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
@@ -135,7 +135,7 @@ public class DataStreamLifecycleTests extends AbstractXContentSerializingTestCas
             var parsed = DataStreamLifecycle.fromXContent(parser);
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
             assertNull(parser.nextToken());
-            assertThat(parsed, equalTo(DataStreamLifecycle.DEFAULT));
+            assertThat(parsed, equalTo(DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleWithRetentionWarningsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleWithRetentionWarningsTests.java
@@ -144,10 +144,14 @@ public class DataStreamLifecycleWithRetentionWarningsTests extends ESTestCase {
             DataStreamGlobalRetentionSettings.create(ClusterSettings.createBuiltInClusterSettings(settingsWithDefaultRetention))
         );
 
-        ClusterState after = metadataDataStreamsService.updateDataLifecycle(before, List.of(dataStream), DataStreamLifecycle.DEFAULT);
+        ClusterState after = metadataDataStreamsService.updateDataLifecycle(
+            before,
+            List.of(dataStream),
+            DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE
+        );
         DataStream updatedDataStream = after.metadata().dataStreams().get(dataStream);
         assertNotNull(updatedDataStream);
-        assertThat(updatedDataStream.getDataLifecycle(), equalTo(DataStreamLifecycle.DEFAULT));
+        assertThat(updatedDataStream.getDataLifecycle(), equalTo(DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE));
         Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
         assertThat(responseHeaders.size(), is(1));
         assertThat(
@@ -168,7 +172,7 @@ public class DataStreamLifecycleWithRetentionWarningsTests extends ESTestCase {
             Metadata.builder().build(),
             randomAlphaOfLength(10),
             ComposableIndexTemplate.builder()
-                .template(Template.builder().lifecycle(DataStreamLifecycle.Template.DEFAULT))
+                .template(Template.builder().lifecycle(DataStreamLifecycle.Template.DATA_DEFAULT))
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
                 .indexPatterns(List.of(randomAlphaOfLength(10)))
                 .build(),
@@ -194,7 +198,7 @@ public class DataStreamLifecycleWithRetentionWarningsTests extends ESTestCase {
             Metadata.builder().build(),
             randomAlphaOfLength(10),
             ComposableIndexTemplate.builder()
-                .template(Template.builder().lifecycle(DataStreamLifecycle.Template.DEFAULT))
+                .template(Template.builder().lifecycle(DataStreamLifecycle.Template.DATA_DEFAULT))
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
                 .indexPatterns(List.of("." + randomAlphaOfLength(10)))
                 .build(),
@@ -228,7 +232,7 @@ public class DataStreamLifecycleWithRetentionWarningsTests extends ESTestCase {
                 .build(),
             randomAlphaOfLength(10),
             ComposableIndexTemplate.builder()
-                .template(Template.builder().lifecycle(DataStreamLifecycle.Template.DEFAULT))
+                .template(Template.builder().lifecycle(DataStreamLifecycle.Template.DATA_DEFAULT))
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
                 .indexPatterns(List.of(randomAlphaOfLength(10)))
                 .componentTemplates(List.of("component-template"))
@@ -281,7 +285,7 @@ public class DataStreamLifecycleWithRetentionWarningsTests extends ESTestCase {
         Template template = Template.builder()
             .settings(ComponentTemplateTests.randomSettings())
             .aliases(ComponentTemplateTests.randomAliases())
-            .lifecycle(DataStreamLifecycle.Template.DEFAULT)
+            .lifecycle(DataStreamLifecycle.Template.DATA_DEFAULT)
             .build();
         ComponentTemplate componentTemplate = new ComponentTemplate(template, 1L, new HashMap<>());
         state = metadataIndexTemplateService.addComponentTemplate(state, false, "foo", componentTemplate);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -1371,7 +1371,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
             dataStreamName,
             creationAndRolloverTimes,
             settings(IndexVersion.current()),
-            new DataStreamLifecycle() {
+            new DataStreamLifecycle(null, null, null) {
                 public TimeValue dataRetention() {
                     return retention.get();
                 }
@@ -1513,7 +1513,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
             dataStreamName,
             creationAndRolloverTimes,
             settings(IndexVersion.current()),
-            new DataStreamLifecycle() {
+            new DataStreamLifecycle(null, null, null) {
                 public TimeValue dataRetention() {
                     return retention.get();
                 }
@@ -1616,7 +1616,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
             dataStreamName,
             creationAndRolloverTimes,
             settings(IndexVersion.current()),
-            new DataStreamLifecycle() {
+            new DataStreamLifecycle(null, null, null) {
                 public TimeValue dataRetention() {
                     return testRetentionReference.get();
                 }
@@ -1667,7 +1667,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
             dataStreamName,
             creationAndRolloverTimes,
             settings(IndexVersion.current()),
-            new DataStreamLifecycle() {
+            new DataStreamLifecycle(null, null, null) {
                 public TimeValue dataRetention() {
                     return testRetentionReference.get();
                 }
@@ -1917,7 +1917,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
                 Settings.builder()
                     .put(IndexMetadata.LIFECYCLE_NAME, "ILM_policy")
                     .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()),
-                new DataStreamLifecycle()
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE
             );
             Metadata metadataIlm = builderWithIlm.build();
             for (Index index : ds.getIndices()) {
@@ -1938,7 +1938,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
                         .put(IndexMetadata.LIFECYCLE_NAME, "ILM_policy")
                         .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
                         .put(IndexSettings.PREFER_ILM, false),
-                    new DataStreamLifecycle()
+                    DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE
                 );
                 Metadata metadataIlm = builderWithIlm.build();
                 for (Index index : ds.getIndices()) {
@@ -2038,7 +2038,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
             failureIndices = randomNonEmptyIndexInstances();
         }
 
-        DataStreamLifecycle lifecycle = new DataStreamLifecycle();
+        DataStreamLifecycle lifecycle = DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE;
         boolean isSystem = randomBoolean();
         DataStream dataStream = new DataStream(
             dataStreamName,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -77,7 +77,10 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         assertThat(newState.metadata().dataStreams().get(dataStreamName).isSystem(), is(false));
         assertThat(newState.metadata().dataStreams().get(dataStreamName).isHidden(), is(false));
         assertThat(newState.metadata().dataStreams().get(dataStreamName).isReplicated(), is(false));
-        assertThat(newState.metadata().dataStreams().get(dataStreamName).getDataLifecycle(), equalTo(DataStreamLifecycle.DEFAULT));
+        assertThat(
+            newState.metadata().dataStreams().get(dataStreamName).getDataLifecycle(),
+            equalTo(DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE)
+        );
         assertThat(newState.metadata().dataStreams().get(dataStreamName).getIndexMode(), nullValue());
         assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)), notNullValue());
         assertThat(
@@ -114,7 +117,10 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         assertThat(newState.metadata().dataStreams().get(dataStreamName).isHidden(), is(false));
         assertThat(newState.metadata().dataStreams().get(dataStreamName).isReplicated(), is(false));
         assertThat(newState.metadata().dataStreams().get(dataStreamName).getIndexMode(), equalTo(IndexMode.LOGSDB));
-        assertThat(newState.metadata().dataStreams().get(dataStreamName).getDataLifecycle(), equalTo(DataStreamLifecycle.DEFAULT));
+        assertThat(
+            newState.metadata().dataStreams().get(dataStreamName).getDataLifecycle(),
+            equalTo(DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE)
+        );
         assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)), notNullValue());
         assertThat(
             newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)).getSettings().get("index.hidden"),

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -1473,7 +1473,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         final MetadataIndexTemplateService service = getMetadataIndexTemplateService();
         ClusterState state = ClusterState.EMPTY_STATE;
 
-        DataStreamLifecycle.Template emptyLifecycle = DataStreamLifecycle.Template.DEFAULT;
+        DataStreamLifecycle.Template emptyLifecycle = DataStreamLifecycle.Template.DATA_DEFAULT;
 
         DataStreamLifecycle.Template lifecycle30d = DataStreamLifecycle.builder()
             .dataRetention(TimeValue.timeValueDays(30))
@@ -1550,7 +1550,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         // Composable Z: -
         // Result: "lifecycle": {"enabled": true}, here the result of the composition is with retention explicitly
         // nullified, but effectively this is equivalent to infinite retention.
-        assertLifecycleResolution(service, state, List.of(ct30d, ctNullRetention), null, DataStreamLifecycle.Template.DEFAULT);
+        assertLifecycleResolution(service, state, List.of(ct30d, ctNullRetention), null, DataStreamLifecycle.Template.DATA_DEFAULT);
 
         // Component A: "lifecycle": {"enabled": true}
         // Component B: "lifecycle": {"retention": "45d", "downsampling": [{"after": "30d", "fixed_interval": "3h"}]}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIsManagedByILMTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIsManagedByILMTests.java
@@ -66,7 +66,7 @@ public class MetadataIsManagedByILMTests extends ESTestCase {
                 1,
                 null,
                 false,
-                new DataStreamLifecycle()
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE
             );
             Metadata metadata = Metadata.builder().put(indexMetadata, true).put(dataStream).build();
 
@@ -89,7 +89,7 @@ public class MetadataIsManagedByILMTests extends ESTestCase {
                 1,
                 null,
                 false,
-                new DataStreamLifecycle()
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE
             );
             Metadata metadata = Metadata.builder().put(indexMetadata, true).put(dataStream).build();
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/DataStreamLifecycleFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/DataStreamLifecycleFeatureSetUsageTests.java
@@ -109,7 +109,7 @@ public class DataStreamLifecycleFeatureSetUsageTests extends AbstractWireSeriali
                 1L,
                 null,
                 false,
-                new DataStreamLifecycle()
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE
             ),
             DataStreamTestHelper.newInstance(
                 randomAlphaOfLength(10),

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataStreamAndIndexLifecycleMixingTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataStreamAndIndexLifecycleMixingTests.java
@@ -233,7 +233,7 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
                 TEST_REQUEST_TIMEOUT,
                 TEST_REQUEST_TIMEOUT,
                 new String[] { dataStreamName },
-                new DataStreamLifecycle()
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE
             )
         ).actionGet();
 
@@ -381,7 +381,7 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
             List.of(dataStreamName + "*"),
             Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy).build(),
             null,
-            DataStreamLifecycle.Template.DEFAULT
+            DataStreamLifecycle.Template.DATA_DEFAULT
         );
 
         indexDocs(dataStreamName, 2);
@@ -441,7 +441,7 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
             List.of(dataStreamName + "*"),
             Settings.builder().put(IndexSettings.PREFER_ILM, false).put(LifecycleSettings.LIFECYCLE_NAME, policy).build(),
             null,
-            DataStreamLifecycle.Template.DEFAULT
+            DataStreamLifecycle.Template.DATA_DEFAULT
         );
 
         // note that all indices now are still managed by ILM, so we index 2 documents. the new write index will be managed by the data
@@ -629,7 +629,7 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
                 TEST_REQUEST_TIMEOUT,
                 TEST_REQUEST_TIMEOUT,
                 new String[] { dataStreamName },
-                new DataStreamLifecycle()
+                DataStreamLifecycle.DEFAULT_DATA_LIFECYCLE
             )
         ).actionGet();
 
@@ -764,7 +764,7 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
             List.of(dataStreamName + "*"),
             null,
             null,
-            DataStreamLifecycle.Template.DEFAULT
+            DataStreamLifecycle.Template.DATA_DEFAULT
         );
 
         // this will create the data stream and trigger a rollover so we will end up with a data stream with 2 backing indices

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataStreamLifecycleServiceRuntimeSecurityIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataStreamLifecycleServiceRuntimeSecurityIT.java
@@ -94,7 +94,7 @@ public class DataStreamLifecycleServiceRuntimeSecurityIT extends SecurityIntegTe
     public void testRolloverLifecycleAndForceMergeAuthorized() throws Exception {
         String dataStreamName = randomDataStreamName();
         // empty lifecycle contains the default rollover
-        prepareDataStreamAndIndex(dataStreamName, DataStreamLifecycle.Template.DEFAULT);
+        prepareDataStreamAndIndex(dataStreamName, DataStreamLifecycle.Template.DATA_DEFAULT);
 
         assertBusy(() -> {
             assertNoAuthzErrors();
@@ -133,7 +133,7 @@ public class DataStreamLifecycleServiceRuntimeSecurityIT extends SecurityIntegTe
     public void testUnauthorized() throws Exception {
         // this is an example index pattern for a system index that the data stream lifecycle does not have access for. Data stream
         // lifecycle will therefore fail at runtime with an authz exception
-        prepareDataStreamAndIndex(SECURITY_MAIN_ALIAS, DataStreamLifecycle.Template.DEFAULT);
+        prepareDataStreamAndIndex(SECURITY_MAIN_ALIAS, DataStreamLifecycle.Template.DATA_DEFAULT);
 
         assertBusy(() -> {
             Map<String, String> indicesAndErrors = collectErrorsFromStoreAsMap();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DLM]Use default lifecycle instance instead of default constructor (#126461)](https://github.com/elastic/elasticsearch/pull/126461)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)