### PR TITLE
Skip region validation in `S3BlobStoreRepositoryTests`

### DIFF
--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -645,7 +645,9 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
             assertTrue(
                 isValidAwsV4SignedAuthorizationHeader(
                     "test_access_key",
-                    Objects.requireNonNullElse(region, "us-east-1"),
+                    // If unset, the region used by the SDK is usually going to be `us-east-1` but sometimes these tests run on bare EC2
+                    // machines and the SDK picks up the region from the IMDS there, so for now we use '*' to skip validation.
+                    Objects.requireNonNullElse(region, "*"),
                     "s3",
                     exchange.getRequestHeaders().getFirst("Authorization")
                 )


### PR DESCRIPTION
Today these tests assert that the requests received by the handler are
signed in region `us-east-1` with no region specified, but in fact when
running in EC2 the SDK will pick up the actual region which may be
different. This commit skips this region validation for now (it is
tested elsewhere).

Closes #127360
Closes #127361
Closes #127362
Closes #127363
Closes #127364
Closes #127366
Closes #127367
Closes #127373
Closes #127374
Closes #127376
Closes #127377
