### PR TITLE
[8.19] Set `connection: close` header on shutdown (#128025)

### DIFF
--- a/docs/changelog/128025.yaml
+++ b/docs/changelog/128025.yaml
@@ -1,0 +1,6 @@
+pr: 128025
+summary: "Set `connection: close` header on shutdown"
+area: Network
+type: enhancement
+issues:
+ - 127984


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Set `connection: close` header on shutdown (#128025)