### PR TITLE
Fix DocValuesConsumerUtil to detect usage of source pruning filter doc values producer

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/FilterDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/FilterDocValuesProducer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec;
+
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+
+import java.io.IOException;
+
+/**
+ * Implementation that allows wrapping another {@link DocValuesProducer} and alter behaviour of the wrapped instance.
+ */
+public abstract class FilterDocValuesProducer extends DocValuesProducer {
+    private final DocValuesProducer in;
+
+    protected FilterDocValuesProducer(DocValuesProducer in) {
+        this.in = in;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(FieldInfo field) throws IOException {
+        return in.getNumeric(field);
+    }
+
+    @Override
+    public BinaryDocValues getBinary(FieldInfo field) throws IOException {
+        return in.getBinary(field);
+    }
+
+    @Override
+    public SortedDocValues getSorted(FieldInfo field) throws IOException {
+        return in.getSorted(field);
+    }
+
+    @Override
+    public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+        return in.getSortedNumeric(field);
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSet(FieldInfo field) throws IOException {
+        return in.getSortedSet(field);
+    }
+
+    @Override
+    public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+        return in.getSkipper(field);
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        in.checkIntegrity();
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+    public DocValuesProducer getIn() {
+        return in;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/DocValuesConsumerUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/DocValuesConsumerUtil.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.codec.tsdb.es819;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergeState;
+import org.elasticsearch.index.codec.FilterDocValuesProducer;
 import org.elasticsearch.index.codec.perfield.XPerFieldDocValuesFormat;
 
 /**
@@ -40,6 +41,10 @@ class DocValuesConsumerUtil {
 
         for (int i = 0; i < mergeState.docValuesProducers.length; i++) {
             DocValuesProducer docValuesProducer = mergeState.docValuesProducers[i];
+            if (docValuesProducer instanceof FilterDocValuesProducer filterDocValuesProducer) {
+                docValuesProducer = filterDocValuesProducer.getIn();
+            }
+
             if (docValuesProducer instanceof XPerFieldDocValuesFormat.FieldsReader perFieldReader) {
                 var wrapped = perFieldReader.getDocValuesProducer(fieldInfo);
                 if (wrapped instanceof ES819TSDBDocValuesProducer tsdbDocValuesProducer) {

--- a/server/src/main/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicy.java
@@ -11,18 +11,13 @@ package org.elasticsearch.index.engine;
 
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.StoredFieldsReader;
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.CodecReader;
-import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FilterCodecReader;
 import org.apache.lucene.index.FilterNumericDocValues;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.OneMergeWrappingMergePolicy;
-import org.apache.lucene.index.SortedDocValues;
-import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.search.ConjunctionUtils;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -34,6 +29,7 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.codec.FilterDocValuesProducer;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.search.internal.FilterStoredFieldVisitor;
 
@@ -175,54 +171,6 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
         @Override
         public CacheHelper getReaderCacheHelper() {
             return null;
-        }
-
-        private static class FilterDocValuesProducer extends DocValuesProducer {
-            private final DocValuesProducer in;
-
-            FilterDocValuesProducer(DocValuesProducer in) {
-                this.in = in;
-            }
-
-            @Override
-            public NumericDocValues getNumeric(FieldInfo field) throws IOException {
-                return in.getNumeric(field);
-            }
-
-            @Override
-            public BinaryDocValues getBinary(FieldInfo field) throws IOException {
-                return in.getBinary(field);
-            }
-
-            @Override
-            public SortedDocValues getSorted(FieldInfo field) throws IOException {
-                return in.getSorted(field);
-            }
-
-            @Override
-            public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
-                return in.getSortedNumeric(field);
-            }
-
-            @Override
-            public SortedSetDocValues getSortedSet(FieldInfo field) throws IOException {
-                return in.getSortedSet(field);
-            }
-
-            @Override
-            public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
-                return in.getSkipper(field);
-            }
-
-            @Override
-            public void checkIntegrity() throws IOException {
-                in.checkIntegrity();
-            }
-
-            @Override
-            public void close() throws IOException {
-                in.close();
-            }
         }
 
         private abstract static class FilterStoredFieldsReader extends StoredFieldsReader {


### PR DESCRIPTION
The compatibleWithOptimizedMerge() method doesn't handle codec readers that are wrapped by our source pruning filter codec reader. This change addresses that.

Failing to detect this means that the optimized merge will not kick in.