### PR TITLE
[test] Unmute `SearchWithRandomIOExceptionsIT#testRandomDirectoryIOExceptions`

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -494,7 +494,6 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             }
         } catch (final org.apache.lucene.index.IndexNotFoundException e) {
             // happens on an empty folder. no need to log
-            assert startingSeqNo == UNASSIGNED_SEQ_NO : startingSeqNo;
             logger.trace("{} shard folder empty, recovering all files", recoveryTarget);
             metadataSnapshot = Store.MetadataSnapshot.EMPTY;
         } catch (final IOException e) {


### PR DESCRIPTION
Remove an assumption that `IndexNotFoundException` can only be thrown on an empty folder. `IndexNotFoundException` can be thrown if we can't read index data.

We ran this test in a loop in #127014 and it doesn't fail.

Resolve #118733
