### PR TITLE
[ML] Directly call Inference API from Proxy

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/BaseTransportInferenceAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/BaseTransportInferenceAction.java
@@ -102,8 +102,6 @@ public abstract class BaseTransportInferenceAction<Request extends BaseInference
         NodeClient nodeClient,
         ThreadPool threadPool
     ) {
-        // TransportInferenceActionProxy depends on this action passing EsExecutors.DIRECT_EXECUTOR_SERVICE to preserve the headers.
-        // If we change the ExecutorService, change the listener in TransportInferenceActionProxy to ContextPreservingActionListener.
         super(inferenceActionName, transportService, actionFilters, requestReader, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.licenseState = licenseState;
         this.modelRegistry = modelRegistry;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/BaseTransportInferenceAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/BaseTransportInferenceAction.java
@@ -102,6 +102,8 @@ public abstract class BaseTransportInferenceAction<Request extends BaseInference
         NodeClient nodeClient,
         ThreadPool threadPool
     ) {
+        // TransportInferenceActionProxy depends on this action passing EsExecutors.DIRECT_EXECUTOR_SERVICE to preserve the headers.
+        // If we change the ExecutorService, change the listener in TransportInferenceActionProxy to ContextPreservingActionListener.
         super(inferenceActionName, transportService, actionFilters, requestReader, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.licenseState = licenseState;
         this.modelRegistry = modelRegistry;


### PR DESCRIPTION
In order to propagate response headers back from the proxied actions, we are directly calling the Transport actions via the NodeClient.

