### PR TITLE
Add a custom toString to DynamicMap

### DIFF
--- a/docs/changelog/126562.yaml
+++ b/docs/changelog/126562.yaml
@@ -1,0 +1,6 @@
+pr: 126562
+summary: Add a custom `toString` to `DynamicMap`
+area: Infra/Scripting
+type: bug
+issues:
+ - 70262

--- a/server/src/main/java/org/elasticsearch/script/DynamicMap.java
+++ b/server/src/main/java/org/elasticsearch/script/DynamicMap.java
@@ -96,19 +96,21 @@ public final class DynamicMap implements Map<String, Object> {
         return delegate.entrySet();
     }
 
+
+
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("DynamicMap [");
+        StringBuilder sb = new StringBuilder("{");
         int count = 0;
         for (Map.Entry<String, Object> entry : entrySet()) {
             sb.append(entry.getKey());
-            sb.append(": ");
+            sb.append("=");
             sb.append(entry.getValue());
             if (++count < size()) {
                 sb.append(", ");
             }
         }
-        sb.append("]");
+        sb.append("}");
         return sb.toString();
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/DynamicMap.java
+++ b/server/src/main/java/org/elasticsearch/script/DynamicMap.java
@@ -96,8 +96,6 @@ public final class DynamicMap implements Map<String, Object> {
         return delegate.entrySet();
     }
 
-
-
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("{");

--- a/server/src/main/java/org/elasticsearch/script/DynamicMap.java
+++ b/server/src/main/java/org/elasticsearch/script/DynamicMap.java
@@ -98,6 +98,17 @@ public final class DynamicMap implements Map<String, Object> {
 
     @Override
     public String toString() {
-        return delegate.toString();
+        StringBuilder sb = new StringBuilder("DynamicMap [");
+        int count = 0;
+        for (Map.Entry<String, Object> entry : entrySet()) {
+            sb.append(entry.getKey());
+            sb.append(": ");
+            sb.append(entry.getValue());
+            if (++count < size()) {
+                sb.append(", ");
+            }
+        }
+        sb.append("]");
+        return sb.toString();
     }
 }

--- a/server/src/test/java/org/elasticsearch/script/ScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptTests.java
@@ -194,6 +194,6 @@ public class ScriptTests extends ESTestCase {
         map.put("long", 1L);
         map.put("string", "value");
         DynamicMap dm = new DynamicMap(map, Collections.emptyMap());
-        assertThat(dm.toString(), both(containsString("long: 1")).and(containsString("string: value")));
+        assertThat(dm.toString(), both(containsString("long=1")).and(containsString("string=value")));
     }
 }

--- a/server/src/test/java/org/elasticsearch/script/ScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptTests.java
@@ -30,10 +30,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.both;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 public class ScriptTests extends ESTestCase {
 

--- a/server/src/test/java/org/elasticsearch/script/ScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptTests.java
@@ -29,7 +29,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class ScriptTests extends ESTestCase {
 
@@ -192,7 +196,6 @@ public class ScriptTests extends ESTestCase {
         map.put("long", 1L);
         map.put("string", "value");
         DynamicMap dm = new DynamicMap(map, Collections.emptyMap());
-        assertTrue(dm.toString().contains("string=value"));
-        assertTrue(dm.toString().contains("long=1"));
+        assertThat(dm.toString(), both(containsString("long: 1")).and(containsString("string: value")));
     }
 }


### PR DESCRIPTION
This change prevents a delegate map from giving an inconsistent toString or an empty toString.

Closes #70262 