### PR TITLE
[8.x] ESQL: Updated RENAME docs with the behaviour of multiple column renames

### DIFF
--- a/docs/reference/esql/processing-commands/rename.asciidoc
+++ b/docs/reference/esql/processing-commands/rename.asciidoc
@@ -26,6 +26,8 @@ name, all but the rightmost column with the same new name are dropped.
 The `RENAME` processing command renames one or more columns. If a column with
 the new name already exists, it will be replaced by the new column.
 
+A `RENAME` with multiple column renames is equivalent to multiple sequential `RENAME` commands.
+
 *Examples*
 
 [source,esql]
@@ -39,4 +41,12 @@ Multiple columns can be renamed with a single `RENAME` command:
 [source,esql]
 ----
 include::{esql-specs}/docs.csv-spec[tag=renameMultipleColumns]
+----
+
+
+With multiple `RENAME` commands:
+
+[source,esql]
+----
+include::{esql-specs}/docs.csv-spec[tag=renameMultipleColumnsDifferentCommands]
 ----

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
@@ -112,6 +112,18 @@ FROM employees
 fn:keyword | ln:keyword
 ;
 
+docsRenameMultipleColumnsDifferentCommands
+// tag::renameMultipleColumnsDifferentCommands[]
+FROM employees
+| KEEP first_name, last_name
+| RENAME first_name AS fn
+| RENAME last_name AS ln
+// end::renameMultipleColumnsDifferentCommands[]
+| LIMIT 0;
+
+fn:keyword | ln:keyword
+;
+
 docsSort
 // tag::sort[]
 FROM employees


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/126462

As docs changed in 9.x, it had to be manually backported to the old asciidoc format.