### PR TITLE
ESQL: stabilise one FORK test

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ForkIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ForkIT.java
@@ -544,7 +544,7 @@ public class ForkIT extends AbstractEsqlIntegTestCase {
     public void testWithStatsSimple() {
         var query = """
                 FROM test
-                | FORK (STATS x=COUNT(*), y=VALUES(id))
+                | FORK (STATS x=COUNT(*), y=MV_SORT(VALUES(id)))
                        (WHERE id == 2)
                 | KEEP _fork, x, y, id
                 | SORT _fork, id


### PR DESCRIPTION
Add sorting on a MV result set in ForkIT#testWithStatsSimple

(fails with `-Dtests.seed=B5E39E375A34C8E7 -Dtests.locale=en-AT -Dtests.timezone=Asia/Yangon -Druntime.java=24`)