### PR TITLE
[DOCS]: Fix superscripts in documentation

### DIFF
--- a/docs/reference/aggregations/search-aggregations-metrics-max-aggregation.md
+++ b/docs/reference/aggregations/search-aggregations-metrics-max-aggregation.md
@@ -10,7 +10,7 @@ mapped_pages:
 A `single-value` metrics aggregation that keeps track and returns the maximum value among the numeric values extracted from the aggregated documents.
 
 ::::{note}
-The `min` and `max` aggregation operate on the `double` representation of the data. As a consequence, the result may be approximate when running on longs whose absolute value is greater than `2^53`.
+The `min` and `max` aggregation operate on the `double` representation of the data. As a consequence, the result may be approximate when running on longs whose absolute value is greater than `2`^`53`^.
 ::::
 
 

--- a/docs/reference/aggregations/search-aggregations-metrics-min-aggregation.md
+++ b/docs/reference/aggregations/search-aggregations-metrics-min-aggregation.md
@@ -10,7 +10,7 @@ mapped_pages:
 A `single-value` metrics aggregation that keeps track and returns the minimum value among numeric values extracted from the aggregated documents.
 
 ::::{note}
-The `min` and `max` aggregation operate on the `double` representation of the data. As a consequence, the result may be approximate when running on longs whose absolute value is greater than `2^53`.
+The `min` and `max` aggregation operate on the `double` representation of the data. As a consequence, the result may be approximate when running on longs whose absolute value is greater than `2`^`53`^.
 ::::
 
 

--- a/docs/reference/elasticsearch/mapping-reference/number.md
+++ b/docs/reference/elasticsearch/mapping-reference/number.md
@@ -10,10 +10,10 @@ mapped_pages:
 The following numeric types are supported:
 
 `long`
-:   A signed 64-bit integer with a minimum value of `-263` and a maximum value of `263-1`.
+:   A signed 64-bit integer with a minimum value of `-2`^`63`^ and a maximum value of `2`^`63`^`-1`.
 
 `integer`
-:   A signed 32-bit integer with a minimum value of `-231` and a maximum value of `231-1`.
+:   A signed 32-bit integer with a minimum value of `-2`^`31`^ and a maximum value of `2`^`31`^`-1`.
 
 `short`
 :   A signed 16-bit integer with a minimum value of `-32,768` and a maximum value of `32,767`.
@@ -34,7 +34,7 @@ The following numeric types are supported:
 :   A floating point number that is backed by a `long`, scaled by a fixed `double` scaling factor.
 
 `unsigned_long`
-:   An unsigned 64-bit integer with a minimum value of 0 and a maximum value of `264-1`.
+:   An unsigned 64-bit integer with a minimum value of 0 and a maximum value of `2`^`64`^`-1`.
 
 Below is an example of configuring a mapping with numeric fields:
 
@@ -75,9 +75,9 @@ $$$floating_point$$$
 
 | Type | Minimum value | Maximum value | Significant<br>                                                      bits / digits | Example precision loss |
 | --- | --- | --- | --- | --- |
-| `double` | `2-1074` | `(2-2-52)·21023` | `53` / `15.95` | `1.2345678912345678`→<br>                                                                      `1.234567891234568` |
-| `float` | `2-149` | `(2-2-23)·2127` | `24` / `7.22` | `1.23456789`→<br>                                                                      `1.2345679` |
-| `half_float` | `2-24` | `65504` | `11` / `3.31` | `1.2345`→<br>                                                                      `1.234375` |
+| `double` | `2`^`-1074`^ | `(2-2`^`-52`^`)·2`^`1023`^ | `53` / `15.95` | `1.2345678912345678`→<br>                                                                      `1.234567891234568` |
+| `float` | `2`^`-149`^ | `(2-2`^`-23`^`)·2`^`127`^ | `24` / `7.22` | `1.23456789`→<br>                                                                      `1.2345679` |
+| `half_float` | `2`^`-24`^ | `65504` | `11` / `3.31` | `1.2345`→<br>                                                                      `1.234375` |
 
 ::::{admonition} Mapping numeric identifiers
 :class: tip

--- a/docs/reference/elasticsearch/mapping-reference/range.md
+++ b/docs/reference/elasticsearch/mapping-reference/range.md
@@ -12,13 +12,13 @@ Range field types represent a continuous range of values between an upper and lo
 The following range types are supported:
 
 `integer_range`
