### PR TITLE
Fork time-series source to allow field extractions

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -11,6 +11,7 @@ import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.EnableSpatialDistancePushdown;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.InsertFieldExtraction;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushFieldExtractionToTimeSeriesSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushFiltersToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushLimitToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushSampleToSource;
@@ -79,7 +80,8 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             Limiter.ONCE,
             new InsertFieldExtraction(),
             new SpatialDocValuesExtraction(),
-            new SpatialShapeBoundsExtraction()
+            new SpatialShapeBoundsExtraction(),
+            new PushFieldExtractionToTimeSeriesSource()
         );
         return List.of(pushdown, fieldExtraction);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFieldExtractionToTimeSeriesSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFieldExtractionToTimeSeriesSource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules;
+import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesSourceExec;
+
+/**
+ * A rule that moves field extractions to occur before the time-series aggregation in the time-series source plan.
+ */
+public class PushFieldExtractionToTimeSeriesSource extends PhysicalOptimizerRules.ParameterizedOptimizerRule<
+    EsQueryExec,
+    LocalPhysicalOptimizerContext> {
+
+    public PushFieldExtractionToTimeSeriesSource() {
+        super(OptimizerRules.TransformDirection.UP);
+    }
+
+    @Override
+    public PhysicalPlan rule(EsQueryExec plan, LocalPhysicalOptimizerContext context) {
+        if (plan.indexMode() == IndexMode.TIME_SERIES) {
+            return new TimeSeriesSourceExec(plan.source(), plan.output(), plan.query(), plan.limit(), plan.estimatedRowSize());
+        } else {
+            return plan;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesSourceExec.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Similar to {@link EsQueryExec}, but this is a physical plan specifically for time series indices.
+ * This plan is forked from {@link EsQueryExec} to allow field extractions, leveraging caching
+ * and avoiding the cost of sorting and rebuilding blocks.
+ */
+public class TimeSeriesSourceExec extends LeafExec implements EstimatesRowSize {
+    private final List<Attribute> attrs;
+    private final QueryBuilder query;
+    private final Expression limit;
+
+    /**
+     * Estimate of the number of bytes that'll be loaded per position before
+     * the stream of pages is consumed.
+     */
+    private final Integer estimatedRowSize;
+
+    public TimeSeriesSourceExec(Source source, List<Attribute> attrs, QueryBuilder query, Expression limit, Integer estimatedRowSize) {
+        super(source);
+        this.attrs = attrs;
+        this.query = query;
+        this.limit = limit;
+        this.estimatedRowSize = estimatedRowSize;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("local plan");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("local plan");
+    }
+
+    @Override
+    protected NodeInfo<TimeSeriesSourceExec> info() {
+        return NodeInfo.create(this, TimeSeriesSourceExec::new, attrs, query, limit, estimatedRowSize);
+    }
+
+    public QueryBuilder query() {
+        return query;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        return attrs;
+    }
+
+    public List<Attribute> attrs() {
+        return attrs;
+    }
+
+    public Expression limit() {
+        return limit;
+    }
+
+    /**
+     * Estimate of the number of bytes that'll be loaded per position before
+     * the stream of pages is consumed.
+     */
+    public Integer estimatedRowSize() {
+        return estimatedRowSize;
+    }
+
+    @Override
+    public PhysicalPlan estimateRowSize(State state) {
+        state.add(false, Integer.BYTES * 2);
+        state.add(false, 22); // tsid
+        state.add(false, 8); // timestamp
+        int size = state.consumeAllFields(false);
+        return Objects.equals(this.estimatedRowSize, size) ? this : new TimeSeriesSourceExec(source(), attrs, query, limit, size);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(attrs, query, limit, estimatedRowSize);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        TimeSeriesSourceExec other = (TimeSeriesSourceExec) obj;
+        return Objects.equals(attrs, other.attrs)
+            && Objects.equals(query, other.query)
+            && Objects.equals(limit, other.limit)
+            && Objects.equals(estimatedRowSize, other.estimatedRowSize);
+    }
+
+    @Override
+    public String nodeString() {
+        return nodeName()
+            + "["
+            + "query["
+            + (query != null ? Strings.toString(query, false, true) : "")
+            + "] attributes: ["
+            + NodeUtils.limitedToString(attrs)
+            + "], estimatedRowSize["
+            + estimatedRowSize
+            + "]";
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -112,6 +112,7 @@ import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.RrfScoreEvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.SampleExec;
 import org.elasticsearch.xpack.esql.plan.physical.ShowExec;
+import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 import org.elasticsearch.xpack.esql.plan.physical.inference.RerankExec;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.ShardContext;
@@ -271,6 +272,8 @@ public class LocalExecutionPlanner {
             return planShow(show);
         } else if (node instanceof ExchangeSourceExec exchangeSource) {
             return planExchangeSource(exchangeSource, context);
+        } else if (node instanceof TimeSeriesSourceExec ts) {
+            return planTimeSeriesNode(ts, context);
         }
         // lookups and joins
         else if (node instanceof EnrichExec enrich) {
@@ -326,6 +329,10 @@ public class LocalExecutionPlanner {
 
     private PhysicalOperation planEsQueryNode(EsQueryExec esQueryExec, LocalExecutionPlannerContext context) {
         return physicalOperationProviders.sourcePhysicalOperation(esQueryExec, context);
+    }
+
+    private PhysicalOperation planTimeSeriesNode(TimeSeriesSourceExec esQueryExec, LocalExecutionPlannerContext context) {
+        return physicalOperationProviders.timeSeriesSourceOperation(esQueryExec, context);
     }
 
     private PhysicalOperation planEsStats(EsStatsQueryExec statsQuery, LocalExecutionPlannerContext context) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PhysicalOperationProviders.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.planner;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesSourceExec;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecutionPlannerContext;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperation;
 
@@ -17,6 +18,8 @@ interface PhysicalOperationProviders {
     PhysicalOperation fieldExtractPhysicalOperation(FieldExtractExec fieldExtractExec, PhysicalOperation source);
 
     PhysicalOperation sourcePhysicalOperation(EsQueryExec esQuery, LocalExecutionPlannerContext context);
+
+    PhysicalOperation timeSeriesSourceOperation(TimeSeriesSourceExec ts, LocalExecutionPlannerContext context);
 
     PhysicalOperation groupingPhysicalOperation(
         AggregateExec aggregateExec,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
@@ -58,6 +58,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesSourceExec;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecutionPlannerContext;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperation;
 import org.elasticsearch.xpack.ml.MachineLearning;
@@ -126,6 +127,11 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
         Layout.Builder layout = new Layout.Builder();
         layout.append(esQueryExec.output());
         return PhysicalOperation.fromSource(new TestSourceOperatorFactory(), layout.build());
+    }
+
+    @Override
+    public PhysicalOperation timeSeriesSourceOperation(TimeSeriesSourceExec ts, LocalExecutionPlannerContext context) {
+        throw new UnsupportedOperationException("time-series source is not supported in CSV tests");
     }
 
     @Override


### PR DESCRIPTION
This change prepares for pushing down field extractions to the time-series source for performance reasons. It is a non-issue, as the actual change will occur in a follow-up.