### PR TITLE
Retrievers - Fix rank_window_size validation

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
@@ -249,8 +249,7 @@ public abstract class CompoundRetrieverBuilder<T extends CompoundRetrieverBuilde
         }
         if (rankWindowSize < 0) {
             validationException = addValidationError(
-                "[" + getRankWindowSizeField().getPreferredName() +
-                    "] parameter cannot be negative, found [" + rankWindowSize + "]",
+                "[" + getRankWindowSizeField().getPreferredName() + "] parameter cannot be negative, found [" + rankWindowSize + "]",
                 validationException
             );
         }

--- a/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
@@ -287,6 +287,10 @@ public abstract class CompoundRetrieverBuilder<T extends CompoundRetrieverBuilde
         return Objects.hash(innerRetrievers);
     }
 
+    public int rankWindowSize() {
+        return rankWindowSize;
+    }
+
     protected final SearchSourceBuilder createSearchSourceBuilder(PointInTimeBuilder pit, RetrieverBuilder retrieverBuilder) {
         var sourceBuilder = new SearchSourceBuilder().pointInTimeBuilder(pit)
             .trackTotalHits(false)

--- a/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
@@ -247,6 +247,14 @@ public abstract class CompoundRetrieverBuilder<T extends CompoundRetrieverBuilde
         if (isScroll) {
             validationException = addValidationError("cannot specify [" + getName() + "] and [scroll]", validationException);
         }
+        if (rankWindowSize < 0) {
+            validationException = addValidationError(
+                "[" + getRankWindowSizeField().getPreferredName() +
+                    "] parameter cannot be negative, found [" + rankWindowSize + "]",
+                validationException
+            );
+        }
+
         for (RetrieverSource innerRetriever : innerRetrievers) {
             validationException = innerRetriever.retriever().validate(source, validationException, isScroll, allowPartialSearchResults);
             if (innerRetriever.retriever() instanceof CompoundRetrieverBuilder<?> compoundChild) {

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
@@ -19,9 +19,15 @@ import java.util.Set;
  * retrievers can be added individually with additional functionality.
  */
 public class RetrieversFeatures implements FeatureSpecification {
+    public static final NodeFeature NEGATIVE_RANK_WINDOW_SIZE_FIX = new NodeFeature("retriever.negative_rank_window_size_fix");
 
     @Override
     public Set<NodeFeature> getFeatures() {
         return Set.of();
+    }
+
+    @Override
+    public Set<NodeFeature> getTestFeatures() {
+        return Set.of(NEGATIVE_RANK_WINDOW_SIZE_FIX);
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/QueryRuleRetrieverBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/QueryRuleRetrieverBuilder.java
@@ -119,10 +119,6 @@ public final class QueryRuleRetrieverBuilder extends CompoundRetrieverBuilder<Qu
         return NAME;
     }
 
-    public int rankWindowSize() {
-        return rankWindowSize;
-    }
-
     @Override
     protected SearchSourceBuilder finalizeSourceBuilder(SearchSourceBuilder source) {
         checkValidSort(source.sorts());

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -193,10 +193,6 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
         return inferenceId;
     }
 
-    public int rankWindowSize() {
-        return rankWindowSize;
-    }
-
     public boolean failuresAllowed() {
         return failuresAllowed;
     }

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/10_linear_retriever.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/10_linear_retriever.yml
@@ -1063,3 +1063,41 @@ setup:
   - close_to: { hits.hits.0._score: { value: 10.5, error: 0.001 } }
   - match: { hits.hits.1._id: "1" }
   - match: { hits.hits.1._score: 10 }
+
+---
+"should throw when rank_window_size is negative":
+  - requires:
+      cluster_features: [ "retriever.negative_rank_window_size_fix" ]
+      reason: "Fix for negative rank_window_size error message"
+  - do:
+      catch: /\[rank_window_size\] parameter cannot be negative, found \[-10\]/
+      search:
+        index: test
+        body:
+          retriever:
+            linear:
+              retrievers: [
+                {
+                  retriever: {
+                    standard: {
+                      query: {
+                        match_all: { }
+                      }
+                    }
+                  },
+                  weight: 10.0,
+                  normalizer: "minmax"
+                },
+                {
+                  retriever: {
+                    knn: {
+                      field: "vector",
+                      query_vector: [ 4 ],
+                      k: 1,
+                      num_candidates: 1
+                    }
+                  },
+                  weight: 2.0
+                }
+              ]
+              rank_window_size: -10

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/10_linear_retriever.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/10_linear_retriever.yml
@@ -1101,3 +1101,4 @@ setup:
                 }
               ]
               rank_window_size: -10
+  - match: { status: 400 }

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/retriever/PinnedRetrieverBuilder.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/retriever/PinnedRetrieverBuilder.java
@@ -151,10 +151,6 @@ public final class PinnedRetrieverBuilder extends CompoundRetrieverBuilder<Pinne
         return NAME;
     }
 
-    public int rankWindowSize() {
-        return rankWindowSize;
-    }
-
     /**
      * Creates a PinnedQueryBuilder with the appropriate pinned documents.
      *


### PR DESCRIPTION
When passing a negative `rank_window_size` to a compound retriever, we return an error message that references `size` instead of `rank_window_size`:

```
POST search-movies/_search
{
  "retriever": {
    "rrf": {
      "retrievers": [
        {
          "standard": {
            "query": {
              "match": {
                "title": "Shakespeare"
              }
            }
          }
        },
                {
          "standard": {
            "query": {
              "match": {
                "title": "Shakespeare"
              }
            }
          }
        }
      ],
      "rank_window_size": -1
    }
  }
}
```

Response:

```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "[size] parameter cannot be negative, found [-1]"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "[size] parameter cannot be negative, found [-1]"
  },
  "status": 400
}
```

This is coming from:

https://github.com/elastic/elasticsearch/blob/f0d7ec47b5e998cf19ebef107ea53b1b1aee4a82/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java#L517-L519

This validation needs to happen at the compound retriever level.

Besides fixing the error message, I also moved `rankWindowSize` to the base class for compound retrievers, instead of having it duplicated in 3 inherited retrievers.

