### PR TITLE
[ML] Fixing Google Vertex AI Rerank task type location field

### DIFF
--- a/docs/changelog/127856.yaml
+++ b/docs/changelog/127856.yaml
@@ -1,0 +1,5 @@
+pr: 127856
+summary: Fixing Google Vertex AI Rerank task type location field
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/127856.yaml
+++ b/docs/changelog/127856.yaml
@@ -1,5 +1,5 @@
 pr: 127856
-summary: Fixing Google Vertex AI Rerank task type location field
+summary: Fix services API Google Vertex AI Rerank location field requirement
 area: Machine Learning
 type: bug
 issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiService.java
@@ -348,7 +348,7 @@ public class GoogleVertexAiService extends SenderService {
 
                 configurationMap.put(
                     LOCATION,
-                    new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.TEXT_EMBEDDING)).setDescription(
                         "Please provide the GCP region where the Vertex AI API(s) is enabled. "
                             + "For more information, refer to the {geminiVertexAIDocs}."
                     )

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiServiceTests.java
@@ -898,7 +898,7 @@ public class GoogleVertexAiServiceTests extends ESTestCase {
                                    "sensitive": false,
                                    "updatable": false,
                                    "type": "str",
-                                   "supported_task_types": ["text_embedding", "rerank"]
+                                   "supported_task_types": ["text_embedding"]
                                },
                                "rate_limit.requests_per_minute": {
                                    "description": "Minimize the number of rate limit errors.",


### PR DESCRIPTION
This PR fixes an issue where the `location` field is not needed for the rerank task type. The services API was reporting that it was required.