### PR TITLE
[docs] Fix assembler warnings

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/enrich-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/enrich-settings.md
@@ -7,7 +7,7 @@ applies_to:
 
 # Enrich settings [enrich_settings]
 
-You can configure these enrich settings in the `elasticsearch.yml` file. For more information, see [Set up an enrich processor](docs-content:///manage-data/ingest/transform-enrich/set-up-an-enrich-processor.md).
+You can configure these enrich settings in the `elasticsearch.yml` file. For more information, see [Set up an enrich processor](docs-content://manage-data/ingest/transform-enrich/set-up-an-enrich-processor.md).
 
 `enrich.cache_size` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :   Maximum number of searches to cache for enriching documents. Defaults to 1000. There is a single cache for all enrich processors in the cluster. This setting determines the size of that cache.


### PR DESCRIPTION
Fixes assembler warnings by fixing link syntax.