### PR TITLE
Don't think skipped ones should be initialized with total number

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -462,9 +462,6 @@ tests:
 - class: org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDeciderIT
   method: testRestoreSnapshotAllocationDoesNotExceedWatermarkWithMultipleRestores
   issue: https://github.com/elastic/elasticsearch/issues/127787
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithFiltersIT
-  method: testTimestampFilterFromQuery
-  issue: https://github.com/elastic/elasticsearch/issues/127332
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
@@ -350,9 +350,9 @@ public class EsqlCCSUtils {
             Cluster.Builder builder = new Cluster.Builder(v).setStatus(status)
                 .setTook(executionInfo.tookSoFar())
                 .setTotalShards(Objects.requireNonNullElse(v.getTotalShards(), 0))
-                .setSuccessfulShards(Objects.requireNonNullElse(v.getTotalShards(), 0))
-                .setSkippedShards(Objects.requireNonNullElse(v.getTotalShards(), 0))
-                .setFailedShards(Objects.requireNonNullElse(v.getTotalShards(), 0));
+                .setSuccessfulShards(Objects.requireNonNullElse(v.getSuccessfulShards(), 0))
+                .setSkippedShards(Objects.requireNonNullElse(v.getSkippedShards(), 0))
+                .setFailedShards(Objects.requireNonNullElse(v.getFailedShards(), 0));
             if (ex != null) {
                 builder.setFailures(List.of(new ShardSearchFailure(ex)));
             }


### PR DESCRIPTION
I suspect this might be the reason for failures in CrossClusterQueryWithFiltersIT
