### PR TITLE
[9.0] Handle streaming request body in audit log (#127798)

### DIFF
--- a/docs/changelog/127798.yaml
+++ b/docs/changelog/127798.yaml
@@ -1,0 +1,5 @@
+pr: 127798
+summary: Handle streaming request body in audit log
+area: Audit
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditUtil.java
@@ -27,6 +27,9 @@ public class AuditUtil {
 
     public static String restRequestContent(RestRequest request) {
         if (request.hasContent()) {
+            if (request.isStreamedContent()) {
+                return "Request body had not been received at the time of the audit event";
+            }
             var content = request.content();
             try {
                 return XContentHelper.convertToJson(content, false, false, request.getXContentType());


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Handle streaming request body in audit log (#127798)