### PR TITLE
Fix test: set up mocks before starting the service

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -153,9 +153,6 @@ tests:
 - class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
   method: testCleanShardFollowTaskAfterDeleteFollower
   issue: https://github.com/elastic/elasticsearch/issues/120339
-- class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
-  method: testInvalidJSON
-  issue: https://github.com/elastic/elasticsearch/issues/120482
 - class: org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeToCharProcessorTests
   issue: https://github.com/elastic/elasticsearch/issues/120575
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -297,6 +297,10 @@ public class FileSettingsServiceTests extends ESTestCase {
         // contents of the JSON don't matter, we just need a file to exist
         writeTestFile(watchedFile, "{}");
 
+        // It's important to configure all the mocks before calling start() here,
+        // because otherwise there can be races between configuration and use of mocks
+        // which leads to a UnfinishedStubbingException.
+
         fileSettingsService.start();
         fileSettingsService.clusterChanged(new ClusterChangedEvent("test", clusterService.state(), ClusterState.EMPTY_STATE));
 


### PR DESCRIPTION
[Reportedly](https://piotrd.hashnode.dev/mockito-and-strange-unfinishedstubbing-problems), Mockito uses some shared global state that cannot tolerate races between setup and usage of mocks.

This PR moves some mock setup code up earlier before `FileSettingsService.start()` to make sure we don't try to use some mocks while still configuring others.

Fixes #120482.