### PR TITLE
Update TestSparseInferenceServiceExtension to not support text embeddings

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetServicesIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetServicesIT.java
@@ -64,7 +64,7 @@ public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
     @SuppressWarnings("unchecked")
     public void testGetServicesWithTextEmbeddingTaskType() throws IOException {
         List<Object> services = getServices(TaskType.TEXT_EMBEDDING);
-        assertThat(services.size(), equalTo(16));
+        assertThat(services.size(), equalTo(15));
 
         String[] providers = new String[services.size()];
         for (int i = 0; i < services.size(); i++) {
@@ -86,7 +86,6 @@ public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
                 "jinaai",
                 "mistral",
                 "openai",
-                "test_service",
                 "text_embedding_test_service",
                 "voyageai",
                 "watsonxai"

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestSparseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestSparseInferenceServiceExtension.java
@@ -35,7 +35,6 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
-import org.elasticsearch.xpack.core.inference.results.TextEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.ml.search.WeightedToken;
 
 import java.io.IOException;
@@ -64,7 +63,7 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
     public static class TestInferenceService extends AbstractTestInferenceService {
         public static final String NAME = "test_service";
 
-        private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.SPARSE_EMBEDDING, TaskType.TEXT_EMBEDDING);
+        private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.SPARSE_EMBEDDING);
 
         public TestInferenceService(InferenceServiceExtension.InferenceServiceFactoryContext context) {}
 
@@ -115,8 +114,7 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
             ActionListener<InferenceServiceResults> listener
         ) {
             switch (model.getConfigurations().getTaskType()) {
-                case ANY, SPARSE_EMBEDDING -> listener.onResponse(makeSparseEmbeddingResults(input));
-                case TEXT_EMBEDDING -> listener.onResponse(makeTextEmbeddingResults(input));
+                case ANY, SPARSE_EMBEDDING -> listener.onResponse(makeResults(input));
                 default -> listener.onFailure(
                     new ElasticsearchStatusException(
                         TaskType.unsupportedTaskTypeErrorMsg(model.getConfigurations().getTaskType(), name()),
@@ -157,7 +155,7 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
             }
         }
 
-        private SparseEmbeddingResults makeSparseEmbeddingResults(List<String> input) {
+        private SparseEmbeddingResults makeResults(List<String> input) {
             var embeddings = new ArrayList<SparseEmbeddingResults.Embedding>();
             for (int i = 0; i < input.size(); i++) {
                 var tokens = new ArrayList<WeightedToken>();
@@ -167,18 +165,6 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
                 embeddings.add(new SparseEmbeddingResults.Embedding(tokens, false));
             }
             return new SparseEmbeddingResults(embeddings);
-        }
-
-        private TextEmbeddingFloatResults makeTextEmbeddingResults(List<String> input) {
-            var embeddings = new ArrayList<TextEmbeddingFloatResults.Embedding>();
-            for (int i = 0; i < input.size(); i++) {
-                var values = new float[5];
-                for (int j = 0; j < 5; j++) {
-                    values[j] = random.nextFloat();
-                }
-                embeddings.add(new TextEmbeddingFloatResults.Embedding(values));
-            }
-            return new TextEmbeddingFloatResults(embeddings);
         }
 
         private List<ChunkedInference> makeChunkedResults(List<ChunkInferenceInput> inputs) {


### PR DESCRIPTION
Does what the title says. Fixes incorrect behavior introduced by #123044, which is wrong for a couple reasons:

- A sparse embedding inference service should not support text embeddings
- The text embedding generation implemented creates a random embedding for each call, which effectively makes it useless for most of our test cases. Many of our test cases rely on consistent result ordering, which won't happen if the embedding changes on subsequent calls with the same input. See [`generateEmbedding`](https://github.com/elastic/elasticsearch/blob/e7d4a28a87b351238ac2a93db4d586fde5022dc8/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java#L233) for how we generate a text embedding fit for purpose.