### PR TITLE
[8.x] Use Terminal.readSecret in add string keystore command (#126966)

### DIFF
--- a/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/AddStringKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/cli/keystore/AddStringKeyStoreCommand.java
@@ -19,10 +19,7 @@ import org.elasticsearch.common.settings.KeyStoreWrapper;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.env.Environment;
 
-import java.io.CharArrayWriter;
-import java.io.Closeable;
 import java.io.IOException;
-import java.io.Reader;
 import java.util.Arrays;
 import java.util.List;
 
@@ -53,42 +50,28 @@ class AddStringKeyStoreCommand extends BaseKeyStoreCommand {
 
         final KeyStoreWrapper keyStore = getKeyStore();
 
-        final Closeable closeable;
-        final CheckedFunction<String, char[], IOException> valueSupplier;
-        if (options.has(stdinOption)) {
-            final Reader stdinReader = terminal.getReader();
-            valueSupplier = s -> {
-                try (CharArrayWriter writer = new CharArrayWriter()) {
-                    int c;
-                    while ((c = stdinReader.read()) != -1) {
-                        if ((char) c == '\r' || (char) c == '\n') {
-                            break;
-                        }
-                        writer.write((char) c);
-                    }
-                    return writer.toCharArray();
-                }
-            };
-            closeable = stdinReader;
-        } else {
-            valueSupplier = s -> terminal.readSecret("Enter value for " + s + ": ");
-            closeable = () -> {};
-        }
+        final CheckedFunction<String, char[], IOException> valueSupplier = s -> {
+            final String prompt;
+            if (options.has(stdinOption)) {
+                prompt = "";
+            } else {
+                prompt = "Enter value for " + s + ": ";
+            }
+            return terminal.readSecret(prompt);
+        };
 
-        try (closeable) {
-            for (final String setting : settings) {
-                if (keyStore.getSettingNames().contains(setting) && options.has(forceOption) == false) {
-                    if (terminal.promptYesNo("Setting " + setting + " already exists. Overwrite?", false) == false) {
-                        terminal.println("Exiting without modifying keystore.");
-                        return;
-                    }
+        for (final String setting : settings) {
+            if (keyStore.getSettingNames().contains(setting) && options.has(forceOption) == false) {
+                if (terminal.promptYesNo("Setting " + setting + " already exists. Overwrite?", false) == false) {
+                    terminal.println("Exiting without modifying keystore.");
+                    return;
                 }
+            }
 
-                try {
-                    keyStore.setString(setting, valueSupplier.apply(setting));
-                } catch (final IllegalArgumentException e) {
-                    throw new UserException(ExitCodes.DATA_ERROR, e.getMessage());
-                }
+            try {
+                keyStore.setString(setting, valueSupplier.apply(setting));
+            } catch (final IllegalArgumentException e) {
+                throw new UserException(ExitCodes.DATA_ERROR, e.getMessage());
             }
         }
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Use Terminal.readSecret in add string keystore command (#126966)