### PR TITLE
Unmute FileAccessTreeTests.testDuplicatePrunedPaths

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -237,9 +237,6 @@ tests:
 - class: org.elasticsearch.indices.recovery.IndexRecoveryIT
   method: testSourceThrottling
   issue: https://github.com/elastic/elasticsearch/issues/123680
-- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
-  method: testDuplicatePrunedPaths
-  issue: https://github.com/elastic/elasticsearch/issues/124006
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
   issue: https://github.com/elastic/elasticsearch/issues/120814


### PR DESCRIPTION
This should have been unmuted a few weeks ago, in https://github.com/elastic/elasticsearch/pull/125217.

Fixes #124006.