### PR TITLE
[ML] Reduce Datafeed log severity

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
@@ -377,7 +377,7 @@ class DatafeedJob {
                 extractedData = result.data();
                 searchInterval = result.searchInterval();
             } catch (Exception e) {
-                LOGGER.error(() -> "[" + jobId + "] error while extracting data", e);
+                LOGGER.warn(() -> "[" + jobId + "] error while extracting data", e);
                 // When extraction problems are encountered, we do not want to advance time.
                 // Instead, it is preferable to retry the given interval next time an extraction
                 // is triggered.


### PR DESCRIPTION
This PR reduces the severity of the log message `[job id] error while extracting data ...` from an error to a warning. My reasoning is that the operation will be retried in the future.

Fixes https://github.com/elastic/elasticsearch/issues/107872