### PR TITLE
Bump the MP x-pack YAML test suite timeout to 60m

### DIFF
--- a/x-pack/qa/multi-project/xpack-rest-tests-with-multiple-projects/src/yamlRestTest/java/org/elasticsearch/multiproject/test/XpackWithMultipleProjectsClientYamlTestSuiteIT.java
+++ b/x-pack/qa/multi-project/xpack-rest-tests-with-multiple-projects/src/yamlRestTest/java/org/elasticsearch/multiproject/test/XpackWithMultipleProjectsClientYamlTestSuiteIT.java
@@ -20,7 +20,7 @@ import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.junit.ClassRule;
 
-@TimeoutSuite(millis = 30 * TimeUnits.MINUTE)
+@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 public class XpackWithMultipleProjectsClientYamlTestSuiteIT extends MultipleProjectsClientYamlSuiteTestCase {
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()


### PR DESCRIPTION
After the `IndexTemplateRegistry` was made project-aware in #126986, we were seeing timeouts of the MP version of the x-pack YAML test suite. The original version has a timeout of 60 minutes but the MP-version still had a timeout of 30 minutes. We've gotten away with that difference because there are still tests on the blacklist for the MP version, but now that we're making more and more features project-aware, we need to align the timeout.

Fixes #127433