### PR TITLE
Esql clean up constructors in field attribute

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RLikePattern;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -205,8 +206,8 @@ public class EvalBenchmark {
                 FieldAttribute timestamp = new FieldAttribute(
                     Source.EMPTY,
                         null, "timestamp",
-                    new EsField("timestamp", DataType.DATETIME, Map.of(), true)
-                );
+                    new EsField("timestamp", DataType.DATETIME, Map.of(), true),
+                    Nullability.TRUE, null, false);
                 yield EvalMapper.toEvaluator(
                     FOLD_CONTEXT,
                     new DateTrunc(Source.EMPTY, new Literal(Source.EMPTY, Duration.ofHours(24), DataType.TIME_DURATION), timestamp),
@@ -255,19 +256,19 @@ public class EvalBenchmark {
     }
 
     private static FieldAttribute longField() {
-        return new FieldAttribute(Source.EMPTY, null, "long", new EsField("long", DataType.LONG, Map.of(), true));
+        return new FieldAttribute(Source.EMPTY, null, "long", new EsField("long", DataType.LONG, Map.of(), true), Nullability.TRUE, null, false);
     }
 
     private static FieldAttribute doubleField() {
-        return new FieldAttribute(Source.EMPTY, null, "double", new EsField("double", DataType.DOUBLE, Map.of(), true));
+        return new FieldAttribute(Source.EMPTY, null, "double", new EsField("double", DataType.DOUBLE, Map.of(), true), Nullability.TRUE, null, false);
     }
 
     private static FieldAttribute intField() {
-        return new FieldAttribute(Source.EMPTY, null, "int", new EsField("int", DataType.INTEGER, Map.of(), true));
+        return new FieldAttribute(Source.EMPTY, null, "int", new EsField("int", DataType.INTEGER, Map.of(), true), Nullability.TRUE, null, false);
     }
 
     private static FieldAttribute keywordField() {
-        return new FieldAttribute(Source.EMPTY, null, "keyword", new EsField("keyword", DataType.KEYWORD, Map.of(), true));
+        return new FieldAttribute(Source.EMPTY, null, "keyword", new EsField("keyword", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false);
     }
 
     private static Configuration configuration() {

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
@@ -205,9 +205,13 @@ public class EvalBenchmark {
             case "date_trunc" -> {
                 FieldAttribute timestamp = new FieldAttribute(
                     Source.EMPTY,
-                        null, "timestamp",
+                    null,
+                    "timestamp",
                     new EsField("timestamp", DataType.DATETIME, Map.of(), true),
-                    Nullability.TRUE, null, false);
+                    Nullability.TRUE,
+                    null,
+                    false
+                );
                 yield EvalMapper.toEvaluator(
                     FOLD_CONTEXT,
                     new DateTrunc(Source.EMPTY, new Literal(Source.EMPTY, Duration.ofHours(24), DataType.TIME_DURATION), timestamp),
@@ -256,19 +260,51 @@ public class EvalBenchmark {
     }
 
     private static FieldAttribute longField() {
-        return new FieldAttribute(Source.EMPTY, null, "long", new EsField("long", DataType.LONG, Map.of(), true), Nullability.TRUE, null, false);
+        return new FieldAttribute(
+            Source.EMPTY,
+            null,
+            "long",
+            new EsField("long", DataType.LONG, Map.of(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
     }
 
     private static FieldAttribute doubleField() {
-        return new FieldAttribute(Source.EMPTY, null, "double", new EsField("double", DataType.DOUBLE, Map.of(), true), Nullability.TRUE, null, false);
+        return new FieldAttribute(
+            Source.EMPTY,
+            null,
+            "double",
+            new EsField("double", DataType.DOUBLE, Map.of(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
     }
 
     private static FieldAttribute intField() {
-        return new FieldAttribute(Source.EMPTY, null, "int", new EsField("int", DataType.INTEGER, Map.of(), true), Nullability.TRUE, null, false);
+        return new FieldAttribute(
+            Source.EMPTY,
+            null,
+            "int",
+            new EsField("int", DataType.INTEGER, Map.of(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
     }
 
     private static FieldAttribute keywordField() {
-        return new FieldAttribute(Source.EMPTY, null, "keyword", new EsField("keyword", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false);
+        return new FieldAttribute(
+            Source.EMPTY,
+            null,
+            "keyword",
+            new EsField("keyword", DataType.KEYWORD, Map.of(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
     }
 
     private static Configuration configuration() {

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
@@ -204,7 +204,7 @@ public class EvalBenchmark {
             case "date_trunc" -> {
                 FieldAttribute timestamp = new FieldAttribute(
                     Source.EMPTY,
-                    "timestamp",
+                        null, "timestamp",
                     new EsField("timestamp", DataType.DATETIME, Map.of(), true)
                 );
                 yield EvalMapper.toEvaluator(
@@ -255,19 +255,19 @@ public class EvalBenchmark {
     }
 
     private static FieldAttribute longField() {
-        return new FieldAttribute(Source.EMPTY, "long", new EsField("long", DataType.LONG, Map.of(), true));
+        return new FieldAttribute(Source.EMPTY, null, "long", new EsField("long", DataType.LONG, Map.of(), true));
     }
 
     private static FieldAttribute doubleField() {
-        return new FieldAttribute(Source.EMPTY, "double", new EsField("double", DataType.DOUBLE, Map.of(), true));
+        return new FieldAttribute(Source.EMPTY, null, "double", new EsField("double", DataType.DOUBLE, Map.of(), true));
     }
 
     private static FieldAttribute intField() {
-        return new FieldAttribute(Source.EMPTY, "int", new EsField("int", DataType.INTEGER, Map.of(), true));
+        return new FieldAttribute(Source.EMPTY, null, "int", new EsField("int", DataType.INTEGER, Map.of(), true));
     }
 
     private static FieldAttribute keywordField() {
-        return new FieldAttribute(Source.EMPTY, "keyword", new EsField("keyword", DataType.KEYWORD, Map.of(), true));
+        return new FieldAttribute(Source.EMPTY, null, "keyword", new EsField("keyword", DataType.KEYWORD, Map.of(), true));
     }
 
     private static Configuration configuration() {

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
@@ -44,14 +44,6 @@ public class FieldAttribute extends TypedAttribute {
     private final String parentName;
     private final EsField field;
 
-    public FieldAttribute(Source source, @Nullable String parentName, String name, EsField field) {
-        this(source, parentName, name, field, Nullability.TRUE, null, false);
-    }
-
-    public FieldAttribute(Source source, @Nullable String parentName, String name, EsField field, boolean synthetic) {
-        this(source, parentName, name, field, Nullability.TRUE, null, synthetic);
-    }
-
     public FieldAttribute(
         Source source,
         @Nullable String parentName,

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
@@ -44,10 +44,6 @@ public class FieldAttribute extends TypedAttribute {
     private final String parentName;
     private final EsField field;
 
-    public FieldAttribute(Source source, String name, EsField field) {
-        this(source, null, name, field);
-    }
-
     public FieldAttribute(Source source, @Nullable String parentName, String name, EsField field) {
         this(source, parentName, name, field, Nullability.TRUE, null, false);
     }

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/util/TestUtils.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/util/TestUtils.java
@@ -46,7 +46,7 @@ public final class TestUtils {
     }
 
     public static FieldAttribute fieldAttribute(String name, DataType type) {
-        return new FieldAttribute(EMPTY, name, new EsField(name, type, emptyMap(), randomBoolean()));
+        return new FieldAttribute(EMPTY, null, name, new EsField(name, type, emptyMap(), randomBoolean()));
     }
 
     public static FieldAttribute getFieldAttribute(String name) {
@@ -54,7 +54,7 @@ public final class TestUtils {
     }
 
     public static FieldAttribute getFieldAttribute(String name, DataType dataType) {
-        return new FieldAttribute(EMPTY, name, new EsField(name + "f", dataType, emptyMap(), true));
+        return new FieldAttribute(EMPTY, null, name, new EsField(name + "f", dataType, emptyMap(), true));
     }
 
     /** Similar to {@link String#strip()}, but removes the WS throughout the entire string. */

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/util/TestUtils.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/util/TestUtils.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.core.util;
 
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
@@ -46,7 +47,7 @@ public final class TestUtils {
     }
 
     public static FieldAttribute fieldAttribute(String name, DataType type) {
-        return new FieldAttribute(EMPTY, null, name, new EsField(name, type, emptyMap(), randomBoolean()));
+        return new FieldAttribute(EMPTY, null, name, new EsField(name, type, emptyMap(), randomBoolean()), Nullability.TRUE, null, false);
     }
 
     public static FieldAttribute getFieldAttribute(String name) {
@@ -54,7 +55,7 @@ public final class TestUtils {
     }
 
     public static FieldAttribute getFieldAttribute(String name, DataType dataType) {
-        return new FieldAttribute(EMPTY, null, name, new EsField(name + "f", dataType, emptyMap(), true));
+        return new FieldAttribute(EMPTY, null, name, new EsField(name + "f", dataType, emptyMap(), true), Nullability.TRUE, null, false);
     }
 
     /** Similar to {@link String#strip()}, but removes the WS throughout the entire string. */

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -54,6 +54,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RLikePattern;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
@@ -202,7 +203,7 @@ public final class EsqlTestUtils {
     }
 
     public static FieldAttribute getFieldAttribute(String name, DataType dataType) {
-        return new FieldAttribute(EMPTY, null, name, new EsField(name + "f", dataType, emptyMap(), true));
+        return new FieldAttribute(EMPTY, null, name, new EsField(name + "f", dataType, emptyMap(), true), Nullability.TRUE, null, false);
     }
 
     public static FieldAttribute fieldAttribute() {
@@ -210,7 +211,7 @@ public final class EsqlTestUtils {
     }
 
     public static FieldAttribute fieldAttribute(String name, DataType type) {
-        return new FieldAttribute(EMPTY, null, name, new EsField(name, type, emptyMap(), randomBoolean()));
+        return new FieldAttribute(EMPTY, null, name, new EsField(name, type, emptyMap(), randomBoolean()), Nullability.TRUE, null, false);
     }
 
     public static Literal of(Object value) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -202,7 +202,7 @@ public final class EsqlTestUtils {
     }
 
     public static FieldAttribute getFieldAttribute(String name, DataType dataType) {
-        return new FieldAttribute(EMPTY, name, new EsField(name + "f", dataType, emptyMap(), true));
+        return new FieldAttribute(EMPTY, null, name, new EsField(name + "f", dataType, emptyMap(), true));
     }
 
     public static FieldAttribute fieldAttribute() {
@@ -210,7 +210,7 @@ public final class EsqlTestUtils {
     }
 
     public static FieldAttribute fieldAttribute(String name, DataType type) {
-        return new FieldAttribute(EMPTY, name, new EsField(name, type, emptyMap(), randomBoolean()));
+        return new FieldAttribute(EMPTY, null, name, new EsField(name, type, emptyMap(), randomBoolean()));
     }
 
     public static Literal of(Object value) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -881,11 +881,11 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         fa.dataType().typeName()
                     )
                 );
-            return new FieldAttribute(fa.source(), name, field);
+            return new FieldAttribute(fa.source(), null, name, field);
         }
 
         private static FieldAttribute insistKeyword(Attribute attribute) {
-            return new FieldAttribute(attribute.source(), attribute.name(), new PotentiallyUnmappedKeywordEsField(attribute.name()));
+            return new FieldAttribute(attribute.source(), null, attribute.name(), new PotentiallyUnmappedKeywordEsField(attribute.name()));
         }
 
         private LogicalPlan resolveDedup(Dedup dedup, List<Attribute> childrenOutput) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -885,7 +885,15 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
         }
 
         private static FieldAttribute insistKeyword(Attribute attribute) {
-            return new FieldAttribute(attribute.source(), null, attribute.name(), new PotentiallyUnmappedKeywordEsField(attribute.name()), Nullability.TRUE, null, false);
+            return new FieldAttribute(
+                attribute.source(),
+                null,
+                attribute.name(),
+                new PotentiallyUnmappedKeywordEsField(attribute.name()),
+                Nullability.TRUE,
+                null,
+                false
+            );
         }
 
         private LogicalPlan resolveDedup(Dedup dedup, List<Attribute> childrenOutput) {
@@ -1687,7 +1695,15 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             // NOTE: The name has to start with $$ to not break bwc with 8.15 - in that version, this is how we had to mark this as
             // synthetic to work around a bug.
             String unionTypedFieldName = Attribute.rawTemporaryName(fa.name(), "converted_to", resolvedField.getDataType().typeName());
-            FieldAttribute unionFieldAttribute = new FieldAttribute(fa.source(), fa.parentName(), unionTypedFieldName, resolvedField, Nullability.TRUE, null, true);
+            FieldAttribute unionFieldAttribute = new FieldAttribute(
+                fa.source(),
+                fa.parentName(),
+                unionTypedFieldName,
+                resolvedField,
+                Nullability.TRUE,
+                null,
+                true
+            );
             int existingIndex = unionFieldAttributes.indexOf(unionFieldAttribute);
             if (existingIndex >= 0) {
                 // Do not generate multiple name/type combinations with different IDs

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -292,7 +292,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
 
                 FieldAttribute attribute = t instanceof UnsupportedEsField uef
                     ? new UnsupportedAttribute(source, name, uef)
-                    : new FieldAttribute(source, parentName, name, t);
+                    : new FieldAttribute(source, parentName, name, t, Nullability.TRUE, null, false);
                 // primitive branch
                 if (DataType.isPrimitive(type)) {
                     list.add(attribute);
@@ -458,7 +458,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 Column column = entry.getValue();
                 // create a fake ES field - alternative is to use a ReferenceAttribute
                 EsField field = new EsField(name, column.type(), Map.of(), false, false);
-                attributes.add(new FieldAttribute(source, null, name, field));
+                attributes.add(new FieldAttribute(source, null, name, field, Nullability.TRUE, null, false));
                 // prepare the block for the supplier
                 blocks[i++] = column.values();
             }
@@ -881,11 +881,11 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         fa.dataType().typeName()
                     )
                 );
-            return new FieldAttribute(fa.source(), null, name, field);
+            return new FieldAttribute(fa.source(), null, name, field, Nullability.TRUE, null, false);
         }
 
         private static FieldAttribute insistKeyword(Attribute attribute) {
-            return new FieldAttribute(attribute.source(), null, attribute.name(), new PotentiallyUnmappedKeywordEsField(attribute.name()));
+            return new FieldAttribute(attribute.source(), null, attribute.name(), new PotentiallyUnmappedKeywordEsField(attribute.name()), Nullability.TRUE, null, false);
         }
 
         private LogicalPlan resolveDedup(Dedup dedup, List<Attribute> childrenOutput) {
@@ -1687,7 +1687,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             // NOTE: The name has to start with $$ to not break bwc with 8.15 - in that version, this is how we had to mark this as
             // synthetic to work around a bug.
             String unionTypedFieldName = Attribute.rawTemporaryName(fa.name(), "converted_to", resolvedField.getDataType().typeName());
-            FieldAttribute unionFieldAttribute = new FieldAttribute(fa.source(), fa.parentName(), unionTypedFieldName, resolvedField, true);
+            FieldAttribute unionFieldAttribute = new FieldAttribute(fa.source(), fa.parentName(), unionTypedFieldName, resolvedField, Nullability.TRUE, null, true);
             int existingIndex = unionFieldAttributes.indexOf(unionFieldAttribute);
             if (existingIndex >= 0) {
                 // Do not generate multiple name/type combinations with different IDs

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
@@ -30,7 +30,15 @@ public class ReplaceSourceAttributes extends PhysicalOptimizerRules.OptimizerRul
 
     @Override
     protected PhysicalPlan rule(EsSourceExec plan) {
-        var docId = new FieldAttribute(plan.source(), null, EsQueryExec.DOC_ID_FIELD.getName(), EsQueryExec.DOC_ID_FIELD, Nullability.TRUE, null, false);
+        var docId = new FieldAttribute(
+            plan.source(),
+            null,
+            EsQueryExec.DOC_ID_FIELD.getName(),
+            EsQueryExec.DOC_ID_FIELD,
+            Nullability.TRUE,
+            null,
+            false
+        );
         final List<Attribute> attributes = new ArrayList<>();
         attributes.add(docId);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
@@ -29,7 +29,7 @@ public class ReplaceSourceAttributes extends PhysicalOptimizerRules.OptimizerRul
 
     @Override
     protected PhysicalPlan rule(EsSourceExec plan) {
-        var docId = new FieldAttribute(plan.source(), EsQueryExec.DOC_ID_FIELD.getName(), EsQueryExec.DOC_ID_FIELD);
+        var docId = new FieldAttribute(plan.source(), null, EsQueryExec.DOC_ID_FIELD.getName(), EsQueryExec.DOC_ID_FIELD);
         final List<Attribute> attributes = new ArrayList<>();
         attributes.add(docId);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
@@ -11,6 +11,7 @@ import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsSourceExec;
@@ -29,7 +30,7 @@ public class ReplaceSourceAttributes extends PhysicalOptimizerRules.OptimizerRul
 
     @Override
     protected PhysicalPlan rule(EsSourceExec plan) {
-        var docId = new FieldAttribute(plan.source(), null, EsQueryExec.DOC_ID_FIELD.getName(), EsQueryExec.DOC_ID_FIELD);
+        var docId = new FieldAttribute(plan.source(), null, EsQueryExec.DOC_ID_FIELD.getName(), EsQueryExec.DOC_ID_FIELD, Nullability.TRUE, null, false);
         final List<Attribute> attributes = new ArrayList<>();
         attributes.add(docId);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -141,7 +141,10 @@ public class EsRelation extends LeafPlan {
                     parent != null ? parent.name() : null,
                     parent != null ? parent.name() + "." + name : name,
                     t,
-                    Nullability.TRUE, null, false);
+                    Nullability.TRUE,
+                    null,
+                    false
+                );
                 list.add(f);
                 // object or nested
                 if (t.getProperties().isEmpty() == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -139,8 +140,8 @@ public class EsRelation extends LeafPlan {
                     source,
                     parent != null ? parent.name() : null,
                     parent != null ? parent.name() + "." + name : name,
-                    t
-                );
+                    t,
+                    Nullability.TRUE, null, false);
                 list.add(f);
                 // object or nested
                 if (t.getProperties().isEmpty() == false) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -184,7 +184,7 @@ public class AnalyzerTests extends ESTestCase {
         var limit = as(plan, Limit.class);
         var eval = as(limit.child(), Eval.class);
         assertEquals(1, eval.fields().size());
-        assertEquals(new Alias(EMPTY, "e", new FieldAttribute(EMPTY, "emp_no", idx.mapping().get("emp_no"))), eval.fields().get(0));
+        assertEquals(new Alias(EMPTY, "e", new FieldAttribute(EMPTY, null, "emp_no", idx.mapping().get("emp_no"))), eval.fields().get(0));
 
         assertEquals(2, eval.output().size());
         Attribute empNo = eval.output().get(0);
@@ -2911,7 +2911,7 @@ public class AnalyzerTests extends ESTestCase {
         var limit = as(plan, Limit.class);
         var insist = as(limit.child(), Insist.class);
         assertThat(insist.output(), hasSize(analyze("FROM test").output().size() + 1));
-        var expectedAttribute = new FieldAttribute(Source.EMPTY, "foo", new PotentiallyUnmappedKeywordEsField("foo"));
+        var expectedAttribute = new FieldAttribute(Source.EMPTY, null, "foo", new PotentiallyUnmappedKeywordEsField("foo"));
         assertThat(insist.insistedAttributes(), is(List.of(expectedAttribute)));
         assertThat(insist.output().getLast(), is(expectedAttribute));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -185,7 +185,10 @@ public class AnalyzerTests extends ESTestCase {
         var limit = as(plan, Limit.class);
         var eval = as(limit.child(), Eval.class);
         assertEquals(1, eval.fields().size());
-        assertEquals(new Alias(EMPTY, "e", new FieldAttribute(EMPTY, null, "emp_no", idx.mapping().get("emp_no"), Nullability.TRUE, null, false)), eval.fields().get(0));
+        assertEquals(
+            new Alias(EMPTY, "e", new FieldAttribute(EMPTY, null, "emp_no", idx.mapping().get("emp_no"), Nullability.TRUE, null, false)),
+            eval.fields().get(0)
+        );
 
         assertEquals(2, eval.output().size());
         Attribute empNo = eval.output().get(0);
@@ -2912,7 +2915,15 @@ public class AnalyzerTests extends ESTestCase {
         var limit = as(plan, Limit.class);
         var insist = as(limit.child(), Insist.class);
         assertThat(insist.output(), hasSize(analyze("FROM test").output().size() + 1));
-        var expectedAttribute = new FieldAttribute(Source.EMPTY, null, "foo", new PotentiallyUnmappedKeywordEsField("foo"), Nullability.TRUE, null, false);
+        var expectedAttribute = new FieldAttribute(
+            Source.EMPTY,
+            null,
+            "foo",
+            new PotentiallyUnmappedKeywordEsField("foo"),
+            Nullability.TRUE,
+            null,
+            false
+        );
         assertThat(insist.insistedAttributes(), is(List.of(expectedAttribute)));
         assertThat(insist.output().getLast(), is(expectedAttribute));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MapExpression;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -184,7 +185,7 @@ public class AnalyzerTests extends ESTestCase {
         var limit = as(plan, Limit.class);
         var eval = as(limit.child(), Eval.class);
         assertEquals(1, eval.fields().size());
-        assertEquals(new Alias(EMPTY, "e", new FieldAttribute(EMPTY, null, "emp_no", idx.mapping().get("emp_no"))), eval.fields().get(0));
+        assertEquals(new Alias(EMPTY, "e", new FieldAttribute(EMPTY, null, "emp_no", idx.mapping().get("emp_no"), Nullability.TRUE, null, false)), eval.fields().get(0));
 
         assertEquals(2, eval.output().size());
         Attribute empNo = eval.output().get(0);
@@ -2911,7 +2912,7 @@ public class AnalyzerTests extends ESTestCase {
         var limit = as(plan, Limit.class);
         var insist = as(limit.child(), Insist.class);
         assertThat(insist.output(), hasSize(analyze("FROM test").output().size() + 1));
-        var expectedAttribute = new FieldAttribute(Source.EMPTY, null, "foo", new PotentiallyUnmappedKeywordEsField("foo"));
+        var expectedAttribute = new FieldAttribute(Source.EMPTY, null, "foo", new PotentiallyUnmappedKeywordEsField("foo"), Nullability.TRUE, null, false);
         assertThat(insist.insistedAttributes(), is(List.of(expectedAttribute)));
         assertThat(insist.output().getLast(), is(expectedAttribute));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -446,7 +446,7 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
      * Build an {@link Attribute} that loads a field.
      */
     public static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.synthetic(name), name, new EsField(name, type, Map.of(), true));
+        return new FieldAttribute(Source.synthetic(name), null, name, new EsField(name, type, Map.of(), true));
     }
 
     /**
@@ -455,7 +455,7 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
     public static Expression deepCopyOfField(String name, DataType type) {
         return new DeepCopy(
             Source.synthetic(name),
-            new FieldAttribute(Source.synthetic(name), name, new EsField(name, type, Map.of(), true))
+            new FieldAttribute(Source.synthetic(name), null, name, new EsField(name, type, Map.of(), true))
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -446,7 +447,7 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
      * Build an {@link Attribute} that loads a field.
      */
     public static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.synthetic(name), null, name, new EsField(name, type, Map.of(), true));
+        return new FieldAttribute(Source.synthetic(name), null, name, new EsField(name, type, Map.of(), true), Nullability.TRUE, null, false);
     }
 
     /**
@@ -455,7 +456,7 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
     public static Expression deepCopyOfField(String name, DataType type) {
         return new DeepCopy(
             Source.synthetic(name),
-            new FieldAttribute(Source.synthetic(name), null, name, new EsField(name, type, Map.of(), true))
+            new FieldAttribute(Source.synthetic(name), null, name, new EsField(name, type, Map.of(), true), Nullability.TRUE, null, false)
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -447,7 +447,15 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
      * Build an {@link Attribute} that loads a field.
      */
     public static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.synthetic(name), null, name, new EsField(name, type, Map.of(), true), Nullability.TRUE, null, false);
+        return new FieldAttribute(
+            Source.synthetic(name),
+            null,
+            name,
+            new EsField(name, type, Map.of(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/NamedExpressionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/NamedExpressionTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.Location;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -53,7 +54,7 @@ public class NamedExpressionTests extends ESTestCase {
     }
 
     public void testNameForArithmeticFunctionAppliedOnTableColumn() {
-        FieldAttribute fa = new FieldAttribute(EMPTY, null, "myField", new EsField("myESField", DataType.INTEGER, emptyMap(), true));
+        FieldAttribute fa = new FieldAttribute(EMPTY, null, "myField", new EsField("myESField", DataType.INTEGER, emptyMap(), true), Nullability.TRUE, null, false);
         String e = "myField  + 10";
         Add add = new Add(s(e), fa, l(10));
         assertEquals(e, add.sourceText());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/NamedExpressionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/NamedExpressionTests.java
@@ -53,7 +53,7 @@ public class NamedExpressionTests extends ESTestCase {
     }
 
     public void testNameForArithmeticFunctionAppliedOnTableColumn() {
-        FieldAttribute fa = new FieldAttribute(EMPTY, "myField", new EsField("myESField", DataType.INTEGER, emptyMap(), true));
+        FieldAttribute fa = new FieldAttribute(EMPTY, null, "myField", new EsField("myESField", DataType.INTEGER, emptyMap(), true));
         String e = "myField  + 10";
         Add add = new Add(s(e), fa, l(10));
         assertEquals(e, add.sourceText());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/NamedExpressionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/NamedExpressionTests.java
@@ -54,7 +54,15 @@ public class NamedExpressionTests extends ESTestCase {
     }
 
     public void testNameForArithmeticFunctionAppliedOnTableColumn() {
-        FieldAttribute fa = new FieldAttribute(EMPTY, null, "myField", new EsField("myESField", DataType.INTEGER, emptyMap(), true), Nullability.TRUE, null, false);
+        FieldAttribute fa = new FieldAttribute(
+            EMPTY,
+            null,
+            "myField",
+            new EsField("myESField", DataType.INTEGER, emptyMap(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
         String e = "myField  + 10";
         Add add = new Add(s(e), fa, l(10));
         assertEquals(e, add.sourceText());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
@@ -205,7 +205,15 @@ public class CoalesceTests extends AbstractScalarFunctionTestCase {
 
     public void testCoalesceIsLazy() {
         List<Expression> sub = new ArrayList<>(testCase.getDataAsFields());
-        FieldAttribute evil = new FieldAttribute(Source.EMPTY, null, "evil", new EsField("evil", sub.get(0).dataType(), Map.of(), true), Nullability.TRUE, null, false);
+        FieldAttribute evil = new FieldAttribute(
+            Source.EMPTY,
+            null,
+            "evil",
+            new EsField("evil", sub.get(0).dataType(), Map.of(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
         sub.add(evil);
         Coalesce exp = build(Source.EMPTY, sub);
         Layout.Builder builder = new Layout.Builder();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
@@ -205,7 +205,7 @@ public class CoalesceTests extends AbstractScalarFunctionTestCase {
 
     public void testCoalesceIsLazy() {
         List<Expression> sub = new ArrayList<>(testCase.getDataAsFields());
-        FieldAttribute evil = new FieldAttribute(Source.EMPTY, null, "evil", new EsField("evil", sub.get(0).dataType(), Map.of(), true));
+        FieldAttribute evil = new FieldAttribute(Source.EMPTY, null, "evil", new EsField("evil", sub.get(0).dataType(), Map.of(), true), Nullability.TRUE, null, false);
         sub.add(evil);
         Coalesce exp = build(Source.EMPTY, sub);
         Layout.Builder builder = new Layout.Builder();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
@@ -205,7 +205,7 @@ public class CoalesceTests extends AbstractScalarFunctionTestCase {
 
     public void testCoalesceIsLazy() {
         List<Expression> sub = new ArrayList<>(testCase.getDataAsFields());
-        FieldAttribute evil = new FieldAttribute(Source.EMPTY, "evil", new EsField("evil", sub.get(0).dataType(), Map.of(), true));
+        FieldAttribute evil = new FieldAttribute(Source.EMPTY, null, "evil", new EsField("evil", sub.get(0).dataType(), Map.of(), true));
         sub.add(evil);
         Coalesce exp = build(Source.EMPTY, sub);
         Layout.Builder builder = new Layout.Builder();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithTests.java
@@ -120,8 +120,24 @@ public class EndsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldableSuffix_NonTranslatable() {
         var function = new EndsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false),
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false)
+            new FieldAttribute(
+                Source.EMPTY,
+                null,
+                "field",
+                new EsField("field", DataType.KEYWORD, Map.of(), true),
+                Nullability.TRUE,
+                null,
+                false
+            ),
+            new FieldAttribute(
+                Source.EMPTY,
+                null,
+                "field",
+                new EsField("suffix", DataType.KEYWORD, Map.of(), true),
+                Nullability.TRUE,
+                null,
+                false
+            )
         );
 
         assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(false));
@@ -130,7 +146,15 @@ public class EndsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldableSuffix_Translatable() {
         var function = new EndsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false),
+            new FieldAttribute(
+                Source.EMPTY,
+                null,
+                "field",
+                new EsField("suffix", DataType.KEYWORD, Map.of(), true),
+                Nullability.TRUE,
+                null,
+                false
+            ),
             new Literal(Source.EMPTY, "a*b?c\\", DataType.KEYWORD)
         );
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithTests.java
@@ -119,8 +119,8 @@ public class EndsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldableSuffix_NonTranslatable() {
         var function = new EndsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, "field", new EsField("field", DataType.KEYWORD, Map.of(), true)),
-            new FieldAttribute(Source.EMPTY, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true))
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.KEYWORD, Map.of(), true)),
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true))
         );
 
         assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(false));
@@ -129,7 +129,7 @@ public class EndsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldableSuffix_Translatable() {
         var function = new EndsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true)),
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true)),
             new Literal(Source.EMPTY, "a*b?c\\", DataType.KEYWORD)
         );
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.querydsl.query.WildcardQuery;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -119,8 +120,8 @@ public class EndsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldableSuffix_NonTranslatable() {
         var function = new EndsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.KEYWORD, Map.of(), true)),
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true))
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false),
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false)
         );
 
         assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(false));
@@ -129,7 +130,7 @@ public class EndsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldableSuffix_Translatable() {
         var function = new EndsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true)),
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false),
             new Literal(Source.EMPTY, "a*b?c\\", DataType.KEYWORD)
         );
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatStaticTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatStaticTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.test.TestBlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
@@ -82,7 +83,7 @@ public class RepeatStaticTests extends ESTestCase {
     }
 
     private static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.synthetic(name), null, name, new EsField(name, type, Map.of(), true));
+        return new FieldAttribute(Source.synthetic(name), null, name, new EsField(name, type, Map.of(), true), Nullability.TRUE, null, false);
     }
 
     private DriverContext driverContext() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatStaticTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatStaticTests.java
@@ -83,7 +83,15 @@ public class RepeatStaticTests extends ESTestCase {
     }
 
     private static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.synthetic(name), null, name, new EsField(name, type, Map.of(), true), Nullability.TRUE, null, false);
+        return new FieldAttribute(
+            Source.synthetic(name),
+            null,
+            name,
+            new EsField(name, type, Map.of(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
     }
 
     private DriverContext driverContext() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatStaticTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatStaticTests.java
@@ -82,7 +82,7 @@ public class RepeatStaticTests extends ESTestCase {
     }
 
     private static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.synthetic(name), name, new EsField(name, type, Map.of(), true));
+        return new FieldAttribute(Source.synthetic(name), null, name, new EsField(name, type, Map.of(), true));
     }
 
     private DriverContext driverContext() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.querydsl.query.WildcardQuery;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -79,8 +80,8 @@ public class StartsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldablePrefix_NonTranslatable() {
         var function = new StartsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.KEYWORD, Map.of(), true)),
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("prefix", DataType.KEYWORD, Map.of(), true))
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false),
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("prefix", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false)
         );
 
         assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(false));
@@ -89,7 +90,7 @@ public class StartsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldablePrefix_Translatable() {
         var function = new StartsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("prefix", DataType.KEYWORD, Map.of(), true)),
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("prefix", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false),
             new Literal(Source.EMPTY, "a*b?c\\", DataType.KEYWORD)
         );
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithTests.java
@@ -80,8 +80,24 @@ public class StartsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldablePrefix_NonTranslatable() {
         var function = new StartsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false),
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("prefix", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false)
+            new FieldAttribute(
+                Source.EMPTY,
+                null,
+                "field",
+                new EsField("field", DataType.KEYWORD, Map.of(), true),
+                Nullability.TRUE,
+                null,
+                false
+            ),
+            new FieldAttribute(
+                Source.EMPTY,
+                null,
+                "field",
+                new EsField("prefix", DataType.KEYWORD, Map.of(), true),
+                Nullability.TRUE,
+                null,
+                false
+            )
         );
 
         assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(false));
@@ -90,7 +106,15 @@ public class StartsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldablePrefix_Translatable() {
         var function = new StartsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("prefix", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false),
+            new FieldAttribute(
+                Source.EMPTY,
+                null,
+                "field",
+                new EsField("prefix", DataType.KEYWORD, Map.of(), true),
+                Nullability.TRUE,
+                null,
+                false
+            ),
             new Literal(Source.EMPTY, "a*b?c\\", DataType.KEYWORD)
         );
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithTests.java
@@ -79,8 +79,8 @@ public class StartsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldablePrefix_NonTranslatable() {
         var function = new StartsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, "field", new EsField("field", DataType.KEYWORD, Map.of(), true)),
-            new FieldAttribute(Source.EMPTY, "field", new EsField("prefix", DataType.KEYWORD, Map.of(), true))
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.KEYWORD, Map.of(), true)),
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("prefix", DataType.KEYWORD, Map.of(), true))
         );
 
         assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(false));
@@ -89,7 +89,7 @@ public class StartsWithTests extends AbstractScalarFunctionTestCase {
     public void testLuceneQuery_NonFoldablePrefix_Translatable() {
         var function = new StartsWith(
             Source.EMPTY,
-            new FieldAttribute(Source.EMPTY, "field", new EsField("prefix", DataType.KEYWORD, Map.of(), true)),
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("prefix", DataType.KEYWORD, Map.of(), true)),
             new Literal(Source.EMPTY, "a*b?c\\", DataType.KEYWORD)
         );
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.querydsl.query.TermsQuery;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -90,7 +91,7 @@ public class InTests extends AbstractFunctionTestCase {
     public void testConvertedNull() {
         In in = new In(
             EMPTY,
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true)),
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false),
             Arrays.asList(ONE, new Literal(Source.EMPTY, null, randomFrom(DataType.types())), THREE)
         );
         var query = in.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
@@ -91,7 +91,15 @@ public class InTests extends AbstractFunctionTestCase {
     public void testConvertedNull() {
         In in = new In(
             EMPTY,
-            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false),
+            new FieldAttribute(
+                Source.EMPTY,
+                null,
+                "field",
+                new EsField("suffix", DataType.KEYWORD, Map.of(), true),
+                Nullability.TRUE,
+                null,
+                false
+            ),
             Arrays.asList(ONE, new Literal(Source.EMPTY, null, randomFrom(DataType.types())), THREE)
         );
         var query = in.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
@@ -90,7 +90,7 @@ public class InTests extends AbstractFunctionTestCase {
     public void testConvertedNull() {
         In in = new In(
             EMPTY,
-            new FieldAttribute(Source.EMPTY, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true)),
+            new FieldAttribute(Source.EMPTY, null, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true)),
             Arrays.asList(ONE, new Literal(Source.EMPTY, null, randomFrom(DataType.types())), THREE)
         );
         var query = in.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -328,7 +328,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
             new MockFieldAttributeCommand(
                 EMPTY,
                 new Row(EMPTY, List.of()),
-                new FieldAttribute(EMPTY, "last_name", new EsField("last_name", DataType.KEYWORD, Map.of(), true))
+                new FieldAttribute(EMPTY, null, "last_name", new EsField("last_name", DataType.KEYWORD, Map.of(), true))
             ),
             testStats
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -328,7 +329,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
             new MockFieldAttributeCommand(
                 EMPTY,
                 new Row(EMPTY, List.of()),
-                new FieldAttribute(EMPTY, null, "last_name", new EsField("last_name", DataType.KEYWORD, Map.of(), true))
+                new FieldAttribute(EMPTY, null, "last_name", new EsField("last_name", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false)
             ),
             testStats
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -329,7 +329,15 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
             new MockFieldAttributeCommand(
                 EMPTY,
                 new Row(EMPTY, List.of()),
-                new FieldAttribute(EMPTY, null, "last_name", new EsField("last_name", DataType.KEYWORD, Map.of(), true), Nullability.TRUE, null, false)
+                new FieldAttribute(
+                    EMPTY,
+                    null,
+                    "last_name",
+                    new EsField("last_name", DataType.KEYWORD, Map.of(), true),
+                    Nullability.TRUE,
+                    null,
+                    false
+                )
             ),
             testStats
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -1585,7 +1585,11 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
                 new Alias(
                     EMPTY,
                     "y",
-                    new Mul(EMPTY, new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no"), Nullability.TRUE, null, false), new Literal(EMPTY, 2, INTEGER))
+                    new Mul(
+                        EMPTY,
+                        new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no"), Nullability.TRUE, null, false),
+                        new Literal(EMPTY, 2, INTEGER)
+                    )
                 )
             )
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -1585,7 +1585,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
                 new Alias(
                     EMPTY,
                     "y",
-                    new Mul(EMPTY, new FieldAttribute(EMPTY, "emp_no", mapping.get("emp_no")), new Literal(EMPTY, 2, INTEGER))
+                    new Mul(EMPTY, new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")), new Literal(EMPTY, 2, INTEGER))
                 )
             )
         );
@@ -2890,19 +2890,19 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
                     Order.OrderDirection.ASC,
                     Order.NullsPosition.LAST
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, "salary", mapping.get("salary")),
+                    new FieldAttribute(EMPTY, null, "salary", mapping.get("salary")),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.FIRST
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.FIRST
                 )
@@ -2933,19 +2933,19 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.FIRST
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, "salary", mapping.get("salary")),
+                    new FieldAttribute(EMPTY, null, "salary", mapping.get("salary")),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.FIRST
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.LAST
                 )
@@ -2969,7 +2969,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
             contains(
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
                     Order.OrderDirection.ASC,
                     Order.NullsPosition.LAST
                 )
@@ -2992,7 +2992,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
             contains(
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.FIRST
                 )

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -1585,7 +1585,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
                 new Alias(
                     EMPTY,
                     "y",
-                    new Mul(EMPTY, new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")), new Literal(EMPTY, 2, INTEGER))
+                    new Mul(EMPTY, new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no"), Nullability.TRUE, null, false), new Literal(EMPTY, 2, INTEGER))
                 )
             )
         );
@@ -2890,19 +2890,19 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no"), Nullability.TRUE, null, false),
                     Order.OrderDirection.ASC,
                     Order.NullsPosition.LAST
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, null, "salary", mapping.get("salary")),
+                    new FieldAttribute(EMPTY, null, "salary", mapping.get("salary"), Nullability.TRUE, null, false),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.FIRST
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no"), Nullability.TRUE, null, false),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.FIRST
                 )
@@ -2933,19 +2933,19 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no"), Nullability.TRUE, null, false),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.FIRST
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, null, "salary", mapping.get("salary")),
+                    new FieldAttribute(EMPTY, null, "salary", mapping.get("salary"), Nullability.TRUE, null, false),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.FIRST
                 ),
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no"), Nullability.TRUE, null, false),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.LAST
                 )
