### PR TITLE
ESQL: Fix transport versions

### DIFF
--- a/docs/changelog/127668.yaml
+++ b/docs/changelog/127668.yaml
@@ -1,6 +1,6 @@
 pr: 127668
 summary: Fix transport versions
-area: "ES|QL, Data streams, Relevance"
+area: "ES|QL"
 type: bug
 issues:
  - 127667

--- a/docs/changelog/127668.yaml
+++ b/docs/changelog/127668.yaml
@@ -1,0 +1,6 @@
+pr: 127668
+summary: Fix transport versions
+area: "ES|QL, Data streams, Relevance"
+type: bug
+issues:
+ - 127667

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -164,7 +164,8 @@ public class TransportVersions {
     public static final TransportVersion SEARCH_INCREMENTAL_TOP_DOCS_NULL_BACKPORT_8_19 = def(8_841_0_20);
     public static final TransportVersion ML_INFERENCE_SAGEMAKER_8_19 = def(8_841_0_21);
     public static final TransportVersion ESQL_REPORT_ORIGINAL_TYPES_BACKPORT_8_19 = def(8_841_0_22);
-    public static final TransportVersion INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19 = def(8_841_0_23);
+    public static final TransportVersion PINNED_RETRIEVER_8_19 = def(8_841_0_23);
+    public static final TransportVersion ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK_8_19 = def(8_841_0_24);
     public static final TransportVersion V_9_0_0 = def(9_000_0_09);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0_1 = def(9_000_0_10);
     public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED = def(9_001_0_00);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStore.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStore.java
@@ -75,9 +75,8 @@ public record DataStreamFailureStore(@Nullable Boolean enabled, @Nullable DataSt
         this(
             in.readOptionalBoolean(),
             in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
-                    ? in.readOptionalWriteable(DataStreamLifecycle::new)
-                    : null
+                ? in.readOptionalWriteable(DataStreamLifecycle::new)
+                : null
         );
     }
 
@@ -88,8 +87,7 @@ public record DataStreamFailureStore(@Nullable Boolean enabled, @Nullable DataSt
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalBoolean(enabled);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-            || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
             out.writeOptionalWriteable(lifecycle);
         }
     }
@@ -169,8 +167,7 @@ public record DataStreamFailureStore(@Nullable Boolean enabled, @Nullable DataSt
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             ResettableValue.write(out, enabled, StreamOutput::writeBoolean);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
                 ResettableValue.write(out, lifecycle, (o, v) -> v.writeTo(o));
             }
         }
@@ -178,8 +175,7 @@ public record DataStreamFailureStore(@Nullable Boolean enabled, @Nullable DataSt
         public static Template read(StreamInput in) throws IOException {
             ResettableValue<Boolean> enabled = ResettableValue.read(in, StreamInput::readBoolean);
             ResettableValue<DataStreamLifecycle.Template> lifecycle = ResettableValue.undefined();
-            if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
+            if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
                 lifecycle = ResettableValue.read(in, DataStreamLifecycle.Template::read);
             }
             return new Template(enabled, lifecycle);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -341,8 +341,7 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
             }
             out.writeBoolean(enabled());
         }
-        if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-            || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
             lifecycleType.writeTo(out);
         }
     }
@@ -371,9 +370,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
             enabled = true;
         }
         lifecycleType = in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-            || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
