### PR TITLE
Add rest API capability for failures default retention

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestGetDataStreamsAction.java
@@ -48,7 +48,8 @@ public class RestGetDataStreamsAction extends BaseRestHandler {
     public static final String FAILURES_LIFECYCLE_API_CAPABILITY = "failure_store.lifecycle";
     private static final Set<String> CAPABILITIES = Set.of(
         DataStreamLifecycle.EFFECTIVE_RETENTION_REST_API_CAPABILITY,
-        FAILURES_LIFECYCLE_API_CAPABILITY
+        FAILURES_LIFECYCLE_API_CAPABILITY,
+        "failure_store.lifecycle.default_retention"
     );
 
     @Override

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_failure_store_info.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_failure_store_info.yml
@@ -199,6 +199,13 @@ teardown:
 
 ---
 "Get failure store info from cluster setting enabled failure store":
+  - requires:
+      test_runner_features: [ capabilities ]
+      reason: "Default retention for failures was added in 9.1+"
+      capabilities:
+        - method: GET
+          path: /_data_stream/{target}
+          capabilities: [ 'failure_store.lifecycle.default_retention' ]
   - do:
       indices.create_data_stream:
         name: fs-default-data-stream


### PR DESCRIPTION
This PR is adding the API capability to ensure that the API tests that check for the default failures retention will only be executed when the version supports this. This was missed in the original PR (https://github.com/elastic/elasticsearch/pull/127573).