@@ -2969,7 +2969,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
             contains(
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no"), Nullability.TRUE, null, false),
                     Order.OrderDirection.ASC,
                     Order.NullsPosition.LAST
                 )
@@ -2992,7 +2992,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
             contains(
                 new Order(
                     EMPTY,
-                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no")),
+                    new FieldAttribute(EMPTY, null, "emp_no", mapping.get("emp_no"), Nullability.TRUE, null, false),
                     Order.OrderDirection.DESC,
                     Order.NullsPosition.FIRST
                 )

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
@@ -505,7 +505,7 @@ public class PushTopNToSourceTests extends ESTestCase {
         }
 
         private static void addFieldAttribute(Map<String, FieldAttribute> fields, String name, DataType type) {
-            fields.put(name, new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, new HashMap<>(), true)));
+            fields.put(name, new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, new HashMap<>(), true), Nullability.TRUE, null, false));
         }
 
         static TestPhysicalPlanBuilder from(String index) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
@@ -505,7 +505,7 @@ public class PushTopNToSourceTests extends ESTestCase {
         }
 
         private static void addFieldAttribute(Map<String, FieldAttribute> fields, String name, DataType type) {
-            fields.put(name, new FieldAttribute(Source.EMPTY, name, new EsField(name, type, new HashMap<>(), true)));
+            fields.put(name, new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, new HashMap<>(), true)));
         }
 
         static TestPhysicalPlanBuilder from(String index) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
