### PR TITLE
[9.0] [otel-data] Bump plugin version to release _metric_names_hash changes (#126850)

### DIFF
--- a/docs/changelog/126850.yaml
+++ b/docs/changelog/126850.yaml
@@ -1,0 +1,5 @@
+pr: 126850
+summary: "[otel-data] Bump plugin version to release _metric_names_hash changes"
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/otel-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin otel-data. This must be increased whenever an existing template is
 # changed, in order for it to be updated on Elasticsearch upgrade.
-version: 8
+version: 9
 
 component-templates:
   - otel@mappings


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [otel-data] Bump plugin version to release _metric_names_hash changes (#126850)