### PR TITLE
[9.0] Add docker hub specific docker context (#126625)

### DIFF
--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -70,6 +70,7 @@ echo --- Building release artifacts
   $VERSION_QUALIFIER_ARG \
   buildReleaseArtifacts \
   exportCompressedDockerImages \
+  exportDockerContexts \
   :distribution:generateDependenciesReport
 
 PATH="$PATH:${JAVA_HOME}/bin" # Required by the following script

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -117,7 +117,7 @@ dependencies {
   fips "org.bouncycastle:bctls-fips:1.0.19"
 }
 
-ext.expansions = { Architecture architecture, DockerBase base ->
+ext.expansions = { Architecture architecture, DockerBase base, String publicationContext = '' ->
   def (major, minor) = VersionProperties.elasticsearch.split("\\.")
 
   // We tag our Docker images with various pieces of information, including a timestamp
@@ -137,6 +137,7 @@ ext.expansions = { Architecture architecture, DockerBase base ->
     'license'            : base == DockerBase.IRON_BANK ? 'Elastic License 2.0' : 'Elastic-License-2.0',
     'package_manager'    : base.packageManager,
     'docker_base'        : base.name().toLowerCase(),
+    'docker_context'     : publicationContext,
     'version'            : VersionProperties.elasticsearch,
     'major_minor_version': "${major}.${minor}",
     'retry'              : ShellRetry
@@ -164,9 +165,9 @@ private static String taskName(String prefix, Architecture architecture, DockerB
     suffix
 }
 
-ext.dockerBuildContext = { Architecture architecture, DockerBase base ->
+ext.dockerBuildContext = { Architecture architecture, DockerBase base, String publicationContext = '' ->
   copySpec {
-    final Map<String, String> varExpansions = expansions(architecture, base)
+    final Map<String, String> varExpansions = expansions(architecture, base, publicationContext)
     final Path projectDir = project.projectDir.toPath()
 
     if (base == DockerBase.IRON_BANK) {
@@ -276,17 +277,22 @@ tasks.named("composeUp").configure {
   dependsOn tasks.named("preProcessFixture")
 }
 
-void addBuildDockerContextTask(Architecture architecture, DockerBase base) {
+
+def exportDockerImages = tasks.register("exportDockerImages")
+def exportCompressedDockerImages = tasks.register("exportCompressedDockerImages")
+def exportDockerContexts = tasks.register("exportDockerContexts")
+
+void addBuildDockerContextTask(Architecture architecture, DockerBase base, String taskSuffix = 'DockerContext', String classifier = "docker-build-context") {
   String configDirectory = base == DockerBase.IRON_BANK ? 'scripts' : 'config'
   String arch = architecture == Architecture.AARCH64 ? '-aarch64' : ''
 
   final TaskProvider<Tar> buildDockerContextTask =
-    tasks.register(taskName('build', architecture, base, 'DockerContext'), Tar) {
+    tasks.register(taskName('build', architecture, base, taskSuffix), Tar) {
       archiveExtension = 'tar.gz'
       compression = Compression.GZIP
-      archiveClassifier = "docker-build-context${arch}"
+      archiveClassifier = "${classifier}${arch}"
       archiveBaseName = "elasticsearch${base.suffix}"
-      with dockerBuildContext(architecture, base)
+      with dockerBuildContext(architecture, base, classifier)
 
       into(configDirectory) {
         from(configurations.log4jConfig) {
@@ -328,6 +334,10 @@ void addBuildDockerContextTask(Architecture architecture, DockerBase base) {
       )
       onlyIf("$architecture supported") { serviceProvider.get().isArchitectureSupported(architecture) }
     }
+
+  exportDockerContexts.configure {
+    dependsOn buildDockerContextTask
+  }
 
   if (base == DockerBase.IRON_BANK) {
     tasks.named("assemble").configure {
@@ -563,11 +573,13 @@ for (final Architecture architecture : Architecture.values()) {
       addTransformDockerContextTask(architecture, base)
       addBuildDockerImageTask(architecture, base)
     }
+    if(base == DockerBase.DEFAULT) {
+      // Add additional docker hub specific context which we use solely for publishing to docker hub.
+      // At the moment it only differs in not labels added that we need for openshift certification
+      addBuildDockerContextTask(architecture, base, 'DockerHubContext', "docker-hub-build-context")
+    }
   }
 }
-
-def exportDockerImages = tasks.register("exportDockerImages")
-def exportCompressedDockerImages = tasks.register("exportCompressedDockerImages")
 
 /*
  * The export subprojects write out the generated Docker images to disk, so

--- a/distribution/docker/src/docker/Dockerfile.default
+++ b/distribution/docker/src/docker/Dockerfile.default
@@ -139,6 +139,7 @@ LABEL org.label-schema.build-date="${build_date}" \\
   org.opencontainers.image.vendor="Elastic" \\
   org.opencontainers.image.version="${version}"
 
+<% if (docker_context != 'docker-hub-build-context') { %>
 LABEL name="Elasticsearch" \\
   maintainer="infra@elastic.co" \\
   vendor="Elastic" \\
@@ -146,6 +147,7 @@ LABEL name="Elasticsearch" \\
   release="1" \\
   summary="Elasticsearch" \\
   description="You know, for search."
+<% } %>
 
 RUN mkdir /licenses && ln LICENSE.txt /licenses/LICENSE
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Add docker hub specific docker context (#126625)](https://github.com/elastic/elasticsearch/pull/126625)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)