### PR TITLE
[9.0] Update Documentation URLs (#125089)

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationChecker.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.deprecation;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -93,9 +94,9 @@ public class DataStreamDeprecationChecker implements ResourceDeprecationChecker 
         if (indicesNeedingUpgrade.isEmpty() == false) {
             return new DeprecationIssue(
                 DeprecationIssue.Level.CRITICAL,
-                "Old data stream with a compatibility version < 9.0",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
-                "This data stream has backing indices that were created before Elasticsearch 9.0.0",
+                "Old data stream with a compatibility version < " + Version.CURRENT.major + ".0",
+                "https://ela.st/es-deprecation-ds-reindex",
+                "This data stream has backing indices that were created before Elasticsearch " + Version.CURRENT.major + ".0",
                 false,
                 ofEntries(
                     entry("reindex_required", true),
@@ -115,10 +116,11 @@ public class DataStreamDeprecationChecker implements ResourceDeprecationChecker 
         if (ignoredIndices.isEmpty() == false) {
             return new DeprecationIssue(
                 DeprecationIssue.Level.WARNING,
-                "Old data stream with a compatibility version < 9.0 Have Been Ignored",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
-                "This data stream has read only backing indices that were created before Elasticsearch 9.0.0 and have been marked as "
-                    + "OK to remain read-only after upgrade",
+                "Old data stream with a compatibility version < " + Version.CURRENT.major + ".0 has Been Ignored",
+                "https://ela.st/es-deprecation-ds-reindex",
+                "This data stream has read only backing indices that were created before Elasticsearch "
+                    + Version.CURRENT.major
+                    + ".0 and have been marked as OK to remain read-only after upgrade",
                 false,
                 ofEntries(
                     entry("reindex_required", false),

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IlmPolicyDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IlmPolicyDeprecationChecker.java
@@ -104,7 +104,7 @@ public class IlmPolicyDeprecationChecker implements ResourceDeprecationChecker {
                     "ILM policy ["
                         + policy.getName()
                         + "] contains the action 'freeze' that is deprecated and will be removed in a future version.",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/frozen-indices.html",
+                    "https://ela.st/es-deprecation-7-frozen-index",
                     "This action is already a noop so it can be safely removed, because frozen indices no longer offer any advantages."
                         + " Consider cold or frozen tiers in place of frozen indices.",
                     false,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecker.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.deprecation;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -100,14 +101,14 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
             if (transforms.isEmpty() == false) {
                 return new DeprecationIssue(
                     DeprecationIssue.Level.CRITICAL,
-                    "One or more Transforms write to this index with a compatibility version < 9.0",
-                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
-                        + "#breaking_90_transform_destination_index",
+                    "One or more Transforms write to this index with a compatibility version < " + Version.CURRENT.major + ".0",
+                    "https://ela.st/es-deprecation-9-transform-destination-index",
                     Strings.format(
-                        "This index was created in version [%s] and requires action before upgrading to 9.0. The following transforms are "
+                        "This index was created in version [%s] and requires action before upgrading to %d.0. The following transforms are "
                             + "configured to write to this index: [%s]. Refer to the migration guide to learn more about how to prepare "
                             + "transforms destination indices for your upgrade.",
                         currentCompatibilityVersion.toReleaseVersion(),
+                        Version.CURRENT.major,
                         String.join(", ", transforms)
                     ),
                     false,
@@ -116,8 +117,8 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
             } else {
                 return new DeprecationIssue(
                     DeprecationIssue.Level.CRITICAL,
-                    "Old index with a compatibility version < 9.0",
-                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html",
+                    "Old index with a compatibility version < " + Version.CURRENT.major + ".0",
+                    "https://ela.st/es-deprecation-9-index-version",
                     "This index has version: " + currentCompatibilityVersion.toReleaseVersion(),
                     false,
                     Map.of("reindex_required", true)
@@ -143,14 +144,14 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
             if (transforms.isEmpty() == false) {
                 return new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
-                    "One or more Transforms write to this old index with a compatibility version < 9.0",
-                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
-                        + "#breaking_90_transform_destination_index",
+                    "One or more Transforms write to this old index with a compatibility version < " + Version.CURRENT.major + ".0",
+                    "https://ela.st/es-deprecation-9-transform-destination-index",
                     Strings.format(
-                        "This index was created in version [%s] and will be supported as a read-only index in 9.0. The following "
+                        "This index was created in version [%s] and will be supported as a read-only index in %d.0. The following "
                             + "transforms are no longer able to write to this index: [%s]. Refer to the migration guide to learn more "
                             + "about how to handle your transforms destination indices.",
                         currentCompatibilityVersion.toReleaseVersion(),
+                        Version.CURRENT.major,
                         String.join(", ", transforms)
                     ),
                     false,
@@ -159,11 +160,13 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
             } else {
                 return new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
-                    "Old index with a compatibility version < 9.0 has been ignored",
-                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html",
+                    "Old index with a compatibility version < " + Version.CURRENT.major + ".0 has been ignored",
+                    "https://ela.st/es-deprecation-9-index-version",
                     "This read-only index has version: "
                         + currentCompatibilityVersion.toReleaseVersion()
-                        + " and will be supported as read-only in 9.0",
+                        + " and will be supported as read-only in "
+                        + Version.CURRENT.major
+                        + ".0",
                     false,
                     Map.of("reindex_required", true)
                 );
@@ -196,7 +199,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
                 return new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
                     "translog retention settings are ignored",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-translog.html",
+                    "https://ela.st/es-deprecation-7-translog-retention",
                     "translog retention settings [index.translog.retention.size] and [index.translog.retention.age] are ignored "
                         + "because translog is no longer used in peer recoveries with soft-deletes enabled (default in 7.0 or later)",
                     false,
@@ -214,8 +217,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
                 "setting [%s] is deprecated and will be removed in a future version",
                 IndexMetadata.INDEX_DATA_PATH_SETTING.getKey()
             );
-            final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/"
-                + "breaking-changes-7.13.html#deprecate-shared-data-path-setting";
+            final String url = "https://ela.st/es-deprecation-7-index-data-path";
             final String details = "Found index data path configured. Discontinue use of this setting.";
             return new DeprecationIssue(DeprecationIssue.Level.WARNING, message, url, details, false, null);
         }
@@ -232,7 +234,7 @@ public class IndexDeprecationChecker implements ResourceDeprecationChecker {
             return new DeprecationIssue(
                 DeprecationIssue.Level.WARNING,
                 "[simplefs] is deprecated and will be removed in future versions",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-store.html",
+                "https://ela.st/es-deprecation-7-simplefs",
                 "[simplefs] is deprecated and will be removed in 8.0. Use [niofs] or other file systems instead. "
                     + "Elasticsearch 7.15 or later uses [niofs] for the [simplefs] store type "
                     + "as it offers superior or equivalent performance to [simplefs].",

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
@@ -39,7 +39,7 @@ public class MlDeprecationChecker implements DeprecationChecker {
                 new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
                     "Datafeed [" + datafeedConfig.getId() + "] uses deprecated query options",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html#breaking_70_search_changes",
+                    "https://ela.st/es-deprecation-7-data-feed-query",
                     deprecations.toString(),
                     false,
                     null
@@ -57,8 +57,7 @@ public class MlDeprecationChecker implements DeprecationChecker {
                 new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
                     "Datafeed [" + datafeedConfig.getId() + "] uses deprecated aggregation options",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html"
-                        + "#breaking_70_aggregations_changes",
+                    "https://ela.st/es-deprecation-7-data-feed-aggregation",
                     deprecations.toString(),
                     false,
                     null
@@ -98,7 +97,7 @@ public class MlDeprecationChecker implements DeprecationChecker {
                         modelSnapshot.getJobId(),
                         modelSnapshot.getMinVersion()
                     ),
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-upgrade-job-model-snapshot.html",
+                    "https://ela.st/es-deprecation-8-model-snapshot-version",
                     details.toString(),
                     false,
                     Map.of("job_id", modelSnapshot.getJobId(), "snapshot_id", modelSnapshot.getSnapshotId())

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -251,8 +251,7 @@ public class NodeDeprecationChecks {
                 "setting [%s] is deprecated and will be removed in a future version",
                 Environment.PATH_SHARED_DATA_SETTING.getKey()
             );
-            final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/"
-                + "breaking-changes-7.13.html#deprecate-shared-data-path-setting";
+            final String url = "https://ela.st/es-deprecation-7-shared-data-path";
             final String details = "Found shared data path configured. Discontinue use of this setting.";
             return new DeprecationIssue(DeprecationIssue.Level.WARNING, message, url, details, false, null);
         }
@@ -281,7 +280,7 @@ public class NodeDeprecationChecks {
             return new DeprecationIssue(
                 DeprecationIssue.Level.CRITICAL,
                 "Realm that start with [" + RESERVED_REALM_AND_DOMAIN_NAME_PREFIX + "] will not be permitted in a future major release.",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/deprecated-7.14.html#reserved-prefixed-realm-names",
+                "https://ela.st/es-deprecation-7-realm-prefix",
                 String.format(
                     Locale.ROOT,
                     "Found realm "
@@ -972,7 +971,7 @@ public class NodeDeprecationChecks {
             Setting.Property.NodeScope,
             Setting.Property.DeprecatedWarning
         );
-        String url = "https://ela.st/es-deprecation-8-eql-enabled-setting";
+        String url = "https://ela.st/es-deprecation-7-eql-enabled-setting";
         return checkRemovedSetting(
             clusterState.metadata().settings(),
             settings,
@@ -1019,7 +1018,7 @@ public class NodeDeprecationChecks {
             Setting.Property.NodeScope,
             Setting.Property.Deprecated
         );
-        String url = "https://ela.st/es-deprecation-8-watcher-bulk-concurrency-setting";
+        String url = "https://ela.st/es-deprecation-8-watcher-settings";
         return checkRemovedSetting(
             clusterState.metadata().settings(),
             settings,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationCheckerTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.deprecation;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -56,9 +57,9 @@ public class DataStreamDeprecationCheckerTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
-            "Old data stream with a compatibility version < 9.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
-            "This data stream has backing indices that were created before Elasticsearch 9.0.0",
+            "Old data stream with a compatibility version < " + Version.CURRENT.major + ".0",
+            "https://ela.st/es-deprecation-ds-reindex",
+            "This data stream has backing indices that were created before Elasticsearch " + Version.CURRENT.major + ".0",
             false,
             ofEntries(
                 entry("reindex_required", true),
@@ -125,9 +126,9 @@ public class DataStreamDeprecationCheckerTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
-            "Old data stream with a compatibility version < 9.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
-            "This data stream has backing indices that were created before Elasticsearch 9.0.0",
+            "Old data stream with a compatibility version < " + Version.CURRENT.major + ".0",
+            "https://ela.st/es-deprecation-ds-reindex",
+            "This data stream has backing indices that were created before Elasticsearch " + Version.CURRENT.major + ".0",
             false,
             ofEntries(
                 entry("reindex_required", true),
@@ -284,10 +285,11 @@ public class DataStreamDeprecationCheckerTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.WARNING,
-            "Old data stream with a compatibility version < 9.0 Have Been Ignored",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
-            "This data stream has read only backing indices that were created before Elasticsearch 9.0.0 and have been marked as "
-                + "OK to remain read-only after upgrade",
+            "Old data stream with a compatibility version < " + Version.CURRENT.major + ".0 has Been Ignored",
+            "https://ela.st/es-deprecation-ds-reindex",
+            "This data stream has read only backing indices that were created before Elasticsearch "
+                + Version.CURRENT.major
+                + ".0 and have been marked as OK to remain read-only after upgrade",
             false,
             ofEntries(
                 entry("reindex_required", false),

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IlmPolicyDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IlmPolicyDeprecationCheckerTests.java
@@ -140,7 +140,7 @@ public class IlmPolicyDeprecationCheckerTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.WARNING,
             "ILM policy [deprecated-action] contains the action 'freeze' that is deprecated and will be removed in a future version.",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/frozen-indices.html",
+            "https://ela.st/es-deprecation-7-frozen-index",
             "This action is already a noop so it can be safely removed, because frozen indices no longer offer any advantages."
                 + " Consider cold or frozen tiers in place of frozen indices.",
             false,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.deprecation;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -78,8 +79,8 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             .build();
         DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
-            "Old index with a compatibility version < 9.0",
-            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html",
+            "Old index with a compatibility version < " + Version.CURRENT.major + ".0",
+            "https://ela.st/es-deprecation-9-index-version",
             "This index has version: " + OLD_VERSION.toReleaseVersion(),
             false,
             singletonMap("reindex_required", true)
@@ -102,11 +103,13 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             .build();
         var expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
-            "One or more Transforms write to this index with a compatibility version < 9.0",
-            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html#breaking_90_transform_destination_index",
+            "One or more Transforms write to this index with a compatibility version < " + Version.CURRENT.major + ".0",
+            "https://ela.st/es-deprecation-9-transform-destination-index",
             "This index was created in version ["
                 + OLD_VERSION.toReleaseVersion()
-                + "] and requires action before upgrading to 9.0. "
+                + "] and requires action before upgrading to "
+                + Version.CURRENT.major
+                + ".0. "
                 + "The following transforms are configured to write to this index: [test-transform]. Refer to the "
                 + "migration guide to learn more about how to prepare transforms destination indices for your upgrade.",
             false,
@@ -128,11 +131,13 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             .build();
         var expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
-            "One or more Transforms write to this index with a compatibility version < 9.0",
-            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html#breaking_90_transform_destination_index",
+            "One or more Transforms write to this index with a compatibility version < " + Version.CURRENT.major + ".0",
+            "https://ela.st/es-deprecation-9-transform-destination-index",
             "This index was created in version ["
                 + OLD_VERSION.toReleaseVersion()
-                + "] and requires action before upgrading to 9.0. "
+                + "] and requires action before upgrading to "
+                + Version.CURRENT.major
+                + ".0. "
                 + "The following transforms are configured to write to this index: [test-transform1, test-transform2]. Refer to the "
                 + "migration guide to learn more about how to prepare transforms destination indices for your upgrade.",
             false,
@@ -158,12 +163,13 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             List.of(
                 new DeprecationIssue(
                     DeprecationIssue.Level.CRITICAL,
-                    "One or more Transforms write to this index with a compatibility version < 9.0",
-                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
-                        + "#breaking_90_transform_destination_index",
+                    "One or more Transforms write to this index with a compatibility version < " + Version.CURRENT.major + ".0",
+                    "https://ela.st/es-deprecation-9-transform-destination-index",
                     "This index was created in version ["
                         + OLD_VERSION.toReleaseVersion()
-                        + "] and requires action before upgrading to 9.0. "
+                        + "] and requires action before upgrading to "
+                        + Version.CURRENT.major
+                        + ".0. "
                         + "The following transforms are configured to write to this index: [test-transform1]. Refer to the "
                         + "migration guide to learn more about how to prepare transforms destination indices for your upgrade.",
                     false,
@@ -174,12 +180,13 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             List.of(
                 new DeprecationIssue(
                     DeprecationIssue.Level.CRITICAL,
-                    "One or more Transforms write to this index with a compatibility version < 9.0",
-                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
-                        + "#breaking_90_transform_destination_index",
+                    "One or more Transforms write to this index with a compatibility version < " + Version.CURRENT.major + ".0",
+                    "https://ela.st/es-deprecation-9-transform-destination-index",
                     "This index was created in version ["
                         + OLD_VERSION.toReleaseVersion()
-                        + "] and requires action before upgrading to 9.0. "
+                        + "] and requires action before upgrading to "
+                        + Version.CURRENT.major
+                        + ".0. "
                         + "The following transforms are configured to write to this index: [test-transform2]. Refer to the "
                         + "migration guide to learn more about how to prepare transforms destination indices for your upgrade.",
                     false,
@@ -282,7 +289,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
         DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.WARNING,
             "Old index with a compatibility version < 9.0 has been ignored",
-            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html",
+            "https://ela.st/es-deprecation-9-index-version",
             "This read-only index has version: " + OLD_VERSION.toReleaseVersion() + " and will be supported as read-only in 9.0",
             false,
             singletonMap("reindex_required", true)
@@ -332,11 +339,13 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             .build();
         var expected = new DeprecationIssue(
             DeprecationIssue.Level.WARNING,
-            "One or more Transforms write to this old index with a compatibility version < 9.0",
-            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html#breaking_90_transform_destination_index",
+            "One or more Transforms write to this old index with a compatibility version < " + Version.CURRENT.major + ".0",
+            "https://ela.st/es-deprecation-9-transform-destination-index",
             "This index was created in version ["
                 + OLD_VERSION.toReleaseVersion()
-                + "] and will be supported as a read-only index in 9.0. "
+                + "] and will be supported as a read-only index in "
+                + Version.CURRENT.major
+                + ".0. "
                 + "The following transforms are no longer able to write to this index: [test-transform]. Refer to the "
                 + "migration guide to learn more about how to handle your transforms destination indices.",
             false,
@@ -358,11 +367,13 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             .build();
         var expected = new DeprecationIssue(
             DeprecationIssue.Level.WARNING,
-            "One or more Transforms write to this old index with a compatibility version < 9.0",
-            "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html#breaking_90_transform_destination_index",
+            "One or more Transforms write to this old index with a compatibility version < " + Version.CURRENT.major + ".0",
+            "https://ela.st/es-deprecation-9-transform-destination-index",
             "This index was created in version ["
                 + OLD_VERSION.toReleaseVersion()
-                + "] and will be supported as a read-only index in 9.0. "
+                + "] and will be supported as a read-only index in "
+                + Version.CURRENT.major
+                + ".0. "
                 + "The following transforms are no longer able to write to this index: [test-transform1, test-transform2]. Refer to the "
                 + "migration guide to learn more about how to handle your transforms destination indices.",
             false,
@@ -388,12 +399,13 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             List.of(
                 new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
-                    "One or more Transforms write to this old index with a compatibility version < 9.0",
-                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
-                        + "#breaking_90_transform_destination_index",
+                    "One or more Transforms write to this old index with a compatibility version < " + Version.CURRENT.major + ".0",
+                    "https://ela.st/es-deprecation-9-transform-destination-index",
                     "This index was created in version ["
                         + OLD_VERSION.toReleaseVersion()
-                        + "] and will be supported as a read-only index in 9.0. "
+                        + "] and will be supported as a read-only index in "
+                        + Version.CURRENT.major
+                        + ".0. "
                         + "The following transforms are no longer able to write to this index: [test-transform1]. Refer to the "
                         + "migration guide to learn more about how to handle your transforms destination indices.",
                     false,
@@ -404,12 +416,13 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             List.of(
                 new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
-                    "One or more Transforms write to this old index with a compatibility version < 9.0",
-                    "https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html"
-                        + "#breaking_90_transform_destination_index",
+                    "One or more Transforms write to this old index with a compatibility version < " + Version.CURRENT.major + ".0",
+                    "https://ela.st/es-deprecation-9-transform-destination-index",
                     "This index was created in version ["
                         + OLD_VERSION.toReleaseVersion()
-                        + "] and will be supported as a read-only index in 9.0. "
+                        + "] and will be supported as a read-only index in "
+                        + Version.CURRENT.major
+                        + ".0. "
                         + "The following transforms are no longer able to write to this index: [test-transform2]. Refer to the "
                         + "migration guide to learn more about how to handle your transforms destination indices.",
                     false,
@@ -451,7 +464,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
                 new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
                     "translog retention settings are ignored",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-translog.html",
+                    "https://ela.st/es-deprecation-7-translog-retention",
                     "translog retention settings [index.translog.retention.size] and [index.translog.retention.age] are ignored "
                         + "because translog is no longer used in peer recoveries with soft-deletes enabled (default in 7.0 or later)",
                     false,
@@ -509,8 +522,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             new DeprecationInfoAction.Request(TimeValue.THIRTY_SECONDS),
             emptyPrecomputedData
         );
-        final String expectedUrl =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/breaking-changes-7.13.html#deprecate-shared-data-path-setting";
+        final String expectedUrl = "https://ela.st/es-deprecation-7-index-data-path";
         assertThat(
             issuesByIndex.get("test"),
             contains(
@@ -550,7 +562,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
                 new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
                     "[simplefs] is deprecated and will be removed in future versions",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-store.html",
+                    "https://ela.st/es-deprecation-7-simplefs",
                     "[simplefs] is deprecated and will be removed in 8.0. Use [niofs] or other file systems instead. "
                         + "Elasticsearch 7.15 or later uses [niofs] for the [simplefs] store type "
                         + "as it offers superior or equivalent performance to [simplefs].",

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -160,8 +160,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             SINGLE_NODE_CHECKS,
             c -> c.apply(settings, null, ClusterState.EMPTY_STATE, new XPackLicenseState(() -> 0))
         );
-        final String expectedUrl =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/breaking-changes-7.13.html#deprecate-shared-data-path-setting";
+        final String expectedUrl = "https://ela.st/es-deprecation-7-shared-data-path";
         assertThat(
             issues,
             contains(
@@ -220,10 +219,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
         final DeprecationIssue deprecationIssue = deprecationIssues.get(0);
         assertEquals("Realm that start with [_] will not be permitted in a future major release.", deprecationIssue.getMessage());
-        assertEquals(
-            "https://www.elastic.co/guide/en/elasticsearch/reference" + "/7.14/deprecated-7.14.html#reserved-prefixed-realm-names",
-            deprecationIssue.getUrl()
-        );
+        assertEquals("https://ela.st/es-deprecation-7-realm-prefix", deprecationIssue.getUrl());
         assertEquals(
             "Found realm "
                 + (invalidRealmNames.size() == 1 ? "name" : "names")
@@ -779,7 +775,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.WARNING,
             "Setting [xpack.eql.enabled] is deprecated",
-            "https://ela.st/es-deprecation-8-eql-enabled-setting",
+            "https://ela.st/es-deprecation-7-eql-enabled-setting",
             "Remove the [xpack.eql.enabled] setting. As of 7.9.2 basic license level features are always enabled.",
             false,
             null


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Update Documentation URLs (#125089)](https://github.com/elastic/elasticsearch/pull/125089)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)