### PR TITLE
Save heap when dynamically mapping arrays

### DIFF
--- a/docs/changelog/127439.yaml
+++ b/docs/changelog/127439.yaml
@@ -1,0 +1,6 @@
+pr: 127439
+summary: Save heap when dynamically mapping arrays
+area: Mapping
+type: bug
+issues:
+ - 117593

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -122,9 +122,9 @@ public class DynamicMappingIT extends ESIntegTestCase {
             .get();
 
         assertTrue(bulkResponse.hasFailures());
-        assertEquals(
-            "mapper [foo] cannot be changed from type [long] to [text]",
-            bulkResponse.getItems()[0].getFailure().getCause().getMessage()
+        assertThat(
+            bulkResponse.getItems()[0].getFailure().getCause().getMessage(),
+            containsString("mapper [foo] cannot be changed from type [long] to [text]")
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -21,6 +21,8 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.time.DateTimeException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -312,12 +314,37 @@ final class DynamicFieldsBuilder {
         boolean createDynamicField(Mapper.Builder builder, DocumentParserContext context, MapperBuilderContext mapperBuilderContext)
             throws IOException {
             Mapper mapper = builder.build(mapperBuilderContext);
+            List<Mapper> existing;
+            if ((existing = context.getDynamicMappers(mapper.fullPath())) != null && existing.isEmpty() == false) {
+                maybeMergeWithExistingField(context, mapperBuilderContext, mapper, existing);
+                return true;
+            }
             if (context.addDynamicMapper(mapper)) {
                 parseField.accept(context, mapper);
                 return true;
             } else {
                 return false;
             }
+        }
+
+        // Attempts to deduplicate arrays of mapper instances my merging with the most recently added mapper for the same path
+        // if there is one already and then replacing all entries for the field with the merge result
+        // TODO: this is only as complicated as it is to enable DocumentParser.postProcessDynamicArrayMapping, technically there is no need
+        // to duplicate the mapper other than to enabled this method's translation of multiple numeric field mappers into a vector mapper
+        // it seems?
+        private void maybeMergeWithExistingField(
+            DocumentParserContext context,
+            MapperBuilderContext mapperBuilderContext,
+            Mapper fieldMapper,
+            List<Mapper> existing
+        ) throws IOException {
+            var last = existing.getLast();
+            var merged = last.merge(fieldMapper, MapperMergeContext.from(mapperBuilderContext, Long.MAX_VALUE));
+            if (merged != last) {
+                Collections.fill(existing, merged);
+            }
+            existing.add(merged);
+            parseField.accept(context, merged);
         }
 
         boolean createDynamicField(Mapper.Builder builder, DocumentParserContext context) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -37,8 +37,8 @@ public class ObjectMapperTests extends MapperServiceTestCase {
 
     public void testDifferentInnerObjectTokenFailure() throws Exception {
         DocumentMapper defaultMapper = createDocumentMapper(mapping(b -> {}));
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
             () -> defaultMapper.parse(new SourceToParse("1", new BytesArray("""
                 {
                      "object": {


### PR DESCRIPTION
We can do the merging more eagerly to save on heap at the cost of some cycles (though the overhead should be reasonably limited because we save a little down the line if all the mappers are the same instance). Obviously a bit of a dirty trick but this logic is quite brittle now with things like the vector mapper special case and this seems to me like the shortest path to avoiding runaway heap use.

This yet again shows the need to implement actual mapper equality checks and stronger deduplication for them to avoid having mapping merging be our only mechanism for deduplication.

This comes with a slight behavior change too by making unparseable objects with conflicting field types fail to parse a little more eagerly at the parsing stage (as they should IMO). This helps with some of the extreme slowdowns that a steady stream of these eventually unparseable documents has been introducing here and there in heavily loaded deployments.

closes #117593
