### PR TITLE
Disable SecurityManager in tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -120,7 +120,7 @@ public class BootstrapForTesting {
         IfConfig.logIfNecessary();
 
         // install security manager if available and requested
-        if (RuntimeVersionFeature.isSecurityManagerAvailable() && systemPropertyAsBoolean("tests.security.manager", true)) {
+        if (RuntimeVersionFeature.isSecurityManagerAvailable() && systemPropertyAsBoolean("tests.security.manager", false)) {
             try {
                 // initialize paths the same exact way as bootstrap
                 Permissions perms = new Permissions();


### PR DESCRIPTION
SecurityManager is already removed in 9.1 and 8.19, but those changes are too large to backport to 8.18 and 9.0. This commit changes tests there to not run with security manager to avoid security manager specific failures even though release versions only runs with entitlements.

closes #127784
closes #127785
closes #127786