### PR TITLE
[9.0] Fix 8.x page mapping for ES release notes (#126820)

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,7 +1,6 @@
 ---
 navigation_title: "Elasticsearch"
 mapped_pages:
-  - https://www.elastic.co/guide/en/elasticsearch/reference/current/es-connectors-release-notes.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/master/release-notes-9.0.0.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-9.0.html


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Fix 8.x page mapping for ES release notes (#126820)