### PR TITLE
Force all per-node query response handling onto a single thread

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -32,11 +32,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThrottledTaskRunner;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
@@ -148,7 +146,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         if (ccsCheckCompatibility) {
             checkCCSVersionCompatibility(request);
         }
-        final Executor singleThreadedExecutor = buildSingleThreadedExecutor();
+        final Executor singleThreadedExecutor = ThrottledTaskRunner.buildSingleThreadedExecutor("field_caps", searchCoordinationExecutor);
         assert task instanceof CancellableTask;
         final CancellableTask fieldCapTask = (CancellableTask) task;
         // retrieve the initial timestamp in case the action is a cross cluster search
@@ -312,29 +310,6 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                 );
             }
         }
-    }
-
-    private Executor buildSingleThreadedExecutor() {
-        final ThrottledTaskRunner throttledTaskRunner = new ThrottledTaskRunner("field_caps", 1, searchCoordinationExecutor);
-        return r -> throttledTaskRunner.enqueueTask(new ActionListener<>() {
-            @Override
-            public void onResponse(Releasable releasable) {
-                try (releasable) {
-                    r.run();
-                }
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                if (r instanceof AbstractRunnable abstractRunnable) {
-                    abstractRunnable.onFailure(e);
-                } else {
-                    // should be impossible, we should always submit an AbstractRunnable
-                    logger.error("unexpected failure running " + r, e);
-                    assert false : new AssertionError("unexpected failure running " + r, e);
-                }
-            }
-        });
     }
 
     public interface RemoteRequestExecutor {

--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -188,9 +188,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
     }
 
     void addBatchedPartialResult(TopDocsStats topDocsStats, MergeResult mergeResult) {
-        synchronized (batchedResults) {
-            batchedResults.add(new Tuple<>(topDocsStats, mergeResult));
-        }
+        batchedResults.add(new Tuple<>(topDocsStats, mergeResult));
     }
 
     @Override
@@ -215,10 +213,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         buffer.sort(RESULT_COMPARATOR);
         final TopDocsStats topDocsStats = this.topDocsStats;
         var mergeResult = this.mergeResult;
-        final ArrayDeque<Tuple<TopDocsStats, MergeResult>> batchedResults;
-        synchronized (this.batchedResults) {
-            batchedResults = this.batchedResults;
-        }
+        final ArrayDeque<Tuple<TopDocsStats, MergeResult>> batchedResults = this.batchedResults;
         final int resultSize = buffer.size() + (mergeResult == null ? 0 : 1) + batchedResults.size();
         final List<TopDocs> topDocsList = hasTopDocs ? new ArrayList<>(resultSize) : null;
         final Deque<DelayableWriteable<InternalAggregations>> aggsList = hasAggs ? new ArrayDeque<>(resultSize) : null;

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledTaskRunner.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledTaskRunner.java
@@ -25,6 +25,12 @@ public class ThrottledTaskRunner extends AbstractThrottledTaskRunner<ActionListe
         super(name, maxRunningTasks, executor, ConcurrentCollections.newBlockingQueue());
     }
 
+    /**
+     * Builds an executor that executes one task at a time from a throttled task runner.
+     * @param name name for the executor
+     * @param executor executor to use for executing the tasks
+     * @return executor that forwards and runs a single task at a time on the provided {@code executor}
+     */
     public static Executor buildSingleThreadedExecutor(String name, Executor executor) {
         final ThrottledTaskRunner throttledTaskRunner = new ThrottledTaskRunner(name, 1, executor);
         return r -> throttledTaskRunner.enqueueTask(new ActionListener<>() {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledTaskRunner.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledTaskRunner.java
@@ -11,12 +11,40 @@ package org.elasticsearch.common.util.concurrent;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 
 import java.util.concurrent.Executor;
 
 public class ThrottledTaskRunner extends AbstractThrottledTaskRunner<ActionListener<Releasable>> {
+
+    private static final Logger logger = LogManager.getLogger(ThrottledTaskRunner.class);
+
     // a simple AbstractThrottledTaskRunner which fixes the task type and uses a regular FIFO blocking queue.
     public ThrottledTaskRunner(String name, int maxRunningTasks, Executor executor) {
         super(name, maxRunningTasks, executor, ConcurrentCollections.newBlockingQueue());
+    }
+
+    public static Executor buildSingleThreadedExecutor(String name, Executor executor) {
+        final ThrottledTaskRunner throttledTaskRunner = new ThrottledTaskRunner(name, 1, executor);
+        return r -> throttledTaskRunner.enqueueTask(new ActionListener<>() {
+            @Override
+            public void onResponse(Releasable releasable) {
+                try (releasable) {
+                    r.run();
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (r instanceof AbstractRunnable abstractRunnable) {
+                    abstractRunnable.onFailure(e);
+                } else {
+                    // should be impossible, we should always submit an AbstractRunnable
+                    logger.error("unexpected failure running [" + r + "] on [" + name + "]", e);
+                    assert false : new AssertionError("unexpected failure running " + r, e);
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
Same reasoning as for field_caps in https://github.com/elastic/elasticsearch/pull/120863, no need to have multiple threads contending the same mutex(s) when the heavy lifting step in handling the results is sequential anyway.
