### PR TITLE
[8.17] [Test] Use version range for elasticsearch-java (#127510)

### DIFF
--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -22,21 +22,15 @@ subprojects {
 
   repositories {
     // Only necessary when building plugins against SNAPSHOT versions of Elasticsearch
-    maven {
-      url = 'https://snapshots.elastic.co/maven/'
-      mavenContent {
-        if (gradle.includedBuilds) {
-          // When building in a composite, restrict this to only resolve the Java REST client
-          includeModule 'co.elastic.clients', 'elasticsearch-java'
-        }
-      }
-    }
     if (gradle.includedBuilds.isEmpty()) {
       maven {
         url = "https://artifacts-snapshot.elastic.co/elasticsearch/${elasticsearchVersion}/maven"
         mavenContent {
           includeModule 'org.elasticsearch', 'elasticsearch'
         }
+      }
+      maven {
+        url = 'https://snapshots.elastic.co/maven/'
       }
     }
 

--- a/plugins/examples/security-authorization-engine/build.gradle
+++ b/plugins/examples/security-authorization-engine/build.gradle
@@ -16,7 +16,7 @@ dependencies {
   testImplementation "org.elasticsearch.plugin:x-pack-core:${elasticsearchVersion}"
   javaRestTestImplementation "org.elasticsearch.plugin:x-pack-core:${elasticsearchVersion}"
   javaRestTestImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}"
-  javaRestTestImplementation("co.elastic.clients:elasticsearch-java:${elasticsearchVersion}")
+  javaRestTestImplementation "co.elastic.clients:elasticsearch-java:[8.0,9.0)"
   javaRestTestImplementation "org.elasticsearch.client:elasticsearch-rest-client:${elasticsearchVersion}"
   javaRestTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
   javaRestTestImplementation "org.elasticsearch.test:framework:${elasticsearchVersion}"


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [Test] Use version range for elasticsearch-java (#127510)