### PR TITLE
ESQL: Remaining unmutes for esql/10_basic/basic with documents_found

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -417,15 +417,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test026InstallBundledRepositoryPlugins
   issue: https://github.com/elastic/elasticsearch/issues/127081
-- class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=esql/10_basic/basic with documents_found}
-  issue: https://github.com/elastic/elasticsearch/issues/127088
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlClientYamlAsyncIT
-  method: test {p0=esql/10_basic/basic with documents_found}
-  issue: https://github.com/elastic/elasticsearch/issues/127080
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
-  method: test {p0=esql/10_basic/basic with documents_found}
-  issue: https://github.com/elastic/elasticsearch/issues/127046
 - class: org.elasticsearch.search.query.QueryPhaseTimeoutTests
   method: testBulkScorerTimeout
   issue: https://github.com/elastic/elasticsearch/issues/127156


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/127088

We got some mutes after https://github.com/elastic/elasticsearch/pull/127065 already introduced a fix, seemingly from PRs that didn't have the fix yet.

Let's unmute the remaining versions of this test.