### PR TITLE
[8.17] Update keyword documentation for logsdb (#126652)

### DIFF
--- a/docs/reference/data-streams/logs.asciidoc
+++ b/docs/reference/data-streams/logs.asciidoc
@@ -170,8 +170,9 @@ can be indexed without causing ingestion failures.
 ==== `ignore_above`
 
 In `logsdb` index mode, the `index.mapping.ignore_above` setting is applied by default at the index level to ensure
-efficient storage and indexing of large keyword fields.The index-level default for `ignore_above` is 8191
-_characters._ Using UTF-8 encoding, this results in a limit of 32764 bytes, depending on character encoding.
+efficient storage and indexing of large keyword fields. This applies to all members of the keyword type family (keyword,
+constant_keyword, and wildcard). The index-level default for `ignore_above` is 8191 _characters._ Using UTF-8 encoding,
+this results in a limit of 32764 bytes, depending on character encoding.
 
 The mapping-level `ignore_above` setting takes precedence. If a specific field has an `ignore_above` value
 defined in its mapping, that value overrides the index-level `index.mapping.ignore_above` value. This default

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -74,9 +74,10 @@ The following parameters are accepted by `keyword` fields:
 <<ignore-above,`ignore_above`>>::
 
     Do not index any string longer than this value. Defaults to `2147483647`
-    so that all values would be accepted. Please however note that default
-    dynamic mapping rules create a sub `keyword` field that overrides this
-    default by setting `ignore_above: 256`.
+    in standard indices so that all values would be accepted, and `8191` in logsdb
+    indices to protect against Lucene's term byte-length limit of `32766`. Please
+    however note that default dynamic mapping rules create a sub `keyword` field
+    that overrides this default by setting `ignore_above: 256`.
 
 <<mapping-index,`index`>>::
 

--- a/docs/reference/mapping/types/wildcard.asciidoc
+++ b/docs/reference/mapping/types/wildcard.asciidoc
@@ -123,7 +123,8 @@ The following parameters are accepted by `wildcard` fields:
 <<ignore-above,`ignore_above`>>::
 
     Do not index any string longer than this value. Defaults to `2147483647`
-    so that all values would be accepted.
+    in standard indices so that all values would be accepted, and `8191` in
+    logsdb indices to protect against Lucene's term byte-length limit of `32766`.
 
 [discrete]
 ==== Limitations


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Update keyword documentation for logsdb (#126652)