### PR TITLE
[9.0] Backport Semantic Text Mapper Test Fixes

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -207,6 +207,12 @@ public abstract class MapperServiceTestCase extends FieldTypeTestCase {
         return mapperService;
     }
 
+    protected final MapperService createMapperService(IndexVersion indexVersion, Settings settings, XContentBuilder mappings)
+        throws IOException {
+        MapperService mapperService = createMapperService(indexVersion, settings, () -> true, mappings);
+        return mapperService;
+    }
+
     protected final MapperService createMapperService(IndexVersion version, XContentBuilder mapping) throws IOException {
         return createMapperService(version, getIndexSettings(), () -> true, mapping);
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
@@ -37,12 +37,6 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
         assertFalse(InferenceMetadataFieldsMapper.isEnabled(settings));
 
         settings = Settings.builder()
-            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), getRandomCompatibleIndexVersion(true))
-            .put(InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT.getKey(), false)
-            .build();
-        assertFalse(InferenceMetadataFieldsMapper.isEnabled(settings));
-
-        settings = Settings.builder()
             .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), getRandomCompatibleIndexVersion(false))
             .put(InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT.getKey(), true)
             .build();
@@ -53,6 +47,34 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
             .put(InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT.getKey(), false)
             .build();
         assertTrue(InferenceMetadataFieldsMapper.isEnabled(settings));
+
+        // Test that index.mapping.semantic_text.use_legacy_format == false is ignored when the index version is too old to support the new
+        // format
+        settings = Settings.builder()
+            .put(
+                IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
+                IndexVersionUtils.randomVersionBetween(
+                    random(),
+                    IndexVersions.SEMANTIC_TEXT_FIELD_TYPE,
+                    IndexVersionUtils.getPreviousVersion(IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT)
+                )  // 8.x version range prior to the introduction of the new format
+            )
+            .put(InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT.getKey(), false)
+            .build();
+        assertFalse(InferenceMetadataFieldsMapper.isEnabled(settings));
+
+        settings = Settings.builder()
+            .put(
+                IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
+                IndexVersionUtils.randomVersionBetween(
+                    random(),
+                    IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
+                    IndexVersionUtils.getPreviousVersion(IndexVersions.INFERENCE_METADATA_FIELDS)
+                )  // 9.x version range prior to the introduction of the new format
+            )
+            .put(InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT.getKey(), false)
+            .build();
+        assertFalse(InferenceMetadataFieldsMapper.isEnabled(settings));
     }
 
     public void testIsEnabledByDefault() {
@@ -115,18 +137,26 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
 
     static IndexVersion getRandomCompatibleIndexVersion(boolean useLegacyFormat) {
         if (useLegacyFormat) {
+            // Randomly choose an index version compatible with the legacy semantic text format
             if (randomBoolean()) {
-                return IndexVersionUtils.randomVersionBetween(
-                    random(),
-                    IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
-                    IndexVersionUtils.getPreviousVersion(IndexVersions.INFERENCE_METADATA_FIELDS)
-                );
+                // 9.x+ version
+                return IndexVersionUtils.randomVersionBetween(random(), IndexVersions.UPGRADE_TO_LUCENE_10_0_0, IndexVersion.current());
             }
-            return IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT);
+
+            // 8.x version
+            return IndexVersionUtils.randomVersionBetween(
+                random(),
+                IndexVersions.SEMANTIC_TEXT_FIELD_TYPE,
+                IndexVersionUtils.getPreviousVersion(IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
+            );
         } else {
+            // Randomly choose an index version compatible with the new semantic text format
             if (randomBoolean()) {
+                // 9.x+ version
                 return IndexVersionUtils.randomVersionBetween(random(), IndexVersions.INFERENCE_METADATA_FIELDS, IndexVersion.current());
             }
+
+            // 8.x version
             return IndexVersionUtils.randomVersionBetween(
                 random(),
                 IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT,


### PR DESCRIPTION
Backport fixes from https://github.com/elastic/elasticsearch/pull/127853:

- Ensure all mappers are correctly propagating index version
- Synchronize `testIsEnabled` and `testIsEnabledByDefault` implementations 