### PR TITLE
[8.18] [ML] Fix text structure NPE when fields in list have null value (#125922)

### DIFF
--- a/docs/changelog/125922.yaml
+++ b/docs/changelog/125922.yaml
@@ -1,0 +1,5 @@
+pr: 125922 
+summary: Fix text structure NPE when fields in list have null value
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtils.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtils.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -329,7 +330,7 @@ public final class TextStructureUtils {
 
             List<Object> fieldValues = sampleRecords.stream()
                 .map(record -> record.get(fieldName))
-                .filter(fieldValue -> fieldValue != null)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
             Tuple<Map<String, String>, FieldStats> mappingAndFieldStats = guessMappingAndCalculateFieldStats(
@@ -425,7 +426,10 @@ public final class TextStructureUtils {
             );
         }
 
-        Collection<String> fieldValuesAsStrings = fieldValues.stream().map(Object::toString).collect(Collectors.toList());
+        Collection<String> fieldValuesAsStrings = fieldValues.stream()
+            .filter(Objects::nonNull)
+            .map(Object::toString)
+            .collect(Collectors.toList());
         Map<String, String> mapping = guessScalarMapping(
             explanation,
             fieldName,

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtilsTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtilsTests.java
@@ -1106,6 +1106,16 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         }
     }
 
+    public void testGuessMappingWithNullValue() {
+        Map<String, String> expected = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword");
+
+        Consumer<Boolean> testGuessMappingGivenEcsCompatibility = (ecsCompatibility) -> {
+            assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList("ERROR", null, "DEBUG"), ecsCompatibility));
+        };
+
+        ecsCompatibilityModes.forEach(testGuessMappingGivenEcsCompatibility);
+    }
+
     private Map<String, String> guessMapping(
         List<String> explanation,
         String fieldName,


### PR DESCRIPTION
Backports the following commits to 8.18:
 - [ML] Fix text structure NPE when fields in list have null value (#125922)