### PR TITLE
Fix painless return type cast for list shortcut

### DIFF
--- a/docs/changelog/126724.yaml
+++ b/docs/changelog/126724.yaml
@@ -1,0 +1,5 @@
+pr: 126724
+summary: Fix painless return type cast for list shortcut
+area: Infra/Scripting
+type: bug
+issues: []

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultIRTreeToASMBytesPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultIRTreeToASMBytesPhase.java
@@ -1465,7 +1465,7 @@ public class DefaultIRTreeToASMBytesPhase implements IRTreeVisitor<WriteScope> {
         PainlessMethod getterPainlessMethod = irDotSubShortcutNode.getDecorationValue(IRDMethod.class);
         methodWriter.invokeMethodCall(getterPainlessMethod);
 
-        if (getterPainlessMethod.returnType().equals(getterPainlessMethod.javaMethod().getReturnType()) == false) {
+        if (getterPainlessMethod.returnType() != getterPainlessMethod.javaMethod().getReturnType()) {
             methodWriter.checkCast(MethodWriter.getType(getterPainlessMethod.returnType()));
         }
     }
@@ -1478,7 +1478,7 @@ public class DefaultIRTreeToASMBytesPhase implements IRTreeVisitor<WriteScope> {
         PainlessMethod getterPainlessMethod = irLoadListShortcutNode.getDecorationValue(IRDMethod.class);
         methodWriter.invokeMethodCall(getterPainlessMethod);
 
-        if (getterPainlessMethod.returnType() == getterPainlessMethod.javaMethod().getReturnType()) {
+        if (getterPainlessMethod.returnType() != getterPainlessMethod.javaMethod().getReturnType()) {
             methodWriter.checkCast(MethodWriter.getType(getterPainlessMethod.returnType()));
         }
     }


### PR DESCRIPTION
This fixes an issue where if a Painless getter method return type didn't match a Java getter method return type we add a cast. Currently this is adding an extraneous cast.

Closes: https://github.com/elastic/elasticsearch/issues/70682