### PR TITLE
[8.18] Enable FAILURE_STORE feature flag for LogsIndexModeFullClusterRestartIT (#127480)

### DIFF
--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/LogsIndexModeFullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/LogsIndexModeFullClusterRestartIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.RestTestLegacyFeatures;
 import org.hamcrest.Matcher;
@@ -47,7 +48,9 @@ public class LogsIndexModeFullClusterRestartIT extends ParameterizedFullClusterR
             .module("x-pack-aggregate-metric")
             .module("x-pack-stack")
             .setting("xpack.security.enabled", "false")
-            .setting("xpack.license.self_generated.type", "trial");
+            .setting("xpack.license.self_generated.type", "trial")
+            .feature(FeatureFlag.FAILURE_STORE_ENABLED);
+        ;
 
         if (oldVersion.before(Version.fromString("8.18.0"))) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.0` to `8.18`:
 - [Enable FAILURE_STORE feature flag for LogsIndexModeFullClusterRestartIT (#127480)](https://github.com/elastic/elasticsearch/pull/127480)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)