### PR TITLE
Remove some needless abstractions from AbstractInternalTerms

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.util.PriorityQueue;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.AggregationErrors;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
@@ -46,13 +47,33 @@ import static org.elasticsearch.search.aggregations.bucket.terms.InternalTerms.S
 public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B>, B extends AbstractInternalTerms.AbstractTermsBucket<B>>
     extends InternalMultiBucketAggregation<A, B> {
 
-    public AbstractInternalTerms(String name, Map<String, Object> metadata) {
+    protected final BucketOrder reduceOrder;
+    protected final BucketOrder order;
+
+    protected final int requiredSize;
+    protected final long minDocCount;
+
+    public AbstractInternalTerms(
+        String name,
+        Map<String, Object> metadata,
+        BucketOrder reduceOrder,
+        BucketOrder order,
+        int requiredSize,
+        long minDocCount
+    ) {
         super(name, metadata);
+        this.reduceOrder = reduceOrder;
+        this.order = order;
+        this.requiredSize = requiredSize;
+        this.minDocCount = minDocCount;
     }
 
     protected AbstractInternalTerms(StreamInput in) throws IOException {
-
         super(in);
+        reduceOrder = InternalOrder.Streams.readOrder(in);
+        order = InternalOrder.Streams.readOrder(in);
+        requiredSize = readSize(in);
+        minDocCount = in.readVLong();
     }
 
     public abstract static class AbstractTermsBucket<B extends AbstractTermsBucket<B>> extends InternalMultiBucketAggregation.InternalBucket
@@ -75,9 +96,13 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
 
     protected abstract int getShardSize();
 
-    protected abstract BucketOrder getReduceOrder();
+    public BucketOrder getReduceOrder() {
+        return reduceOrder;
+    }
 
-    protected abstract BucketOrder getOrder();
+    public BucketOrder getOrder() {
+        return order;
+    }
 
     protected abstract long getSumOfOtherDocCounts();
 
@@ -85,9 +110,13 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
 
     protected abstract void setDocCountError(long docCountError);
 
-    protected abstract long getMinDocCount();
+    public long getMinDocCount() {
+        return minDocCount;
+    }
 
-    protected abstract int getRequiredSize();
+    public int getRequiredSize() {
+        return requiredSize;
+    }
 
     protected abstract boolean getShowDocCountError();
 
@@ -383,4 +412,11 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
         return builder;
     }
 
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        reduceOrder.writeTo(out);
+        order.writeTo(out);
+        writeSize(requiredSize, out);
+        out.writeVLong(minDocCount);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/Terms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/Terms.java
@@ -44,9 +44,5 @@ public interface Terms extends MultiBucketsAggregation {
      */
     Long getDocCountError();
 
-    /**
-     * Return the sum of the document counts of all buckets that did not make
-     * it to the top buckets.
-     */
     long getSumOfOtherDocCounts();
 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTermsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTermsTests.java
@@ -265,7 +265,7 @@ public class InternalMultiTermsTests extends InternalAggregationTestCase<Interna
     protected InternalMultiTerms mutateInstance(InternalMultiTerms instance) {
         String name = instance.getName();
         Map<String, Object> metadata = instance.getMetadata();
-        BucketOrder order = instance.order;
+        BucketOrder order = instance.getOrder();
         switch (between(0, 2)) {
             case 0 -> name += randomAlphaOfLength(5);
             case 1 -> order = randomValueOtherThan(order, InternalMultiTermsTests::randomBucketOrder);
@@ -282,9 +282,9 @@ public class InternalMultiTermsTests extends InternalAggregationTestCase<Interna
         return new InternalMultiTerms(
             name,
             order,
-            instance.reduceOrder,
-            instance.requiredSize,
-            instance.minDocCount,
+            instance.getReduceOrder(),
+            instance.getRequiredSize(),
+            instance.getMinDocCount(),
             instance.shardSize,
             instance.showTermDocCountError,
             instance.otherDocCount,


### PR DESCRIPTION
We can move quite a few things into AbstractInternalTerms that are duplicated by all children. Also, removing a dead method and turning a needlessly named class into a lambda.

