### PR TITLE
[ML] Fixing EIS authorization description strings

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandler.java
@@ -24,7 +24,6 @@ import org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferen
 import org.elasticsearch.xpack.inference.services.elastic.response.ElasticInferenceServiceAuthorizationResponseEntity;
 import org.elasticsearch.xpack.inference.telemetry.TraceContext;
 
-import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +43,7 @@ public class ElasticInferenceServiceAuthorizationRequestHandler {
 
     private static ResponseHandler createAuthResponseHandler() {
         return new ElasticInferenceServiceResponseHandler(
-            String.format(Locale.ROOT, "%s sparse embeddings", ELASTIC_INFERENCE_SERVICE_IDENTIFIER),
+            Strings.format("%s authorization", ELASTIC_INFERENCE_SERVICE_IDENTIFIER),
             ElasticInferenceServiceAuthorizationResponseEntity::fromResponse
         );
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceAuthorizationRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceAuthorizationRequest.java
@@ -63,7 +63,7 @@ public class ElasticInferenceServiceAuthorizationRequest extends ElasticInferenc
     @Override
     public String getInferenceEntityId() {
         // TODO look into refactoring so we don't even need to return this, look at the RetryingHttpSender to fix this
-        return "";
+        return "authorization_request";
     }
 
     @Override


### PR DESCRIPTION
This PR fixes the description strings for the authorization request when it fails and we log a message.

The logged messages will look something like this now

`inference entity id [authorization_request] of type [Elastic Inference Service authorization]`

```
[2025-05-01T14:11:59,172][WARN ][o.e.x.i.s.e.a.ElasticInferenceServiceAuthorizationRequestHandler] [runTask-0] Failed while sending request from inference entity id [authorization_request] of type [Elastic Inference Service authorization] java.net.ConnectException: Connection refused
        at java.base/sun.nio.ch.Net.pollConnect(Native Method)
        at java.base/sun.nio.ch.Net.pollConnectNow(Net.java:628)
        at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:1046)
        at org.apache.httpcomponents.httpcore.nio@4.4.16/org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor.processEvent(DefaultConnectingIOReactor.java:174)
        at org.apache.httpcomponents.httpcore.nio@4.4.16/org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor.processEvents(DefaultConnectingIOReactor.java:148)
        at org.apache.httpcomponents.httpcore.nio@4.4.16/org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor.execute(AbstractMultiworkerIOReactor.java:351)
        at org.apache.httpcomponents.httpasyncclient@4.1.5/org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager.execute(PoolingNHttpClientConnectionManager.java:221)
        at org.apache.httpcomponents.httpasyncclient@4.1.5/org.apache.http.impl.nio.client.CloseableHttpAsyncClientBase$1.run(CloseableHttpAsyncClientBase.java:64)
        at java.base/java.lang.Thread.run(Thread.java:1447)
```