### PR TITLE
Enable sort optimization on float and half_float (#126342)

### DIFF
--- a/docs/changelog/126342.yaml
+++ b/docs/changelog/126342.yaml
@@ -1,0 +1,5 @@
+pr: 126342
+summary: Enable sort optimization on float and `half_float`
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
@@ -37,7 +37,7 @@ import java.io.IOException;
  */
 public class FloatValuesComparatorSource extends IndexFieldData.XFieldComparatorSource {
 
-    private final IndexNumericFieldData indexFieldData;
+    final IndexNumericFieldData indexFieldData;
 
     public FloatValuesComparatorSource(
         IndexNumericFieldData indexFieldData,
@@ -54,7 +54,7 @@ public class FloatValuesComparatorSource extends IndexFieldData.XFieldComparator
         return SortField.Type.FLOAT;
     }
 
-    private NumericDoubleValues getNumericDocValues(LeafReaderContext context, double missingValue) throws IOException {
+    NumericDoubleValues getNumericDocValues(LeafReaderContext context, double missingValue) throws IOException {
         final SortedNumericDoubleValues values = indexFieldData.load(context).getDoubleValues();
         if (nested == null) {
             return FieldData.replaceMissing(sortMode.select(values), missingValue);

--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/HalfFloatComparator.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/HalfFloatComparator.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.fielddata.fieldcomparator;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.sandbox.document.HalfFloatPoint;
+import org.apache.lucene.search.LeafFieldComparator;
+import org.apache.lucene.search.Pruning;
+import org.apache.lucene.search.comparators.NumericComparator;
+import org.apache.lucene.util.BitUtil;
+
+import java.io.IOException;
+
+/**
+ * Comparator for hal_float values.
+ * This comparator provides a skipping functionality – an iterator that can skip over non-competitive documents.
+ */
+public class HalfFloatComparator extends NumericComparator<Float> {
+    private final float[] values;
+    protected float topValue;
+    protected float bottom;
+
+    public HalfFloatComparator(int numHits, String field, Float missingValue, boolean reverse, Pruning pruning) {
+        super(field, missingValue != null ? missingValue : 0.0f, reverse, pruning, HalfFloatPoint.BYTES);
+        values = new float[numHits];
+    }
+
+    @Override
+    public int compare(int slot1, int slot2) {
+        return Float.compare(values[slot1], values[slot2]);
+    }
+
+    @Override
+    public void setTopValue(Float value) {
+        super.setTopValue(value);
+        topValue = value;
+    }
+
+    @Override
+    public Float value(int slot) {
+        return Float.valueOf(values[slot]);
+    }
+
+    @Override
+    protected long missingValueAsComparableLong() {
+        return HalfFloatPoint.halfFloatToSortableShort(missingValue);
+    }
+
+    @Override
+    protected long sortableBytesToLong(byte[] bytes) {
+        // Copied form HalfFloatPoint::sortableBytesToShort
+        short x = (short) BitUtil.VH_BE_SHORT.get(bytes, 0);
+        // Re-flip the sign bit to restore the original value:
+        return (short) (x ^ 0x8000);
+    }
+
+    @Override
+    public LeafFieldComparator getLeafComparator(LeafReaderContext context) throws IOException {
+        return new HalfFloatLeafComparator(context);
+    }
+
+    /** Leaf comparator for {@link HalfFloatComparator} that provides skipping functionality */
+    public class HalfFloatLeafComparator extends NumericLeafComparator {
+
+        public HalfFloatLeafComparator(LeafReaderContext context) throws IOException {
+            super(context);
+        }
+
+        private float getValueForDoc(int doc) throws IOException {
+            if (docValues.advanceExact(doc)) {
+                return Float.intBitsToFloat((int) docValues.longValue());
+            } else {
+                return missingValue;
+            }
+        }
+
+        @Override
+        public void setBottom(int slot) throws IOException {
+            bottom = values[slot];
+            super.setBottom(slot);
+        }
+
+        @Override
+        public int compareBottom(int doc) throws IOException {
+            return Float.compare(bottom, getValueForDoc(doc));
+        }
+
+        @Override
+        public int compareTop(int doc) throws IOException {
+            return Float.compare(topValue, getValueForDoc(doc));
+        }
+
+        @Override
+        public void copy(int slot, int doc) throws IOException {
+            values[slot] = getValueForDoc(doc);
+            super.copy(slot, doc);
+        }
+
+        @Override
+        protected long bottomAsComparableLong() {
+            return HalfFloatPoint.halfFloatToSortableShort(bottom);
+        }
+
+        @Override
+        protected long topAsComparableLong() {
+            return HalfFloatPoint.halfFloatToSortableShort(topValue);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/HalfFloatValuesComparatorSource.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/HalfFloatValuesComparatorSource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.index.fielddata.fieldcomparator;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.LeafFieldComparator;
+import org.apache.lucene.search.Pruning;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.search.MultiValueMode;
+
+import java.io.IOException;
+
+/**
+ * Comparator source for half_float values.
+ */
+public class HalfFloatValuesComparatorSource extends FloatValuesComparatorSource {
+    public HalfFloatValuesComparatorSource(
+        IndexNumericFieldData indexFieldData,
+        @Nullable Object missingValue,
+        MultiValueMode sortMode,
+        Nested nested
+    ) {
+        super(indexFieldData, missingValue, sortMode, nested);
+    }
+
+    @Override
+    public FieldComparator<?> newComparator(String fieldname, int numHits, Pruning enableSkipping, boolean reversed) {
+        assert indexFieldData == null || fieldname.equals(indexFieldData.getFieldName());
+
+        final float fMissingValue = (Float) missingObject(missingValue, reversed);
+        // NOTE: it's important to pass null as a missing value in the constructor so that
+        // the comparator doesn't check docsWithField since we replace missing values in select()
+        return new HalfFloatComparator(numHits, fieldname, null, reversed, enableSkipping) {
+            @Override
+            public LeafFieldComparator getLeafComparator(LeafReaderContext context) throws IOException {
+                return new HalfFloatLeafComparator(context) {
+                    @Override
+                    protected NumericDocValues getNumericDocValues(LeafReaderContext context, String field) throws IOException {
+                        return HalfFloatValuesComparatorSource.this.getNumericDocValues(context, fMissingValue).getRawFloatValues();
+                    }
+                };
+            }
+        };
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
@@ -60,6 +60,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
+import org.elasticsearch.index.fielddata.fieldcomparator.HalfFloatValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.sort.ShardDocSortField;
@@ -642,7 +643,7 @@ public class LuceneTests extends ESTestCase {
         IndexFieldData.XFieldComparatorSource comparatorSource;
         boolean reverse = randomBoolean();
         Object missingValue = null;
-        switch (randomIntBetween(0, 3)) {
+        switch (randomIntBetween(0, 4)) {
             case 0 -> comparatorSource = new LongValuesComparatorSource(
                 null,
                 randomBoolean() ? randomLong() : null,
@@ -662,7 +663,13 @@ public class LuceneTests extends ESTestCase {
                 randomFrom(MultiValueMode.values()),
                 null
             );
-            case 3 -> {
+            case 3 -> comparatorSource = new HalfFloatValuesComparatorSource(
+                null,
+                randomBoolean() ? randomFloat() : null,
+                randomFrom(MultiValueMode.values()),
+                null
+            );
+            case 4 -> {
                 comparatorSource = new BytesRefFieldComparatorSource(
                     null,
                     randomBoolean() ? "_first" : "_last",

--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -109,6 +109,17 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
                 null,
                 null
             ).docValues(docValues).build(context).fieldType();
+        } else if (type.equals("half_float")) {
+            fieldType = new NumberFieldMapper.Builder(
+                fieldName,
+                NumberFieldMapper.NumberType.HALF_FLOAT,
+                ScriptCompiler.NONE,
+                false,
+                true,
+                IndexVersion.current(),
+                null,
+                null
+            ).docValues(docValues).build(context).fieldType();
         } else if (type.equals("double")) {
             fieldType = new NumberFieldMapper.Builder(
                 fieldName,

--- a/server/src/test/java/org/elasticsearch/index/search/nested/HalfFloatNestedSortingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/nested/HalfFloatNestedSortingTests.java
@@ -10,33 +10,28 @@ package org.elasticsearch.index.search.nested;
 
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.util.NumericUtils;
-import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.apache.lucene.sandbox.document.HalfFloatPoint;
+import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
-import org.elasticsearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
+import org.elasticsearch.index.fielddata.fieldcomparator.HalfFloatValuesComparatorSource;
 import org.elasticsearch.search.MultiValueMode;
 
-public class FloatNestedSortingTests extends DoubleNestedSortingTests {
+public class HalfFloatNestedSortingTests extends DoubleNestedSortingTests {
 
     @Override
     protected String getFieldDataType() {
-        return "float";
+        return "half_float";
     }
 
     @Override
-    protected IndexFieldData.XFieldComparatorSource createFieldComparator(
-        String fieldName,
-        MultiValueMode sortMode,
-        Object missingValue,
-        Nested nested
-    ) {
+    protected XFieldComparatorSource createFieldComparator(String fieldName, MultiValueMode sortMode, Object missingValue, Nested nested) {
         IndexNumericFieldData fieldData = getForField(fieldName);
-        return new FloatValuesComparatorSource(fieldData, missingValue, sortMode, nested);
+        return new HalfFloatValuesComparatorSource(fieldData, missingValue, sortMode, nested);
     }
 
     @Override
     protected IndexableField createField(String name, int value) {
-        return new SortedNumericDocValuesField(name, NumericUtils.floatToSortableInt(value));
+        return new SortedNumericDocValuesField(name, HalfFloatPoint.halfFloatToSortableShort(value));
     }
 }


### PR DESCRIPTION
Before we enabled sort optimization on long, double and date types, but left other types for follow-up.

This enables sort optimization on float and half_float types.

Optimizations on INT, BYTE, SHORT are left for follow-up, because they need more work: we currently use SORT.LONG type for all integer types and this doesn't allow to use optimization.

Backport for #126342