### PR TITLE
Unmute SemanticInferenceMetadataFieldsRecoveryTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -396,15 +396,6 @@ tests:
 - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
   method: testChildrenTasksCancelledOnTimeout
   issue: https://github.com/elastic/elasticsearch/issues/123568
-- class: org.elasticsearch.xpack.inference.mapper.SemanticInferenceMetadataFieldsRecoveryTests
-  method: testSnapshotRecovery {p0=false p1=false}
-  issue: https://github.com/elastic/elasticsearch/issues/124385
-- class: org.elasticsearch.xpack.inference.mapper.SemanticInferenceMetadataFieldsRecoveryTests
-  method: testSnapshotRecovery {p0=false p1=true}
-  issue: https://github.com/elastic/elasticsearch/issues/124383
-- class: org.elasticsearch.xpack.inference.mapper.SemanticInferenceMetadataFieldsRecoveryTests
-  method: testSnapshotRecovery {p0=true p1=false}
-  issue: https://github.com/elastic/elasticsearch/issues/124384
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/cat/nodes/line_361}
   issue: https://github.com/elastic/elasticsearch/issues/124103


### PR DESCRIPTION
The test is green in main so unmuting in 8.x

Closes #124383
Closes #124384
Closes #124385