### PR TITLE
(Reapply) Failure store lifecycle - claim backport transport version

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -166,6 +166,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_REPORT_ORIGINAL_TYPES_BACKPORT_8_19 = def(8_841_0_22);
     public static final TransportVersion PINNED_RETRIEVER_8_19 = def(8_841_0_23);
     public static final TransportVersion ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK_8_19 = def(8_841_0_24);
+    public static final TransportVersion INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19 = def(8_841_0_25);
     public static final TransportVersion V_9_0_0 = def(9_000_0_09);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0_1 = def(9_000_0_10);
     public static final TransportVersion COHERE_BIT_EMBEDDING_TYPE_SUPPORT_ADDED = def(9_001_0_00);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStore.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStore.java
@@ -75,8 +75,9 @@ public record DataStreamFailureStore(@Nullable Boolean enabled, @Nullable DataSt
         this(
             in.readOptionalBoolean(),
             in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                ? in.readOptionalWriteable(DataStreamLifecycle::new)
-                : null
+                || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
+                    ? in.readOptionalWriteable(DataStreamLifecycle::new)
+                    : null
         );
     }
 
@@ -87,7 +88,8 @@ public record DataStreamFailureStore(@Nullable Boolean enabled, @Nullable DataSt
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalBoolean(enabled);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
+            || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
             out.writeOptionalWriteable(lifecycle);
         }
     }
@@ -167,7 +169,8 @@ public record DataStreamFailureStore(@Nullable Boolean enabled, @Nullable DataSt
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             ResettableValue.write(out, enabled, StreamOutput::writeBoolean);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
+                || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
                 ResettableValue.write(out, lifecycle, (o, v) -> v.writeTo(o));
             }
         }
@@ -175,7 +178,8 @@ public record DataStreamFailureStore(@Nullable Boolean enabled, @Nullable DataSt
         public static Template read(StreamInput in) throws IOException {
             ResettableValue<Boolean> enabled = ResettableValue.read(in, StreamInput::readBoolean);
             ResettableValue<DataStreamLifecycle.Template> lifecycle = ResettableValue.undefined();
-            if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
+            if (in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
+                || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
                 lifecycle = ResettableValue.read(in, DataStreamLifecycle.Template::read);
             }
             return new Template(enabled, lifecycle);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -341,7 +341,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
             }
             out.writeBoolean(enabled());
         }
-        if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
+            || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
             lifecycleType.writeTo(out);
         }
     }
@@ -370,8 +371,9 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
             enabled = true;
         }
         lifecycleType = in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-            ? LifecycleType.read(in)
-            : LifecycleType.DATA;
+            || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
+                ? LifecycleType.read(in)
+                : LifecycleType.DATA;
     }
 
     /**
@@ -733,7 +735,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
                 }
                 out.writeBoolean(enabled);
             }
-            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
+                || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
                 lifecycleType.writeTo(out);
             }
         }
@@ -796,8 +799,9 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
                 enabled = in.readBoolean();
             }
             var lifecycleTarget = in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                ? LifecycleType.read(in)
-                : LifecycleType.DATA;
+                || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
+                    ? LifecycleType.read(in)
+                    : LifecycleType.DATA;
             return new Template(lifecycleTarget, enabled, dataRetention, downsampling);
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamOptions.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamOptions.java
@@ -74,6 +74,7 @@ public record DataStreamOptions(@Nullable DataStreamFailureStore failureStore)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
+            || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
             || failureStore == null
             || failureStore().enabled() != null) {
             out.writeOptionalWriteable(failureStore);
@@ -139,6 +140,7 @@ public record DataStreamOptions(@Nullable DataStreamFailureStore failureStore)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
+                || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
                 || failureStore.get() == null
                 || failureStore().mapAndGet(DataStreamFailureStore.Template::enabled).get() != null) {
                 ResettableValue.write(out, failureStore, (o, v) -> v.writeTo(o));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/DataStreamFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/DataStreamFeatureSetUsage.java
@@ -134,17 +134,26 @@ public class DataStreamFeatureSetUsage extends XPackFeatureUsage {
                 in.getTransportVersion().onOrAfter(TransportVersions.V_8_15_0) ? in.readVLong() : 0,
                 in.getTransportVersion().onOrAfter(TransportVersions.FAILURE_STORE_ENABLED_BY_CLUSTER_SETTING) ? in.readVLong() : 0,
                 in.getTransportVersion().onOrAfter(TransportVersions.V_8_15_0) ? in.readVLong() : 0,
-                in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE) ? in.readVLong() : 0,
-                in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE) ? in.readVLong() : 0,
                 in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                    ? DataStreamLifecycleFeatureSetUsage.RetentionStats.read(in)
-                    : DataStreamLifecycleFeatureSetUsage.RetentionStats.NO_DATA,
+                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
+                        ? in.readVLong()
+                        : 0,
                 in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                    ? DataStreamLifecycleFeatureSetUsage.RetentionStats.read(in)
-                    : DataStreamLifecycleFeatureSetUsage.RetentionStats.NO_DATA,
+                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
+                        ? in.readVLong()
+                        : 0,
                 in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
-                    ? in.readMap(DataStreamLifecycleFeatureSetUsage.GlobalRetentionStats::new)
-                    : Map.of()
+                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
+                        ? DataStreamLifecycleFeatureSetUsage.RetentionStats.read(in)
+                        : DataStreamLifecycleFeatureSetUsage.RetentionStats.NO_DATA,
+                in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
+                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
+                        ? DataStreamLifecycleFeatureSetUsage.RetentionStats.read(in)
+                        : DataStreamLifecycleFeatureSetUsage.RetentionStats.NO_DATA,
+                in.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
+                    || in.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)
+                        ? in.readMap(DataStreamLifecycleFeatureSetUsage.GlobalRetentionStats::new)
+                        : Map.of()
             );
         }
 
@@ -159,7 +168,8 @@ public class DataStreamFeatureSetUsage extends XPackFeatureUsage {
                 }
                 out.writeVLong(this.failureStoreIndicesCount);
             }
-            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE)
+                || out.getTransportVersion().isPatchFrom(TransportVersions.INTRODUCE_FAILURES_LIFECYCLE_BACKPORT_8_19)) {
                 out.writeVLong(failuresLifecycleExplicitlyEnabledCount);
                 out.writeVLong(failuresLifecycleEffectivelyEnabledCount);
                 failuresLifecycleDataRetentionStats.writeTo(out);


### PR DESCRIPTION
Reapply https://github.com/elastic/elasticsearch/commit/218c252a450ee2d22e8d9efc132372473fa35318 that was reverted to fix a conflict in transport version backport.