-:   A range of signed 32-bit integers with a minimum value of `-231` and maximum of `231-1`.
+:   A range of signed 32-bit integers with a minimum value of `-2`^`31`^ and maximum of `2`^`31`^`-1`.
 
 `float_range`
 :   A range of single-precision 32-bit IEEE 754 floating point values.
 
 `long_range`
-:   A range of signed 64-bit integers with a minimum value of `-263` and maximum of `263-1`.
+:   A range of signed 64-bit integers with a minimum value of `-2`^`63`^ and maximum of `2`^`63`^`-1`.
 
 `double_range`
 :   A range of double-precision 64-bit IEEE 754 floating point values.

--- a/docs/reference/elasticsearch/mapping-reference/unsigned-long.md
+++ b/docs/reference/elasticsearch/mapping-reference/unsigned-long.md
@@ -7,7 +7,7 @@ mapped_pages:
 # Unsigned long field type [unsigned-long]
 
 
-Unsigned long is a numeric field type that represents an unsigned 64-bit integer with a minimum value of 0 and a maximum value of `264-1` (from 0 to 18446744073709551615 inclusive).
+Unsigned long is a numeric field type that represents an unsigned 64-bit integer with a minimum value of 0 and a maximum value of `2`^`64`^`-1` (from 0 to 18446744073709551615 inclusive).
 
 ```console
 PUT my_index

--- a/docs/reference/query-languages/query-dsl/query-dsl-mlt-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-mlt-query.md
@@ -150,7 +150,7 @@ The only required parameter is `like`, all other parameters have sensible defaul
 :   The minimum document frequency below which the terms will be ignored from the input document. Defaults to `5`.
 
 `max_doc_freq`
-:   The maximum document frequency above which the terms will be ignored from the input document. This could be useful in order to ignore highly frequent words such as stop words. Defaults to unbounded (`Integer.MAX_VALUE`, which is `2^31-1` or 2147483647).
+:   The maximum document frequency above which the terms will be ignored from the input document. This could be useful in order to ignore highly frequent words such as stop words. Defaults to unbounded (`Integer.MAX_VALUE`, which is `2`^`31`^`-1` or 2147483647).
 
 `min_word_length`
 :   The minimum word length below which the terms will be ignored. Defaults to `0`.

--- a/docs/reference/scripting-languages/painless/painless-types.md
+++ b/docs/reference/scripting-languages/painless/painless-types.md
@@ -28,10 +28,10 @@ The following primitive types are available. The corresponding reference type is
 :   16-bit, unsigned, Unicode character. Range: [`0`, `65535`]. Default: `0` or `\u0000`.
 
 `int` (`Integer`)
-:   32-bit, signed, two’s complement integer. Range: [`-2^31`, `2^31-1`]. Default: `0`.
+:   32-bit, signed, two’s complement integer. Range: [`-2`^`31`^, `2`^`31`^`-1`]. Default: `0`.
 
 `long` (`Long`)
-:   64-bit, signed, two’s complement integer. Range: [`-2^63`, `2^63-1`]. Default: `0`.
+:   64-bit, signed, two’s complement integer. Range: [`-2`^`63`^, `2`^`63`^`-1`]. Default: `0`.
 
 `float (`Float`)`
 :   32-bit, signed, single-precision, IEEE 754 floating point number. Default `0.0`.

--- a/docs/reference/text-analysis/analysis-length-tokenfilter.md
+++ b/docs/reference/text-analysis/analysis-length-tokenfilter.md
@@ -70,7 +70,7 @@ PUT length_example
 :   (Optional, integer) Minimum character length of a token. Shorter tokens are excluded from the output. Defaults to `0`.
 
 `max`
-:   (Optional, integer) Maximum character length of a token. Longer tokens are excluded from the output. Defaults to `Integer.MAX_VALUE`, which is `2^31-1` or `2147483647`.
+:   (Optional, integer) Maximum character length of a token. Longer tokens are excluded from the output. Defaults to `Integer.MAX_VALUE`, which is `2`^`31`^`-1` or `2147483647`.
 
 
 ## Customize [analysis-length-tokenfilter-customize]


### PR DESCRIPTION
Re-add and fix superscripts in the documentation.

Based on: https://github.com/elastic/docs-content/issues/1170