### PR TITLE
Skip region validation in `S3BlobStoreRepositoryTests` (#127372)

### DIFF
--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -617,7 +617,9 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
             assertTrue(
                 isValidAwsV4SignedAuthorizationHeader(
                     "test_access_key",
-                    Objects.requireNonNullElse(region, "us-east-1"),
+                    // If unset, the region used by the SDK is usually going to be `us-east-1` but sometimes these tests run on bare EC2
+                    // machines and the SDK picks up the region from the IMDS there, so for now we use '*' to skip validation.
+                    Objects.requireNonNullElse(region, "*"),
                     "s3",
                     exchange.getRequestHeaders().getFirst("Authorization")
                 )


### PR DESCRIPTION
Today these tests assert that the requests received by the handler are signed in region `us-east-1` with no region specified, but in fact when running in EC2 the SDK will pick up the actual region which may be different. This commit skips this region validation for now (it is tested elsewhere).

(cherry picked from commit 15b6e8540083407bf5fdd3bb4cde95f8ce4dfc18)

The [original PR](https://github.com/elastic/elasticsearch/pull/127372) claims to have been backported to 8.x but for some reason didn't appear in 8.19. I wonder if it could have been unfortunate timing with the branch rename somehow?

Closes #127447 
Closes #127448

And probably some others yet to be recorded.
