### PR TITLE
Enable FAILURE_STORE feature flag for LogsIndexModeFullClusterRestartIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -248,9 +248,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.convert.ParseIpTests
   method: testLeadingZerosAreOctal {TestCase[str=v4, validLeadingZerosRejected=true, validLeadingZerosAreDecimal=true, validLeadingZerosAreOctal=true]}
   issue: https://github.com/elastic/elasticsearch/issues/126496
-- class: org.elasticsearch.upgrades.LogsIndexModeFullClusterRestartIT
-  method: testLogsIndexing {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/126967
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/data_frame_analytics_crud/Test get stats on newly created config}
   issue: https://github.com/elastic/elasticsearch/issues/121726

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/LogsIndexModeFullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/LogsIndexModeFullClusterRestartIT.java
@@ -48,7 +48,8 @@ public class LogsIndexModeFullClusterRestartIT extends ParameterizedFullClusterR
             .module("x-pack-stack")
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
-            .feature(FeatureFlag.FAILURE_STORE_ENABLED);;
+            .feature(FeatureFlag.FAILURE_STORE_ENABLED);
+        ;
 
         if (oldVersion.before(Version.fromString("8.18.0"))) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/LogsIndexModeFullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/LogsIndexModeFullClusterRestartIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.Version;
 import org.hamcrest.Matcher;
@@ -46,7 +47,8 @@ public class LogsIndexModeFullClusterRestartIT extends ParameterizedFullClusterR
             .module("x-pack-aggregate-metric")
             .module("x-pack-stack")
             .setting("xpack.security.enabled", "false")
-            .setting("xpack.license.self_generated.type", "trial");
+            .setting("xpack.license.self_generated.type", "trial")
+            .feature(FeatureFlag.FAILURE_STORE_ENABLED);;
 
         if (oldVersion.before(Version.fromString("8.18.0"))) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");


### PR DESCRIPTION
Test was failing due to unable to parse failure store template, this enables the failure store feature flag for the test cluster.

```
Caused by: org.elasticsearch.xcontent.XContentParseException: [-1:45511] [data_stream_template] unknown field [failure_store]
```

Closes https://github.com/elastic/elasticsearch/issues/126967