### PR TITLE
[8.17] Mark semantic text inference_id param as optional (#127587)

### DIFF
--- a/docs/reference/mapping/types/semantic-text.asciidoc
+++ b/docs/reference/mapping/types/semantic-text.asciidoc
@@ -81,7 +81,7 @@ PUT my-index-000003
 ==== Parameters for `semantic_text` fields
 
 `inference_id`::
-(Required, string)
+(Optional, string)
 {infer-cap} endpoint that will be used to generate embeddings for the field.
 By default, `.elser-2-elasticsearch` is used.
 This parameter cannot be updated.


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Mark semantic text inference_id param as optional (#127587)