### PR TITLE
[8.19] [ML] Use INTERNAL_INGEST for Inference (#127522)

### DIFF
--- a/docs/changelog/127522.yaml
+++ b/docs/changelog/127522.yaml
@@ -1,0 +1,6 @@
+pr: 127522
+summary: Use INTERNAL_INGEST for Inference
+area: Machine Learning
+type: bug
+issues:
+ - 127519

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
@@ -431,7 +431,15 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
                 }
             };
             inferenceProvider.service()
-                .chunkedInfer(inferenceProvider.model(), null, inputs, Map.of(), InputType.INGEST, TimeValue.MAX_VALUE, completionListener);
+                .chunkedInfer(
+                    inferenceProvider.model(),
+                    null,
+                    inputs,
+                    Map.of(),
+                    InputType.INTERNAL_INGEST,
+                    TimeValue.MAX_VALUE,
+                    completionListener
+                );
         }
 
         /**


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ML] Use INTERNAL_INGEST for Inference (#127522)