### PR TITLE
[8.19] Fix assertion in DiskThresholdDeciderIT (part 2) (#127846)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -458,9 +458,6 @@ tests:
 - class: org.elasticsearch.test.index.IndexVersionUtilsTests
   method: testIndexCompatibleVersionMatches
   issue: https://github.com/elastic/elasticsearch/issues/120760
-- class: org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDeciderIT
-  method: testRestoreSnapshotAllocationDoesNotExceedWatermarkWithMultipleRestores
-  issue: https://github.com/elastic/elasticsearch/issues/127787
 - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityFcActionAuthorizationIT
   method: testIndicesPrivilegesAreEnforcedForCcrRestoreSessionActions
   issue: https://github.com/elastic/elasticsearch/issues/127782

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -280,7 +280,12 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
             tinyNodeShardIds.size() + tinyNodeShardIdsCopy.size(),
             is(1)
         );
-        assertThat(tinyNodeShardIds.iterator().next(), in(shardSizes.getShardIdsWithSizeSmallerOrEqual(usableSpace)));
+        final var useableSpaceShardSizes = shardSizes.getShardIdsWithSizeSmallerOrEqual(usableSpace);
+        final var tinyNodeShardId = tinyNodeShardIds.isEmpty() == false
+            ? tinyNodeShardIds.iterator().next()
+            // shardSizes only contains the sizes from the original index, not the copy, so we map the copied shard back to the original idx
+            : new ShardId(useableSpaceShardSizes.iterator().next().getIndex(), tinyNodeShardIdsCopy.iterator().next().id());
+        assertThat(tinyNodeShardId, in(useableSpaceShardSizes));
     }
 
     private Set<ShardId> getShardIds(final String nodeId, final String indexName) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix assertion in DiskThresholdDeciderIT (part 2) (#127846)](https://github.com/elastic/elasticsearch/pull/127846)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)