### PR TITLE
[8.x] [DOCS] 8.x mention categorize license requirement (#126670)

### DIFF
--- a/docs/reference/esql/functions/grouping-functions.asciidoc
+++ b/docs/reference/esql/functions/grouping-functions.asciidoc
@@ -9,8 +9,10 @@ The <<esql-stats-by>> command supports these grouping functions:
 
 // tag::group_list[]
 * <<esql-bucket>>
-* experimental:[] <<esql-categorize>>
+* experimental:[] <<esql-categorize>> NOTE: Requires a https://www.elastic.co/subscriptions[platinum license].
 // end::group_list[]
 
 include::layout/bucket.asciidoc[]
+
+NOTE: The `CATEGORIZE` function requires a https://www.elastic.co/subscriptions[platinum license].
 include::layout/categorize.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [DOCS] 8.x mention categorize license requirement (#126670)