### PR TITLE
[9.0][Entitlements] Add missing outbound_network entitlement to x-pack-core

### DIFF
--- a/docs/changelog/126992.yaml
+++ b/docs/changelog/126992.yaml
@@ -1,0 +1,6 @@
+pr: 126992
+summary: Add missing `outbound_network` entitlement to x-pack-core
+area: Infra/Core
+type: bug
+issues:
+ - 127003

--- a/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
@@ -17,6 +17,8 @@ org.apache.httpcomponents.httpcore.nio:
 org.apache.httpcomponents.httpasyncclient:
   - manage_threads
 unboundid.ldapsdk:
+  - set_https_connection_properties # TODO: review if we need this once we have proper test coverage
+  - outbound_network
   - manage_threads
   - write_system_properties:
       properties:


### PR DESCRIPTION
Backport of #126992