### PR TITLE
Speedup resolving index aliases in TransportSearchAction (and in general)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -691,26 +691,6 @@ public class IndexNameExpressionResolver {
         }
     }
 
-    private static void resolveWriteIndexForDataStreams(
-        Context context,
-        DataStream dataStream,
-        Set<Index> concreteIndicesResult,
-        IndexComponentSelector selector
-    ) {
-        if (shouldIncludeRegularIndices(context.getOptions(), selector)) {
-            Index writeIndex = dataStream.getWriteIndex();
-            if (addIndex(writeIndex, null, context)) {
-                concreteIndicesResult.add(writeIndex);
-            }
-        }
-        if (shouldIncludeFailureIndices(context.getOptions(), selector)) {
-            Index failureStoreWriteIndex = dataStream.getWriteFailureIndex();
-            if (failureStoreWriteIndex != null && addIndex(failureStoreWriteIndex, null, context)) {
-                concreteIndicesResult.add(failureStoreWriteIndex);
-            }
-        }
-    }
-
     public static boolean shouldIncludeRegularIndices(IndicesOptions indicesOptions, IndexComponentSelector expressionSelector) {
         if (indicesOptions.allowSelectors()) {
             return expressionSelector == null || expressionSelector.shouldIncludeData();
@@ -876,19 +856,6 @@ public class IndexNameExpressionResolver {
     /**
      * Utility method that allows to resolve an index expression to its corresponding single write index.
      *
-     * @param state             the cluster state containing all the data to resolve to expression to a concrete index
-     * @param request           The request that defines how an alias or an index need to be resolved to a concrete index
-     *                          and the expression that can be resolved to an alias or an index name.
-     * @throws IllegalArgumentException if the index resolution does not lead to an index, or leads to more than one index
-     * @return the write index obtained as a result of the index resolution
-     */
-    public Index concreteWriteIndex(ClusterState state, IndicesRequest request) {
-        return concreteWriteIndex(projectResolver.getProjectMetadata(state), request);
-    }
-
-    /**
-     * Utility method that allows to resolve an index expression to its corresponding single write index.
-     *
      * @param project           the project containing all the data to resolve to expression to a concrete index
      * @param request           The request that defines how the an alias or an index need to be resolved to a concrete index
      *                          and the expression that can be resolved to an alias or an index name.
@@ -981,14 +948,6 @@ public class IndexNameExpressionResolver {
      * @return whether the specified index, data stream or alias exists.
      *         If the data stream, index or alias contains date math then that is resolved too.
      */
-    public boolean hasIndexAbstraction(String indexAbstraction, ClusterState state) {
-        return hasIndexAbstraction(indexAbstraction, projectResolver.getProjectMetadata(state));
-    }
-
-    /**
-     * @return whether the specified index, data stream or alias exists.
-     *         If the data stream, index or alias contains date math then that is resolved too.
-     */
     public boolean hasIndexAbstraction(String indexAbstraction, ProjectMetadata project) {
         String resolvedAliasOrIndex = DateMathExpressionResolver.resolveExpression(indexAbstraction);
         return project.hasIndexAbstraction(resolvedAliasOrIndex);
@@ -1044,29 +1003,8 @@ public class IndexNameExpressionResolver {
     /**
      * Resolve an array of expressions to the set of indices and aliases that these expressions match.
      */
-    public Set<ResolvedExpression> resolveExpressions(ClusterState state, String... expressions) {
-        return resolveExpressions(projectResolver.getProjectMetadata(state), expressions);
-    }
-
-    /**
-     * Resolve an array of expressions to the set of indices and aliases that these expressions match.
-     */
     public Set<ResolvedExpression> resolveExpressions(ProjectMetadata project, String... expressions) {
         return resolveExpressions(project, IndicesOptions.lenientExpandOpen(), false, expressions);
-    }
-
-    /**
-     * Resolve the expression to the set of indices, aliases, and, optionally, datastreams that the expression matches.
-     * If {@param preserveDataStreams} is {@code true}, datastreams that are covered by the wildcards from the
-     * {@param expressions} are returned as-is, without expanding them further to their respective backing indices.
-     */
-    public Set<ResolvedExpression> resolveExpressions(
-        ClusterState state,
-        IndicesOptions indicesOptions,
-        boolean preserveDataStreams,
-        String... expressions
-    ) {
-        return resolveExpressions(projectResolver.getProjectMetadata(state), indicesOptions, preserveDataStreams, expressions);
     }
 
     /**
@@ -1106,17 +1044,6 @@ public class IndexNameExpressionResolver {
      * given index.
      * <p>Only aliases with filters are returned. If the indices list contains a non-filtering reference to
      * the index itself - null is returned. Returns {@code null} if no filtering is required.
-     * <b>NOTE</b>: The provided expressions must have been resolved already via {@link #resolveExpressionsToResources(Context, String...)}.
-     */
-    public String[] filteringAliases(ClusterState state, String index, Set<ResolvedExpression> resolvedExpressions) {
-        return filteringAliases(projectResolver.getProjectMetadata(state), index, resolvedExpressions);
-    }
-
-    /**
-     * Iterates through the list of indices and selects the effective list of filtering aliases for the
-     * given index.
-     * <p>Only aliases with filters are returned. If the indices list contains a non-filtering reference to
-     * the index itself - null is returned. Returns {@code null} if no filtering is required.
      * <b>NOTE</b>: The provided expressions must have been resolved already via {@link #resolveExpressions}.
      */
     public String[] filteringAliases(ProjectMetadata project, String index, Set<ResolvedExpression> resolvedExpressions) {
@@ -1138,31 +1065,6 @@ public class IndexNameExpressionResolver {
     // pkg-private for testing
     boolean iterateIndexAliases(int indexAliasesSize, int resolvedExpressionsSize) {
         return indexAliasesSize <= resolvedExpressionsSize;
-    }
-
-    /**
-     * Iterates through the list of indices and selects the effective list of required aliases for the given index.
-     * <p>Only aliases where the given predicate tests successfully are returned. If the indices list contains a non-required reference to
-     * the index itself - null is returned. Returns {@code null} if no filtering is required.
-     * <p><b>NOTE</b>: the provided expressions must have been resolved already via
-     * {@link #resolveExpressionsToResources(Context, String...)}.
-     */
-    public String[] indexAliases(
-        ClusterState state,
-        String index,
-        Predicate<AliasMetadata> requiredAlias,
-        Predicate<DataStreamAlias> requiredDataStreamAlias,
-        boolean skipIdentity,
-        Set<ResolvedExpression> resolvedExpressions
-    ) {
-        return indexAliases(
-            projectResolver.getProjectMetadata(state),
-            index,
-            requiredAlias,
-            requiredDataStreamAlias,
-            skipIdentity,
-            resolvedExpressions
-        );
     }
 
     /**
@@ -1827,9 +1729,9 @@ public class IndexNameExpressionResolver {
             final IndexMetadata.State excludeState;
             if (options.expandWildcardsOpen() && options.expandWildcardsClosed()) {
                 excludeState = null;
-            } else if (options.expandWildcardsOpen() && options.expandWildcardsClosed() == false) {
+            } else if (options.expandWildcardsOpen()) {
                 excludeState = IndexMetadata.State.CLOSE;
-            } else if (options.expandWildcardsClosed() && options.expandWildcardsOpen() == false) {
+            } else if (options.expandWildcardsClosed()) {
                 excludeState = IndexMetadata.State.OPEN;
             } else {
                 assert false : "this shouldn't get called if wildcards expand to none";

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -1149,38 +1149,34 @@ public class IndexNameExpressionResolver {
             return requiredAliases.toArray(Strings.EMPTY_ARRAY);
         } else {
             final Map<String, AliasMetadata> indexAliases = indexMetadata.getAliases();
-            final AliasMetadata[] aliasCandidates;
-            if (iterateIndexAliases(indexAliases.size(), resolvedExpressions.size())) {
+            final int aliasCount = indexAliases.size();
+            if (aliasCount == 0) {
+                return null;
+            }
+            final List<String> aliases = new ArrayList<>(aliasCount);
+            if (iterateIndexAliases(aliasCount, resolvedExpressions.size())) {
                 // faster to iterate indexAliases
-                aliasCandidates = indexAliases.values()
-                    .stream()
-                    // Indices can only be referenced with a data selector, or a null selector if selectors are disabled
-                    .filter(aliasMetadata -> resolvedExpressionsContainsAbstraction(resolvedExpressions, aliasMetadata.alias()))
-                    .toArray(AliasMetadata[]::new);
+                // Indices can only be referenced with a data selector, or a null selector if selectors are disabled
+                for (AliasMetadata aliasMetadata : indexAliases.values()) {
+                    var alias = aliasMetadata.alias();
+                    if (resolvedExpressionsContainsAbstraction(resolvedExpressions, alias)) {
+                        if (requiredAlias.test(aliasMetadata) == false) {
+                            return null;
+                        }
+                        aliases.add(alias);
+                    }
+                }
             } else {
                 // faster to iterate resolvedExpressions
-                aliasCandidates = resolvedExpressions.stream()
-                    .map(ResolvedExpression::resource)
-                    .map(indexAliases::get)
-                    .filter(Objects::nonNull)
-                    .toArray(AliasMetadata[]::new);
-            }
-            List<String> aliases = null;
-            for (int i = 0; i < aliasCandidates.length; i++) {
-                AliasMetadata aliasMetadata = aliasCandidates[i];
-                if (requiredAlias.test(aliasMetadata)) {
-                    // If required - add it to the list of aliases
-                    if (aliases == null) {
-                        aliases = new ArrayList<>();
+                for (ResolvedExpression resolvedExpression : resolvedExpressions) {
+                    AliasMetadata aliasMetadata = indexAliases.get(resolvedExpression.resource());
+                    if (aliasMetadata != null) {
+                        if (requiredAlias.test(aliasMetadata) == false) {
+                            return null;
+                        }
+                        aliases.add(aliasMetadata.getAlias());
                     }
-                    aliases.add(aliasMetadata.alias());
-                } else {
-                    // If not, we have a non required alias for this index - no further checking needed
-                    return null;
                 }
-            }
-            if (aliases == null) {
-                return null;
             }
             return aliases.toArray(Strings.EMPTY_ARRAY);
         }


### PR DESCRIPTION
Very often there are no aliases, no need to create a bunch of objects in this case.
Also, no need to build an intermediary candidate list either.
Plus the nested streams do get very costly when running this logic over a large number
of indices.