### PR TITLE
[9.0] [Test] Fix testGenerateMultipleCertificateWithNewCA (#126621)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -256,9 +256,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.convert.ParseIpTests
   method: testLeadingZerosAreOctal {TestCase[str=v4, validLeadingZerosRejected=true, validLeadingZerosAreDecimal=true, validLeadingZerosAreOctal=true]}
   issue: https://github.com/elastic/elasticsearch/issues/126496
-- class: org.elasticsearch.xpack.security.cli.HttpCertificateCommandTests
-  method: testGenerateMultipleCertificateWithNewCA
-  issue: https://github.com/elastic/elasticsearch/issues/126471
 
 # Examples:
 #

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommandTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommandTests.java
@@ -380,7 +380,7 @@ public class HttpCertificateCommandTests extends ESTestCase {
             caDN = "CN=" + randomAlphaOfLengthBetween(3, 8);
             caYears = randomIntBetween(1, 3);
             caKeySize = randomFrom(2048, 3072, 4096);
-            caKeyUsage = randomSubsetOf(CertGenUtils.KEY_USAGE_MAPPINGS.keySet());
+            caKeyUsage = randomNonEmptySubsetOf(CertGenUtils.KEY_USAGE_MAPPINGS.keySet());
             terminal.addTextInput(caDN);
             terminal.addTextInput(caYears + "y");
             terminal.addTextInput(Integer.toString(caKeySize));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Test] Fix testGenerateMultipleCertificateWithNewCA (#126621)](https://github.com/elastic/elasticsearch/pull/126621)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)