### PR TITLE
[9.0] Fix #123425 numerical floating point edge case (#127982)

### DIFF
--- a/libs/geo/src/test/java/org/elasticsearch/geometry/utils/SpatialEnvelopeVisitorTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/utils/SpatialEnvelopeVisitorTests.java
@@ -134,7 +134,7 @@ public class SpatialEnvelopeVisitorTests extends ESTestCase {
             } else {
                 // Both positive and negative x values exist, we need to decide which way to wrap the bbox
                 double unwrappedWidth = maxPosX - minNegX;
-                double wrappedWidth = (180 - minPosX) - (-180 - maxNegX);
+                double wrappedWidth = 360.0 + maxNegX - minPosX;
                 if (unwrappedWidth <= wrappedWidth) {
                     // The smaller bbox is around the front of the planet, no dateline wrapping required
                     assertRectangleResult(i + ": " + point, result, minNegX, maxPosX, maxY, minY, false);


### PR DESCRIPTION
Manual backport of #123425

This was only muted in main, so all backports are simply the test fix. The failure rate was extremely low, hence the lack of mutes.
