### PR TITLE
[8.18] Rare terms aggregation false **positive** fix (#126884)

### DIFF
--- a/docs/changelog/126884.yaml
+++ b/docs/changelog/126884.yaml
@@ -1,0 +1,5 @@
+pr: 126884
+summary: Rare terms aggregation false **positive** fix
+area: Aggregations
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilter.java
+++ b/server/src/main/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilter.java
@@ -341,7 +341,7 @@ public class SetBackedScalingCuckooFilter implements Writeable {
         } else if (isSetMode == false && other.isSetMode) {
             // Rather than converting the other to a cuckoo first, we can just
             // replay the values directly into our filter.
-            other.hashes.forEach(this::add);
+            other.hashes.forEach(this::addHash);
         } else {
             // Both are in cuckoo mode, merge raw fingerprints
 

--- a/server/src/test/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilterTests.java
@@ -132,6 +132,34 @@ public class SetBackedScalingCuckooFilterTests extends AbstractWireSerializingTe
         );
     }
 
+    public void testMergeBigSmall() {
+        int threshold = 1000;
+
+        // Setup the first filter
+        SetBackedScalingCuckooFilter filter = new SetBackedScalingCuckooFilter(threshold, Randomness.get(), 0.01);
+        int counter = 0;
+        Set<Long> values = new HashSet<>();
+        while (counter < threshold + 1) {
+            long value = randomLong();
+            filter.add(value);
+            boolean newValue = values.add(value);
+            if (newValue) {
+                counter += 1;
+            }
+        }
+
+        SetBackedScalingCuckooFilter filter2 = new SetBackedScalingCuckooFilter(threshold, Randomness.get(), 0.01);
+        long value = randomLong();
+        while (filter.mightContain(value)) {
+            value = randomLong();
+        }
+
+        filter2.add(value);
+
+        filter.merge(filter2);
+        assertTrue(filter.mightContain(value));
+    }
+
     public void testMergeSmall() {
         int threshold = 1000;
 


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Rare terms aggregation false **positive** fix (#126884)