### PR TITLE
[9.0] Use explicit newline with keystore stdin test (#127094)

### DIFF
--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/AddStringKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/AddStringKeyStoreCommandTests.java
@@ -193,7 +193,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
         String password = "keystorepassword";
         KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
-        terminal.addSecretInput("Typedthisandhitenter\r");
+        terminal.addSecretInput("Typedthisandhitenter\r\n");
         execute("-x", "foo");
         assertSecureString("foo", "Typedthisandhitenter", password);
     }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Use explicit newline with keystore stdin test (#127094)