### PR TITLE
NOOP some transport versions

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -222,10 +222,14 @@ public class TransportVersions {
     public static final TransportVersion REPO_ANALYSIS_COPY_BLOB = def(9_048_0_00);
     public static final TransportVersion AMAZON_BEDROCK_TASK_SETTINGS = def(9_049_0_00);
     public static final TransportVersion ESQL_REPORT_SHARD_PARTITIONING = def(9_050_0_00);
-    public static final TransportVersion ESQL_QUERY_PLANNING_DURATION = def(9_051_0_00);
-    public static final TransportVersion ESQL_DOCUMENTS_FOUND_AND_VALUES_LOADED = def(9_052_0_00);
-    public static final TransportVersion BATCHED_QUERY_EXECUTION_DELAYABLE_WRITABLE = def(9_053_0_00);
-    public static final TransportVersion SEARCH_INCREMENTAL_TOP_DOCS_NULL = def(9_054_0_00);
+    public static final TransportVersion NOOP_ESQL_QUERY_PLANNING_DURATION = def(9_051_0_00);
+    public static final TransportVersion NOOP_ESQL_DOCUMENTS_FOUND_AND_VALUES_LOADED = def(9_052_0_00);
+    public static final TransportVersion NOOP_BATCHED_QUERY_EXECUTION_DELAYABLE_WRITABLE = def(9_053_0_00);
+    public static final TransportVersion NOOP_SEARCH_INCREMENTAL_TOP_DOCS_NULL = def(9_054_0_00);
+    public static final TransportVersion ESQL_QUERY_PLANNING_DURATION = def(9_055_0_00);
+    public static final TransportVersion ESQL_DOCUMENTS_FOUND_AND_VALUES_LOADED = def(9_056_0_00);
+    public static final TransportVersion BATCHED_QUERY_EXECUTION_DELAYABLE_WRITABLE = def(9_057_0_00);
+    public static final TransportVersion SEARCH_INCREMENTAL_TOP_DOCS_NULL = def(9_058_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -222,10 +222,10 @@ public class TransportVersions {
     public static final TransportVersion REPO_ANALYSIS_COPY_BLOB = def(9_048_0_00);
     public static final TransportVersion AMAZON_BEDROCK_TASK_SETTINGS = def(9_049_0_00);
     public static final TransportVersion ESQL_REPORT_SHARD_PARTITIONING = def(9_050_0_00);
-    public static final TransportVersion NOOP_ESQL_QUERY_PLANNING_DURATION = def(9_051_0_00);
-    public static final TransportVersion NOOP_ESQL_DOCUMENTS_FOUND_AND_VALUES_LOADED = def(9_052_0_00);
-    public static final TransportVersion NOOP_BATCHED_QUERY_EXECUTION_DELAYABLE_WRITABLE = def(9_053_0_00);
-    public static final TransportVersion NOOP_SEARCH_INCREMENTAL_TOP_DOCS_NULL = def(9_054_0_00);
+    public static final TransportVersion DEAD_ESQL_QUERY_PLANNING_DURATION = def(9_051_0_00);
+    public static final TransportVersion DEAD_ESQL_DOCUMENTS_FOUND_AND_VALUES_LOADED = def(9_052_0_00);
+    public static final TransportVersion DEAD_BATCHED_QUERY_EXECUTION_DELAYABLE_WRITABLE = def(9_053_0_00);
+    public static final TransportVersion DEAD_SEARCH_INCREMENTAL_TOP_DOCS_NULL = def(9_054_0_00);
     public static final TransportVersion ESQL_QUERY_PLANNING_DURATION = def(9_055_0_00);
     public static final TransportVersion ESQL_DOCUMENTS_FOUND_AND_VALUES_LOADED = def(9_056_0_00);
     public static final TransportVersion BATCHED_QUERY_EXECUTION_DELAYABLE_WRITABLE = def(9_057_0_00);


### PR DESCRIPTION
We accidentally released the `9_051_0_00` and `9_052_0_00` transport versions to serverless without their backing code. We can't take that back. It's live. You can't unbake the cake.

That version of Elasticsearch will claim to be `9_052_0_00` but actually speak `9_050_0_00` code. To make main compatible with that version we're bumping all transport versions in main *past* those numbers.

This is a forbidden action. You may not do this. I may not do this. It is not safe. But it is the only way to make the world whole again.

In all seriousness, everything will be fine. It's against the rules but sometimes you have to break rules to put things right. We believe some serverless dev environments may break which is sad but it's worth it to bring everything back to sane land.
