### PR TITLE
[8.18] [8.19] Fixes flaky ST_CENTROID_AGG tests (#114892) (#128037)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -52,12 +52,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testMultiIndexDelete
   issue: https://github.com/elastic/elasticsearch/issues/112381
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroidTests
-  method: "testAggregateIntermediate {TestCase=<geo_point> #2}"
-  issue: https://github.com/elastic/elasticsearch/issues/112461
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroidTests
-  method: testAggregateIntermediate {TestCase=<geo_point>}
-  issue: https://github.com/elastic/elasticsearch/issues/112463
 - class: org.elasticsearch.xpack.inference.external.http.RequestBasedTaskRunnerTests
   method: testLoopOneAtATime
   issue: https://github.com/elastic/elasticsearch/issues/112471


### PR DESCRIPTION
Backports the following commits to 8.18:
 - [8.19] Fixes flaky ST_CENTROID_AGG tests (#114892) (#128037)