### PR TITLE
ES|QL: Unmute fixed RRF and FORK tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -408,9 +408,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {rerank.Reranker before a limit ASYNC}
   issue: https://github.com/elastic/elasticsearch/issues/127051
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
-  method: test {rrf.SimpleRrf ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/127063
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test026InstallBundledRepositoryPlugins
   issue: https://github.com/elastic/elasticsearch/issues/127081
@@ -426,9 +423,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/127157
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
-  method: test {fork.ForkWithWhereSortDescAndLimit SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/127326
 - class: org.elasticsearch.geometry.utils.SpatialEnvelopeVisitorTests
   method: testVisitGeoPointsWrapping
   issue: https://github.com/elastic/elasticsearch/issues/123425


### PR DESCRIPTION
These were fixed with https://github.com/elastic/elasticsearch/pull/127328 so we can unmute them now.
