### PR TITLE
Fix Semantic Text Rolling Upgrade Tests in 9.0

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -257,12 +257,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryIT
   method: testStopQueryLocal
   issue: https://github.com/elastic/elasticsearch/issues/125946
-- class: org.elasticsearch.upgrades.SemanticTextUpgradeIT
-  method: testSemanticTextOperations {p0=true}
-  issue: https://github.com/elastic/elasticsearch/issues/127937
-- class: org.elasticsearch.upgrades.SemanticTextUpgradeIT
-  method: testSemanticTextOperations {p0=false}
-  issue: https://github.com/elastic/elasticsearch/issues/127938
 
 # Examples:
 #

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/model/TestModel.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/model/TestModel.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.inference.services.ServiceUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,16 +44,35 @@ public class TestModel extends Model {
     }
 
     public static TestModel createRandomInstance(TaskType taskType) {
-        return createRandomInstance(taskType, null);
+        return createRandomInstance(taskType, null, null);
     }
 
-    public static TestModel createRandomInstance(TaskType taskType, List<SimilarityMeasure> excludedSimilarities) {
+    public static TestModel createRandomInstance(
+        TaskType taskType,
+        List<DenseVectorFieldMapper.ElementType> excludedElementTypes,
+        List<SimilarityMeasure> excludedSimilarities
+    ) {
         // Use a max dimension count that has a reasonable probability of being compatible with BBQ
-        return createRandomInstance(taskType, excludedSimilarities, BBQ_MIN_DIMS * 2);
+        return createRandomInstance(taskType, excludedElementTypes, excludedSimilarities, BBQ_MIN_DIMS * 2);
     }
 
-    public static TestModel createRandomInstance(TaskType taskType, List<SimilarityMeasure> excludedSimilarities, int maxDimensions) {
-        var elementType = taskType == TaskType.TEXT_EMBEDDING ? randomFrom(DenseVectorFieldMapper.ElementType.values()) : null;
+    public static TestModel createRandomInstance(
+        TaskType taskType,
+        List<DenseVectorFieldMapper.ElementType> excludedElementTypes,
+        List<SimilarityMeasure> excludedSimilarities,
+        int maxDimensions
+    ) {
+        List<DenseVectorFieldMapper.ElementType> supportedElementTypes = new ArrayList<>(
+            Arrays.asList(DenseVectorFieldMapper.ElementType.values())
+        );
+        if (excludedElementTypes != null) {
+            supportedElementTypes.removeAll(excludedElementTypes);
+            if (supportedElementTypes.isEmpty()) {
+                throw new IllegalArgumentException("No supported element types with excluded element types " + excludedElementTypes);
+            }
+        }
+
+        var elementType = taskType == TaskType.TEXT_EMBEDDING ? randomFrom(supportedElementTypes) : null;
         var dimensions = taskType == TaskType.TEXT_EMBEDDING
             ? DenseVectorFieldMapperTestUtils.randomCompatibleDimensions(elementType, maxDimensions)
             : null;

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SemanticTextUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SemanticTextUpgradeIT.java
@@ -70,8 +70,13 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
     @BeforeClass
     public static void beforeClass() {
         SPARSE_MODEL = TestModel.createRandomInstance(TaskType.SPARSE_EMBEDDING);
+        // Exclude bit vectors because semantic text does not fully support them
         // Exclude dot product because we are not producing unit length vectors
-        DENSE_MODEL = TestModel.createRandomInstance(TaskType.TEXT_EMBEDDING, List.of(SimilarityMeasure.DOT_PRODUCT));
+        DENSE_MODEL = TestModel.createRandomInstance(
+            TaskType.TEXT_EMBEDDING,
+            List.of(DenseVectorFieldMapper.ElementType.BIT),
+            List.of(SimilarityMeasure.DOT_PRODUCT)
+        );
     }
 
     public SemanticTextUpgradeIT(boolean useLegacyFormat) {


### PR DESCRIPTION
Fixes #127937
Fixes #127938

The rolling upgrade tests were failing when a bit vector was randomly used because semantic text does not fully support bit vectors in this stack release.