### PR TITLE
[ML] Adding placeholder functionality for custom model request logic

### DIFF
--- a/x-pack/plugin/inference/build.gradle
+++ b/x-pack/plugin/inference/build.gradle
@@ -18,7 +18,7 @@ restResources {
 esplugin {
   name = 'x-pack-inference'
   description = 'Configuration and evaluation of inference models'
-  classname ='org.elasticsearch.xpack.inference.InferencePlugin'
+  classname = 'org.elasticsearch.xpack.inference.InferencePlugin'
   extendedPlugins = ['x-pack-core']
 }
 
@@ -57,9 +57,11 @@ dependencies {
   implementation 'io.grpc:grpc-context:1.49.2'
   implementation 'io.opencensus:opencensus-api:0.31.1'
   implementation 'io.opencensus:opencensus-contrib-http-util:0.31.1'
+  implementation "org.apache.commons:commons-lang3:${versions.commons_lang3}"
+  implementation 'org.apache.commons:commons-text:1.4'
 
   /* AWS SDK v2 */
-  implementation ("software.amazon.awssdk:bedrockruntime:${versions.awsv2sdk}")
+  implementation("software.amazon.awssdk:bedrockruntime:${versions.awsv2sdk}")
   api "software.amazon.awssdk:protocol-core:${versions.awsv2sdk}"
   api "software.amazon.awssdk:aws-json-protocol:${versions.awsv2sdk}"
   api "software.amazon.awssdk:third-party-jackson-core:${versions.awsv2sdk}"
@@ -400,4 +402,3 @@ tasks.named("thirdPartyAudit").configure {
 tasks.named('yamlRestTest') {
   usesDefaultDistribution("to be triaged")
 }
-

--- a/x-pack/plugin/inference/licenses/commons-lang3-LICENSE.txt
+++ b/x-pack/plugin/inference/licenses/commons-lang3-LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/x-pack/plugin/inference/licenses/commons-lang3-NOTICE.txt
+++ b/x-pack/plugin/inference/licenses/commons-lang3-NOTICE.txt
@@ -1,0 +1,5 @@
+Apache Commons Lang
+Copyright 2001-2019 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/x-pack/plugin/inference/licenses/commons-text-LICENSE.txt
+++ b/x-pack/plugin/inference/licenses/commons-text-LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/x-pack/plugin/inference/licenses/commons-text-NOTICE.txt
+++ b/x-pack/plugin/inference/licenses/commons-text-NOTICE.txt
@@ -1,0 +1,6 @@
+Apache Commons Text
+Copyright 2014-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+

--- a/x-pack/plugin/inference/src/main/java/module-info.java
+++ b/x-pack/plugin/inference/src/main/java/module-info.java
@@ -35,6 +35,7 @@ module org.elasticsearch.inference {
     requires org.reactivestreams;
     requires org.elasticsearch.logging;
     requires org.elasticsearch.sslconfig;
+    requires org.apache.commons.text;
 
     exports org.elasticsearch.xpack.inference.action;
     exports org.elasticsearch.xpack.inference.registry;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/JsonUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/JsonUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+public class JsonUtils {
+
+    public static <T> String toJson(T value, String field) {
+        try {
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.value(value);
+            return Strings.toString(builder);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                Strings.format("Failed to serialize custom request value as JSON, field: %s, error: %s", field, e.getMessage()),
+                e
+            );
+        }
+    }
+
+    private JsonUtils() {}
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/JsonUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/JsonUtils.java
@@ -13,6 +13,13 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 
 public class JsonUtils {
 
+    /**
+     * Converts an object into a JSON value.
+     * @param value the generic object to serialize, this must be a type that the {@link JsonXContent} provider supports.
+     * @param field a description of the object being serialized, can be the name of the field
+     * @return a String representation of the object serialized
+     * @param <T> the type of the object being serialized
+     */
     public static <T> String toJson(T value, String field) {
         try {
             XContentBuilder builder = JsonXContent.contentBuilder();
@@ -20,7 +27,7 @@ public class JsonUtils {
             return Strings.toString(builder);
         } catch (Exception e) {
             throw new IllegalStateException(
-                Strings.format("Failed to serialize custom request value as JSON, field: %s, error: %s", field, e.getMessage()),
+                Strings.format("Failed to serialize value as JSON, field: %s, error: %s", field, e.getMessage()),
                 e
             );
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutor.java
@@ -37,20 +37,20 @@ public class ValidatingSubstitutor {
      * Substitutes placeholder values in a string that match the keys in a provided map with the map's corresponding values.
      * After replacement, if the source still contains a placeholder an {@link IllegalStateException} is thrown.
      * @param source the string that will be searched for placeholders to be replaced
-     * @param settingName a description of the source string
+     * @param field a description of the source string
      * @return a string with the placeholders replaced by string values
      */
-    public String replace(String source, String settingName) {
+    public String replace(String source, String field) {
         var replacedString = substitutor.replace(source);
-        ensureNoMorePlaceholdersExist(replacedString, settingName);
+        ensureNoMorePlaceholdersExist(replacedString, field);
         return replacedString;
     }
 
-    private static void ensureNoMorePlaceholdersExist(String substitutedString, String settingName) {
+    private static void ensureNoMorePlaceholdersExist(String substitutedString, String field) {
         Matcher matcher = VARIABLE_PLACEHOLDER_PATTERN.matcher(substitutedString);
         if (matcher.find()) {
             throw new IllegalStateException(
-                String.format("Found placeholder [%s] in setting [%s] after replacement call", matcher.group(), settingName)
+                String.format("Found placeholder [%s] in field [%s] after replacement call", matcher.group(), field)
             );
         }
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.apache.commons.text.StringSubstitutor;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Substitutes placeholder values in a string that match the keys in a provided map with the map's corresponding values.
+ */
+public class ValidatingSubstitutor {
+    /**
+     * This regex pattern matches on the string {@code ${<any characters>}} excluding newlines.
+     */
+    private static final Pattern VARIABLE_PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{.*?\\}");
+
+    private final StringSubstitutor substitutor;
+
+    /**
+     * @param params a map containing the placeholders as the keys, the values will be used to replace the placeholders
+     * @param prefix a string indicating the start of a placeholder
+     * @param suffix a string indicating the end of a placeholder
+     */
+    public ValidatingSubstitutor(Map<String, String> params, String prefix, String suffix) {
+        substitutor = new StringSubstitutor(params, prefix, suffix);
+    }
+
+    /**
+     * Substitutes placeholder values in a string that match the keys in a provided map with the map's corresponding values.
+     * After replacement, if the source still contains a placeholder an {@link IllegalStateException} is thrown.
+     * @param source the string that will be searched for placeholders to be replaced
+     * @param settingName a description of the source string
+     * @return a string with the placeholders replaced by string values
+     */
+    public String replace(String source, String settingName) {
+        var replacedString = substitutor.replace(source);
+        ensureNoMorePlaceholdersExist(replacedString, settingName);
+        return replacedString;
+    }
+
+    private static void ensureNoMorePlaceholdersExist(String substitutedString, String settingName) {
+        Matcher matcher = VARIABLE_PLACEHOLDER_PATTERN.matcher(substitutedString);
+        if (matcher.find()) {
+            throw new IllegalStateException(
+                String.format("Found placeholder [%s] in setting [%s] after replacement call", matcher.group(), settingName)
+            );
+        }
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutor.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.inference.common;
 
 import org.apache.commons.text.StringSubstitutor;
+import org.elasticsearch.common.Strings;
 
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -50,7 +51,7 @@ public class ValidatingSubstitutor {
         Matcher matcher = VARIABLE_PLACEHOLDER_PATTERN.matcher(substitutedString);
         if (matcher.find()) {
             throw new IllegalStateException(
-                String.format("Found placeholder [%s] in field [%s] after replacement call", matcher.group(), field)
+                Strings.format("Found placeholder [%s] in field [%s] after replacement call", matcher.group(), field)
             );
         }
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/JsonUtilsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/JsonUtilsTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.elasticsearch.xpack.inference.common.JsonUtils.toJson;
+import static org.hamcrest.Matchers.is;
+
+public class JsonUtilsTests extends ESTestCase {
+    public void testToJson() throws IOException {
+        assertThat(toJson("string", "field"), is("\"string\""));
+        assertThat(toJson(1, "field"), is("1"));
+        assertThat(toJson(List.of("a", "b"), "field"), is("[\"a\",\"b\"]"));
+
+        {
+            var expected = XContentHelper.stripWhitespace("""
+                {
+                  "key": "value",
+                  "key2": [1, 2]
+                }
+                """);
+            assertThat(toJson(new TreeMap<>(Map.of("key", "value", "key2", List.of(1, 2))), "field"), is(expected));
+        }
+        {
+            var serializer = new ToXContentFragment() {
+                @Override
+                public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                    builder.value("string");
+                    return builder;
+                }
+            };
+
+            assertThat(toJson(serializer, "field"), is("\"string\""));
+        }
+        assertThat(toJson(1.1d, "field"), is("1.1"));
+        assertThat(toJson(1.1f, "field"), is("1.1"));
+        assertThat(toJson(true, "field"), is("true"));
+        assertThat(toJson(false, "field"), is("false"));
+    }
+
+    public void testToJson_ThrowsException_WhenUnableToSerialize() {
+        var exception = expectThrows(IllegalStateException.class, () -> toJson(new SecureString("string".toCharArray()), "field"));
+        assertThat(
+            exception.getMessage(),
+            is(
+                "Failed to serialize custom request value as JSON, field: field, error: "
+                    + "cannot write xcontent for unknown value of type class org.elasticsearch.common.settings.SecureString"
+            )
+        );
+    }
+
+    public void testToJson_ThrowsException_WhenValueSerializationFAils() {
+        var failingToXContent = new ToXContent() {
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                throw new IOException("failed");
+            }
+        };
+
+        var exception = expectThrows(IllegalStateException.class, () -> toJson(failingToXContent, "field"));
+        assertThat(exception.getMessage(), is("Failed to serialize custom request value as JSON, field: field, error: failed"));
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/JsonUtilsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/JsonUtilsTests.java
@@ -59,13 +59,13 @@ public class JsonUtilsTests extends ESTestCase {
         assertThat(
             exception.getMessage(),
             is(
-                "Failed to serialize custom request value as JSON, field: field, error: "
+                "Failed to serialize value as JSON, field: field, error: "
                     + "cannot write xcontent for unknown value of type class org.elasticsearch.common.settings.SecureString"
             )
         );
     }
 
-    public void testToJson_ThrowsException_WhenValueSerializationFAils() {
+    public void testToJson_ThrowsException_WhenValueSerializationFails() {
         var failingToXContent = new ToXContent() {
             @Override
             public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -74,6 +74,6 @@ public class JsonUtilsTests extends ESTestCase {
         };
 
         var exception = expectThrows(IllegalStateException.class, () -> toJson(failingToXContent, "field"));
-        assertThat(exception.getMessage(), is("Failed to serialize custom request value as JSON, field: field, error: failed"));
+        assertThat(exception.getMessage(), is("Failed to serialize value as JSON, field: field, error: failed"));
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutorTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+
+public class ValidatingSubstitutorTests extends ESTestCase {
+    public void testReplace() {
+        var sub = new ValidatingSubstitutor(Map.of("key", "value", "key2", "value2"), "${", "}");
+        assertThat(sub.replace("super:${key}", "setting"), is("super:value"));
+        assertThat(sub.replace("super, ${key}, ${key2}", "setting"), is("super, value, value2"));
+        assertThat(sub.replace("super", "setting"), is("super"));
+    }
+
+    public void testReplace_MatchesComplexPlaceholder() {
+        var sub = new ValidatingSubstitutor(Map.of("\t\b\f'\"\\key", "value"), "${", "}");
+        assertThat(sub.replace("super, ${\t\b\f'\"\\key}", "setting"), is("super, value"));
+    }
+
+    public void testReplace_IgnoresPlaceholdersWithNewlines() {
+        var sub = new ValidatingSubstitutor(Map.of("key", "value", "key2", "value2"), "${", "}");
+        assertThat(sub.replace("super:${key\n}", "setting"), is("super:${key\n}"));
+        assertThat(sub.replace("super:${\nkey}", "setting"), is("super:${\nkey}"));
+    }
+
+    public void testReplace_ThrowsException_WhenPlaceHolderStillExists() {
+        {
+            var sub = new ValidatingSubstitutor(Map.of("some_key", "value", "key2", "value2"), "${", "}");
+            var exception = expectThrows(IllegalStateException.class, () -> sub.replace("super:${key}", "setting"));
+
+            assertThat(exception.getMessage(), is("Found placeholder [${key}] in setting [setting] after replacement call"));
+        }
+        // only reports the first placeholder pattern
+        {
+            var sub = new ValidatingSubstitutor(Map.of("some_key", "value", "some_key2", "value2"), "${", "}");
+            var exception = expectThrows(IllegalStateException.class, () -> sub.replace("super, ${key}, ${key2}", "setting"));
+
+            assertThat(exception.getMessage(), is("Found placeholder [${key}] in setting [setting] after replacement call"));
+        }
+        {
+            var sub = new ValidatingSubstitutor(Map.of("some_key", "value", "key2", "value2"), "${", "}");
+            var exception = expectThrows(IllegalStateException.class, () -> sub.replace("super:${     \\/\tkey\"}", "setting"));
+
+            assertThat(exception.getMessage(), is("Found placeholder [${     \\/\tkey\"}] in setting [setting] after replacement call"));
+        }
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutorTests.java
@@ -37,20 +37,20 @@ public class ValidatingSubstitutorTests extends ESTestCase {
             var sub = new ValidatingSubstitutor(Map.of("some_key", "value", "key2", "value2"), "${", "}");
             var exception = expectThrows(IllegalStateException.class, () -> sub.replace("super:${key}", "setting"));
 
-            assertThat(exception.getMessage(), is("Found placeholder [${key}] in setting [setting] after replacement call"));
+            assertThat(exception.getMessage(), is("Found placeholder [${key}] in field [setting] after replacement call"));
         }
         // only reports the first placeholder pattern
         {
             var sub = new ValidatingSubstitutor(Map.of("some_key", "value", "some_key2", "value2"), "${", "}");
             var exception = expectThrows(IllegalStateException.class, () -> sub.replace("super, ${key}, ${key2}", "setting"));
 
-            assertThat(exception.getMessage(), is("Found placeholder [${key}] in setting [setting] after replacement call"));
+            assertThat(exception.getMessage(), is("Found placeholder [${key}] in field [setting] after replacement call"));
         }
         {
             var sub = new ValidatingSubstitutor(Map.of("some_key", "value", "key2", "value2"), "${", "}");
             var exception = expectThrows(IllegalStateException.class, () -> sub.replace("super:${     \\/\tkey\"}", "setting"));
 
-            assertThat(exception.getMessage(), is("Found placeholder [${     \\/\tkey\"}] in setting [setting] after replacement call"));
+            assertThat(exception.getMessage(), is("Found placeholder [${     \\/\tkey\"}] in field [setting] after replacement call"));
         }
     }
 }


### PR DESCRIPTION
This PR adds logic to serialize java objects into JSON values and implement the placeholder replacement logic. The Custom service was leveraging `gson` to handle the serialization into json. This implementation uses our internal `XContent` provider instead.

This is needed for the Custom service functionality in the inference API. The Custom service will support PUT requests with placeholders (`${some_key}`). The `ValidatingSubstitutor` handles replacing the placeholders with the values passed in via a map.

## Example PUT Request

```
PUT _inference/sparse_embedding/custom_sparse_embedding
{
  "service":"custom-model",
  "service_settings":{
    "secret_parameters":{
      "api_key":<<your api_key>>
    },
    "url":"http://url",
    "headers":{
      "Authorization": "Bearer ${api_key}",
      "Content-Type": "application/json;charset=utf-8"
    },
    "request":{
      "content":"""
        {
          "input": ${input},
          "input_type": "${input_type}",
          "return_token": ${return_token}
        }
        """
    },
    "response":{
      "json_parser":{
        "token_path":"$.result[*].embeddings[*].token",
         "weight_path":"$.result[*].embeddings[*].weight"
      }
    }
  },
  "task_settings":{
    "parameters":{
      "input_type":"query",
      "return_token":true
    }
  }
}
```

In this example `${input_type}` would be replaced with `query` and `${return_token}` would be replaced with `true`.