### PR TITLE
[ML] Refactor inference request executor to leverage scheduled execution

### DIFF
--- a/docs/changelog/126858.yaml
+++ b/docs/changelog/126858.yaml
@@ -1,5 +1,5 @@
 pr: 126858
-summary: Refactor inference request executor to leverage scheduled execution
+summary: Leverage threadpool schedule for inference api to avoid long running thread
 area: Machine Learning
 type: bug
 issues:

--- a/docs/changelog/126858.yaml
+++ b/docs/changelog/126858.yaml
@@ -1,0 +1,6 @@
+pr: 126858
+summary: Refactor inference request executor to leverage scheduled execution
+area: Machine Learning
+type: bug
+issues:
+ - 126853

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
@@ -232,7 +232,7 @@ public class RequestExecutorService implements RequestExecutor {
 
     private void scheduleNextHandleTasks(TimeValue timeToWait) {
         if (shutdown.get()) {
-            logger.debug("Shutdown requested while scheduling next task, cleaning up");
+            logger.debug("Shutdown requested while scheduling next handle task call, cleaning up");
             cleanup();
             return;
         }
@@ -268,7 +268,6 @@ public class RequestExecutorService implements RequestExecutor {
             logger.warn("Encountered an error while handling tasks", e);
             cleanup();
         }
-        // sleeper.sleep(timeToWait);
     }
 
     private void notifyRequestsOfShutdown() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
@@ -57,15 +57,6 @@ import static org.elasticsearch.xpack.inference.InferencePlugin.UTILITY_THREAD_P
  */
 public class RequestExecutorService implements RequestExecutor {
 
-    /**
-     * Provides dependency injection mainly for testing
-     */
-    interface Sleeper {
-        void sleep(TimeValue sleepTime) throws InterruptedException;
-    }
-
-    // default for tests
-    static final Sleeper DEFAULT_SLEEPER = sleepTime -> sleepTime.timeUnit().sleep(sleepTime.duration());
     // default for tests
     static final AdjustableCapacityBlockingQueue.QueueCreator<RejectableTask> DEFAULT_QUEUE_CREATOR =
         new AdjustableCapacityBlockingQueue.QueueCreator<>() {
@@ -118,7 +109,6 @@ public class RequestExecutorService implements RequestExecutor {
     private final Clock clock;
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
     private final AdjustableCapacityBlockingQueue.QueueCreator<RejectableTask> queueCreator;
-    private final Sleeper sleeper;
     private final RateLimiterCreator rateLimiterCreator;
     private final AtomicReference<Scheduler.Cancellable> cancellableCleanupTask = new AtomicReference<>();
     private final AtomicBoolean started = new AtomicBoolean(false);
@@ -129,16 +119,7 @@ public class RequestExecutorService implements RequestExecutor {
         RequestExecutorServiceSettings settings,
         RequestSender requestSender
     ) {
-        this(
-            threadPool,
-            DEFAULT_QUEUE_CREATOR,
-            startupLatch,
-            settings,
-            requestSender,
-            Clock.systemUTC(),
-            DEFAULT_SLEEPER,
-            DEFAULT_RATE_LIMIT_CREATOR
-        );
+        this(threadPool, DEFAULT_QUEUE_CREATOR, startupLatch, settings, requestSender, Clock.systemUTC(), DEFAULT_RATE_LIMIT_CREATOR);
     }
 
     public RequestExecutorService(
@@ -148,7 +129,6 @@ public class RequestExecutorService implements RequestExecutor {
         RequestExecutorServiceSettings settings,
         RequestSender requestSender,
         Clock clock,
-        Sleeper sleeper,
         RateLimiterCreator rateLimiterCreator
     ) {
         this.threadPool = Objects.requireNonNull(threadPool);
@@ -157,7 +137,6 @@ public class RequestExecutorService implements RequestExecutor {
         this.requestSender = Objects.requireNonNull(requestSender);
         this.settings = Objects.requireNonNull(settings);
         this.clock = Objects.requireNonNull(clock);
-        this.sleeper = Objects.requireNonNull(sleeper);
         this.rateLimiterCreator = Objects.requireNonNull(rateLimiterCreator);
     }
 
@@ -213,15 +192,10 @@ public class RequestExecutorService implements RequestExecutor {
             startCleanupTask();
             signalStartInitiated();
 
-            while (isShutdown() == false) {
-                handleTasks();
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            shutdown();
-            notifyRequestsOfShutdown();
-            terminationLatch.countDown();
+            handleTasks();
+        } catch (Exception e) {
+            logger.warn("Failed to start request executor", e);
+            cleanup();
         }
     }
 
@@ -256,13 +230,45 @@ public class RequestExecutorService implements RequestExecutor {
         }
     }
 
-    private void handleTasks() throws InterruptedException {
-        var timeToWait = settings.getTaskPollFrequency();
-        for (var endpoint : rateLimitGroupings.values()) {
-            timeToWait = TimeValue.min(endpoint.executeEnqueuedTask(), timeToWait);
+    private void scheduleNextHandleTasks(TimeValue timeToWait) {
+        if (shutdown.get()) {
+            logger.debug("Shutdown requested while scheduling next task, cleaning up");
+            cleanup();
+            return;
         }
 
-        sleeper.sleep(timeToWait);
+        threadPool.schedule(this::handleTasks, timeToWait, threadPool.executor(UTILITY_THREAD_POOL_NAME));
+    }
+
+    private void cleanup() {
+        try {
+            shutdown();
+            notifyRequestsOfShutdown();
+            terminationLatch.countDown();
+        } catch (Exception e) {
+            logger.warn("Encountered an error while cleaning up", e);
+        }
+    }
+
+    private void handleTasks() {
+        try {
+            if (shutdown.get()) {
+                logger.debug("Shutdown requested while handling tasks, cleaning up");
+                cleanup();
+                return;
+            }
+
+            var timeToWait = settings.getTaskPollFrequency();
+            for (var endpoint : rateLimitGroupings.values()) {
+                timeToWait = TimeValue.min(endpoint.executeEnqueuedTask(), timeToWait);
+            }
+
+            scheduleNextHandleTasks(timeToWait);
+        } catch (Exception e) {
+            logger.warn("Encountered an error while handling tasks", e);
+            cleanup();
+        }
+        // sleeper.sleep(timeToWait);
     }
 
     private void notifyRequestsOfShutdown() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
@@ -50,6 +50,7 @@ import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
 import static org.elasticsearch.xpack.inference.external.http.Utils.getUrl;
+import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
 import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.ELASTIC_INFERENCE_SERVICE_IDENTIFIER;
 import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceRequestTests.randomElasticInferenceServiceRequestMetadata;
 import static org.elasticsearch.xpack.inference.services.openai.OpenAiUtils.ORGANIZATION_HEADER;
@@ -90,7 +91,7 @@ public class HttpRequestSenderTests extends ESTestCase {
     }
 
     public void testCreateSender_SendsRequestAndReceivesResponse() throws Exception {
-        var senderFactory = createSenderFactory(clientManager, threadRef);
+        var senderFactory = new HttpRequestSender.Factory(createWithEmptySettings(threadPool), clientManager, mockClusterServiceEmpty());
 
         try (var sender = createSender(senderFactory)) {
             sender.start();


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/126853

This PR refactors the `RequestExecutorService` to use `ThreadPool.schedule` instead of having a long lived thread that sleeps.

## Testing

The `inference_utility` thread should no longer report an always active thread:

```
GET http://localhost:9200/_cat/thread_pool
```

```
runTask-0 analyze                                0 0 0
runTask-0 auto_complete                          0 0 0
runTask-0 azure_event_loop                       0 0 0
runTask-0 ccr                                    0 0 0
runTask-0 cluster_coordination                   0 0 0
runTask-0 downsample_indexing                    0 0 0
runTask-0 esql_worker                            0 0 0
runTask-0 fetch_shard_started                    0 0 0
runTask-0 fetch_shard_store                      0 0 0
runTask-0 flush                                  0 0 0
runTask-0 force_merge                            0 0 0
runTask-0 generic                                0 0 0
runTask-0 get                                    0 0 0
runTask-0 inference_utility                      0 0 0 <-----------
runTask-0 management                             1 0 0
runTask-0 merge                                  0 0 0
runTask-0 ml_datafeed                            0 0 0
runTask-0 ml_job_comms                           0 0 0
runTask-0 ml_native_inference_comms              0 0 0
runTask-0 ml_utility                             0 0 0
runTask-0 model_download                         0 0 0
runTask-0 profiling                              0 0 0
runTask-0 refresh                                0 0 0
runTask-0 repository_azure                       0 0 0
runTask-0 rollup_indexing                        0 0 0
runTask-0 search                                 0 0 0
runTask-0 search_coordination                    0 0 0
runTask-0 searchable_snapshots_cache_fetch_async 0 0 0
runTask-0 searchable_snapshots_cache_prewarming  0 0 0
runTask-0 security-crypto                        0 0 0
runTask-0 security-token-key                     0 0 0
runTask-0 snapshot                               0 0 0
runTask-0 snapshot_meta                          0 0 0
runTask-0 system_critical_read                   0 0 0
runTask-0 system_critical_write                  0 0 0
runTask-0 system_read                            0 0 0
runTask-0 system_write                           0 0 0
runTask-0 warmer                                 0 0 0
runTask-0 watcher                                0 0 0
runTask-0 write                                  0 0 0
```

Retrieving hot threads shouldn't show the utility thread all the time now

```
GET http://localhost:9200/_nodes/hot_threads?threads=9999
```