### PR TITLE
[8.x] Fix bbq quantization algorithm but for differently distributed components (#126778)

### DIFF
--- a/docs/changelog/126778.yaml
+++ b/docs/changelog/126778.yaml
@@ -1,0 +1,5 @@
+pr: 126778
+summary: Fix bbq quantization algorithm but for differently distributed components
+area: Vector Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/OptimizedScalarQuantizer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/OptimizedScalarQuantizer.java
@@ -75,8 +75,8 @@ class OptimizedScalarQuantizer {
             assert bits[i] > 0 && bits[i] <= 8;
             int points = (1 << bits[i]);
             // Linearly scale the interval to the standard deviation of the vector, ensuring we are within the min/max bounds
-            intervalScratch[0] = (float) clamp((MINIMUM_MSE_GRID[bits[i] - 1][0] + vecMean) * vecStd, min, max);
-            intervalScratch[1] = (float) clamp((MINIMUM_MSE_GRID[bits[i] - 1][1] + vecMean) * vecStd, min, max);
+            intervalScratch[0] = (float) clamp(MINIMUM_MSE_GRID[bits[i] - 1][0] * vecStd + vecMean, min, max);
+            intervalScratch[1] = (float) clamp(MINIMUM_MSE_GRID[bits[i] - 1][1] * vecStd + vecMean, min, max);
             optimizeIntervals(intervalScratch, vector, norm2, points);
             float nSteps = ((1 << bits[i]) - 1);
             float a = intervalScratch[0];
@@ -128,8 +128,8 @@ class OptimizedScalarQuantizer {
         vecVar /= vector.length;
         double vecStd = Math.sqrt(vecVar);
         // Linearly scale the interval to the standard deviation of the vector, ensuring we are within the min/max bounds
-        intervalScratch[0] = (float) clamp((MINIMUM_MSE_GRID[bits - 1][0] + vecMean) * vecStd, min, max);
-        intervalScratch[1] = (float) clamp((MINIMUM_MSE_GRID[bits - 1][1] + vecMean) * vecStd, min, max);
+        intervalScratch[0] = (float) clamp(MINIMUM_MSE_GRID[bits - 1][0] * vecStd + vecMean, min, max);
+        intervalScratch[1] = (float) clamp(MINIMUM_MSE_GRID[bits - 1][1] * vecStd + vecMean, min, max);
         optimizeIntervals(intervalScratch, vector, norm2, points);
         float nSteps = ((1 << bits) - 1);
         // Now we have the optimized intervals, quantize the vector


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix bbq quantization algorithm but for differently distributed components (#126778)