### PR TITLE
[Test] Rework detecting elasticsearch process in docker tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -447,33 +447,27 @@ tests:
 - class: org.elasticsearch.indices.stats.IndexStatsIT
   method: testThrottleStats
   issue: https://github.com/elastic/elasticsearch/issues/126359
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test040JavaUsesTheOsProvidedKeystore
-  issue: https://github.com/elastic/elasticsearch/issues/127437
+- class: org.elasticsearch.search.vectors.IVFKnnFloatVectorQueryTests
+  method: testRandomWithFilter
+  issue: https://github.com/elastic/elasticsearch/issues/127963
+- class: org.elasticsearch.search.vectors.IVFKnnFloatVectorQueryTests
+  method: testSearchBoost
+  issue: https://github.com/elastic/elasticsearch/issues/127969
+- class: org.elasticsearch.search.vectors.IVFKnnFloatVectorQueryTests
+  method: testFindFewer
+  issue: https://github.com/elastic/elasticsearch/issues/128002
 - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityRestIT
   method: testTaskCancellation
   issue: https://github.com/elastic/elasticsearch/issues/128009
 - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
   method: testOneRemoteClusterPartial
   issue: https://github.com/elastic/elasticsearch/issues/124055
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test041AmazonCaCertsAreInTheKeystore
-  issue: https://github.com/elastic/elasticsearch/issues/128007
 - class: org.elasticsearch.compute.aggregation.SampleDoubleAggregatorFunctionTests
   method: testSimpleWithCranky
   issue: https://github.com/elastic/elasticsearch/issues/128024
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {lookup-join.MvJoinKeyOnTheLookupIndex ASYNC}
   issue: https://github.com/elastic/elasticsearch/issues/128030
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test072RunEsAsDifferentUserAndGroup
-  issue: https://github.com/elastic/elasticsearch/issues/128031
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test042KeystorePermissionsAreCorrect
-  issue: https://github.com/elastic/elasticsearch/issues/128019
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test073RunEsAsDifferentUserAndGroupWithoutBindMounting
-  issue: https://github.com/elastic/elasticsearch/issues/128044
 - class: org.elasticsearch.compute.aggregation.PercentileIntGroupingAggregatorFunctionTests
   method: testManyInitialManyPartialFinalRunner
   issue: https://github.com/elastic/elasticsearch/issues/128092

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -186,10 +186,10 @@ public class Docker {
                 // Give the container enough time for security auto-configuration or a chance to crash out
                 Thread.sleep(STARTUP_SLEEP_INTERVAL_MILLISECONDS);
 
-                // Set COLUMNS so that `ps` doesn't truncate its output
-                psOutput = dockerShell.run("bash -c 'COLUMNS=1000 jdk/bin/jps -ml'").stdout();
-
-                if (psOutput.contains("org.elasticsearch.bootstrap.Elasticsearch")) {
+                // The length of the command exceeds what we can use for COLUMNS so we use a pipe to detect the process we're looking for
+                psOutput = dockerShell.run("bash -c 'ps -ax | grep org.elasticsearch.bootstrap.Elasticsearch | grep -v grep | wc -l'")
+                    .stdout();
+                if (psOutput.contains("1")) {
                     isElasticsearchRunning = true;
                     break;
                 }

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -185,10 +185,14 @@ public class Docker {
             try {
                 // Give the container enough time for security auto-configuration or a chance to crash out
                 Thread.sleep(STARTUP_SLEEP_INTERVAL_MILLISECONDS);
-
+                String detectCommand =
+                    "for pid in $(ps -eo pid,comm | grep java | awk '\\''{print $1}'\\''); do cmdline=$(tr \"\\0\" \" \" < /proc/$pid/cmdline 2>/dev/null); [[ $cmdline == *org.elasticsearch.bootstrap.Elasticsearch* ]] && echo \"PID $pid: $cmdline\"; done | wc -l";
                 // The length of the command exceeds what we can use for COLUMNS so we use a pipe to detect the process we're looking for
-                psOutput = dockerShell.run("bash -c 'ps -ax | grep org.elasticsearch.bootstrap.Elasticsearch | grep -v grep | wc -l'")
-                    .stdout();
+                psOutput = dockerShell.run("bash -c '" + detectCommand + "'").stdout();
+                // System.out.println("psOutput = " + psOutput);
+                // psOutput = dockerShell.run(
+                // "bash -c 'COLUMNS=4000 ps w | grep org.elasticsearch.bootstrap.Elasticsearch | grep -v grep | wc -l'"
+                // ).stdout();
                 if (psOutput.contains("1")) {
                     isElasticsearchRunning = true;
                     break;

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -78,7 +78,8 @@ public class Docker {
     private static final String ELASTICSEARCH_FULL_CLASSNAME = "org.elasticsearch.bootstrap.Elasticsearch";
     private static final String FIND_ELASTICSEARCH_PROCESS = "for pid in $(ps -eo pid,comm | grep java | awk '\\''{print $1}'\\''); "
         + "do cmdline=$(tr \"\\0\" \" \" < /proc/$pid/cmdline 2>/dev/null); [[ $cmdline == *"
-        + ELASTICSEARCH_FULL_CLASSNAME + "* ]] && echo \"$pid: $cmdline\"; done";
+        + ELASTICSEARCH_FULL_CLASSNAME
+        + "* ]] && echo \"$pid: $cmdline\"; done";
     // The length of the command exceeds what we can use for COLUMNS so we use a pipe to detect the process we're looking for
 
     /**

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -187,7 +187,7 @@ public class Docker {
                 Thread.sleep(STARTUP_SLEEP_INTERVAL_MILLISECONDS);
 
                 // Set COLUMNS so that `ps` doesn't truncate its output
-                psOutput = dockerShell.run("bash -c 'COLUMNS=4000 ps ax'").stdout();
+                psOutput = dockerShell.run("bash -c 'COLUMNS=1000 jdk/bin/jps -ml'").stdout();
 
                 if (psOutput.contains("org.elasticsearch.bootstrap.Elasticsearch")) {
                     isElasticsearchRunning = true;


### PR DESCRIPTION
This tweaks detecting the elasticsearch process id by using jps instead of ps which has been problematic in the past exceeding available COLUMN sizes due to es commandline invocation getting longer and longer.

fixes #128007 #128019 #128031 #127437 #128044
