### PR TITLE
ESQL: Document LU JOIN/MV_EXPAND not respecting SORT

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
@@ -42,7 +42,7 @@ If multiple documents in the lookup index match a single row in your
 results, the output will contain one row for each matching combination.
 
 ::::{tip}
-For important information about using `LOOKUP JOIN`, refer to [Usage notes](../../../../esql/esql-lookup-join.md#implementation-details).
+For important information about using `LOOKUP JOIN`, refer to [Usage notes](../../../../esql/esql-lookup-join.md#usage-notes).
 ::::
 
 **Examples**

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
@@ -42,7 +42,7 @@ If multiple documents in the lookup index match a single row in your
 results, the output will contain one row for each matching combination.
 
 ::::{tip}
-For important information about using `LOOKUP JOIN`, refer to [Implementation details](../../../../esql/esql-lookup-join.md#implementation-details).
+For important information about using `LOOKUP JOIN`, refer to [Usage notes](../../../../esql/esql-lookup-join.md#implementation-details).
 ::::
 
 **Examples**

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
@@ -42,13 +42,7 @@ If multiple documents in the lookup index match a single row in your
 results, the output will contain one row for each matching combination.
 
 ::::{tip}
-In case of name collisions, the newly created columns will override existing columns.
-::::
-
-::::{warning}
-The output rows produced by `LOOKUP JOIN` can be in any order and may not
-respect preceding `SORT`s. To guarantee a certain ordering, place a `SORT` after
-any `LOOKUP JOIN`s.
+For important information about using the `LOOKUP JOIN`, refer to [Implementation details](../../../../esql/esql-lookup-join.md#implementation-details).
 ::::
 
 **Examples**

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
@@ -42,7 +42,7 @@ If multiple documents in the lookup index match a single row in your
 results, the output will contain one row for each matching combination.
 
 ::::{tip}
-For important information about using the `LOOKUP JOIN`, refer to [Implementation details](../../../../esql/esql-lookup-join.md#implementation-details).
+For important information about using `LOOKUP JOIN`, refer to [Implementation details](../../../../esql/esql-lookup-join.md#implementation-details).
 ::::
 
 **Examples**

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
@@ -45,6 +45,12 @@ results, the output will contain one row for each matching combination.
 In case of name collisions, the newly created columns will override existing columns.
 ::::
 
+::::{warning}
+The output rows produced by `LOOKUP JOIN` can be in any order and may not
+respect preceding `SORT`s. To guarantee a certain ordering, place a `SORT` after
+any `LOOKUP JOIN`s.
+::::
+
 **Examples**
 
 **IP Threat correlation**: This query would allow you to see if any source

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/mv_expand.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/mv_expand.md
@@ -22,6 +22,12 @@ MV_EXPAND column
 `column`
 :   The multivalued column to expand.
 
+::::{warning}
+The output rows produced by `MV_EXPAND` can be in any order and may not respect
+preceding `SORT`s. To guarantee a certain ordering, place a `SORT` after any
+`MV_EXPAND`s.
+::::
+
 **Example**
 
 :::{include} ../examples/mv_expand.csv-spec/simple.md

--- a/docs/reference/query-languages/esql/esql-lookup-join.md
+++ b/docs/reference/query-languages/esql/esql-lookup-join.md
@@ -156,13 +156,17 @@ To obtain a join key with a compatible type, use a [conversion function](/refere
 
 For a complete list of supported data types and their internal representations, see the [Supported Field Types documentation](/reference/query-languages/esql/limitations.md#_supported_types).
 
-## Implementation details
+## Usage notes
 
-This section covers key implementation aspects of `LOOKUP JOIN` that affect query behavior and results. Review these details to ensure your queries work as expected and to troubleshoot unexpected results.
+This section covers important details about `LOOKUP JOIN` that impact query behavior and results. Review these details to ensure your queries work as expected and to troubleshoot unexpected results.
 
 ### Handling name collisions
 
-In case of name collisions, the newly created columns will override existing columns.
+When fields from the lookup index match existing column names, the new columns override the existing ones.
+Before the `LOOKUP JOIN`, preserve columns by either:
+
+* Using `RENAME` to assign non-conflicting names
+* Using `EVAL` to create new columns with different names, then `DROP` the original columns
 
 ### Sorting behavior
 

--- a/docs/reference/query-languages/esql/esql-lookup-join.md
+++ b/docs/reference/query-languages/esql/esql-lookup-join.md
@@ -156,9 +156,23 @@ To obtain a join key with a compatible type, use a [conversion function](/refere
 
 For a complete list of supported data types and their internal representations, see the [Supported Field Types documentation](/reference/query-languages/esql/limitations.md#_supported_types).
 
+## Implementation details
+
+This section covers key implementation aspects of `LOOKUP JOIN` that affect query behavior and results. Review these details to ensure your queries work as expected and to troubleshoot unexpected results.
+
+### Handling name collisions
+
+In case of name collisions, the newly created columns will override existing columns.
+
+### Sorting behavior
+
+The output rows produced by `LOOKUP JOIN` can be in any order and may not
+respect preceding `SORT`s. To guarantee a certain ordering, place a `SORT` after
+any `LOOKUP JOIN`s.
+
 ## Limitations
 
-The following are the current limitations with `LOOKUP JOIN`
+The following are the current limitations with `LOOKUP JOIN`:
 
 * Indices in [`lookup` mode](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting) are always single-sharded.
 * Cross cluster search is unsupported initially. Both source and lookup indices must be local.

--- a/docs/reference/query-languages/esql/esql-lookup-join.md
+++ b/docs/reference/query-languages/esql/esql-lookup-join.md
@@ -163,10 +163,10 @@ This section covers important details about `LOOKUP JOIN` that impact query beha
 ### Handling name collisions
 
 When fields from the lookup index match existing column names, the new columns override the existing ones.
-Before the `LOOKUP JOIN`, preserve columns by either:
+Before the `LOOKUP JOIN` command, preserve columns by either:
 
 * Using `RENAME` to assign non-conflicting names
-* Using `EVAL` to create new columns with different names, then `DROP` the original columns
+* Using `EVAL` to create new columns with different names, then `DROP` to remove the original columns
 
 ### Sorting behavior
 

--- a/docs/reference/query-languages/esql/esql-lookup-join.md
+++ b/docs/reference/query-languages/esql/esql-lookup-join.md
@@ -166,7 +166,7 @@ When fields from the lookup index match existing column names, the new columns o
 Before the `LOOKUP JOIN` command, preserve columns by either:
 
 * Using `RENAME` to assign non-conflicting names
-* Using `EVAL` to create new columns with different names, then `DROP` to remove the original columns
+* Using `EVAL` to create new columns with different names
 
 ### Sorting behavior
 


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/121884.

We currently cannot run all queries that have a `SORT` before either `LOOKUP JOIN` or `MV_EXPAND`. This is because we cannot push down these commands past `SORT`s without breaking the sort order in some cases. We may or may not want to choose to push down in these cases in the future, even though this affects sort order.

Moreover, further work and generalizations of `LOOKUP JOIN` may be even less compatible with sorting - e.g. if we generalize lookup indices to have multiple shards residing on different nodes.

To keep all possibilities open, let's just document that we give no guarantees whatsoever; we can revisit this later when needed.