### PR TITLE
Fix `UploadPartCopy` source handling

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -447,9 +447,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.PushQueriesIT
   method: testPushCaseInsensitiveEqualityOnDefaults
   issue: https://github.com/elastic/elasticsearch/issues/127431
-- class: org.elasticsearch.repositories.blobstore.testkit.analyze.S3RepositoryAnalysisRestIT
-  method: testRepositoryAnalysis
-  issue: https://github.com/elastic/elasticsearch/issues/127436
 
 # Examples:
 #

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -158,9 +158,9 @@ public class S3HttpHandler implements HttpHandler {
                     exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
                 } else {
                     // CopyPart is UploadPart with an x-amz-copy-source header
-                    final var sourceBlobName = exchange.getRequestHeaders().get("X-amz-copy-source");
-                    if (sourceBlobName != null) {
-                        var sourceBlob = blobs.get(sourceBlobName.getFirst());
+                    final var copySource = copySourceName(exchange);
+                    if (copySource != null) {
+                        var sourceBlob = blobs.get(copySource);
                         if (sourceBlob == null) {
                             exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
                         } else {
@@ -230,12 +230,10 @@ public class S3HttpHandler implements HttpHandler {
                 exchange.sendResponseHeaders((upload == null ? RestStatus.NOT_FOUND : RestStatus.NO_CONTENT).getStatus(), -1);
 
             } else if (request.isPutObjectRequest()) {
-                // a copy request is a put request with a copy source header
-                final var copySources = exchange.getRequestHeaders().get("X-amz-copy-source");
-                if (copySources != null) {
-                    final var copySource = copySources.getFirst();
-                    final var prefix = copySource.length() > 0 && copySource.charAt(0) == '/' ? "" : "/";
-                    var sourceBlob = blobs.get(prefix + copySource);
+                // a copy request is a put request with an X-amz-copy-source header
+                final var copySource = copySourceName(exchange);
+                if (copySource != null) {
+                    var sourceBlob = blobs.get(copySource);
                     if (sourceBlob == null) {
                         exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
                     } else {
@@ -513,6 +511,21 @@ public class S3HttpHandler implements HttpHandler {
             return result;
         } catch (Exception e) {
             throw ExceptionsHelper.convertToRuntime(e);
+        }
+    }
+
+    @Nullable // if no X-amz-copy-source header present
+    private static String copySourceName(final HttpExchange exchange) {
+        final var copySources = exchange.getRequestHeaders().get("X-amz-copy-source");
+        if (copySources != null) {
+            if (copySources.size() != 1) {
+                throw new AssertionError("multiple X-amz-copy-source headers found: " + copySources);
+            }
+            final var copySource = copySources.get(0);
+            // SDKv1 uses format /bucket/path/blob whereas SDKv2 omits the leading / so we must add it back in
+            return copySource.length() > 0 && copySource.charAt(0) == '/' ? copySource : ("/" + copySource);
+        } else {
+            return null;
         }
     }
 


### PR DESCRIPTION
The leading `/` on the `x-amz-copy-source` header is optional; SDKv1
includes it but SDKv2 does not. Today we handle its omission when
handling a `CopyObject` request but we must do the same for the
`UploadPartCopy` path.

Closes #127436