### PR TITLE
[DOCS]: Remove redirects.yml

### DIFF
--- a/docs/redirects.yml
+++ b/docs/redirects.yml
@@ -1,3 +1,0 @@
-redirects:
-  'reference/query-languages/esql/esql-functions-operators.md': '!reference/query-languages/esql/functions-operators/aggregation-functions.md'
-  'reference/query-languages/esql/esql-commands.md': '!reference/query-languages/esql/commands/processing-commands.md'


### PR DESCRIPTION
After fixing all the links pointg to the elasticsearch repo in https://github.com/elastic/docs-content/pull/1095, https://github.com/elastic/elasticsearch-py/pull/2904 and https://github.com/elastic/docs-content/pull/1118 this PR removes the redirects.yml file.

Based on: https://github.com/elastic/docs-content/issues/1072