### PR TITLE
[DOCS][8.x] Hide misleading banner from behavioral analytics docs

### DIFF
--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-api.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-api.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>API overview</titleabbrev>
 ++++
 
+++++
+<style>
+  div#url-to-v3 {
+    display: none !important;
+  }
+</style>
+++++
+
 This page outlines all the APIs available for behavioral analytics and links to their documentation.
 
 [discrete]

--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-cors.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-cors.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>Set up CORs</titleabbrev>
 ++++
 
+++++
+<style>
+  div#url-to-v3 {
+    display: none !important;
+  }
+</style>
+++++
+
 Behavioral Analytics sends events directly to the {es} API.
 This means that the browser makes requests to the {es} API directly.
 {es} supports https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[Cross-Origin Resource Sharing (CORS)^], but this feature is disabled by default.

--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-event-reference.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-event-reference.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>Events reference</titleabbrev>
 ++++
 
+++++
+<style>
+  div#url-to-v3 {
+    display: none !important;
+  }
+</style>
+++++
+
 Behavioral Analytics logs events using the {ecs-ref}/ecs-reference.html[Elastic Common Schema^], including a custom field set for analytics events.
 Refer to <<behavioral-analytics-event-reference-examples,examples>> of the full data objects that are logged.
 

--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-event.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-event.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>View events</titleabbrev>
 ++++
 
+++++
+<style>
+  div#url-to-v3 {
+    display: none !important;
+  }
+</style>
+++++
+
 [TIP]
 ====
 Refer to <<behavioral-analytics-event-reference>> for a complete list of the fields logged by events.

--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-overview.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-overview.asciidoc
@@ -1,6 +1,14 @@
 [[behavioral-analytics-overview]]
 == Search analytics
 
+++++
+<style>
+  div#url-to-v3 {
+    display: none !important;
+  }
+</style>
+++++
+
 Behavioral Analytics is an analytics event collection platform.
 Use these tools to analyze your users' searching and clicking behavior.
 Leverage this information to improve the relevance of your search results and identify gaps in your content.

--- a/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-start.asciidoc
+++ b/docs/reference/search/search-your-data/behavioral-analytics/behavioral-analytics-start.asciidoc
@@ -4,6 +4,14 @@
 <titleabbrev>Get started</titleabbrev>
 ++++
 
+++++
+<style>
+  div#url-to-v3 {
+    display: none !important;
+  }
+</style>
+++++
+
 You can manage your analytics in the {kib} UI.
 Go to *Search > Behavioral Analytics* to get started.
 


### PR DESCRIPTION
Banner says newer docs are available but this isn't true because BA is deprecated as of 9.0 and therefore we didn't port the docs over to the new system.

The passthrough block will hide it
<img width="482" alt="Screenshot 2025-04-29 at 14 22 43" src="https://github.com/user-attachments/assets/1948a6a6-6950-4063-84a6-f75ff8d7d4a9" />
