### PR TITLE
Fix `ILMDownsampleDisruptionIT.testILMDownsampleRollingRestart`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -399,9 +399,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
   issue: https://github.com/elastic/elasticsearch/issues/126466
-- class: org.elasticsearch.xpack.downsample.ILMDownsampleDisruptionIT
-  method: testILMDownsampleRollingRestart
-  issue: https://github.com/elastic/elasticsearch/issues/126495
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/get_trained_model_stats/Test get stats given trained models}
   issue: https://github.com/elastic/elasticsearch/issues/126510

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1735,15 +1735,23 @@ public abstract class ESIntegTestCase extends ESTestCase {
     }
 
     public static void awaitIndexExists(String index) {
-        awaitIndexExists(index, client());
+        awaitIndexExists(index, client(), SAFE_AWAIT_TIMEOUT);
+    }
+
+    public static void awaitIndexExists(String index, TimeValue timeout) {
+        awaitIndexExists(index, client(), timeout);
     }
 
     public static void awaitIndexExists(String index, Client client) {
+        awaitIndexExists(index, client, SAFE_AWAIT_TIMEOUT);
+    }
+
+    public static void awaitIndexExists(String index, Client client, TimeValue timeout) {
         assertThat("wildcards not supported", index, allOf(not(Metadata.ALL), not(containsString("*"))));
         safeGet(
             client.admin()
                 .cluster()
-                .prepareHealth(SAFE_AWAIT_TIMEOUT, index)
+                .prepareHealth(timeout, index)
                 .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED)
                 .execute()
         );

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1749,11 +1749,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
     public static void awaitIndexExists(String index, Client client, TimeValue timeout) {
         assertThat("wildcards not supported", index, allOf(not(Metadata.ALL), not(containsString("*"))));
         safeGet(
-            client.admin()
-                .cluster()
-                .prepareHealth(timeout, index)
-                .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED)
-                .execute()
+            client.admin().cluster().prepareHealth(timeout, index).setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED).execute()
         );
     }
 

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
@@ -192,8 +192,8 @@ public class ILMDownsampleDisruptionIT extends ESIntegTestCase {
                 throw new AssertionError(e);
             }
         }, 1, TimeUnit.MINUTES);
+        awaitIndexExists(targetIndex, TimeValue.timeValueSeconds(60));
         assertBusy(() -> {
-            assertTrue("target index [" + targetIndex + "] does not exist", indexExists(targetIndex));
             var getSettingsResponse = client().admin()
                 .indices()
                 .getSettings(new GetSettingsRequest(TEST_REQUEST_TIMEOUT).indices(targetIndex))


### PR DESCRIPTION
Wait for the index to exist on the master node to ensure all nodes have the latest cluster state.

Fixes #126495