### PR TITLE
[8.x] Apply recent TSDB codec merge optimizations to binary values (#127278)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/DocValuesConsumerUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/DocValuesConsumerUtil.java
@@ -20,9 +20,9 @@ import org.elasticsearch.index.codec.perfield.XPerFieldDocValuesFormat;
  */
 class DocValuesConsumerUtil {
 
-    static final MergeStats UNSUPPORTED = new MergeStats(false, -1, -1);
+    static final MergeStats UNSUPPORTED = new MergeStats(false, -1, -1, -1, -1);
 
-    record MergeStats(boolean supported, long sumNumValues, int sumNumDocsWithField) {}
+    record MergeStats(boolean supported, long sumNumValues, int sumNumDocsWithField, int minLength, int maxLength) {}
 
     static MergeStats compatibleWithOptimizedMerge(boolean optimizedMergeEnabled, MergeState mergeState, FieldInfo fieldInfo) {
         if (optimizedMergeEnabled == false || mergeState.needsIndexSort == false) {
@@ -38,6 +38,8 @@ class DocValuesConsumerUtil {
 
         long sumNumValues = 0;
         int sumNumDocsWithField = 0;
+        int minLength = Integer.MAX_VALUE;
+        int maxLength = 0;
 
         for (int i = 0; i < mergeState.docValuesProducers.length; i++) {
             DocValuesProducer docValuesProducer = mergeState.docValuesProducers[i];
@@ -86,6 +88,14 @@ class DocValuesConsumerUtil {
                                 }
                             }
                         }
+                        case BINARY -> {
+                            var entry = tsdbDocValuesProducer.binaries.get(fieldInfo.number);
+                            if (entry != null) {
+                                sumNumDocsWithField += entry.numDocsWithField;
+                                minLength = Math.min(minLength, entry.minLength);
+                                maxLength = Math.max(maxLength, entry.maxLength);
+                            }
+                        }
                         default -> throw new IllegalStateException("unexpected doc values producer type: " + fieldInfo.getDocValuesType());
                     }
                 } else {
@@ -96,7 +106,7 @@ class DocValuesConsumerUtil {
             }
         }
 
-        return new MergeStats(true, sumNumValues, sumNumDocsWithField);
+        return new MergeStats(true, sumNumValues, sumNumDocsWithField, minLength, maxLength);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesConsumer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesConsumer.java
@@ -248,70 +248,145 @@ final class ES819TSDBDocValuesConsumer extends XDocValuesConsumer {
     }
 
     @Override
+    public void mergeBinaryField(FieldInfo mergeFieldInfo, MergeState mergeState) throws IOException {
+        var result = compatibleWithOptimizedMerge(enableOptimizedMerge, mergeState, mergeFieldInfo);
+        if (result.supported()) {
+            mergeBinaryField(result, mergeFieldInfo, mergeState);
+        } else {
+            super.mergeBinaryField(mergeFieldInfo, mergeState);
+        }
+    }
+
+    @Override
     public void addBinaryField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
         meta.writeInt(field.number);
         meta.writeByte(ES819TSDBDocValuesFormat.BINARY);
 
-        BinaryDocValues values = valuesProducer.getBinary(field);
-        long start = data.getFilePointer();
-        meta.writeLong(start); // dataOffset
-        int numDocsWithField = 0;
-        int minLength = Integer.MAX_VALUE;
-        int maxLength = 0;
-        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
-            numDocsWithField++;
-            BytesRef v = values.binaryValue();
-            int length = v.length;
-            data.writeBytes(v.bytes, v.offset, v.length);
-            minLength = Math.min(length, minLength);
-            maxLength = Math.max(length, maxLength);
-        }
-        assert numDocsWithField <= maxDoc;
-        meta.writeLong(data.getFilePointer() - start); // dataLength
+        if (valuesProducer instanceof TsdbDocValuesProducer tsdbValuesProducer && tsdbValuesProducer.mergeStats.supported()) {
+            final int numDocsWithField = tsdbValuesProducer.mergeStats.sumNumDocsWithField();
+            final int minLength = tsdbValuesProducer.mergeStats.minLength();
+            final int maxLength = tsdbValuesProducer.mergeStats.maxLength();
 
-        if (numDocsWithField == 0) {
-            meta.writeLong(-2); // docsWithFieldOffset
-            meta.writeLong(0L); // docsWithFieldLength
-            meta.writeShort((short) -1); // jumpTableEntryCount
-            meta.writeByte((byte) -1); // denseRankPower
-        } else if (numDocsWithField == maxDoc) {
-            meta.writeLong(-1); // docsWithFieldOffset
-            meta.writeLong(0L); // docsWithFieldLength
-            meta.writeShort((short) -1); // jumpTableEntryCount
-            meta.writeByte((byte) -1); // denseRankPower
-        } else {
-            long offset = data.getFilePointer();
-            meta.writeLong(offset); // docsWithFieldOffset
-            values = valuesProducer.getBinary(field);
-            final short jumpTableEntryCount = IndexedDISI.writeBitSet(values, data, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
-            meta.writeLong(data.getFilePointer() - offset); // docsWithFieldLength
-            meta.writeShort(jumpTableEntryCount);
-            meta.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
-        }
+            assert numDocsWithField <= maxDoc;
 
-        meta.writeInt(numDocsWithField);
-        meta.writeInt(minLength);
-        meta.writeInt(maxLength);
-        if (maxLength > minLength) {
-            start = data.getFilePointer();
-            meta.writeLong(start);
-            meta.writeVInt(ES819TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT);
+            BinaryDocValues values = valuesProducer.getBinary(field);
+            long start = data.getFilePointer();
+            meta.writeLong(start); // dataOffset
 
-            final DirectMonotonicWriter writer = DirectMonotonicWriter.getInstance(
-                meta,
-                data,
-                numDocsWithField + 1,
-                ES819TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT
-            );
-            long addr = 0;
-            writer.add(addr);
-            values = valuesProducer.getBinary(field);
-            for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
-                addr += values.binaryValue().length;
-                writer.add(addr);
+            OffsetsAccumulator offsetsAccumulator = null;
+            DISIAccumulator disiAccumulator = null;
+            try {
+                if (numDocsWithField > 0 && numDocsWithField < maxDoc) {
+                    disiAccumulator = new DISIAccumulator(dir, context, data, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+                }
+
+                assert maxLength >= minLength;
+                if (maxLength > minLength) {
+                    offsetsAccumulator = new OffsetsAccumulator(dir, context, data, numDocsWithField);
+                }
+
+                for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+                    BytesRef v = values.binaryValue();
+                    data.writeBytes(v.bytes, v.offset, v.length);
+                    if (disiAccumulator != null) {
+                        disiAccumulator.addDocId(doc);
+                    }
+                    if (offsetsAccumulator != null) {
+                        offsetsAccumulator.addDoc(v.length);
+                    }
+                }
+                meta.writeLong(data.getFilePointer() - start); // dataLength
+
+                if (numDocsWithField == 0) {
+                    meta.writeLong(-2); // docsWithFieldOffset
+                    meta.writeLong(0L); // docsWithFieldLength
+                    meta.writeShort((short) -1); // jumpTableEntryCount
+                    meta.writeByte((byte) -1); // denseRankPower
+                } else if (numDocsWithField == maxDoc) {
+                    meta.writeLong(-1); // docsWithFieldOffset
+                    meta.writeLong(0L); // docsWithFieldLength
+                    meta.writeShort((short) -1); // jumpTableEntryCount
+                    meta.writeByte((byte) -1); // denseRankPower
+                } else {
+                    long offset = data.getFilePointer();
+                    meta.writeLong(offset); // docsWithFieldOffset
+                    final short jumpTableEntryCount = disiAccumulator.build(data);
+                    meta.writeLong(data.getFilePointer() - offset); // docsWithFieldLength
+                    meta.writeShort(jumpTableEntryCount);
+                    meta.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+                }
+
+                meta.writeInt(numDocsWithField);
+                meta.writeInt(minLength);
+                meta.writeInt(maxLength);
+                if (offsetsAccumulator != null) {
+                    offsetsAccumulator.build(meta, data);
+                }
+            } finally {
+                IOUtils.close(disiAccumulator, offsetsAccumulator);
             }
-            writer.finish();
-            meta.writeLong(data.getFilePointer() - start);
+        } else {
+            BinaryDocValues values = valuesProducer.getBinary(field);
+            long start = data.getFilePointer();
+            meta.writeLong(start); // dataOffset
+            int numDocsWithField = 0;
+            int minLength = Integer.MAX_VALUE;
+            int maxLength = 0;
+            for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+                numDocsWithField++;
+                BytesRef v = values.binaryValue();
+                int length = v.length;
+                data.writeBytes(v.bytes, v.offset, v.length);
+                minLength = Math.min(length, minLength);
+                maxLength = Math.max(length, maxLength);
+            }
+            assert numDocsWithField <= maxDoc;
+            meta.writeLong(data.getFilePointer() - start); // dataLength
+
+            if (numDocsWithField == 0) {
+                meta.writeLong(-2); // docsWithFieldOffset
+                meta.writeLong(0L); // docsWithFieldLength
+                meta.writeShort((short) -1); // jumpTableEntryCount
+                meta.writeByte((byte) -1); // denseRankPower
+            } else if (numDocsWithField == maxDoc) {
+                meta.writeLong(-1); // docsWithFieldOffset
+                meta.writeLong(0L); // docsWithFieldLength
+                meta.writeShort((short) -1); // jumpTableEntryCount
+                meta.writeByte((byte) -1); // denseRankPower
+            } else {
+                long offset = data.getFilePointer();
+                meta.writeLong(offset); // docsWithFieldOffset
+                values = valuesProducer.getBinary(field);
+                final short jumpTableEntryCount = IndexedDISI.writeBitSet(values, data, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+                meta.writeLong(data.getFilePointer() - offset); // docsWithFieldLength
+                meta.writeShort(jumpTableEntryCount);
+                meta.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+            }
+
+            meta.writeInt(numDocsWithField);
+            meta.writeInt(minLength);
+            meta.writeInt(maxLength);
+            if (maxLength > minLength) {
+                start = data.getFilePointer();
+                meta.writeLong(start);
+                meta.writeVInt(ES819TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT);
+
+                final DirectMonotonicWriter writer = DirectMonotonicWriter.getInstance(
+                    meta,
+                    data,
+                    numDocsWithField + 1,
+                    ES819TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT
+                );
+                long addr = 0;
+                writer.add(addr);
+                values = valuesProducer.getBinary(field);
+                for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+                    addr += values.binaryValue().length;
+                    writer.add(addr);
+                }
+                writer.finish();
+                meta.writeLong(data.getFilePointer() - start);
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -47,7 +47,7 @@ import static org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat.
 
 final class ES819TSDBDocValuesProducer extends DocValuesProducer {
     final IntObjectHashMap<NumericEntry> numerics;
-    private final IntObjectHashMap<BinaryEntry> binaries;
+    final IntObjectHashMap<BinaryEntry> binaries;
     final IntObjectHashMap<SortedEntry> sorted;
     final IntObjectHashMap<SortedSetEntry> sortedSets;
     final IntObjectHashMap<SortedNumericEntry> sortedNumerics;
@@ -1318,7 +1318,7 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
         long valuesLength;
     }
 
-    private static class BinaryEntry {
+    static class BinaryEntry {
         long dataOffset;
         long dataLength;
         long docsWithFieldOffset;

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.codec.tsdb.es819;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
@@ -86,8 +87,10 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
 
                 int numTags = 1 + random().nextInt(8);
                 for (int j = 0; j < numTags; j++) {
-                    d.add(new SortedSetDocValuesField("tags", new BytesRef(tags[j])));
+                    d.add(new SortedSetDocValuesField("tags", new BytesRef(tags[(i + j) % tags.length])));
                 }
+
+                d.add(new BinaryDocValuesField("tags_as_bytes", new BytesRef(tags[i % tags.length])));
 
                 iw.addDocument(d);
                 if (i % 100 == 0) {
@@ -119,6 +122,8 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 assertNotNull(gaugeTwoDV);
                 var tagsDV = leaf.getSortedSetDocValues("tags");
                 assertNotNull(tagsDV);
+                var tagBytesDV = leaf.getBinaryDocValues("tags_as_bytes");
+                assertNotNull(tagBytesDV);
                 for (int i = 0; i < numDocs; i++) {
                     assertEquals(i, hostNameDV.nextDoc());
                     int batchIndex = i / numHosts;
@@ -161,6 +166,10 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                         String actualTag = tagsDV.lookupOrd(ordinal).utf8ToString();
                         assertTrue("unexpected tag [" + actualTag + "]", Arrays.binarySearch(tags, actualTag) >= 0);
                     }
+
+                    assertEquals(i, tagBytesDV.nextDoc());
+                    BytesRef tagBytesValue = tagBytesDV.binaryValue();
+                    assertTrue("unexpected bytes " + tagBytesValue, Arrays.binarySearch(tags, tagBytesValue.utf8ToString()) >= 0);
                 }
             }
         }
@@ -182,6 +191,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 d.add(new SortedNumericDocValuesField(timestampField, timestamp - 1));
                 d.add(new NumericDocValuesField("counter_1", counter1));
                 d.add(new SortedNumericDocValuesField("gauge_1", 2));
+                d.add(new BinaryDocValuesField("binary_1", new BytesRef("foo")));
                 iw.addDocument(d);
                 iw.commit();
             }
@@ -191,6 +201,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 d.add(new SortedNumericDocValuesField(timestampField, timestamp));
                 d.add(new SortedNumericDocValuesField("counter_2", counter2));
                 d.add(new SortedNumericDocValuesField("gauge_2", -2));
+                d.add(new BinaryDocValuesField("binary_2", new BytesRef("bar")));
                 iw.addDocument(d);
                 iw.commit();
             }
@@ -213,6 +224,10 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 assertNotNull(gaugeOneDV);
                 var gaugeTwoDV = leaf.getSortedNumericDocValues("gauge_2");
                 assertNotNull(gaugeTwoDV);
+                var binaryOneDV = leaf.getBinaryDocValues("binary_1");
+                assertNotNull(binaryOneDV);
+                var binaryTwoDv = leaf.getBinaryDocValues("binary_2");
+                assertNotNull(binaryTwoDv);
                 for (int i = 0; i < 2; i++) {
                     assertEquals(i, hostNameDV.nextDoc());
                     assertEquals("host-001", hostNameDV.lookupOrd(hostNameDV.ordValue()).utf8ToString());
@@ -242,6 +257,16 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                         assertEquals(1, gaugeTwoDV.docValueCount());
                         long gaugeTwoValue = gaugeTwoDV.nextValue();
                         assertEquals(-2, gaugeTwoValue);
+                    }
+
+                    if (binaryOneDV.advanceExact(i)) {
+                        BytesRef binaryOneValue = binaryOneDV.binaryValue();
+                        assertEquals(new BytesRef("foo"), binaryOneValue);
+                    }
+
+                    if (binaryTwoDv.advanceExact(i)) {
+                        BytesRef binaryTwoValue = binaryTwoDv.binaryValue();
+                        assertEquals(new BytesRef("bar"), binaryTwoValue);
                     }
                 }
             }
