### PR TITLE
Fix #123425 numerical floating point edge case

### DIFF
--- a/libs/geo/src/test/java/org/elasticsearch/geometry/utils/SpatialEnvelopeVisitorTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/utils/SpatialEnvelopeVisitorTests.java
@@ -134,7 +134,7 @@ public class SpatialEnvelopeVisitorTests extends ESTestCase {
             } else {
                 // Both positive and negative x values exist, we need to decide which way to wrap the bbox
                 double unwrappedWidth = maxPosX - minNegX;
-                double wrappedWidth = (180 - minPosX) - (-180 - maxNegX);
+                double wrappedWidth = 360.0 + maxNegX - minPosX;
                 if (unwrappedWidth <= wrappedWidth) {
                     // The smaller bbox is around the front of the planet, no dateline wrapping required
                     assertRectangleResult(i + ": " + point, result, minNegX, maxPosX, maxY, minY, false);

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -396,9 +396,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
   method: testSearchWhileRelocating
   issue: https://github.com/elastic/elasticsearch/issues/127188
-- class: org.elasticsearch.geometry.utils.SpatialEnvelopeVisitorTests
-  method: testVisitGeoPointsWrapping
-  issue: https://github.com/elastic/elasticsearch/issues/123425
 - class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS2EnrichUnavailableRemotesIT
   method: testEsqlEnrichWithSkipUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/127368


### PR DESCRIPTION
So, this was an odd one, two seemingly identical calculations can lead to different results under extreme conditions. Floating point arithmetic edge case. These two functions do not always agree:

* `double wrappedWidth = (180 - minPosX) - (-180 - maxNegX);`
  * used in the test
  * results in exactly 360.0 when maxNegX was a very small negative number (about -1e-14 in the failing test)
* `double wrappedWidth = 360.0 + maxNegX - minPosX;`
  * used in the production code
  * Results in 359.99999999... for the same case, which is more accurate

We now use the production formula in the test. The reason I wrote the original test formula was it was more explanatory than the production code. I did not expect a different result. Running with `-Dtests.iters=10000` had 6 failures (0.06%, which is a very low failure rate). With this fix there were zero failures.

Fixes #123425
