### PR TITLE
[8.19] Clean up semantic text field mapper tests (#127853)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -210,7 +210,6 @@ public abstract class MapperServiceTestCase extends FieldTypeTestCase {
     protected final MapperService createMapperService(IndexVersion indexVersion, Settings settings, XContentBuilder mappings)
         throws IOException {
         MapperService mapperService = createMapperService(indexVersion, settings, () -> true, mappings);
-        merge(mapperService, mappings);
         return mapperService;
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
@@ -22,22 +22,6 @@ import java.util.Collection;
 import java.util.Collections;
 
 public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTestCase {
-
-    static IndexVersion getRandomCompatibleIndexVersion(boolean useLegacyFormat) {
-        return getRandomCompatibleIndexVersion(useLegacyFormat, IndexVersion.current());
-    }
-
-    static IndexVersion getRandomCompatibleIndexVersion(boolean useLegacyFormat, IndexVersion maxVersion) {
-        if (useLegacyFormat) {
-            if (randomBoolean()) {
-                return IndexVersionUtils.randomVersionBetween(random(), IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT, maxVersion);
-            }
-            return IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT);
-        } else {
-            return IndexVersionUtils.randomVersionBetween(random(), IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT, maxVersion);
-        }
-    }
-
     @Override
     protected Collection<? extends Plugin> getPlugins() {
         return Collections.singletonList(new InferencePlugin(Settings.EMPTY));
@@ -61,4 +45,19 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
     public MappedFieldType getMappedFieldType() {
         return new SemanticInferenceMetadataFieldsMapper.FieldType();
     }
+
+    static IndexVersion getRandomCompatibleIndexVersion(boolean useLegacyFormat) {
+        if (useLegacyFormat) {
+            // Randomly choose an index version compatible with the legacy semantic text format
+            return IndexVersionUtils.randomVersionBetween(random(), IndexVersions.SEMANTIC_TEXT_FIELD_TYPE, IndexVersion.current());
+        } else {
+            // Randomly choose an index version compatible with the new semantic text format
+            return IndexVersionUtils.randomVersionBetween(
+                random(),
+                IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT,
+                IndexVersion.current()
+            );
+        }
+    }
+
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -153,20 +153,19 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
 
     private MapperService createMapperService(XContentBuilder mappings, boolean useLegacyFormat) throws IOException {
         IndexVersion indexVersion = SemanticInferenceMetadataFieldsMapperTests.getRandomCompatibleIndexVersion(useLegacyFormat);
-        return createMapperService(mappings, useLegacyFormat, indexVersion, indexVersion, false);
+        return createMapperService(mappings, useLegacyFormat, indexVersion, indexVersion);
     }
 
     private MapperService createMapperService(XContentBuilder mappings, boolean useLegacyFormat, IndexVersion minIndexVersion)
         throws IOException {
-        return createMapperService(mappings, useLegacyFormat, minIndexVersion, IndexVersion.current(), false);
+        return createMapperService(mappings, useLegacyFormat, minIndexVersion, IndexVersion.current());
     }
 
     private MapperService createMapperService(
         XContentBuilder mappings,
         boolean useLegacyFormat,
         IndexVersion minIndexVersion,
-        IndexVersion maxIndexVersion,
-        boolean propagateIndexVersion
+        IndexVersion maxIndexVersion
     ) throws IOException {
         validateIndexVersion(minIndexVersion, useLegacyFormat);
         IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(random(), minIndexVersion, maxIndexVersion);
@@ -174,14 +173,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
             .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), indexVersion)
             .put(InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT.getKey(), useLegacyFormat)
             .build();
-        // TODO - This is added, because we discovered a bug where the index version was not being correctly propagated
-        // in our mappings even though we were specifying the index version in settings. We will fix this in a followup and
-        // remove the boolean flag accordingly.
-        if (propagateIndexVersion) {
-            return createMapperService(indexVersion, settings, mappings);
-        } else {
-            return createMapperService(settings, mappings);
-        }
+        return createMapperService(indexVersion, settings, mappings);
     }
 
     private static void validateIndexVersion(IndexVersion indexVersion, boolean useLegacyFormat) {
@@ -1187,8 +1179,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
         }),
             useLegacyFormat,
             IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT,
-            IndexVersionUtils.getPreviousVersion(IndexVersions.SEMANTIC_TEXT_DEFAULTS_TO_BBQ_BACKPORT_8_X),
-            true
+            IndexVersionUtils.getPreviousVersion(IndexVersions.SEMANTIC_TEXT_DEFAULTS_TO_BBQ_BACKPORT_8_X)
         );
         assertSemanticTextField(mapperService, "field", true, null, defaultDenseVectorIndexOptions());
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Clean up semantic text field mapper tests (#127853)](https://github.com/elastic/elasticsearch/pull/127853)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)