### PR TITLE
[Backport][8.18] ESQL: Known issue enrich missing field (#126701)

### DIFF
--- a/docs/reference/release-notes/8.16.0.asciidoc
+++ b/docs/reference/release-notes/8.16.0.asciidoc
@@ -510,4 +510,10 @@ Snapshot/Restore::
 * Upgrade Azure SDK {es-pull}111225[#111225]
 * Upgrade `repository-azure` dependencies {es-pull}112277[#112277]
 
+[discrete]
+[[known-issues-8.16.0]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.1.asciidoc
+++ b/docs/reference/release-notes/8.16.1.asciidoc
@@ -47,4 +47,10 @@ Snapshot/Restore::
 * Improve message about insecure S3 settings {es-pull}116915[#116915]
 * Split searchable snapshot into multiple repo operations {es-pull}116918[#116918]
 
+[discrete]
+[[known-issues-8.16.1]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.2.asciidoc
+++ b/docs/reference/release-notes/8.16.2.asciidoc
@@ -61,6 +61,14 @@ Inference::
 * [8.16] Update sparse text embeddings API route for Inference Service {es-pull}118367[#118367]
 
 Packaging::
-* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi] 
-image to provide secure containers to our self-managed customers, help with compliance regulations, 
+* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi]
+image to provide secure containers to our self-managed customers, help with compliance regulations,
 and improve our supply chain security posture. {es-pull}118684[#118684]
+
+[discrete]
+[[known-issues-8.16.2]]
+=== Known issues
+
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.3.asciidoc
+++ b/docs/reference/release-notes/8.16.3.asciidoc
@@ -42,8 +42,8 @@ Authorization::
 * Improve handling of nested fields in index reader wrappers {es-pull}118757[#118757]
 
 Packaging::
-* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi] 
-image to provide secure containers to our self-managed customers, help with compliance regulations, 
+* In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi]
+image to provide secure containers to our self-managed customers, help with compliance regulations,
 and improve our supply chain security posture. {es-pull}118684[#118684]
 
 [[upgrade-8.16.3]]
@@ -53,4 +53,10 @@ and improve our supply chain security posture. {es-pull}118684[#118684]
 Security::
 * Upgrade Bouncy Castle FIPS dependencies {es-pull}112989[#112989]
 
+[discrete]
+[[known-issues-8.16.3]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.4.asciidoc
+++ b/docs/reference/release-notes/8.16.4.asciidoc
@@ -39,4 +39,10 @@ Snapshot/Restore::
 Ingest Node::
 * Improve memory aspects of enrich cache {es-pull}120256[#120256] (issues: {es-issue}96050[#96050], {es-issue}120021[#120021])
 
+[discrete]
+[[known-issues-8.16.4]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.16.5.asciidoc
+++ b/docs/reference/release-notes/8.16.5.asciidoc
@@ -1,6 +1,10 @@
 [[release-notes-8.16.5]]
 == {es} version 8.16.5
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))
 Also see <<breaking-changes-8.16,Breaking changes in 8.16>>.
 
 [[bug-8.16.5]]
@@ -45,3 +49,13 @@ Mapping::
 Authentication::
 * Bump json-smart and oauth2-oidc-sdk {es-pull}122737[#122737]
 
+<<<<<<< HEAD
+=======
+[discrete]
+[[known-issues-8.16.5]]
+=== Known issues
+
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].
+>>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))

--- a/docs/reference/release-notes/8.16.5.asciidoc
+++ b/docs/reference/release-notes/8.16.5.asciidoc
@@ -1,10 +1,6 @@
 [[release-notes-8.16.5]]
 == {es} version 8.16.5
 
-<<<<<<< HEAD
-=======
-
->>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))
 Also see <<breaking-changes-8.16,Breaking changes in 8.16>>.
 
 [[bug-8.16.5]]
@@ -49,8 +45,6 @@ Mapping::
 Authentication::
 * Bump json-smart and oauth2-oidc-sdk {es-pull}122737[#122737]
 
-<<<<<<< HEAD
-=======
 [discrete]
 [[known-issues-8.16.5]]
 === Known issues
@@ -58,4 +52,3 @@ Authentication::
 {esql}::
 
 * Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].
->>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))

--- a/docs/reference/release-notes/8.16.6.asciidoc
+++ b/docs/reference/release-notes/8.16.6.asciidoc
@@ -1,6 +1,10 @@
 [[release-notes-8.16.6]]
 == {es} version 8.16.6
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))
 Also see <<breaking-changes-8.16,Breaking changes in 8.16>>.
 
 [[bug-8.16.6]]
@@ -24,3 +28,14 @@ Search::
 Security::
 * Bump nimbus-jose-jwt to 10.0.2 {es-pull}124544[#124544]
 
+<<<<<<< HEAD
+=======
+
+[discrete]
+[[known-issues-8.16.6]]
+=== Known issues
+
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].
+>>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))

