### PR TITLE
Workaround max name limit imposed by Jackson 2.17

### DIFF
--- a/docs/changelog/126806.yaml
+++ b/docs/changelog/126806.yaml
@@ -1,0 +1,5 @@
+pr: 126806
+summary: Workaround max name limit imposed by Jackson 2.17
+area: Infra/Core
+type: bug
+issues: []

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/XContentImplUtils.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/XContentImplUtils.java
@@ -17,6 +17,10 @@ public class XContentImplUtils {
     public static <F extends JsonFactory, B extends TSFBuilder<F, B>> F configure(TSFBuilder<F, B> builder) {
         // jackson 2.15 introduced a max string length. We have other limits in place to constrain max doc size,
         // so here we set to max value (2GiB) so as not to constrain further than those existing limits.
-        return builder.streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build()).build();
+        // jackson 2.16 further introduced a max name length, which we also relax here temporarily.
+        // see https://github.com/elastic/elasticsearch/issues/58952
+        return builder.streamReadConstraints(
+            StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).maxNameLength(Integer.MAX_VALUE).build()
+        ).build();
     }
 }


### PR DESCRIPTION
In Jackson 2.15 a maximum string length of 50k characters was introduced. We worked around that by override the length to max int on all parsers created by xcontent. Jackson 2.17 introduced a similar limit on field names. This commit mimics the workaround for string length by overriding the max name length to be unlimited.

relates #58952