### PR TITLE
[DOCS][8.x] ESQL: Document LU JOIN/MV_EXPAND not respecting SORT

### DIFF
--- a/docs/reference/esql/esql-lookup-join.asciidoc
+++ b/docs/reference/esql/esql-lookup-join.asciidoc
@@ -252,8 +252,7 @@ Before the `LOOKUP JOIN` command, preserve columns by either:
 ===== Sorting behavior
 
 The output rows produced by `LOOKUP JOIN` can be in any order and may not
-respect preceding `SORT`s. To guarantee a certain ordering, place a `SORT` after
-any `LOOKUP JOIN`s.
+respect preceding `SORT` commands. To guarantee a certain ordering, place a `SORT` after any `LOOKUP JOIN` commands.
 
 [discrete]
 [[esql-lookup-join-limitations]]

--- a/docs/reference/esql/esql-lookup-join.asciidoc
+++ b/docs/reference/esql/esql-lookup-join.asciidoc
@@ -232,6 +232,30 @@ For a complete list of supported data types and their internal
 representations, see the <<esql-supported-types,Supported Field Types documentation>>.
 
 [discrete]
+[[esql-lookup-join-usage-notes]]
+==== Usage notes
+
+This section covers important details about `LOOKUP JOIN` that impact query behavior and results. Review these details to ensure your queries work as expected and to troubleshoot unexpected results.
+
+[discrete]
+[[esql-lookup-join-usage-notes-name-collisions]]
+===== Handling name collisions
+
+When fields from the lookup index match existing column names, the new columns override the existing ones.
+Before the `LOOKUP JOIN` command, preserve columns by either:
+
+* Using `RENAME` to assign non-conflicting names
+* Using `EVAL` to create new columns with different names
+
+[discrete]
+[[esql-lookup-join-usage-notes-sorting]]
+===== Sorting behavior
+
+The output rows produced by `LOOKUP JOIN` can be in any order and may not
+respect preceding `SORT`s. To guarantee a certain ordering, place a `SORT` after
+any `LOOKUP JOIN`s.
+
+[discrete]
 [[esql-lookup-join-limitations]]
 ==== Limitations
 

--- a/docs/reference/esql/processing-commands/lookup.asciidoc
+++ b/docs/reference/esql/processing-commands/lookup.asciidoc
@@ -50,7 +50,7 @@ results, the output will contain one row for each matching combination.
 
 [TIP]
 ====
-In case of name collisions, the newly created columns will override existing columns.
+For important information about using `LOOKUP JOIN`, refer to <<esql-lookup-join-usage-notes,Usage notes>>.
 ====
 
 *Examples*

--- a/docs/reference/esql/processing-commands/mv_expand.asciidoc
+++ b/docs/reference/esql/processing-commands/mv_expand.asciidoc
@@ -22,8 +22,8 @@ The multivalued column to expand.
 [WARNING]
 ======
 The output rows produced by `MV_EXPAND` can be in any order and may not respect
-preceding `SORT`s. To guarantee a certain ordering, place a `SORT` after any
-`MV_EXPAND`s.
+preceding `SORT` commands. To guarantee a certain ordering, place a `SORT` after any
+`MV_EXPAND` commands.
 ======
 
 *Example*

--- a/docs/reference/esql/processing-commands/mv_expand.asciidoc
+++ b/docs/reference/esql/processing-commands/mv_expand.asciidoc
@@ -19,6 +19,13 @@ MV_EXPAND column
 `column`::
 The multivalued column to expand.
 
+[WARNING]
+======
+The output rows produced by `MV_EXPAND` can be in any order and may not respect
+preceding `SORT`s. To guarantee a certain ordering, place a `SORT` after any
+`MV_EXPAND`s.
+======
+
 *Example*
 
 [source.merge.styled,esql]


### PR DESCRIPTION
Manual 'backport" of https://github.com/elastic/elasticsearch/pull/127808 for 8.x