@@ -505,7 +505,10 @@ public class PushTopNToSourceTests extends ESTestCase {
         }
 
         private static void addFieldAttribute(Map<String, FieldAttribute> fields, String name, DataType type) {
-            fields.put(name, new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, new HashMap<>(), true), Nullability.TRUE, null, false));
+            fields.put(
+                name,
+                new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, new HashMap<>(), true), Nullability.TRUE, null, false)
+            );
         }
 
         static TestPhysicalPlanBuilder from(String index) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QueryPlanTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QueryPlanTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
@@ -64,7 +65,7 @@ public class QueryPlanTests extends ESTestCase {
         Project project = new Project(EMPTY, relation(), asList(one, two));
         LogicalPlan transformed = project.transformExpressionsOnly(
             NamedExpression.class,
-            n -> n.name().equals("one") ? new FieldAttribute(EMPTY, null, "changed", one.field()) : n
+            n -> n.name().equals("one") ? new FieldAttribute(EMPTY, null, "changed", one.field(), Nullability.TRUE, null, false) : n
         );
 
         assertEquals(Project.class, transformed.getClass());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QueryPlanTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QueryPlanTests.java
@@ -64,7 +64,7 @@ public class QueryPlanTests extends ESTestCase {
         Project project = new Project(EMPTY, relation(), asList(one, two));
         LogicalPlan transformed = project.transformExpressionsOnly(
             NamedExpression.class,
-            n -> n.name().equals("one") ? new FieldAttribute(EMPTY, "changed", one.field()) : n
+            n -> n.name().equals("one") ? new FieldAttribute(EMPTY, null, "changed", one.field()) : n
         );
 
         assertEquals(Project.class, transformed.getClass());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
@@ -161,7 +161,7 @@ public class EvalMapperTests extends ESTestCase {
     }
 
     private static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.EMPTY, name, new EsField(name, type, Collections.emptyMap(), false));
+        return new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, Collections.emptyMap(), false));
     }
 
     static DriverContext driverContext() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
