### PR TITLE
[9.0] Delete obsolete SecurityManager testing (#127243)

### DIFF
--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.IndexModule;
-import org.elasticsearch.jdk.RuntimeVersionFeature;
 import org.elasticsearch.plugin.analysis.CharFilterFactory;
 import org.elasticsearch.plugins.scanners.PluginInfo;
 import org.elasticsearch.plugins.spi.BarPlugin;
@@ -38,7 +37,6 @@ import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessControlException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -870,22 +868,6 @@ public class PluginsServiceTests extends ESTestCase {
             // TODO should we add something to pluginInfos.get(0).pluginApiInfo() ?
         } finally {
             closePluginLoaders(pluginService);
-        }
-    }
-
-    public void testCanCreateAClassLoader() {
-        assumeTrue("security manager must be available", RuntimeVersionFeature.isSecurityManagerAvailable());
-        assertEquals(
-            "access denied (\"java.lang.RuntimePermission\" \"createClassLoader\")",
-            expectThrows(AccessControlException.class, () -> new Loader(this.getClass().getClassLoader())).getMessage()
-        );
-        var loader = PrivilegedOperations.supplierWithCreateClassLoader(() -> new Loader(this.getClass().getClassLoader()));
-        assertEquals(this.getClass().getClassLoader(), loader.getParent());
-    }
-
-    static final class Loader extends ClassLoader {
-        Loader(ClassLoader parent) {
-            super(parent);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/PrivilegedOperations.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/PrivilegedOperations.java
@@ -26,7 +26,6 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.security.ProtectionDomain;
 import java.util.Enumeration;
-import java.util.function.Supplier;
 
 import javax.tools.JavaCompiler;
 
@@ -69,15 +68,6 @@ public final class PrivilegedOperations {
             new RuntimePermission("closeClassLoader"),
             new RuntimePermission("accessSystemModules"),
             newAllFilesReadPermission()
-        );
-    }
-
-    public static <T> T supplierWithCreateClassLoader(Supplier<T> supplier) {
-        return AccessController.doPrivileged(
-            (PrivilegedAction<T>) () -> supplier.get(),
-            context,
-            new RuntimePermission("createClassLoader"),
-            new RuntimePermission("closeClassLoader")
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Delete obsolete SecurityManager testing (#127243)