### PR TITLE
[8.16] ESQL: Known issue enrich missing field (#126701)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,13 @@
 
 This section summarizes the changes in each release.
 
+
+* <<release-notes-8.18.0>>
+* <<release-notes-8.17.4>>
+* <<release-notes-8.17.3>>
+* <<release-notes-8.17.2>>
+* <<release-notes-8.17.1>>
+* <<release-notes-8.17.0>>
 * <<release-notes-8.16.6>>
 * <<release-notes-8.16.5>>
 * <<release-notes-8.16.4>>
@@ -82,6 +89,14 @@ This section summarizes the changes in each release.
 
 --
 
+
+include::release-notes/8.19.0.asciidoc[]
+include::release-notes/8.18.0.asciidoc[]
+include::release-notes/8.17.4.asciidoc[]
+include::release-notes/8.17.3.asciidoc[]
+include::release-notes/8.17.2.asciidoc[]
+include::release-notes/8.17.1.asciidoc[]
+include::release-notes/8.17.0.asciidoc[]
 include::release-notes/8.16.6.asciidoc[]
 include::release-notes/8.16.5.asciidoc[]
 include::release-notes/8.16.4.asciidoc[]

--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -7,12 +7,6 @@
 This section summarizes the changes in each release.
 
 
-* <<release-notes-8.18.0>>
-* <<release-notes-8.17.4>>
-* <<release-notes-8.17.3>>
-* <<release-notes-8.17.2>>
-* <<release-notes-8.17.1>>
-* <<release-notes-8.17.0>>
 * <<release-notes-8.16.6>>
 * <<release-notes-8.16.5>>
 * <<release-notes-8.16.4>>
@@ -89,14 +83,6 @@ This section summarizes the changes in each release.
 
 --
 
-
-include::release-notes/8.19.0.asciidoc[]
-include::release-notes/8.18.0.asciidoc[]
-include::release-notes/8.17.4.asciidoc[]
-include::release-notes/8.17.3.asciidoc[]
-include::release-notes/8.17.2.asciidoc[]
-include::release-notes/8.17.1.asciidoc[]
-include::release-notes/8.17.0.asciidoc[]
 include::release-notes/8.16.6.asciidoc[]
 include::release-notes/8.16.5.asciidoc[]
 include::release-notes/8.16.4.asciidoc[]

--- a/docs/reference/release-notes/8.16.0.asciidoc
+++ b/docs/reference/release-notes/8.16.0.asciidoc
@@ -510,4 +510,10 @@ Snapshot/Restore::
 * Upgrade Azure SDK {es-pull}111225[#111225]
 * Upgrade `repository-azure` dependencies {es-pull}112277[#112277]
 
+[discrete]
+[[known-issues-8.16.0]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.1.asciidoc
+++ b/docs/reference/release-notes/8.16.1.asciidoc
@@ -47,4 +47,10 @@ Snapshot/Restore::
 * Improve message about insecure S3 settings {es-pull}116915[#116915]
 * Split searchable snapshot into multiple repo operations {es-pull}116918[#116918]
 
+[discrete]
+[[known-issues-8.16.1]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.2.asciidoc
+++ b/docs/reference/release-notes/8.16.2.asciidoc
@@ -61,8 +61,15 @@ Inference::
 * [8.16] Update sparse text embeddings API route for Inference Service {es-pull}118367[#118367]
 
 Packaging::
-* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi] 
-image to provide secure containers to our self-managed customers, help with compliance regulations, 
+
+* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi]
+image to provide secure containers to our self-managed customers, help with compliance regulations,
 and improve our supply chain security posture. {es-pull}118684[#118684]
 
+[discrete]
+[[known-issues-8.16.2]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.3.asciidoc
+++ b/docs/reference/release-notes/8.16.3.asciidoc
@@ -42,8 +42,8 @@ Authorization::
 * Improve handling of nested fields in index reader wrappers {es-pull}118757[#118757]
 
 Packaging::
-* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi] 
-image to provide secure containers to our self-managed customers, help with compliance regulations, 
+* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi]
+image to provide secure containers to our self-managed customers, help with compliance regulations,
 and improve our supply chain security posture. {es-pull}118684[#118684]
 
 [[upgrade-8.16.3]]
@@ -53,4 +53,10 @@ and improve our supply chain security posture. {es-pull}118684[#118684]
 Security::
 * Upgrade Bouncy Castle FIPS dependencies {es-pull}112989[#112989]
 
+[discrete]
+[[known-issues-8.16.3]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.4.asciidoc
+++ b/docs/reference/release-notes/8.16.4.asciidoc
@@ -46,3 +46,4 @@ Ingest Node::
 ES|QL::
 
 * The `VALUES` aggregate function can run for an extremely long time when collecting many groups. Processing hundreds of thousands of groups may take several minutes on a single thread, while processing millions of groups can take days. The function has O(n^2) complexity with respect to the number of groups. During execution, these operations will not respond to the tasks cancellation API. This issue has been fixed by {es-pull}#123073[#123073] and the fix is available in versions 8.16.5, 8.17.3, 8.18.0, and all releases after that.
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.5.asciidoc
+++ b/docs/reference/release-notes/8.16.5.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.16.5]]
 == {es} version 8.16.5
 
-coming[8.16.5]
-
 Also see <<breaking-changes-8.16,Breaking changes in 8.16>>.
 
 [[bug-8.16.5]]
@@ -47,4 +45,10 @@ Mapping::
 Authentication::
 * Bump json-smart and oauth2-oidc-sdk {es-pull}122737[#122737]
 
+[discrete]
+[[known-issues-8.16.5]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.6.asciidoc
+++ b/docs/reference/release-notes/8.16.6.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.16.6]]
 == {es} version 8.16.6
 
-coming[8.16.6]
-
 Also see <<breaking-changes-8.16,Breaking changes in 8.16>>.
 
 [[bug-8.16.6]]
@@ -26,4 +24,10 @@ Search::
 Security::
 * Bump nimbus-jose-jwt to 10.0.2 {es-pull}124544[#124544]
 
+[discrete]
+[[known-issues-8.16.6]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.16`:
 - [ESQL: Known issue enrich missing field (#126701)](https://github.com/elastic/elasticsearch/pull/126701)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)