### PR TITLE
ESQL: Fix test locale

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/StoredFieldsSequentialIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/StoredFieldsSequentialIT.java
@@ -184,7 +184,7 @@ public class StoredFieldsSequentialIT extends ESRestTestCase {
         bulk.addParameter("refresh", "");
         StringBuilder b = new StringBuilder();
         for (int i = 0; i < 1000; i++) {
-            b.append(String.format("""
+            b.append(String.format(Locale.ROOT, """
                 {"create":{"_index":"test"}}
                 {"test":"test%03d", "i": %d}
                 """, i, i));


### PR DESCRIPTION
Was formatting a string and didn't include `Locale.ROOT` so sometimes the string would use the Arabic ٩ instead of 9. And JSON doesn't parse those.

Closes #127562
