### PR TITLE
Using DataStream::getEffectiveSettings

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
@@ -258,7 +258,7 @@ public class TransportGetDataStreamsAction extends TransportLocalProjectMetadata
             } else {
                 indexTemplate = MetadataIndexTemplateService.findV2Template(state.metadata(), dataStream.getName(), false);
                 if (indexTemplate != null) {
-                    Settings settings = MetadataIndexTemplateService.resolveSettings(state.metadata(), indexTemplate);
+                    Settings settings = dataStream.getEffectiveSettings(state.metadata());
                     ilmPolicyName = settings.get(IndexMetadata.LIFECYCLE_NAME);
                     if (indexMode == null && state.metadata().templatesV2().get(indexTemplate) != null) {
                         indexMode = resolveMode(
@@ -266,7 +266,7 @@ public class TransportGetDataStreamsAction extends TransportLocalProjectMetadata
                             indexSettingProviders,
                             dataStream,
                             settings,
-                            state.metadata().templatesV2().get(indexTemplate)
+                            dataStream.getEffectiveIndexTemplate(state.metadata())
                         );
                     }
                     indexTemplatePreferIlmValue = PREFER_ILM_SETTING.get(settings);

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsActionTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsActionTests.java
@@ -11,14 +11,18 @@ package org.elasticsearch.datastreams.action;
 import org.elasticsearch.action.datastreams.GetDataStreamAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamFailureStoreSettings;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetention;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetentionSettings;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -27,15 +31,20 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexSettingProviders;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.test.ESTestCase;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import static org.elasticsearch.cluster.metadata.DataStream.getDefaultBackingIndexName;
+import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createIndexMetadata;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.getClusterStateWithDataStreams;
 import static org.elasticsearch.test.LambdaMatchers.transformedItemsMatch;
 import static org.elasticsearch.test.LambdaMatchers.transformedMatch;
@@ -317,9 +326,9 @@ public class TransportGetDataStreamsActionTests extends ESTestCase {
             null
         );
 
-        var name1 = DataStream.getDefaultBackingIndexName("ds-1", 1, instant.toEpochMilli());
-        var name2 = DataStream.getDefaultBackingIndexName("ds-1", 2, instant.toEpochMilli());
-        var name3 = DataStream.getDefaultBackingIndexName("ds-1", 3, twoHoursAgo.toEpochMilli());
+        var name1 = getDefaultBackingIndexName("ds-1", 1, instant.toEpochMilli());
+        var name2 = getDefaultBackingIndexName("ds-1", 2, instant.toEpochMilli());
+        var name3 = getDefaultBackingIndexName("ds-1", 3, twoHoursAgo.toEpochMilli());
         assertThat(
             response.getDataStreams(),
             contains(
@@ -526,5 +535,121 @@ public class TransportGetDataStreamsActionTests extends ESTestCase {
                 .orElse("bad"),
             equalTo("standard")
         );
+    }
+
+    public void testGetEffectiveSettingsTemplateOnlySettings() {
+        // Set a lifecycle only in the template, and make sure that is in the response:
+        ProjectId projectId = randomProjectIdOrDefault();
+        GetDataStreamAction.Request req = new GetDataStreamAction.Request(TEST_REQUEST_TIMEOUT, new String[] {});
+        final String templatePolicy = "templatePolicy";
+        final String templateIndexMode = IndexMode.LOOKUP.getName();
+        final String dataStreamPolicy = "dataStreamPolicy";
+        final String dataStreamIndexMode = IndexMode.LOGSDB.getName();
+
+        ClusterState state = getClusterStateWithDataStreamWithSettings(
+            projectId,
+            Settings.builder()
+                .put(IndexMetadata.LIFECYCLE_NAME, templatePolicy)
+                .put(IndexSettings.MODE.getKey(), templateIndexMode)
+                .build(),
+            Settings.EMPTY
+        );
+
+        GetDataStreamAction.Response response = TransportGetDataStreamsAction.innerOperation(
+            state.projectState(projectId),
+            req,
+            resolver,
+            systemIndices,
+            ClusterSettings.createBuiltInClusterSettings(),
+            dataStreamGlobalRetentionSettings,
+            emptyDataStreamFailureStoreSettings,
+            new IndexSettingProviders(Set.of()),
+            null
+        );
+        assertNotNull(response.getDataStreams());
+        assertThat(response.getDataStreams().size(), equalTo(1));
+        assertThat(response.getDataStreams().get(0).getIlmPolicy(), equalTo(templatePolicy));
+        assertThat(response.getDataStreams().get(0).getIndexModeName(), equalTo(templateIndexMode));
+    }
+
+    public void testGetEffectiveSettings() {
+        ProjectId projectId = randomProjectIdOrDefault();
+        GetDataStreamAction.Request req = new GetDataStreamAction.Request(TEST_REQUEST_TIMEOUT, new String[] {});
+        final String templatePolicy = "templatePolicy";
+        final String templateIndexMode = IndexMode.LOOKUP.getName();
+        final String dataStreamPolicy = "dataStreamPolicy";
+        final String dataStreamIndexMode = IndexMode.LOGSDB.getName();
+        // Now set a lifecycle in both the template and the data stream, and make sure the response has the data stream one:
+        ClusterState state = getClusterStateWithDataStreamWithSettings(
+            projectId,
+            Settings.builder()
+                .put(IndexMetadata.LIFECYCLE_NAME, templatePolicy)
+                .put(IndexSettings.MODE.getKey(), templateIndexMode)
+                .build(),
+            Settings.builder()
+                .put(IndexMetadata.LIFECYCLE_NAME, dataStreamPolicy)
+                .put(IndexSettings.MODE.getKey(), dataStreamIndexMode)
+                .build()
+        );
+        GetDataStreamAction.Response response = TransportGetDataStreamsAction.innerOperation(
+            state.projectState(projectId),
+            req,
+            resolver,
+            systemIndices,
+            ClusterSettings.createBuiltInClusterSettings(),
+            dataStreamGlobalRetentionSettings,
+            emptyDataStreamFailureStoreSettings,
+            new IndexSettingProviders(Set.of()),
+            null
+        );
+        assertNotNull(response.getDataStreams());
+        assertThat(response.getDataStreams().size(), equalTo(1));
+        assertThat(response.getDataStreams().get(0).getIlmPolicy(), equalTo(dataStreamPolicy));
+        assertThat(response.getDataStreams().get(0).getIndexModeName(), equalTo(dataStreamIndexMode));
+    }
+
+    private static ClusterState getClusterStateWithDataStreamWithSettings(
+        ProjectId projectId,
+        Settings templateSettings,
+        Settings dataStreamSettings
+    ) {
+        String dataStreamName = "data-stream-1";
+        int numberOfBackingIndices = randomIntBetween(1, 5);
+        long currentTime = System.currentTimeMillis();
+        int replicas = 0;
+        boolean replicated = false;
+        ProjectMetadata.Builder builder = ProjectMetadata.builder(projectId);
+        builder.put(
+            "template_1",
+            ComposableIndexTemplate.builder()
+                .indexPatterns(List.of("*"))
+                .template(Template.builder().settings(templateSettings))
+                .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
+                .build()
+        );
+
+        List<IndexMetadata> backingIndices = new ArrayList<>();
+        for (int backingIndexNumber = 1; backingIndexNumber <= numberOfBackingIndices; backingIndexNumber++) {
+            backingIndices.add(
+                createIndexMetadata(
+                    getDefaultBackingIndexName(dataStreamName, backingIndexNumber, currentTime),
+                    true,
+                    templateSettings,
+                    replicas
+                )
+            );
+        }
+        List<IndexMetadata> allIndices = new ArrayList<>(backingIndices);
+
+        DataStream ds = DataStream.builder(
+            dataStreamName,
+            backingIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList())
+        ).setGeneration(numberOfBackingIndices).setSettings(dataStreamSettings).setReplicated(replicated).build();
+        builder.put(ds);
+
+        for (IndexMetadata index : allIndices) {
+            builder.put(index, false);
+        }
+        return ClusterState.builder(new ClusterName("_name")).putProjectMetadata(builder.build()).build();
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.support.master.ShardsAcknowledgedResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class MetadataCreateIndexServiceIT extends ESIntegTestCase {
+
+    public void testRequestTemplateIsRespected() throws InterruptedException {
+        /*
+         * This test passes a template in the CreateIndexClusterStateUpdateRequest, and makes sure that the settings from that template
+         * are used when creating the index.
+         */
+        MetadataCreateIndexService metadataCreateIndexService = internalCluster().getCurrentMasterNodeInstance(
+            MetadataCreateIndexService.class
+        );
+        final String indexName = randomAlphaOfLength(20).toLowerCase(Locale.ROOT);
+        final int numberOfReplicas = randomIntBetween(1, 7);
+        CreateIndexClusterStateUpdateRequest request = new CreateIndexClusterStateUpdateRequest(
+            "testRequestTemplateIsRespected",
+            ProjectId.DEFAULT,
+            indexName,
+            randomAlphaOfLength(20)
+        );
+        request.setMatchingTemplate(
+            ComposableIndexTemplate.builder()
+                .template(Template.builder().settings(Settings.builder().put("index.number_of_replicas", numberOfReplicas)))
+                .build()
+        );
+        final CountDownLatch listenerCalledLatch = new CountDownLatch(1);
+        ActionListener<ShardsAcknowledgedResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(ShardsAcknowledgedResponse shardsAcknowledgedResponse) {
+                listenerCalledLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error(e);
+                listenerCalledLatch.countDown();
+            }
+        };
+
+        metadataCreateIndexService.createIndex(
+            TimeValue.THIRTY_SECONDS,
+            TimeValue.THIRTY_SECONDS,
+            TimeValue.THIRTY_SECONDS,
+            request,
+            listener
+        );
+        listenerCalledLatch.await(10, TimeUnit.SECONDS);
+        GetIndexResponse response = admin().indices()
+            .getIndex(new GetIndexRequest(TimeValue.THIRTY_SECONDS).indices(indexName))
+            .actionGet();
+        Settings settings = response.getSettings().get(indexName);
+        assertThat(settings.get("index.number_of_replicas"), equalTo(Integer.toString(numberOfReplicas)));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -66,7 +66,6 @@ import java.util.regex.Pattern;
 
 import static org.elasticsearch.cluster.metadata.IndexAbstraction.Type.ALIAS;
 import static org.elasticsearch.cluster.metadata.IndexAbstraction.Type.DATA_STREAM;
-import static org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService.lookupTemplateForDataStream;
 import static org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.findV1Templates;
 import static org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.findV2Template;
 import static org.elasticsearch.cluster.routing.allocation.allocator.AllocationActionListener.rerouteCompletionIsNotRequired;
@@ -325,7 +324,7 @@ public class MetadataRolloverService {
         final SystemDataStreamDescriptor systemDataStreamDescriptor;
         if (dataStream.isSystem() == false) {
             systemDataStreamDescriptor = null;
-            templateV2 = lookupTemplateForDataStream(dataStreamName, metadata);
+            templateV2 = dataStream.getEffectiveIndexTemplate(projectState.metadata());
         } else {
             systemDataStreamDescriptor = systemIndices.findMatchingDataStreamDescriptor(dataStreamName);
             if (systemDataStreamDescriptor == null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -267,7 +267,7 @@ public class TransportSimulateIndexTemplateAction extends TransportLocalProjectM
         List<CompressedXContent> mappings = MetadataCreateIndexService.collectV2Mappings(
             null, // empty request mapping as the user can't specify any explicit mappings via the simulate api
             simulatedProject,
-            matchingTemplate,
+            template,
             xContentRegistry,
             simulatedIndexName
         );

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -381,7 +381,12 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
 
     public Settings getEffectiveSettings(ProjectMetadata projectMetadata) {
         ComposableIndexTemplate template = getMatchingIndexTemplate(projectMetadata);
-        Settings templateSettings = template.template() == null ? Settings.EMPTY : template.template().settings();
+        final Settings templateSettings;
+        if (template.template() == null || template.template().settings() == null) {
+            templateSettings = Settings.EMPTY;
+        } else {
+            templateSettings = template.template().settings();
+        }
         return templateSettings.merge(settings);
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -63,6 +63,8 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -648,7 +650,15 @@ public class MetadataRolloverServiceTests extends ESTestCase {
                 false
             );
             long after = testThreadPool.absoluteTimeInMillis();
-
+            Settings rolledOverIndexSettings = rolloverResult.clusterState()
+                .projectState(projectId)
+                .metadata()
+                .index(rolloverResult.rolloverIndexName())
+                .getSettings();
+            Set<String> rolledOverIndexSettingNames = rolledOverIndexSettings.keySet();
+            for (String settingName : dataStream.getEffectiveSettings(clusterState.projectState(projectId).metadata()).keySet()) {
+                assertTrue(rolledOverIndexSettingNames.contains(settingName));
+            }
             String newIndexName = DataStream.getDefaultBackingIndexName(dataStream.getName(), dataStream.getGeneration() + 1);
             assertEquals(sourceIndexName, rolloverResult.sourceIndexName());
             assertEquals(newIndexName, rolloverResult.rolloverIndexName());
@@ -719,7 +729,15 @@ public class MetadataRolloverServiceTests extends ESTestCase {
                 true
             );
             long after = testThreadPool.absoluteTimeInMillis();
-
+            Settings rolledOverIndexSettings = rolloverResult.clusterState()
+                .projectState(projectId)
+                .metadata()
+                .index(rolloverResult.rolloverIndexName())
+                .getSettings();
+            Set<String> rolledOverIndexSettingNames = rolledOverIndexSettings.keySet();
+            for (String settingName : dataStream.getSettings().keySet()) {
+                assertFalse(rolledOverIndexSettingNames.contains(settingName));
+            }
             var epochMillis = System.currentTimeMillis();
             String sourceIndexName = DataStream.getDefaultFailureStoreName(dataStream.getName(), dataStream.getGeneration(), epochMillis);
             String newIndexName = DataStream.getDefaultFailureStoreName(dataStream.getName(), dataStream.getGeneration() + 1, epochMillis);


### PR DESCRIPTION
This builds on #126947, by using the DataStream::getEffectiveSettings and DataStream::getEffectiveIndexTemplate methods introduced in that PR.
As of this PR, no externally-visible behavior is different. Rollover will now use the effective settings from the data stream, but since the settings actually stored on the data stream area always empty, the result is that the template settings continue to be used. Similarly, the settings used in the GetDataStreamAction will be the effective settings but will appear unchanged since the data stream settings are always empty.
A follow-up PR will introduce a transport action to set the data stream's settings.