### PR TITLE
[ML] Refactoring inference API non-streaming response validation error object check

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandler.java
@@ -76,13 +76,21 @@ public abstract class BaseResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result) {
+    public void validateResponse(
+        ThrottlerManager throttlerManager,
+        Logger logger,
+        Request request,
+        HttpResult result,
+        boolean checkForErrorObject
+    ) {
         checkForFailureStatusCode(request, result);
         checkForEmptyBody(throttlerManager, logger, request, result);
 
-        // When the response is streamed the status code could be 200 but the error object will be set
-        // so we need to check for that specifically
-        checkForErrorObject(request, result);
+        if (checkForErrorObject) {
+            // When the response is streamed the status code could be 200 but the error object will be set
+            // so we need to check for that specifically
+            checkForErrorObject(request, result);
+        }
     }
 
     protected abstract void checkForFailureStatusCode(Request request, HttpResult result);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ResponseHandler.java
@@ -29,9 +29,12 @@ public interface ResponseHandler {
      * @param logger the logger to use for logging
      * @param request the original request
      * @param result the response from the server
+     * @param checkForErrorObject if true, the validation function should check for the presence of an error object even if the status code
+     *                            indicates a success
      * @throws RetryException if the response is invalid
      */
-    void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result) throws RetryException;
+    void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result, boolean checkForErrorObject)
+        throws RetryException;
 
     /**
      * A method for parsing the response from the server.

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
@@ -121,7 +121,7 @@ public class RetryingHttpSender implements RequestSender {
                         } else {
                             r.readFullResponse(l.delegateFailureAndWrap((ll, httpResult) -> {
                                 try {
-                                    responseHandler.validateResponse(throttlerManager, logger, request, httpResult);
+                                    responseHandler.validateResponse(throttlerManager, logger, request, httpResult, true);
                                     InferenceServiceResults inferenceResults = responseHandler.parseResult(request, httpResult);
                                     ll.onResponse(inferenceResults);
                                 } catch (Exception e) {
@@ -134,7 +134,7 @@ public class RetryingHttpSender implements RequestSender {
                 } else {
                     httpClient.send(request.createHttpRequest(), context, retryableListener.delegateFailure((l, r) -> {
                         try {
-                            responseHandler.validateResponse(throttlerManager, logger, request, r);
+                            responseHandler.validateResponse(throttlerManager, logger, request, r, false);
                             InferenceServiceResults inferenceResults = responseHandler.parseResult(request, r);
 
                             l.onResponse(inferenceResults);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/response/AmazonBedrockResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/response/AmazonBedrockResponseHandler.java
@@ -22,8 +22,13 @@ public abstract class AmazonBedrockResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public final void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result)
-        throws RetryException {
+    public final void validateResponse(
+        ThrottlerManager throttlerManager,
+        Logger logger,
+        Request request,
+        HttpResult result,
+        boolean checkForErrorObject
+    ) throws RetryException {
         // do nothing as the AWS SDK will take care of validation for us
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureMistralOpenAiExternalResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureMistralOpenAiExternalResponseHandler.java
@@ -63,8 +63,13 @@ public class AzureMistralOpenAiExternalResponseHandler extends BaseResponseHandl
     }
 
     @Override
-    public void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result)
-        throws RetryException {
+    public void validateResponse(
+        ThrottlerManager throttlerManager,
+        Logger logger,
+        Request request,
+        HttpResult result,
+        boolean checkForErrorObject
+    ) throws RetryException {
         checkForFailureStatusCode(request, result);
         checkForEmptyBody(throttlerManager, logger, request, result);
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/AlwaysRetryingResponseHandler.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/AlwaysRetryingResponseHandler.java
@@ -35,8 +35,14 @@ public class AlwaysRetryingResponseHandler implements ResponseHandler {
         this.parseFunction = Objects.requireNonNull(parseFunction);
     }
 
-    public void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result)
-        throws RetryException {
+    @Override
+    public void validateResponse(
+        ThrottlerManager throttlerManager,
+        Logger logger,
+        Request request,
+        HttpResult result,
+        boolean checkForErrorObject
+    ) throws RetryException {
         try {
             checkForFailureStatusCode(throttlerManager, logger, request, result);
             checkForEmptyBody(throttlerManager, logger, request, result);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandlerTests.java
@@ -59,7 +59,8 @@ public class BaseResponseHandlerTests extends ESTestCase {
             mock(ThrottlerManager.class),
             mock(Logger.class),
             request,
-            new HttpResult(response, responseJson.getBytes(StandardCharsets.UTF_8))
+            new HttpResult(response, responseJson.getBytes(StandardCharsets.UTF_8)),
+            true
         );
     }
 
@@ -85,7 +86,8 @@ public class BaseResponseHandlerTests extends ESTestCase {
                 mock(ThrottlerManager.class),
                 mock(Logger.class),
                 request,
-                new HttpResult(response, responseJson.getBytes(StandardCharsets.UTF_8))
+                new HttpResult(response, responseJson.getBytes(StandardCharsets.UTF_8)),
+                true
             )
         );
 
@@ -119,7 +121,8 @@ public class BaseResponseHandlerTests extends ESTestCase {
                 mock(ThrottlerManager.class),
                 mock(Logger.class),
                 request,
-                new HttpResult(response, responseJson.getBytes(StandardCharsets.UTF_8))
+                new HttpResult(response, responseJson.getBytes(StandardCharsets.UTF_8)),
+                true
             )
         );
 
@@ -127,6 +130,32 @@ public class BaseResponseHandlerTests extends ESTestCase {
         assertThat(
             exception.getCause().getMessage(),
             is("Received an error response for request from inference entity id [abc] status [200]. Error message: [a message]")
+        );
+    }
+
+    public void testValidateResponse_DoesNot_ThrowErrorWhenWellFormedErrorObjectExists_WhenCheckForErrorIsFalse() {
+        var handler = getBaseResponseHandler();
+
+        String responseJson = """
+            {
+              "error": {
+                "type": "not_found_error",
+                "message": "a message"
+              }
+            }
+            """;
+
+        var response = mock200Response();
+
+        var request = mock(Request.class);
+        when(request.getInferenceEntityId()).thenReturn("abc");
+
+        handler.validateResponse(
+            mock(ThrottlerManager.class),
+            mock(Logger.class),
+            request,
+            new HttpResult(response, responseJson.getBytes(StandardCharsets.UTF_8)),
+            false
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSenderTests.java
@@ -76,7 +76,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        doThrow(new RetryException(true, "failed")).doNothing().when(handler).validateResponse(any(), any(), any(), any());
+        doThrow(new RetryException(true, "failed")).doNothing().when(handler).validateResponse(any(), any(), any(), any(), any());
         // Mockito.thenReturn() does not compile when returning a
         // bounded wild card list, thenAnswer must be used instead.
         when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
@@ -351,7 +351,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         var handler = mock(ResponseHandler.class);
         doThrow(new RetryException(true, "failed")).doThrow(new IllegalStateException("failed again"))
             .when(handler)
-            .validateResponse(any(), any(), any(), any());
+            .validateResponse(any(), any(), any(), any(), any());
         when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(sender);
@@ -388,7 +388,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         var handler = mock(ResponseHandler.class);
         doThrow(new RetryException(true, "failed")).doThrow(new RetryException(false, "failed again"))
             .when(handler)
-            .validateResponse(any(), any(), any(), any());
+            .validateResponse(any(), any(), any(), any(), any());
         when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(httpClient);
@@ -701,8 +701,13 @@ public class RetryingHttpSenderTests extends ESTestCase {
         // testing failed requests
         return new ResponseHandler() {
             @Override
-            public void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result)
-                throws RetryException {
+            public void validateResponse(
+                ThrottlerManager throttlerManager,
+                Logger logger,
+                Request request,
+                HttpResult result,
+                boolean checkForErrorObject
+            ) throws RetryException {
                 throw new RetryException(true, new IOException("response handler validate failed as designed"));
             }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSenderTests.java
@@ -42,6 +42,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -76,7 +77,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        doThrow(new RetryException(true, "failed")).doNothing().when(handler).validateResponse(any(), any(), any(), any(), any());
+        doThrow(new RetryException(true, "failed")).doNothing().when(handler).validateResponse(any(), any(), any(), any(), anyBoolean());
         // Mockito.thenReturn() does not compile when returning a
         // bounded wild card list, thenAnswer must be used instead.
         when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
@@ -351,7 +352,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         var handler = mock(ResponseHandler.class);
         doThrow(new RetryException(true, "failed")).doThrow(new IllegalStateException("failed again"))
             .when(handler)
-            .validateResponse(any(), any(), any(), any(), any());
+            .validateResponse(any(), any(), any(), any(), anyBoolean());
         when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(sender);
@@ -388,7 +389,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         var handler = mock(ResponseHandler.class);
         doThrow(new RetryException(true, "failed")).doThrow(new RetryException(false, "failed again"))
             .when(handler)
-            .validateResponse(any(), any(), any(), any(), any());
+            .validateResponse(any(), any(), any(), any(), anyBoolean());
         when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(httpClient);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedChatCompletionResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedChatCompletionResponseHandlerTests.java
@@ -96,7 +96,8 @@ public class OpenAiUnifiedChatCompletionResponseHandlerTests extends ESTestCase 
                 mock(),
                 mock(),
                 mockRequest(),
-                new HttpResult(mock500Response(), responseJson.getBytes(StandardCharsets.UTF_8))
+                new HttpResult(mock500Response(), responseJson.getBytes(StandardCharsets.UTF_8)),
+                true
             )
         );
     }


### PR DESCRIPTION
This PR refactors the response validation logic to only check for the presence of an error object in a streaming request logic. This avoids having to perform parse attempt for an error object on each request in the non-stream case where we expect most requests to succeed.

The error object is still parsed when the response handler encounters a non-200 status code.