### PR TITLE
Fix `IndexStatsIT#testThrottleStats`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -444,9 +444,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/120_profile/avg 8.14 or after}
   issue: https://github.com/elastic/elasticsearch/issues/127879
-- class: org.elasticsearch.indices.stats.IndexStatsIT
-  method: testThrottleStats
-  issue: https://github.com/elastic/elasticsearch/issues/126359
 - class: org.elasticsearch.search.vectors.IVFKnnFloatVectorQueryTests
   method: testRandomWithFilter
   issue: https://github.com/elastic/elasticsearch/issues/127963

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -612,7 +612,6 @@ public abstract class Engine implements Closeable {
         }
 
         public void throttle() {
-            assert semaphore.availablePermits() == Integer.MAX_VALUE;
             semaphore.acquireUninterruptibly(Integer.MAX_VALUE - allowThreads);
         }
 


### PR DESCRIPTION
`Engine.PauseLock#throttle` can be called when the lock is being throttled, so we can't guarantee that all permits are available before throttling.

Resolve #126359
See #127173
