### PR TITLE
[bwc] Add bugfix3 project

### DIFF
--- a/build-tools-internal/src/integTest/resources/org/elasticsearch/gradle/internal/fake_git/remote/settings.gradle
+++ b/build-tools-internal/src/integTest/resources/org/elasticsearch/gradle/internal/fake_git/remote/settings.gradle
@@ -11,6 +11,7 @@ rootProject.name = "root"
 
 include ":distribution:bwc:bugfix"
 include ":distribution:bwc:bugfix2"
+include ":distribution:bwc:bugfix3"
 include ":distribution:bwc:minor"
 include ":distribution:bwc:major"
 include ":distribution:bwc:staged"

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -165,7 +165,7 @@ public class BwcVersions implements Serializable {
             .sorted(reverseOrder(comparing(s -> Version.fromString(s, Version.Mode.RELAXED))))
             .toList();
 
-        boolean existingBugfix = false;
+        int bugfixCount = 0;
         boolean existingStaged = false;
         for (int i = 0; i < featureFreezeBranches.size(); i++) {
             String branch = featureFreezeBranches.get(i);
@@ -198,9 +198,9 @@ public class BwcVersions implements Serializable {
                 result.put(version, new UnreleasedVersionInfo(version, branch, ":distribution:bwc:" + project));
                 existingStaged = true;
             } else { // This is a bugfix
-                String project = existingBugfix ? "bugfix2" : "bugfix";
+                bugfixCount++;
+                String project = "bugfix" + (bugfixCount > 1 ? bugfixCount : "");
                 result.put(version, new UnreleasedVersionInfo(version, branch, ":distribution:bwc:" + project));
-                existingBugfix = true;
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -301,6 +301,7 @@ allprojects {
       // ensure we have best possible caching of bwc builds
       dependsOn ":distribution:bwc:bugfix:buildBwcLinuxTar"
       dependsOn ":distribution:bwc:bugfix2:buildBwcLinuxTar"
+      dependsOn ":distribution:bwc:bugfix3:buildBwcLinuxTar"
       dependsOn ":distribution:bwc:minor:buildBwcLinuxTar"
       dependsOn ":distribution:bwc:staged:buildBwcLinuxTar"
       dependsOn ":distribution:bwc:staged2:buildBwcLinuxTar"

--- a/settings.gradle
+++ b/settings.gradle
@@ -78,6 +78,7 @@ List projects = [
   'distribution:packages:rpm',
   'distribution:bwc:bugfix',
   'distribution:bwc:bugfix2',
+  'distribution:bwc:bugfix3',
   'distribution:bwc:maintenance',
   'distribution:bwc:minor',
   'distribution:bwc:staged',


### PR DESCRIPTION
There are now 3 "bugfix" projects from a BWC standpoint, which causes the following error:

```
./gradlew --quiet --console=plain tagVersions --release=8.18.0 --tag-version=TransportVersion:8840002 --tag-version=IndexVersion:8525000
...
        | A problem occurred evaluating project ':distribution:bwc'.
        | > Failed to apply plugin 'elasticsearch.internal-distribution-bwc-setup'.
        |    > Cannot add extension with name 'bwcSetup', as there is an extension already registered with that name.
```

Because there are two `bugfix2` projects. This adds a 3rd one. I'm not sure if this is the best approach here.

Finalizing the `8.18.0` release is blocked until this is solved.