### PR TITLE
[9.0] Fix vec_caps to test for OS support too (on x64) (#126911)

### DIFF
--- a/docs/changelog/126911.yaml
+++ b/docs/changelog/126911.yaml
@@ -1,0 +1,6 @@
+pr: 126911
+summary: Fix `vec_caps` to test for OS support too (on x64)
+area: Vector Search
+type: bug
+issues:
+ - 126809

--- a/libs/native/libraries/build.gradle
+++ b/libs/native/libraries/build.gradle
@@ -19,7 +19,7 @@ configurations {
 }
 
 var zstdVersion = "1.5.5"
-var vecVersion = "1.0.10"
+var vecVersion = "1.0.11"
 
 repositories {
   exclusiveContent {

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
@@ -41,7 +41,7 @@ public final class JdkVectorLibrary implements VectorLibrary {
         try {
             int caps = (int) vecCaps$mh.invokeExact();
             logger.info("vec_caps=" + caps);
-            if (caps != 0) {
+            if (caps > 0) {
                 if (caps == 2) {
                     dot7u$mh = downcallHandle(
                         "dot7u_2",
@@ -67,6 +67,11 @@ public final class JdkVectorLibrary implements VectorLibrary {
                 }
                 INSTANCE = new JdkVectorSimilarityFunctions();
             } else {
+                if (caps < 0) {
+                    logger.warn("""
+                        Your CPU supports vector capabilities, but they are disabled at OS level. For optimal performance, \
+                        enable them in your OS/Hypervisor/VM/container""");
+                }
                 dot7u$mh = null;
                 sqr7u$mh = null;
                 INSTANCE = null;

--- a/libs/simdvec/native/build.gradle
+++ b/libs/simdvec/native/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'cpp'
 
 var os = org.gradle.internal.os.OperatingSystem.current()
 
-// To update this library run publish_vec_binaries.sh  ( or ./gradlew vecSharedLibrary )
+// To update this library run publish_vec_binaries.sh  ( or ./gradlew buildSharedLibrary )
 // Or
 // For local development, build the docker image with:
 //   docker build --platform linux/arm64 --progress=plain --file=Dockerfile.aarch64 . (for aarch64)

--- a/libs/simdvec/native/publish_vec_binaries.sh
+++ b/libs/simdvec/native/publish_vec_binaries.sh
@@ -20,7 +20,7 @@ if [ -z "$ARTIFACTORY_API_KEY" ]; then
   exit 1;
 fi
 
-VERSION="1.0.10"
+VERSION="1.0.11"
 ARTIFACTORY_REPOSITORY="${ARTIFACTORY_REPOSITORY:-https://artifactory.elastic.dev/artifactory/elasticsearch-native/}"
 TEMP=$(mktemp -d)
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Fix vec_caps to test for OS support too (on x64) (#126911)