### PR TITLE
WIP: Release transport messages incrementally while reading them

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
@@ -168,6 +168,10 @@ public final class CompositeBytesReference extends AbstractBytesReference {
         return CompositeBytesReference.ofMultiple(inSlice);
     }
 
+    public BytesReference[] components() {
+        return references;
+    }
+
     private int getOffsetIndex(int offset) {
         final int i = Arrays.binarySearch(offsets, offset);
         return i < 0 ? (-(i + 1)) - 1 : i;

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -259,30 +259,14 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
                 }
             }
 
-            @Override
-            public int read(byte[] b, int bOffset, int len) throws IOException {
-                int res = super.read(b, bOffset, len);
+            public void tryDiscard() {
                 if (markEnd == 0) {
-                    tryDiscard();
+                    if (bytesReference instanceof CompositeBytesReference c) {
+                        maybeDiscardReadBytes(c.components());
+                    } else if (available() == 0) {
+                        close();
+                    }
                 }
-                return res;
-            }
-
-            private void tryDiscard() {
-                if (bytesReference instanceof CompositeBytesReference c) {
-                    maybeDiscardReadBytes(c.components());
-                } else if (available() == 0) {
-                    close();
-                }
-            }
-
-            @Override
-            public int read() throws IOException {
-                int res = super.read();
-                if (res == -1 && markEnd == 0) {
-                    close();
-                }
-                return res;
             }
 
             private int markEnd = 0;

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -157,6 +157,144 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
         return delegate.ramBytesUsed();
     }
 
