### PR TITLE
ESQL: Create fewer documents in lookup tests

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -641,7 +641,7 @@ public class HeapAttackIT extends ESRestTestCase {
     }
 
     public void testLookupExplosion() throws IOException {
-        int sensorDataCount = 500;
+        int sensorDataCount = 400;
         int lookupEntries = 10000;
         Map<?, ?> map = lookupExplosion(sensorDataCount, lookupEntries);
         assertMap(map, matchesMap().extraOk().entry("values", List.of(List.of(sensorDataCount * lookupEntries))));
@@ -653,7 +653,7 @@ public class HeapAttackIT extends ESRestTestCase {
     }
 
     public void testLookupExplosionNoFetch() throws IOException {
-        int sensorDataCount = 7500;
+        int sensorDataCount = 7000;
         int lookupEntries = 10000;
         Map<?, ?> map = lookupExplosionNoFetch(sensorDataCount, lookupEntries);
         assertMap(map, matchesMap().extraOk().entry("values", List.of(List.of(sensorDataCount * lookupEntries))));


### PR DESCRIPTION
This lowers the number of documents used to test lookup because we have a few failures over the last few months. These are all cases that we expect to *pass* so fewer documents should make them even more likely to pass.

Closes #125913
Closes #125779
