### PR TITLE
[9.0] Add license mention to ESQL categorize (#126666)

### DIFF
--- a/docs/reference/query-languages/esql/functions-operators/grouping-functions.md
+++ b/docs/reference/query-languages/esql/functions-operators/grouping-functions.md
@@ -16,6 +16,10 @@ The [`STATS`](/reference/query-languages/esql/commands/processing-commands.md#es
 :::{include} ../_snippets/functions/layout/bucket.md
 :::
 
+:::{note} 
+The `CATEGORIZE` function requires a [platinum license](https://www.elastic.co/subscriptions).
+:::
+
 :::{include} ../_snippets/functions/layout/categorize.md
 :::
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Add license mention to ESQL categorize (#126666)