### PR TITLE
[8.19] Address review feedback on fips docker image (#126330)

### DIFF
--- a/.ci/scripts/packaging-test.sh
+++ b/.ci/scripts/packaging-test.sh
@@ -3,7 +3,7 @@
 # opensuse 15 has a missing dep for systemd
 
 if which zypper > /dev/null ; then
-    sudo zypper install -y insserv-compat
+    sudo zypper install -y insserv-compat docker-buildx
 fi
 
 if [ -e /etc/sysctl.d/99-gce.conf ]; then

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
@@ -13,10 +13,10 @@ package org.elasticsearch.gradle.internal;
  * This class models the different Docker base images that are used to build Docker distributions of Elasticsearch.
  */
 public enum DockerBase {
-    DEFAULT("ubuntu:20.04", "", "apt-get"),
+    DEFAULT("ubuntu:20.04", "", "apt-get", "Dockerfile"),
 
     // "latest" here is intentional, since the image name specifies "8"
-    UBI("docker.elastic.co/ubi8/ubi-minimal:latest", "-ubi8", "microdnf"),
+    UBI("docker.elastic.co/ubi8/ubi-minimal:latest", "-ubi8", "microdnf", "Dockerfile"),
 
     // The Iron Bank base image is UBI (albeit hardened), but we are required to parameterize the Docker build
     IRON_BANK("${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}", "-ironbank", "yum", "Dockerfile"),
@@ -34,11 +34,13 @@ public enum DockerBase {
 
     // Based on WOLFI above, with more extras. We don't set a base image because
     // we programmatically extend from the wolfi image.
-    CLOUD_ESS(null, "-cloud-ess", "apk"),
+    CLOUD_ESS(null, "-cloud-ess", "apk", "Dockerfile.ess"),
+
     CLOUD_ESS_FIPS(
         "docker.elastic.co/wolfi/chainguard-base-fips:sha256-ebfc3f1d7dba992231747a2e05ad1b859843e81b5e676ad342859d7cf9e425a7",
         "-cloud-ess-fips",
-        "apk"
+        "apk",
+        "Dockerfile.ess-fips"
     );
 
     private final String image;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
@@ -19,7 +19,7 @@ public enum DockerBase {
     UBI("docker.elastic.co/ubi8/ubi-minimal:latest", "-ubi8", "microdnf"),
 
     // The Iron Bank base image is UBI (albeit hardened), but we are required to parameterize the Docker build
-    IRON_BANK("${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}", "-ironbank", "yum"),
+    IRON_BANK("${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}", "-ironbank", "yum", "Dockerfile"),
 
     // Chainguard based wolfi image with latest jdk
     // This is usually updated via renovatebot
@@ -27,7 +27,8 @@ public enum DockerBase {
     WOLFI(
         "docker.elastic.co/wolfi/chainguard-base:latest@sha256:1c7f5aa0e7997455b8500d095c7a90e617102d3941eb0757ac62cfea509e09b9",
         "-wolfi",
-        "apk"
+        "apk",
+        "Dockerfile"
     ),
     // spotless:on
 
@@ -43,15 +44,17 @@ public enum DockerBase {
     private final String image;
     private final String suffix;
     private final String packageManager;
+    private final String dockerfile;
 
     DockerBase(String image, String suffix) {
-        this(image, suffix, "apt-get");
+        this(image, suffix, "apt-get", "dockerfile");
     }
 
-    DockerBase(String image, String suffix, String packageManager) {
+    DockerBase(String image, String suffix, String packageManager, String dockerfile) {
         this.image = image;
         this.suffix = suffix;
         this.packageManager = packageManager;
+        this.dockerfile = dockerfile;
     }
 
     public String getImage() {
@@ -64,5 +67,9 @@ public enum DockerBase {
 
     public String getPackageManager() {
         return packageManager;
+    }
+
+    public String getDockerfile() {
+        return dockerfile;
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerBuildTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerBuildTask.java
@@ -170,6 +170,7 @@ public abstract class DockerBuildTask extends DefaultTask {
                         maybeConfigureDockerConfig(spec);
                         spec.executable("docker");
                         spec.args("pull");
+                        spec.environment("DOCKER_BUILDKIT", "1");
                         spec.args(baseImage);
                     });
 
@@ -205,7 +206,7 @@ public abstract class DockerBuildTask extends DefaultTask {
                 maybeConfigureDockerConfig(spec);
 
                 spec.executable("docker");
-
+                spec.environment("DOCKER_BUILDKIT", "1");
                 if (isCrossPlatform) {
                     spec.args("buildx");
                 }

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -201,9 +201,10 @@ ext.dockerBuildContext = { Architecture architecture, DockerBase base ->
         from projectDir.resolve("src/docker/config")
       }
     }
-    from(projectDir.resolve("src/docker/Dockerfile")) {
+    from(projectDir.resolve("src/docker/${base.dockerfile}")) {
       expand(varExpansions)
       filter SquashNewlinesFilter
+      rename base.dockerfile, "Dockerfile"
     }
   }
 }
@@ -360,14 +361,24 @@ void addTransformDockerContextTask(Architecture architecture, DockerBase base) {
     String distributionFolderName = "elasticsearch-${VersionProperties.elasticsearch}"
 
     from(tarTree("${project.buildDir}/distributions/${archiveName}.tar.gz")) {
-
-      if (base != DockerBase.IRON_BANK) {
+      if (base != DockerBase.IRON_BANK && base != DockerBase.DEFAULT) {
         // iron bank always needs a COPY with the tarball file path
         eachFile { FileCopyDetails details ->
           if (details.name.equals("Dockerfile")) {
             filter { String contents ->
               return contents.replaceAll('^RUN curl.*artifacts-no-kpi.*$', "COPY $distributionFolderName .")
                 .replaceAll('^RUN tar -zxf /tmp/elasticsearch.tar.gz --strip-components=1$', "")
+            }
+          }
+        }
+      }
+      if (base == DockerBase.DEFAULT) {
+        // iron bank always needs a COPY with the tarball file path
+        eachFile { FileCopyDetails details ->
+          if (details.name.equals("Dockerfile")) {
+            filter { String contents ->
+              return contents.replaceAll('^RUN *.*artifacts-no-kpi.*$', "COPY $distributionFolderName .")
+                .replaceAll('^RUN tar -zxf /tmp/elasticsearch.tar.gz --strip-components=1 &&', "RUN ")
             }
           }
         }

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -361,24 +361,14 @@ void addTransformDockerContextTask(Architecture architecture, DockerBase base) {
     String distributionFolderName = "elasticsearch-${VersionProperties.elasticsearch}"
 
     from(tarTree("${project.buildDir}/distributions/${archiveName}.tar.gz")) {
-      if (base != DockerBase.IRON_BANK && base != DockerBase.DEFAULT) {
+
+      if (base != DockerBase.IRON_BANK) {
         // iron bank always needs a COPY with the tarball file path
         eachFile { FileCopyDetails details ->
           if (details.name.equals("Dockerfile")) {
             filter { String contents ->
               return contents.replaceAll('^RUN curl.*artifacts-no-kpi.*$', "COPY $distributionFolderName .")
                 .replaceAll('^RUN tar -zxf /tmp/elasticsearch.tar.gz --strip-components=1$', "")
-            }
-          }
-        }
-      }
-      if (base == DockerBase.DEFAULT) {
-        // iron bank always needs a COPY with the tarball file path
-        eachFile { FileCopyDetails details ->
-          if (details.name.equals("Dockerfile")) {
-            filter { String contents ->
-              return contents.replaceAll('^RUN *.*artifacts-no-kpi.*$', "COPY $distributionFolderName .")
-                .replaceAll('^RUN tar -zxf /tmp/elasticsearch.tar.gz --strip-components=1 &&', "RUN ")
             }
           }
         }

--- a/distribution/docker/src/docker/Dockerfile.ess-fips
+++ b/distribution/docker/src/docker/Dockerfile.ess-fips
@@ -19,12 +19,6 @@
   add as many newlines here as necessary to improve legibility.
 */ %>
 
-<% if (docker_base == 'iron_bank') { %>
-ARG BASE_REGISTRY=registry1.dso.mil
-ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
-ARG BASE_TAG=9.5
-<% } %>
-
 ################################################################################
 # Build stage 1 `builder`:
 # Extract Elasticsearch artifact
@@ -32,64 +26,17 @@ ARG BASE_TAG=9.5
 
 FROM ${base_image} AS builder
 
-<% if (docker_base == 'iron_bank') { %>
-# `tini` is a tiny but valid init for containers. This is used to cleanly
-# control how ES and any child processes are shut down.
-COPY tini /bin/tini
-RUN chmod 0555 /bin/tini
-
-<% } else { %>
-
 # Install required packages to extract the Elasticsearch distribution
-<% if (docker_base == 'default') { %>
-RUN <%= retry.loop(package_manager, "${package_manager} update && DEBIAN_FRONTEND=noninteractive ${package_manager} install -y curl ") %>
-<% } else if (docker_base == "wolfi") { %>
 RUN <%= retry.loop(package_manager, "export DEBIAN_FRONTEND=noninteractive && ${package_manager} update && ${package_manager} update && ${package_manager} add --no-cache curl") %>
-<% } else { %>
-RUN <%= retry.loop(package_manager, "${package_manager} install -y findutils tar gzip") %>
-<% } %>
-
-<% if (docker_base != 'wolfi') { %>
-    # `tini` is a tiny but valid init for containers. This is used to cleanly
-    # control how ES and any child processes are shut down.
-    # For wolfi we pick it from the blessed wolfi package registry.
-    #
-    # The tini GitHub page gives instructions for verifying the binary using
-    # gpg, but the keyservers are slow to return the key and this can fail the
-    # build. Instead, we check the binary against the published checksum.
-    RUN set -eux ; \\
-        tini_bin="" ; \\
-        case "\$(arch)" in \\
-            aarch64) tini_bin='tini-arm64' ;; \\
-            x86_64)  tini_bin='tini-amd64' ;; \\
-            *) echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ;; \\
-        esac ; \\
-        curl --retry 10 -S -L -O https://github.com/krallin/tini/releases/download/v0.19.0/\${tini_bin} ; \\
-        curl --retry 10 -S -L -O https://github.com/krallin/tini/releases/download/v0.19.0/\${tini_bin}.sha256sum ; \\
-        sha256sum -c \${tini_bin}.sha256sum ; \\
-        rm \${tini_bin}.sha256sum ; \\
-        mv \${tini_bin} /bin/tini ; \\
-        chmod 0555 /bin/tini
-<% } %>
-
-<% } %>
 
 RUN mkdir /usr/share/elasticsearch
 WORKDIR /usr/share/elasticsearch
 
-<% if (docker_base == "iron_bank") {
-  // Iron Bank always copies the local artifact. It uses `arch` from the
-  // template context variables.
-%>
-COPY elasticsearch-${version}-linux-${arch}.tar.gz /tmp/elasticsearch.tar.gz
-<% } else {
-  // Fetch the appropriate Elasticsearch distribution for this architecture.
-  // Keep this command on one line - it is replaced with a `COPY` during local builds.
-  // It uses the `arch` shell command to fetch the correct distro for the build machine,
-  // which is needed for Docker Hub builds.
-%>
+# Fetch the appropriate Elasticsearch distribution for this architecture.
+# Keep this command on one line - it is replaced with a `COPY` during local builds.
+# It uses the `arch` shell command to fetch the correct distro for the build machine,
+# which is needed for Docker Hub builds.
 RUN curl --retry 10 -S -L --output /tmp/elasticsearch.tar.gz https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/elasticsearch-${version}-linux-\$(arch).tar.gz
-<% } %>
 
 RUN tar -zxf /tmp/elasticsearch.tar.gz --strip-components=1
 
@@ -117,6 +64,46 @@ RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' bin/elas
     chmod 0775 bin config config/jvm.options.d data logs plugins && \\
     find config -type f -exec chmod 0664 {} +
 
+# Add plugins infrastructure
+RUN mkdir -p /opt/plugins/archive
+RUN chmod -R 0555 /opt/plugins
+
+RUN mkdir -p /fips/libs
+COPY fips/libs/*.jar /fips/libs/
+
+COPY filebeat-${version}.tar.gz metricbeat-${version}.tar.gz /tmp/
+RUN set -eux ; \\
+    for beat in filebeat metricbeat ; do \\
+      if [ ! -s /tmp/\$beat-${version}.tar.gz ]; then \\
+        echo "/tmp/\$beat-${version}.tar.gz is empty - cannot uncompress" 2>&1 ; \\
+        exit 1 ; \\
+      fi ; \\
+      if ! tar tf /tmp/\$beat-${version}.tar.gz >/dev/null; then \\
+        echo "/tmp/\$beat-${version}.tar.gz is corrupt - cannot uncompress" 2>&1 ; \\
+        exit 1 ; \\
+      fi ; \\
+      mkdir -p /opt/\$beat ; \\
+      tar xf /tmp/\$beat-${version}.tar.gz -C /opt/\$beat --strip-components=1 ; \\
+    done
+
+COPY plugins/*.zip /opt/plugins/archive/
+
+RUN chown 1000:1000 /opt/plugins/archive/*
+RUN chmod 0444 /opt/plugins/archive/*
+
+COPY fips/resources/fips_java.security /usr/share/elasticsearch/config/fips_java.security
+COPY fips/resources/fips_java.policy /usr/share/elasticsearch/config/fips_java.policy
+
+WORKDIR /usr/share/elasticsearch/config
+
+## Add fips specific JVM options
+RUN cat <<EOF > /usr/share/elasticsearch/config/jvm.options.d/fips.options
+-Djavax.net.ssl.keyStoreType=BCFKS
+-Dorg.bouncycastle.fips.approved_only=true
+-Djava.security.properties=config/fips_java.security
+-Djava.security.policy=config/fips_java.policy
+EOF
+
 
 ################################################################################
 # Build stage 2 (the actual Elasticsearch image):
@@ -127,17 +114,6 @@ RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' bin/elas
 
 FROM ${base_image}
 
-<% if (docker_base == "iron_bank") { %>
-<%
-/* Reviews of the Iron Bank Dockerfile said that they preferred simpler */
-/* scripting so this version doesn't have the retry loop featured below. */
-%>
-RUN ${package_manager} update --setopt=tsflags=nodocs -y && \\
-    ${package_manager} install --setopt=tsflags=nodocs -y \\
-      nc shadow-utils zip findutils unzip procps-ng && \\
-    ${package_manager} clean all
-
-<% } else if (docker_base == "wolfi") { %>
 RUN <%= retry.loop(package_manager,
           "export DEBIAN_FRONTEND=noninteractive && \n" +
           "      ${package_manager} update && \n" +
@@ -150,68 +126,18 @@ RUN <%= retry.loop(package_manager,
 # Set Bash as the default shell for future commands
 SHELL ["/bin/bash", "-c"]
 
-# Optionally set Bash as the default shell in the container at runtime
-CMD ["/bin/bash"]
-
-<% } else if (docker_base == "default" || docker_base == "cloud") { %>
-
-# Change default shell to bash, then install required packages with retries.
-RUN yes no | dpkg-reconfigure dash && \\
-    <%= retry.loop(
-    package_manager,
-      "export DEBIAN_FRONTEND=noninteractive && \n" +
-      "      ${package_manager} update && \n" +
-      "      ${package_manager} upgrade -y && \n" +
-      "      ${package_manager} install -y --no-install-recommends \n" +
-      "        ca-certificates curl netcat p11-kit unzip zip ${docker_base == 'cloud' ? 'wget' : '' } && \n" +
-      "      ${package_manager} clean && \n" +
-      "      rm -rf /var/lib/apt/lists/*"
-  ) %>
-
-<% } else { %>
-
-RUN <%= retry.loop(
-    package_manager,
-      "${package_manager} update --setopt=tsflags=nodocs -y && \n" +
-      "      ${package_manager} install --setopt=tsflags=nodocs -y \n" +
-      "        nc shadow-utils zip unzip findutils procps-ng && \n" +
-      "      ${package_manager} clean all"
-    ) %>
-
-<% } %>
-
-
-<% if (docker_base == "default") { %>
-RUN groupadd -g 1000 elasticsearch && \\
-    adduser --uid 1000 --gid 1000 --home /usr/share/elasticsearch elasticsearch && \\
-    adduser elasticsearch root && \\
-    chown -R 0:0 /usr/share/elasticsearch
-<% } else if (docker_base == "wolfi") { %>
 RUN groupadd -g 1000 elasticsearch && \
     adduser -G elasticsearch -u 1000 elasticsearch -D --home /usr/share/elasticsearch elasticsearch && \
     adduser elasticsearch root && \
     chown -R 0:0 /usr/share/elasticsearch
-<% } else { %>
-RUN groupadd -g 1000 elasticsearch && \\
-    adduser -u 1000 -g 1000 -G 0 -d /usr/share/elasticsearch elasticsearch && \\
-    chown -R 0:0 /usr/share/elasticsearch
-<% } %>
 
-ENV ELASTIC_CONTAINER true
+ENV ELASTIC_CONTAINER=true
 
 WORKDIR /usr/share/elasticsearch
 
 COPY --from=builder --chown=0:0 /usr/share/elasticsearch /usr/share/elasticsearch
-<% if (docker_base != "wolfi") { %>
-COPY --from=builder --chown=0:0 /bin/tini /bin/tini
-<% } %>
-
-<% if (docker_base == 'cloud') { %>
-COPY --from=builder --chown=0:0 /opt /opt
-<% } %>
-
-ENV PATH /usr/share/elasticsearch/bin:\$PATH
-ENV SHELL /bin/bash
+ENV PATH=/usr/share/elasticsearch/bin:\$PATH
+ENV SHELL=/bin/bash
 COPY ${bin_dir}/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # 1. Sync the user and group permissions of /etc/passwd
@@ -231,20 +157,10 @@ RUN chmod g=u /etc/passwd && \\
     chmod 0775 /usr/share/elasticsearch && \\
     chown elasticsearch bin config config/jvm.options.d data logs plugins
 
-<% if (docker_base == 'default') { %>
-# Update "cacerts" bundle to use Ubuntu's CA certificates (and make sure it
-# stays up-to-date with changes to Ubuntu's store)
-COPY bin/docker-openjdk /etc/ca-certificates/update.d/docker-openjdk
-RUN /etc/ca-certificates/update.d/docker-openjdk
-<% } else if (docker_base == 'wolfi') { %>
 RUN ln -sf /etc/ssl/certs/java/cacerts /usr/share/elasticsearch/jdk/lib/security/cacerts
-<% } else { %>
-RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /usr/share/elasticsearch/jdk/lib/security/cacerts
-<% } %>
 
 EXPOSE 9200 9300
 
-<% if (docker_base != 'iron_bank') { %>
 LABEL org.label-schema.build-date="${build_date}" \\
   org.label-schema.license="${license}" \\
   org.label-schema.name="Elasticsearch" \\
@@ -264,9 +180,7 @@ LABEL org.label-schema.build-date="${build_date}" \\
   org.opencontainers.image.url="https://www.elastic.co/products/elasticsearch" \\
   org.opencontainers.image.vendor="Elastic" \\
   org.opencontainers.image.version="${version}"
-<% } %>
 
-<% if (docker_base == 'ubi') { %>
 LABEL name="Elasticsearch" \\
   maintainer="infra@elastic.co" \\
   vendor="Elastic" \\
@@ -274,34 +188,19 @@ LABEL name="Elasticsearch" \\
   release="1" \\
   summary="Elasticsearch" \\
   description="You know, for search."
-<% } %>
 
-<% if (docker_base == 'ubi') { %>
-RUN mkdir /licenses && cp LICENSE.txt /licenses/LICENSE
-<% } else if (docker_base == 'iron_bank') { %>
-RUN mkdir /licenses && cp LICENSE.txt /licenses/LICENSE
-COPY LICENSE /licenses/LICENSE.addendum
-<% } %>
+RUN mkdir /licenses && ln LICENSE.txt /licenses/LICENSE
 
-<% if (docker_base == "wolfi") { %>
-# Our actual entrypoint is `tini`, a minimal but functional init program. It
-# calls the entrypoint we provide, while correctly forwarding signals.
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
-# Dummy overridable parameter parsed by entrypoint
-CMD ["eswrapper"]
-<% } else { %>
-# Our actual entrypoint is `tini`, a minimal but functional init program. It
-# calls the entrypoint we provide, while correctly forwarding signals.
-ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
-# Dummy overridable parameter parsed by entrypoint
-CMD ["eswrapper"]
-<% } %>
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/app/elasticsearch.sh"]
 
 USER 1000:0
 
-<% if (docker_base == 'iron_bank') { %>
-HEALTHCHECK --interval=10s --timeout=5s --start-period=1m --retries=5 CMD curl -I -f --max-time 5 http://localhost:9200 || exit 1
-<% } %>
+COPY --from=builder --chown=0:0 /opt /opt
+ENV ES_PLUGIN_ARCHIVE_DIR=/opt/plugins/archive
+WORKDIR /usr/share/elasticsearch
+COPY --from=builder --chown=0:0 /fips/libs/*.jar /usr/share/elasticsearch/lib/
+
 ################################################################################
 # End of multi-stage Dockerfile
 ################################################################################


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Address review feedback on es default docker image (#126330)](https://github.com/elastic/elasticsearch/pull/126330)
 - [Adjust docker fips entrypoint and cmd (#127630)](https://github.com/elastic/elasticsearch/pull/127630)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)