### PR TITLE
[DOCS][ESQL] Cleanup and cross-reference LOOKUP JOIN reference and landing pages

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
@@ -11,6 +11,8 @@ SLA of official GA features.
 index, to your {{esql}} query results, simplifying data enrichment
 and analysis workflows.
 
+Refer to [the high-level landing page](../../../../esql/esql-lookup-join.md) for an overview of the `LOOKUP JOIN` command, including use cases, prerequisites, and current limitations.
+
 **Syntax**
 
 ```esql
@@ -21,18 +23,14 @@ FROM <source_index>
 **Parameters**
 
 `<lookup_index>`
-: The name of the lookup index. This must be a specific index name - wildcards, aliases, and remote cluster
-  references are not supported.
+:   The name of the lookup index. This must be a specific index name - wildcards, aliases, and remote cluster references are not supported. Indices used for lookups must be configured with the [`lookup` index mode](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting).
 
 `<field_name>`
-: The field to join on. This field must exist
-  in both your current query results and in the lookup index. If the field
-  contains multi-valued entries, those entries will not match anything
-  (the added fields will contain `null` for those rows).
+:   The field to join on. This field must exist in both your current query results and in the lookup index. If the field contains multi-valued entries, those entries will not match anything (the added fields will contain `null` for those rows).
 
 **Description**
 
-The `LOOKUP JOIN` command adds new columns to your {esql} query
+The `LOOKUP JOIN` command adds new columns to your {{esql}} query
 results table by finding documents in a lookup index that share the same
 join field value as your result rows.
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/elasticsearch/issues/126897

## URL Previews

- [Command reference](https://docs-v3-preview.elastic.dev/elastic/elasticsearch/pull/127215/reference/query-languages/esql/commands/processing-commands#esql-lookup-join)
- [Landing page](https://docs-v3-preview.elastic.dev/elastic/elasticsearch/pull/127215/reference/query-languages/esql/esql-lookup-join)

## Summary 

Main goal is to ensure both pages have clear distinctions and cross-reference each other.

**lookup-join.md (syntax reference)**:
- add link to high-level landing page
- improved parameter formatting and descriptions
- fixed template variable from `{esql}` to `{{esql}}`

**esql-lookup-join.md (landing page)**:

https://github.com/elastic/elasticsearch/pull/127215/commits/9d23f244c7e200ff279ff5f2d245c9d5a53db50c adds improved example with setup code


improve layout:
- added "compare with enrich" section header
- simplified "how the command works" with clearer parameter explanation
- added code example in how it works section
- improved image alt text for accessibility
- organized example section with better context and SQL comparison
- added dropdown for sample tables to reduce visual clutter
- added "query" subheading for clearer organization
- included reference to additional examples in command reference
