### PR TITLE
[8.19] [semantic_text] Warn on inference endpoint not created (#127574)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -303,6 +303,13 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
                      * This will delay the creation of sub-fields, so indexing and querying for this field won't work
                      * until the corresponding inference endpoint is created.
                      */
+                    logger.warn(
+                        "The field [{}] references an unknown inference ID [{}]. "
+                            + "Indexing and querying this field will not work correctly until the corresponding "
+                            + "inference endpoint is created.",
+                        leafName(),
+                        inferenceId.get()
+                    );
                 }
             } else {
                 resolvedModelSettings = modelSettings.get();
@@ -310,14 +317,6 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
             if (modelSettings.get() != null) {
                 validateServiceSettings(modelSettings.get(), resolvedModelSettings);
-            } else {
-                logger.warn(
-                    "The field [{}] references an unknown inference ID [{}]. "
-                        + "Indexing and querying this field will not work correctly until the corresponding "
-                        + "inference endpoint is created.",
-                    leafName(),
-                    inferenceId.get()
-                );
             }
 
             final String fullName = context.buildFullName(leafName());


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [semantic_text] Warn on inference endpoint not created (#127574)