### PR TITLE
Add missing entitlement to `repository-azure`

### DIFF
--- a/docs/changelog/128047.yaml
+++ b/docs/changelog/128047.yaml
@@ -2,4 +2,5 @@ pr: 128047
 summary: Add missing entitlement to `repository-azure`
 area: Snapshot/Restore
 type: bug
-issues: []
+issues:
+ - 128046

--- a/docs/changelog/128047.yaml
+++ b/docs/changelog/128047.yaml
@@ -1,0 +1,5 @@
+pr: 128047
+summary: Add missing entitlement to `repository-azure`
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/modules/repository-azure/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/repository-azure/src/main/plugin-metadata/entitlement-policy.yaml
@@ -16,3 +16,5 @@ com.azure.identity:
       mode: read
 reactor.core:
   - manage_threads
+reactor.netty.core:
+  - manage_threads # https://github.com/elastic/elasticsearch/issues/128046


### PR DESCRIPTION
This entitlement is required, but only if validating the metadata
endpoint against `https://login.microsoft.com/` which isn't something we
can do in a test. Kind of a SDK bug, we should be using an existing
event loop rather than spawning threads randomly like this.

Closes #128046