+    public static StreamInput consumingStreamInput(ReleasableBytesReference... references) throws IOException {
+        final BytesReference bytesReference;
+        final RefCounted[] refs = new RefCounted[references.length];
+        if (references.length == 1) {
+            final var ref = references[0];
+            bytesReference = ref;
+            refs[0] = ref.refCounted;
+        } else {
+            bytesReference = CompositeBytesReference.of(references);
+            for (int i = 0; i < references.length; i++) {
+                refs[i] = references[i].refCounted;
+            }
+        }
+        return new BytesReferenceStreamInput(bytesReference) {
+            private ReleasableBytesReference retainAndSkip(int len) throws IOException {
+                if (len == 0) {
+                    return ReleasableBytesReference.empty();
+                }
+
+                int offset = offset();
+                skip(len);
+                // move the stream manually since creating the slice didn't move it
+                if (bytesReference instanceof ReleasableBytesReference releasable) {
+                    ReleasableBytesReference res = releasable.retainedSlice(offset, len);
+                    if (markEnd == 0 && available() == 0) {
+                        close();
+                    }
+                    return res;
+                }
+                assert bytesReference instanceof CompositeBytesReference;
+                final CompositeBytesReference composite = (CompositeBytesReference) bytesReference;
+                // instead of reading the bytes from a stream we just create a slice of the underlying bytes
+                final BytesReference result = composite.slice(offset, len);
+                if (result instanceof ReleasableBytesReference releasable) {
+                    return releasable.retain();
+                }
+                assert result instanceof CompositeBytesReference;
+                var compositeSlice = (CompositeBytesReference) result;
+                var components = compositeSlice.components();
+                final RefCounted[] refCounteds = new RefCounted[components.length];
+                for (int i = 0; i < components.length; i++) {
+                    refCounteds[i] = ((ReleasableBytesReference) components[i]).retain();
+                }
+                if (markEnd == 0) {
+                    maybeDiscardReadBytes(composite.components());
+                }
+                return new ReleasableBytesReference(compositeSlice, () -> {
+                    for (int i = 0; i < refCounteds.length; i++) {
+                        refCounteds[i].decRef();
+                        refCounteds[i] = null;
+                    }
+                });
+            }
+
+            private void maybeDiscardReadBytes(BytesReference[] components) {
+                int offset = offset();
+                int p = 0;
+                for (int i = 0; i < components.length; i++) {
+                    p += components[i].length();
+                    if (p >= offset) {
+                        return;
+                    }
+                    var r = refs[i];
+                    if (r != null) {
+                        r.decRef();
+                        refs[i] = null;
+                    }
+                }
+            }
+
+            @Override
+            public ReleasableBytesReference readReleasableBytesReference() throws IOException {
+                final int len = readVInt();
+                return retainAndSkip(len);
+            }
+
+            @Override
+            public ReleasableBytesReference readReleasableBytesReference(int len) throws IOException {
+                return retainAndSkip(len);
+            }
+
+            @Override
+            public ReleasableBytesReference readAllToReleasableBytesReference() throws IOException {
+                return retainAndSkip(bytesReference.length() - offset());
+            }
+
+            @Override
+            public boolean supportReadAllToReleasableBytesReference() {
+                return true;
+            }
+
+            @Override
+            public void close() {
+                for (int i = 0; i < refs.length; i++) {
+                    RefCounted ref = refs[i];
+                    if (ref != null) {
+                        refs[i] = null;
+                        ref.decRef();
+                    }
+                }
+            }
+
+            @Override
+            public int read(byte[] b, int bOffset, int len) throws IOException {
+                int res = super.read(b, bOffset, len);
+                if (markEnd == 0) {
+                    tryDiscard();
+                }
+                return res;
+            }
+
+            private void tryDiscard() {
+                if (bytesReference instanceof CompositeBytesReference c) {
+                    maybeDiscardReadBytes(c.components());
+                } else if (available() == 0) {
+                    close();
+                }
+            }
+
+            @Override
+            public int read() throws IOException {
+                int res = super.read();
+                if (res == -1 && markEnd == 0) {
+                    close();
+                }
+                return res;
+            }
+
+            private int markEnd = 0;
+
+            @Override
+            public void mark(int readLimit) {
+                super.mark(readLimit);
+                markEnd = offset() + readLimit;
+            }
+        };
+    }
+
     @Override
     public StreamInput streamInput() throws IOException {
         assert hasReferences();

--- a/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -109,6 +109,11 @@ public abstract class FilterStreamInput extends StreamInput {
     }
 
     @Override
+    public void tryDiscard() {
+        delegate.tryDiscard();
+    }
+
+    @Override
     public void close() throws IOException {
         delegate.close();
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -109,13 +109,17 @@ public abstract class StreamInput extends InputStream {
     @Override
     public abstract int read(byte[] b, int off, int len) throws IOException;
 
+    public void tryDiscard() {}
+
     /**
      * Reads a bytes reference from this stream, copying any bytes read to a new {@code byte[]}. Use {@link #readReleasableBytesReference()}
      * when reading large bytes references where possible top avoid needless allocations and copying.
      */
     public BytesReference readBytesReference() throws IOException {
         int length = readArraySize();
-        return readBytesReference(length);
+        var res = readBytesReference(length);
+        tryDiscard();
+        return res;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
@@ -118,35 +118,24 @@ public final class TransportLogger {
         if (message.isPing()) {
             sb.append(" [ping]").append(' ').append(event).append(": ").append(6).append('B');
         } else {
-            boolean success = false;
             Header header = message.getHeader();
             int networkMessageSize = header.getNetworkMessageSize();
             int messageLengthWithHeader = HEADER_SIZE + networkMessageSize;
-            StreamInput streamInput = message.openOrGetStreamInput();
-            try {
-                final long requestId = header.getRequestId();
-                final boolean isRequest = header.isRequest();
-                final String type = isRequest ? "request" : "response";
-                final String version = header.getVersion().toString();
-                sb.append(" [length: ").append(messageLengthWithHeader);
-                sb.append(", request id: ").append(requestId);
-                sb.append(", type: ").append(type);
-                sb.append(", version: ").append(version);
+            final long requestId = header.getRequestId();
+            final boolean isRequest = header.isRequest();
+            final String type = isRequest ? "request" : "response";
+            final String version = header.getVersion().toString();
+            sb.append(" [length: ").append(messageLengthWithHeader);
+            sb.append(", request id: ").append(requestId);
+            sb.append(", type: ").append(type);
+            sb.append(", version: ").append(version);
 
-                // TODO: Maybe Fix for BWC
-                if (header.needsToReadVariableHeader() == false && isRequest) {
-                    sb.append(", action: ").append(header.getActionName());
-                }
-                sb.append(']');
-                sb.append(' ').append(event).append(": ").append(messageLengthWithHeader).append('B');
-                success = true;
-            } finally {
-                if (success) {
-                    IOUtils.close(streamInput);
-                } else {
-                    IOUtils.closeWhileHandlingException(streamInput);
-                }
+            // TODO: Maybe Fix for BWC
+            if (header.needsToReadVariableHeader() == false && isRequest) {
+                sb.append(", action: ").append(header.getActionName());
             }
+            sb.append(']');
+            sb.append(' ').append(event).append(": ").append(messageLengthWithHeader).append('B');
         }
         return sb.toString();
     }

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -190,7 +189,7 @@ public class InboundHandlerTests extends ESTestCase {
             TransportStatus.setRequest((byte) 0),
             TransportVersion.current()
         );
-        InboundMessage requestMessage = new InboundMessage(requestHeader, ReleasableBytesReference.wrap(requestContent), () -> {});
+        InboundMessage requestMessage = new InboundMessage(requestHeader, requestContent.streamInput(), requestContent.length(), () -> {});
         requestHeader.finishParsingHeader(requestMessage.openOrGetStreamInput());
         handler.inboundMessage(channel, requestMessage);
 
@@ -210,7 +209,12 @@ public class InboundHandlerTests extends ESTestCase {
         BytesReference fullResponseBytes = channel.getMessageCaptor().get();
         BytesReference responseContent = fullResponseBytes.slice(TcpHeader.HEADER_SIZE, fullResponseBytes.length() - TcpHeader.HEADER_SIZE);
         Header responseHeader = new Header(fullRequestBytes.length() - 6, requestId, responseStatus, TransportVersion.current());
-        InboundMessage responseMessage = new InboundMessage(responseHeader, ReleasableBytesReference.wrap(responseContent), () -> {});
+        InboundMessage responseMessage = new InboundMessage(
+            responseHeader,
+            responseContent.streamInput(),
+            responseContent.length(),
+            () -> {}
+        );
         responseHeader.finishParsingHeader(responseMessage.openOrGetStreamInput());
         handler.inboundMessage(channel, responseMessage);
 
@@ -298,7 +302,8 @@ public class InboundHandlerTests extends ESTestCase {
             }
             final InboundMessage requestMessage = new InboundMessage(
                 requestHeader,
-                ReleasableBytesReference.wrap(byteData.bytes()),
+                byteData.bytes().streamInput(),
+                byteData.size(),
                 () -> safeSleep(TimeValue.timeValueSeconds(1))
             );
             requestHeader.actionName = TransportHandshaker.HANDSHAKE_ACTION_NAME;
@@ -327,14 +332,14 @@ public class InboundHandlerTests extends ESTestCase {
                     safeSleep(TimeValue.timeValueSeconds(1));
                 }
             });
-            handler.inboundMessage(channel, new InboundMessage(responseHeader, ReleasableBytesReference.empty(), () -> {}));
+            handler.inboundMessage(channel, new InboundMessage(responseHeader, BytesArray.EMPTY.streamInput(), 0, () -> {}));
 
             mockLog.assertAllExpectationsMatched();
         }
     }
 
     private static InboundMessage unreadableInboundHandshake(TransportVersion remoteVersion, Header requestHeader) {
-        return new InboundMessage(requestHeader, ReleasableBytesReference.wrap(BytesArray.EMPTY), () -> {}) {
+        return new InboundMessage(requestHeader, BytesArray.EMPTY.streamInput(), 0, () -> {}) {
             @Override
             public StreamInput openOrGetStreamInput() {
                 final StreamInput streamInput = new InputStreamStreamInput(new InputStream() {


### PR DESCRIPTION
Code is still WIP but not too much work left actually.

That said ... even in this form the solution essentially up to halves the heap used for
handling large bulk shard requests on non-coordinating data nodes (this is
just one example, there's a couple spots where this saves a lot of memory).
Also, this could be extended to be a little smarter around compression easily, allowing
for potential order of magnitude savings around indexing if we lazy deserialize
individual docs or play similar tricks.