### PR TITLE
Forward port 8.19 semantic text chunking config transport version

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -160,6 +160,7 @@ public class TransportVersions {
     public static final TransportVersion RERANK_COMMON_OPTIONS_ADDED_8_19 = def(8_841_0_15);
     public static final TransportVersion REMOTE_EXCEPTION_8_19 = def(8_841_0_16);
     public static final TransportVersion AMAZON_BEDROCK_TASK_SETTINGS_8_19 = def(8_841_0_17);
+    public static final TransportVersion SEMANTIC_TEXT_CHUNKING_CONFIG_8_19 = def(8_841_0_18);
     public static final TransportVersion BATCHED_QUERY_PHASE_VERSION_BACKPORT_8_X = def(8_841_0_19);
     public static final TransportVersion SEARCH_INCREMENTAL_TOP_DOCS_NULL_BACKPORT_8_19 = def(8_841_0_20);
     public static final TransportVersion ML_INFERENCE_SAGEMAKER_8_19 = def(8_841_0_21);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadata.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.TransportVersions.SEMANTIC_TEXT_CHUNKING_CONFIG;
+import static org.elasticsearch.TransportVersions.SEMANTIC_TEXT_CHUNKING_CONFIG_8_19;
+import static org.elasticsearch.TransportVersions.V_9_0_0;
 
 /**
  * Contains inference field data for fields.
@@ -74,7 +76,8 @@ public final class InferenceFieldMetadata implements SimpleDiffable<InferenceFie
             this.searchInferenceId = this.inferenceId;
         }
         this.sourceFields = input.readStringArray();
-        if (input.getTransportVersion().onOrAfter(SEMANTIC_TEXT_CHUNKING_CONFIG)) {
+        if (input.getTransportVersion().onOrAfter(SEMANTIC_TEXT_CHUNKING_CONFIG)
+            || input.getTransportVersion().between(SEMANTIC_TEXT_CHUNKING_CONFIG_8_19, V_9_0_0)) {
             this.chunkingSettings = input.readGenericMap();
         } else {
             this.chunkingSettings = null;
@@ -89,7 +92,8 @@ public final class InferenceFieldMetadata implements SimpleDiffable<InferenceFie
             out.writeString(searchInferenceId);
         }
         out.writeStringArray(sourceFields);
-        if (out.getTransportVersion().onOrAfter(SEMANTIC_TEXT_CHUNKING_CONFIG)) {
+        if (out.getTransportVersion().onOrAfter(SEMANTIC_TEXT_CHUNKING_CONFIG)
+            || out.getTransportVersion().between(SEMANTIC_TEXT_CHUNKING_CONFIG_8_19, V_9_0_0)) {
             out.writeGenericMap(chunkingSettings);
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadata.java
@@ -28,7 +28,6 @@ import java.util.Objects;
 
 import static org.elasticsearch.TransportVersions.SEMANTIC_TEXT_CHUNKING_CONFIG;
 import static org.elasticsearch.TransportVersions.SEMANTIC_TEXT_CHUNKING_CONFIG_8_19;
-import static org.elasticsearch.TransportVersions.V_9_0_0;
 
 /**
  * Contains inference field data for fields.
@@ -77,7 +76,7 @@ public final class InferenceFieldMetadata implements SimpleDiffable<InferenceFie
         }
         this.sourceFields = input.readStringArray();
         if (input.getTransportVersion().onOrAfter(SEMANTIC_TEXT_CHUNKING_CONFIG)
-            || input.getTransportVersion().between(SEMANTIC_TEXT_CHUNKING_CONFIG_8_19, V_9_0_0)) {
+            || input.getTransportVersion().isPatchFrom(SEMANTIC_TEXT_CHUNKING_CONFIG_8_19)) {
             this.chunkingSettings = input.readGenericMap();
         } else {
             this.chunkingSettings = null;
@@ -93,7 +92,7 @@ public final class InferenceFieldMetadata implements SimpleDiffable<InferenceFie
         }
         out.writeStringArray(sourceFields);
         if (out.getTransportVersion().onOrAfter(SEMANTIC_TEXT_CHUNKING_CONFIG)
-            || out.getTransportVersion().between(SEMANTIC_TEXT_CHUNKING_CONFIG_8_19, V_9_0_0)) {
+            || out.getTransportVersion().isPatchFrom(SEMANTIC_TEXT_CHUNKING_CONFIG_8_19)) {
             out.writeGenericMap(chunkingSettings);
         }
     }


### PR DESCRIPTION
Forward-port the semantic text chunking config transport version from 8.19. A missing check for this transport version caused cluster state deserialization errors when upgrading from 8.19 to 9.1.