### PR TITLE
[DOCS][8.x] Fix dodgy backticks + move tip

### DIFF
--- a/docs/reference/esql/esql-lookup-join.asciidoc
+++ b/docs/reference/esql/esql-lookup-join.asciidoc
@@ -79,7 +79,7 @@ contains multi-valued entries, those entries will not match anything
 image::images/esql/esql-lookup-join.png[align="center"]
 
 If you're familiar with SQL, `LOOKUP JOIN` has left-join behavior. This means that 
-if no rows match in the lookup index, the incoming row is retained and `null`s are added. If many rows in the lookup index match, `LOOKUP JOIN` adds one row per match.
+if no rows match in the lookup index, the incoming row is retained and `null` values are added. If many rows in the lookup index match, `LOOKUP JOIN` adds one row per match.
 
 [discrete]
 [[esql-lookup-join-example]]

--- a/docs/reference/esql/processing-commands/lookup.asciidoc
+++ b/docs/reference/esql/processing-commands/lookup.asciidoc
@@ -48,12 +48,12 @@ added as new columns to that row.
 If multiple documents in the lookup index match a single row in your
 results, the output will contain one row for each matching combination.
 
-*Examples*
-
 [TIP]
 ====
 In case of name collisions, the newly created columns will override existing columns.
 ====
+
+*Examples*
 
 *IP Threat correlation*: This query would allow you to see if any source
 IPs match known malicious addresses.


### PR DESCRIPTION
TIL need to always add a space between the closing backtick and any following punctuation or text in asciidoc

h/t @alex-spies

