### PR TITLE
[8.17] Document known limitation for Salesforce connector #9545 (#126791)

### DIFF
--- a/docs/reference/connector/docs/connectors-salesforce.asciidoc
+++ b/docs/reference/connector/docs/connectors-salesforce.asciidoc
@@ -388,6 +388,11 @@ Instead, if a given user/group can have access to _any_ Objects of a given type 
 See https://github.com/elastic/connectors/issues/3028 for more details.
 +
 
+* *Only first 500 nested entities are ingested*
++
+Some of the entities that Salesforce connector fetches are nested - they are ingested along the parent objects using a `JOIN` query. Examples of such entities are `EmailMessages`, `CaseComments` and `FeedComments`. When Salesforce connector fetches these entities it sets a limit to fetch only first 500 entities per parent object. The only possible workaround for it now is to fork the Connectors repository and modify the code in Salesforce connector to increase these limits.
++
+
 Refer to <<es-connectors-known-issues,connector known issues>> for a list of known issues for all connectors.
 
 [discrete#es-connectors-salesforce-security]
@@ -792,6 +797,11 @@ See <<es-connectors-content-extraction,content extraction>> for more specifics o
 Salesforce DLS, added in 8.13.0, does not accomodate specific access controls to specific Salesforce Objects.
 Instead, if a given user/group can have access to _any_ Objects of a given type (`Case`, `Lead`, `Opportunity`, etc), that user/group will appear in the `\_allow_access_control` list for _all_ of the Objects of that type.
 See https://github.com/elastic/connectors/issues/3028 for more details.
++
+
+* *Only first 500 nested entities are ingested*
++
+Some of the entities that Salesforce connector fetches are nested - they are ingested along the parent objects using a `JOIN` query. Examples of such entities are `EmailMessages`, `CaseComments` and `FeedComments`. When Salesforce connector fetches these entities it sets a limit to fetch only first 500 entities per parent object. The only possible workaround for it now is to fork the Connectors repository and modify the code in Salesforce connector to increase these limits.
 +
 
 Refer to <<es-connectors-known-issues,connector known issues>> for a list of known issues for all connectors.


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Document known limitation for Salesforce connector #9545 (#126791)