### PR TITLE
[8.18]  ESQL: Fix ShapeGeometryFieldMapperTests (and rename) (#122871)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -332,9 +332,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/119396
 - class: org.elasticsearch.xpack.security.authc.ldap.ADLdapUserSearchSessionFactoryTests
   issue: https://github.com/elastic/elasticsearch/issues/119882
-- class: org.elasticsearch.index.mapper.AbstractShapeGeometryFieldMapperTests
-  method: testCartesianBoundsBlockLoader
-  issue: https://github.com/elastic/elasticsearch/issues/119201
 - class: org.elasticsearch.xpack.security.operator.OperatorPrivilegesIT
   method: testEveryActionIsEitherOperatorOnlyOrNonOperator
   issue: https://github.com/elastic/elasticsearch/issues/119911
@@ -450,9 +447,6 @@ tests:
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/120148
-- class: org.elasticsearch.index.mapper.ShapeGeometryFieldMapperTests
-  method: testCartesianBoundsBlockLoader
-  issue: https://github.com/elastic/elasticsearch/issues/125129
 - class: org.elasticsearch.xpack.ilm.history.ILMHistoryItemTests
   method: testTruncateLongError
   issue: https://github.com/elastic/elasticsearch/issues/125216


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/124251

Fixes #119201
Fixes #125129

The issue was caused by RandomIndexWriter (randomly) reshuffling the document writing order. Since this test also ensures that the documents are read in the input order, I've opted to use a regular IndexWriter instead. I've also renamed the class to AbstractShapeGeometryFieldMapperTests since it was originally renamed due to a misunderstanding of muted tests (which caused it to be muted again! Busted 😅).

