### PR TITLE
Temporarily bypass competitive iteration for filters aggregation

### DIFF
--- a/docs/changelog/126956.yaml
+++ b/docs/changelog/126956.yaml
@@ -1,0 +1,5 @@
+pr: 126956
+summary: Temporarily bypass competitive iteration for filters aggregation
+area: Aggregations
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregator.java
@@ -328,11 +328,13 @@ public abstract class FiltersAggregator extends BucketsAggregator {
                     hasOtherBucket
                 );
             }
-            if (usesCompetitiveIterator) {
-                return new MultiFilterCompetitiveLeafCollector(sub, filterWrappers, numFilters, totalNumKeys, hasOtherBucket);
-            } else {
-                return new MultiFilterLeafCollector(sub, filterWrappers, numFilters, totalNumKeys, hasOtherBucket);
-            }
+            // TODO: https://github.com/elastic/elasticsearch/issues/126955
+            // competitive iterator is currently broken, we would rather be slow than broken
+            return new MultiFilterLeafCollector(sub, filterWrappers, numFilters, totalNumKeys, hasOtherBucket);
+            // if (usesCompetitiveIterator) {
+            // return new MultiFilterCompetitiveLeafCollector(sub, filterWrappers, numFilters, totalNumKeys, hasOtherBucket);
+            // } else {
+            // }
         }
     }
 


### PR DESCRIPTION
In certain conditions, using a query with filters aggregation can result in non-deterministic aggregation counts. 

This is caused by how we handle the competitive iteration of the query and the filters aggregation.

This commit will temporarily bypass our competitive iteration for filters aggs.

related to: https://github.com/elastic/elasticsearch/issues/126955