### PR TITLE
Uniform main and backport code

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementCheckerUtils.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementCheckerUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.initialization;
+
+class EntitlementCheckerUtils {
+
+    /**
+     * Returns the "most recent" checker class compatible with the provided runtime Java version.
+     * For checkers, we have (optionally) version specific classes, each with a prefix (e.g. Java23).
+     * The mapping cannot be automatic, as it depends on the actual presence of these classes in the final Jar (see
+     * the various mainXX source sets).
+     */
+    static Class<?> getVersionSpecificCheckerClass(Class<?> baseClass, int javaVersion) {
+        String packageName = baseClass.getPackageName();
+        String baseClassName = baseClass.getSimpleName();
+
+        final String classNamePrefix;
+        if (javaVersion >= 23) {
+            // All Java version from 23 onwards will be able to use che checks in the Java23EntitlementChecker interface and implementation
+            classNamePrefix = "Java23";
+        } else {
+            // For any other Java version, the basic EntitlementChecker interface and implementation contains all the supported checks
+            classNamePrefix = "";
+        }
+        final String className = packageName + "." + classNamePrefix + baseClassName;
+        Class<?> clazz;
+        try {
+            clazz = Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError("entitlement lib cannot find entitlement class " + className, e);
+        }
+        return clazz;
+    }
+}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -68,7 +68,11 @@ public class EntitlementInitialization {
             ensureClassesSensitiveToVerificationAreInitialized();
         }
 
-        DynamicInstrumentation.initialize(inst, getVersionSpecificCheckerClass(EntitlementChecker.class), verifyBytecode);
+        DynamicInstrumentation.initialize(
+            inst,
+            EntitlementCheckerUtils.getVersionSpecificCheckerClass(EntitlementChecker.class, Runtime.version().feature()),
+            verifyBytecode
+        );
     }
 
     private static PolicyManager createPolicyManager() {
@@ -108,39 +112,13 @@ public class EntitlementInitialization {
         }
     }
 
-    /**
-     * Returns the "most recent" checker class compatible with the current runtime Java version.
-     * For checkers, we have (optionally) version specific classes, each with a prefix (e.g. Java23).
-     * The mapping cannot be automatic, as it depends on the actual presence of these classes in the final Jar (see
-     * the various mainXX source sets).
-     */
-    private static Class<?> getVersionSpecificCheckerClass(Class<?> baseClass) {
-        String packageName = baseClass.getPackageName();
-        String baseClassName = baseClass.getSimpleName();
-        int javaVersion = Runtime.version().feature();
-
-        final String classNamePrefix;
-        if (javaVersion >= 23) {
-            // All Java version from 23 onwards will be able to use che checks in the Java23EntitlementChecker interface and implementation
-            classNamePrefix = "Java23";
-        } else {
-            // For any other Java version, the basic EntitlementChecker interface and implementation contains all the supported checks
-            classNamePrefix = "";
-        }
-        final String className = packageName + "." + classNamePrefix + baseClassName;
-        Class<?> clazz;
-        try {
-            clazz = Class.forName(className);
-        } catch (ClassNotFoundException e) {
-            throw new AssertionError("entitlement lib cannot find entitlement class " + className, e);
-        }
-        return clazz;
-    }
-
     private static ElasticsearchEntitlementChecker initChecker() {
         final PolicyManager policyManager = createPolicyManager();
 
-        final Class<?> clazz = getVersionSpecificCheckerClass(ElasticsearchEntitlementChecker.class);
+        final Class<?> clazz = EntitlementCheckerUtils.getVersionSpecificCheckerClass(
+            ElasticsearchEntitlementChecker.class,
+            Runtime.version().feature()
+        );
 
         Constructor<?> constructor;
         try {


### PR DESCRIPTION
While backporting entitlement initialization refactorings, I realized there is a mismatch in getVersionSpecificCheckerClass signature, and also that this function in the backports is used in more places (DynamicInstrumentation), making it "strange" to have this in EntitlementInitialization. This PR extracts the function to a separate static class (package-private) and makes the signature uniform with backports.
This will need to be backported manually to the 8.x branches, and will make the backported version of DynamicInstrumentation cleaner.