### PR TITLE
ES|QL: Collect profile information for FORK and fix race condition with markEndQuery

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -244,21 +244,24 @@ public class ComputeService {
                 )
             ) {
                 runCompute(rootTask, computeContext, finalMainPlan, localListener.acquireCompute());
-            }
 
-            for (PhysicalPlan subplan : subplans) {
-                var childSessionId = newChildSession(sessionId);
-                ExchangeSinkHandler exchangeSink = exchangeService.createSinkHandler(childSessionId, queryPragmas.exchangeBufferSize());
-                // funnel sub plan pages into the main plan exchange source
-                mainExchangeSource.addRemoteSink(exchangeSink::fetchPageAsync, true, () -> {}, 1, ActionListener.noop());
-                executePlan(childSessionId, rootTask, subplan, configuration, foldContext, execInfo, ActionListener.wrap(result -> {
-                    exchangeSink.addCompletionListener(
-                        ActionListener.running(() -> { exchangeService.finishSinkHandler(childSessionId, null); })
-                    );
-                }, e -> {
-                    exchangeService.finishSinkHandler(childSessionId, e);
-                    finalListener.onFailure(e);
-                }), () -> exchangeSink.createExchangeSink(() -> {}));
+                for (PhysicalPlan subplan : subplans) {
+                    var childSessionId = newChildSession(sessionId);
+                    ExchangeSinkHandler exchangeSink = exchangeService.createSinkHandler(childSessionId, queryPragmas.exchangeBufferSize());
+                    // funnel sub plan pages into the main plan exchange source
+                    mainExchangeSource.addRemoteSink(exchangeSink::fetchPageAsync, true, () -> {}, 1, ActionListener.noop());
+                    var subPlanListener = localListener.acquireCompute();
+
+                    executePlan(childSessionId, rootTask, subplan, configuration, foldContext, execInfo, ActionListener.wrap(result -> {
+                        exchangeSink.addCompletionListener(
+                            ActionListener.running(() -> { exchangeService.finishSinkHandler(childSessionId, null); })
+                        );
+                        subPlanListener.onResponse(result.completionInfo());
+                    }, e -> {
+                        exchangeService.finishSinkHandler(childSessionId, e);
+                        subPlanListener.onFailure(e);
+                    }), () -> exchangeSink.createExchangeSink(() -> {}));
+                }
             }
         }
     }


### PR DESCRIPTION
fix for the following test failures:
https://github.com/elastic/elasticsearch/issues/127326
https://github.com/elastic/elasticsearch/issues/127063

We would expect that the final listener for the main coordinator plan is called after all the final listener for the sub plans have executed.
This is the final listener for the main coordinator plan:

https://github.com/elastic/elasticsearch/blob/8f9c96b05d8869f5e96b42e900648b66893de076/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java#L237-L244

This is the final listener for the sub plans:

https://github.com/elastic/elasticsearch/blob/8f9c96b05d8869f5e96b42e900648b66893de076/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java#L360-L364

Currently the listeners for the sub plans can be called after we call the main plan one.
This can easily tested with a debugger by adding a `Thread.sleep` in the sub plan listener.
This caused issues with how we report `took` time (see https://github.com/elastic/elasticsearch/issues/127063#issuecomment-2827407785).

Another issue that we currently have with FORK is that we don't collect proper profile information.

The root cause is that we don't use the same `ComputeListener` for both the main coordinator plan and sub plans.
We only use it for the main coordinator plan - see how we call `localListener.acquireCompute()`.

https://github.com/elastic/elasticsearch/blob/8f9c96b05d8869f5e96b42e900648b66893de076/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java#L236-L247

To fix this I made sure that for each sub plan we also use `localListener.acquireCompute()`.
The `ComputeListener` receives an action listener that will be called after each task that's created with `#acquireCompute` is finished:

https://github.com/elastic/elasticsearch/blob/49a9137388b26d242b0361c46a12fb20eec6cd91/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java#L18-L39

This change also ensures that we are now collecting driver information from sub plans.
As a follow up I'd like to see if we can label the driver information from the profile response so it's more obvious to which sub plan it belongs to.


