### PR TITLE
Cleanup needlessly holding Exceptions in the can_match phase

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -343,7 +343,7 @@ final class CanMatchPreFilterSearchPhase {
         }
 
         private void onOperation(int idx, CanMatchShardResponse response) {
-            failedResponses.add(idx);
+            failedResponses.remove(idx);
             consumeResult(response);
             if (countDown.countDown()) {
                 finishRound();


### PR DESCRIPTION
Exceptions can be quite expensive heap-wise and we don't use them here any longer, not even for logging -> replace atomic array with a set of shard indices and dry up the logic a tiny bit as a result as well.
We could also adjust the response class to not even have the exception but with #127471 inbound, the actual transport responses will shortly turn into a BwC only thing anyway.