### PR TITLE
[8.18] Fix RepositoriesFileSettingsIT to wait for metadataVersion (#126720) (#126728)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -311,9 +311,6 @@ tests:
 - class: org.elasticsearch.repositories.s3.RepositoryS3EcsCredentialsRestIT
   method: testNonexistentBucketReadonlyFalse
   issue: https://github.com/elastic/elasticsearch/issues/118225
-- class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
-  method: testSettingsApplied
-  issue: https://github.com/elastic/elasticsearch/issues/116694
 - class: org.elasticsearch.discovery.ec2.DiscoveryEc2AvailabilityZoneAttributeNoImdsIT
   method: testAvailabilityZoneAttribute
   issue: https://github.com/elastic/elasticsearch/issues/118564


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix RepositoriesFileSettingsIT to wait for metadataVersion (#126720) (#126728)