### PR TITLE
Collapse transport versions

### DIFF
--- a/docs/internal/Versioning.md
+++ b/docs/internal/Versioning.md
@@ -85,6 +85,25 @@ usually after each new minor release, to collapse the transport versions
 for the previous minor release. An example of such an operation can be found
 [here](https://github.com/elastic/elasticsearch/pull/104937).
 
+#### Tips
+
+- We collapse versions only on the `main` branch.
+- Use [TransportVersions.csv](../../server/src/main/resources/org/elasticsearch/TransportVersions.csv) as your guide.
+- For each release version listed in that file with a corresponding `INITIAL_ELASTICSEARCH_` entry corresponding to that version,
+  - change the prefix to `V_`
+  - replace all intervening entries since the previous patch `V_` entry with the new `V_` entry
+  - look at all uses of the new `V_` entry and look for dead code that can be deleted
+
+For example, if there's a version `1.2.3` in the CSV file,
+and `TransportVersions.java` has an entry called `INITIAL_ELASTICSEARCH_1_2_3`,
+then:
+- rename it to `V_1_2_3`,
+- replace any other intervening symbols between `V_1_2_2` and `V_1_2_3` with `V_1_2_3` itself, and
+- look through all the uses of the new `V_1_2_3` symbol; if any contain dead code, simplify it.
+
+When in doubt, you can always leave the code as-is.
+This is an optional cleanup step that is never required for correctness.
+
 ### Minimum compatibility versions
 
 The transport version used between two nodes is determined by the initial handshake

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -88,13 +88,13 @@ public class TransportVersions {
     public static final TransportVersion V_8_15_2 = def(8_702_0_03);
     public static final TransportVersion V_8_16_0 = def(8_772_0_01);
     public static final TransportVersion V_8_16_1 = def(8_772_0_04);
-    public static final TransportVersion INITIAL_ELASTICSEARCH_8_16_5 = def(8_772_0_05);
-    public static final TransportVersion INITIAL_ELASTICSEARCH_8_16_6 = def(8_772_0_06);
+    public static final TransportVersion V_8_16_5 = def(8_772_0_05);
+    public static final TransportVersion V_8_16_6 = def(8_772_0_06);
     public static final TransportVersion INITIAL_ELASTICSEARCH_8_16_7 = def(8_772_0_07);
     public static final TransportVersion V_8_17_0 = def(8_797_0_02);
-    public static final TransportVersion INITIAL_ELASTICSEARCH_8_17_3 = def(8_797_0_03);
-    public static final TransportVersion INITIAL_ELASTICSEARCH_8_17_4 = def(8_797_0_04);
-    public static final TransportVersion INITIAL_ELASTICSEARCH_8_17_5 = def(8_797_0_05);
+    public static final TransportVersion V_8_17_3 = def(8_797_0_03);
+    public static final TransportVersion V_8_17_4 = def(8_797_0_04);
+    public static final TransportVersion V_8_17_5 = def(8_797_0_05);
     public static final TransportVersion INITIAL_ELASTICSEARCH_8_17_6 = def(8_797_0_06);
     public static final TransportVersion INDEXING_PRESSURE_THROTTLING_STATS = def(8_798_0_00);
     public static final TransportVersion REINDEX_DATA_STREAMS = def(8_799_0_00);
@@ -140,7 +140,7 @@ public class TransportVersions {
     public static final TransportVersion INFERENCE_REQUEST_ADAPTIVE_RATE_LIMITING = def(8_839_0_00);
     public static final TransportVersion ML_INFERENCE_IBM_WATSONX_RERANK_ADDED = def(8_840_0_00);
     public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR_BACKPORT_8_18 = def(8_840_0_01);
-    public static final TransportVersion RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR_8_18 = def(8_840_0_02);
+    public static final TransportVersion V_8_18_0 = def(8_840_0_02);
     public static final TransportVersion INITIAL_ELASTICSEARCH_8_18_1 = def(8_840_0_03);
     public static final TransportVersion INITIAL_ELASTICSEARCH_8_19 = def(8_841_0_00);
     public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED_BACKPORT_8_X = def(8_841_0_01);
@@ -162,16 +162,7 @@ public class TransportVersions {
     public static final TransportVersion AMAZON_BEDROCK_TASK_SETTINGS_8_19 = def(8_841_0_17);
     public static final TransportVersion BATCHED_QUERY_PHASE_VERSION_BACKPORT_8_X = def(8_841_0_19);
     public static final TransportVersion SEARCH_INCREMENTAL_TOP_DOCS_NULL_BACKPORT_8_19 = def(8_841_0_20);
-    public static final TransportVersion INITIAL_ELASTICSEARCH_9_0 = def(9_000_0_00);
-    public static final TransportVersion REMOVE_SNAPSHOT_FAILURES_90 = def(9_000_0_01);
-    public static final TransportVersion TRANSPORT_STATS_HANDLING_TIME_REQUIRED_90 = def(9_000_0_02);
-    public static final TransportVersion REMOVE_DESIRED_NODE_VERSION_90 = def(9_000_0_03);
-    public static final TransportVersion ESQL_DRIVER_TASK_DESCRIPTION_90 = def(9_000_0_04);
-    public static final TransportVersion REMOVE_ALL_APPLICABLE_SELECTOR_9_0 = def(9_000_0_05);
-    public static final TransportVersion BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_90 = def(9_000_0_06);
-    public static final TransportVersion RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR_90 = def(9_000_0_07);
-    public static final TransportVersion RE_REMOVE_MIN_COMPATIBLE_SHARD_NODE_90 = def(9_000_0_08);
-    public static final TransportVersion STORED_SCRIPT_CONTENT_LENGTH_90 = def(9_000_0_09);
+    public static final TransportVersion V_9_0_0 = def(9_000_0_09);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0_1 = def(9_000_0_10);
     public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED = def(9_001_0_00);
     public static final TransportVersion REMOVE_SNAPSHOT_FAILURES = def(9_002_0_00);
@@ -298,7 +289,7 @@ public class TransportVersions {
      * Reference to the minimum transport version that can be used with CCS.
      * This should be the transport version used by the previous minor release.
      */
-    public static final TransportVersion MINIMUM_CCS_VERSION = STORED_SCRIPT_CONTENT_LENGTH_90;
+    public static final TransportVersion MINIMUM_CCS_VERSION = V_9_0_0;
 
     /**
      * Sorted list of all versions defined in this class

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -50,7 +50,7 @@ public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXCo
     public GetSnapshotsResponse(StreamInput in) throws IOException {
         this.snapshots = in.readCollectionAsImmutableList(SnapshotInfo::readFrom);
         if (in.getTransportVersion().before(TransportVersions.REMOVE_SNAPSHOT_FAILURES)
-            && in.getTransportVersion().isPatchFrom(TransportVersions.REMOVE_SNAPSHOT_FAILURES_90) == false) {
+            && in.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0) == false) {
             // Deprecated `failures` field
             in.readMap(StreamInput::readException);
         }
@@ -85,7 +85,7 @@ public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXCo
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(snapshots);
         if (out.getTransportVersion().before(TransportVersions.REMOVE_SNAPSHOT_FAILURES)
-            && out.getTransportVersion().isPatchFrom(TransportVersions.REMOVE_SNAPSHOT_FAILURES_90) == false) {
+            && out.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0) == false) {
             // Deprecated `failures` field
             out.writeMap(Map.of(), StreamOutput::writeException);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequest.java
@@ -45,7 +45,7 @@ public class PutStoredScriptRequest extends AcknowledgedRequest<PutStoredScriptR
     public PutStoredScriptRequest(StreamInput in) throws IOException {
         super(in);
         id = in.readOptionalString();
-        if (in.getTransportVersion().isPatchFrom(TransportVersions.STORED_SCRIPT_CONTENT_LENGTH_90)
+        if (in.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0)
             || in.getTransportVersion().onOrAfter(TransportVersions.STORED_SCRIPT_CONTENT_LENGTH)) {
             contentLength = in.readVInt();
         } else {
@@ -106,7 +106,7 @@ public class PutStoredScriptRequest extends AcknowledgedRequest<PutStoredScriptR
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeOptionalString(id);
-        if (out.getTransportVersion().isPatchFrom(TransportVersions.STORED_SCRIPT_CONTENT_LENGTH_90)
+        if (out.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0)
             || out.getTransportVersion().onOrAfter(TransportVersions.STORED_SCRIPT_CONTENT_LENGTH)) {
             out.writeVInt(contentLength);
         } else {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -253,7 +253,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             finalReduce = true;
         }
         ccsMinimizeRoundtrips = in.readBoolean();
-        if ((in.getTransportVersion().isPatchFrom(TransportVersions.RE_REMOVE_MIN_COMPATIBLE_SHARD_NODE_90) == false
+        if ((in.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0) == false
             && in.getTransportVersion().before(TransportVersions.RE_REMOVE_MIN_COMPATIBLE_SHARD_NODE)) && in.readBoolean()) {
             Version.readVersion(in); // and drop on the floor
         }
@@ -298,7 +298,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             out.writeBoolean(finalReduce);
         }
         out.writeBoolean(ccsMinimizeRoundtrips);
-        if ((out.getTransportVersion().isPatchFrom(TransportVersions.RE_REMOVE_MIN_COMPATIBLE_SHARD_NODE_90) == false
+        if ((out.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0) == false
             && out.getTransportVersion().before(TransportVersions.RE_REMOVE_MIN_COMPATIBLE_SHARD_NODE))) {
             out.writeBoolean(false);
         }

--- a/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndexComponentSelector.java
@@ -93,7 +93,7 @@ public enum IndexComponentSelector implements Writeable {
     public static IndexComponentSelector read(StreamInput in) throws IOException {
         byte id = in.readByte();
         if (in.getTransportVersion().onOrAfter(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR)
-            || in.getTransportVersion().isPatchFrom(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR_9_0)
+            || in.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0)
             || in.getTransportVersion().isPatchFrom(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR_BACKPORT_8_18)
             || in.getTransportVersion().isPatchFrom(TransportVersions.REMOVE_ALL_APPLICABLE_SELECTOR_BACKPORT_8_19)) {
             return getById(id);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNode.java
@@ -162,7 +162,7 @@ public final class DesiredNode implements Writeable, ToXContentObject, Comparabl
         final var memory = ByteSizeValue.readFrom(in);
         final var storage = ByteSizeValue.readFrom(in);
         if (in.getTransportVersion().before(TransportVersions.REMOVE_DESIRED_NODE_VERSION)
-            && in.getTransportVersion().isPatchFrom(TransportVersions.REMOVE_DESIRED_NODE_VERSION_90) == false) {
+            && in.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0) == false) {
             in.readOptionalString();
         }
         return new DesiredNode(settings, processors, processorsRange, memory, storage);
@@ -182,7 +182,7 @@ public final class DesiredNode implements Writeable, ToXContentObject, Comparabl
         memory.writeTo(out);
         storage.writeTo(out);
         if (out.getTransportVersion().before(TransportVersions.REMOVE_DESIRED_NODE_VERSION)
-            && out.getTransportVersion().isPatchFrom(TransportVersions.REMOVE_DESIRED_NODE_VERSION_90) == false) {
+            && out.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0) == false) {
             out.writeOptionalString(null);
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES;
 import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1;
-import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_90;
+import static org.elasticsearch.TransportVersions.V_9_0_0;
 import static org.elasticsearch.TransportVersions.REVERT_BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1;
 import static org.elasticsearch.common.unit.ByteSizeUnit.BYTES;
 import static org.elasticsearch.common.unit.ByteSizeUnit.GB;
@@ -134,7 +134,7 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
 
     private static boolean alwaysUseBytes(TransportVersion tv) {
         return tv.onOrAfter(BYTE_SIZE_VALUE_ALWAYS_USES_BYTES)
-            || tv.isPatchFrom(BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_90)
+            || tv.isPatchFrom(V_9_0_0)
             || tv.between(BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1, REVERT_BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -27,8 +27,8 @@ import java.util.Objects;
 
 import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES;
 import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1;
-import static org.elasticsearch.TransportVersions.V_9_0_0;
 import static org.elasticsearch.TransportVersions.REVERT_BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_1;
+import static org.elasticsearch.TransportVersions.V_9_0_0;
 import static org.elasticsearch.common.unit.ByteSizeUnit.BYTES;
 import static org.elasticsearch.common.unit.ByteSizeUnit.GB;
 import static org.elasticsearch.common.unit.ByteSizeUnit.KB;

--- a/server/src/main/java/org/elasticsearch/transport/TransportStats.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportStats.java
@@ -70,7 +70,7 @@ public class TransportStats implements Writeable, ChunkedToXContent {
         txCount = in.readVLong();
         txSize = in.readVLong();
         if (in.getTransportVersion().before(TransportVersions.TRANSPORT_STATS_HANDLING_TIME_REQUIRED)
-            && in.getTransportVersion().isPatchFrom(TransportVersions.TRANSPORT_STATS_HANDLING_TIME_REQUIRED_90) == false) {
+            && in.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0) == false) {
             in.readBoolean();
         }
         inboundHandlingTimeBucketFrequencies = new long[HandlingTimeTracker.BUCKET_COUNT];
@@ -100,7 +100,7 @@ public class TransportStats implements Writeable, ChunkedToXContent {
         assert inboundHandlingTimeBucketFrequencies.length == HandlingTimeTracker.BUCKET_COUNT;
         assert outboundHandlingTimeBucketFrequencies.length == HandlingTimeTracker.BUCKET_COUNT;
         if (out.getTransportVersion().before(TransportVersions.TRANSPORT_STATS_HANDLING_TIME_REQUIRED)
-            && out.getTransportVersion().isPatchFrom(TransportVersions.TRANSPORT_STATS_HANDLING_TIME_REQUIRED_90) == false) {
+            && out.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0) == false) {
             out.writeBoolean(true);
         }
         for (long handlingTimeBucketFrequency : inboundHandlingTimeBucketFrequencies) {

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -24,7 +24,6 @@ import java.util.function.Function;
 
 import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES;
 import static org.elasticsearch.TransportVersions.V_8_16_0;
-import static org.elasticsearch.TransportVersions.V_9_0_0;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -523,7 +522,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
 
     public void testBWCTransportFormat() throws IOException {
         var tenMegs = ByteSizeValue.ofMb(10);
-        for (var tv : List.of(V_8_16_0, V_9_0_0)) {
+        for (var tv : List.of(V_8_16_0)) {
             try (BytesStreamOutput expected = new BytesStreamOutput(); BytesStreamOutput actual = new BytesStreamOutput()) {
                 expected.writeZLong(10);
                 ByteSizeUnit.MB.writeTo(expected);

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.function.Function;
 
 import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES;
-import static org.elasticsearch.TransportVersions.V_9_0_0;
 import static org.elasticsearch.TransportVersions.V_8_16_0;
+import static org.elasticsearch.TransportVersions.V_9_0_0;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.common.unit;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -22,8 +23,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES;
-import static org.elasticsearch.TransportVersions.BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_90;
-import static org.elasticsearch.TransportVersions.INITIAL_ELASTICSEARCH_9_0;
+import static org.elasticsearch.TransportVersions.V_9_0_0;
 import static org.elasticsearch.TransportVersions.V_8_16_0;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -523,7 +523,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
 
     public void testBWCTransportFormat() throws IOException {
         var tenMegs = ByteSizeValue.ofMb(10);
-        for (var tv : List.of(V_8_16_0, INITIAL_ELASTICSEARCH_9_0)) {
+        for (var tv : List.of(V_8_16_0, V_9_0_0)) {
             try (BytesStreamOutput expected = new BytesStreamOutput(); BytesStreamOutput actual = new BytesStreamOutput()) {
                 expected.writeZLong(10);
                 ByteSizeUnit.MB.writeTo(expected);
@@ -539,7 +539,7 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     }
 
     public void testTransportRoundTripsWithTwoDigitFractions() throws IOException {
-        for (var tv : List.of(TransportVersion.current(), BYTE_SIZE_VALUE_ALWAYS_USES_BYTES, BYTE_SIZE_VALUE_ALWAYS_USES_BYTES_90)) {
+        for (var tv : List.of(TransportVersion.current(), BYTE_SIZE_VALUE_ALWAYS_USES_BYTES, TransportVersions.V_9_0_0)) {
             for (var desiredUnit : ByteSizeUnit.values()) {
                 if (desiredUnit == ByteSizeUnit.BYTES) {
                     // Can't have a fraction of a byte!

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/RetryActionRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/RetryActionRequest.java
@@ -35,9 +35,9 @@ public class RetryActionRequest extends AcknowledgedRequest<RetryActionRequest> 
         this.indices = in.readStringArray();
         this.indicesOptions = IndicesOptions.readIndicesOptions(in);
         if (in.getTransportVersion().onOrAfter(TransportVersions.RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR)
-            || in.getTransportVersion().isPatchFrom(TransportVersions.RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR_90)
+            || in.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0)
             || in.getTransportVersion().isPatchFrom(TransportVersions.RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR_8_19)
-            || in.getTransportVersion().isPatchFrom(TransportVersions.RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR_8_18)) {
+            || in.getTransportVersion().isPatchFrom(TransportVersions.V_8_18_0)) {
             this.requireError = in.readBoolean();
         }
     }
@@ -82,9 +82,9 @@ public class RetryActionRequest extends AcknowledgedRequest<RetryActionRequest> 
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
         if (out.getTransportVersion().onOrAfter(TransportVersions.RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR)
-            || out.getTransportVersion().isPatchFrom(TransportVersions.RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR_90)
+            || out.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0)
             || out.getTransportVersion().isPatchFrom(TransportVersions.RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR_8_19)
-            || out.getTransportVersion().isPatchFrom(TransportVersions.RETRY_ILM_ASYNC_ACTION_REQUIRE_ERROR_8_18)) {
+            || out.getTransportVersion().isPatchFrom(TransportVersions.V_8_18_0)) {
             out.writeBoolean(requireError);
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverProfile.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverProfile.java
@@ -52,7 +52,7 @@ public record DriverProfile(
     public static DriverProfile readFrom(StreamInput in) throws IOException {
         return new DriverProfile(
             in.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_TASK_DESCRIPTION)
-                || in.getTransportVersion().isPatchFrom(TransportVersions.ESQL_DRIVER_TASK_DESCRIPTION_90) ? in.readString() : "",
+                || in.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0) ? in.readString() : "",
             in.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_NODE_DESCRIPTION) ? in.readString() : "",
             in.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_NODE_DESCRIPTION) ? in.readString() : "",
             in.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0) ? in.readVLong() : 0,
@@ -68,7 +68,7 @@ public record DriverProfile(
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_TASK_DESCRIPTION)
-            || out.getTransportVersion().isPatchFrom(TransportVersions.ESQL_DRIVER_TASK_DESCRIPTION_90)) {
+            || out.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0)) {
             out.writeString(description);
         }
         if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_NODE_DESCRIPTION)) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverStatus.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverStatus.java
@@ -63,7 +63,7 @@ public record DriverStatus(
         return new DriverStatus(
             in.readString(),
             in.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_TASK_DESCRIPTION)
-                || in.getTransportVersion().isPatchFrom(TransportVersions.ESQL_DRIVER_TASK_DESCRIPTION_90) ? in.readString() : "",
+                || in.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0) ? in.readString() : "",
             in.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_NODE_DESCRIPTION) ? in.readString() : "",
             in.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_NODE_DESCRIPTION) ? in.readString() : "",
             in.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0) ? in.readLong() : 0,
@@ -83,7 +83,7 @@ public record DriverStatus(
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(sessionId);
         if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_TASK_DESCRIPTION)
-            || out.getTransportVersion().isPatchFrom(TransportVersions.ESQL_DRIVER_TASK_DESCRIPTION_90)) {
+            || out.getTransportVersion().isPatchFrom(TransportVersions.V_9_0_0)) {
             out.writeString(description);
         }
         if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_NODE_DESCRIPTION)) {


### PR DESCRIPTION
I drove my work based on [`TransportVersions.csv`](https://github.com/elastic/elasticsearch/blob/68b81454064a1e41b07048e36f83e27cffd55cd9/server/src/main/resources/org/elasticsearch/TransportVersions.csv):
- If there's an `INITIAL_ELASTICSEARCH` entry for a version in the CSV, rename it to `V_`.
- Make a `V_9_0_0` and use it for all `9xxx` versions up to and including the value from the CSV, which was `9_000_0_09`

I did not notice any obvious dead code using `V_9_0_0`.

I did not try to differentiate between 8.17.6 and 8.18.0.