### PR TITLE
[8.19] Adjust `ForkJoinPool` prefix in `HdfsClientThreadLeakFilter` (#127534)

### DIFF
--- a/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsClientThreadLeakFilter.java
+++ b/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsClientThreadLeakFilter.java
@@ -35,6 +35,7 @@ public final class HdfsClientThreadLeakFilter implements ThreadFilter {
             || t.getName().startsWith("SSL Certificates Store Monitor") // hadoop 3 brings that in
             || t.getName().startsWith("GcTimeMonitor") // hadoop 3
             || t.getName().startsWith("Command processor") // hadoop 3
-            || t.getName().startsWith("ForkJoinPool-"); // hadoop 3
+            || t.getName().startsWith("ForkJoinPool-") // hadoop 3
+            || t.getName().startsWith("ForkJoinPool.commonPool-worker-"); // hadoop 3
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Adjust `ForkJoinPool` prefix in `HdfsClientThreadLeakFilter` (#127534)](https://github.com/elastic/elasticsearch/pull/127534)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Closes #127676
Closes #127677
Closes #127678
Closes #127679