### PR TITLE
[8.16] Fixing ScheduledEventTest generating same start and end time (#115877)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
@@ -207,7 +207,7 @@ public class ScheduledEventTests extends AbstractXContentSerializingTestCase<Sch
         String description = randomAlphaOfLength(10);
         String calendarId = randomAlphaOfLength(10);
         Instant startTime = Instant.ofEpochMilli(Instant.now().toEpochMilli());
-        Instant endTime = startTime.plusSeconds(randomInt(3600));
+        Instant endTime = startTime.plusSeconds(randomIntBetween(1, 3600));
 
         ScheduledEvent.Builder builder = new ScheduledEvent.Builder().description(description)
             .calendarId(calendarId)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Fixing ScheduledEventTest generating same start and end time (#115877)](https://github.com/elastic/elasticsearch/pull/115877)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Closes #126642