### PR TITLE
Remove time unit from rate aggregation

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateFloatAggregator.java
@@ -41,8 +41,8 @@ import java.util.Arrays;
 )
 public class RateFloatAggregator {
 
-    public static FloatRateGroupingState initGrouping(DriverContext driverContext, long unitInMillis) {
-        return new FloatRateGroupingState(driverContext.bigArrays(), driverContext.breaker(), unitInMillis);
+    public static FloatRateGroupingState initGrouping(DriverContext driverContext) {
+        return new FloatRateGroupingState(driverContext.bigArrays(), driverContext.breaker());
     }
 
     public static void combine(FloatRateGroupingState current, int groupId, long timestamp, float value) {
@@ -120,16 +120,14 @@ public class RateFloatAggregator {
 
     public static final class FloatRateGroupingState implements Releasable, Accountable, GroupingAggregatorState {
         private ObjectArray<FloatRateState> states;
-        private final long unitInMillis;
         private final BigArrays bigArrays;
         private final CircuitBreaker breaker;
         private long stateBytes; // for individual states
 
-        FloatRateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, long unitInMillis) {
+        FloatRateGroupingState(BigArrays bigArrays, CircuitBreaker breaker) {
             this.bigArrays = bigArrays;
             this.breaker = breaker;
             this.states = bigArrays.newObjectArray(1);
-            this.unitInMillis = unitInMillis;
         }
 
         void ensureCapacity(int groupId) {
@@ -317,7 +315,7 @@ public class RateFloatAggregator {
             }
         }
 
-        private static double computeRateWithoutExtrapolate(FloatRateState state, long unitInMillis) {
+        private static double computeRateWithoutExtrapolate(FloatRateState state) {
             final int len = state.entries();
             assert len >= 2 : "rate requires at least two samples; got " + len;
             final long firstTS = state.timestamps[state.timestamps.length - 1];
@@ -330,7 +328,7 @@ public class RateFloatAggregator {
             }
             final double firstValue = state.values[len - 1];
             final double lastValue = state.values[0] + reset;
-            return (lastValue - firstValue) * unitInMillis / (lastTS - firstTS);
+            return (lastValue - firstValue) * 1000.0 / (lastTS - firstTS);
         }
 
         /**
@@ -342,7 +340,7 @@ public class RateFloatAggregator {
          * We still extrapolate the rate in this case, but not all the way to the boundary, only by half of the average duration between
          * samples (which is our guess for where the series actually starts or ends).
          */
-        private static double extrapolateRate(FloatRateState state, long rangeStart, long rangeEnd, long unitInMillis) {
+        private static double extrapolateRate(FloatRateState state, long rangeStart, long rangeEnd) {
             final int len = state.entries();
             assert len >= 2 : "rate requires at least two samples; got " + len;
             final long firstTS = state.timestamps[state.timestamps.length - 1];
@@ -372,7 +370,7 @@ public class RateFloatAggregator {
                 }
                 lastValue = lastValue + endGap * slope;
             }
-            return (lastValue - firstValue) * unitInMillis / (rangeEnd - rangeStart);
+            return (lastValue - firstValue) * 1000.0 / (rangeEnd - rangeStart);
         }
 
         Block evaluateFinal(IntVector selected, GroupingAggregatorEvaluationContext evalContext) {
@@ -388,14 +386,9 @@ public class RateFloatAggregator {
                     int len = state.entries();
                     final double rate;
                     if (evalContext instanceof TimeSeriesGroupingAggregatorEvaluationContext tsContext) {
-                        rate = extrapolateRate(
-                            state,
-                            tsContext.rangeStartInMillis(groupId),
-                            tsContext.rangeEndInMillis(groupId),
-                            unitInMillis
-                        );
+                        rate = extrapolateRate(state, tsContext.rangeStartInMillis(groupId), tsContext.rangeEndInMillis(groupId));
                     } else {
-                        rate = computeRateWithoutExtrapolate(state, unitInMillis);
+                        rate = computeRateWithoutExtrapolate(state);
                     }
                     rates.appendDouble(rate);
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateDoubleAggregatorFunctionSupplier.java
@@ -15,10 +15,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
  */
 public final class RateDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final long unitInMillis;
-
-  public RateDoubleAggregatorFunctionSupplier(long unitInMillis) {
-    this.unitInMillis = unitInMillis;
+  public RateDoubleAggregatorFunctionSupplier() {
   }
 
   @Override
@@ -39,7 +36,7 @@ public final class RateDoubleAggregatorFunctionSupplier implements AggregatorFun
   @Override
   public RateDoubleGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return RateDoubleGroupingAggregatorFunction.create(channels, driverContext, unitInMillis);
+    return RateDoubleGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -37,20 +37,16 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
 
   private final DriverContext driverContext;
 
-  private final long unitInMillis;
-
   public RateDoubleGroupingAggregatorFunction(List<Integer> channels,
-      RateDoubleAggregator.DoubleRateGroupingState state, DriverContext driverContext,
-      long unitInMillis) {
+      RateDoubleAggregator.DoubleRateGroupingState state, DriverContext driverContext) {
     this.channels = channels;
     this.state = state;
     this.driverContext = driverContext;
-    this.unitInMillis = unitInMillis;
   }
 
   public static RateDoubleGroupingAggregatorFunction create(List<Integer> channels,
-      DriverContext driverContext, long unitInMillis) {
-    return new RateDoubleGroupingAggregatorFunction(channels, RateDoubleAggregator.initGrouping(driverContext, unitInMillis), driverContext, unitInMillis);
+      DriverContext driverContext) {
+    return new RateDoubleGroupingAggregatorFunction(channels, RateDoubleAggregator.initGrouping(driverContext), driverContext);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateFloatAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateFloatAggregatorFunctionSupplier.java
@@ -15,10 +15,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
  */
 public final class RateFloatAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final long unitInMillis;
-
-  public RateFloatAggregatorFunctionSupplier(long unitInMillis) {
-    this.unitInMillis = unitInMillis;
+  public RateFloatAggregatorFunctionSupplier() {
   }
 
   @Override
@@ -39,7 +36,7 @@ public final class RateFloatAggregatorFunctionSupplier implements AggregatorFunc
   @Override
   public RateFloatGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return RateFloatGroupingAggregatorFunction.create(channels, driverContext, unitInMillis);
+    return RateFloatGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateFloatGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateFloatGroupingAggregatorFunction.java
@@ -39,20 +39,16 @@ public final class RateFloatGroupingAggregatorFunction implements GroupingAggreg
 
   private final DriverContext driverContext;
 
-  private final long unitInMillis;
-
   public RateFloatGroupingAggregatorFunction(List<Integer> channels,
-      RateFloatAggregator.FloatRateGroupingState state, DriverContext driverContext,
-      long unitInMillis) {
+      RateFloatAggregator.FloatRateGroupingState state, DriverContext driverContext) {
     this.channels = channels;
     this.state = state;
     this.driverContext = driverContext;
-    this.unitInMillis = unitInMillis;
   }
 
   public static RateFloatGroupingAggregatorFunction create(List<Integer> channels,
-      DriverContext driverContext, long unitInMillis) {
-    return new RateFloatGroupingAggregatorFunction(channels, RateFloatAggregator.initGrouping(driverContext, unitInMillis), driverContext, unitInMillis);
+      DriverContext driverContext) {
+    return new RateFloatGroupingAggregatorFunction(channels, RateFloatAggregator.initGrouping(driverContext), driverContext);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateIntAggregatorFunctionSupplier.java
@@ -15,10 +15,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
  */
 public final class RateIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final long unitInMillis;
-
-  public RateIntAggregatorFunctionSupplier(long unitInMillis) {
-    this.unitInMillis = unitInMillis;
+  public RateIntAggregatorFunctionSupplier() {
   }
 
   @Override
@@ -39,7 +36,7 @@ public final class RateIntAggregatorFunctionSupplier implements AggregatorFuncti
   @Override
   public RateIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return RateIntGroupingAggregatorFunction.create(channels, driverContext, unitInMillis);
+    return RateIntGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -37,20 +37,16 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
 
   private final DriverContext driverContext;
 
-  private final long unitInMillis;
-
   public RateIntGroupingAggregatorFunction(List<Integer> channels,
-      RateIntAggregator.IntRateGroupingState state, DriverContext driverContext,
-      long unitInMillis) {
+      RateIntAggregator.IntRateGroupingState state, DriverContext driverContext) {
     this.channels = channels;
     this.state = state;
     this.driverContext = driverContext;
-    this.unitInMillis = unitInMillis;
   }
 
   public static RateIntGroupingAggregatorFunction create(List<Integer> channels,
-      DriverContext driverContext, long unitInMillis) {
-    return new RateIntGroupingAggregatorFunction(channels, RateIntAggregator.initGrouping(driverContext, unitInMillis), driverContext, unitInMillis);
+      DriverContext driverContext) {
+    return new RateIntGroupingAggregatorFunction(channels, RateIntAggregator.initGrouping(driverContext), driverContext);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateLongAggregatorFunctionSupplier.java
@@ -15,10 +15,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
  */
 public final class RateLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final long unitInMillis;
-
-  public RateLongAggregatorFunctionSupplier(long unitInMillis) {
-    this.unitInMillis = unitInMillis;
+  public RateLongAggregatorFunctionSupplier() {
   }
 
   @Override
@@ -39,7 +36,7 @@ public final class RateLongAggregatorFunctionSupplier implements AggregatorFunct
   @Override
   public RateLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return RateLongGroupingAggregatorFunction.create(channels, driverContext, unitInMillis);
+    return RateLongGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -37,20 +37,16 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
 
   private final DriverContext driverContext;
 
-  private final long unitInMillis;
-
   public RateLongGroupingAggregatorFunction(List<Integer> channels,
-      RateLongAggregator.LongRateGroupingState state, DriverContext driverContext,
-      long unitInMillis) {
+      RateLongAggregator.LongRateGroupingState state, DriverContext driverContext) {
     this.channels = channels;
     this.state = state;
     this.driverContext = driverContext;
-    this.unitInMillis = unitInMillis;
   }
 
   public static RateLongGroupingAggregatorFunction create(List<Integer> channels,
-      DriverContext driverContext, long unitInMillis) {
-    return new RateLongGroupingAggregatorFunction(channels, RateLongAggregator.initGrouping(driverContext, unitInMillis), driverContext, unitInMillis);
+      DriverContext driverContext) {
+    return new RateLongGroupingAggregatorFunction(channels, RateLongAggregator.initGrouping(driverContext), driverContext);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateAggregator.java.st
@@ -45,8 +45,8 @@ import java.util.Arrays;
 )
 public class Rate$Type$Aggregator {
 
-    public static $Type$RateGroupingState initGrouping(DriverContext driverContext, long unitInMillis) {
-        return new $Type$RateGroupingState(driverContext.bigArrays(), driverContext.breaker(), unitInMillis);
+    public static $Type$RateGroupingState initGrouping(DriverContext driverContext) {
+        return new $Type$RateGroupingState(driverContext.bigArrays(), driverContext.breaker());
     }
 
     public static void combine($Type$RateGroupingState current, int groupId, long timestamp, $type$ value) {
@@ -124,16 +124,14 @@ public class Rate$Type$Aggregator {
 
     public static final class $Type$RateGroupingState implements Releasable, Accountable, GroupingAggregatorState {
         private ObjectArray<$Type$RateState> states;
-        private final long unitInMillis;
         private final BigArrays bigArrays;
         private final CircuitBreaker breaker;
         private long stateBytes; // for individual states
 
-        $Type$RateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, long unitInMillis) {
+        $Type$RateGroupingState(BigArrays bigArrays, CircuitBreaker breaker) {
             this.bigArrays = bigArrays;
             this.breaker = breaker;
             this.states = bigArrays.newObjectArray(1);
-            this.unitInMillis = unitInMillis;
         }
 
         void ensureCapacity(int groupId) {
@@ -321,7 +319,7 @@ public class Rate$Type$Aggregator {
             }
         }
 
-        private static double computeRateWithoutExtrapolate($Type$RateState state, long unitInMillis) {
+        private static double computeRateWithoutExtrapolate($Type$RateState state) {
             final int len = state.entries();
             assert len >= 2 : "rate requires at least two samples; got " + len;
             final long firstTS = state.timestamps[state.timestamps.length - 1];
@@ -334,7 +332,7 @@ public class Rate$Type$Aggregator {
             }
             final double firstValue = state.values[len - 1];
             final double lastValue = state.values[0] + reset;
-            return (lastValue - firstValue) * unitInMillis / (lastTS - firstTS);
+            return (lastValue - firstValue) * 1000.0 / (lastTS - firstTS);
         }
 
         /**
@@ -346,7 +344,7 @@ public class Rate$Type$Aggregator {
          * We still extrapolate the rate in this case, but not all the way to the boundary, only by half of the average duration between
          * samples (which is our guess for where the series actually starts or ends).
          */
-        private static double extrapolateRate($Type$RateState state, long rangeStart, long rangeEnd, long unitInMillis) {
+        private static double extrapolateRate($Type$RateState state, long rangeStart, long rangeEnd) {
             final int len = state.entries();
             assert len >= 2 : "rate requires at least two samples; got " + len;
             final long firstTS = state.timestamps[state.timestamps.length - 1];
@@ -376,7 +374,7 @@ public class Rate$Type$Aggregator {
                 }
                 lastValue = lastValue + endGap * slope;
             }
-            return (lastValue - firstValue) * unitInMillis / (rangeEnd - rangeStart);
+            return (lastValue - firstValue) * 1000.0 / (rangeEnd - rangeStart);
         }
 
         Block evaluateFinal(IntVector selected, GroupingAggregatorEvaluationContext evalContext) {
@@ -392,14 +390,9 @@ public class Rate$Type$Aggregator {
                     int len = state.entries();
                     final double rate;
                     if (evalContext instanceof TimeSeriesGroupingAggregatorEvaluationContext tsContext) {
-                        rate = extrapolateRate(
-                            state,
-                            tsContext.rangeStartInMillis(groupId),
-                            tsContext.rangeEndInMillis(groupId),
-                            unitInMillis
-                        );
+                        rate = extrapolateRate(state, tsContext.rangeStartInMillis(groupId), tsContext.rangeEndInMillis(groupId));
                     } else {
-                        rate = computeRateWithoutExtrapolate(state, unitInMillis);
+                        rate = computeRateWithoutExtrapolate(state);
                     }
                     rates.appendDouble(rate);
                 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -21,13 +21,22 @@ max_bytes:long | cluster: keyword
 7403           | staging
 ;
 
-maxRateAndSourceTripleQuoting
+maxRate
 required_capability: metrics_command
 required_capability: double_quotes_source_enclosing
-TS k8s | STATS max(rate(network.total_bytes_in, 1minute));
+TS k8s | STATS max(rate(network.total_bytes_in));
 
-max(rate(network.total_bytes_in, 1minute)): double
-790.4235090751945
+max(rate(network.total_bytes_in)): double
+13.17372515125324
+;
+
+maxRatePerMinute
+required_capability: metrics_command
+required_capability: double_quotes_source_enclosing
+TS k8s | STATS max(60 * rate(network.total_bytes_in));
+
+max(60 * rate(network.total_bytes_in)): double
+790.4235090751944
 ;
 
 maxCost
@@ -40,26 +49,26 @@ max_cost: double
 
 maxRateAndBytes
 required_capability: metrics_command
-TS k8s | STATS max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in);
+TS k8s | STATS max(60 * rate(network.total_bytes_in)), max(network.bytes_in);
 
-max(rate(network.total_bytes_in, 1minute)): double | max(network.bytes_in): long
-790.4235090751945                                  | 1021
+max(60 * rate(network.total_bytes_in)): double | max(network.bytes_in): long
+790.4235090751944                                  | 1021
 ;
 
-`maxRateAndMarkupBytes`
+maxRateAndMarkupBytes
 required_capability: metrics_command
-TS k8s | STATS max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in * 1.05);
+TS k8s | STATS max(rate(network.total_bytes_in)), max(network.bytes_in * 1.05);
 
-max(rate(network.total_bytes_in, 1minute)): double | max(network.bytes_in * 1.05): double
-790.4235090751945                                  | 1072.05
+max(rate(network.total_bytes_in)): double | max(network.bytes_in * 1.05): double
+  13.17372515125324                       | 1072.05
 ;
 
 maxRateAndBytesAndCost
 required_capability: metrics_command
-TS k8s | STATS max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in), max(rate(network.total_cost));
+TS k8s | STATS max(rate(network.total_bytes_in)), max(network.bytes_in), max(rate(network.total_cost));
 
-max(rate(network.total_bytes_in, 1minute)): double| max(network.bytes_in): long| max(rate(network.total_cost)): double
-790.4235090751945                                 | 1021                       | 0.16151685393258428
+max(rate(network.total_bytes_in)): double| max(network.bytes_in): long| max(rate(network.total_cost)): double
+13.17372515125324                        | 1021                       | 0.16151685393258428
 ;
 
 sumRate

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Rate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Rate.java
@@ -7,18 +7,14 @@
 
 package org.elasticsearch.xpack.esql.expression.function.aggregate;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.RateDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.RateIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.RateLongAggregatorFunctionSupplier;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -32,20 +28,15 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.planner.ToTimeSeriesAggregator;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.List;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
-import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
-import static org.elasticsearch.xpack.esql.core.util.CollectionUtils.nullSafeList;
 
 public class Rate extends AggregateFunction implements OptionalArgument, ToTimeSeriesAggregator {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Rate", Rate::new);
-    private static final TimeValue DEFAULT_UNIT = TimeValue.timeValueSeconds(1);
 
     private final Expression timestamp;
-    private final Expression unit;
 
     @FunctionInfo(
         returnType = { "double" },
@@ -55,38 +46,28 @@ public class Rate extends AggregateFunction implements OptionalArgument, ToTimeS
     public Rate(
         Source source,
         @Param(name = "field", type = { "counter_long|counter_integer|counter_double" }, description = "counter field") Expression field,
-        Expression timestamp,
-        @Param(optional = true, name = "unit", type = { "time_duration" }, description = "the unit") Expression unit
+        Expression timestamp
     ) {
-        this(source, field, Literal.TRUE, timestamp, unit);
+        this(source, field, Literal.TRUE, timestamp);
     }
 
     // compatibility constructor used when reading from the stream
     private Rate(Source source, Expression field, Expression filter, List<Expression> children) {
-        this(source, field, filter, children.get(0), children.size() > 1 ? children.get(1) : null);
+        this(source, field, filter, children.getFirst());
     }
 
-    private Rate(Source source, Expression field, Expression filter, Expression timestamp, Expression unit) {
-        super(source, field, filter, unit != null ? List.of(timestamp, unit) : List.of(timestamp));
+    private Rate(Source source, Expression field, Expression filter, Expression timestamp) {
+        super(source, field, filter, List.of(timestamp));
         this.timestamp = timestamp;
-        this.unit = unit;
     }
 
     public Rate(StreamInput in) throws IOException {
         this(
             Source.readFrom((PlanStreamInput) in),
             in.readNamedWriteable(Expression.class),
-            in.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0) ? in.readNamedWriteable(Expression.class) : Literal.TRUE,
-            in.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)
-                ? in.readNamedWriteableCollectionAsList(Expression.class)
-                : nullSafeList(in.readNamedWriteable(Expression.class), in.readOptionalNamedWriteable(Expression.class))
+            in.readNamedWriteable(Expression.class),
+            in.readNamedWriteableCollectionAsList(Expression.class)
         );
-    }
-
-    @Override
-    protected void deprecatedWriteParams(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(timestamp);
-        out.writeOptionalNamedWriteable(unit);
     }
 
     @Override
@@ -94,35 +75,27 @@ public class Rate extends AggregateFunction implements OptionalArgument, ToTimeS
         return ENTRY.name;
     }
 
-    public static Rate withUnresolvedTimestamp(Source source, Expression field, Expression unit) {
-        return new Rate(source, field, new UnresolvedAttribute(source, "@timestamp"), unit);
+    public static Rate withUnresolvedTimestamp(Source source, Expression field) {
+        return new Rate(source, field, new UnresolvedAttribute(source, "@timestamp"));
     }
 
     @Override
     protected NodeInfo<Rate> info() {
-        return NodeInfo.create(this, Rate::new, field(), timestamp, unit);
+        return NodeInfo.create(this, Rate::new, field(), timestamp);
     }
 
     @Override
     public Rate replaceChildren(List<Expression> newChildren) {
-        if (unit != null) {
-            if (newChildren.size() == 4) {
-                return new Rate(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2), newChildren.get(3));
-            }
-            assert false : "expected 4 children for field, filter, @timestamp, and unit; got " + newChildren;
-            throw new IllegalArgumentException("expected 4 children for field, filter, @timestamp, and unit; got " + newChildren);
-        } else {
-            if (newChildren.size() == 3) {
-                return new Rate(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2), null);
-            }
-            assert false : "expected 3 children for field, filter and @timestamp; got " + newChildren;
-            throw new IllegalArgumentException("expected 3 children for field, filter and @timestamp; got " + newChildren);
+        if (newChildren.size() != 3) {
+            assert false : "expected 3 children for field, filter, @timestamp; got " + newChildren;
+            throw new IllegalArgumentException("expected 3 children for field, filter, @timestamp; got " + newChildren);
         }
+        return new Rate(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
 
     @Override
     public Rate withFilter(Expression filter) {
-        return new Rate(source(), field(), filter, timestamp, unit);
+        return new Rate(source(), field(), filter, timestamp);
     }
 
     @Override
@@ -132,68 +105,26 @@ public class Rate extends AggregateFunction implements OptionalArgument, ToTimeS
 
     @Override
     protected TypeResolution resolveType() {
-        TypeResolution resolution = isType(
-            field(),
-            dt -> DataType.isCounter(dt),
-            sourceText(),
-            FIRST,
-            "counter_long",
-            "counter_integer",
-            "counter_double"
-        );
-        if (unit != null) {
-            resolution = resolution.and(
-                isType(unit, dt -> dt.isWholeNumber() || DataType.isTemporalAmount(dt), sourceText(), SECOND, "time_duration")
-            );
-        }
-        return resolution;
-    }
-
-    long unitInMillis() {
-        if (unit == null) {
-            return DEFAULT_UNIT.millis();
-        }
-        if (unit.foldable() == false) {
-            throw new IllegalArgumentException("function [" + sourceText() + "] has invalid unit [" + unit.sourceText() + "]");
-        }
-        final Object foldValue;
-        try {
-            foldValue = unit.fold(FoldContext.small() /* TODO remove me */);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("function [" + sourceText() + "] has invalid unit [" + unit.sourceText() + "]");
-        }
-        if (foldValue instanceof Duration duration) {
-            return duration.toMillis();
-        }
-        throw new IllegalArgumentException("function [" + sourceText() + "] has invalid unit [" + unit.sourceText() + "]");
+        return isType(field(), dt -> DataType.isCounter(dt), sourceText(), FIRST, "counter_long", "counter_integer", "counter_double");
     }
 
     @Override
     public AggregatorFunctionSupplier supplier() {
-        final long unitInMillis = unitInMillis();
         final DataType type = field().dataType();
         return switch (type) {
-            case COUNTER_LONG -> new RateLongAggregatorFunctionSupplier(unitInMillis);
-            case COUNTER_INTEGER -> new RateIntAggregatorFunctionSupplier(unitInMillis);
-            case COUNTER_DOUBLE -> new RateDoubleAggregatorFunctionSupplier(unitInMillis);
+            case COUNTER_LONG -> new RateLongAggregatorFunctionSupplier();
+            case COUNTER_INTEGER -> new RateIntAggregatorFunctionSupplier();
+            case COUNTER_DOUBLE -> new RateDoubleAggregatorFunctionSupplier();
             default -> throw EsqlIllegalArgumentException.illegalDataType(type);
         };
     }
 
     @Override
     public String toString() {
-        if (unit != null) {
-            return "rate(" + field() + "," + unit + ")";
-        } else {
-            return "rate(" + field() + ")";
-        }
+        return "rate(" + field() + ")";
     }
 
     Expression timestamp() {
         return timestamp;
-    }
-
-    Expression unit() {
-        return unit;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/RateSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/RateSerializationTests.java
@@ -19,8 +19,7 @@ public class RateSerializationTests extends AbstractExpressionSerializationTests
         Source source = randomSource();
         Expression field = randomChild();
         Expression timestamp = randomChild();
-        Expression unit = randomBoolean() ? null : randomChild();
-        return new Rate(source, field, timestamp, unit);
+        return new Rate(source, field, timestamp);
     }
 
     @Override
@@ -28,12 +27,10 @@ public class RateSerializationTests extends AbstractExpressionSerializationTests
         Source source = randomSource();
         Expression field = instance.field();
         Expression timestamp = instance.timestamp();
-        Expression unit = instance.unit();
-        switch (between(0, 2)) {
+        switch (between(0, 1)) {
             case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
             case 1 -> timestamp = randomValueOtherThan(timestamp, AbstractExpressionSerializationTests::randomChild);
-            case 2 -> unit = randomValueOtherThan(unit, () -> randomBoolean() ? null : randomChild());
         }
-        return new Rate(source, field, timestamp, unit);
+        return new Rate(source, field, timestamp);
     }
 }


### PR DESCRIPTION
Currently, the rate aggregation accepts two parameters: the first specifies the counter field, and the second specifies the time unit of the rate. The time unit parameter was introduced to conveniently compute requests per minute or per hour. However, this can be replaced easily - for example, `rate(field, 1minute)` with `60 * rate(field)`.

This change removes the time unit parameter and reserves it for potential future usage, such as introducing a sliding window unit. If we decide on other options later, we can reintroduce it. Removing it now avoids breaking changes while the rate aggregation is not yet available.