### PR TITLE
Tweak the delta used for vector scorer tests

### DIFF
--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/VectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/VectorScorerFactoryTests.java
@@ -50,8 +50,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 // @com.carrotsearch.randomizedtesting.annotations.Repeat(iterations = 100)
 public class VectorScorerFactoryTests extends AbstractVectorTestCase {
 
-    private static final float DELTA = 1e-4f;
-
     // bounds of the range of values that can be seen by int7 scalar quantized vectors
     static final byte MIN_INT7_VALUE = 0;
     static final byte MAX_INT7_VALUE = 127;
@@ -260,6 +258,8 @@ public class VectorScorerFactoryTests extends AbstractVectorTestCase {
                 final byte[][] qVectors = new byte[size][];
                 final float[] corrections = new float[size];
 
+                float delta = 1e-6f * dims;
+
                 String fileName = "testRandom-" + sim + "-" + dims + ".vex";
                 logger.info("Testing " + fileName);
                 try (IndexOutput out = dir.createOutput(fileName, IOContext.DEFAULT)) {
@@ -280,7 +280,7 @@ public class VectorScorerFactoryTests extends AbstractVectorTestCase {
 
                         var expected = luceneScore(sim, qVectors[idx0], qVectors[idx1], correction, corrections[idx0], corrections[idx1]);
                         var scorer = factory.getInt7SQVectorScorer(VectorSimilarityType.of(sim), values, vectors[idx0]).get();
-                        assertEquals(scorer.score(idx1), expected, DELTA);
+                        assertEquals(scorer.score(idx1), expected, delta);
                     }
                 }
             }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -396,18 +396,12 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
   issue: https://github.com/elastic/elasticsearch/issues/126755
-- class: org.elasticsearch.simdvec.VectorScorerFactoryTests
-  method: testRandomScorerMax
-  issue: https://github.com/elastic/elasticsearch/issues/126797
 - class: org.elasticsearch.search.SearchServiceSingleNodeTests
   method: testBeforeShardLockDuringShardCreate
   issue: https://github.com/elastic/elasticsearch/issues/126812
 - class: org.elasticsearch.search.SearchServiceSingleNodeTests
   method: testLookUpSearchContext
   issue: https://github.com/elastic/elasticsearch/issues/126813
-- class: org.elasticsearch.simdvec.VectorScorerFactoryTests
-  method: testRandomScorerChunkSizeSmall
-  issue: https://github.com/elastic/elasticsearch/issues/126847
 
 # Examples:
 #


### PR DESCRIPTION
Make the delta scale with the number of dimensions (the more dims, the more inaccurate FP can be)

Fixes #126847, fixes #126797