### PR TITLE
[8.17] [CI] Use official UBI9 image for testing (#126455)

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -395,8 +395,8 @@ void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
       // is functional.
       if (base == DockerBase.IRON_BANK) {
         Map<String, String> buildArgsMap = [
-          'BASE_REGISTRY': 'docker.elastic.co',
-          'BASE_IMAGE'   : 'ubi9/ubi',
+          'BASE_REGISTRY': 'docker.io',
+          'BASE_IMAGE'   : 'redhat/ubi9',
           'BASE_TAG'     : 'latest'
         ]
 


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [CI] Use official UBI9 image for testing (#126455)