### PR TITLE
[docs] Update mapped_pages

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/rank-vectors.md
+++ b/docs/reference/elasticsearch/mapping-reference/rank-vectors.md
@@ -1,7 +1,9 @@
 ---
 navigation_title: "Rank Vectors"
 mapped_pages:
-  - https://www.elastic.co/guide/en/elasticsearch/reference/master/rank-vectors.html
+  - https://www.elastic.co/guide/en/elasticsearch/reference/current/rank-vectors.html
+  # That link will 404 until 8.18 is current
+  # (see https://www.elastic.co/guide/en/elasticsearch/reference/8.18/rank-vectors.html)
 ---
 
 # Rank Vectors [rank-vectors]

--- a/docs/reference/elasticsearch/rest-apis/create-index-from-source.md
+++ b/docs/reference/elasticsearch/rest-apis/create-index-from-source.md
@@ -1,7 +1,9 @@
 ---
 navigation_title: "Create index from source"
 mapped_pages:
-  - https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index-from-source.html
+  - https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index-from-source.html
+  # That link will 404 until 8.18 is current
+  # (see https://www.elastic.co/guide/en/elasticsearch/reference/8.18/indices-create-index-from-source.html)
 applies_to:
   stack: all
 ---

--- a/docs/reference/elasticsearch/rest-apis/reindex-data-stream.md
+++ b/docs/reference/elasticsearch/rest-apis/reindex-data-stream.md
@@ -1,7 +1,9 @@
 ---
 navigation_title: "Reindex data stream"
 mapped_pages:
-  - https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-reindex-api.html
+  - https://www.elastic.co/guide/en/elasticsearch/reference/current/data-stream-reindex-api.html
+  # That link will 404 until 8.18 is current
+  # (see https://www.elastic.co/guide/en/elasticsearch/reference/8.18/data-stream-reindex-api.html)
 applies_to:
   stack: all
 ---

--- a/docs/reference/query-languages/esql/commands/processing-commands.md
+++ b/docs/reference/query-languages/esql/commands/processing-commands.md
@@ -1,7 +1,7 @@
 ---
 navigation_title: "Processing commands"
 mapped_pages:
-  - https://www.elastic.co/guide/en/elasticsearch/reference/current/commands/processing-commands.html
+  - https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-commands.html
 ---
 
 # {{esql}} processing commands [esql-processing-commands]

--- a/docs/reference/query-languages/esql/commands/source-commands.md
+++ b/docs/reference/query-languages/esql/commands/source-commands.md
@@ -1,7 +1,7 @@
 ---
 navigation_title: "Source commands"
 mapped_pages:
-  - https://www.elastic.co/guide/en/elasticsearch/reference/current/commands/source-commands.html
+  - https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-commands.html
 ---
 
 # {{esql}} source commands [esql-source-commands]


### PR DESCRIPTION
Updates `mapped_pages` to be compatible with the _View previous version_ link.