### PR TITLE
Inline TimedRunnable.beforeExecute

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
@@ -163,7 +163,6 @@ public final class TaskExecutionTimeTrackingEsThreadPoolExecutor extends EsThrea
         }
         assert super.unwrap(r) instanceof TimedRunnable : "expected only TimedRunnables in queue";
         final TimedRunnable timedRunnable = (TimedRunnable) super.unwrap(r);
-        timedRunnable.beforeExecute();
         final long taskQueueLatency = timedRunnable.getQueueTimeNanos();
         assert taskQueueLatency >= 0;
         queueLatencyMillisHistogram.addObservation(TimeUnit.NANOSECONDS.toMillis(taskQueueLatency));

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
@@ -66,8 +66,7 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
      */
     long getQueueTimeNanos() {
         if (beforeExecuteTime == -1) {
-            assert false : "beforeExecute must be called before getQueueTimeNanos";
-            return -1;
+            beforeExecuteTime = System.nanoTime();
         }
         return beforeExecuteTime - creationTimeNanos;
     }
@@ -82,13 +81,6 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
             return -1;
         }
         return Math.max(finishTimeNanos - startTimeNanos, 1);
-    }
-
-    /**
-     * Called when the task has reached the front of the queue and is about to be executed
-     */
-    public void beforeExecute() {
-        beforeExecuteTime = System.nanoTime();
     }
 
     /**


### PR DESCRIPTION
No need to call the method separately as it can be invoked the first time getQueueTimeNanos is called.

Relates: #120488
