### PR TITLE
Don't emit deprecation issue for compatible date format patterns

### DIFF
--- a/docs/changelog/127418.yaml
+++ b/docs/changelog/127418.yaml
@@ -1,0 +1,5 @@
+pr: 127418
+summary: Don't issue deprecation issue for compatible date format patterns
+area: Infra/Core
+type: bug
+issues: []

--- a/docs/changelog/127418.yaml
+++ b/docs/changelog/127418.yaml
@@ -1,5 +1,5 @@
 pr: 127418
-summary: Don't issue deprecation issue for compatible date format patterns
+summary: Don't emit deprecation issue for compatible date format patterns
 area: Infra/Core
 type: bug
 issues: []

--- a/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -481,6 +482,6 @@ public class DateUtils {
     }
 
     public static boolean containsCompatOnlyDateFormat(String format) {
-        return LEGACY_DATE_FORMAT_MATCHER.test(format);
+        return LEGACY_DATE_FORMAT_MATCHER.test(format) && Arrays.stream(FormatNames.values()).noneMatch(f -> f.getName().equals(format));
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
@@ -243,7 +244,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
             .numberOfShards(1)
             .numberOfReplicas(0)
             .state(indexMetdataState)
-            .putMapping("""
+            .putMapping(String.format(Locale.ROOT, """
                 {
                   "properties": {
                     "date": {
@@ -251,7 +252,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
                       "format": "%s"
                     }
                   }
-                }""".formatted(pattern))
+                }""", pattern))
             .build();
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
             .metadata(Metadata.builder().put(indexMetadata, true))


### PR DESCRIPTION
This is a follow up to #124597 which fixes a bug where we could return a false positive deprecation issue for certain valid date format patterns. We now ignore fields if the date mapping pattern is one of those in `FormatNames`.