### PR TITLE
[8.19] Retrievers - Fix rank_window_size validation (#128108)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
@@ -247,6 +247,13 @@ public abstract class CompoundRetrieverBuilder<T extends CompoundRetrieverBuilde
         if (isScroll) {
             validationException = addValidationError("cannot specify [" + getName() + "] and [scroll]", validationException);
         }
+        if (rankWindowSize < 0) {
+            validationException = addValidationError(
+                "[" + getRankWindowSizeField().getPreferredName() + "] parameter cannot be negative, found [" + rankWindowSize + "]",
+                validationException
+            );
+        }
+
         for (RetrieverSource innerRetriever : innerRetrievers) {
             validationException = innerRetriever.retriever().validate(source, validationException, isScroll, allowPartialSearchResults);
             if (innerRetriever.retriever() instanceof CompoundRetrieverBuilder<?> compoundChild) {
@@ -277,6 +284,10 @@ public abstract class CompoundRetrieverBuilder<T extends CompoundRetrieverBuilde
     @Override
     public int doHashCode() {
         return Objects.hash(innerRetrievers);
+    }
+
+    public int rankWindowSize() {
+        return rankWindowSize;
     }
 
     protected final SearchSourceBuilder createSearchSourceBuilder(PointInTimeBuilder pit, RetrieverBuilder retrieverBuilder) {

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
@@ -19,6 +19,7 @@ import java.util.Set;
  * retrievers can be added individually with additional functionality.
  */
 public class RetrieversFeatures implements FeatureSpecification {
+    public static final NodeFeature NEGATIVE_RANK_WINDOW_SIZE_FIX = new NodeFeature("retriever.negative_rank_window_size_fix");
 
     @Override
     public Set<NodeFeature> getFeatures() {
@@ -27,5 +28,10 @@ public class RetrieversFeatures implements FeatureSpecification {
             StandardRetrieverBuilder.STANDARD_RETRIEVER_SUPPORTED,
             KnnRetrieverBuilder.KNN_RETRIEVER_SUPPORTED
         );
+    }
+
+    @Override
+    public Set<NodeFeature> getTestFeatures() {
+        return Set.of(NEGATIVE_RANK_WINDOW_SIZE_FIX);
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/QueryRuleRetrieverBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/QueryRuleRetrieverBuilder.java
@@ -124,10 +124,6 @@ public final class QueryRuleRetrieverBuilder extends CompoundRetrieverBuilder<Qu
         return NAME;
     }
 
-    public int rankWindowSize() {
-        return rankWindowSize;
-    }
-
     @Override
     protected SearchSourceBuilder finalizeSourceBuilder(SearchSourceBuilder source) {
         checkValidSort(source.sorts());

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -195,10 +195,6 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
         return inferenceId;
     }
 
-    public boolean failuresAllowed() {
-        return failuresAllowed;
-    }
-
     @Override
     protected void doToXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field(RETRIEVER_FIELD.getPreferredName(), innerRetrievers.get(0).retriever());

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -195,8 +195,8 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
         return inferenceId;
     }
 
-    public int rankWindowSize() {
-        return rankWindowSize;
+    public boolean failuresAllowed() {
+        return failuresAllowed;
     }
 
     @Override

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/10_linear_retriever.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/10_linear_retriever.yml
@@ -1063,3 +1063,42 @@ setup:
   - close_to: { hits.hits.0._score: { value: 10.5, error: 0.001 } }
   - match: { hits.hits.1._id: "1" }
   - match: { hits.hits.1._score: 10 }
+
+---
+"should throw when rank_window_size is negative":
+  - requires:
+      cluster_features: [ "retriever.negative_rank_window_size_fix" ]
+      reason: "Fix for negative rank_window_size error message"
+  - do:
+      catch: /\[rank_window_size\] parameter cannot be negative, found \[-10\]/
+      search:
+        index: test
+        body:
+          retriever:
+            linear:
+              retrievers: [
+                {
+                  retriever: {
+                    standard: {
+                      query: {
+                        match_all: { }
+                      }
+                    }
+                  },
+                  weight: 10.0,
+                  normalizer: "minmax"
+                },
+                {
+                  retriever: {
+                    knn: {
+                      field: "vector",
+                      query_vector: [ 4 ],
+                      k: 1,
+                      num_candidates: 1
+                    }
+                  },
+                  weight: 2.0
+                }
+              ]
+              rank_window_size: -10
+  - match: { status: 400 }

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/retriever/PinnedRetrieverBuilder.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/retriever/PinnedRetrieverBuilder.java
@@ -151,10 +151,6 @@ public final class PinnedRetrieverBuilder extends CompoundRetrieverBuilder<Pinne
         return NAME;
     }
 
-    public int rankWindowSize() {
-        return rankWindowSize;
-    }
-
     /**
      * Creates a PinnedQueryBuilder with the appropriate pinned documents.
      *


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Retrievers - Fix rank_window_size validation (#128108)](https://github.com/elastic/elasticsearch/pull/128108)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)