### PR TITLE
Improve listing of index mode options in docs

### DIFF
--- a/docs/reference/elasticsearch/index-settings/index-modules.md
+++ b/docs/reference/elasticsearch/index-settings/index-modules.md
@@ -49,27 +49,27 @@ $$$index-codec$$$ `index.codec`
 
 $$$index-mode-setting$$$ `index.mode`
 :   The `index.mode` setting is used to control settings applied in specific domains like ingestion of time series data or logs. Different mutually exclusive modes exist, which are used to apply settings or default values controlling indexing of documents, sorting and other parameters whose value affects indexing or query performance.
+        
+        **Example**
 
-```console
-PUT my-index-000001
-{
-  "settings": {
-    "index":{
-      "mode":"standard" <1>
-    }
-  }
-}
-```
+      ```console
+      PUT my-index-000001
+      {
+        "settings": {
+          "index":{
+            "mode":"standard" # This index uses the `standard` index mode
+          }
+        }
+      }
+      ```
+    **Supported values**
 
-1. This index uses the `standard` index mode
-
-
-Index mode supports the following values:
-* `null` - Default value (same as `standard`).
-* `standard` - Standard indexing with default settings.
-* `lookup` -  Index that can be used for lookup joins in ES|QL. Limited to 1 shard.
-* `time_series` - *(data streams only)* Index mode optimized for storage of metrics. For more information, see [Time series index settings](time-series.md).
-* `logsdb` -  *(data streams only)* Index mode optimized for [logs](docs-content://manage-data/data-store/data-streams/logs-data-stream.md).
+    The `index.mode` setting supports the following values:
+       - `null`:   Default value (same as `standard`).
+       -  `standard`:   Standard indexing with default settings.
+       -  `lookup`: Index that can be used for [LOOKUP JOIN](/reference/query-languages/esql/esql-lookup-join) in ES|QL. Limited to 1 shard.
+       - `time_series`:   *(data streams only)* Index mode optimized for storage of metrics. For more information, see [Time series index settings](time-series.md).
+       - `logsdb`: *(data streams only)* Index mode optimized for [logs](docs-content://manage-data/data-store/data-streams/logs-data-stream.md).
 
 $$$routing-partition-size$$$ `index.routing_partition_size`
 :   The number of shards a custom routing value can go to. Defaults to 1 and can only be set at index creation time. This value must be less than the `index.number_of_routing_shards` unless the `index.number_of_routing_shards` value is also 1. for more details about how this setting is used, refer to [](/reference/elasticsearch/mapping-reference/mapping-routing-field.md#routing-index-partition).

--- a/docs/reference/elasticsearch/index-settings/index-modules.md
+++ b/docs/reference/elasticsearch/index-settings/index-modules.md
@@ -65,23 +65,11 @@ PUT my-index-000001
 
 
 Index mode supports the following values:
-
-`null`
-:   Default value (same as `standard`).
-
-`standard`
-:   Standard indexing with default settings.
-
-`lookup`
-: Index that can be used for lookup joins in ES|QL. Limited to 1 shard.
-
-
-`time_series`
-:   *(data streams only)* Index mode optimized for storage of metrics. For more information, see [Time series index settings](time-series.md).
-
-`logsdb`
-:   *(data streams only)* Index mode optimized for [logs](docs-content://manage-data/data-store/data-streams/logs-data-stream.md).
-
+* `null` - Default value (same as `standard`).
+* `standard` - Standard indexing with default settings.
+* `lookup` -  Index that can be used for lookup joins in ES|QL. Limited to 1 shard.
+* `time_series` - *(data streams only)* Index mode optimized for storage of metrics. For more information, see [Time series index settings](time-series.md).
+* `logsdb` -  *(data streams only)* Index mode optimized for [logs](docs-content://manage-data/data-store/data-streams/logs-data-stream.md).
 
 $$$routing-partition-size$$$ `index.routing_partition_size`
 :   The number of shards a custom routing value can go to. Defaults to 1 and can only be set at index creation time. This value must be less than the `index.number_of_routing_shards` unless the `index.number_of_routing_shards` value is also 1. for more details about how this setting is used, refer to [](/reference/elasticsearch/mapping-reference/mapping-routing-field.md#routing-index-partition).

--- a/docs/reference/elasticsearch/index-settings/index-modules.md
+++ b/docs/reference/elasticsearch/index-settings/index-modules.md
@@ -67,7 +67,7 @@ $$$index-mode-setting$$$ `index.mode`
     The `index.mode` setting supports the following values:
        - `null`:   Default value (same as `standard`).
        -  `standard`:   Standard indexing with default settings.
-       -  `lookup`: Index that can be used for [LOOKUP JOIN](/reference/query-languages/esql/esql-lookup-join) in ES|QL. Limited to 1 shard.
+       -  `lookup`: Index that can be used for [LOOKUP JOIN](/reference/query-languages/esql/esql-lookup-join.md) in ES|QL. Limited to 1 shard.
        - `time_series`:   *(data streams only)* Index mode optimized for storage of metrics. For more information, see [Time series index settings](time-series.md).
        - `logsdb`: *(data streams only)* Index mode optimized for [logs](docs-content://manage-data/data-store/data-streams/logs-data-stream.md).
 


### PR DESCRIPTION
currently there is no visual break between the options for `index.mode` and `index.routing_partition_size` which is an index setting:

<img width="814" alt="Screenshot 2025-04-22 at 16 31 39" src="https://github.com/user-attachments/assets/186a8976-3cb1-4d0b-a01a-886ed639badf" />

checking to see if this change makes it better (looks good in my editor), but in the end it depends on how the docs are actually rendered.

EDIT: this is how it looks in the preview


<img width="758" alt="Screenshot 2025-04-22 at 17 35 34" src="https://github.com/user-attachments/assets/a866a017-8aad-4801-9e1d-11729e554e5d" />
