### PR TITLE
RepositoryAnalysisFailureIT: disrupt earlier

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -411,9 +411,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test024InstallPluginFromArchiveUsingConfigFile
   issue: https://github.com/elastic/elasticsearch/issues/126936
-- class: org.elasticsearch.repositories.blobstore.testkit.analyze.RepositoryAnalysisFailureIT
-  method: testFailsOnReadError
-  issue: https://github.com/elastic/elasticsearch/issues/127029
 
 # Examples:
 #

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
@@ -134,7 +134,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
-        final CountDown countDown = new CountDown(between(1, request.getBlobCount() / 2));
+        final CountDown countDown = randomRequestCountDown(request);
         blobStore.setDisruption(new Disruption() {
             @Override
             public byte[] onRead(byte[] actualContents, long position, long length) throws IOException {
@@ -158,7 +158,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         request.abortWritePermitted(false);
         request.rareActionProbability(0.0); // not found on an early read or an overwrite is ok
 
-        final CountDown countDown = new CountDown(between(1, request.getBlobCount() / 2));
+        final CountDown countDown = randomRequestCountDown(request);
 
         blobStore.setDisruption(new Disruption() {
             @Override
@@ -212,7 +212,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         // leads to CI failures. Therefore, we disable rare actions to improve CI stability.
         request.rareActionProbability(0.0);
 
-        final CountDown countDown = new CountDown(between(1, request.getBlobCount() / 2));
+        final CountDown countDown = randomRequestCountDown(request);
 
         blobStore.setDisruption(new Disruption() {
             @Override
@@ -234,9 +234,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
-        // requests that create copies count as two blobs. Halving the count ensures that we trigger the disruption
-        // even if every request is a copy
-        final CountDown countDown = new CountDown(between(1, request.getBlobCount() / 2));
+        final CountDown countDown = randomRequestCountDown(request);
 
         blobStore.setDisruption(new Disruption() {
 
@@ -524,6 +522,12 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     private static void assertPurpose(OperationPurpose purpose) {
         assertEquals(OperationPurpose.REPOSITORY_ANALYSIS, purpose);
+    }
+
+    private static CountDown randomRequestCountDown(RepositoryAnalyzeAction.Request request) {
+        // requests that create copies count as two blobs. Halving the count ensures that we trigger the disruption
+        // even if every request is a copy
+        return new CountDown(between(1, request.getBlobCount() / 2));
     }
 
     public static class TestPlugin extends Plugin implements RepositoryPlugin {

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
@@ -134,7 +134,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
-        final CountDown countDown = new CountDown(between(1, request.getBlobCount()));
+        final CountDown countDown = new CountDown(between(1, request.getBlobCount() / 2));
         blobStore.setDisruption(new Disruption() {
             @Override
             public byte[] onRead(byte[] actualContents, long position, long length) throws IOException {
@@ -158,7 +158,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         request.abortWritePermitted(false);
         request.rareActionProbability(0.0); // not found on an early read or an overwrite is ok
 
-        final CountDown countDown = new CountDown(between(1, request.getBlobCount()));
+        final CountDown countDown = new CountDown(between(1, request.getBlobCount() / 2));
 
         blobStore.setDisruption(new Disruption() {
             @Override
@@ -212,7 +212,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         // leads to CI failures. Therefore, we disable rare actions to improve CI stability.
         request.rareActionProbability(0.0);
 
-        final CountDown countDown = new CountDown(between(1, request.getBlobCount()));
+        final CountDown countDown = new CountDown(between(1, request.getBlobCount() / 2));
 
         blobStore.setDisruption(new Disruption() {
             @Override

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
@@ -134,7 +134,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
-        final CountDown countDown = randomRequestCountDown(request);
+        final CountDown countDown = createDisruptionCountdown(request);
         blobStore.setDisruption(new Disruption() {
             @Override
             public byte[] onRead(byte[] actualContents, long position, long length) throws IOException {
@@ -158,7 +158,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         request.abortWritePermitted(false);
         request.rareActionProbability(0.0); // not found on an early read or an overwrite is ok
 
-        final CountDown countDown = randomRequestCountDown(request);
+        final CountDown countDown = createDisruptionCountdown(request);
 
         blobStore.setDisruption(new Disruption() {
             @Override
@@ -212,7 +212,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         // leads to CI failures. Therefore, we disable rare actions to improve CI stability.
         request.rareActionProbability(0.0);
 
-        final CountDown countDown = randomRequestCountDown(request);
+        final CountDown countDown = createDisruptionCountdown(request);
 
         blobStore.setDisruption(new Disruption() {
             @Override
@@ -234,7 +234,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
-        final CountDown countDown = randomRequestCountDown(request);
+        final CountDown countDown = createDisruptionCountdown(request);
 
         blobStore.setDisruption(new Disruption() {
 
@@ -524,7 +524,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         assertEquals(OperationPurpose.REPOSITORY_ANALYSIS, purpose);
     }
 
-    private static CountDown randomRequestCountDown(RepositoryAnalyzeAction.Request request) {
+    private static CountDown createDisruptionCountdown(RepositoryAnalyzeAction.Request request) {
         // requests that create copies count as two blobs. Halving the count ensures that we trigger the disruption
         // even if every request is a copy
         return new CountDown(between(1, request.getBlobCount() / 2));


### PR DESCRIPTION
The fix to #126747 was only for one test. This applies that change to all the tests in this suite that need it.

Fixes #127029 