-                ? LifecycleType.read(in)
-                : LifecycleType.DATA;
+            ? LifecycleType.read(in)
+            : LifecycleType.DATA;
     }
 
     /**
@@ -735,8 +733,7 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
                 }
                 out.writeBoolean(enabled);
             }
-            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
                 lifecycleType.writeTo(out);
             }
         }
@@ -799,9 +796,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
                 enabled = in.readBoolean();
             }
             var lifecycleTarget = in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
-                    ? LifecycleType.read(in)
-                    : LifecycleType.DATA;
+                ? LifecycleType.read(in)
+                : LifecycleType.DATA;
             return new Template(lifecycleTarget, enabled, dataRetention, downsampling);
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamOptions.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamOptions.java
@@ -74,7 +74,6 @@ public record DataStreamOptions(@Nullable DataStreamFailureStore failureStore)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-            || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
             || failureStore == null
             || failureStore().enabled() != null) {
             out.writeOptionalWriteable(failureStore);
@@ -140,7 +139,6 @@ public record DataStreamOptions(@Nullable DataStreamFailureStore failureStore)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
                 || failureStore.get() == null
                 || failureStore().mapAndGet(DataStreamFailureStore.Template::enabled).get() != null) {
                 ResettableValue.write(out, failureStore, (o, v) -> v.writeTo(o));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/DataStreamFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/DataStreamFeatureSetUsage.java
@@ -134,26 +134,17 @@ public class DataStreamFeatureSetUsage extends XPackFeatureUsage {
                 in.getTransportVersion().onOrAfter(TransportVersions.V_8_15_0) ? in.readVLong() : 0,
                 in.getTransportVersion().onOrAfter(TransportVersions.FAILURE_STORE_ENABLED_BY_CLUSTER_SETTING) ? in.readVLong() : 0,
                 in.getTransportVersion().onOrAfter(TransportVersions.V_8_15_0) ? in.readVLong() : 0,
+                in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE) ? in.readVLong() : 0,
+                in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE) ? in.readVLong() : 0,
                 in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
-                        ? in.readVLong()
-                        : 0,
+                    ? DataStreamLifecycleFeatureSetUsage.RetentionStats.read(in)
+                    : DataStreamLifecycleFeatureSetUsage.RetentionStats.NO_DATA,
                 in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
-                        ? in.readVLong()
-                        : 0,
+                    ? DataStreamLifecycleFeatureSetUsage.RetentionStats.read(in)
+                    : DataStreamLifecycleFeatureSetUsage.RetentionStats.NO_DATA,
                 in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
-                        ? DataStreamLifecycleFeatureSetUsage.RetentionStats.read(in)
-                        : DataStreamLifecycleFeatureSetUsage.RetentionStats.NO_DATA,
-                in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
-                        ? DataStreamLifecycleFeatureSetUsage.RetentionStats.read(in)
-                        : DataStreamLifecycleFeatureSetUsage.RetentionStats.NO_DATA,
-                in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
-                        ? in.readMap(DataStreamLifecycleFeatureSetUsage.GlobalRetentionStats::new)
-                        : Map.of()
+                    ? in.readMap(DataStreamLifecycleFeatureSetUsage.GlobalRetentionStats::new)
+                    : Map.of()
             );
         }
 
@@ -168,8 +159,7 @@ public class DataStreamFeatureSetUsage extends XPackFeatureUsage {
                 }
                 out.writeVLong(this.failureStoreIndicesCount);
             }
-            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
                 out.writeVLong(failuresLifecycleExplicitlyEnabledCount);
                 out.writeVLong(failuresLifecycleEffectivelyEnabledCount);
                 failuresLifecycleDataRetentionStats.writeTo(out);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -344,9 +345,8 @@ public interface Block extends Accountable, BlockLoader.Block, Writeable, RefCou
      * This should be paired with {@link #readTypedBlock(BlockStreamInput)}
      */
     static void writeTypedBlock(Block block, StreamOutput out) throws IOException {
-        if (out.getTransportVersion().before(TransportVersions.AGGREGATE_METRIC_DOUBLE_BLOCK)
-            && block instanceof AggregateMetricDoubleBlock aggregateMetricDoubleBlock) {
-            block = aggregateMetricDoubleBlock.asCompositeBlock();
+        if (false == supportsAggregateMetricDoubleBlock(out.getTransportVersion()) && block instanceof AggregateMetricDoubleBlock a) {
+            block = a.asCompositeBlock();
         }
         block.elementType().writeTo(out);
         block.writeTo(out);
@@ -359,11 +359,15 @@ public interface Block extends Accountable, BlockLoader.Block, Writeable, RefCou
     static Block readTypedBlock(BlockStreamInput in) throws IOException {
         ElementType elementType = ElementType.readFrom(in);
         Block block = elementType.reader.readBlock(in);
-        if (in.getTransportVersion().before(TransportVersions.AGGREGATE_METRIC_DOUBLE_BLOCK)
-            && block instanceof CompositeBlock compositeBlock) {
+        if (false == supportsAggregateMetricDoubleBlock(in.getTransportVersion()) && block instanceof CompositeBlock compositeBlock) {
             block = AggregateMetricDoubleBlock.fromCompositeBlock(compositeBlock);
         }
         return block;
+    }
+
+    static boolean supportsAggregateMetricDoubleBlock(TransportVersion version) {
+        return version.after(TransportVersions.AGGREGATE_METRIC_DOUBLE_BLOCK)
+            || version.isPatchFrom(TransportVersions.ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK_8_19);
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -366,7 +366,7 @@ public interface Block extends Accountable, BlockLoader.Block, Writeable, RefCou
     }
 
     static boolean supportsAggregateMetricDoubleBlock(TransportVersion version) {
-        return version.after(TransportVersions.AGGREGATE_METRIC_DOUBLE_BLOCK)
+        return version.onOrAfter(TransportVersions.AGGREGATE_METRIC_DOUBLE_BLOCK)
             || version.isPatchFrom(TransportVersions.ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK_8_19);
     }
 

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/retriever/PinnedRankDoc.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/retriever/PinnedRankDoc.java
@@ -76,6 +76,11 @@ public class PinnedRankDoc extends RankDoc {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.PINNED_RETRIEVER;
+        throw new IllegalStateException("not used");
+    }
+
+    @Override
+    public boolean supportsVersion(TransportVersion version) {
+        return version.onOrAfter(TransportVersions.PINNED_RETRIEVER) || version.isPatchFrom(TransportVersions.PINNED_RETRIEVER_8_19);
     }
 }


### PR DESCRIPTION
In #127623 we backported #127299 and added a backport transport version for it - `ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK_8_19` aka `8_841_0_24`. This brings that version forwards to `main` and adds support for parsing streams with that version.

In #127639 we backported #126401 and added a backport transport version for it - `PINNED_RETRIEVER_8_19` aka `8_841_0_23`. This brings that version forwards to `main` and adds support for parsing streams with that versions.

In #127633 we a claimed a backport transport version to backport #127314 - `INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19` aka `8_841_0_23`. That's the same versions as `PINNED_RETRIEVER_8_19`. It's just that this one is in `main` and `PINNED_RETRIEVER_8_19` is in `8.19`. To allow me to bring `PINNED_RETRIEVER_8_19` for wards I've had to revert #127633.

Closes #127667
