### PR TITLE
ES|QL: Tests for column pruning after JOIN

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -50,7 +50,6 @@ public abstract class GenerativeRestTest extends ESRestTestCase {
         // Awaiting fixes
         "Unknown column \\[<all-fields-projected>\\]", // https://github.com/elastic/elasticsearch/issues/121741,
         "Plan \\[ProjectExec\\[\\[<no-fields>.* optimized incorrectly due to missing references", // https://github.com/elastic/elasticsearch/issues/125866
-        "only supports KEYWORD or TEXT values, found expression", // https://github.com/elastic/elasticsearch/issues/126017
         "token recognition error at: '``", // https://github.com/elastic/elasticsearch/issues/125870
         "Unknown column \\[.*\\]", // https://github.com/elastic/elasticsearch/issues/126026
         "optimized incorrectly due to missing references", // https://github.com/elastic/elasticsearch/issues/116781

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -1641,7 +1641,7 @@ from sample_data
 ;
 
 ignoreOrder: true
-event_duration
+event_duration:long
 ---------------
 1756467
 5033755

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -1628,3 +1628,26 @@ French
 Spanish
 German
 ;
+
+
+pruningJoinResult
+required_capability: join_lookup_v12
+required_capability: fix_join_masking_eval
+from sample_data
+| eval type = 1000
+| lookup join message_types_lookup on message
+| grok type "%{WORD:foo}"
+| keep event_duration
+;
+
+ignoreOrder: true
+event_duration
+---------------
+1756467
+5033755
+8268153
+725448
+1232382
+2764889
+3450233
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -1642,7 +1642,6 @@ from sample_data
 
 ignoreOrder: true
 event_duration:long
----------------
 1756467
 5033755
 8268153


### PR DESCRIPTION
Fixes: #126017

The issue was fixed by #126614

This adds a test for that use case.