### PR TITLE
[8.18] Add missing entitlement to `repository-azure` (#128047)

### DIFF
--- a/docs/changelog/128047.yaml
+++ b/docs/changelog/128047.yaml
@@ -1,0 +1,6 @@
+pr: 128047
+summary: Add missing entitlement to `repository-azure`
+area: Snapshot/Restore
+type: bug
+issues:
+ - 128046

--- a/modules/repository-azure/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/modules/repository-azure/src/main/plugin-metadata/entitlement-policy.yaml
@@ -16,3 +16,5 @@ com.azure.identity:
       mode: read
 reactor.core:
   - manage_threads
+reactor.netty.core:
+  - manage_threads # https://github.com/elastic/elasticsearch/issues/128046


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Add missing entitlement to `repository-azure` (#128047)