### PR TITLE
[8.19] Check hidden frames in entitlements (#127877)

### DIFF
--- a/docs/changelog/127877.yaml
+++ b/docs/changelog/127877.yaml
@@ -1,0 +1,5 @@
+pr: 127877
+summary: Check hidden frames in entitlements
+area: Infra/Core
+type: bug
+issues: []

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
@@ -182,7 +182,9 @@ public record FilesEntitlement(List<FileData> filesData) implements Entitlement 
             case "config" -> BaseDir.CONFIG;
             case "data" -> BaseDir.DATA;
             case "home" -> BaseDir.USER_HOME;
-            // NOTE: shared_repo is _not_ accessible to policy files, only internally
+            // it would be nice to limit this to just ES modules, but we don't have a way to plumb that through to here
+            // however, we still don't document in the error case below that shared_repo is valid
+            case "shared_repo" -> BaseDir.SHARED_REPO;
             default -> throw new PolicyValidationException(
                 "invalid relative directory: " + baseDir + ", valid values: [config, data, home]"
             );

--- a/modules/repository-url/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/repository-url/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,2 +1,8 @@
+org.elasticsearch.repository.url:
+  - outbound_network
+  - files:
+      - relative_path: .
+        relative_to: shared_repo
+        mode: read
 org.apache.httpcomponents.httpclient:
   - outbound_network # for URLHttpClient


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Check hidden frames in entitlements (#127877)