### PR TITLE
[8.x] Fix missing index exception handling (#126738)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithFiltersIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithFiltersIT.java
@@ -9,8 +9,10 @@ package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.RemoteException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -275,13 +277,13 @@ public class CrossClusterQueryWithFiltersIT extends AbstractCrossClusterTestCase
             );
             assertThat(e.getDetailedMessage(), containsString("Unknown index [missing]"));
             // Local index missing + wildcards
-            // FIXME: planner does not catch this now
-            // e = expectThrows(VerificationException.class, () -> runQuery("from missing,logs*", randomBoolean(), filter).close());
-            // assertThat(e.getDetailedMessage(), containsString("Unknown index [missing]"));
+            // FIXME: planner does not catch this now, it should be VerificationException but for now it's runtime IndexNotFoundException
+            var ie = expectThrows(IndexNotFoundException.class, () -> runQuery("from missing,logs*", randomBoolean(), filter).close());
+            assertThat(ie.getDetailedMessage(), containsString("no such index [missing]"));
             // Local index missing + existing index
-            // FIXME: planner does not catch this now
-            // e = expectThrows(VerificationException.class, () -> runQuery("from missing,logs-1", randomBoolean(), filter).close());
-            // assertThat(e.getDetailedMessage(), containsString("Unknown index [missing]"));
+            // FIXME: planner does not catch this now, it should be VerificationException but for now it's runtime IndexNotFoundException
+            ie = expectThrows(IndexNotFoundException.class, () -> runQuery("from missing,logs-1", randomBoolean(), filter).close());
+            assertThat(ie.getDetailedMessage(), containsString("no such index [missing]"));
             // Local index missing + existing remote
             e = expectThrows(VerificationException.class, () -> runQuery("from missing,cluster-a:logs-2", randomBoolean(), filter).close());
             assertThat(e.getDetailedMessage(), containsString("Unknown index [missing]"));
@@ -318,15 +320,19 @@ public class CrossClusterQueryWithFiltersIT extends AbstractCrossClusterTestCase
             );
             assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:missing]"));
             // Local index missing + wildcards
-            // FIXME: planner does not catch this now
-            // e = expectThrows(VerificationException.class, () -> runQuery("from cluster-a:missing,cluster-a:logs*", randomBoolean(),
-            // filter).close());
-            // assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:missing]"));
+            // FIXME: planner does not catch this now, it should be VerificationException but for now it's runtime RemoteException
+            var ie = expectThrows(
+                RemoteException.class,
+                () -> runQuery("from cluster-a:missing,cluster-a:logs*", randomBoolean(), filter).close()
+            );
+            assertThat(ie.getDetailedMessage(), containsString("no such index [missing]"));
             // Local index missing + existing index
-            // FIXME: planner does not catch this now
-            // e = expectThrows(VerificationException.class, () -> runQuery("from cluster-a:missing,cluster-a:logs-2", randomBoolean(),
-            // filter).close());
-            // assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:missing]"));
+            // FIXME: planner does not catch this now, it should be VerificationException but for now it's runtime RemoteException
+            ie = expectThrows(
+                RemoteException.class,
+                () -> runQuery("from cluster-a:missing,cluster-a:logs-2", randomBoolean(), filter).close()
+            );
+            assertThat(ie.getDetailedMessage(), containsString("no such index [missing]"));
             // Local index + missing remote
             e = expectThrows(VerificationException.class, () -> runQuery("from logs-1,cluster-a:missing", randomBoolean(), filter).close());
             assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:missing]"));

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterUsageTelemetryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterUsageTelemetryIT.java
@@ -138,32 +138,6 @@ public class CrossClusterUsageTelemetryIT extends AbstractCrossClusterUsageTelem
         assertThat(telemetry.getByRemoteCluster().size(), equalTo(0));
     }
 
-    // TODO: enable when skip-un patch is merged
-    // public void testSkipAllRemotes() throws Exception {
-    // var telemetry = getTelemetryFromQuery("from logs-*,c*:no_such_index | stats sum (v)", "unknown");
-    //
-    // assertThat(telemetry.getTotalCount(), equalTo(1L));
-    // assertThat(telemetry.getSuccessCount(), equalTo(1L));
-    // assertThat(telemetry.getFailureReasons().size(), equalTo(0));
-    // assertThat(telemetry.getTook().count(), equalTo(1L));
-    // assertThat(telemetry.getTookMrtFalse().count(), equalTo(0L));
-    // assertThat(telemetry.getTookMrtTrue().count(), equalTo(0L));
-    // assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(2.0));
-    // assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
-    // assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(1L));
-    // assertThat(telemetry.getClientCounts().size(), equalTo(0));
-    //
-    // var perCluster = telemetry.getByRemoteCluster();
-    // assertThat(perCluster.size(), equalTo(3));
-    // for (String clusterAlias : remoteClusterAlias()) {
-    // var clusterData = perCluster.get(clusterAlias);
-    // assertThat(clusterData.getCount(), equalTo(0L));
-    // assertThat(clusterData.getSkippedCount(), equalTo(1L));
-    // assertThat(clusterData.getTook().count(), equalTo(0L));
-    // }
-    // assertPerClusterCount(perCluster.get(LOCAL_CLUSTER), 1L);
-    // }
-
     public void testRemoteOnly() throws Exception {
         setupClusters();
         var telemetry = getTelemetryFromQuery("from c*:logs-* | stats sum (v)", "kibana");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.search.SearchRequest;
@@ -27,6 +28,7 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -274,7 +276,8 @@ public class ComputeService {
                                 );
                                 dataNodesListener.onResponse(r.getProfiles());
                             }, e -> {
-                                if (configuration.allowPartialResults()) {
+                                if (configuration.allowPartialResults()
+                                    && (ExceptionsHelper.unwrapCause(e) instanceof IndexNotFoundException) == false) {
                                     execInfo.swapCluster(
                                         LOCAL_CLUSTER,
                                         (k, v) -> new EsqlExecutionInfo.Cluster.Builder(v).setStatus(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix missing index exception handling (#126738)](https://github.com/elastic/elasticsearch/pull/126738)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)