### PR TITLE
Fix bug in EsqlDataTypeConverterTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -444,9 +444,6 @@ tests:
 - class: org.elasticsearch.action.admin.cluster.state.TransportClusterStateActionDisruptionIT
   method: testLocalRequestWaitsForMetadata
   issue: https://github.com/elastic/elasticsearch/issues/127466
-- class: org.elasticsearch.xpack.esql.type.EsqlDataTypeConverterTests
-  method: testSuggestedCast
-  issue: https://github.com/elastic/elasticsearch/issues/127535
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/127536

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.test.cluster.LogType;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.esql.core.plugin.EsqlCorePlugin;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase;
 import org.elasticsearch.xpack.esql.tools.ProfileParser;
@@ -42,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -672,19 +674,25 @@ public class RestEsqlIT extends RestEsqlTestCase {
                   "type": "Point",
                   "coordinates": [-77.03653, 38.897676]
                 }
-                """),
-            Map.entry(DataType.AGGREGATE_METRIC_DOUBLE, """
+                """)
+        );
+        if (EsqlCorePlugin.AGGREGATE_METRIC_DOUBLE_FEATURE_FLAG.isEnabled()) {
+            typesAndValues = new HashMap<>(typesAndValues);
+            typesAndValues.put(DataType.AGGREGATE_METRIC_DOUBLE, """
                 {
                   "max": 14983.1
                 }
-                """)
-        );
+                """);
+        }
         Set<DataType> shouldBeSupported = Stream.of(DataType.values()).filter(DataType::isRepresentable).collect(Collectors.toSet());
         shouldBeSupported.remove(DataType.CARTESIAN_POINT);
         shouldBeSupported.remove(DataType.CARTESIAN_SHAPE);
         shouldBeSupported.remove(DataType.NULL);
         shouldBeSupported.remove(DataType.DOC_DATA_TYPE);
         shouldBeSupported.remove(DataType.TSID_DATA_TYPE);
+        if (EsqlCorePlugin.AGGREGATE_METRIC_DOUBLE_FEATURE_FLAG.isEnabled() == false) {
+            shouldBeSupported.remove(DataType.AGGREGATE_METRIC_DOUBLE);
+        }
         for (DataType type : shouldBeSupported) {
             assertTrue(typesAndValues.containsKey(type));
         }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/convert.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/convert.csv-spec
@@ -484,6 +484,7 @@ x:integer            | agg_metric:aggregate_metric_double
 
 convertToAggregateMetricDoubleCastingOperatorFromDouble
 required_capability: suggested_cast
+required_capability: aggregate_metric_double_convert_to
 ROW x = 29384.1256
 | EVAL agg_metric = x::aggregate_metric_double
 ;
@@ -494,6 +495,7 @@ x:double   | agg_metric:aggregate_metric_double
 
 convertToAggregateMetricDoubleCastingOperatorFromInt
 required_capability: suggested_cast
+required_capability: aggregate_metric_double_convert_to
 ROW x = 55555
 | EVAL agg_metric = x::aggregate_metric_double
 ;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverterTests.java
@@ -196,9 +196,12 @@ public class EsqlDataTypeConverterTests extends ESTestCase {
     public void testSuggestedCast() {
         // date
         {
-            assertEquals(DATE_NANOS, DataType.suggestedCast(Set.of(DATETIME, DATE_NANOS)));
+            Set<DataType> typesToTest = new HashSet<>(Set.of(DATETIME, DATE_NANOS));
+            assertEquals(DATE_NANOS, DataType.suggestedCast(typesToTest));
+
             DataType randomType = DataType.values()[random().nextInt(DataType.values().length)];
-            DataType suggested = DataType.suggestedCast(Set.of(DATETIME, DATE_NANOS, randomType));
+            typesToTest.add(randomType);
+            DataType suggested = DataType.suggestedCast(typesToTest);
             if (randomType != DATETIME && randomType != DATE_NANOS) {
                 assertEquals(KEYWORD, suggested);
             } else {
@@ -218,7 +221,10 @@ public class EsqlDataTypeConverterTests extends ESTestCase {
         // unsupported tests
         {
             assertNull(DataType.suggestedCast(Set.of()));
-            assertNull(DataType.suggestedCast(Set.of(UNSUPPORTED, DataType.values()[random().nextInt(DataType.values().length)])));
+            Set<DataType> typesWithUnsupported = new HashSet<>();
+            typesWithUnsupported.add(UNSUPPORTED);
+            typesWithUnsupported.add(DataType.values()[random().nextInt(DataType.values().length)]);
+            assertNull(DataType.suggestedCast(typesWithUnsupported));
         }
     }
 }


### PR DESCRIPTION
There was a bug when trying to generate a Set using Set.of when a
randomly picked DataType is already present in one of the other
arguments, causing an IllegalArgumentException to be thrown

Fixes https://github.com/elastic/elasticsearch/issues/127514, https://github.com/elastic/elasticsearch/issues/127535
