### PR TITLE
ESQL: Add fields to detailed query fetch api

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlListQueriesActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlListQueriesActionIT.java
@@ -67,6 +67,8 @@ public class EsqlListQueriesActionIT extends AbstractPausableIntegTestCase {
                 jsonEntityToMap(getQueryResponse.getEntity()),
                 basicMatcher.entry("coordinating_node", isA(String.class))
                     .entry("data_nodes", allOf(isA(List.class), everyItem(isA(String.class))))
+                    .entry("documents_found", IntOrLongMatcher.isIntOrLong())
+                    .entry("values_loaded", IntOrLongMatcher.isIntOrLong())
             );
         } finally {
             if (id != null) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlGetQueryResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlGetQueryResponse.java
@@ -22,6 +22,8 @@ public class EsqlGetQueryResponse extends ActionResponse implements ToXContentOb
         TaskId id,
         long startTimeMillis,
         long runningTimeNanos,
+        long documentsFound,
+        long valuesLoaded,
         String query,
         String coordinatingNode,
         List<String> dataNodes
@@ -33,6 +35,8 @@ public class EsqlGetQueryResponse extends ActionResponse implements ToXContentOb
             builder.field("node", id.getNodeId());
             builder.field("start_time_millis", startTimeMillis);
             builder.field("running_time_nanos", runningTimeNanos);
+            builder.field("documents_found", documentsFound);
+            builder.field("values_loaded", valuesLoaded);
             builder.field("query", query);
             builder.field("coordinating_node", coordinatingNode);
             builder.field("data_nodes", dataNodes);


### PR DESCRIPTION
This adds `documents_found` and `values_loaded` to the ESQL query get API. Sadly, this is only the sum of the of statistics from currently running drivers. Completed drivers are forgotten. That information is available, but it's not plumbed into a place where we can get it. That's next!
