### PR TITLE
Zero copy proxy responses in TransportActionProxy

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -74,7 +73,7 @@ public final class TransportActionProxy {
                 @Override
                 public TransportResponse read(StreamInput in) throws IOException {
                     if (in.getTransportVersion().equals(channel.getVersion()) && in.supportReadAllToReleasableBytesReference()) {
-                        return new BytesTransportResponse(in);
+                        return new BytesTransportResponse(in.readAllToReleasableBytesReference());
                     } else {
                         return responseFunction.apply(wrappedRequest).read(in);
                     }
@@ -94,34 +93,6 @@ public final class TransportActionProxy {
                     + (proxyTask instanceof CancellableTask)
                     + "]";
             return true;
-        }
-    }
-
-    static final class BytesTransportResponse extends TransportResponse {
-        final ReleasableBytesReference bytes;
-
-        BytesTransportResponse(StreamInput in) throws IOException {
-            this.bytes = in.readAllToReleasableBytesReference();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            bytes.writeTo(out);
-        }
-
-        @Override
-        public void incRef() {
-            bytes.incRef();
-        }
-
-        @Override
-        public boolean tryIncRef() {
-            return bytes.tryIncRef();
-        }
-
-        @Override
-        public boolean decRef() {
-            return bytes.decRef();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -257,7 +257,7 @@ public class TransportActionProxyTests extends ESTestCase {
             );
             latch.await();
             assertThat(responses, hasSize(1));
-            assertThat(responses.get(0), instanceOf(TransportActionProxy.BytesTransportResponse.class));
+            assertThat(responses.get(0), instanceOf(BytesTransportResponse.class));
             serviceB.clearAllRules();
         }
     }


### PR DESCRIPTION
Easy win on top of https://github.com/elastic/elasticsearch/pull/127112 essentially halving the heap use for proxying responses :)
<= With the new bytes response infrastructure we can save a duplicate class and actually get zero copy on the write side of things as well.