### PR TITLE
[8.17] ESQL: Known issue enrich missing field (#126701)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.18.0>>
 * <<release-notes-8.17.4>>
 * <<release-notes-8.17.3>>
 * <<release-notes-8.17.2>>
@@ -85,6 +86,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/8.18.0.asciidoc[]
 include::release-notes/8.17.4.asciidoc[]
 include::release-notes/8.17.3.asciidoc[]
 include::release-notes/8.17.2.asciidoc[]

--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,7 +6,6 @@
 
 This section summarizes the changes in each release.
 
-* <<release-notes-8.18.0>>
 * <<release-notes-8.17.4>>
 * <<release-notes-8.17.3>>
 * <<release-notes-8.17.2>>
@@ -86,7 +85,6 @@ This section summarizes the changes in each release.
 
 --
 
-include::release-notes/8.18.0.asciidoc[]
 include::release-notes/8.17.4.asciidoc[]
 include::release-notes/8.17.3.asciidoc[]
 include::release-notes/8.17.2.asciidoc[]

--- a/docs/reference/release-notes/8.16.0.asciidoc
+++ b/docs/reference/release-notes/8.16.0.asciidoc
@@ -510,4 +510,10 @@ Snapshot/Restore::
 * Upgrade Azure SDK {es-pull}111225[#111225]
 * Upgrade `repository-azure` dependencies {es-pull}112277[#112277]
 
+[discrete]
+[[known-issues-8.16.0]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.1.asciidoc
+++ b/docs/reference/release-notes/8.16.1.asciidoc
@@ -47,4 +47,10 @@ Snapshot/Restore::
 * Improve message about insecure S3 settings {es-pull}116915[#116915]
 * Split searchable snapshot into multiple repo operations {es-pull}116918[#116918]
 
+[discrete]
+[[known-issues-8.16.1]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.2.asciidoc
+++ b/docs/reference/release-notes/8.16.2.asciidoc
@@ -61,6 +61,14 @@ Inference::
 * [8.16] Update sparse text embeddings API route for Inference Service {es-pull}118367[#118367]
 
 Packaging::
-* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi] 
-image to provide secure containers to our self-managed customers, help with compliance regulations, 
+* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi]
+image to provide secure containers to our self-managed customers, help with compliance regulations,
 and improve our supply chain security posture. {es-pull}118684[#118684]
+
+[discrete]
+[[known-issues-8.16.2]]
+=== Known issues
+
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.3.asciidoc
+++ b/docs/reference/release-notes/8.16.3.asciidoc
@@ -42,8 +42,8 @@ Authorization::
 * Improve handling of nested fields in index reader wrappers {es-pull}118757[#118757]
 
 Packaging::
-* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi] 
-image to provide secure containers to our self-managed customers, help with compliance regulations, 
+* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi]
+image to provide secure containers to our self-managed customers, help with compliance regulations,
 and improve our supply chain security posture. {es-pull}118684[#118684]
 
 [[upgrade-8.16.3]]
@@ -53,4 +53,10 @@ and improve our supply chain security posture. {es-pull}118684[#118684]
 Security::
 * Upgrade Bouncy Castle FIPS dependencies {es-pull}112989[#112989]
 
+[discrete]
+[[known-issues-8.16.3]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.4.asciidoc
+++ b/docs/reference/release-notes/8.16.4.asciidoc
@@ -39,4 +39,10 @@ Snapshot/Restore::
 Ingest Node::
 * Improve memory aspects of enrich cache {es-pull}120256[#120256] (issues: {es-issue}96050[#96050], {es-issue}120021[#120021])
 
+[discrete]
+[[known-issues-8.16.4]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.5.asciidoc
+++ b/docs/reference/release-notes/8.16.5.asciidoc
@@ -1,14 +1,12 @@
-[[release-notes-8.17.3]]
-== {es} version 8.17.3
+[[release-notes-8.16.5]]
+== {es} version 8.16.5
 
-Also see <<breaking-changes-8.17,Breaking changes in 8.17>>.
 
-[[bug-8.17.3]]
+Also see <<breaking-changes-8.16,Breaking changes in 8.16>>.
+
+[[bug-8.16.5]]
 [float]
 === Bug fixes
-
-Aggregations::
-* Disable concurrency when `top_hits` sorts on anything but `_score` {es-pull}123610[#123610]
 
 Allocation::
 * Deduplicate allocation stats calls {es-pull}123246[#123246]
@@ -27,11 +25,7 @@ EQL::
 
 ES|QL::
 * Fix ENRICH validation for use of wildcards {es-pull}121911[#121911]
-* Fix listener leak in exchange service {es-pull}122417[#122417] (issue: {es-issue}122271[#122271])
 * Speed up VALUES for many buckets {es-pull}123073[#123073]
-
-Infra/Node Lifecycle::
-* Block running ES 8.17 with JDK 24+ {es-pull}122517[#122517]
 
 Ingest::
 * Fix `ArrayIndexOutOfBoundsException` in `ShardBulkInferenceActionFilter` {es-pull}122538[#122538]
@@ -41,20 +35,11 @@ Ingest Node::
 * Deduplicate `IngestStats` and `IngestStats.Stats` identity records when deserializing {es-pull}122496[#122496]
 * Fix redact processor arraycopy bug {es-pull}122640[#122640]
 * Register `IngestGeoIpMetadata` as a NamedXContent {es-pull}123079[#123079]
-* Use ordered maps for `PipelineConfiguration` xcontent deserialization {es-pull}123403[#123403]
-
-Logs::
-* Fix issues that prevents using search only snapshots for indices that use index sorting. This is includes Logsdb and time series indices. {es-pull}122199[#122199]
-* Use min node version to guard injecting settings in logs provider {es-pull}123005[#123005] (issue: {es-issue}122950[#122950])
 
 Mapping::
-* Fix synthetic source bug that would mishandle nested `dense_vector` fields {es-pull}122425[#122425]
 * fix stale data in synthetic source for string stored field {es-pull}123105[#123105] (issue: {es-issue}123110[#123110])
 
-Stats::
-* Fixing serialization of `ScriptStats` `cache_evictions_history` {es-pull}123384[#123384]
-
-[[upgrade-8.17.3]]
+[[upgrade-8.16.5]]
 [float]
 === Upgrades
 
@@ -62,7 +47,7 @@ Authentication::
 * Bump json-smart and oauth2-oidc-sdk {es-pull}122737[#122737]
 
 [discrete]
-[[known-issues-8.17.3]]
+[[known-issues-8.16.5]]
 === Known issues
 
 {esql}::

--- a/docs/reference/release-notes/8.16.6.asciidoc
+++ b/docs/reference/release-notes/8.16.6.asciidoc
@@ -1,19 +1,12 @@
-[[release-notes-8.17.4]]
-== {es} version 8.17.4
+[[release-notes-8.16.6]]
+== {es} version 8.16.6
 
-Also see <<breaking-changes-8.17,Breaking changes in 8.17>>.
 
-[[bug-8.17.4]]
+Also see <<breaking-changes-8.16,Breaking changes in 8.16>>.
+
+[[bug-8.16.6]]
 [float]
 === Bug fixes
-
-ES|QL::
-* Catch parsing exception {es-pull}124958[#124958] (issue: {es-issue}119025[#119025])
-* Fix early termination in `LuceneSourceOperator` {es-pull}123197[#123197]
-
-Indices APIs::
-* Avoid hoarding cluster state references during rollover {es-pull}124107[#124107] (issue: {es-issue}123893[#123893])
-* [8.17] Avoid hoarding cluster state references during rollover {es-pull}124267[#124267]
 
 Infra/Core::
 * Prevent rare starvation bug when using scaling `EsThreadPoolExecutor` with empty core pool size. {es-pull}124732[#124732] (issue: {es-issue}124667[#124667])
@@ -23,19 +16,18 @@ Machine Learning::
 
 Search::
 * Do not let `ShardBulkInferenceActionFilter` unwrap / rewrap ESExceptions {es-pull}123890[#123890]
-* Don't generate stacktrace in `TaskCancelledException` {es-pull}125002[#125002]
-* Fix concurrency issue in `ScriptSortBuilder` {es-pull}123757[#123757]
 * Revert fail-fast disconnect strategy for `_resolve/cluster` {es-pull}124241[#124241]
 
-[[upgrade-8.17.4]]
+[[upgrade-8.16.6]]
 [float]
 === Upgrades
 
 Security::
 * Bump nimbus-jose-jwt to 10.0.2 {es-pull}124544[#124544]
 
+
 [discrete]
-[[known-issues-8.17.4]]
+[[known-issues-8.16.6]]
 === Known issues
 
 {esql}::

--- a/docs/reference/release-notes/8.17.0.asciidoc
+++ b/docs/reference/release-notes/8.17.0.asciidoc
@@ -12,14 +12,14 @@ Also see <<breaking-changes-8.17,Breaking changes in 8.17>>.
 [float]
 === License changes
 
-[float] 
+[float]
 ==== Change to synthetic `_source` licensing
 
-Starting with this release, the <<synthetic-source,synthetic `_source`>> feature is available exclusively with the Enterprise subscription. Synthetic `_source` is used in logs data streams (`logsdb` index mode), time series data streams (TSDS, using `time_series` index mode), application performance monitoring (APM), and Universal Profiling. 
+Starting with this release, the <<synthetic-source,synthetic `_source`>> feature is available exclusively with the Enterprise subscription. Synthetic `_source` is used in logs data streams (`logsdb` index mode), time series data streams (TSDS, using `time_series` index mode), application performance monitoring (APM), and Universal Profiling.
 
-If you are using these capabilities and are not on an Enterprise license, the change will result in increased storage requirements for new data, as the synthetic `_source` setting will be ignored. Existing indices that used synthetic `_source` will remain seamlessly accessible. 
+If you are using these capabilities and are not on an Enterprise license, the change will result in increased storage requirements for new data, as the synthetic `_source` setting will be ignored. Existing indices that used synthetic `_source` will remain seamlessly accessible.
 
-Refer to the subscription page for https://www.elastic.co/subscriptions/cloud[Elastic Cloud] and {subscriptions}[Elastic Stack/self-managed] for the breakdown of available features and their associated subscription tiers. For further details and subscription options, contact your Elastic sales representative or https://www.elastic.co/contact[contact us]. 
+Refer to the subscription page for https://www.elastic.co/subscriptions/cloud[Elastic Cloud] and {subscriptions}[Elastic Stack/self-managed] for the breakdown of available features and their associated subscription tiers. For further details and subscription options, contact your Elastic sales representative or https://www.elastic.co/contact[contact us].
 
 [[bug-8.17.0]]
 [float]
@@ -206,4 +206,10 @@ Search::
 Security::
 * Upgrade Bouncy Castle FIPS dependencies {es-pull}112989[#112989]
 
+[discrete]
+[[known-issues-8.17.0]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.17.1.asciidoc
+++ b/docs/reference/release-notes/8.17.1.asciidoc
@@ -74,4 +74,10 @@ Monitoring::
 Logs::
 * Make logsdb general available {es-pull}118559[#118559]
 
+[discrete]
+[[known-issues-8.17.1]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.17.2.asciidoc
+++ b/docs/reference/release-notes/8.17.2.asciidoc
@@ -53,3 +53,4 @@ Ingest Node::
 === Known issues
 
 * `VALUES` aggregate function can run for a long, long time when collecting many, many groups. Hundreds of thousands of groups can run on one thread for many minutes and millions of groups run for days. It is O(n^2^) with the number of groups. These will not respond to the tasks cancellation API the whole time. Fixed by {es-pull}123073[#123073] and available in 8.16.5, 8.17.3, 8.18.0, and all releases after that.
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.17`:
 - [ESQL: Known issue enrich missing field (#126701)](https://github.com/elastic/elasticsearch/pull/126701)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)