### PR TITLE
[9.0] ESQL: Fix bug in octal ip parsing tests (#126552)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIpTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIpTests.java
@@ -191,6 +191,7 @@ public class ParseIpTests extends ESTestCase {
                 lastWasBreak = true;
                 b.append(current).append('.');
                 current = 0;
+                octalMode = false;
                 continue;
             }
             lastWasBreak = false;


### PR DESCRIPTION
Backports the following commits to 9.0:
 - ESQL: Fix bug in octal ip parsing tests (#126552)