### PR TITLE
[Tests] Fix index compatibility checks for AArch64

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/test/index/IndexVersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/index/IndexVersionUtilsTests.java
@@ -30,7 +30,19 @@ public class IndexVersionUtilsTests extends ESTestCase {
 
         String minIndexVersion = IndexVersions.MINIMUM_COMPATIBLE.toReleaseVersion();
         String lowestCompatibleVersion = indexCompatible.released.get(0);
-        assertThat(lowestCompatibleVersion, equalTo(minIndexVersion));
+
+        var arch = System.getProperty("os.arch");
+        var osName = System.getProperty("os.name");
+
+        if (arch.equals("aarch64") && osName.startsWith("Mac") && minIndexVersion.startsWith("7.0")) {
+            // AArch64 is supported on Mac since 7.16.0
+            assertThat(lowestCompatibleVersion, equalTo("7.16.0"));
+        } else if (arch.equals("aarch64") && osName.startsWith("Linux") && minIndexVersion.startsWith("7.0")) {
+            // AArch64 is supported on Linux since 7.12.0
+            assertThat(lowestCompatibleVersion, equalTo("7.12.0"));
+        } else {
+            assertThat(lowestCompatibleVersion, equalTo(minIndexVersion));
+        }
     }
 
     /**


### PR DESCRIPTION
This is required to follow the same logic as for filtering supported versions in BwC:
https://github.com/elastic/elasticsearch/blob/c5d3799af18fcd88b27856d8a4fec196b12fd015/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java#L294-L306 

AArch64 distro wasn't supported before 7.16 on Mac and before 7.12 on Linux.

This fixes the failing test on CI for AArch64 OSes.