### PR TITLE
Add friendly error message when using more than one FORK

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Fork.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Fork.java
@@ -144,6 +144,14 @@ public class Fork extends LogicalPlan implements PostAnalysisPlanVerificationAwa
         }
         Fork fork = (Fork) plan;
 
+        fork.forEachDown(Fork.class, otherFork -> {
+            if (fork == otherFork) {
+                return;
+            }
+
+            failures.add(Failure.fail(otherFork, "Only a single FORK command is allowed, but found multiple"));
+        });
+
         Map<String, DataType> outputTypes = fork.children()
             .getFirst()
             .output()

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -3288,6 +3288,13 @@ public class AnalyzerTests extends ESTestCase {
                    ( WHERE emp_no > 2 | SORT emp_no | LIMIT 10 )
             """));
         assertThat(e.getMessage(), containsString("aggregate function [COUNT(first_name)] not allowed outside STATS command"));
+
+        e = expectThrows(VerificationException.class, () -> analyze("""
+            FROM test
+            | FORK (EVAL a = 1) (EVAL a = 2)
+            | FORK (EVAL b = 3) (EVAL b = 4)
+            """));
+        assertThat(e.getMessage(), containsString("Only a single FORK command is allowed, but found multiple"));
     }
 
     public void testValidRrf() {


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/issues/121950

Since initially we won't support multiple FORK commands in the same query, this adds proper verification for this case, so we don't fail with an unexpected and unfriendly error.