### PR TITLE
[8.18] Remove unnecessary request from log tests (#126556)

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchErrorTraceIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchErrorTraceIT.java
@@ -197,7 +197,6 @@ public class AsyncSearchErrorTraceIT extends ESIntegTestCase {
                 responseEntity = performRequestAndGetResponseEntityAfterDelay(request, TimeValue.timeValueSeconds(1L));
             }
 
-            getRestClient().performRequest(searchRequest);
             mockLog.assertAllExpectationsMatched();
         }
     }
@@ -241,7 +240,6 @@ public class AsyncSearchErrorTraceIT extends ESIntegTestCase {
                 responseEntity = performRequestAndGetResponseEntityAfterDelay(request, TimeValue.timeValueSeconds(1L));
             }
 
-            getRestClient().performRequest(searchRequest);
             mockLog.assertAllExpectationsMatched();
         }
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Remove unnecessary request from log tests (#126556)](https://github.com/elastic/elasticsearch/pull/126556)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)