### PR TITLE
ESQL: Remove capabilities we shouldn't have added

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -792,36 +792,6 @@ public class EsqlCapabilities {
         FIX_DOUBLY_RELEASED_NULL_BLOCKS_IN_VALUESOURCEREADER,
 
         /**
-         * Listing queries and getting information on a specific query.
-         */
-        QUERY_MONITORING,
-
-        /**
-         * Support max_over_time aggregation that gets evaluated per time-series
-         */
-        MAX_OVER_TIME(Build.current().isSnapshot()),
-
-        /**
-         * Support STATS/EVAL/DISSECT in Fork branches
-         */
-        FORK_V2(Build.current().isSnapshot()),
-
-        /**
-         * Support for the {@code leading_zeros} named parameter.
-         */
-        TO_IP_LEADING_ZEROS,
-
-        /**
-         * Does the usage information for ESQL contain a histogram of {@code took} values?
-         */
-        USAGE_CONTAINS_TOOK,
-
-        /**
-         * Support avg_over_time aggregation that gets evaluated per time-series
-         */
-        AVG_OVER_TIME(Build.current().isSnapshot()),
-
-        /**
          * Support loading of ip fields if they are not indexed.
          */
         LOADING_NON_INDEXED_IP_FIELDS;


### PR DESCRIPTION
8.x doesn't have these capabilities.
