### PR TITLE
Fix docs wording - it's actually average, call it so

### DIFF
--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -1422,7 +1422,7 @@ as a human-readable string.
 (integer) The maximum time taken to execute a {ccs} request, in milliseconds.
 
 `avg`:::
-(integer) The median time taken to execute a {ccs} request, in milliseconds.
+(integer) The average time taken to execute a {ccs} request, in milliseconds.
 
 `p90`:::
 (integer) The 90th percentile of the time taken to execute {ccs} requests, in milliseconds.
@@ -1440,7 +1440,7 @@ as a human-readable string.
 (integer) The maximum time taken to execute a {ccs} request, in milliseconds.
 
 `avg`:::
-(integer) The median time taken to execute a {ccs} request, in milliseconds.
+(integer) The average time taken to execute a {ccs} request, in milliseconds.
 
 `p90`:::
 (integer) The 90th percentile of the time taken to execute {ccs} requests, in milliseconds.
@@ -1458,7 +1458,7 @@ as a human-readable string.
 (integer) The maximum time taken to execute a {ccs} request, in milliseconds.
 
 `avg`:::
-(integer) The median time taken to execute a {ccs} request, in milliseconds.
+(integer) The average time taken to execute a {ccs} request, in milliseconds.
 
 `p90`:::
 (integer) The 90th percentile of the time taken to execute {ccs} requests, in milliseconds.
@@ -1518,7 +1518,7 @@ This may include requests where partial results were returned, but not requests 
 (integer) The maximum time taken to execute a {ccs} request, in milliseconds.
 
 `avg`:::
-(integer) The median time taken to execute a {ccs} request, in milliseconds.
+(integer) The average time taken to execute a {ccs} request, in milliseconds.
 
 `p90`:::
 (integer) The 90th percentile of the time taken to execute {ccs} requests, in milliseconds.


### PR DESCRIPTION
Use the correct term "average" since that's how it is actually calculated. 

Fixes https://github.com/elastic/elasticsearch/issues/126660