### PR TITLE
ESQL: Add description to status and profile (#121783)

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -218,6 +218,7 @@ public class TransportVersions {
     public static final TransportVersion RESCORE_VECTOR_ALLOW_ZERO_BACKPORT_8_19 = def(8_841_0_27);
     public static final TransportVersion INFERENCE_ADD_TIMEOUT_PUT_ENDPOINT_8_19 = def(8_841_0_28);
     public static final TransportVersion ESQL_REPORT_SHARD_PARTITIONING_8_19 = def(8_841_0_29);
+    public static final TransportVersion ESQL_DRIVER_TASK_DESCRIPTION_8_19 = def(8_841_0_30);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
@@ -53,6 +53,13 @@ public class Driver implements Releasable, Describable {
     private final String sessionId;
 
     /**
+     * Description of the task this driver is running. This description should be
+     * short and meaningful as a grouping identifier. We use the phase of the
+     * query right now: "data", "node_reduce", "final".
+     */
+    private final String taskDescription;
+
+    /**
      * The wall clock time when this driver was created in milliseconds since epoch.
      * Compared to {@link #startNanos} this is less accurate and is measured by a
      * timer that can go backwards. This is only useful for presenting times to a
@@ -96,6 +103,10 @@ public class Driver implements Releasable, Describable {
     /**
      * Creates a new driver with a chain of operators.
      * @param sessionId session Id
+     * @param taskDescription Description of the task this driver is running. This
+     *                        description should be short and meaningful as a grouping
+     *                        identifier. We use the phase of the query right now:
+     *                        "data", "node_reduce", "final".
      * @param driverContext the driver context
      * @param source source operator
      * @param intermediateOperators  the chain of operators to execute
@@ -105,6 +116,7 @@ public class Driver implements Releasable, Describable {
      */
     public Driver(
         String sessionId,
+        String taskDescription,
         long startTime,
         long startNanos,
         DriverContext driverContext,
@@ -116,6 +128,7 @@ public class Driver implements Releasable, Describable {
         Releasable releasable
     ) {
         this.sessionId = sessionId;
+        this.taskDescription = taskDescription;
         this.startTime = startTime;
         this.startNanos = startNanos;
         this.driverContext = driverContext;
@@ -129,6 +142,7 @@ public class Driver implements Releasable, Describable {
         this.status = new AtomicReference<>(
             new DriverStatus(
                 sessionId,
+                taskDescription,
                 startTime,
                 System.currentTimeMillis(),
                 0,
@@ -150,6 +164,7 @@ public class Driver implements Releasable, Describable {
      * @param releasable a {@link Releasable} to invoked once the chain of operators has run to completion
      */
     public Driver(
+        String taskDescription,
         DriverContext driverContext,
         SourceOperator source,
         List<Operator> intermediateOperators,
@@ -158,6 +173,7 @@ public class Driver implements Releasable, Describable {
     ) {
         this(
             "unset",
+            taskDescription,
             System.currentTimeMillis(),
             System.nanoTime(),
             driverContext,
@@ -497,6 +513,7 @@ public class Driver implements Releasable, Describable {
             throw new IllegalStateException("can only get profile from finished driver");
         }
         return new DriverProfile(
+            status.taskDescription(),
             status.started(),
             status.lastUpdated(),
             finishNanos - startNanos,
@@ -543,6 +560,7 @@ public class Driver implements Releasable, Describable {
 
             return new DriverStatus(
                 sessionId,
+                taskDescription,
                 startTime,
                 now,
                 prev.cpuNanos() + extraCpuNanos,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverProfile.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverProfile.java
@@ -27,6 +27,13 @@ import java.util.Objects;
  */
 public class DriverProfile implements Writeable, ChunkedToXContentObject {
     /**
+     * Description of the task this driver is running. This description should be
+     * short and meaningful as a grouping identifier. We use the phase of the
+     * query right now: "data", "node_reduce", "final".
+     */
+    private final String taskDescription;
+
+    /**
      * Millis since epoch when the driver started.
      */
     private final long startMillis;
@@ -61,6 +68,7 @@ public class DriverProfile implements Writeable, ChunkedToXContentObject {
     private final DriverSleeps sleeps;
 
     public DriverProfile(
+        String taskDescription,
         long startMillis,
         long stopMillis,
         long tookNanos,
@@ -69,6 +77,7 @@ public class DriverProfile implements Writeable, ChunkedToXContentObject {
         List<DriverStatus.OperatorStatus> operators,
         DriverSleeps sleeps
     ) {
+        this.taskDescription = taskDescription;
         this.startMillis = startMillis;
         this.stopMillis = stopMillis;
         this.tookNanos = tookNanos;
@@ -79,6 +88,9 @@ public class DriverProfile implements Writeable, ChunkedToXContentObject {
     }
 
     public DriverProfile(StreamInput in) throws IOException {
+        this.taskDescription = in.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_TASK_DESCRIPTION_8_19)
+            ? in.readString()
+            : "";
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
             this.startMillis = in.readVLong();
             this.stopMillis = in.readVLong();
@@ -101,6 +113,9 @@ public class DriverProfile implements Writeable, ChunkedToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_DRIVER_TASK_DESCRIPTION_8_19)) {
+            out.writeString(taskDescription);
+        }
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
             out.writeVLong(startMillis);
             out.writeVLong(stopMillis);
@@ -112,6 +127,13 @@ public class DriverProfile implements Writeable, ChunkedToXContentObject {
         }
         out.writeCollection(operators);
         sleeps.writeTo(out);
+    }
+
+    /**
+     * Description of the task this driver is running.
+     */
+    public String taskDescription() {
+        return taskDescription;
     }
 
     /**
@@ -169,6 +191,7 @@ public class DriverProfile implements Writeable, ChunkedToXContentObject {
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return ChunkedToXContent.builder(params).object(ob -> {
             ob.append((b, p) -> {
+                b.field("task_description", taskDescription);
                 b.timestampFieldsFromUnixEpochMillis("start_millis", "start", startMillis);
                 b.timestampFieldsFromUnixEpochMillis("stop_millis", "stop", stopMillis);
                 b.field("took_nanos", tookNanos);
@@ -196,7 +219,8 @@ public class DriverProfile implements Writeable, ChunkedToXContentObject {
             return false;
         }
         DriverProfile that = (DriverProfile) o;
-        return startMillis == that.startMillis
+        return taskDescription.equals(that.taskDescription)
+            && startMillis == that.startMillis
             && stopMillis == that.stopMillis
             && tookNanos == that.tookNanos
             && cpuNanos == that.cpuNanos
@@ -207,7 +231,7 @@ public class DriverProfile implements Writeable, ChunkedToXContentObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(startMillis, stopMillis, tookNanos, cpuNanos, iterations, operators, sleeps);
+        return Objects.hash(taskDescription, startMillis, stopMillis, tookNanos, cpuNanos, iterations, operators, sleeps);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
@@ -123,7 +123,7 @@ public class OperatorTests extends MapperServiceTestCase {
                         }
                     });
                     DriverContext driverContext = driverContext();
-                    drivers.add(new Driver(driverContext, factory.get(driverContext), List.of(), docCollector, () -> {}));
+                    drivers.add(new Driver("test", driverContext, factory.get(driverContext), List.of(), docCollector, () -> {}));
                 }
                 OperatorTestCase.runDriver(drivers);
                 Set<Integer> expectedDocIds = searchForDocIds(reader, query);
@@ -215,6 +215,7 @@ public class OperatorTests extends MapperServiceTestCase {
                     )
                 );
                 Driver driver = new Driver(
+                    "test",
                     driverContext,
                     luceneOperatorFactory(reader, new MatchAllDocsQuery(), LuceneOperator.NO_LIMIT).get(driverContext),
                     operators,
@@ -248,6 +249,7 @@ public class OperatorTests extends MapperServiceTestCase {
         DriverContext driverContext = driverContext();
         try (
             var driver = new Driver(
+                "test",
                 driverContext,
                 new SequenceLongBlockSourceOperator(driverContext.blockFactory(), values, 100),
                 List.of((new LimitOperator.Factory(limit)).get(driverContext)),
@@ -335,6 +337,7 @@ public class OperatorTests extends MapperServiceTestCase {
             var actualPrimeOrds = new ArrayList<>();
             try (
                 var driver = new Driver(
+                    "test",
                     driverContext,
                     new SequenceLongBlockSourceOperator(driverContext.blockFactory(), values, 100),
                     List.of(

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
@@ -111,6 +111,7 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
 
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new NullInsertingSourceOperator(new CannedSourceOperator(input.iterator()), blockFactory),
                 List.of(simple().get(driverContext)),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunctionTests.java
@@ -65,6 +65,7 @@ public class CountDistinctIntAggregatorFunctionTests extends AggregatorFunctionT
         BlockFactory blockFactory = driverContext.blockFactory();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(Iterators.single(new Page(blockFactory.newDoubleArrayVector(new double[] { 1.0 }, 1).asBlock()))),
                 List.of(simple().get(driverContext)),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunctionTests.java
@@ -66,6 +66,7 @@ public class CountDistinctLongAggregatorFunctionTests extends AggregatorFunction
         BlockFactory blockFactory = driverContext.blockFactory();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(Iterators.single(new Page(blockFactory.newDoubleArrayVector(new double[] { 1.0 }, 1).asBlock()))),
                 List.of(simple().get(driverContext)),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionTests.java
@@ -53,6 +53,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
         List<Page> results = new ArrayList<>();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new SequenceDoubleBlockSourceOperator(driverContext.blockFactory(), DoubleStream.of(Double.MAX_VALUE - 1, 2)),
                 List.of(simple().get(driverContext)),
@@ -71,6 +72,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
         List<Page> results = new ArrayList<>();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new SequenceDoubleBlockSourceOperator(
                     driverContext.blockFactory(),
@@ -100,6 +102,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
         driverContext = driverContext();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new SequenceDoubleBlockSourceOperator(driverContext.blockFactory(), DoubleStream.of(values)),
                 List.of(simple().get(driverContext)),
@@ -122,6 +125,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
         driverContext = driverContext();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new SequenceDoubleBlockSourceOperator(driverContext.blockFactory(), DoubleStream.of(largeValues)),
                 List.of(simple().get(driverContext)),
@@ -141,6 +145,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
         driverContext = driverContext();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new SequenceDoubleBlockSourceOperator(driverContext.blockFactory(), DoubleStream.of(largeValues)),
                 List.of(simple().get(driverContext)),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumFloatAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumFloatAggregatorFunctionTests.java
@@ -53,6 +53,7 @@ public class SumFloatAggregatorFunctionTests extends AggregatorFunctionTestCase 
         List<Page> results = new ArrayList<>();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new SequenceFloatBlockSourceOperator(driverContext.blockFactory(), Stream.of(Float.MAX_VALUE - 1, 2f)),
                 List.of(simple().get(driverContext)),
@@ -71,6 +72,7 @@ public class SumFloatAggregatorFunctionTests extends AggregatorFunctionTestCase 
         List<Page> results = new ArrayList<>();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new SequenceFloatBlockSourceOperator(
                     driverContext.blockFactory(),
@@ -100,6 +102,7 @@ public class SumFloatAggregatorFunctionTests extends AggregatorFunctionTestCase 
         driverContext = driverContext();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new SequenceFloatBlockSourceOperator(driverContext.blockFactory(), Stream.of(values)),
                 List.of(simple().get(driverContext)),
@@ -122,6 +125,7 @@ public class SumFloatAggregatorFunctionTests extends AggregatorFunctionTestCase 
         driverContext = driverContext();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new SequenceFloatBlockSourceOperator(driverContext.blockFactory(), Stream.of(largeValues)),
                 List.of(simple().get(driverContext)),
@@ -141,6 +145,7 @@ public class SumFloatAggregatorFunctionTests extends AggregatorFunctionTestCase 
         driverContext = driverContext();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new SequenceFloatBlockSourceOperator(driverContext.blockFactory(), Stream.of(largeValues)),
                 List.of(simple().get(driverContext)),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumIntAggregatorFunctionTests.java
@@ -52,6 +52,7 @@ public class SumIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
         BlockFactory blockFactory = driverContext.blockFactory();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(Iterators.single(new Page(blockFactory.newDoubleArrayVector(new double[] { 1.0 }, 1).asBlock()))),
                 List.of(simple().get(driverContext)),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionTests.java
@@ -51,6 +51,7 @@ public class SumLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
         DriverContext driverContext = driverContext();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new SequenceLongBlockSourceOperator(driverContext.blockFactory(), LongStream.of(Long.MAX_VALUE - 1, 2)),
                 List.of(simple().get(driverContext)),
@@ -68,6 +69,7 @@ public class SumLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
         BlockFactory blockFactory = driverContext.blockFactory();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(Iterators.single(new Page(blockFactory.newDoubleArrayVector(new double[] { 1.0 }, 1).asBlock()))),
                 List.of(simple().get(driverContext)),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/CategorizeBlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/CategorizeBlockHashTests.java
@@ -416,6 +416,7 @@ public class CategorizeBlockHashTests extends BlockHashTestCase {
         List<Page> intermediateOutput = new ArrayList<>();
 
         Driver driver = new Driver(
+            "test",
             driverContext,
             new LocalSourceOperator(input1),
             List.of(
@@ -436,6 +437,7 @@ public class CategorizeBlockHashTests extends BlockHashTestCase {
         runDriver(driver);
 
         driver = new Driver(
+            "test",
             driverContext,
             new LocalSourceOperator(input2),
             List.of(
@@ -458,6 +460,7 @@ public class CategorizeBlockHashTests extends BlockHashTestCase {
         List<Page> finalOutput = new ArrayList<>();
 
         driver = new Driver(
+            "test",
             driverContext,
             new CannedSourceOperator(intermediateOutput.iterator()),
             List.of(

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/CategorizePackedValuesBlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/CategorizePackedValuesBlockHashTests.java
@@ -137,6 +137,7 @@ public class CategorizePackedValuesBlockHashTests extends BlockHashTestCase {
         List<Page> intermediateOutput = new ArrayList<>();
 
         Driver driver = new Driver(
+            "test",
             driverContext,
             new LocalSourceOperator(input1),
             List.of(
@@ -154,6 +155,7 @@ public class CategorizePackedValuesBlockHashTests extends BlockHashTestCase {
         runDriver(driver);
 
         driver = new Driver(
+            "test",
             driverContext,
             new LocalSourceOperator(input2),
             List.of(
@@ -173,6 +175,7 @@ public class CategorizePackedValuesBlockHashTests extends BlockHashTestCase {
         List<Page> finalOutput = new ArrayList<>();
 
         driver = new Driver(
+            "test",
             driverContext,
             new CannedSourceOperator(intermediateOutput.iterator()),
             List.of(

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
@@ -151,7 +151,7 @@ public class LuceneCountOperatorTests extends AnyOperatorTestCase {
         int taskConcurrency = between(1, 8);
         for (int i = 0; i < taskConcurrency; i++) {
             DriverContext ctx = contexts.get();
-            drivers.add(new Driver(ctx, factory.get(ctx), List.of(), new TestResultPageSinkOperator(results::add), () -> {}));
+            drivers.add(new Driver("test", ctx, factory.get(ctx), List.of(), new TestResultPageSinkOperator(results::add), () -> {}));
         }
         OperatorTestCase.runDriver(drivers);
         assertThat(results.size(), lessThanOrEqualTo(taskConcurrency));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneMaxOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneMaxOperatorTestCase.java
@@ -166,7 +166,7 @@ public abstract class LuceneMaxOperatorTestCase extends AnyOperatorTestCase {
         int taskConcurrency = between(1, 8);
         for (int i = 0; i < taskConcurrency; i++) {
             DriverContext ctx = contexts.get();
-            drivers.add(new Driver(ctx, factory.get(ctx), List.of(), new TestResultPageSinkOperator(results::add), () -> {}));
+            drivers.add(new Driver("test", ctx, factory.get(ctx), List.of(), new TestResultPageSinkOperator(results::add), () -> {}));
         }
         OperatorTestCase.runDriver(drivers);
         assertThat(results.size(), lessThanOrEqualTo(taskConcurrency));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneMinOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneMinOperatorTestCase.java
@@ -166,7 +166,7 @@ public abstract class LuceneMinOperatorTestCase extends AnyOperatorTestCase {
         int taskConcurrency = between(1, 8);
         for (int i = 0; i < taskConcurrency; i++) {
             DriverContext ctx = contexts.get();
-            drivers.add(new Driver(ctx, factory.get(ctx), List.of(), new TestResultPageSinkOperator(results::add), () -> {}));
+            drivers.add(new Driver("test", ctx, factory.get(ctx), List.of(), new TestResultPageSinkOperator(results::add), () -> {}));
         }
         OperatorTestCase.runDriver(drivers);
         assertThat(results.size(), lessThanOrEqualTo(taskConcurrency));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneQueryEvaluatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneQueryEvaluatorTests.java
@@ -216,6 +216,7 @@ public abstract class LuceneQueryEvaluatorTests<T extends Vector, U extends Vect
             operators.add(createOperator(blockFactory, shards));
             List<Page> results = new ArrayList<>();
             Driver driver = new Driver(
+                "test",
                 driverContext,
                 luceneOperatorFactory(reader, new MatchAllDocsQuery(), usesScoring()).get(driverContext),
                 operators,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
@@ -164,6 +164,7 @@ public class LuceneSourceOperatorTests extends AnyOperatorTestCase {
             });
             Driver driver = new Driver(
                 "driver" + i,
+                "test",
                 0,
                 0,
                 driverContext,
@@ -229,7 +230,7 @@ public class LuceneSourceOperatorTests extends AnyOperatorTestCase {
         List<Page> results = new ArrayList<>();
 
         OperatorTestCase.runDriver(
-            new Driver(ctx, factory.get(ctx), List.of(readS.get(ctx)), new TestResultPageSinkOperator(results::add), () -> {})
+            new Driver("test", ctx, factory.get(ctx), List.of(readS.get(ctx)), new TestResultPageSinkOperator(results::add), () -> {})
         );
         OperatorTestCase.assertDriverContext(ctx);
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperatorScoringTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperatorScoringTests.java
@@ -127,7 +127,7 @@ public class LuceneTopNSourceOperatorScoringTests extends LuceneTopNSourceOperat
 
         List<Page> results = new ArrayList<>();
         OperatorTestCase.runDriver(
-            new Driver(ctx, factory.get(ctx), List.of(readS.get(ctx)), new TestResultPageSinkOperator(results::add), () -> {})
+            new Driver("test", ctx, factory.get(ctx), List.of(readS.get(ctx)), new TestResultPageSinkOperator(results::add), () -> {})
         );
         OperatorTestCase.assertDriverContext(ctx);
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperatorTests.java
@@ -187,7 +187,7 @@ public class LuceneTopNSourceOperatorTests extends AnyOperatorTestCase {
 
         List<Page> results = new ArrayList<>();
         OperatorTestCase.runDriver(
-            new Driver(ctx, factory.get(ctx), List.of(readS.get(ctx)), new TestResultPageSinkOperator(results::add), () -> {})
+            new Driver("test", ctx, factory.get(ctx), List.of(readS.get(ctx)), new TestResultPageSinkOperator(results::add), () -> {})
         );
         OperatorTestCase.assertDriverContext(ctx);
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorTests.java
@@ -174,6 +174,7 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
         var metricField = new NumberFieldMapper.NumberFieldType("metric", NumberFieldMapper.NumberType.LONG);
         OperatorTestCase.runDriver(
             new Driver(
+                "test",
                 driverContext,
                 timeSeriesFactory.get(driverContext),
                 List.of(ValuesSourceReaderOperatorTests.factory(reader, metricField, ElementType.LONG).get(driverContext)),
@@ -248,6 +249,7 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
                 List<Page> results = new ArrayList<>();
                 OperatorTestCase.runDriver(
                     new Driver(
+                        "test",
                         driverContext,
                         timeSeriesFactory.get(driverContext),
                         List.of(),
@@ -306,6 +308,7 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
         var hostnameField = new KeywordFieldMapper.KeywordFieldType("hostname");
         OperatorTestCase.runDriver(
             new Driver(
+                "test",
                 ctx,
                 timeSeriesFactory.get(ctx),
                 List.of(

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValueSourceReaderTypeConversionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValueSourceReaderTypeConversionTests.java
@@ -1299,6 +1299,7 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
         var vsShardContext = new ValuesSourceReaderOperator.ShardContext(reader(indexKey), () -> SourceLoader.FROM_STORED_SOURCE, 0.2);
         try (
             Driver driver = new Driver(
+                "test",
                 driverContext,
                 luceneFactory.get(driverContext),
                 List.of(
@@ -1376,6 +1377,7 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
         int[] pages = new int[] { 0 };
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 simpleInput(driverContext, 10),
                 List.of(
@@ -1499,6 +1501,7 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
         boolean success = false;
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(input),
                 operators,
@@ -1526,6 +1529,7 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
         for (int i = 0; i < dummyDrivers; i++) {
             drivers.add(
                 new Driver(
+                    "test",
                     "dummy-session",
                     0,
                     0,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
@@ -1342,6 +1342,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         );
         try (
             Driver driver = new Driver(
+                "test",
                 driverContext,
                 luceneFactory.get(driverContext),
                 List.of(
@@ -1444,6 +1445,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         int[] pages = new int[] { 0 };
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 simpleInput(driverContext.blockFactory(), 10),
                 List.of(

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -165,7 +165,14 @@ public class AsyncOperatorTests extends ESTestCase {
             }
         });
         PlainActionFuture<Void> future = new PlainActionFuture<>();
-        Driver driver = new Driver(driverContext, sourceOperator, intermediateOperators, outputOperator, () -> assertFalse(it.hasNext()));
+        Driver driver = new Driver(
+            "test",
+            driverContext,
+            sourceOperator,
+            intermediateOperators,
+            outputOperator,
+            () -> assertFalse(it.hasNext())
+        );
         Driver.start(threadPool.getThreadContext(), threadPool.executor(ESQL_TEST_EXECUTOR), driver, between(1, 10000), future);
         future.actionGet();
         Releasables.close(localBreaker);
@@ -295,7 +302,7 @@ public class AsyncOperatorTests extends ESTestCase {
         };
         SinkOperator outputOperator = new PageConsumerOperator(Page::releaseBlocks);
         PlainActionFuture<Void> future = new PlainActionFuture<>();
-        Driver driver = new Driver(driverContext, sourceOperator, List.of(asyncOperator), outputOperator, localBreaker);
+        Driver driver = new Driver("test", driverContext, sourceOperator, List.of(asyncOperator), outputOperator, localBreaker);
         Driver.start(threadPool.getThreadContext(), threadPool.executor(ESQL_TEST_EXECUTOR), driver, between(1, 1000), future);
         assertBusy(() -> assertTrue(future.isDone()));
         if (failed.get()) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverProfileTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverProfileTests.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class DriverProfileTests extends AbstractWireSerializingTestCase<DriverProfile> {
     public void testToXContent() {
         DriverProfile status = new DriverProfile(
+            "test",
             123413220000L,
             123413243214L,
             10012,
@@ -44,6 +45,7 @@ public class DriverProfileTests extends AbstractWireSerializingTestCase<DriverPr
         );
         assertThat(Strings.toString(status, true, true), equalTo("""
             {
+              "task_description" : "test",
               "start" : "1973-11-29T09:27:00.000Z",
               "start_millis" : 123413220000,
               "stop" : "1973-11-29T09:27:23.214Z",
@@ -101,6 +103,7 @@ public class DriverProfileTests extends AbstractWireSerializingTestCase<DriverPr
     @Override
     protected DriverProfile createTestInstance() {
         return new DriverProfile(
+            DriverStatusTests.randomTaskDescription(),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
@@ -113,6 +116,7 @@ public class DriverProfileTests extends AbstractWireSerializingTestCase<DriverPr
 
     @Override
     protected DriverProfile mutateInstance(DriverProfile instance) throws IOException {
+        String taskDescription = instance.taskDescription();
         long startMillis = instance.startMillis();
         long stopMillis = instance.stopMillis();
         long tookNanos = instance.tookNanos();
@@ -120,17 +124,18 @@ public class DriverProfileTests extends AbstractWireSerializingTestCase<DriverPr
         long iterations = instance.iterations();
         var operators = instance.operators();
         var sleeps = instance.sleeps();
-        switch (between(0, 6)) {
-            case 0 -> startMillis = randomValueOtherThan(startMillis, ESTestCase::randomNonNegativeLong);
-            case 1 -> stopMillis = randomValueOtherThan(startMillis, ESTestCase::randomNonNegativeLong);
-            case 2 -> tookNanos = randomValueOtherThan(tookNanos, ESTestCase::randomNonNegativeLong);
-            case 3 -> cpuNanos = randomValueOtherThan(cpuNanos, ESTestCase::randomNonNegativeLong);
-            case 4 -> iterations = randomValueOtherThan(iterations, ESTestCase::randomNonNegativeLong);
-            case 5 -> operators = randomValueOtherThan(operators, DriverStatusTests::randomOperatorStatuses);
-            case 6 -> sleeps = randomValueOtherThan(sleeps, DriverSleepsTests::randomDriverSleeps);
+        switch (between(0, 7)) {
+            case 0 -> taskDescription = randomValueOtherThan(taskDescription, DriverStatusTests::randomTaskDescription);
+            case 1 -> startMillis = randomValueOtherThan(startMillis, ESTestCase::randomNonNegativeLong);
+            case 2 -> stopMillis = randomValueOtherThan(startMillis, ESTestCase::randomNonNegativeLong);
+            case 3 -> tookNanos = randomValueOtherThan(tookNanos, ESTestCase::randomNonNegativeLong);
+            case 4 -> cpuNanos = randomValueOtherThan(cpuNanos, ESTestCase::randomNonNegativeLong);
+            case 5 -> iterations = randomValueOtherThan(iterations, ESTestCase::randomNonNegativeLong);
+            case 6 -> operators = randomValueOtherThan(operators, DriverStatusTests::randomOperatorStatuses);
+            case 7 -> sleeps = randomValueOtherThan(sleeps, DriverSleepsTests::randomDriverSleeps);
             default -> throw new UnsupportedOperationException();
         }
-        return new DriverProfile(startMillis, stopMillis, tookNanos, cpuNanos, iterations, operators, sleeps);
+        return new DriverProfile(taskDescription, startMillis, stopMillis, tookNanos, cpuNanos, iterations, operators, sleeps);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverStatusTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverStatusTests.java
@@ -32,6 +32,7 @@ public class DriverStatusTests extends AbstractWireSerializingTestCase<DriverSta
     public void testToXContent() {
         DriverStatus status = new DriverStatus(
             "ABC:123",
+            "test",
             123413220000L,
             123413243214L,
             123213L,
@@ -50,7 +51,8 @@ public class DriverStatusTests extends AbstractWireSerializingTestCase<DriverSta
         );
         assertThat(Strings.toString(status, true, true), equalTo("""
             {
-              "sessionId" : "ABC:123",
+              "session_id" : "ABC:123",
+              "task_description" : "test",
               "started" : "1973-11-29T09:27:00.000Z",
               "last_updated" : "1973-11-29T09:27:23.214Z",
               "cpu_nanos" : 123213,
@@ -114,6 +116,7 @@ public class DriverStatusTests extends AbstractWireSerializingTestCase<DriverSta
     protected DriverStatus createTestInstance() {
         return new DriverStatus(
             randomSessionId(),
+            randomTaskDescription(),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
@@ -127,6 +130,10 @@ public class DriverStatusTests extends AbstractWireSerializingTestCase<DriverSta
 
     private String randomSessionId() {
         return RandomStrings.randomAsciiLettersOfLengthBetween(random(), 1, 15);
+    }
+
+    public static String randomTaskDescription() {
+        return RandomStrings.randomAsciiLettersOfLength(random(), 5);
     }
 
     private DriverStatus.Status randomStatus() {
@@ -150,6 +157,7 @@ public class DriverStatusTests extends AbstractWireSerializingTestCase<DriverSta
     @Override
     protected DriverStatus mutateInstance(DriverStatus instance) throws IOException {
         var sessionId = instance.sessionId();
+        var taskDescription = instance.taskDescription();
         long started = instance.started();
         long lastUpdated = instance.lastUpdated();
         long cpuNanos = instance.cpuNanos();
@@ -158,19 +166,31 @@ public class DriverStatusTests extends AbstractWireSerializingTestCase<DriverSta
         var completedOperators = instance.completedOperators();
         var activeOperators = instance.activeOperators();
         var sleeps = instance.sleeps();
-        switch (between(0, 8)) {
+        switch (between(0, 9)) {
             case 0 -> sessionId = randomValueOtherThan(sessionId, this::randomSessionId);
-            case 1 -> started = randomValueOtherThan(started, ESTestCase::randomNonNegativeLong);
-            case 2 -> lastUpdated = randomValueOtherThan(lastUpdated, ESTestCase::randomNonNegativeLong);
-            case 3 -> cpuNanos = randomValueOtherThan(cpuNanos, ESTestCase::randomNonNegativeLong);
-            case 4 -> iterations = randomValueOtherThan(iterations, ESTestCase::randomNonNegativeLong);
-            case 5 -> status = randomValueOtherThan(status, this::randomStatus);
-            case 6 -> completedOperators = randomValueOtherThan(completedOperators, DriverStatusTests::randomOperatorStatuses);
-            case 7 -> activeOperators = randomValueOtherThan(activeOperators, DriverStatusTests::randomOperatorStatuses);
-            case 8 -> sleeps = randomValueOtherThan(sleeps, DriverSleepsTests::randomDriverSleeps);
+            case 1 -> taskDescription = randomValueOtherThan(taskDescription, DriverStatusTests::randomTaskDescription);
+            case 2 -> started = randomValueOtherThan(started, ESTestCase::randomNonNegativeLong);
+            case 3 -> lastUpdated = randomValueOtherThan(lastUpdated, ESTestCase::randomNonNegativeLong);
+            case 4 -> cpuNanos = randomValueOtherThan(cpuNanos, ESTestCase::randomNonNegativeLong);
+            case 5 -> iterations = randomValueOtherThan(iterations, ESTestCase::randomNonNegativeLong);
+            case 6 -> status = randomValueOtherThan(status, this::randomStatus);
+            case 7 -> completedOperators = randomValueOtherThan(completedOperators, DriverStatusTests::randomOperatorStatuses);
+            case 8 -> activeOperators = randomValueOtherThan(activeOperators, DriverStatusTests::randomOperatorStatuses);
+            case 9 -> sleeps = randomValueOtherThan(sleeps, DriverSleepsTests::randomDriverSleeps);
             default -> throw new UnsupportedOperationException();
         }
-        return new DriverStatus(sessionId, started, lastUpdated, cpuNanos, iterations, status, completedOperators, activeOperators, sleeps);
+        return new DriverStatus(
+            sessionId,
+            taskDescription,
+            started,
+            lastUpdated,
+            cpuNanos,
+            iterations,
+            status,
+            completedOperators,
+            activeOperators,
+            sleeps
+        );
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverTests.java
@@ -67,6 +67,7 @@ public class DriverTests extends ESTestCase {
 
         Driver driver = new Driver(
             "unset",
+            "test",
             startEpoch,
             startNanos,
             driverContext,
@@ -116,6 +117,7 @@ public class DriverTests extends ESTestCase {
 
         Driver driver = new Driver(
             "unset",
+            "test",
             startEpoch,
             startNanos,
             driverContext,
@@ -166,6 +168,7 @@ public class DriverTests extends ESTestCase {
 
         Driver driver = new Driver(
             "unset",
+            "test",
             startEpoch,
             startNanos,
             driverContext,
@@ -212,6 +215,7 @@ public class DriverTests extends ESTestCase {
 
         Driver driver = new Driver(
             "unset",
+            "test",
             startEpoch,
             startNanos,
             driverContext,
@@ -280,7 +284,7 @@ public class DriverTests extends ESTestCase {
             WarningsOperator warning1 = new WarningsOperator(threadPool);
             WarningsOperator warning2 = new WarningsOperator(threadPool);
             CyclicBarrier allPagesProcessed = new CyclicBarrier(2);
-            Driver driver = new Driver(driverContext, new CannedSourceOperator(inPages.iterator()) {
+            Driver driver = new Driver("test", driverContext, new CannedSourceOperator(inPages.iterator()) {
                 @Override
                 public Page getOutput() {
                     assertRunningWithRegularUser(threadPool);
@@ -364,7 +368,7 @@ public class DriverTests extends ESTestCase {
 
                 }
             });
-            Driver driver = new Driver(driverContext, sourceOperator, List.of(delayOperator), sinkOperator, () -> {});
+            Driver driver = new Driver("test", driverContext, sourceOperator, List.of(delayOperator), sinkOperator, () -> {});
             ThreadContext threadContext = threadPool.getThreadContext();
             PlainActionFuture<Void> future = new PlainActionFuture<>();
 
@@ -384,7 +388,7 @@ public class DriverTests extends ESTestCase {
             var sinkHandler = new ExchangeSinkHandler(driverContext.blockFactory(), between(1, 5), System::currentTimeMillis);
             var sourceOperator = new ExchangeSourceOperator(sourceHandler.createExchangeSource());
             var sinkOperator = new ExchangeSinkOperator(sinkHandler.createExchangeSink(() -> {}), Function.identity());
-            Driver driver = new Driver(driverContext, sourceOperator, List.of(), sinkOperator, () -> {});
+            Driver driver = new Driver("test", driverContext, sourceOperator, List.of(), sinkOperator, () -> {});
             PlainActionFuture<Void> future = new PlainActionFuture<>();
             Driver.start(threadPool.getThreadContext(), threadPool.executor("esql"), driver, between(1, 1000), future);
             assertBusy(

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
@@ -68,6 +68,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
         List<Page> results = new ArrayList<>();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(input.iterator()),
                 List.of(simpleWithMode(AggregatorMode.INITIAL).get(driverContext), simpleWithMode(AggregatorMode.FINAL).get(driverContext)),
@@ -89,6 +90,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
         List<Page> results = new ArrayList<>();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(partials.iterator()),
                 List.of(simpleWithMode(AggregatorMode.FINAL).get(driverContext)),
@@ -110,6 +112,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
 
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(input.iterator()),
                 List.of(
@@ -142,6 +145,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
         List<Page> results = new ArrayList<>();
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(intermediates.iterator()),
                 List.of(simpleWithMode(AggregatorMode.FINAL).get(driverContext)),
@@ -236,6 +240,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
             DriverContext driver1Context = driverContext();
             drivers.add(
                 new Driver(
+                    "test",
                     driver1Context,
                     new CannedSourceOperator(pages.iterator()),
                     List.of(
@@ -253,6 +258,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
         DriverContext driver2Context = driverContext();
         drivers.add(
             new Driver(
+                "test",
                 driver2Context,
                 new ExchangeSourceOperator(sourceExchanger.createExchangeSource()),
                 List.of(

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
@@ -167,6 +167,7 @@ public class LimitOperatorTests extends OperatorTestCase {
             drivers.add(
                 new Driver(
                     "unset",
+                    "test",
                     0,
                     0,
                     driverContext,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
@@ -304,6 +304,7 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
         List<Page> results = new ArrayList<>();
         OperatorTestCase.runDriver(
             new Driver(
+                "test",
                 ctx,
                 sourceOperatorFactory.get(ctx),
                 CollectionUtils.concatLists(intermediateOperators, List.of(intialAgg, intermediateAgg, finalAgg)),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -304,6 +304,7 @@ public class ExchangeServiceTests extends ESTestCase {
             DriverContext dc = driverContext();
             Driver d = new Driver(
                 "test-session:1",
+                "test",
                 0,
                 0,
                 dc,
@@ -322,6 +323,7 @@ public class ExchangeServiceTests extends ESTestCase {
             DriverContext dc = driverContext();
             Driver d = new Driver(
                 "test-session:2",
+                "test",
                 0,
                 0,
                 dc,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -544,6 +544,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         List<List<Object>> actualTop = new ArrayList<>();
         try (
             Driver driver = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(List.of(new Page(blocks.toArray(Block[]::new))).iterator()),
                 List.of(
@@ -634,6 +635,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         List<List<Object>> actualTop = new ArrayList<>();
         try (
             Driver driver = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(List.of(new Page(blocks.toArray(Block[]::new))).iterator()),
                 List.of(
@@ -669,6 +671,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         List<Tuple<Long, Long>> outputValues = new ArrayList<>();
         try (
             Driver driver = new Driver(
+                "test",
                 driverContext,
                 new TupleBlockSourceOperator(driverContext.blockFactory(), inputValues, randomIntBetween(1, 1000)),
                 List.of(
@@ -939,6 +942,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         int topCount = randomIntBetween(1, values.size());
         try (
             Driver driver = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(List.of(page).iterator()),
                 List.of(
@@ -1113,6 +1117,7 @@ public class TopNOperatorTests extends OperatorTestCase {
             List<List<Object>> actual = new ArrayList<>();
             try (
                 Driver driver = new Driver(
+                    "test",
                     driverContext,
                     new CannedSourceOperator(List.of(new Page(builder.build())).iterator()),
                     List.of(
@@ -1240,6 +1245,7 @@ public class TopNOperatorTests extends OperatorTestCase {
             DriverContext driverContext = driverContext();
             try (
                 Driver driver = new Driver(
+                    "test",
                     driverContext,
                     new CannedSourceOperator(List.of(new Page(builder.build())).iterator()),
                     List.of(
@@ -1328,6 +1334,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         DriverContext driverContext = driverContext();
         try (
             Driver driver = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(List.of(new Page(blocks.toArray(Block[]::new))).iterator()),
                 List.of(
@@ -1368,6 +1375,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         DriverContext driverContext = driverContext();
         try (
             Driver driver = new Driver(
+                "test",
                 driverContext,
                 new SequenceLongBlockSourceOperator(driverContext.blockFactory(), LongStream.range(0, docCount)),
                 List.of(

--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/OperatorTestCase.java
@@ -189,6 +189,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
             List<Page> in = source.next();
             try (
                 Driver d = new Driver(
+                    "test",
                     driverContext(),
                     new CannedSourceOperator(in.iterator()),
                     operators.get(),
@@ -263,6 +264,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
         boolean success = false;
         try (
             Driver d = new Driver(
+                "test",
                 driverContext,
                 new CannedSourceOperator(input),
                 operators,
@@ -290,6 +292,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
         for (int i = 0; i < dummyDrivers; i++) {
             drivers.add(
                 new Driver(
+                    "test",
                     "dummy-session",
                     0,
                     0,

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -52,6 +52,7 @@ import static org.elasticsearch.test.MapMatcher.matchesMap;
 import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.Mode.SYNC;
 import static org.elasticsearch.xpack.esql.tools.ProfileParser.parseProfile;
 import static org.elasticsearch.xpack.esql.tools.ProfileParser.readProfileFromResponse;
+import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
@@ -303,7 +304,6 @@ public class RestEsqlIT extends RestEsqlTestCase {
             equalTo(List.of(List.of(499.5d)))
         );
 
-        List<List<String>> signatures = new ArrayList<>();
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> profiles = (List<Map<String, Object>>) ((Map<String, Object>) result.get("profile")).get("drivers");
         for (Map<String, Object> p : profiles) {
@@ -315,25 +315,34 @@ public class RestEsqlIT extends RestEsqlTestCase {
             for (Map<String, Object> o : operators) {
                 sig.add(checkOperatorProfile(o));
             }
-            signatures.add(sig);
+            String taskDescription = p.get("task_description").toString();
+            switch (taskDescription) {
+                case "data" -> assertMap(
+                    sig,
+                    matchesList().item("LuceneSourceOperator")
+                        .item("ValuesSourceReaderOperator")
+                        .item("AggregationOperator")
+                        .item("ExchangeSinkOperator")
+                );
+                case "node_reduce" -> assertThat(
+                    sig,
+                    either(matchesList().item("ExchangeSourceOperator").item("ExchangeSinkOperator")).or(
+                        matchesList().item("ExchangeSourceOperator").item("AggregationOperator").item("ExchangeSinkOperator")
+                    )
+                );
+                case "final" -> assertMap(
+                    sig,
+                    matchesList().item("ExchangeSourceOperator")
+                        .item("AggregationOperator")
+                        .item("ProjectOperator")
+                        .item("LimitOperator")
+                        .item("EvalOperator")
+                        .item("ProjectOperator")
+                        .item("OutputOperator")
+                );
+                default -> throw new IllegalArgumentException("can't match " + taskDescription);
+            }
         }
-        assertThat(
-            signatures,
-            containsInAnyOrder(
-                matchesList().item("LuceneSourceOperator")
-                    .item("ValuesSourceReaderOperator")
-                    .item("AggregationOperator")
-                    .item("ExchangeSinkOperator"),
-                matchesList().item("ExchangeSourceOperator").item("ExchangeSinkOperator"),
-                matchesList().item("ExchangeSourceOperator")
-                    .item("AggregationOperator")
-                    .item("ProjectOperator")
-                    .item("LimitOperator")
-                    .item("EvalOperator")
-                    .item("ProjectOperator")
-                    .item("OutputOperator")
-            )
-        );
     }
 
     private final String PROCESS_NAME = "process_name";
@@ -520,6 +529,7 @@ public class RestEsqlIT extends RestEsqlTestCase {
             }
             signatures.add(sig);
         }
+        // TODO adapt this to use task_description once this is reenabled
         assertThat(
             signatures,
             containsInAnyOrder(
@@ -620,28 +630,38 @@ public class RestEsqlIT extends RestEsqlTestCase {
             MapMatcher sleepMatcher = matchesMap().entry("reason", "exchange empty")
                 .entry("sleep_millis", greaterThan(0L))
                 .entry("wake_millis", greaterThan(0L));
-            if (operators.contains("LuceneSourceOperator")) {
-                assertMap(sleeps, matchesMap().entry("counts", Map.of()).entry("first", List.of()).entry("last", List.of()));
-            } else if (operators.contains("ExchangeSourceOperator")) {
-                assertMap(sleeps, matchesMap().entry("counts", matchesMap().entry("exchange empty", greaterThan(0))).extraOk());
-                @SuppressWarnings("unchecked")
-                List<Map<String, Object>> first = (List<Map<String, Object>>) sleeps.get("first");
-                for (Map<String, Object> s : first) {
-                    assertMap(s, sleepMatcher);
+            String taskDescription = p.get("task_description").toString();
+            switch (taskDescription) {
+                case "data" -> assertMap(sleeps, matchesMap().entry("counts", Map.of()).entry("first", List.of()).entry("last", List.of()));
+                case "node_reduce" -> {
+                    assertMap(sleeps, matchesMap().entry("counts", matchesMap().entry("exchange empty", greaterThan(0))).extraOk());
+                    @SuppressWarnings("unchecked")
+                    List<Map<String, Object>> first = (List<Map<String, Object>>) sleeps.get("first");
+                    for (Map<String, Object> s : first) {
+                        assertMap(s, sleepMatcher);
+                    }
+                    @SuppressWarnings("unchecked")
+                    List<Map<String, Object>> last = (List<Map<String, Object>>) sleeps.get("last");
+                    for (Map<String, Object> s : last) {
+                        assertMap(s, sleepMatcher);
+                    }
                 }
-                @SuppressWarnings("unchecked")
-                List<Map<String, Object>> last = (List<Map<String, Object>>) sleeps.get("last");
-                for (Map<String, Object> s : last) {
-                    assertMap(s, sleepMatcher);
+                case "final" -> {
+                    assertMap(
+                        sleeps,
+                        matchesMap().entry("counts", matchesMap().entry("exchange empty", 1))
+                            .entry("first", List.of(sleepMatcher))
+                            .entry("last", List.of(sleepMatcher))
+                    );
                 }
-            } else {
-                fail("unknown signature: " + operators);
+                default -> throw new IllegalArgumentException("unknown task: " + taskDescription);
             }
         }
     }
 
     public static MapMatcher commonProfile() {
-        return matchesMap().entry("start_millis", greaterThan(0L))
+        return matchesMap().entry("task_description", any(String.class))
+            .entry("start_millis", greaterThan(0L))
             .entry("stop_millis", greaterThan(0L))
             .entry("iterations", greaterThan(0L))
             .entry("cpu_nanos", greaterThan(0L))

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupFromIndexIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupFromIndexIT.java
@@ -227,6 +227,7 @@ public class LookupFromIndexIT extends AbstractEsqlIntegTestCase {
             DriverContext driverContext = driverContext();
             try (
                 var driver = new Driver(
+                    "test",
                     driverContext,
                     source.get(driverContext),
                     List.of(reader.get(driverContext), lookup.get(driverContext)),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
@@ -330,6 +330,7 @@ public abstract class AbstractLookupService<R extends AbstractLookupService.Requ
             releasables.add(outputOperator);
             Driver driver = new Driver(
                 "enrich-lookup:" + request.sessionId,
+                "enrich",
                 System.currentTimeMillis(),
                 System.nanoTime(),
                 driverContext,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -174,7 +174,7 @@ public class LocalExecutionPlanner {
     /**
      * turn the given plan into a list of drivers to execute
      */
-    public LocalExecutionPlan plan(FoldContext foldCtx, PhysicalPlan localPhysicalPlan) {
+    public LocalExecutionPlan plan(String taskDescription, FoldContext foldCtx, PhysicalPlan localPhysicalPlan) {
         var context = new LocalExecutionPlannerContext(
             new ArrayList<>(),
             new Holder<>(DriverParallelism.SINGLE),
@@ -195,7 +195,7 @@ public class LocalExecutionPlanner {
         final TimeValue statusInterval = configuration.pragmas().statusInterval();
         context.addDriverFactory(
             new DriverFactory(
-                new DriverSupplier(context.bigArrays, context.blockFactory, physicalOperation, statusInterval, settings),
+                new DriverSupplier(taskDescription, context.bigArrays, context.blockFactory, physicalOperation, statusInterval, settings),
                 context.driverParallelism().get()
             )
         );
@@ -871,6 +871,7 @@ public class LocalExecutionPlanner {
     }
 
     record DriverSupplier(
+        String taskDescription,
         BigArrays bigArrays,
         BlockFactory blockFactory,
         PhysicalOperation physicalOperation,
@@ -897,6 +898,7 @@ public class LocalExecutionPlanner {
                 success = true;
                 return new Driver(
                     sessionId,
+                    taskDescription,
                     System.currentTimeMillis(),
                     System.nanoTime(),
                     driverContext,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
@@ -264,6 +264,7 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                     parentTask,
                     new ComputeContext(
                         localSessionId,
+                        "remote_reduce",
                         clusterAlias,
                         List.of(),
                         configuration,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeContext.java
@@ -19,6 +19,7 @@ import java.util.function.Supplier;
 
 record ComputeContext(
     String sessionId,
+    String taskDescription,
     String clusterAlias,
     List<SearchContext> searchContexts,
     Configuration configuration,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -168,6 +168,7 @@ public class ComputeService {
             }
             var computeContext = new ComputeContext(
                 newChildSession(sessionId),
+                "single",
                 LOCAL_CLUSTER,
                 List.of(),
                 configuration,
@@ -243,6 +244,7 @@ public class ComputeService {
                         rootTask,
                         new ComputeContext(
                             sessionId,
+                            "final",
                             LOCAL_CLUSTER,
                             List.of(),
                             configuration,
@@ -413,7 +415,7 @@ public class ComputeService {
             // the planner will also set the driver parallelism in LocalExecutionPlanner.LocalExecutionPlan (used down below)
             // it's doing this in the planning of EsQueryExec (the source of the data)
             // see also EsPhysicalOperationProviders.sourcePhysicalOperation
-            LocalExecutionPlanner.LocalExecutionPlan localExecutionPlan = planner.plan(context.foldCtx(), plan);
+            LocalExecutionPlanner.LocalExecutionPlan localExecutionPlan = planner.plan(context.taskDescription(), context.foldCtx(), plan);
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Local execution plan:\n{}", localExecutionPlan.describe());
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -288,6 +288,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                 }
                 var computeContext = new ComputeContext(
                     sessionId,
+                    "data",
                     clusterAlias,
                     searchContexts,
                     configuration,
@@ -431,6 +432,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                     task,
                     new ComputeContext(
                         request.sessionId(),
+                        "node_reduce",
                         request.clusterAlias(),
                         List.of(),
                         request.configuration(),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -648,6 +648,7 @@ public class CsvTests extends ESTestCase {
         // replace fragment inside the coordinator plan
         List<Driver> drivers = new ArrayList<>();
         LocalExecutionPlan coordinatorNodeExecutionPlan = executionPlanner.plan(
+            "final",
             foldCtx,
             new OutputExec(coordinatorPlan, collectedPages::add)
         );
@@ -669,7 +670,7 @@ public class CsvTests extends ESTestCase {
                     throw new AssertionError("expected no failure", e);
                 })
             );
-            LocalExecutionPlan dataNodeExecutionPlan = executionPlanner.plan(foldCtx, csvDataNodePhysicalPlan);
+            LocalExecutionPlan dataNodeExecutionPlan = executionPlanner.plan("data", foldCtx, csvDataNodePhysicalPlan);
 
             drivers.addAll(dataNodeExecutionPlan.createDrivers(getTestName()));
             Randomness.shuffle(drivers);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseProfileTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseProfileTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.esql.action;
 
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.compute.operator.AbstractPageMappingOperator;
@@ -45,6 +47,7 @@ public class EsqlQueryResponseProfileTests extends AbstractWireSerializingTestCa
 
     private DriverProfile randomDriverProfile() {
         return new DriverProfile(
+            RandomStrings.randomAsciiLettersOfLength(random(), 5),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             randomNonNegativeLong(),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -746,6 +746,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 new EsqlQueryResponse.Profile(
                     List.of(
                         new DriverProfile(
+                            "test",
                             1723489812649L,
                             1723489819929L,
                             20021,
@@ -780,6 +781,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                   "profile" : {
                     "drivers" : [
                       {
+                        "task_description" : "test",
                         "start_millis" : 1723489812649,
                         "stop_millis" : 1723489819929,
                         "took_nanos" : 20021,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -7581,7 +7581,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             List.of()
         );
 
-        return planner.plan(FoldContext.small(), plan);
+        return planner.plan("test", FoldContext.small(), plan);
     }
 
     private List<Set<String>> findFieldNamesInLookupJoinDescription(LocalExecutionPlanner.LocalExecutionPlan physicalOperations) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -104,6 +104,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
     public void testLuceneSourceOperatorHugeRowSize() throws IOException {
         int estimatedRowSize = randomEstimatedRowSize(estimatedRowSizeIsHuge);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(
+            "test",
             FoldContext.small(),
             new EsQueryExec(
                 Source.EMPTY,
@@ -130,6 +131,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
         EsQueryExec.FieldSort sort = new EsQueryExec.FieldSort(sortField, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
         Literal limit = new Literal(Source.EMPTY, 10, DataType.INTEGER);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(
+            "test",
             FoldContext.small(),
             new EsQueryExec(
                 Source.EMPTY,
@@ -156,6 +158,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
         EsQueryExec.GeoDistanceSort sort = new EsQueryExec.GeoDistanceSort(sortField, Order.OrderDirection.ASC, 1, -1);
         Literal limit = new Literal(Source.EMPTY, 10, DataType.INTEGER);
         LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(
+            "test",
             FoldContext.small(),
             new EsQueryExec(
                 Source.EMPTY,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -62,6 +64,7 @@ public class ComputeListenerTests extends ESTestCase {
         for (int i = 0; i < numProfiles; i++) {
             profiles.add(
                 new DriverProfile(
+                    RandomStrings.randomAsciiLettersOfLength(random(), 5),
                     randomNonNegativeLong(),
                     randomNonNegativeLong(),
                     randomNonNegativeLong(),


### PR DESCRIPTION
This adds a `task_description` field to `profile` output and task `status`. This looks like:
```
...
  "profile" : {
    "drivers" : [
      {
        "task_description" : "final",
        "start_millis" : 1738768795349,
        "stop_millis" : 1738768795405,
...
        "task_description" : "node_reduce",
        "start_millis" : 1738768795392,
        "stop_millis" : 1738768795406,
...
        "task_description" : "data",
        "start_millis" : 1738768795391,
        "stop_millis" : 1738768795404,
...
```

Previously you had to look at the signature of the operators in the driver to figure out what the driver is *doing*. You had to know enough about how ESQL works to guess. Now you can look at this description to see what the server *thinks* it is doing. No more manual classification.

This will be useful when debugging failures and performance regressions because it is much easier to use `jq` to group on it:
```
| jq '.profile[] | group_by(.task_description)[]'
```