@@ -299,6 +324,10 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                     int randomIndex = random().nextInt(tags.length);
                     d.add(new SortedDocValuesField("other_tag", new BytesRef(tags[randomIndex])));
                 }
+                if (random().nextBoolean()) {
+                    int randomIndex = random().nextInt(tags.length);
+                    d.add(new BinaryDocValuesField("tags_as_bytes", new BytesRef(tags[randomIndex])));
+                }
 
                 iw.addDocument(d);
                 if (i % 100 == 0) {
@@ -332,6 +361,8 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 assertNotNull(tagsDV);
                 var otherTagDV = leaf.getSortedDocValues("other_tag");
                 assertNotNull(otherTagDV);
+                var tagBytesDV = leaf.getBinaryDocValues("tags_as_bytes");
+                assertNotNull(tagBytesDV);
                 for (int i = 0; i < numDocs; i++) {
                     assertEquals(i, hostNameDV.nextDoc());
                     int batchIndex = i / numHosts;
@@ -383,6 +414,11 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                         int ordinal = otherTagDV.ordValue();
                         String actualTag = otherTagDV.lookupOrd(ordinal).utf8ToString();
                         assertTrue("unexpected tag [" + actualTag + "]", Arrays.binarySearch(tags, actualTag) >= 0);
+                    }
+
+                    if (tagBytesDV.advanceExact(i)) {
+                        BytesRef tagBytesValue = tagBytesDV.binaryValue();
+                        assertTrue("unexpected bytes " + tagBytesValue, Arrays.binarySearch(tags, tagBytesValue.utf8ToString()) >= 0);
                     }
                 }
             }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Apply recent TSDB codec merge optimizations to binary values (#127278)