### PR TITLE
[Failure Store] Fix resolved alias retrieval for failure indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -25,7 +25,6 @@ import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.injection.guice.Inject;
@@ -105,14 +104,7 @@ public class TransportClusterSearchShardsAction extends TransportMasterNodeReadA
         Set<ResolvedExpression> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(project.metadata(), request.indices());
         for (String index : concreteIndices) {
             final AliasFilter aliasFilter = indicesService.buildAliasFilter(project, index, indicesAndAliases);
-            final String[] aliases = indexNameExpressionResolver.indexAliases(
-                project.metadata(),
-                index,
-                Predicates.always(),
-                Predicates.always(),
-                true,
-                indicesAndAliases
-            );
+            final String[] aliases = indexNameExpressionResolver.allIndexAliases(project.metadata(), index, indicesAndAliases);
             indicesAndFilters.put(index, AliasFilter.of(aliasFilter.getQueryBuilder(), aliases));
         }
 

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -62,7 +62,6 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -232,14 +231,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 blocks.indexBlockedRaiseException(projectState.projectId(), ClusterBlockLevel.READ, index);
             }
 
-            String[] aliases = indexNameExpressionResolver.indexAliases(
-                projectState.metadata(),
-                index,
-                Predicates.always(),
-                Predicates.always(),
-                true,
-                indicesAndAliases
-            );
+            String[] aliases = indexNameExpressionResolver.allIndexAliases(projectState.metadata(), index, indicesAndAliases);
             String[] finalIndices = Strings.EMPTY_ARRAY;
             if (aliases == null
                 || aliases.length == 0

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -59,6 +59,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Predicate;
@@ -79,6 +80,13 @@ public class IndexNameExpressionResolver {
 
     public static final String EXCLUDED_DATA_STREAMS_KEY = "es.excluded_ds";
     public static final IndexVersion SYSTEM_INDEX_ENFORCEMENT_INDEX_VERSION = IndexVersions.V_8_0_0;
+
+    private static final BiPredicate<DataStreamAlias, Boolean> ALL_DATA_STREAM_ALIASES = (ignoredAlias, ignoredIsData) -> true;
+    // Alias filters are not applied against indices in an abstraction's failure component.
+    // They do not match the mapping of the data stream nor are the documents mapped for searching.
+    private static final BiPredicate<DataStreamAlias, Boolean> ONLY_FILTERING_DATA_STREAM_ALIASES = (
+        dataStreamAlias,
+        isData) -> dataStreamAlias.filteringRequired() && isData;
 
     private final ThreadContext threadContext;
     private final SystemIndices systemIndices;
@@ -1054,10 +1062,19 @@ public class IndexNameExpressionResolver {
             project,
             index,
             AliasMetadata::filteringRequired,
-            DataStreamAlias::filteringRequired,
+            ONLY_FILTERING_DATA_STREAM_ALIASES,
             false,
             resolvedExpressions
         );
+    }
+
+    /**
+     * Iterates through the list of indices and selects the effective list of all aliases for the
+     * given index. Aliases are returned even if the index is included in the resolved expressions.
+     * <b>NOTE</b>: The provided expressions must have been resolved already via {@link #resolveExpressions}.
+     */
+    public String[] allIndexAliases(ProjectMetadata project, String index, Set<ResolvedExpression> resolvedExpressions) {
+        return indexAliases(project, index, Predicates.always(), ALL_DATA_STREAM_ALIASES, true, resolvedExpressions);
     }
 
     /**
@@ -1080,7 +1097,7 @@ public class IndexNameExpressionResolver {
         ProjectMetadata project,
         String index,
         Predicate<AliasMetadata> requiredAlias,
-        Predicate<DataStreamAlias> requiredDataStreamAlias,
+        BiPredicate<DataStreamAlias, Boolean> requiredDataStreamAlias,
         boolean skipIdentity,
         Set<ResolvedExpression> resolvedExpressions
     ) {
@@ -1107,13 +1124,8 @@ public class IndexNameExpressionResolver {
         IndexAbstraction ia = project.getIndicesLookup().get(index);
         DataStream dataStream = ia.getParentDataStream();
         if (dataStream != null) {
-            if (dataStream.getFailureComponent().containsIndex(index)) {
-                // Alias filters are not applied against indices in an abstraction's failure component.
-                // They do not match the mapping of the data stream nor are the documents mapped for searching.
-                return null;
-            }
-
-            if (skipIdentity == false && resolvedExpressionsContainsAbstraction(resolvedExpressions, dataStream.getName())) {
+            boolean isData = dataStream.isFailureStoreIndex(index) == false;
+            if (skipIdentity == false && resolvedExpressionsContainsAbstraction(resolvedExpressions, dataStream.getName(), isData)) {
                 // skip the filters when the request targets the data stream name + selector directly
                 return null;
             }
@@ -1122,12 +1134,14 @@ public class IndexNameExpressionResolver {
             if (iterateIndexAliases(dataStreamAliases.size(), resolvedExpressions.size())) {
                 aliasesForDataStream = dataStreamAliases.values()
                     .stream()
-                    .filter(dataStreamAlias -> resolvedExpressionsContainsAbstraction(resolvedExpressions, dataStreamAlias.getName()))
+                    .filter(
+                        dataStreamAlias -> resolvedExpressionsContainsAbstraction(resolvedExpressions, dataStreamAlias.getName(), isData)
+                    )
                     .filter(dataStreamAlias -> dataStreamAlias.getDataStreams().contains(dataStream.getName()))
                     .toList();
             } else {
                 aliasesForDataStream = resolvedExpressions.stream()
-                    .filter(expression -> expression.selector() == null || expression.selector().shouldIncludeData())
+                    .filter(expression -> (expression.selector() == null || expression.selector().shouldIncludeData()) == isData)
                     .map(ResolvedExpression::resource)
                     .map(dataStreamAliases::get)
                     .filter(dataStreamAlias -> dataStreamAlias != null && dataStreamAlias.getDataStreams().contains(dataStream.getName()))
@@ -1136,11 +1150,12 @@ public class IndexNameExpressionResolver {
 
             List<String> requiredAliases = null;
             for (DataStreamAlias dataStreamAlias : aliasesForDataStream) {
-                if (requiredDataStreamAlias.test(dataStreamAlias)) {
+                if (requiredDataStreamAlias.test(dataStreamAlias, isData)) {
                     if (requiredAliases == null) {
                         requiredAliases = new ArrayList<>(aliasesForDataStream.size());
                     }
-                    requiredAliases.add(dataStreamAlias.getName());
+                    String alias = isData ? dataStreamAlias.getName() : dataStreamAlias.getName() + "::failures";
+                    requiredAliases.add(alias);
                 } else {
                     // we have a non-required alias for this data stream so no need to check further
                     return null;
@@ -1162,7 +1177,7 @@ public class IndexNameExpressionResolver {
                 // Indices can only be referenced with a data selector, or a null selector if selectors are disabled
                 for (AliasMetadata aliasMetadata : indexAliases.values()) {
                     var alias = aliasMetadata.alias();
-                    if (resolvedExpressionsContainsAbstraction(resolvedExpressions, alias)) {
+                    if (resolvedExpressionsContainsAbstraction(resolvedExpressions, alias, true)) {
                         if (requiredAlias.test(aliasMetadata) == false) {
                             return null;
                         }
@@ -1185,9 +1200,16 @@ public class IndexNameExpressionResolver {
         }
     }
 
-    private static boolean resolvedExpressionsContainsAbstraction(Set<ResolvedExpression> resolvedExpressions, String abstractionName) {
-        return resolvedExpressions.contains(new ResolvedExpression(abstractionName))
-            || resolvedExpressions.contains(new ResolvedExpression(abstractionName, IndexComponentSelector.DATA));
+    private static boolean resolvedExpressionsContainsAbstraction(
+        Set<ResolvedExpression> resolvedExpressions,
+        String abstractionName,
+        boolean isData
+    ) {
+        if (isData) {
+            return resolvedExpressions.contains(new ResolvedExpression(abstractionName))
+                || resolvedExpressions.contains(new ResolvedExpression(abstractionName, IndexComponentSelector.DATA));
+        }
+        return resolvedExpressions.contains(new ResolvedExpression(abstractionName, IndexComponentSelector.FAILURES));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -1864,14 +1864,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             )
             .build();
 
-        String[] strings = indexNameExpressionResolver.indexAliases(
-            project,
-            "test-0",
-            x -> true,
-            (x, y) -> true,
-            true,
-            resolvedExpressionsSet("test-0", "test-alias")
-        );
+        String[] strings = indexNameExpressionResolver.allIndexAliases(project, "test-0", resolvedExpressionsSet("test-0", "test-alias"));
         Arrays.sort(strings);
         assertArrayEquals(new String[] { "test-alias" }, strings);
         IndicesRequest request = new IndicesRequest() {
@@ -1943,12 +1936,9 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                     .putAlias(AliasMetadata.builder("test-alias").writeIndex(testZeroWriteIndex ? randomFrom(false, null) : true))
             )
             .build();
-        String[] strings = indexNameExpressionResolver.indexAliases(
+        String[] strings = indexNameExpressionResolver.allIndexAliases(
             project,
             "test-0",
-            x -> true,
-            (x, y) -> true,
-            true,
             resolvedExpressionsSet("test-0", "test-1", "test-alias")
         );
         Arrays.sort(strings);
@@ -1981,14 +1971,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         ProjectMetadata project = ProjectMetadata.builder(Metadata.DEFAULT_PROJECT_ID)
             .put(indexBuilder("test-0").state(State.OPEN).putAlias(AliasMetadata.builder("test-alias").writeIndex(false)))
             .build();
-        String[] strings = indexNameExpressionResolver.indexAliases(
-            project,
-            "test-0",
-            x -> true,
-            (x, y) -> true,
-            true,
-            resolvedExpressionsSet("test-0", "test-alias")
-        );
+        String[] strings = indexNameExpressionResolver.allIndexAliases(project, "test-0", resolvedExpressionsSet("test-0", "test-alias"));
         Arrays.sort(strings);
         assertArrayEquals(new String[] { "test-alias" }, strings);
         DocWriteRequest<?> request = randomFrom(
@@ -2015,12 +1998,9 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             .put(indexBuilder("test-0").state(State.OPEN).putAlias(AliasMetadata.builder("test-alias").writeIndex(randomFrom(false, null))))
             .put(indexBuilder("test-1").state(State.OPEN).putAlias(AliasMetadata.builder("test-alias").writeIndex(randomFrom(false, null))))
             .build();
-        String[] strings = indexNameExpressionResolver.indexAliases(
+        String[] strings = indexNameExpressionResolver.allIndexAliases(
             project,
             "test-0",
-            x -> true,
-            (x, y) -> true,
-            true,
             Set.of(new ResolvedExpression("test-0"), new ResolvedExpression("test-1"), new ResolvedExpression("test-alias"))
         );
         Arrays.sort(strings);
@@ -2056,12 +2036,9 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                     .putAlias(AliasMetadata.builder("test-alias").writeIndex(randomFrom(test0WriteIndex == false, null)))
             )
             .build();
-        String[] strings = indexNameExpressionResolver.indexAliases(
+        String[] strings = indexNameExpressionResolver.allIndexAliases(
             project,
             "test-0",
-            x -> true,
-            (x, y) -> true,
-            true,
             resolvedExpressionsSet("test-0", "test-1", "test-alias")
         );
         Arrays.sort(strings);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -1668,7 +1668,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             .build();
         Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, "test-*");
 
-        String[] strings = indexNameExpressionResolver.indexAliases(project, "test-0", x -> true, x -> true, true, resolvedExpressions);
+        String[] strings = indexNameExpressionResolver.allIndexAliases(project, "test-0", resolvedExpressions);
         Arrays.sort(strings);
         assertArrayEquals(new String[] { "test-alias-0", "test-alias-1", "test-alias-non-filtering" }, strings);
 
@@ -1676,7 +1676,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             project,
             "test-0",
             x -> x.alias().equals("test-alias-1"),
-            x -> false,
+            (x, y) -> randomBoolean(),
             true,
             resolvedExpressions
         );
@@ -1700,52 +1700,52 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         projectBuilder.put("logs_baz2", dataStreamName2, null, null);
         ProjectMetadata project = projectBuilder.build();
         {
-            // Only resolve aliases with with that refer to dataStreamName1
+            // Only resolve aliases that refer to dataStreamName1
             Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, "l*");
             String index = backingIndex1.getIndex().getName();
-            String[] result = indexNameExpressionResolver.indexAliases(project, index, x -> true, x -> true, true, resolvedExpressions);
+            String[] result = indexNameExpressionResolver.allIndexAliases(project, index, resolvedExpressions);
             assertThat(result, arrayContainingInAnyOrder("logs_foo", "logs", "logs_bar"));
         }
         {
-            // Only resolve aliases with with that refer to dataStreamName2
+            // Only resolve aliases that refer to dataStreamName2
             Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, "l*");
             String index = backingIndex2.getIndex().getName();
-            String[] result = indexNameExpressionResolver.indexAliases(project, index, x -> true, x -> true, true, resolvedExpressions);
+            String[] result = indexNameExpressionResolver.allIndexAliases(project, index, resolvedExpressions);
             assertThat(result, arrayContainingInAnyOrder("logs_baz", "logs_baz2"));
         }
         {
             // Null is returned, because skipping identity check and resolvedExpressions contains the backing index name
             Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, "l*");
             String index = backingIndex2.getIndex().getName();
-            String[] result = indexNameExpressionResolver.indexAliases(project, index, x -> true, x -> true, false, resolvedExpressions);
+            String[] result = indexNameExpressionResolver.indexAliases(
+                project,
+                index,
+                x -> randomBoolean(),
+                (x, y) -> true,
+                false,
+                resolvedExpressions
+            );
             assertThat(result, nullValue());
         }
         {
             // Null is returned, because the wildcard expands to a list of aliases containing an unfiltered alias for dataStreamName1
             Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, "l*");
             String index = backingIndex1.getIndex().getName();
-            String[] result = indexNameExpressionResolver.indexAliases(
-                project,
-                index,
-                x -> true,
-                DataStreamAlias::filteringRequired,
-                true,
-                resolvedExpressions
-            );
+            String[] result = indexNameExpressionResolver.filteringAliases(project, index, resolvedExpressions);
             assertThat(result, nullValue());
         }
         {
             // Null is returned, because an unfiltered alias is targeting the same data stream
             Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, "logs_bar", "logs");
             String index = backingIndex1.getIndex().getName();
-            String[] result = indexNameExpressionResolver.indexAliases(
-                project,
-                index,
-                x -> true,
-                DataStreamAlias::filteringRequired,
-                true,
-                resolvedExpressions
-            );
+            String[] result = indexNameExpressionResolver.filteringAliases(project, index, resolvedExpressions);
+            assertThat(result, nullValue());
+        }
+        {
+            // Null is returned because we target the data stream name and skipIdentity is false
+            Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, dataStreamName1, "logs");
+            String index = backingIndex1.getIndex().getName();
+            String[] result = indexNameExpressionResolver.filteringAliases(project, index, resolvedExpressions);
             assertThat(result, nullValue());
         }
         {
@@ -1756,24 +1756,72 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 project,
                 index,
                 x -> true,
-                DataStreamAlias::filteringRequired,
+                (alias, isData) -> alias.filteringRequired() && isData,
                 true,
                 resolvedExpressions
             );
             assertThat(result, arrayContainingInAnyOrder("logs"));
         }
+    }
+
+    public void testIndexAliasesDataStreamFailureStoreAndAliases() {
+        final String dataStreamName1 = "logs-foobar";
+        final String dataStreamName2 = "logs-barbaz";
+        IndexMetadata backingIndex1 = createBackingIndex(dataStreamName1, 1).build();
+        IndexMetadata failureIndex1 = createFailureStore(dataStreamName1, 2).build();
+        IndexMetadata backingIndex2 = createBackingIndex(dataStreamName2, 1).build();
+        ProjectMetadata.Builder projectBuilder = ProjectMetadata.builder(Metadata.DEFAULT_PROJECT_ID)
+            .put(backingIndex1, false)
+            .put(backingIndex2, false)
+            .put(failureIndex1, false)
+            .put(newInstance(dataStreamName1, List.of(backingIndex1.getIndex()), List.of(failureIndex1.getIndex())))
+            .put(newInstance(dataStreamName2, List.of(backingIndex2.getIndex())));
+        projectBuilder.put("logs_foo", dataStreamName1, null, "{ \"term\": \"foo\"}");
+        projectBuilder.put("logs", dataStreamName1, null, "{ \"term\": \"logs\"}");
+        projectBuilder.put("logs_bar", dataStreamName1, null, null);
+        projectBuilder.put("logs_baz", dataStreamName2, null, "{ \"term\": \"logs\"}");
+        projectBuilder.put("logs_baz2", dataStreamName2, null, null);
+        ProjectMetadata project = projectBuilder.build();
         {
-            // Null is returned because we target the data stream name and skipIdentity is false
-            Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, dataStreamName1, "logs");
-            String index = backingIndex1.getIndex().getName();
+            // Resolving the failure component with a backing index should return null
+            Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, "l*::failures");
+            String index = randomBoolean() ? backingIndex1.getIndex().getName() : backingIndex2.getIndex().getName();
+            String[] result = indexNameExpressionResolver.allIndexAliases(project, index, resolvedExpressions);
+            assertThat(result, nullValue());
+        }
+        {
+            // Only resolve aliases that refer to dataStreamName1 failure store
+            Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, "l*::failures");
+            String index = failureIndex1.getIndex().getName();
+            String[] result = indexNameExpressionResolver.allIndexAliases(project, index, resolvedExpressions);
+            assertThat(result, arrayContainingInAnyOrder("logs_foo::failures", "logs::failures", "logs_bar::failures"));
+        }
+        {
+            // Null is returned, because we perform the identity check and resolvedExpressions contains the failure index name
+            Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, "l*::failures");
+            String index = failureIndex1.getIndex().getName();
             String[] result = indexNameExpressionResolver.indexAliases(
                 project,
                 index,
                 x -> true,
-                DataStreamAlias::filteringRequired,
+                (x, y) -> true,
                 false,
                 resolvedExpressions
             );
+            assertThat(result, nullValue());
+        }
+        {
+            // Null is returned, because the wildcard expands to a list of aliases containing an unfiltered alias for dataStreamName1
+            Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, "l*::failures");
+            String index = failureIndex1.getIndex().getName();
+            String[] result = indexNameExpressionResolver.filteringAliases(project, index, resolvedExpressions);
+            assertThat(result, nullValue());
+        }
+        {
+            // Null is returned because we target the failure store of the data stream
+            Set<ResolvedExpression> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(project, "logs::failures");
+            String index = failureIndex1.getIndex().getName();
+            String[] result = indexNameExpressionResolver.filteringAliases(project, index, resolvedExpressions);
             assertThat(result, nullValue());
         }
     }
@@ -1788,15 +1836,22 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             .build();
 
         Set<ResolvedExpression> resolvedExpressions = resolvedExpressionsSet("test-0", "test-alias");
-        String[] aliases = indexNameExpressionResolver.indexAliases(project, "test-0", x -> true, x -> true, false, resolvedExpressions);
+        String[] aliases = indexNameExpressionResolver.indexAliases(
+            project,
+            "test-0",
+            x -> true,
+            (x, y) -> true,
+            false,
+            resolvedExpressions
+        );
         assertNull(aliases);
-        aliases = indexNameExpressionResolver.indexAliases(project, "test-0", x -> true, x -> true, true, resolvedExpressions);
+        aliases = indexNameExpressionResolver.indexAliases(project, "test-0", x -> true, (x, y) -> true, true, resolvedExpressions);
         assertArrayEquals(new String[] { "test-alias" }, aliases);
 
         resolvedExpressions = Collections.singleton(new ResolvedExpression("other-alias"));
-        aliases = indexNameExpressionResolver.indexAliases(project, "test-0", x -> true, x -> true, false, resolvedExpressions);
+        aliases = indexNameExpressionResolver.indexAliases(project, "test-0", x -> true, (x, y) -> true, false, resolvedExpressions);
         assertArrayEquals(new String[] { "other-alias" }, aliases);
-        aliases = indexNameExpressionResolver.indexAliases(project, "test-0", x -> true, x -> true, true, resolvedExpressions);
+        aliases = indexNameExpressionResolver.indexAliases(project, "test-0", x -> true, (x, y) -> true, true, resolvedExpressions);
         assertArrayEquals(new String[] { "other-alias" }, aliases);
     }
 
@@ -1813,7 +1868,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             project,
             "test-0",
             x -> true,
-            x -> true,
+            (x, y) -> true,
             true,
             resolvedExpressionsSet("test-0", "test-alias")
         );
@@ -1892,7 +1947,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             project,
             "test-0",
             x -> true,
-            x -> true,
+            (x, y) -> true,
             true,
             resolvedExpressionsSet("test-0", "test-1", "test-alias")
         );
@@ -1930,7 +1985,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             project,
             "test-0",
             x -> true,
-            x -> true,
+            (x, y) -> true,
             true,
             resolvedExpressionsSet("test-0", "test-alias")
         );
@@ -1964,7 +2019,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             project,
             "test-0",
             x -> true,
-            x -> true,
+            (x, y) -> true,
             true,
             Set.of(new ResolvedExpression("test-0"), new ResolvedExpression("test-1"), new ResolvedExpression("test-alias"))
         );
@@ -2005,7 +2060,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             project,
             "test-0",
             x -> true,
-            x -> true,
+            (x, y) -> true,
             true,
             resolvedExpressionsSet("test-0", "test-1", "test-alias")
         );

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
@@ -1976,7 +1976,7 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
         expectSearch(username, new Search(aliasName + "::failures"), failuresDocId, otherFailuresDocId);
         expectSearchThrows(
             username,
-            new Search(randomFrom(aliasName + "::data", "my-alias::failures", dataIndexName, failureIndexName)),
+            new Search(randomFrom(aliasName + "::data", aliasName, dataIndexName, failureIndexName)),
             403
         );
 

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
@@ -105,7 +105,7 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
         upsertRole(Strings.format("""
             {
               "cluster": ["all"],
-              "indices": [{"names": ["test*"], "privileges": ["write", "auto_configure"]}]
+              "indices": [{"names": ["test*", "other*"], "privileges": ["write", "auto_configure"]}]
             }"""), WRITE_ACCESS);
     }
 
@@ -1919,6 +1919,245 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
                 }
             }
         }
+    }
+
+    public void testAliasBasedAccess() throws Exception {
+        List<String> docIds = setupDataStream();
+        assertThat(docIds.size(), equalTo(2));
+        assertThat(docIds, hasItem("1"));
+        String dataDocId = "1";
+        String failuresDocId = docIds.stream().filter(id -> false == id.equals(dataDocId)).findFirst().get();
+
+        List<String> otherDocIds = setupOtherDataStream();
+        assertThat(otherDocIds.size(), equalTo(2));
+        assertThat(otherDocIds, hasItem("3"));
+        String otherDataDocId = "3";
+        String otherFailuresDocId = otherDocIds.stream().filter(id -> false == id.equals(otherDataDocId)).findFirst().get();
+
+        final Tuple<String, String> backingIndices = getSingleDataAndFailureIndices("test1");
+        final String dataIndexName = backingIndices.v1();
+        final String failureIndexName = backingIndices.v2();
+
+        final String aliasName = "my-alias";
+        final String username = "user";
+        final String roleName = "role";
+
+        createUser(username, PASSWORD, roleName);
+        // manage is required to add the alias to the data stream
+        createOrUpdateRoleAndApiKey(username, roleName, Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["test1", "%s", "other1"],
+                  "privileges": ["manage"]
+                }
+              ]
+            }
+            """, aliasName));
+
+        addAlias(username, "test1", aliasName, "");
+        addAlias(username, "other1", aliasName, "");
+        assertThat(fetchAliases(username, "test1"), containsInAnyOrder(aliasName));
+        expectSearchThrows(username, new Search(randomFrom(aliasName + "::data", aliasName)), 403);
+        expectSearchThrows(username, new Search(randomFrom(aliasName + "::failures")), 403);
+
+        createOrUpdateRoleAndApiKey(username, roleName, Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["%s"],
+                  "privileges": ["read_failure_store"]
+                }
+              ]
+            }
+            """, aliasName));
+        expectSearch(username, new Search(aliasName + "::failures"), failuresDocId, otherFailuresDocId);
+        expectSearchThrows(
+            username,
+            new Search(randomFrom(aliasName + "::data", "my-alias::failures", dataIndexName, failureIndexName)),
+            403
+        );
+
+        createOrUpdateRoleAndApiKey(username, roleName, Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["%s"],
+                  "privileges": ["read"]
+                }
+              ]
+            }
+            """, aliasName));
+        expectSearch(username, new Search(randomFrom(aliasName + "::data")), dataDocId, otherDataDocId);
+        expectSearchThrows(username, new Search(aliasName + "::failures"), 403);
+
+        expectThrows(() -> removeAlias(username, "test1", aliasName), 403);
+        createOrUpdateRoleAndApiKey(username, roleName, Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["test1", "%s", "other1"],
+                  "privileges": ["manage"]
+                }
+              ]
+            }
+            """, aliasName));
+        removeAlias(username, "test1", aliasName);
+        removeAlias(username, "other1", aliasName);
+
+        final String filteredAliasName = "my-filtered-alias";
+        createOrUpdateRoleAndApiKey(username, roleName, Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["test1", "%s", "other1"],
+                  "privileges": ["manage"]
+                }
+              ]
+            }
+            """, filteredAliasName));
+        addAlias(username, "test1", filteredAliasName, """
+            {
+              "term": {
+                "document.source.name": "jack"
+              }
+            }
+            """);
+        addAlias(username, "other1", filteredAliasName, """
+            {
+              "term": {
+                "document.source.name": "jack"
+              }
+            }
+            """);
+        assertThat(fetchAliases(username, "test1"), containsInAnyOrder(filteredAliasName));
+        assertThat(fetchAliases(username, "other1"), containsInAnyOrder(filteredAliasName));
+
+        createOrUpdateRoleAndApiKey(username, roleName, Strings.format("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["%s"],
+                  "privileges": ["read", "read_failure_store"]
+                }
+              ]
+            }
+            """, filteredAliasName));
+
+        expectSearch(username, new Search(randomFrom(filteredAliasName + "::data", filteredAliasName)));
+        // the alias filter is not applied to the failure store
+        expectSearch(username, new Search(filteredAliasName + "::failures"), failuresDocId, otherFailuresDocId);
+    }
+
+    private void createOrUpdateRoleAndApiKey(String username, String roleName, String roleDescriptor) throws IOException {
+        upsertRole(roleDescriptor, roleName);
+        createOrUpdateApiKey(username, randomBoolean() ? null : Strings.format("""
+            {
+              "%s": %s
+            }
+            """, roleName, roleDescriptor));
+    }
+
+    private void addAlias(String user, String dataStream, String alias, String filter) throws IOException {
+        aliasAction(user, "add", dataStream, alias, filter);
+    }
+
+    private void removeAlias(String user, String dataStream, String alias) throws IOException {
+        aliasAction(user, "remove", dataStream, alias, "");
+    }
+
+    private void aliasAction(String user, String action, String dataStream, String alias, String filter) throws IOException {
+        Request request = new Request("POST", "/_aliases");
+        if (filter == null || filter.isEmpty()) {
+            request.setJsonEntity(Strings.format("""
+                {
+                  "actions": [
+                    {
+                      "%s": {
+                        "index": "%s",
+                        "alias": "%s"
+                      }
+                    }
+                  ]
+                }
+                """, action, dataStream, alias));
+        } else {
+            request.setJsonEntity(Strings.format("""
+                {
+                  "actions": [
+                    {
+                      "%s": {
+                        "index": "%s",
+                        "alias": "%s",
+                        "filter": %s
+                      }
+                    }
+                  ]
+                }
+                """, action, dataStream, alias, filter));
+        }
+        Response response = performRequestMaybeUsingApiKey(user, request);
+        var path = assertOKAndCreateObjectPath(response);
+        assertThat(path.evaluate("acknowledged"), is(true));
+        assertThat(path.evaluate("errors"), is(false));
+
+    }
+
+    private Set<String> fetchAliases(String user, String dataStream) throws IOException {
+        Response response = performRequestMaybeUsingApiKey(user, new Request("GET", dataStream + "/_alias"));
+        ObjectPath path = assertOKAndCreateObjectPath(response);
+        Map<String, Object> aliases = path.evaluate(dataStream + ".aliases");
+        return aliases.keySet();
+    }
+
+    public void testPatternExclusions() throws Exception {
+        List<String> docIds = setupDataStream();
+        assertThat(docIds.size(), equalTo(2));
+        assertThat(docIds, hasItem("1"));
+        String dataDocId = "1";
+        String failuresDocId = docIds.stream().filter(id -> false == id.equals(dataDocId)).findFirst().get();
+
+        List<String> otherDocIds = setupOtherDataStream();
+        assertThat(otherDocIds.size(), equalTo(2));
+        assertThat(otherDocIds, hasItem("3"));
+        String otherDataDocId = "3";
+        String otherFailuresDocId = otherDocIds.stream().filter(id -> false == id.equals(otherDataDocId)).findFirst().get();
+
+        createUser("user", PASSWORD, "role");
+        upsertRole("""
+            {
+              "cluster": ["all"],
+              "indices": [
+                {
+                  "names": ["test*", "other*"],
+                  "privileges": ["read", "read_failure_store"]
+                }
+              ]
+            }
+            """, "role");
+        createAndStoreApiKey("user", randomBoolean() ? null : """
+            {
+              "role": {
+                "cluster": ["all"],
+                "indices": [
+                  {
+                    "names": ["*"],
+                    "privileges": ["read", "read_failure_store"]
+                  }
+                ]
+              }
+            }
+            """);
+
+        // no exclusion -> should return two failure docs
+        expectSearch("user", new Search("*::failures"), failuresDocId, otherFailuresDocId);
+        expectSearch("user", new Search("*::failures,-other*::failures"), failuresDocId);
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/failurestore/FailureStoreSecurityRestIT.java
@@ -1974,11 +1974,7 @@ public class FailureStoreSecurityRestIT extends ESRestTestCase {
             }
             """, aliasName));
         expectSearch(username, new Search(aliasName + "::failures"), failuresDocId, otherFailuresDocId);
-        expectSearchThrows(
-            username,
-            new Search(randomFrom(aliasName + "::data", aliasName, dataIndexName, failureIndexName)),
-            403
-        );
+        expectSearchThrows(username, new Search(randomFrom(aliasName + "::data", aliasName, dataIndexName, failureIndexName)), 403);
 
         createOrUpdateRoleAndApiKey(username, roleName, Strings.format("""
             {


### PR DESCRIPTION
While expanding our tests in https://github.com/elastic/elasticsearch/pull/126891, we discovered that there was a difference in behaviour when an alias was used during search.

**Expected behaviour**

When a user uses an alias to access data, we pass this alias also to the node requests because that ensures that the user's authorisation will be evaluated based on the same premise.

**Observed behaviour**

When a user would use the alias and the `::failures` selector, we noticed that the request was resolved to the failure indices and the alias was not used further which sometimes resulted in an unauthorised error. The reason was that when a node different than the coordinating node would try to evaluate if the user has permissions, they would evaluate that against the failure indices themselves and not the alias with the `::failures` selector.

**Solution**
In this PR we ensure that a resolved alias is retrieved for failure indices too. 

The `indexAliases` method is used in two ways (in production code):

1. To retrieve all the resolved aliases that match an index
2. To retrieve the filtered aliases that match the index (when there is no unfiltered reference to this index) 

Because failure indices are not supported by filtered aliases, the code would return `null` when a failure index was encountered. That works well for the second case and not for the first.

In order to address that we moved the check for the failure index to the data stream alias predicate and we let the code match failure indices against resolved failure expressions and backing indices against resolved data expressions.

Furthermore, we added methods capturing these two common cases so the users of these methods for not need to know the details of how to call them.

