### PR TITLE
ESQL: Fix unlikely error in suggested cast tests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverterTests.java
@@ -199,7 +199,7 @@ public class EsqlDataTypeConverterTests extends ESTestCase {
             Set<DataType> typesToTest = new HashSet<>(Set.of(DATETIME, DATE_NANOS));
             assertEquals(DATE_NANOS, DataType.suggestedCast(typesToTest));
 
-            DataType randomType = randomValueOtherThan(UNSUPPORTED, () -> DataType.values()[random().nextInt(DataType.values().length)]);
+            DataType randomType = randomValueOtherThan(UNSUPPORTED, () -> randomFrom(DataType.values()));
             typesToTest.add(randomType);
             DataType suggested = DataType.suggestedCast(typesToTest);
             if (randomType != DATETIME && randomType != DATE_NANOS) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverterTests.java
@@ -199,7 +199,7 @@ public class EsqlDataTypeConverterTests extends ESTestCase {
             Set<DataType> typesToTest = new HashSet<>(Set.of(DATETIME, DATE_NANOS));
             assertEquals(DATE_NANOS, DataType.suggestedCast(typesToTest));
 
-            DataType randomType = DataType.values()[random().nextInt(DataType.values().length)];
+            DataType randomType = randomValueOtherThan(UNSUPPORTED, () -> DataType.values()[random().nextInt(DataType.values().length)]);
             typesToTest.add(randomType);
             DataType suggested = DataType.suggestedCast(typesToTest);
             if (randomType != DATETIME && randomType != DATE_NANOS) {


### PR DESCRIPTION
The suggested casts tests would error out less than one percent of the time because they tried to suggest a cast for `unsupported` and expected `keyword`. That'll always be null.

Caught this in an unrelated PR.
