### PR TITLE
ES|QL: Unmute fork tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -429,21 +429,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
   method: testSearchWhileRelocating
   issue: https://github.com/elastic/elasticsearch/issues/127188
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {fork.ForkWithMixOfCommands}
-  issue: https://github.com/elastic/elasticsearch/issues/127268
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {fork.FiveFork}
-  issue: https://github.com/elastic/elasticsearch/issues/127272
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {fork.ForkWithStats}
-  issue: https://github.com/elastic/elasticsearch/issues/127279
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/127157
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {fork.ForkWithDissect}
-  issue: https://github.com/elastic/elasticsearch/issues/127304
 
 # Examples:
 #


### PR DESCRIPTION
This just cleans up muted-tests.yml because we no longer need to mute the fork tests for `MultiClusterSpecIT`.

Fork csv tests are skipped for CCS for now - see https://github.com/elastic/elasticsearch/pull/127309