### PR TITLE
ES|QL: Fix generative tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -420,9 +420,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
   method: testSearchWhileRelocating
   issue: https://github.com/elastic/elasticsearch/issues/127188
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/127157
 - class: org.elasticsearch.geometry.utils.SpatialEnvelopeVisitorTests
   method: testVisitGeoPointsWrapping
   issue: https://github.com/elastic/elasticsearch/issues/123425

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -50,10 +50,12 @@ public abstract class GenerativeRestTest extends ESRestTestCase {
         // Awaiting fixes
         "Unknown column \\[<all-fields-projected>\\]", // https://github.com/elastic/elasticsearch/issues/121741,
         "Plan \\[ProjectExec\\[\\[<no-fields>.* optimized incorrectly due to missing references", // https://github.com/elastic/elasticsearch/issues/125866
-        "token recognition error at: '``", // https://github.com/elastic/elasticsearch/issues/125870
-                                           // https://github.com/elastic/elasticsearch/issues/127167
+        "token recognition error at: ", // https://github.com/elastic/elasticsearch/issues/125870
+                                        // https://github.com/elastic/elasticsearch/issues/127167
         "optimized incorrectly due to missing references", // https://github.com/elastic/elasticsearch/issues/116781
         "No matches found for pattern", // https://github.com/elastic/elasticsearch/issues/126418
+        "Unknown column", // https://github.com/elastic/elasticsearch/issues/127467
+        "only supports KEYWORD or TEXT values", // https://github.com/elastic/elasticsearch/issues/127468
         "The incoming YAML document exceeds the limit:" // still to investigate, but it seems to be specific to the test framework
     );
 


### PR DESCRIPTION
Adding more exceptions to generative tests

Fixes: https://github.com/elastic/elasticsearch/issues/127157