### PR TITLE
Fix date convert test

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -200,7 +200,7 @@ birth_date:date         |bd:date
 1964-06-02T00:00:00.000Z|1964-06-02T00:00:00.000Z
 ;
 
-convert with zones
+convert with zones#[skip:-8.13.99, reason: default date formatter is changed in 8.14]
 ROW str = "2025-04-11T05:00:00+0400"
 | EVAL dt = TO_DATETIME(str);
 
@@ -216,7 +216,7 @@ dt:datetime              | bool:boolean
 2025-04-11T01:00:00.000Z | true
 ;
 
-convert no zone
+convert no zone#[skip:-8.13.99, reason: default date formatter is changed in 8.14]
 ROW str = "2025-04-11T05:00:00.000"
 | EVAL dt = TO_DATETIME(str);
 


### PR DESCRIPTION
New tests rely on a common formatting infrastructure introduced in: https://github.com/elastic/elasticsearch/pull/106388
Ensure they are executed only when this change is present.

Closes: #127440
Closes: #127441