### PR TITLE
Remove unnecessary network entitlements from server

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -230,7 +230,6 @@ public class EntitlementInitialization {
                     new ReadStoreAttributesEntitlement(),
                     new CreateClassLoaderEntitlement(),
                     new InboundNetworkEntitlement(),
-                    new OutboundNetworkEntitlement(),
                     new LoadNativeLibrariesEntitlement(),
                     new ManageThreadsEntitlement(),
                     new FilesEntitlement(serverModuleFileDatas)
@@ -238,7 +237,6 @@ public class EntitlementInitialization {
             ),
             new Scope("java.desktop", List.of(new LoadNativeLibrariesEntitlement())),
             new Scope("org.apache.httpcomponents.httpclient", List.of(new OutboundNetworkEntitlement())),
-            new Scope("io.netty.transport", List.of(new InboundNetworkEntitlement(), new OutboundNetworkEntitlement())),
             new Scope(
                 "org.apache.lucene.core",
                 List.of(


### PR DESCRIPTION
These entitlements should not be necessary. Server does not directly create any outbound connections, and netty is not a dependency of server so it should not exist within the server policy.