### PR TITLE
Use explicit newline with keystore stdin test

### DIFF
--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/AddStringKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/AddStringKeyStoreCommandTests.java
@@ -193,7 +193,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
         String password = "keystorepassword";
         KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
-        terminal.addSecretInput("Typedthisandhitenter\r");
+        terminal.addSecretInput("Typedthisandhitenter\r\n");
         execute("-x", "foo");
         assertSecureString("foo", "Typedthisandhitenter", password);
     }


### PR DESCRIPTION
The add string keystore command accepts input on stdin. In this case, the terminal is responsible for separating input by newlines that are system dependent. The mock terminal normally adds the system dependent newline. However, we also have tests that ensure both unix and windows style newlines are tested explicitly. This commit fixes the windows style carriage returns to explicitly contain a newline.

closes #127089