### PR TITLE
[8.18] Fix inference plugin name in entitlements warning suppression (#126470)

### DIFF
--- a/x-pack/plugin/inference/src/main/config/log4j2.properties
+++ b/x-pack/plugin/inference/src/main/config/log4j2.properties
@@ -1,3 +1,3 @@
-logger.entitlements_inference.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.inference.software.amazon.awssdk.profiles
+logger.entitlements_inference.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.x-pack-inference.software.amazon.awssdk.profiles
 logger.entitlements_inference.level = error
 


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix inference plugin name in entitlements warning suppression (#126470)