### PR TITLE
Better behavior around ignore_missing when databases aren't available

### DIFF
--- a/docs/changelog/127520.yaml
+++ b/docs/changelog/127520.yaml
@@ -1,0 +1,6 @@
+pr: 127520
+summary: Better behavior around `ignore_missing` when databases aren't available
+area: Ingest Node
+type: bug
+issues:
+ - 87345

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -105,7 +105,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         } else if (ip == null && ignoreMissing) {
             return document;
         } else if (ip == null) {
-            throw new IllegalArgumentException("field [" + field + "] is null, cannot extract geoip information.");
+            throw new IllegalArgumentException("field [" + field + "] is null, cannot extract " + type + " information");
         }
 
         try (IpDatabase ipDatabase = this.supplier.get()) {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -549,6 +549,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
             Map<String, Object> config = new HashMap<>();
             config.put("field", "source_field");
             config.put("database_file", "GeoLite2-City.mmdb");
+            config.put("ignore_missing", true);
 
             GeoIpProcessor.DatabaseUnavailableProcessor processor = (GeoIpProcessor.DatabaseUnavailableProcessor) factory.create(
                 null,
@@ -564,6 +565,13 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
                 processor.execute(document);
                 assertThat(document.getSourceAndMetadata().get("geoip"), nullValue());
                 assertThat(document.getSourceAndMetadata().get("tags"), equalTo(List.of("_geoip_database_unavailable_GeoLite2-City.mmdb")));
+            }
+            {
+                // if there's no value for the source_field and ignore_missing is true, then we don't tag the document
+                document = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>()); // note: no source_field
+                processor.execute(document);
+                assertThat(document.getSourceAndMetadata().get("geoip"), nullValue());
+                assertThat(document.getSourceAndMetadata().get("tags"), nullValue());
             }
         }
 

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -550,10 +550,6 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
             config.put("field", "source_field");
             config.put("database_file", "GeoLite2-City.mmdb");
 
-            Map<String, Object> document = new HashMap<>();
-            document.put("source_field", "89.160.20.128");
-            IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
-
             GeoIpProcessor.DatabaseUnavailableProcessor processor = (GeoIpProcessor.DatabaseUnavailableProcessor) factory.create(
                 null,
                 null,
@@ -561,12 +557,14 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
                 config,
                 null
             );
-            processor.execute(ingestDocument);
-            assertThat(ingestDocument.getSourceAndMetadata().get("geoip"), nullValue());
-            assertThat(
-                ingestDocument.getSourceAndMetadata().get("tags"),
-                equalTo(List.of("_geoip_database_unavailable_GeoLite2-City.mmdb"))
-            );
+
+            IngestDocument document;
+            {
+                document = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>(Map.of("source_field", "89.160.20.128")));
+                processor.execute(document);
+                assertThat(document.getSourceAndMetadata().get("geoip"), nullValue());
+                assertThat(document.getSourceAndMetadata().get("tags"), equalTo(List.of("_geoip_database_unavailable_GeoLite2-City.mmdb")));
+            }
         }
 
         copyDatabase("GeoLite2-City-Test.mmdb", geoipTmpDir);

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -174,7 +174,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         );
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
         Exception exception = expectThrows(Exception.class, () -> processor.execute(ingestDocument));
-        assertThat(exception.getMessage(), equalTo("field [source_field] is null, cannot extract geoip information."));
+        assertThat(exception.getMessage(), equalTo("field [source_field] is null, cannot extract geoip information"));
     }
 
     public void testNonExistentWithoutIgnoreMissing() {


### PR DESCRIPTION
Closes #87345

The [documentation](https://www.elastic.co/docs/reference/enrich-processor/geoip-processor) for `ignore_missing` says:

> If `true` and `field` does not exist, the processor quietly exits without modifying the document

But if the database isn't available, then we unconditionally add tags to the document regardless of the value of the `ignore_missing` configuration, which doesn't seem correct.

This PR aligns the behavior in the database-unavailable case to better match the behavior in the database-available case (and, by extension, to better match the docs).