--- a/docs/reference/release-notes/8.16.6.asciidoc
+++ b/docs/reference/release-notes/8.16.6.asciidoc
@@ -1,10 +1,6 @@
 [[release-notes-8.16.6]]
 == {es} version 8.16.6
 
-<<<<<<< HEAD
-=======
-
->>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))
 Also see <<breaking-changes-8.16,Breaking changes in 8.16>>.
 
 [[bug-8.16.6]]
@@ -28,8 +24,6 @@ Search::
 Security::
 * Bump nimbus-jose-jwt to 10.0.2 {es-pull}124544[#124544]
 
-<<<<<<< HEAD
-=======
 
 [discrete]
 [[known-issues-8.16.6]]
@@ -38,4 +32,3 @@ Security::
 {esql}::
 
 * Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].
->>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))

--- a/docs/reference/release-notes/8.17.0.asciidoc
+++ b/docs/reference/release-notes/8.17.0.asciidoc
@@ -12,14 +12,14 @@ Also see <<breaking-changes-8.17,Breaking changes in 8.17>>.
 [float]
 === License changes
 
-[float] 
+[float]
 ==== Change to synthetic `_source` licensing
 
-Starting with this release, the <<synthetic-source,synthetic `_source`>> feature is available exclusively with the Enterprise subscription. Synthetic `_source` is used in logs data streams (`logsdb` index mode), time series data streams (TSDS, using `time_series` index mode), application performance monitoring (APM), and Universal Profiling. 
+Starting with this release, the <<synthetic-source,synthetic `_source`>> feature is available exclusively with the Enterprise subscription. Synthetic `_source` is used in logs data streams (`logsdb` index mode), time series data streams (TSDS, using `time_series` index mode), application performance monitoring (APM), and Universal Profiling.
 
-If you are using these capabilities and are not on an Enterprise license, the change will result in increased storage requirements for new data, as the synthetic `_source` setting will be ignored. Existing indices that used synthetic `_source` will remain seamlessly accessible. 
+If you are using these capabilities and are not on an Enterprise license, the change will result in increased storage requirements for new data, as the synthetic `_source` setting will be ignored. Existing indices that used synthetic `_source` will remain seamlessly accessible.
 
-Refer to the subscription page for https://www.elastic.co/subscriptions/cloud[Elastic Cloud] and {subscriptions}[Elastic Stack/self-managed] for the breakdown of available features and their associated subscription tiers. For further details and subscription options, contact your Elastic sales representative or https://www.elastic.co/contact[contact us]. 
+Refer to the subscription page for https://www.elastic.co/subscriptions/cloud[Elastic Cloud] and {subscriptions}[Elastic Stack/self-managed] for the breakdown of available features and their associated subscription tiers. For further details and subscription options, contact your Elastic sales representative or https://www.elastic.co/contact[contact us].
 
 [[bug-8.17.0]]
 [float]
