### PR TITLE
[8.19] Fix assertion in DiskThresholdDeciderIT (#127615)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -455,9 +455,6 @@ tests:
 - class: org.elasticsearch.search.SearchServiceSingleNodeTests
   method: testLookUpSearchContext
   issue: https://github.com/elastic/elasticsearch/issues/126813
-- class: org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDeciderIT
-  method: testRestoreSnapshotAllocationDoesNotExceedWatermarkWithMultipleRestores
-  issue: https://github.com/elastic/elasticsearch/issues/127286
 - class: org.elasticsearch.test.index.IndexVersionUtilsTests
   method: testIndexCompatibleVersionMatches
   issue: https://github.com/elastic/elasticsearch/issues/120760

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -56,7 +56,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -242,7 +241,7 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
                 clusterAdmin().prepareRestoreSnapshot(TEST_REQUEST_TIMEOUT, "repo", "snap")
                     .setWaitForCompletion(true)
                     .setRenamePattern(indexName)
-                    .setRenameReplacement(indexName + "-copy")
+                    .setRenameReplacement(copyIndexName)
                     .execute(ActionTestUtils.assertNoFailureListener(restoreSnapshotResponse -> {
                         final RestoreInfo restoreInfo = restoreSnapshotResponse.getRestoreInfo();
                         assertThat(restoreInfo.successfulShards(), is(snapshotInfo.totalShards()));
@@ -268,10 +267,19 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
 
         // wait for all the shards to finish moving
         safeAwait(allShardsActiveListener);
-        ensureGreen(indexName, indexName + "-copy");
+        ensureGreen(indexName, copyIndexName);
 
         final var tinyNodeShardIds = getShardIds(dataNodeId, indexName);
-        assertThat(tinyNodeShardIds, hasSize(1));
+        final var tinyNodeShardIdsCopy = getShardIds(dataNodeId, copyIndexName);
+        assertThat(
+            "expected just one shard from one index on the tiny node, instead got "
+                + tinyNodeShardIds
+                + " from the original index and "
+                + tinyNodeShardIdsCopy
+                + " from the copy",
+            tinyNodeShardIds.size() + tinyNodeShardIdsCopy.size(),
+            is(1)
+        );
         assertThat(tinyNodeShardIds.iterator().next(), in(shardSizes.getShardIdsWithSizeSmallerOrEqual(usableSpace)));
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix assertion in DiskThresholdDeciderIT (#127615)](https://github.com/elastic/elasticsearch/pull/127615)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)