### PR TITLE
[8.x] Optimize ES819 doc values address offset calculation (#126732)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesConsumer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesConsumer.java
@@ -110,10 +110,11 @@ final class ES819TSDBDocValuesConsumer extends XDocValuesConsumer {
             }
         };
 
-        writeField(field, producer, -1);
+        writeField(field, producer, -1, null);
     }
 
-    private long[] writeField(FieldInfo field, TsdbDocValuesProducer valuesProducer, long maxOrd) throws IOException {
+    private long[] writeField(FieldInfo field, TsdbDocValuesProducer valuesProducer, long maxOrd, OffsetsAccumulator offsetsAccumulator)
+        throws IOException {
         int numDocsWithValue = 0;
         long numValues = 0;
 
@@ -163,6 +164,9 @@ final class ES819TSDBDocValuesConsumer extends XDocValuesConsumer {
                             disiAccumulator.addDocId(doc);
                         }
                         final int count = values.docValueCount();
+                        if (offsetsAccumulator != null) {
+                            offsetsAccumulator.addDoc(count);
+                        }
                         for (int i = 0; i < count; ++i) {
                             buffer[bufferSize++] = values.nextValue();
                             if (bufferSize == ES819TSDBDocValuesFormat.NUMERIC_BLOCK_SIZE) {
@@ -372,7 +376,7 @@ final class ES819TSDBDocValuesConsumer extends XDocValuesConsumer {
         }
         SortedDocValues sorted = valuesProducer.getSorted(field);
         int maxOrd = sorted.getValueCount();
-        writeField(field, producer, maxOrd);
+        writeField(field, producer, maxOrd, null);
         addTermsDict(DocValues.singleton(valuesProducer.getSorted(field)));
     }
 
@@ -528,31 +532,46 @@ final class ES819TSDBDocValuesConsumer extends XDocValuesConsumer {
         if (maxOrd > -1) {
             meta.writeByte((byte) 1); // multiValued (1 = multiValued)
         }
-        long[] stats = writeField(field, valuesProducer, maxOrd);
-        int numDocsWithField = Math.toIntExact(stats[0]);
-        long numValues = stats[1];
-        assert numValues >= numDocsWithField;
 
-        if (numValues > numDocsWithField) {
-            long start = data.getFilePointer();
-            meta.writeLong(start);
-            meta.writeVInt(ES819TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT);
-
-            final DirectMonotonicWriter addressesWriter = DirectMonotonicWriter.getInstance(
-                meta,
-                data,
-                numDocsWithField + 1L,
-                ES819TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT
-            );
-            long addr = 0;
-            addressesWriter.add(addr);
-            SortedNumericDocValues values = valuesProducer.getSortedNumeric(field);
-            for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
-                addr += values.docValueCount();
-                addressesWriter.add(addr);
+        if (valuesProducer.mergeStats.supported()) {
+            int numDocsWithField = valuesProducer.mergeStats.sumNumDocsWithField();
+            long numValues = valuesProducer.mergeStats.sumNumValues();
+            if (numDocsWithField == numValues) {
+                writeField(field, valuesProducer, maxOrd, null);
+            } else {
+                assert numValues > numDocsWithField;
+                try (var accumulator = new OffsetsAccumulator(dir, context, data, numDocsWithField)) {
+                    writeField(field, valuesProducer, maxOrd, accumulator);
+                    accumulator.build(meta, data);
+                }
             }
-            addressesWriter.finish();
-            meta.writeLong(data.getFilePointer() - start);
+        } else {
+            long[] stats = writeField(field, valuesProducer, maxOrd, null);
+            int numDocsWithField = Math.toIntExact(stats[0]);
+            long numValues = stats[1];
+            assert numValues >= numDocsWithField;
+
+            if (numValues > numDocsWithField) {
+                long start = data.getFilePointer();
+                meta.writeLong(start);
+                meta.writeVInt(ES819TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT);
+
+                final DirectMonotonicWriter addressesWriter = DirectMonotonicWriter.getInstance(
+                    meta,
+                    data,
+                    numDocsWithField + 1L,
+                    ES819TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT
+                );
+                long addr = 0;
+                addressesWriter.add(addr);
+                SortedNumericDocValues values = valuesProducer.getSortedNumeric(field);
+                for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+                    addr += values.docValueCount();
+                    addressesWriter.add(addr);
+                }
+                addressesWriter.finish();
+                meta.writeLong(data.getFilePointer() - start);
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/OffsetsAccumulator.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/OffsetsAccumulator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es819;
+
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.packed.DirectMonotonicWriter;
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Builds the doc values address offset table iteratively, one document at a time. Useful to avoid a separate docvalues iteration
+ * to build the address offset table.
+ */
+final class OffsetsAccumulator implements Closeable {
+    private final Directory dir;
+    private final IOContext context;
+
+    private final ByteBuffersDataOutput addressMetaBuffer;
+    private final ByteBuffersIndexOutput addressMetaOutput;
+    private final IndexOutput addressDataOutput;
+    private final DirectMonotonicWriter addressesWriter;
+
+    private final String addressOffsetsTempFileName;
+
+    private long addr = 0;
+
+    OffsetsAccumulator(Directory dir, IOContext context, IndexOutput data, long numDocsWithField) throws IOException {
+        this.dir = dir;
+        this.context = context;
+
+        addressMetaBuffer = new ByteBuffersDataOutput();
+        addressMetaOutput = new ByteBuffersIndexOutput(addressMetaBuffer, "meta-temp", "meta-temp");
+        addressDataOutput = dir.createTempOutput(data.getName(), "address-data", context);
+        addressOffsetsTempFileName = addressDataOutput.getName();
+        addressesWriter = DirectMonotonicWriter.getInstance(
+            addressMetaOutput,
+            addressDataOutput,
+            numDocsWithField + 1L,
+            ES819TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT
+        );
+    }
+
+    public void addDoc(int docValueCount) throws IOException {
+        addressesWriter.add(addr);
+        addr += docValueCount;
+    }
+
+    public void build(IndexOutput meta, IndexOutput data) throws IOException {
+        addressesWriter.add(addr);
+        addressesWriter.finish();
+        long start = data.getFilePointer();
+        meta.writeLong(start);
+        meta.writeVInt(ES819TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT);
+        addressMetaBuffer.copyTo(meta);
+        addressDataOutput.close();
+        try (var addressDataInput = dir.openInput(addressOffsetsTempFileName, context)) {
+            data.copyBytes(addressDataInput, addressDataInput.length());
+            meta.writeLong(data.getFilePointer() - start);
+        }
+    }
+
+    @Override
+    @SuppressForbidden(reason = "require usage of Lucene's IOUtils#deleteFilesIgnoringExceptions(...)")
+    public void close() throws IOException {
+        IOUtils.close(addressMetaOutput, addressDataOutput);
+        if (addressOffsetsTempFileName != null) {
+            IOUtils.deleteFilesIgnoringExceptions(dir, addressOffsetsTempFileName);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -64,6 +64,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
 
             int numDocs = 256 + random().nextInt(1024);
             int numHosts = numDocs / 20;
+
             for (int i = 0; i < numDocs; i++) {
                 var d = new Document();
 
@@ -77,7 +78,12 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 d.add(new NumericDocValuesField("counter_1", counter1++));
                 d.add(new SortedNumericDocValuesField("counter_2", counter2++));
                 d.add(new SortedNumericDocValuesField("gauge_1", gauge1Values[i % gauge1Values.length]));
-                d.add(new SortedNumericDocValuesField("gauge_2", gauge2Values[i % gauge1Values.length]));
+
+                int numGauge2 = 1 + random().nextInt(8);
+                for (int j = 0; j < numGauge2; j++) {
+                    d.add(new SortedNumericDocValuesField("gauge_2", gauge2Values[(i + j) % gauge2Values.length]));
+                }
+
                 int numTags = 1 + random().nextInt(8);
                 for (int j = 0; j < numTags; j++) {
                     d.add(new SortedSetDocValuesField("tags", new BytesRef(tags[j])));
@@ -144,9 +150,10 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                     assertTrue("unexpected gauge [" + gaugeOneValue + "]", Arrays.binarySearch(gauge1Values, gaugeOneValue) >= 0);
 
                     assertEquals(i, gaugeTwoDV.nextDoc());
-                    assertEquals(1, gaugeTwoDV.docValueCount());
-                    long gaugeTwoValue = gaugeTwoDV.nextValue();
-                    assertTrue("unexpected gauge [" + gaugeTwoValue + "]", Arrays.binarySearch(gauge2Values, gaugeTwoValue) >= 0);
+                    for (int j = 0; j < gaugeTwoDV.docValueCount(); j++) {
+                        long gaugeTwoValue = gaugeTwoDV.nextValue();
+                        assertTrue("unexpected gauge [" + gaugeTwoValue + "]", Arrays.binarySearch(gauge2Values, gaugeTwoValue) >= 0);
+                    }
 
                     assertEquals(i, tagsDV.nextDoc());
                     for (int j = 0; j < tagsDV.docValueCount(); j++) {
@@ -277,7 +284,10 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                     d.add(new SortedNumericDocValuesField("gauge_1", gauge1Values[i % gauge1Values.length]));
                 }
                 if (random().nextBoolean()) {
-                    d.add(new SortedNumericDocValuesField("gauge_2", gauge2Values[i % gauge1Values.length]));
+                    int numGauge2 = 1 + random().nextInt(8);
+                    for (int j = 0; j < numGauge2; j++) {
+                        d.add(new SortedNumericDocValuesField("gauge_2", gauge2Values[(i + j) % gauge2Values.length]));
+                    }
                 }
                 if (random().nextBoolean()) {
                     int numTags = 1 + random().nextInt(8);
@@ -356,9 +366,10 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                     }
 
                     if (gaugeTwoDV.advanceExact(i)) {
-                        assertEquals(1, gaugeTwoDV.docValueCount());
-                        long gaugeTwoValue = gaugeTwoDV.nextValue();
-                        assertTrue("unexpected gauge [" + gaugeTwoValue + "]", Arrays.binarySearch(gauge2Values, gaugeTwoValue) >= 0);
+                        for (int j = 0; j < gaugeTwoDV.docValueCount(); j++) {
+                            long gaugeTwoValue = gaugeTwoDV.nextValue();
+                            assertTrue("unexpected gauge [" + gaugeTwoValue + "]", Arrays.binarySearch(gauge2Values, gaugeTwoValue) >= 0);
+                        }
                     }
 
                     if (tagsDV.advanceExact(i)) {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Optimize ES819 doc values address offset calculation (#126732)