### PR TITLE
[9.0] [DOCS] Clarify update behavior for indices with semantic_text fields, flag CCS/CCR limitation (#127310)

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -158,8 +158,10 @@ In case you want to customize data indexing, use the [`sparse_vector`](/referenc
 
 ## Updates to `semantic_text` fields [update-script]
 
-Updates that use scripts are not supported for an index contains a `semantic_text` field. Even if the script targets non-`semantic_text` fields, the update will fail when the index contains a `semantic_text` field.
+For indices containing `semantic_text` fields, updates that use scripts have the following behavior:
 
+* Are supported through the [Update API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-update).
+* Are not supported through the [Bulk API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-bulk-1) and will fail. Even if the script targets non-`semantic_text` fields, the update will fail when the index contains a `semantic_text` field.
 
 ## `copy_to` and multi-fields support [copy-to-support]
 
@@ -213,4 +215,4 @@ PUT test-index
 
 * `semantic_text` fields are not currently supported as elements of [nested fields](/reference/elasticsearch/mapping-reference/nested.md).
 * `semantic_text` fields can’t currently be set as part of [Dynamic templates](docs-content://manage-data/data-store/mapping/dynamic-templates.md).
-
+* `semantic_text` fields are not currently behavior for indices with semantic_text fields, flag CCS/CCR limitation (#127310))

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -215,4 +215,4 @@ PUT test-index
 
 * `semantic_text` fields are not currently supported as elements of [nested fields](/reference/elasticsearch/mapping-reference/nested.md).
 * `semantic_text` fields can’t currently be set as part of [Dynamic templates](docs-content://manage-data/data-store/mapping/dynamic-templates.md).
-* `semantic_text` fields are not currently behavior for indices with semantic_text fields, flag CCS/CCR limitation (#127310))
+* `semantic_text` fields are not currently supported with Cross-Cluster Search (CCS) or Cross-Cluster Replication (CCR).


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[DOCS] Clarify update behavior for indices with semantic_text fields, flag CCS/CCR limitation (#127310)](https://github.com/elastic/elasticsearch/pull/127310)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)