### PR TITLE
[9.0] [DOCS][9.x] Fix tip placement in lookup-join.md (#127552)

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
@@ -41,11 +41,11 @@ added as new columns to that row.
 If multiple documents in the lookup index match a single row in your
 results, the output will contain one row for each matching combination.
 
-**Examples**
-
 ::::{tip}
 In case of name collisions, the newly created columns will override existing columns.
 ::::
+
+**Examples**
 
 **IP Threat correlation**: This query would allow you to see if any source
 IPs match known malicious addresses.


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [DOCS][9.x] Fix tip placement in lookup-join.md (#127552)