### PR TITLE
[8.18] Avoid nested docs in painless execute api (#127991)

### DIFF
--- a/docs/changelog/127991.yaml
+++ b/docs/changelog/127991.yaml
@@ -1,0 +1,6 @@
+pr: 127991
+summary: Avoid nested docs in painless execute api
+area: Infra/Scripting
+type: bug
+issues:
+ - 41004

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -828,7 +828,8 @@ public class PainlessExecuteAction {
                     // This is a problem especially for indices that have no mappings, as no fields will be accessible, neither through doc
                     // nor _source (if there are no mappings there are no metadata fields).
                     ParsedDocument parsedDocument = documentMapper.parse(sourceToParse);
-                    indexWriter.addDocuments(parsedDocument.docs());
+                    // only index the root doc since nested docs are not supported in painless anyways
+                    indexWriter.addDocuments(List.of(parsedDocument.rootDoc()));
                     try (IndexReader indexReader = DirectoryReader.open(indexWriter)) {
                         final IndexSearcher searcher = new IndexSearcher(indexReader);
                         searcher.setQueryCache(null);


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Avoid nested docs in painless execute api (#127991)