@@ -162,7 +162,15 @@ public class EvalMapperTests extends ESTestCase {
     }
 
     private static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, Collections.emptyMap(), false), Nullability.TRUE, null, false);
+        return new FieldAttribute(
+            Source.EMPTY,
+            null,
+            name,
+            new EsField(name, type, Collections.emptyMap(), false),
+            Nullability.TRUE,
+            null,
+            false
+        );
     }
 
     static DriverContext driverContext() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
@@ -161,7 +162,7 @@ public class EvalMapperTests extends ESTestCase {
     }
 
     private static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, Collections.emptyMap(), false));
+        return new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, Collections.emptyMap(), false), Nullability.TRUE, null, false);
     }
 
     static DriverContext driverContext() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -129,7 +129,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
 
     public void testLuceneTopNSourceOperator() throws IOException {
         int estimatedRowSize = randomEstimatedRowSize(estimatedRowSizeIsHuge);
-        FieldAttribute sortField = new FieldAttribute(Source.EMPTY, "field", new EsField("field", DataType.INTEGER, Map.of(), true));
+        FieldAttribute sortField = new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.INTEGER, Map.of(), true));
         EsQueryExec.FieldSort sort = new EsQueryExec.FieldSort(sortField, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
         Literal limit = new Literal(Source.EMPTY, 10, DataType.INTEGER);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(
@@ -156,7 +156,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
 
     public void testLuceneTopNSourceOperatorDistanceSort() throws IOException {
         int estimatedRowSize = randomEstimatedRowSize(estimatedRowSizeIsHuge);
-        FieldAttribute sortField = new FieldAttribute(Source.EMPTY, "point", new EsField("point", DataType.GEO_POINT, Map.of(), true));
+        FieldAttribute sortField = new FieldAttribute(Source.EMPTY, null, "point", new EsField("point", DataType.GEO_POINT, Map.of(), true));
         EsQueryExec.GeoDistanceSort sort = new EsQueryExec.GeoDistanceSort(sortField, Order.OrderDirection.ASC, 1, -1);
         Literal limit = new Literal(Source.EMPTY, 10, DataType.INTEGER);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
@@ -129,7 +130,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
 
     public void testLuceneTopNSourceOperator() throws IOException {
         int estimatedRowSize = randomEstimatedRowSize(estimatedRowSizeIsHuge);
-        FieldAttribute sortField = new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.INTEGER, Map.of(), true));
+        FieldAttribute sortField = new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.INTEGER, Map.of(), true), Nullability.TRUE, null, false);
         EsQueryExec.FieldSort sort = new EsQueryExec.FieldSort(sortField, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
         Literal limit = new Literal(Source.EMPTY, 10, DataType.INTEGER);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(
@@ -156,7 +157,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
 
     public void testLuceneTopNSourceOperatorDistanceSort() throws IOException {
         int estimatedRowSize = randomEstimatedRowSize(estimatedRowSizeIsHuge);
-        FieldAttribute sortField = new FieldAttribute(Source.EMPTY, null, "point", new EsField("point", DataType.GEO_POINT, Map.of(), true));
+        FieldAttribute sortField = new FieldAttribute(Source.EMPTY, null, "point", new EsField("point", DataType.GEO_POINT, Map.of(), true), Nullability.TRUE, null, false);
         EsQueryExec.GeoDistanceSort sort = new EsQueryExec.GeoDistanceSort(sortField, Order.OrderDirection.ASC, 1, -1);
         Literal limit = new Literal(Source.EMPTY, 10, DataType.INTEGER);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -130,7 +130,15 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
 
     public void testLuceneTopNSourceOperator() throws IOException {
         int estimatedRowSize = randomEstimatedRowSize(estimatedRowSizeIsHuge);
-        FieldAttribute sortField = new FieldAttribute(Source.EMPTY, null, "field", new EsField("field", DataType.INTEGER, Map.of(), true), Nullability.TRUE, null, false);
+        FieldAttribute sortField = new FieldAttribute(
+            Source.EMPTY,
+            null,
+            "field",
+            new EsField("field", DataType.INTEGER, Map.of(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
         EsQueryExec.FieldSort sort = new EsQueryExec.FieldSort(sortField, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
         Literal limit = new Literal(Source.EMPTY, 10, DataType.INTEGER);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(
@@ -157,7 +165,15 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
 
     public void testLuceneTopNSourceOperatorDistanceSort() throws IOException {
         int estimatedRowSize = randomEstimatedRowSize(estimatedRowSizeIsHuge);
-        FieldAttribute sortField = new FieldAttribute(Source.EMPTY, null, "point", new EsField("point", DataType.GEO_POINT, Map.of(), true), Nullability.TRUE, null, false);
+        FieldAttribute sortField = new FieldAttribute(
+            Source.EMPTY,
+            null,
+            "point",
+            new EsField("point", DataType.GEO_POINT, Map.of(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
         EsQueryExec.GeoDistanceSort sort = new EsQueryExec.GeoDistanceSort(sortField, Order.OrderDirection.ASC, 1, -1);
         Literal limit = new Literal(Source.EMPTY, 10, DataType.INTEGER);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/MatchQueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/MatchQueryTests.java
@@ -65,14 +65,14 @@ public class MatchQueryTests extends ESTestCase {
 
     private static MatchQueryBuilder getBuilder(Map<String, Object> options) {
         final Source source = new Source(1, 1, StringUtils.EMPTY);
-        FieldAttribute fa = new FieldAttribute(EMPTY, "a", new EsField("af", KEYWORD, emptyMap(), true));
+        FieldAttribute fa = new FieldAttribute(EMPTY, null, "a", new EsField("af", KEYWORD, emptyMap(), true));
         final MatchQuery mmq = new MatchQuery(source, "eggplant", "foo", options);
         return (MatchQueryBuilder) mmq.asBuilder();
     }
 
     public void testToString() {
         final Source source = new Source(1, 1, StringUtils.EMPTY);
-        FieldAttribute fa = new FieldAttribute(EMPTY, "a", new EsField("af", KEYWORD, emptyMap(), true));
+        FieldAttribute fa = new FieldAttribute(EMPTY, null, "a", new EsField("af", KEYWORD, emptyMap(), true));
         final MatchQuery mmq = new MatchQuery(source, "eggplant", "foo");
         assertEquals("MatchQuery@1:2[eggplant:foo]", mmq.toString());
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/MatchQueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/MatchQueryTests.java
@@ -66,14 +66,30 @@ public class MatchQueryTests extends ESTestCase {
 
     private static MatchQueryBuilder getBuilder(Map<String, Object> options) {
         final Source source = new Source(1, 1, StringUtils.EMPTY);
-        FieldAttribute fa = new FieldAttribute(EMPTY, null, "a", new EsField("af", KEYWORD, emptyMap(), true), Nullability.TRUE, null, false);
+        FieldAttribute fa = new FieldAttribute(
+            EMPTY,
+            null,
+            "a",
+            new EsField("af", KEYWORD, emptyMap(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
         final MatchQuery mmq = new MatchQuery(source, "eggplant", "foo", options);
         return (MatchQueryBuilder) mmq.asBuilder();
     }
 
     public void testToString() {
         final Source source = new Source(1, 1, StringUtils.EMPTY);
-        FieldAttribute fa = new FieldAttribute(EMPTY, null, "a", new EsField("af", KEYWORD, emptyMap(), true), Nullability.TRUE, null, false);
+        FieldAttribute fa = new FieldAttribute(
+            EMPTY,
+            null,
+            "a",
+            new EsField("af", KEYWORD, emptyMap(), true),
+            Nullability.TRUE,
+            null,
+            false
+        );
         final MatchQuery mmq = new MatchQuery(source, "eggplant", "foo");
         assertEquals("MatchQuery@1:2[eggplant:foo]", mmq.toString());
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/MatchQueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/MatchQueryTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.tree.SourceTests;
 import org.elasticsearch.xpack.esql.core.type.EsField;
@@ -65,14 +66,14 @@ public class MatchQueryTests extends ESTestCase {
 
     private static MatchQueryBuilder getBuilder(Map<String, Object> options) {
         final Source source = new Source(1, 1, StringUtils.EMPTY);
-        FieldAttribute fa = new FieldAttribute(EMPTY, null, "a", new EsField("af", KEYWORD, emptyMap(), true));
+        FieldAttribute fa = new FieldAttribute(EMPTY, null, "a", new EsField("af", KEYWORD, emptyMap(), true), Nullability.TRUE, null, false);
         final MatchQuery mmq = new MatchQuery(source, "eggplant", "foo", options);
         return (MatchQueryBuilder) mmq.asBuilder();
     }
 
     public void testToString() {
         final Source source = new Source(1, 1, StringUtils.EMPTY);
-        FieldAttribute fa = new FieldAttribute(EMPTY, null, "a", new EsField("af", KEYWORD, emptyMap(), true));
+        FieldAttribute fa = new FieldAttribute(EMPTY, null, "a", new EsField("af", KEYWORD, emptyMap(), true), Nullability.TRUE, null, false);
         final MatchQuery mmq = new MatchQuery(source, "eggplant", "foo");
         assertEquals("MatchQuery@1:2[eggplant:foo]", mmq.toString());
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -734,7 +734,15 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
     }
 
     static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, Collections.emptyMap(), false), Nullability.TRUE, null, false);
+        return new FieldAttribute(
+            Source.EMPTY,
+            null,
+            name,
+            new EsField(name, type, Collections.emptyMap(), false),
+            Nullability.TRUE,
+            null,
+            false
+        );
     }
 
     public static <T> Set<Class<? extends T>> subclassesOf(Class<T> clazz) throws IOException {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.core.capabilities.UnresolvedException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttributeTests;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedNamedExpression;
@@ -733,7 +734,7 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
     }
 
     static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, Collections.emptyMap(), false));
+        return new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, Collections.emptyMap(), false), Nullability.TRUE, null, false);
     }
 
     public static <T> Set<Class<? extends T>> subclassesOf(Class<T> clazz) throws IOException {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -733,7 +733,7 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
     }
 
     static FieldAttribute field(String name, DataType type) {
-        return new FieldAttribute(Source.EMPTY, name, new EsField(name, type, Collections.emptyMap(), false));
+        return new FieldAttribute(Source.EMPTY, null, name, new EsField(name, type, Collections.emptyMap(), false));
     }
 
     public static <T> Set<Class<? extends T>> subclassesOf(Class<T> clazz) throws IOException {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/MultiTypeEsFieldTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/MultiTypeEsFieldTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.test.AbstractWireTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
@@ -169,6 +170,6 @@ public class MultiTypeEsFieldTests extends AbstractWireTestCase<MultiTypeEsField
     }
 
     private static FieldAttribute fieldAttribute(String name, DataType dataType) {
-        return new FieldAttribute(Source.EMPTY, null, name, new EsField(name, dataType, Map.of(), true));
+        return new FieldAttribute(Source.EMPTY, null, name, new EsField(name, dataType, Map.of(), true), Nullability.TRUE, null, false);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/MultiTypeEsFieldTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/MultiTypeEsFieldTests.java
@@ -169,6 +169,6 @@ public class MultiTypeEsFieldTests extends AbstractWireTestCase<MultiTypeEsField
     }
 
     private static FieldAttribute fieldAttribute(String name, DataType dataType) {
-        return new FieldAttribute(Source.EMPTY, name, new EsField(name, dataType, Map.of(), true));
+        return new FieldAttribute(Source.EMPTY, null, name, new EsField(name, dataType, Map.of(), true));
     }
 }


### PR DESCRIPTION
This is an alternative approach to the refactoring in https://github.com/elastic/elasticsearch/pull/127851.  As discussed there, instead of adding a builder, I've just changed all the constructor invocations to explicitly pass in the various optional fields, and only kept the constructor accepting all fields. 

In my opinion, this is a worse solution.  It's more verbose, and it scatters the knowledge of the default values throughout the code base rather than keeping them in one place.  That said, it does avoid extra object creation. 