### PR TITLE
update JWT realm docs to include at+jwt support

### DIFF
--- a/docs/reference/security/authentication/jwt-realm.asciidoc
+++ b/docs/reference/security/authentication/jwt-realm.asciidoc
@@ -294,7 +294,17 @@ token.
 as `HS256`. The algorithm must be in the realm's allow list.
 
 `typ`::
-(Optional, String) Indicates the token type. For an ID token, this must be `JWT`; for access tokens, this must be `JWT` or `at+jwt`.
+(Optional, String) Indicates the token type.
++
+For an ID token, this must be
++
+ - `JWT`
+
++
+For access tokens, this must be one of
++
+ - `JWT`
+ - `at+jwt`
 
 [[jwt-validation-payload]]
 ===== Payload claims

--- a/docs/reference/security/authentication/jwt-realm.asciidoc
+++ b/docs/reference/security/authentication/jwt-realm.asciidoc
@@ -294,7 +294,7 @@ token.
 as `HS256`. The algorithm must be in the realm's allow list.
 
 `typ`::
-(Optional, String) Indicates the token type, which must be `JWT`.
+(Optional, String) Indicates the token type. For an ID token, this must be `JWT`; for access tokens, this must be `JWT` or `at+jwt`.
 
 [[jwt-validation-payload]]
 ===== Payload claims


### PR DESCRIPTION
Update docs to mention `at+jwt` support introduced [here](https://github.com/elastic/elasticsearch/pull/126832)

See also https://github.com/elastic/docs-content/pull/1124