### PR TITLE
ESQL: Fix bug in octal ip parsing tests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIpTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIpTests.java
@@ -191,6 +191,7 @@ public class ParseIpTests extends ESTestCase {
                 lastWasBreak = true;
                 b.append(current).append('.');
                 current = 0;
+                octalMode = false;
                 continue;
             }
             lastWasBreak = false;


### PR DESCRIPTION
This fixes a bug in the tests for parsing ipv4 addresses with leading zeros as octal numbers. The bug was in the expectation code that we use for random input ips.

Closes #126496