@@ -206,4 +206,10 @@ Search::
 Security::
 * Upgrade Bouncy Castle FIPS dependencies {es-pull}112989[#112989]
 
+[discrete]
+[[known-issues-8.17.0]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.17.1.asciidoc
+++ b/docs/reference/release-notes/8.17.1.asciidoc
@@ -74,4 +74,10 @@ Monitoring::
 Logs::
 * Make logsdb general available {es-pull}118559[#118559]
 
+[discrete]
+[[known-issues-8.17.1]]
+=== Known issues
 
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.17.2.asciidoc
+++ b/docs/reference/release-notes/8.17.2.asciidoc
@@ -48,4 +48,5 @@ Snapshot/Restore::
 Ingest Node::
 * Improve memory aspects of enrich cache {es-pull}120256[#120256] (issues: {es-issue}96050[#96050], {es-issue}120021[#120021])
 
-
+* `VALUES` aggregate function can run for a long, long time when collecting many, many groups. Hundreds of thousands of groups can run on one thread for many minutes and millions of groups run for days. It is O(n^2^) with the number of groups. These will not respond to the tasks cancellation API the whole time. Fixed by {es-pull}123073[#123073] and available in 8.16.5, 8.17.3, 8.18.0, and all releases after that.
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].

--- a/docs/reference/release-notes/8.17.3.asciidoc
+++ b/docs/reference/release-notes/8.17.3.asciidoc
@@ -1,6 +1,10 @@
 [[release-notes-8.17.3]]
 == {es} version 8.17.3
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))
 Also see <<breaking-changes-8.17,Breaking changes in 8.17>>.
 
 [[bug-8.17.3]]
@@ -61,3 +65,13 @@ Stats::
 Authentication::
 * Bump json-smart and oauth2-oidc-sdk {es-pull}122737[#122737]
 
+<<<<<<< HEAD
+=======
+[discrete]
+[[known-issues-8.17.3]]
+=== Known issues
+
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].
+>>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))

--- a/docs/reference/release-notes/8.17.3.asciidoc
+++ b/docs/reference/release-notes/8.17.3.asciidoc
@@ -1,10 +1,6 @@
 [[release-notes-8.17.3]]
 == {es} version 8.17.3
 
-<<<<<<< HEAD
-=======
-
->>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))
 Also see <<breaking-changes-8.17,Breaking changes in 8.17>>.
 
 [[bug-8.17.3]]
@@ -65,8 +61,6 @@ Stats::
 Authentication::
 * Bump json-smart and oauth2-oidc-sdk {es-pull}122737[#122737]
 
-<<<<<<< HEAD
-=======
 [discrete]
 [[known-issues-8.17.3]]
 === Known issues
@@ -74,4 +68,3 @@ Authentication::
 {esql}::
 
 * Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].
->>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))

--- a/docs/reference/release-notes/8.17.4.asciidoc
+++ b/docs/reference/release-notes/8.17.4.asciidoc
@@ -34,3 +34,13 @@ Search::
 Security::
 * Bump nimbus-jose-jwt to 10.0.2 {es-pull}124544[#124544]
 
+<<<<<<< HEAD
+=======
+[discrete]
+[[known-issues-8.17.4]]
+=== Known issues
+
+{esql}::
+
+* Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].
+>>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))

--- a/docs/reference/release-notes/8.17.4.asciidoc
+++ b/docs/reference/release-notes/8.17.4.asciidoc
@@ -34,8 +34,7 @@ Search::
 Security::
 * Bump nimbus-jose-jwt to 10.0.2 {es-pull}124544[#124544]
 
-<<<<<<< HEAD
-=======
+
 [discrete]
 [[known-issues-8.17.4]]
 === Known issues
@@ -43,4 +42,3 @@ Security::
 {esql}::
 
 * Some valid queries using an `ENRICH` command can fail when a match field is used that is absent from some indices or shards, either with a 500 status code due to `NullPointerException` or `ClassCastException` or with a 400 status code and `IllegalArgumentException`. This is fixed in {es-pull}126187[#126187].
->>>>>>> f7a52054b29 (ESQL: Known issue enrich missing field (#126701))


### PR DESCRIPTION
# Backport

This will backport the following commits from 8.x to 8.17:

https://github.com/elastic/elasticsearch/pull/126701

### Questions ?

Please refer to the [Backport tool documentation](https://github.com/sqren/backport)