### PR TITLE
Fix formatting of recently added transport versions using old format

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -215,10 +215,10 @@ public class TransportVersions {
     public static final TransportVersion REMOTE_EXCEPTION = def(9_044_0_00);
     public static final TransportVersion ESQL_REMOVE_AGGREGATE_TYPE = def(9_045_0_00);
     public static final TransportVersion ADD_PROJECT_ID_TO_DSL_ERROR_INFO = def(9_046_0_00);
-    public static final TransportVersion SEMANTIC_TEXT_CHUNKING_CONFIG = def(9_047_00_0);
-    public static final TransportVersion REPO_ANALYSIS_COPY_BLOB = def(9_048_00_0);
-    public static final TransportVersion AMAZON_BEDROCK_TASK_SETTINGS = def(9_049_00_0);
-    public static final TransportVersion ESQL_REPORT_SHARD_PARTITIONING = def(9_050_00_0);
+    public static final TransportVersion SEMANTIC_TEXT_CHUNKING_CONFIG = def(9_047_0_00);
+    public static final TransportVersion REPO_ANALYSIS_COPY_BLOB = def(9_048_0_00);
+    public static final TransportVersion AMAZON_BEDROCK_TASK_SETTINGS = def(9_049_0_00);
+    public static final TransportVersion ESQL_REPORT_SHARD_PARTITIONING = def(9_050_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
The format of Transport versions has changed to  `M_NNN_S_PP` a while ago to allow for more patch versions on recent long lived branches. Some recent PRs have switched formatting back to the old formatting. That's dangerous as it might trick devs into creating wrong TVs for serverless. Please be careful!

```
M - The major version of Elasticsearch
NNN - The server version part
S - The subsidiary version part. It should always be 0 here, it is only used in subsidiary repositories.
PP - The patch version part
```