### PR TITLE
Change allocation explain message

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
@@ -177,9 +177,8 @@ public class TransportClusterAllocationExplainAction extends TransportMasterNode
             }
             if (foundShard == null) {
                 throw new IllegalArgumentException(Strings.format("""
-                    No shard was specified in the request which means the response should explain a randomly-chosen unassigned shard, but \
-                    there are no unassigned shards in this cluster. To explain the allocation of an assigned shard you must specify the \
-                    target shard in the request. See %s for more information.""", ReferenceDocs.ALLOCATION_EXPLAIN_API));
+                    There are no unassigned shards in this cluster. To explain the allocation of an assigned shard, specify the target \
+                    shard in the request. See %s for more information.""", ReferenceDocs.ALLOCATION_EXPLAIN_API));
             }
         } else {
             if (projectIds.size() != 1) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
@@ -177,8 +177,8 @@ public class TransportClusterAllocationExplainAction extends TransportMasterNode
             }
             if (foundShard == null) {
                 throw new IllegalArgumentException(Strings.format("""
-                    There are no unassigned shards in this cluster. To explain the allocation of an assigned shard, specify the target \
-                    shard in the request. See %s for more information.""", ReferenceDocs.ALLOCATION_EXPLAIN_API));
+                    There are no unassigned shards in this cluster. Specify an assigned shard in the request body to explain its \
+                    allocation. See %s for more information.""", ReferenceDocs.ALLOCATION_EXPLAIN_API));
             }
         } else {
             if (projectIds.size() != 1) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
@@ -196,8 +196,8 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
             ).getMessage(),
             allOf(
                 // no point in asserting the precise wording of the message into this test, but we care that it contains these bits:
-                containsString("No shard was specified in the request"),
-                containsString("specify the target shard in the request"),
+                containsString("There are no unassigned shards in this cluster."),
+                containsString("Specify an assigned shard in the request body"),
                 containsString("https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-cluster-allocation-explain")
             )
         );


### PR DESCRIPTION
Reduce the amount of text returned when no shard is requested and all
shards are assigned. Less text is easier to digest and hopefully will
not be skimmed.
