### PR TITLE
Bypass competitive iteration in single filter bucket case

### DIFF
--- a/docs/changelog/127267.yaml
+++ b/docs/changelog/127267.yaml
@@ -1,0 +1,5 @@
+pr: 127267
+summary: Bypass competitive iteration in single filter bucket case
+area: "Search, Aggregations"
+type: bug
+issues: []

--- a/docs/changelog/127267.yaml
+++ b/docs/changelog/127267.yaml
@@ -1,5 +1,5 @@
 pr: 127267
 summary: Bypass competitive iteration in single filter bucket case
-area: "Search, Aggregations"
+area: "Aggregations"
 type: bug
-issues: []
+issues: [127262]

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregator.java
@@ -12,7 +12,6 @@ package org.elasticsearch.search.aggregations.bucket.filter;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DisiPriorityQueue;
 import org.apache.lucene.search.DisiWrapper;
-import org.apache.lucene.search.DisjunctionDISIApproximation;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
@@ -313,10 +312,9 @@ public abstract class FiltersAggregator extends BucketsAggregator {
             // and the cost of per-filter doc iterator is smaller than maxDoc, indicating that there are docs matching the main
             // query but not the filter query.
             final boolean hasOtherBucket = otherBucketKey != null;
-            final boolean usesCompetitiveIterator = (parent == null
-                && hasOtherBucket == false
-                && filterWrappers.isEmpty() == false
-                && totalCost < aggCtx.getLeafReaderContext().reader().maxDoc());
+            // TODO: https://github.com/elastic/elasticsearch/issues/126955
+            // competitive iterator is currently broken, we would rather be slow than broken
+            final boolean usesCompetitiveIterator = false;
 
             if (filterWrappers.size() == 1) {
                 return new SingleFilterLeafCollector(
@@ -329,12 +327,7 @@ public abstract class FiltersAggregator extends BucketsAggregator {
                 );
             }
             // TODO: https://github.com/elastic/elasticsearch/issues/126955
-            // competitive iterator is currently broken, we would rather be slow than broken
             return new MultiFilterLeafCollector(sub, filterWrappers, numFilters, totalNumKeys, hasOtherBucket);
-            // if (usesCompetitiveIterator) {
-            // return new MultiFilterCompetitiveLeafCollector(sub, filterWrappers, numFilters, totalNumKeys, hasOtherBucket);
-            // } else {
-            // }
         }
     }
 
@@ -455,46 +448,6 @@ public abstract class FiltersAggregator extends BucketsAggregator {
         @Override
         public DocIdSetIterator competitiveIterator() {
             return null;
-        }
-    }
-
-    private final class MultiFilterCompetitiveLeafCollector extends AbstractLeafCollector {
-
-        private final DisjunctionDISIApproximation disjunctionDisi;
-
-        MultiFilterCompetitiveLeafCollector(
-            LeafBucketCollector sub,
-            List<FilterMatchingDisiWrapper> filterWrappers,
-            int numFilters,
-            int totalNumKeys,
-            boolean hasOtherBucket
-        ) {
-            super(sub, numFilters, totalNumKeys, true, hasOtherBucket);
-            assert filterWrappers.isEmpty() == false;
-            disjunctionDisi = DisjunctionDISIApproximation.of(filterWrappers, Long.MAX_VALUE);
-        }
-
-        public void collect(int doc, long bucket) throws IOException {
-            boolean matched = false;
-            int target = disjunctionDisi.advance(doc);
-            if (target == doc) {
-                for (DisiWrapper w = disjunctionDisi.topList(); w != null; w = w.next) {
-                    FilterMatchingDisiWrapper topMatch = (FilterMatchingDisiWrapper) w;
-                    if (topMatch.checkDocForMatch(doc)) {
-                        collectBucket(sub, doc, bucketOrd(bucket, topMatch.filterOrd));
-                        matched = true;
-                    }
-                }
-            }
-
-            if (hasOtherBucket && false == matched) {
-                collectBucket(sub, doc, bucketOrd(bucket, numFilters));
-            }
-        }
-
-        @Override
-        public DocIdSetIterator competitiveIterator() {
-            return disjunctionDisi;
         }
     }
 


### PR DESCRIPTION
I forgot to bypass the competitive iteration for the single bucket case when previously 




closes: https://github.com/elastic/elasticsearch/issues/127262

related: https://github.com/elastic/elasticsearch/pull/126956
related: https://github.com/elastic/elasticsearch/issues/126955