### PR TITLE
Provide default entrypoint for the cloud-ess-fips image

### DIFF
--- a/distribution/docker/src/docker/Dockerfile.ess-fips
+++ b/distribution/docker/src/docker/Dockerfile.ess-fips
@@ -208,6 +208,11 @@ LABEL name="Elasticsearch" \\
 
 RUN mkdir /licenses && ln LICENSE.txt /licenses/LICENSE
 
+# Generate a stub command that will be overwritten at runtime
+RUN mkdir /app && \\
+    echo -e '#!/bin/bash\\nexec /usr/local/bin/docker-entrypoint.sh eswrapper' > /app/elasticsearch.sh && \\
+    chmod 0555 /app/elasticsearch.sh
+
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/app/elasticsearch.sh"]
 


### PR DESCRIPTION
In order to match the pattern for the other Cloud ESS image, provide a default entrypoint to the container that points to the configured docker entrypoint. This is described in
https://github.com/elastic/elasticsearch/blob/1a1763c591c4c32bf66f0df3bce2040e8f19a1a2/distribution/docker/README.md?plain=1#L16-L19 and implemented in https://github.com/elastic/elasticsearch/blob/1a1763c591c4c32bf66f0df3bce2040e8f19a1a2/distribution/docker/src/docker/Dockerfile.ess#L37-L40
