### PR TITLE
Avoid nested docs in painless execute api

### DIFF
--- a/docs/changelog/127991.yaml
+++ b/docs/changelog/127991.yaml
@@ -1,0 +1,6 @@
+pr: 127991
+summary: Avoid nested docs in painless execute api
+area: Infra/Scripting
+type: bug
+issues:
+ - 41004

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -831,7 +831,8 @@ public class PainlessExecuteAction {
                     // This is a problem especially for indices that have no mappings, as no fields will be accessible, neither through doc
                     // nor _source (if there are no mappings there are no metadata fields).
                     ParsedDocument parsedDocument = documentMapper.parse(sourceToParse);
-                    indexWriter.addDocuments(parsedDocument.docs());
+                    // only index the root doc since nested docs are not supported in painless anyways
+                    indexWriter.addDocuments(List.of(parsedDocument.rootDoc()));
                     try (IndexReader indexReader = DirectoryReader.open(indexWriter)) {
                         final IndexSearcher searcher = new IndexSearcher(indexReader);
                         searcher.setQueryCache(null);

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/action/PainlessExecuteApiTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/action/PainlessExecuteApiTests.java
@@ -77,16 +77,7 @@ public class PainlessExecuteApiTests extends ESSingleNodeTestCase {
         Request.ContextSetup contextSetup = new Request.ContextSetup("index", new BytesArray("""
             {"rank": 4.0, "nested": [{"text": "foo"}, {"text": "bar"}]}"""), new MatchAllQueryBuilder());
         contextSetup.setXContentType(XContentType.JSON);
-        Request request = new Request(
-            new Script(
-                ScriptType.INLINE,
-                "painless",
-                "doc['rank'].value",
-                Map.of()
-            ),
-            "score",
-            contextSetup
-        );
+        Request request = new Request(new Script(ScriptType.INLINE, "painless", "doc['rank'].value", Map.of()), "score", contextSetup);
         Response response = innerShardOperation(request, scriptService, indexService);
         assertThat(response.getResult(), equalTo(4.0D));
     }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/action/PainlessExecuteApiTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/action/PainlessExecuteApiTests.java
@@ -70,6 +70,27 @@ public class PainlessExecuteApiTests extends ESSingleNodeTestCase {
         assertThat(e.getCause().getMessage(), equalTo("cannot resolve symbol [doc]"));
     }
 
+    public void testNestedDocs() throws IOException {
+        ScriptService scriptService = getInstanceFromNode(ScriptService.class);
+        IndexService indexService = createIndex("index", Settings.EMPTY, "doc", "rank", "type=long", "nested", "type=nested");
+
+        Request.ContextSetup contextSetup = new Request.ContextSetup("index", new BytesArray("""
+            {"rank": 4.0, "nested": [{"text": "foo"}, {"text": "bar"}]}"""), new MatchAllQueryBuilder());
+        contextSetup.setXContentType(XContentType.JSON);
+        Request request = new Request(
+            new Script(
+                ScriptType.INLINE,
+                "painless",
+                "doc['rank'].value",
+                Map.of()
+            ),
+            "score",
+            contextSetup
+        );
+        Response response = innerShardOperation(request, scriptService, indexService);
+        assertThat(response.getResult(), equalTo(4.0D));
+    }
+
     public void testFilterExecutionContext() throws IOException {
         ScriptService scriptService = getInstanceFromNode(ScriptService.class);
         IndexService indexService = createIndex("index", Settings.EMPTY, "doc", "field", "type=long");


### PR DESCRIPTION
Painless does not support accessing nested docs (except through _source). Yet the painless execute api indexes any nested docs that are found when parsing the sample document. This commit changes the ram indexing to only index the root document, ignoring any nested docs.

fixes #41004