### PR TITLE
Add refresh to 41_knn_search_byte_quantized as other yaml tests have it as well

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized.yml
@@ -71,6 +71,9 @@ setup:
       indices.forcemerge:
         index: hnsw_byte_quantized
         max_num_segments: 1
+
+  - do:
+      indices.refresh: { }
 ---
 "kNN search only":
   - do:


### PR DESCRIPTION
I noticed that this set of yaml tests doesn't have a refresh. All the others do and it has helped prevent flakiness.