### PR TITLE
Fix reindex yaml test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/20_reindex_status.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/migrate/20_reindex_status.yml
@@ -60,7 +60,6 @@ setup:
   - do:
       indices.get_migrate_reindex_status:
         index: "my-data-stream"
-  - match: { complete: true }
   - match: { total_indices_in_data_stream: 1 }
   - match: { total_indices_requiring_upgrade: 0 }
   - match: { successes: 0 }


### PR DESCRIPTION
Reindex task may not have completed by time status is called, so remove assertion that relies on this. Following assertions are set in the action which starts task, so will be correct whether or not task has completed.

Fixes https://github.com/elastic/elasticsearch/issues/126769