### PR TITLE
[ES|QL] Fix column info bug in Async Rest Test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -432,9 +432,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/127536
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {union_types.MultiIndexSortIpStringEval ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/127537
 - class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
   method: testRestart {p0=false p1=false}
   issue: https://github.com/elastic/elasticsearch/issues/127592


### PR DESCRIPTION
This commit fixes a bug with the async rest tests where some nodes don't
support reporting original types + suggested cast and some do causing a
mismatch in resulting column info.

Fixes https://github.com/elastic/elasticsearch/issues/127537