### PR TITLE
Adjust `ForkJoinPool` prefix in `HdfsClientThreadLeakFilter`

### DIFF
--- a/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsClientThreadLeakFilter.java
+++ b/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsClientThreadLeakFilter.java
@@ -35,6 +35,7 @@ public final class HdfsClientThreadLeakFilter implements ThreadFilter {
             || t.getName().startsWith("SSL Certificates Store Monitor") // hadoop 3 brings that in
             || t.getName().startsWith("GcTimeMonitor") // hadoop 3
             || t.getName().startsWith("Command processor") // hadoop 3
-            || t.getName().startsWith("ForkJoinPool"); // hadoop 3
+            || t.getName().startsWith("ForkJoinPool-") // hadoop 3
+            || t.getName().startsWith("ForkJoinPool.commonPool-worker-"); // hadoop 3
     }
 }

--- a/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsClientThreadLeakFilter.java
+++ b/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsClientThreadLeakFilter.java
@@ -35,6 +35,6 @@ public final class HdfsClientThreadLeakFilter implements ThreadFilter {
             || t.getName().startsWith("SSL Certificates Store Monitor") // hadoop 3 brings that in
             || t.getName().startsWith("GcTimeMonitor") // hadoop 3
             || t.getName().startsWith("Command processor") // hadoop 3
-            || t.getName().startsWith("ForkJoinPool."); // hadoop 3
+            || t.getName().startsWith("ForkJoinPool"); // hadoop 3
     }
 }

--- a/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsClientThreadLeakFilter.java
+++ b/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsClientThreadLeakFilter.java
@@ -35,6 +35,6 @@ public final class HdfsClientThreadLeakFilter implements ThreadFilter {
             || t.getName().startsWith("SSL Certificates Store Monitor") // hadoop 3 brings that in
             || t.getName().startsWith("GcTimeMonitor") // hadoop 3
             || t.getName().startsWith("Command processor") // hadoop 3
-            || t.getName().startsWith("ForkJoinPool-"); // hadoop 3
+            || t.getName().startsWith("ForkJoinPool."); // hadoop 3
     }
 }


### PR DESCRIPTION
Adds the `ForkJoinPool.commonPool-worker-` prefix to the Thread `getName().startsWith()` checks in
`HdfsClientThreadLeakFilter` to pick up `.commonPool-worker-N` threads as well.  This resolves the
"There are still zombie threads that couldn't be terminated" errors in the Hdfs IT tests:

```
    com.carrotsearch.randomizedtesting.ThreadLeakError: 4 threads leaked from SUITE scope at org.elasticsearch.repositories.hdfs.HdfsTests: 
       1) Thread[id=53, name=ForkJoinPool.commonPool-worker-1, state=WAITING, group=TGRP-HdfsTests]
            at java.base/jdk.internal.misc.Unsafe.park(Native Method)
            at java.base/java.util.concurrent.ForkJoinPool.awaitWork(ForkJoinPool.java:2143)
            at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2034)
            at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
```

Closes #127290
Closes #127289
Closes #127288
Closes #127287