### PR TITLE
ES|QL: unmute GenerativeIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -429,9 +429,6 @@ tests:
 - class: org.elasticsearch.search.query.QueryPhaseTimeoutTests
   method: testBulkScorerTimeout
   issue: https://github.com/elastic/elasticsearch/issues/127156
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/127157
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test026InstallBundledRepositoryPluginsViaConfigFile
   issue: https://github.com/elastic/elasticsearch/issues/127158

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/GenerativeIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/GenerativeIT.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xpack.esql.qa.rest.generative.GenerativeRestTest;
 import org.junit.ClassRule;
 
 /**
- * This test generates random queries, runs them agains the CSV test dataset and checks that they don't throw unexpected exceptions.
+ * This test generates random queries, runs them against the CSV test dataset and checks that they don't throw unexpected exceptions.
  *
  * If muted, please:
  * <ul>

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -37,7 +37,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase {
         "Reference \\[.*\\] is ambiguous",
         "Cannot use field \\[.*\\] due to ambiguities",
         "cannot sort on .*",
-        "argument of \\[count_distinct\\(.*\\)\\] must",
+        "argument of \\[count.*\\] must",
         "Cannot use field \\[.*\\] with unsupported type \\[.*_range\\]",
         "Unbounded sort not supported yet",
         "The field names are too complex to process", // field_caps problem
@@ -51,6 +51,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase {
         "Unknown column \\[<all-fields-projected>\\]", // https://github.com/elastic/elasticsearch/issues/121741,
         "Plan \\[ProjectExec\\[\\[<no-fields>.* optimized incorrectly due to missing references", // https://github.com/elastic/elasticsearch/issues/125866
         "token recognition error at: '``", // https://github.com/elastic/elasticsearch/issues/125870
+                                           // https://github.com/elastic/elasticsearch/issues/127167
         "Unknown column \\[.*\\]", // https://github.com/elastic/elasticsearch/issues/126026
         "optimized incorrectly due to missing references", // https://github.com/elastic/elasticsearch/issues/116781
         "No matches found for pattern", // https://github.com/elastic/elasticsearch/issues/126418


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/127157

Unmuting GenerativeIT and adding a more generic exception (the test is generating a query that is not completely valid, using counter fields in `count()`)