### PR TITLE
[8.x] permit at+jwt typ header value in jwt access tokens (#126687)

### DIFF
--- a/docs/changelog/126687.yaml
+++ b/docs/changelog/126687.yaml
@@ -1,0 +1,6 @@
+pr: 126687
+summary: Permit at+jwt typ header value in jwt access tokens
+area: Authentication
+type: enhancement
+issues:
+ - 119370

--- a/x-pack/plugin/security/qa/jwt-realm/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/jwt/JwtWithUnavailableSecurityIndexRestIT.java
+++ b/x-pack/plugin/security/qa/jwt-realm/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/jwt/JwtWithUnavailableSecurityIndexRestIT.java
@@ -279,7 +279,7 @@ public class JwtWithUnavailableSecurityIndexRestIT extends ESRestTestCase {
             issueTime
         );
         final RSASSASigner signer = loadRsaSigner();
-        return JwtRestIT.signJWT(signer, "RS256", claimsSet);
+        return JwtRestIT.signJWT(signer, "RS256", claimsSet, false);
     }
 
     private RSASSASigner loadRsaSigner() throws IOException, ParseException, JOSEException {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtAuthenticator.java
@@ -136,7 +136,7 @@ public class JwtAuthenticator implements Releasable {
         }
 
         return List.of(
-            JwtTypeValidator.INSTANCE,
+            JwtTypeValidator.ID_TOKEN_INSTANCE,
             new JwtStringClaimValidator("iss", true, List.of(realmConfig.getSetting(JwtRealmSettings.ALLOWED_ISSUER)), List.of()),
             subjectClaimValidator,
             new JwtStringClaimValidator("aud", false, realmConfig.getSetting(JwtRealmSettings.ALLOWED_AUDIENCES), List.of()),
@@ -157,7 +157,7 @@ public class JwtAuthenticator implements Releasable {
         final Clock clock = Clock.systemUTC();
 
         return List.of(
-            JwtTypeValidator.INSTANCE,
+            JwtTypeValidator.ACCESS_TOKEN_INSTANCE,
             new JwtStringClaimValidator("iss", true, List.of(realmConfig.getSetting(JwtRealmSettings.ALLOWED_ISSUER)), List.of()),
             getSubjectClaimValidator(realmConfig, fallbackClaimLookup),
             new JwtStringClaimValidator(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtTypeValidator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtTypeValidator.java
@@ -17,14 +17,17 @@ import com.nimbusds.jwt.JWTClaimsSet;
 
 public class JwtTypeValidator implements JwtFieldValidator {
 
-    private static final JOSEObjectTypeVerifier<SecurityContext> JWT_HEADER_TYPE_VERIFIER = new DefaultJOSEObjectTypeVerifier<>(
-        JOSEObjectType.JWT,
-        null
-    );
+    private final JOSEObjectTypeVerifier<SecurityContext> JWT_HEADER_TYPE_VERIFIER;
+    private static final JOSEObjectType AT_PLUS_JWT = new JOSEObjectType("at+jwt");
 
-    public static final JwtTypeValidator INSTANCE = new JwtTypeValidator();
+    public static final JwtTypeValidator ID_TOKEN_INSTANCE = new JwtTypeValidator(JOSEObjectType.JWT, null);
 
-    private JwtTypeValidator() {}
+    // strictly speaking, this should only permit `at+jwt`, but removing the other two options is a breaking change
+    public static final JwtTypeValidator ACCESS_TOKEN_INSTANCE = new JwtTypeValidator(JOSEObjectType.JWT, AT_PLUS_JWT, null);
+
+    private JwtTypeValidator(JOSEObjectType... allowedTypes) {
+        JWT_HEADER_TYPE_VERIFIER = new DefaultJOSEObjectTypeVerifier<>(allowedTypes);
+    }
 
     public void validate(JWSHeader jwsHeader, JWTClaimsSet jwtClaimsSet) {
         final JOSEObjectType jwtHeaderType = jwsHeader.getType();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmAuthenticateAccessTokenTypeTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmAuthenticateAccessTokenTypeTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.security.authc.jwt;
 
-import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.openid.connect.sdk.Nonce;
@@ -134,7 +133,7 @@ public class JwtRealmAuthenticateAccessTokenTypeTests extends JwtRealmTestCase {
 
         final Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
         unsignedJwt = JwtTestCase.buildUnsignedJwt(
-            randomBoolean() ? null : JOSEObjectType.JWT.toString(), // kty
+            randomFrom("at+jwt", "JWT", null), // typ
             randomBoolean() ? null : jwk.getKeyID(), // kid
             algJwkPair.alg(), // alg
             randomAlphaOfLengthBetween(10, 20), // jwtID


### PR DESCRIPTION
Backports the following commits to 8.x:
 - permit at+jwt typ header value in jwt access tokens (#126687)