### PR TITLE
[8.x] [ES|QL] Retrieve token text only when necessary (#126578)

### DIFF
--- a/docs/changelog/126578.yaml
+++ b/docs/changelog/126578.yaml
@@ -1,0 +1,5 @@
+pr: 126578
+summary: Retrieve token text only when necessary
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ParserUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ParserUtils.java
@@ -144,10 +144,10 @@ public final class ParserUtils {
      */
     public static String nameOrPosition(Token token) {
         int tokenType = token.getType();
-        String s = token.getText();
+        // Retrieve text from the token only when necessary, when the token type is known.
         return switch (tokenType) {
-            case EsqlBaseLexer.NAMED_OR_POSITIONAL_PARAM -> s.substring(SINGLE_PARAM);
-            case EsqlBaseLexer.NAMED_OR_POSITIONAL_DOUBLE_PARAMS -> s.substring(DOUBLE_PARAM);
+            case EsqlBaseLexer.NAMED_OR_POSITIONAL_PARAM -> token.getText().substring(SINGLE_PARAM);
+            case EsqlBaseLexer.NAMED_OR_POSITIONAL_DOUBLE_PARAMS -> token.getText().substring(DOUBLE_PARAM);
             default -> EMPTY;
         };
     }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ES|QL] Retrieve token text only when necessary (#126578)