### PR TITLE
Remove unnecessary request from log tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -417,9 +417,6 @@ tests:
 - class: org.elasticsearch.xpack.downsample.ILMDownsampleDisruptionIT
   method: testILMDownsampleRollingRestart
   issue: https://github.com/elastic/elasticsearch/issues/126495
-- class: org.elasticsearch.xpack.search.AsyncSearchErrorTraceIT
-  method: testDataNodeLogsStackTraceWhenErrorTraceFalseOrEmpty
-  issue: https://github.com/elastic/elasticsearch/issues/126357
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/get_trained_model_stats/Test get stats given trained models}
   issue: https://github.com/elastic/elasticsearch/issues/126510

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchErrorTraceIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchErrorTraceIT.java
@@ -185,7 +185,6 @@ public class AsyncSearchErrorTraceIT extends ESIntegTestCase {
                 responseEntity = performRequestAndGetResponseEntityAfterDelay(request, TimeValue.timeValueSeconds(1L));
             }
 
-            getRestClient().performRequest(searchRequest);
             mockLog.assertAllExpectationsMatched();
         }
     }
@@ -228,7 +227,6 @@ public class AsyncSearchErrorTraceIT extends ESIntegTestCase {
                 responseEntity = performRequestAndGetResponseEntityAfterDelay(request, TimeValue.timeValueSeconds(1L));
             }
 
-            getRestClient().performRequest(searchRequest);
             mockLog.assertAllExpectationsMatched();
         }
     }


### PR DESCRIPTION
Attempt to fix https://github.com/elastic/elasticsearch/issues/126358 & https://github.com/elastic/elasticsearch/issues/126357.

This final request is unnecessary - by the nature of the above while loop, the async search will complete before the assertion. My theory is that this final request causes shard locks to remain held in a busy cluster after the assertion has succeeded, explaining the intermittent failures. 

Also, this line is one of the only meaningful differences between these tests and others in the class, which have not been failing :).