### PR TITLE
Simplify FiltersIT test that exercises competitive iterator, if it was enabled

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -402,9 +402,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test024InstallPluginFromArchiveUsingConfigFile
   issue: https://github.com/elastic/elasticsearch/issues/126936
-- class: org.elasticsearch.search.aggregations.bucket.FiltersIT
-  method: testSimpleWithFilterQuery
-  issue: https://github.com/elastic/elasticsearch/issues/127099
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {rerank.Reranker before a limit ASYNC}
   issue: https://github.com/elastic/elasticsearch/issues/127051


### PR DESCRIPTION
We don't really have integration tests for filters aggregation that exercised the competitive iterator. This simplifies the existing (previously muted) test. 

These all pass as we don't bother exercising the competitive iterator any longer.