### PR TITLE
Fix typo in high availability docs

### DIFF
--- a/docs/reference/high-availability.asciidoc
+++ b/docs/reference/high-availability.asciidoc
@@ -18,7 +18,7 @@ To effectively distribute read and write operations across nodes, the nodes in a
 +
 Co-locating nodes in a single location exposes you to the risk of a single outage taking your entire cluster offline. To maintain high availability, you can prepare a second cluster that can take over in case of disaster by implementing {ccr} (CCR).
 +
-CCR provides a way to automatically synchronize indices from a leader cluster to a follower cluster. This cluster could be in a different data center or even a different content from the leader cluster. If the primary cluster fails, the secondary cluster can take over.
+CCR provides a way to automatically synchronize indices from a leader cluster to a follower cluster. This cluster could be in a different data center or even a different continent from the leader cluster. If the primary cluster fails, the secondary cluster can take over.
 +
 TIP: You can also use CCR to create secondary clusters to serve read requests in geo-proximity to your users.
 


### PR DESCRIPTION
content > continent

fixes https://github.com/elastic/docs-content/issues/651