### PR TITLE
[8.x] Make sure SM isn't running alongside entitlements tests (#127082)

### DIFF
--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/initialization/EntitlementInitializationTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/initialization/EntitlementInitializationTests.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.startsWith;
 
+@ESTestCase.WithoutSecurityManager
 public class EntitlementInitializationTests extends ESTestCase {
 
     private static PathLookup TEST_PATH_LOOKUP;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Make sure SM isn't running alongside entitlements tests (#127082)