### PR TITLE
ESQL: Push more ==s on text fields to lucene (backport)

### DIFF
--- a/docs/changelog/126641.yaml
+++ b/docs/changelog/126641.yaml
@@ -1,0 +1,5 @@
+pr: 126641
+summary: Push more `==`s on text fields to lucene
+area: ES|QL
+type: enhancement
+issues: []

--- a/docs/changelog/127199.yaml
+++ b/docs/changelog/127199.yaml
@@ -1,0 +1,6 @@
+pr: 127199
+summary: Disable a bugged commit
+area: ES|QL
+type: bug
+issues:
+ - 127197

--- a/docs/changelog/127355.yaml
+++ b/docs/changelog/127355.yaml
@@ -1,0 +1,5 @@
+pr: 127355
+summary: '`text ==` and `text !=` pushdown'
+area: ES|QL
+type: enhancement
+issues: []

--- a/docs/changelog/128156.yaml
+++ b/docs/changelog/128156.yaml
@@ -1,0 +1,5 @@
+pr: 128156
+summary: Push more ==s on text fields to lucene (backport)
+area: ES|QL
+type: feature
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -986,6 +986,21 @@ public final class TextFieldMapper extends FieldMapper {
                 && syntheticSourceDelegate.isIndexed();
         }
 
+        /**
+         * Returns true if the delegate sub-field can be used for querying only (ie. isIndexed must be true)
+         */
+        public boolean canUseSyntheticSourceDelegateForQueryingEquality(String str) {
+            if (syntheticSourceDelegate == null
+                // Can't push equality to an index if there isn't an index
+                || syntheticSourceDelegate.isIndexed() == false
+                // ESQL needs docs values to push equality
+                || syntheticSourceDelegate.hasDocValues() == false) {
+                return false;
+            }
+            // Can't push equality if the field we're checking for is so big we'd ignore it.
+            return str.length() <= syntheticSourceDelegate.ignoreAbove();
+        }
+
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
             if (canUseSyntheticSourceDelegateForLoading()) {

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -13,6 +13,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.test.ListMatcher;
 import org.elasticsearch.test.MapMatcher;
 import org.elasticsearch.test.TestClustersThreadFilter;
@@ -21,6 +22,7 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.esql.AssertWarnings;
 import org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase;
+import org.hamcrest.Matcher;
 import org.junit.ClassRule;
 
 import java.io.IOException;
@@ -38,6 +40,7 @@ import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.requestObjec
 import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.runEsql;
 import static org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT.commonProfile;
 import static org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT.fixTypesOnProfile;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
@@ -78,7 +81,7 @@ public class PushQueriesIT extends ESRestTestCase {
             case "match_only_text", "semantic_text" -> true;
             default -> throw new UnsupportedOperationException("unknown type [" + type + "]");
         };
-        testPushQuery(value, esqlQuery, luceneQuery, filterInCompute, true);
+        testPushQuery(value, esqlQuery, List.of(luceneQuery), filterInCompute, true);
     }
 
     public void testEqualityTooBigToPush() throws IOException {
@@ -92,7 +95,7 @@ public class PushQueriesIT extends ESRestTestCase {
             case "semantic_text" -> "FieldExistsQuery [field=_primary_term]";
             default -> throw new UnsupportedOperationException("unknown type [" + type + "]");
         };
-        testPushQuery(value, esqlQuery, luceneQuery, true, true);
+        testPushQuery(value, esqlQuery, List.of(luceneQuery), true, true);
     }
 
     /**
@@ -110,7 +113,7 @@ public class PushQueriesIT extends ESRestTestCase {
             case "semantic_text" -> "FieldExistsQuery [field=_primary_term]";
             default -> throw new UnsupportedOperationException("unknown type [" + type + "]");
         };
-        testPushQuery(value, esqlQuery, luceneQuery, true, true);
+        testPushQuery(value, esqlQuery, List.of(luceneQuery), true, true);
     }
 
     public void testEqualityOrOther() throws IOException {
@@ -130,7 +133,7 @@ public class PushQueriesIT extends ESRestTestCase {
             case "match_only_text", "semantic_text" -> true;
             default -> throw new UnsupportedOperationException("unknown type [" + type + "]");
         };
-        testPushQuery(value, esqlQuery, luceneQuery, filterInCompute, true);
+        testPushQuery(value, esqlQuery, List.of(luceneQuery), filterInCompute, true);
     }
 
     public void testEqualityAndOther() throws IOException {
@@ -139,15 +142,15 @@ public class PushQueriesIT extends ESRestTestCase {
             FROM test
             | WHERE test == "%value" AND foo == 1
             """;
-        String luceneQuery = switch (type) {
-            case "text", "auto" -> "#test.keyword:%value -_ignored:test.keyword #foo:[1 TO 1]";
-            case "match_only_text" -> "foo:[1 TO 1]";
+        List<String> luceneQueryOptions = switch (type) {
+            case "text", "auto" -> List.of("#test.keyword:%value -_ignored:test.keyword #foo:[1 TO 1]");
+            case "match_only_text" -> List.of("foo:[1 TO 1]");
             case "semantic_text" ->
                 /*
                  * single_value_match is here because there are extra documents hiding in the index
                  * that don't have the `foo` field.
                  */
-                "#foo:[1 TO 1] #single_value_match(foo)";
+                List.of("#foo:[1 TO 1] #single_value_match(foo)", "foo:[1 TO 1]");
             default -> throw new UnsupportedOperationException("unknown type [" + type + "]");
         };
         boolean filterInCompute = switch (type) {
@@ -155,7 +158,7 @@ public class PushQueriesIT extends ESRestTestCase {
             case "match_only_text", "semantic_text" -> true;
             default -> throw new UnsupportedOperationException("unknown type [" + type + "]");
         };
-        testPushQuery(value, esqlQuery, luceneQuery, filterInCompute, true);
+        testPushQuery(value, esqlQuery, luceneQueryOptions, filterInCompute, true);
     }
 
     public void testInequality() throws IOException {
@@ -170,7 +173,7 @@ public class PushQueriesIT extends ESRestTestCase {
             case "semantic_text" -> "FieldExistsQuery [field=_primary_term]";
             default -> throw new UnsupportedOperationException("unknown type [" + type + "]");
         };
-        testPushQuery(value, esqlQuery, luceneQuery, true, true);
+        testPushQuery(value, esqlQuery, List.of(luceneQuery), true, true);
     }
 
     public void testInequalityTooBigToPush() throws IOException {
@@ -184,7 +187,7 @@ public class PushQueriesIT extends ESRestTestCase {
             case "semantic_text" -> "FieldExistsQuery [field=_primary_term]";
             default -> throw new UnsupportedOperationException("unknown type [" + type + "]");
         };
-        testPushQuery(value, esqlQuery, luceneQuery, true, false);
+        testPushQuery(value, esqlQuery, List.of(luceneQuery), true, false);
     }
 
     public void testCaseInsensitiveEquality() throws IOException {
@@ -198,10 +201,10 @@ public class PushQueriesIT extends ESRestTestCase {
             case "semantic_text" -> "FieldExistsQuery [field=_primary_term]";
             default -> throw new UnsupportedOperationException("unknown type [" + type + "]");
         };
-        testPushQuery(value, esqlQuery, luceneQuery, true, true);
+        testPushQuery(value, esqlQuery, List.of(luceneQuery), true, true);
     }
 
-    private void testPushQuery(String value, String esqlQuery, String luceneQuery, boolean filterInCompute, boolean found)
+    private void testPushQuery(String value, String esqlQuery, List<String> luceneQueryOptions, boolean filterInCompute, boolean found)
         throws IOException {
         indexValue(value);
         String differentValue = randomValueOtherThan(value, () -> randomAlphaOfLength(value.isEmpty() ? 1 : value.length()));
@@ -216,6 +219,12 @@ public class PushQueriesIT extends ESRestTestCase {
             matchesList().item(matchesMap().entry("name", "test").entry("type", "text")),
             equalTo(found ? List.of(List.of(value)) : List.of())
         );
+        Matcher<String> luceneQueryMatcher = anyOf(
+            () -> Iterators.map(
+                luceneQueryOptions.iterator(),
+                (String s) -> equalTo(s.replaceAll("%value", value).replaceAll("%different_value", differentValue))
+            )
+        );
 
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> profiles = (List<Map<String, Object>>) ((Map<String, Object>) result.get("profile")).get("drivers");
@@ -226,7 +235,7 @@ public class PushQueriesIT extends ESRestTestCase {
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> operators = (List<Map<String, Object>>) p.get("operators");
             for (Map<String, Object> o : operators) {
-                sig.add(checkOperatorProfile(o, luceneQuery.replaceAll("%value", value).replaceAll("%different_value", differentValue)));
+                sig.add(checkOperatorProfile(o, luceneQueryMatcher));
             }
             String description = p.get("task_description").toString();
             switch (description) {
@@ -311,7 +320,7 @@ public class PushQueriesIT extends ESRestTestCase {
 
     private static final Pattern TO_NAME = Pattern.compile("\\[.+", Pattern.DOTALL);
 
-    private static String checkOperatorProfile(Map<String, Object> o, String query) {
+    private static String checkOperatorProfile(Map<String, Object> o, Matcher<String> query) {
         String name = (String) o.get("operator");
         name = TO_NAME.matcher(name).replaceAll("");
         if (name.equals("LuceneSourceOperator")) {

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -52,7 +52,7 @@ public class PushQueriesIT extends ESRestTestCase {
         testPushQuery(value, """
             FROM test
             | WHERE test == "%value"
-            """, "#test.keyword:%value -_ignored:test.keyword", false);
+            """, "*:*", true, true);
     }
 
     public void testPushEqualityOnDefaultsTooBigToPush() throws IOException {
@@ -60,7 +60,23 @@ public class PushQueriesIT extends ESRestTestCase {
         testPushQuery(value, """
             FROM test
             | WHERE test == "%value"
-            """, "*:*", true);
+            """, "*:*", true, true);
+    }
+
+    public void testPushInequalityOnDefaults() throws IOException {
+        String value = "v".repeat(between(0, 256));
+        testPushQuery(value, """
+            FROM test
+            | WHERE test != "%different_value"
+            """, "*:*", true, true);
+    }
+
+    public void testPushInequalityOnDefaultsTooBigToPush() throws IOException {
+        String value = "a".repeat(between(257, 1000));
+        testPushQuery(value, """
+            FROM test
+            | WHERE test != "%value"
+            """, "*:*", true, false);
     }
 
     public void testPushCaseInsensitiveEqualityOnDefaults() throws IOException {
@@ -68,22 +84,23 @@ public class PushQueriesIT extends ESRestTestCase {
         testPushQuery(value, """
             FROM test
             | WHERE TO_LOWER(test) == "%value"
-            """, "*:*", true);
+            """, "*:*", true, true);
     }
 
-    private void testPushQuery(String value, String esqlQuery, String luceneQuery, boolean filterInCompute) throws IOException {
+    private void testPushQuery(String value, String esqlQuery, String luceneQuery, boolean filterInCompute, boolean found)
+        throws IOException {
         indexValue(value);
+        String differentValue = randomValueOtherThan(value, () -> randomAlphaOfLength(value.length()));
 
-        RestEsqlTestCase.RequestObjectBuilder builder = requestObjectBuilder().query(
-            esqlQuery.replaceAll("%value", value) + "\n| KEEP test"
-        );
+        String replacedQuery = esqlQuery.replaceAll("%value", value).replaceAll("%different_value", differentValue);
+        RestEsqlTestCase.RequestObjectBuilder builder = requestObjectBuilder().query(replacedQuery + "\n| KEEP test");
         builder.profile(true);
         Map<String, Object> result = runEsql(builder, new AssertWarnings.NoWarnings(), RestEsqlTestCase.Mode.SYNC);
         assertResultMap(
             result,
             getResultMatcher(result).entry("profile", matchesMap().entry("drivers", instanceOf(List.class))),
             matchesList().item(matchesMap().entry("name", "test").entry("type", "text")),
-            equalTo(List.of(List.of(value)))
+            equalTo(found ? List.of(List.of(value)) : List.of())
         );
 
         @SuppressWarnings("unchecked")
@@ -95,7 +112,7 @@ public class PushQueriesIT extends ESRestTestCase {
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> operators = (List<Map<String, Object>>) p.get("operators");
             for (Map<String, Object> o : operators) {
-                sig.add(checkOperatorProfile(o, luceneQuery.replaceAll("%value", value)));
+                sig.add(checkOperatorProfile(o, luceneQuery.replaceAll("%value", value).replaceAll("%different_value", differentValue)));
             }
             String description = p.get("task_description").toString();
             switch (description) {

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.single_node;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.test.ListMatcher;
+import org.elasticsearch.test.MapMatcher;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.esql.AssertWarnings;
+import org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.elasticsearch.test.ListMatcher.matchesList;
+import static org.elasticsearch.test.MapMatcher.assertMap;
+import static org.elasticsearch.test.MapMatcher.matchesMap;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.entityToMap;
+import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.requestObjectBuilder;
+import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.runEsql;
+import static org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT.commonProfile;
+import static org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT.fixTypesOnProfile;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
+
+/**
+ * Tests for pushing queries to lucene.
+ */
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
+public class PushQueriesIT extends ESRestTestCase {
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.testCluster();
+
+    public void testPushEqualityOnDefaults() throws IOException {
+        String value = "v".repeat(between(0, 256));
+        testPushQuery(value, """
+            FROM test
+            | WHERE test == "%value"
+            """, "#test.keyword:%value -_ignored:test.keyword", false);
+    }
+
+    public void testPushEqualityOnDefaultsTooBigToPush() throws IOException {
+        String value = "a".repeat(between(257, 1000));
+        testPushQuery(value, """
+            FROM test
+            | WHERE test == "%value"
+            """, "*:*", true);
+    }
+
+    public void testPushCaseInsensitiveEqualityOnDefaults() throws IOException {
+        String value = "a".repeat(between(0, 256));
+        testPushQuery(value, """
+            FROM test
+            | WHERE TO_LOWER(test) == "%value"
+            """, "*:*", true);
+    }
+
+    private void testPushQuery(String value, String esqlQuery, String luceneQuery, boolean filterInCompute) throws IOException {
+        indexValue(value);
+
+        RestEsqlTestCase.RequestObjectBuilder builder = requestObjectBuilder().query(
+            esqlQuery.replaceAll("%value", value) + "\n| KEEP test"
+        );
+        builder.profile(true);
+        Map<String, Object> result = runEsql(builder, new AssertWarnings.NoWarnings(), RestEsqlTestCase.Mode.SYNC);
+        assertResultMap(
+            result,
+            getResultMatcher(result).entry("profile", matchesMap().entry("drivers", instanceOf(List.class))),
+            matchesList().item(matchesMap().entry("name", "test").entry("type", "text")),
+            equalTo(List.of(List.of(value)))
+        );
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> profiles = (List<Map<String, Object>>) ((Map<String, Object>) result.get("profile")).get("drivers");
+        for (Map<String, Object> p : profiles) {
+            fixTypesOnProfile(p);
+            assertThat(p, commonProfile());
+            List<String> sig = new ArrayList<>();
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> operators = (List<Map<String, Object>>) p.get("operators");
+            for (Map<String, Object> o : operators) {
+                sig.add(checkOperatorProfile(o, luceneQuery.replaceAll("%value", value)));
+            }
+            String description = p.get("task_description").toString();
+            switch (description) {
+                case "data" -> {
+                    ListMatcher matcher = matchesList().item("LuceneSourceOperator").item("ValuesSourceReaderOperator");
+                    if (filterInCompute) {
+                        matcher = matcher.item("FilterOperator").item("LimitOperator");
+                    }
+                    matcher = matcher.item("ProjectOperator").item("ExchangeSinkOperator");
+                    assertMap(sig, matcher);
+                }
+                case "node_reduce" -> assertMap(sig, matchesList().item("ExchangeSourceOperator").item("ExchangeSinkOperator"));
+                case "final" -> assertMap(
+                    sig,
+                    matchesList().item("ExchangeSourceOperator").item("LimitOperator").item("ProjectOperator").item("OutputOperator")
+                );
+                default -> throw new IllegalArgumentException("can't match " + description);
+            }
+        }
+    }
+
+    private void indexValue(String value) throws IOException {
+        Request createIndex = new Request("PUT", "test");
+        createIndex.setJsonEntity("""
+            {
+              "settings": {
+                "index": {
+                  "number_of_shards": 1
+                }
+              }
+            }""");
+        Response createResponse = client().performRequest(createIndex);
+        assertThat(
+            entityToMap(createResponse.getEntity(), XContentType.JSON),
+            matchesMap().entry("shards_acknowledged", true).entry("index", "test").entry("acknowledged", true)
+        );
+
+        Request bulk = new Request("POST", "/_bulk");
+        bulk.addParameter("refresh", "");
+        bulk.setJsonEntity(String.format("""
+            {"create":{"_index":"test"}}
+            {"test":"%s"}
+            """, value));
+        Response bulkResponse = client().performRequest(bulk);
+        assertThat(entityToMap(bulkResponse.getEntity(), XContentType.JSON), matchesMap().entry("errors", false).extraOk());
+    }
+
+    private static final Pattern TO_NAME = Pattern.compile("\\[.+", Pattern.DOTALL);
+
+    private static String checkOperatorProfile(Map<String, Object> o, String query) {
+        String name = (String) o.get("operator");
+        name = TO_NAME.matcher(name).replaceAll("");
+        if (name.equals("LuceneSourceOperator")) {
+            MapMatcher expectedOp = matchesMap().entry("operator", startsWith(name))
+                .entry("status", matchesMap().entry("processed_queries", List.of(query)).extraOk());
+            assertMap(o, expectedOp);
+        }
+        return name;
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+}

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -143,7 +143,7 @@ public class PushQueriesIT extends ESRestTestCase {
             | WHERE test == "%value" AND foo == 1
             """;
         List<String> luceneQueryOptions = switch (type) {
-            case "text", "auto" -> List.of("#test.keyword:%value -_ignored:test.keyword #foo:[1 TO 1]");
+            case "text", "auto" -> List.of("#(#test.keyword:%value -_ignored:test.keyword) #foo:[1 TO 1]");
             case "match_only_text" -> List.of("foo:[1 TO 1]");
             case "semantic_text" ->
                 /*

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -124,7 +124,14 @@ public class PushQueriesIT extends ESRestTestCase {
                     matcher = matcher.item("ProjectOperator").item("ExchangeSinkOperator");
                     assertMap(sig, matcher);
                 }
-                case "node_reduce" -> assertMap(sig, matchesList().item("ExchangeSourceOperator").item("ExchangeSinkOperator"));
+                case "node_reduce" -> {
+                    if (sig.contains("LimitOperator")) {
+                        // TODO figure out why this is sometimes here and sometimes not
+                        assertMap(sig, matchesList().item("ExchangeSourceOperator").item("LimitOperator").item("ExchangeSinkOperator"));
+                    } else {
+                        assertMap(sig, matchesList().item("ExchangeSourceOperator").item("ExchangeSinkOperator"));
+                    }
+                }
                 case "final" -> assertMap(
                     sig,
                     matchesList().item("ExchangeSourceOperator").item("LimitOperator").item("ProjectOperator").item("OutputOperator")

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -660,7 +660,8 @@ public class RestEsqlIT extends RestEsqlTestCase {
     }
 
     public static MapMatcher commonProfile() {
-        return matchesMap().entry("task_description", any(String.class))
+        return matchesMap() //
+            .entry("task_description", any(String.class))
             .entry("start_millis", greaterThan(0L))
             .entry("stop_millis", greaterThan(0L))
             .entry("iterations", greaterThan(0L))

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -115,6 +115,7 @@ public class CsvTestsDataLoader {
     private static final TestDataset ADDRESSES = new TestDataset("addresses");
     private static final TestDataset BOOKS = new TestDataset("books").withSetting("books-settings.json");
     private static final TestDataset SEMANTIC_TEXT = new TestDataset("semantic_text").withInferenceEndpoint(true);
+    private static final TestDataset MV_TEXT = new TestDataset("mv_text");
 
     public static final Map<String, TestDataset> CSV_DATASET_MAP = Map.ofEntries(
         Map.entry(EMPLOYEES.indexName, EMPLOYEES),
@@ -160,7 +161,8 @@ public class CsvTestsDataLoader {
         Map.entry(DISTANCES.indexName, DISTANCES),
         Map.entry(ADDRESSES.indexName, ADDRESSES),
         Map.entry(BOOKS.indexName, BOOKS),
-        Map.entry(SEMANTIC_TEXT.indexName, SEMANTIC_TEXT)
+        Map.entry(SEMANTIC_TEXT.indexName, SEMANTIC_TEXT),
+        Map.entry(MV_TEXT.indexName, MV_TEXT)
     );
 
     private static final EnrichConfig LANGUAGES_ENRICH = new EnrichConfig("languages_policy", "enrich-policy-languages.json");

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -285,6 +285,11 @@ public final class EsqlTestUtils {
         public boolean isSingleValue(String field) {
             return false;
         }
+
+        @Override
+        public boolean canUseEqualityOnSyntheticSourceDelegate(String name, String value) {
+            return false;
+        }
     }
 
     /**

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/mv_text.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/mv_text.csv
@@ -3,3 +3,4 @@
 2023-10-23T13:55:01.544Z,Connected to 10.1.0.1
 2023-10-23T13:55:01.545Z,[Connected to 10.1.0.1, More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100]
 2023-10-23T13:55:01.546Z,More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100
+2023-10-23T13:55:01.547Z,[More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100,Second than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/mv_text.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/mv_text.csv
@@ -1,0 +1,5 @@
+@timestamp:date         ,message:text
+2023-10-23T13:55:01.543Z,[Connected to 10.1.0.1, Banana]
+2023-10-23T13:55:01.544Z,Connected to 10.1.0.1
+2023-10-23T13:55:01.545Z,[Connected to 10.1.0.1, More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100]
+2023-10-23T13:55:01.546Z,More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-basic-limited-raw.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-basic-limited-raw.json
@@ -1,0 +1,42 @@
+{
+    "properties" : {
+        "emp_no" : {
+            "type" : "integer"
+        },
+        "first_name" : {
+            "type" : "keyword"
+        },
+        "gender" : {
+            "type" : "text"
+        },
+        "languages" : {
+            "type" : "byte"
+        },
+        "last_name" : {
+            "type" : "keyword"
+        },
+        "salary" : {
+            "type" : "integer"
+        },
+        "_meta_field": {
+            "type" : "keyword"
+        },
+        "hire_date": {
+          "type": "date"
+        },
+        "job": {
+            "type": "text",
+            "fields": {
+                "raw": {
+                  "type": "keyword",
+                  "ignore_above": 4
+                }
+            }
+        },
+        "long_noidx": {
+          "type": "long",
+          "index": false,
+          "doc_values": false
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-mv_text.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-mv_text.json
@@ -1,0 +1,16 @@
+{
+    "properties": {
+        "@timestamp": {
+            "type": "date"
+        },
+        "message": {
+            "type": "text",
+            "fields": {
+                "raw": {
+                    "type": "keyword",
+                    "ignore_above": 100
+                }
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -2326,3 +2326,40 @@ warning:Line 2:9: java.lang.IllegalArgumentException: single-value function enco
     @timestamp:date     | message:text
 2023-10-23T13:55:01.546Z|More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100
 ;
+
+mvStringNotEquals
+FROM mv_text
+| WHERE message != "Connected to 10.1.0.2"
+| KEEP @timestamp, message
+;
+warning:Line 2:9: evaluation of [message != \"Connected to 10.1.0.2\"] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    @timestamp:date     | message:text
+2023-10-23T13:55:01.544Z|Connected to 10.1.0.1
+2023-10-23T13:55:01.546Z|More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100
+;
+
+mvStringNotEqualsFound
+FROM mv_text
+| WHERE message != "Connected to 10.1.0.1"
+| KEEP @timestamp, message
+;
+warning:Line 2:9: evaluation of [message != \"Connected to 10.1.0.1\"] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    @timestamp:date     | message:text
+2023-10-23T13:55:01.546Z|More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100
+;
+
+mvStringNotEqualsLong
+FROM mv_text
+| WHERE message != "More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100"
+| KEEP @timestamp, message
+;
+warning:Line 2:9: evaluation of [message != \"More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100\"] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    @timestamp:date     | message:text
+2023-10-23T13:55:01.544Z|Connected to 10.1.0.1
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -2302,3 +2302,27 @@ message:keyword
 foo ( bar
 // end::rlikeEscapingTripleQuotes-result[]
 ;
+
+mvStringEquals
+FROM mv_text
+| WHERE message == "Connected to 10.1.0.1"
+| KEEP @timestamp, message
+;
+warning:Line 2:9: evaluation of [message == \"Connected to 10.1.0.1\"] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    @timestamp:date     | message:text
+2023-10-23T13:55:01.544Z|Connected to 10.1.0.1
+;
+
+mvStringEqualsLongString
+FROM mv_text
+| WHERE message == "More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100"
+| KEEP @timestamp, message
+;
+warning:Line 2:9: evaluation of [message == \"More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100\"] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    @timestamp:date     | message:text
+2023-10-23T13:55:01.546Z|More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -2331,6 +2331,7 @@ mvStringNotEquals
 FROM mv_text
 | WHERE message != "Connected to 10.1.0.2"
 | KEEP @timestamp, message
+| SORT @timestamp ASC
 ;
 warning:Line 2:9: evaluation of [message != \"Connected to 10.1.0.2\"] failed, treating result as null. Only first 20 failures recorded.
 warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/TranslationAware.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/TranslationAware.java
@@ -31,7 +31,7 @@ public interface TranslationAware {
      * <p>and <b>not</b> this:</p>
      * <p>{@code Query childQuery = child.asQuery(handler);}</p>
      */
-    Query asQuery(TranslatorHandler handler);
+    Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler);
 
     /**
      * Subinterface for expressions that can only process single values (and null out on MVs).

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -153,7 +153,7 @@ public abstract class FullTextFunction extends Function
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         return queryBuilder != null ? new TranslationAwareExpressionQuery(source(), queryBuilder) : translate(handler);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -147,9 +147,9 @@ public abstract class FullTextFunction extends Function
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
         // In isolation, full text functions are pushable to source. We check if there are no disjunctions in Or conditions
-        return true;
+        return Translatable.YES;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryBuilderResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryBuilderResolver.java
@@ -13,6 +13,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
@@ -76,7 +77,9 @@ public final class QueryBuilderResolver {
             Holder<Boolean> updated = new Holder<>(false);
             LogicalPlan newPlan = plan.transformExpressionsDown(FullTextFunction.class, f -> {
                 QueryBuilder builder = f.queryBuilder(), initial = builder;
-                builder = builder == null ? f.asQuery(TranslatorHandler.TRANSLATOR_HANDLER).toQueryBuilder() : builder;
+                builder = builder == null
+                    ? f.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER).toQueryBuilder()
+                    : builder;
                 try {
                     builder = builder.rewrite(ctx);
                 } catch (IOException e) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/CIDRMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/CIDRMatch.java
@@ -179,8 +179,8 @@ public class CIDRMatch extends EsqlScalarFunction implements TranslationAware.Si
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
-        return pushdownPredicates.isPushableFieldAttribute(ipField) && Expressions.foldable(matches);
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return pushdownPredicates.isPushableFieldAttribute(ipField) && Expressions.foldable(matches) ? Translatable.YES : Translatable.NO;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/CIDRMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/CIDRMatch.java
@@ -184,7 +184,7 @@ public class CIDRMatch extends EsqlScalarFunction implements TranslationAware.Si
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         var fa = LucenePushdownPredicates.checkIsFieldAttribute(ipField);
         Check.isTrue(Expressions.foldable(matches), "Expected foldable matches, but got [{}]", matches);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
+import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
@@ -266,12 +267,14 @@ public abstract class BinarySpatialFunction extends BinaryScalarFunction impleme
     /**
      * Push-down to Lucene is only possible if one field is an indexed spatial field, and the other is a constant spatial or string column.
      */
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
+    public TranslationAware.Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
         // The use of foldable here instead of SpatialEvaluatorFieldKey.isConstant is intentional to match the behavior of the
         // Lucene pushdown code in EsqlTranslationHandler::SpatialRelatesTranslator
         // We could enhance both places to support ReferenceAttributes that refer to constants, but that is a larger change
         return isPushableSpatialAttribute(left(), pushdownPredicates) && right().foldable()
-            || isPushableSpatialAttribute(right(), pushdownPredicates) && left().foldable();
+            || isPushableSpatialAttribute(right(), pushdownPredicates) && left().foldable()
+                ? TranslationAware.Translatable.YES
+                : TranslationAware.Translatable.NO;
 
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
@@ -183,7 +183,7 @@ public abstract class SpatialRelatesFunction extends BinarySpatialFunction
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         if (left().foldable()) {
             checkSpatialRelatesFunction(left(), queryRelation());
             return translate(handler, right(), left());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
@@ -178,7 +178,7 @@ public abstract class SpatialRelatesFunction extends BinarySpatialFunction
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
         return super.translatable(pushdownPredicates); // only for the explicit Override, as only this subclass implements TranslationAware
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWith.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWith.java
@@ -139,8 +139,8 @@ public class EndsWith extends EsqlScalarFunction implements TranslationAware.Sin
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
-        return pushdownPredicates.isPushableAttribute(str) && suffix.foldable();
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return pushdownPredicates.isPushableAttribute(str) && suffix.foldable() ? Translatable.YES : Translatable.NO;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWith.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWith.java
@@ -144,7 +144,7 @@ public class EndsWith extends EsqlScalarFunction implements TranslationAware.Sin
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         LucenePushdownPredicates.checkIsPushableAttribute(str);
         var fieldName = handler.nameOf(str instanceof FieldAttribute fa ? fa.exactAttribute() : str);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RLike.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RLike.java
@@ -113,8 +113,8 @@ public class RLike extends org.elasticsearch.xpack.esql.core.expression.predicat
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
-        return pushdownPredicates.isPushableFieldAttribute(field());
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return pushdownPredicates.isPushableFieldAttribute(field()) ? Translatable.YES : Translatable.NO;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RLike.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RLike.java
@@ -118,7 +118,7 @@ public class RLike extends org.elasticsearch.xpack.esql.core.expression.predicat
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         var fa = LucenePushdownPredicates.checkIsFieldAttribute(field());
         // TODO: see whether escaping is needed
         return new RegexQuery(source(), handler.nameOf(fa.exactAttribute()), pattern().asJavaRegex(), caseInsensitive());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWith.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWith.java
@@ -136,8 +136,8 @@ public class StartsWith extends EsqlScalarFunction implements TranslationAware.S
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
-        return pushdownPredicates.isPushableAttribute(str) && prefix.foldable();
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return pushdownPredicates.isPushableAttribute(str) && prefix.foldable() ? Translatable.YES : Translatable.NO;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWith.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWith.java
@@ -141,7 +141,7 @@ public class StartsWith extends EsqlScalarFunction implements TranslationAware.S
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         LucenePushdownPredicates.checkIsPushableAttribute(str);
         var fieldName = handler.nameOf(str instanceof FieldAttribute fa ? fa.exactAttribute() : str);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLike.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLike.java
@@ -125,8 +125,8 @@ public class WildcardLike extends org.elasticsearch.xpack.esql.core.expression.p
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
-        return pushdownPredicates.isPushableAttribute(field());
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return pushdownPredicates.isPushableAttribute(field()) ? Translatable.YES : Translatable.NO;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLike.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLike.java
@@ -130,7 +130,7 @@ public class WildcardLike extends org.elasticsearch.xpack.esql.core.expression.p
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         var field = field();
         LucenePushdownPredicates.checkIsPushableAttribute(field);
         return translateField(handler.nameOf(field instanceof FieldAttribute fa ? fa.exactAttribute() : field));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/Range.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/Range.java
@@ -215,8 +215,8 @@ public class Range extends ScalarFunction implements TranslationAware.SingleValu
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
-        return pushdownPredicates.isPushableAttribute(value) && lower.foldable() && upper.foldable();
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return pushdownPredicates.isPushableAttribute(value) && lower.foldable() && upper.foldable() ? Translatable.YES : Translatable.NO;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/Range.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/Range.java
@@ -220,7 +220,7 @@ public class Range extends ScalarFunction implements TranslationAware.SingleValu
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         return translate(handler);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/fulltext/MultiMatchQueryPredicate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/fulltext/MultiMatchQueryPredicate.java
@@ -100,7 +100,7 @@ public class MultiMatchQueryPredicate extends FullTextPredicate implements Trans
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         return new MultiMatchQuery(source(), query(), fields(), this);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/fulltext/MultiMatchQueryPredicate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/fulltext/MultiMatchQueryPredicate.java
@@ -95,8 +95,8 @@ public class MultiMatchQueryPredicate extends FullTextPredicate implements Trans
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
-        return true; // needs update if we'll ever validate the fields
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return Translatable.YES; // needs update if we'll ever validate the fields
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/BinaryLogic.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/BinaryLogic.java
@@ -82,11 +82,8 @@ public abstract class BinaryLogic extends BinaryOperator<Boolean, Boolean, Boole
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
-        return left() instanceof TranslationAware leftAware
-            && leftAware.translatable(pushdownPredicates)
-            && right() instanceof TranslationAware rightAware
-            && rightAware.translatable(pushdownPredicates);
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return TranslationAware.translatable(left(), pushdownPredicates).merge(TranslationAware.translatable(right(), pushdownPredicates));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/BinaryLogic.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/BinaryLogic.java
@@ -90,8 +90,13 @@ public abstract class BinaryLogic extends BinaryOperator<Boolean, Boolean, Boole
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
-        return boolQuery(source(), handler.asQuery(left()), handler.asQuery(right()), this instanceof And);
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
+        return boolQuery(
+            source(),
+            handler.asQuery(pushdownPredicates, left()),
+            handler.asQuery(pushdownPredicates, right()),
+            this instanceof And
+        );
     }
 
     public static Query boolQuery(Source source, Query left, Query right, boolean isAnd) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/Not.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/Not.java
@@ -100,8 +100,8 @@ public class Not extends UnaryScalarFunction implements Negatable<Expression>, T
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
-        return field() instanceof TranslationAware aware && aware.translatable(pushdownPredicates);
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return TranslationAware.translatable(field(), pushdownPredicates).negate();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/Not.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/Not.java
@@ -105,7 +105,7 @@ public class Not extends UnaryScalarFunction implements Negatable<Expression>, T
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
-        return handler.asQuery(field()).negate(source());
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
+        return handler.asQuery(pushdownPredicates, field()).negate(source());
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNotNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNotNull.java
@@ -75,7 +75,7 @@ public class IsNotNull extends UnaryScalarFunction implements Negatable<UnarySca
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
         return IsNull.isTranslatable(field(), pushdownPredicates);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNotNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNotNull.java
@@ -80,7 +80,7 @@ public class IsNotNull extends UnaryScalarFunction implements Negatable<UnarySca
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         return new ExistsQuery(source(), handler.nameOf(field()));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNull.java
@@ -72,12 +72,14 @@ public class IsNull extends UnaryScalarFunction implements Negatable<UnaryScalar
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
         return isTranslatable(field(), pushdownPredicates);
     }
 
-    protected static boolean isTranslatable(Expression field, LucenePushdownPredicates pushdownPredicates) {
-        return LucenePushdownPredicates.isPushableTextFieldAttribute(field) || pushdownPredicates.isPushableFieldAttribute(field);
+    protected static Translatable isTranslatable(Expression field, LucenePushdownPredicates pushdownPredicates) {
+        return LucenePushdownPredicates.isPushableTextFieldAttribute(field) || pushdownPredicates.isPushableFieldAttribute(field)
+            ? Translatable.YES
+            : Translatable.NO;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNull.java
@@ -81,7 +81,7 @@ public class IsNull extends UnaryScalarFunction implements Negatable<UnaryScalar
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         return new NotQuery(source(), new ExistsQuery(source(), handler.nameOf(field())));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
@@ -131,7 +131,7 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
     @Override
     public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
         if (right() instanceof Literal lit) {
-            if (left().dataType() == DataType.TEXT && left() instanceof FieldAttribute fa) {
+            if (false && left().dataType() == DataType.TEXT && left() instanceof FieldAttribute fa) {
                 if (pushdownPredicates.canUseEqualityOnSyntheticSourceDelegate(fa, ((BytesRef) lit.value()).utf8ToString())) {
                     return true;
                 }
@@ -143,7 +143,8 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
     @Override
     public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         if (right() instanceof Literal lit) {
-            if (left().dataType() == DataType.TEXT && left() instanceof FieldAttribute fa) {
+            // Disabled because it cased a bug with !=. Fix incoming shortly.
+            if (false && left().dataType() == DataType.TEXT && left() instanceof FieldAttribute fa) {
                 String value = ((BytesRef) lit.value()).utf8ToString();
                 if (pushdownPredicates.canUseEqualityOnSyntheticSourceDelegate(fa, value)) {
                     String name = handler.nameOf(fa);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
@@ -11,13 +11,20 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.predicate.Negatable;
+import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.EsqlArithmeticOperation;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
+import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
+import org.elasticsearch.xpack.esql.querydsl.query.EqualsSyntheticSourceDelegate;
+import org.elasticsearch.xpack.esql.querydsl.query.SingleValueQuery;
 
 import java.time.ZoneId;
 import java.util.Map;
@@ -119,6 +126,32 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
             EqualsNanosMillisEvaluator.Factory::new,
             EqualsMillisNanosEvaluator.Factory::new
         );
+    }
+
+    @Override
+    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
+        if (right() instanceof Literal lit) {
+            if (left().dataType() == DataType.TEXT && left() instanceof FieldAttribute fa) {
+                if (pushdownPredicates.canUseEqualityOnSyntheticSourceDelegate(fa, ((BytesRef) lit.value()).utf8ToString())) {
+                    return true;
+                }
+            }
+        }
+        return super.translatable(pushdownPredicates);
+    }
+
+    @Override
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
+        if (right() instanceof Literal lit) {
+            if (left().dataType() == DataType.TEXT && left() instanceof FieldAttribute fa) {
+                String value = ((BytesRef) lit.value()).utf8ToString();
+                if (pushdownPredicates.canUseEqualityOnSyntheticSourceDelegate(fa, value)) {
+                    String name = handler.nameOf(fa);
+                    return new SingleValueQuery(new EqualsSyntheticSourceDelegate(source(), name, value), name, true);
+                }
+            }
+        }
+        return super.asQuery(pushdownPredicates, handler);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
@@ -129,11 +129,11 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
         if (right() instanceof Literal lit) {
-            if (false && left().dataType() == DataType.TEXT && left() instanceof FieldAttribute fa) {
+            if (left().dataType() == DataType.TEXT && left() instanceof FieldAttribute fa) {
                 if (pushdownPredicates.canUseEqualityOnSyntheticSourceDelegate(fa, ((BytesRef) lit.value()).utf8ToString())) {
-                    return true;
+                    return Translatable.YES_BUT_RECHECK_NEGATED;
                 }
             }
         }
@@ -143,8 +143,7 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
     @Override
     public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         if (right() instanceof Literal lit) {
-            // Disabled because it cased a bug with !=. Fix incoming shortly.
-            if (false && left().dataType() == DataType.TEXT && left() instanceof FieldAttribute fa) {
+            if (left().dataType() == DataType.TEXT && left() instanceof FieldAttribute fa) {
                 String value = ((BytesRef) lit.value()).utf8ToString();
                 if (pushdownPredicates.canUseEqualityOnSyntheticSourceDelegate(fa, value)) {
                     String name = handler.nameOf(fa);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
@@ -328,16 +328,16 @@ public abstract class EsqlBinaryComparison extends BinaryComparison
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
         if (right().foldable()) {
             if (pushdownPredicates.isPushableFieldAttribute(left())) {
-                return true;
+                return Translatable.YES;
             }
             if (LucenePushdownPredicates.isPushableMetadataAttribute(left())) {
-                return this instanceof Equals || this instanceof NotEquals;
+                return this instanceof Equals || this instanceof NotEquals ? Translatable.YES : Translatable.NO;
             }
         }
-        return false;
+        return Translatable.NO;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
@@ -356,7 +356,7 @@ public abstract class EsqlBinaryComparison extends BinaryComparison
      *  input to the operation.
      */
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         Check.isTrue(
             right().foldable(),
             "Line {}:{}: Comparisons against fields are not (currently) supported; offender [{}] in [{}]",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/In.java
@@ -461,8 +461,8 @@ public class In extends EsqlScalarFunction implements TranslationAware.SingleVal
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
-        return pushdownPredicates.isPushableAttribute(value) && Expressions.foldable(list());
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return pushdownPredicates.isPushableAttribute(value) && Expressions.foldable(list()) ? Translatable.YES : Translatable.NO;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/In.java
@@ -466,11 +466,11 @@ public class In extends EsqlScalarFunction implements TranslationAware.SingleVal
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
-        return translate(handler);
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
+        return translate(pushdownPredicates, handler);
     }
 
-    private Query translate(TranslatorHandler handler) {
+    private Query translate(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         logger.trace("Attempting to generate lucene query for IN expression");
         TypedAttribute attribute = LucenePushdownPredicates.checkIsPushableAttribute(value());
 
@@ -483,7 +483,7 @@ public class In extends EsqlScalarFunction implements TranslationAware.SingleVal
                     // delegates to BinaryComparisons translator to ensure consistent handling of date and time values
                     // TODO:
                     // Query query = BinaryComparisons.translate(new Equals(in.source(), in.value(), rhs), handler);
-                    Query query = handler.asQuery(new Equals(source(), value(), rhs));
+                    Query query = handler.asQuery(pushdownPredicates, new Equals(source(), value(), rhs));
 
                     if (query instanceof TermQuery) {
                         terms.add(((TermQuery) query).value());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InsensitiveEquals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InsensitiveEquals.java
@@ -102,7 +102,7 @@ public class InsensitiveEquals extends InsensitiveBinaryComparison {
     }
 
     @Override
-    public Query asQuery(TranslatorHandler handler) {
+    public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         checkInsensitiveComparison();
         return translate();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InsensitiveEquals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InsensitiveEquals.java
@@ -97,8 +97,8 @@ public class InsensitiveEquals extends InsensitiveBinaryComparison {
     }
 
     @Override
-    public boolean translatable(LucenePushdownPredicates pushdownPredicates) {
-        return pushdownPredicates.isPushableFieldAttribute(left()) && right().foldable();
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        return pushdownPredicates.isPushableFieldAttribute(left()) && right().foldable() ? Translatable.YES : Translatable.NO;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/LucenePushdownPredicates.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/LucenePushdownPredicates.java
@@ -47,6 +47,8 @@ public interface LucenePushdownPredicates {
      */
     boolean isIndexed(FieldAttribute attr);
 
+    boolean canUseEqualityOnSyntheticSourceDelegate(FieldAttribute attr, String value);
+
     /**
      * We see fields as pushable if either they are aggregatable or they are indexed.
      * This covers non-indexed cases like <code>AbstractScriptFieldType</code> which hard-coded <code>isAggregatable</code> to true,
@@ -116,6 +118,11 @@ public interface LucenePushdownPredicates {
             // TODO: This is the original behaviour, but is it correct? In FieldType isAggregatable usually only means hasDocValues
             return attr.field().isAggregatable();
         }
+
+        @Override
+        public boolean canUseEqualityOnSyntheticSourceDelegate(FieldAttribute attr, String value) {
+            return false;
+        }
     };
 
     /**
@@ -140,6 +147,11 @@ public interface LucenePushdownPredicates {
             @Override
             public boolean isIndexed(FieldAttribute attr) {
                 return stats.isIndexed(attr.name());
+            }
+
+            @Override
+            public boolean canUseEqualityOnSyntheticSourceDelegate(FieldAttribute attr, String value) {
+                return stats.canUseEqualityOnSyntheticSourceDelegate(attr.field().getName(), value);
             }
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
@@ -36,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.elasticsearch.xpack.esql.capabilities.TranslationAware.translatable;
 import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.splitAnd;
 import static org.elasticsearch.xpack.esql.planner.TranslatorHandler.TRANSLATOR_HANDLER;
 
@@ -57,7 +57,14 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
         List<Expression> pushable = new ArrayList<>();
         List<Expression> nonPushable = new ArrayList<>();
         for (Expression exp : splitAnd(filterExec.condition())) {
-            (canPushToSource(exp, pushdownPredicates) ? pushable : nonPushable).add(exp);
+            switch (translatable(exp, pushdownPredicates).finish()) {
+                case NO -> nonPushable.add(exp);
+                case YES -> pushable.add(exp);
+                case RECHECK -> {
+                    pushable.add(exp);
+                    nonPushable.add(exp);
+                }
+            }
         }
         return rewrite(pushdownPredicates, filterExec, queryExec, pushable, nonPushable, List.of());
     }
@@ -74,7 +81,14 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
         List<Expression> nonPushable = new ArrayList<>();
         for (Expression exp : splitAnd(filterExec.condition())) {
             Expression resExp = exp.transformUp(ReferenceAttribute.class, r -> aliasReplacedBy.resolve(r, r));
-            (canPushToSource(resExp, pushdownPredicates) ? pushable : nonPushable).add(exp);
+            switch (translatable(resExp, pushdownPredicates).finish()) {
+                case NO -> nonPushable.add(exp);
+                case YES -> pushable.add(exp);
+                case RECHECK -> {
+                    nonPushable.add(exp);
+                    nonPushable.add(exp);
+                }
+            }
         }
         // Replace field references with their actual field attributes
         pushable.replaceAll(e -> e.transformDown(ReferenceAttribute.class, r -> aliasReplacedBy.resolve(r, r)));
@@ -201,19 +215,5 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
             }
         }
         return changed ? CollectionUtils.combine(others, bcs, ranges) : pushable;
-    }
-
-    /**
-     * Check if the given expression can be pushed down to the source.
-     * This version of the check is called when we do not have SearchStats available. It assumes no exact subfields for TEXT fields,
-     * and makes the indexed/doc-values check using the isAggregatable flag only, which comes from field-caps, represents the field state
-     * over the entire cluster (is not node specific), and has risks for indexed=false/doc_values=true fields.
-     */
-    public static boolean canPushToSource(Expression exp) {
-        return canPushToSource(exp, LucenePushdownPredicates.DEFAULT);
-    }
-
-    static boolean canPushToSource(Expression exp, LucenePushdownPredicates lucenePushdownPredicates) {
-        return exp instanceof TranslationAware aware && aware.translatable(lucenePushdownPredicates);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToSource.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
@@ -33,7 +34,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushFiltersToSource.canPushToSource;
+import static org.elasticsearch.xpack.esql.capabilities.TranslationAware.translatable;
 import static org.elasticsearch.xpack.esql.plan.physical.EsStatsQueryExec.StatsType.COUNT;
 import static org.elasticsearch.xpack.esql.planner.TranslatorHandler.TRANSLATOR_HANDLER;
 
@@ -107,7 +108,10 @@ public class PushStatsToSource extends PhysicalOptimizerRules.ParameterizedOptim
                                     // That's because stats pushdown only works for 1 agg function (without BY); but in that case, filters
                                     // are extracted into a separate filter node upstream from the aggregation (and hopefully pushed into
                                     // the EsQueryExec separately).
-                                    if (canPushToSource(count.filter()) == false) {
+                                    if (translatable(
+                                        count.filter(),
+                                        LucenePushdownPredicates.DEFAULT
+                                    ) != TranslationAware.Translatable.YES) {
                                         return null; // can't push down
                                     }
                                     var countFilter = TRANSLATOR_HANDLER.asQuery(LucenePushdownPredicates.DEFAULT, count.filter());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToSource.java
@@ -110,7 +110,7 @@ public class PushStatsToSource extends PhysicalOptimizerRules.ParameterizedOptim
                                     if (canPushToSource(count.filter()) == false) {
                                         return null; // can't push down
                                     }
-                                    var countFilter = TRANSLATOR_HANDLER.asQuery(count.filter());
+                                    var countFilter = TRANSLATOR_HANDLER.asQuery(LucenePushdownPredicates.DEFAULT, count.filter());
                                     query = Queries.combine(Queries.Clause.MUST, asList(countFilter.toQueryBuilder(), query));
                                 }
                                 return new EsStatsQueryExec.Stat(fieldName, COUNT, query);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.esql.optimizer.LocalLogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizer;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.plan.QueryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
@@ -220,7 +221,9 @@ public class PlannerUtils {
                     }
                 }
                 if (matches.isEmpty() == false) {
-                    requestFilters.add(TRANSLATOR_HANDLER.asQuery(Predicates.combineAnd(matches)).toQueryBuilder());
+                    requestFilters.add(
+                        TRANSLATOR_HANDLER.asQuery(LucenePushdownPredicates.DEFAULT, Predicates.combineAnd(matches)).toQueryBuilder()
+                    );
                 }
             });
         });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -20,6 +20,7 @@ import org.elasticsearch.index.query.CoordinatorRewriteContext;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
@@ -62,8 +63,8 @@ import static java.util.Arrays.asList;
 import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.DOC_VALUES;
 import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.EXTRACT_SPATIAL_BOUNDS;
 import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.NONE;
+import static org.elasticsearch.xpack.esql.capabilities.TranslationAware.translatable;
 import static org.elasticsearch.xpack.esql.core.util.Queries.Clause.FILTER;
-import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushFiltersToSource.canPushToSource;
 import static org.elasticsearch.xpack.esql.planner.TranslatorHandler.TRANSLATOR_HANDLER;
 
 public class PlannerUtils {
@@ -215,7 +216,9 @@ public class PlannerUtils {
                         boolean matchesField = refsBuilder.removeIf(e -> fieldName.test(e.name()));
                         // the expression only contains the target reference
                         // and the expression is pushable (functions can be fully translated)
-                        if (matchesField && refsBuilder.isEmpty() && canPushToSource(exp)) {
+                        if (matchesField
+                            && refsBuilder.isEmpty()
+                            && translatable(exp, LucenePushdownPredicates.DEFAULT).finish() == TranslationAware.FinishedTranslatable.YES) {
                             matches.add(exp);
                         }
                     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/EqualsSyntheticSourceDelegate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/EqualsSyntheticSourceDelegate.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.querydsl.query;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.index.mapper.TextFieldMapper;
+import org.elasticsearch.index.query.BaseTermQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class EqualsSyntheticSourceDelegate extends Query {
+    private final String fieldName;
+    private final String value;
+
+    public EqualsSyntheticSourceDelegate(Source source, String fieldName, String value) {
+        super(source);
+        this.fieldName = fieldName;
+        this.value = value;
+    }
+
+    @Override
+    protected QueryBuilder asBuilder() {
+        return new Builder(fieldName, value);
+    }
+
+    @Override
+    protected String innerToString() {
+        return fieldName + "(delegate):" + value;
+    }
+
+    private class Builder extends BaseTermQueryBuilder<Builder> {
+        private Builder(String name, String value) {
+            super(name, value);
+        }
+
+        @Override
+        protected org.apache.lucene.search.Query doToQuery(SearchExecutionContext context) {
+            TextFieldMapper.TextFieldType ft = (TextFieldMapper.TextFieldType) context.getFieldType(fieldName);
+            return ft.syntheticSourceDelegate().termQuery(value, context);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "equals_synthetic_source_delegate";
+        }
+
+        @Override
+        public TransportVersion getMinimalSupportedVersion() {
+            // This is just translated on the data node and not sent over the wire.
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
@@ -11,6 +11,7 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -19,7 +20,9 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Warnings;
 import org.elasticsearch.compute.querydsl.query.SingleValueMatchQuery;
+import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -57,16 +60,28 @@ public class SingleValueQuery extends Query {
 
     private final Query next;
     private final String field;
+    private final boolean useSyntheticSourceDelegate;
 
-    public SingleValueQuery(Query next, String field) {
+    /**
+     * Build.
+     * @param next the query whose documents we should use for single-valued fields
+     * @param field the name of the field whose values to check
+     * @param useSyntheticSourceDelegate Should we check the field's synthetic source delegate (true)
+     *                                   or it's values itself? If the field is a {@code text} field
+     *                                   we often want to use its delegate.
+     */
+    public SingleValueQuery(Query next, String field, boolean useSyntheticSourceDelegate) {
         super(next.source());
         this.next = next;
         this.field = field;
+        this.useSyntheticSourceDelegate = useSyntheticSourceDelegate;
     }
 
     @Override
-    protected Builder asBuilder() {
-        return new Builder(next.toQueryBuilder(), field, next.source());
+    protected AbstractBuilder asBuilder() {
+        return useSyntheticSourceDelegate
+            ? new SyntheticSourceDelegateBuilder(next.toQueryBuilder(), field, next.source())
+            : new Builder(next.toQueryBuilder(), field, next.source());
     }
 
     @Override
@@ -76,7 +91,7 @@ public class SingleValueQuery extends Query {
 
     @Override
     public SingleValueQuery negate(Source source) {
-        return new SingleValueQuery(next.negate(source), field);
+        return new SingleValueQuery(next.negate(source), field, useSyntheticSourceDelegate);
     }
 
     @Override
@@ -85,26 +100,28 @@ public class SingleValueQuery extends Query {
             return false;
         }
         SingleValueQuery other = (SingleValueQuery) o;
-        return Objects.equals(next, other.next) && Objects.equals(field, other.field);
+        return Objects.equals(next, other.next)
+            && Objects.equals(field, other.field)
+            && useSyntheticSourceDelegate == other.useSyntheticSourceDelegate;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), next, field);
+        return Objects.hash(super.hashCode(), next, field, useSyntheticSourceDelegate);
     }
 
-    public static class Builder extends AbstractQueryBuilder<Builder> {
+    public abstract static class AbstractBuilder extends AbstractQueryBuilder<AbstractBuilder> {
         private final QueryBuilder next;
         private final String field;
         private final Source source;
 
-        Builder(QueryBuilder next, String field, Source source) {
+        AbstractBuilder(QueryBuilder next, String field, Source source) {
             this.next = next;
             this.field = field;
             this.source = source;
         }
 
-        Builder(StreamInput in) throws IOException {
+        AbstractBuilder(StreamInput in) throws IOException {
             super(in);
             this.next = in.readNamedWriteable(QueryBuilder.class);
             this.field = in.readString();
@@ -126,7 +143,7 @@ public class SingleValueQuery extends Query {
         }
 
         @Override
-        protected void doWriteTo(StreamOutput out) throws IOException {
+        protected final void doWriteTo(StreamOutput out) throws IOException {
             out.writeNamedWriteable(next);
             out.writeString(field);
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
@@ -148,6 +165,43 @@ public class SingleValueQuery extends Query {
             return source;
         }
 
+        protected abstract AbstractBuilder rewrite(QueryBuilder next);
+
+        @Override
+        protected final QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+            QueryBuilder rewritten = next.rewrite(queryRewriteContext);
+            if (rewritten instanceof MatchNoneQueryBuilder) {
+                return rewritten;
+            }
+            if (rewritten == next) {
+                return this;
+            }
+            return rewrite(rewritten);
+        }
+
+        @Override
+        protected final boolean doEquals(AbstractBuilder other) {
+            return next.equals(other.next) && field.equals(other.field);
+        }
+
+        @Override
+        protected final int doHashCode() {
+            return Objects.hash(next, field);
+        }
+    }
+
+    /**
+     * Builds a {@code bool} query combining the "next" query and a {@link SingleValueMatchQuery}.
+     */
+    public static class Builder extends AbstractBuilder {
+        Builder(QueryBuilder next, String field, Source source) {
+            super(next, field, source);
+        }
+
+        Builder(StreamInput in) throws IOException {
+            super(in);
+        }
+
         @Override
         public String getWriteableName() {
             return ENTRY.name;
@@ -156,9 +210,9 @@ public class SingleValueQuery extends Query {
         @Override
         protected void doXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject(ENTRY.name);
-            builder.field("field", field);
-            builder.field("next", next, params);
-            builder.field("source", source.toString());
+            builder.field("field", field());
+            builder.field("next", next(), params);
+            builder.field("source", source().toString());
             builder.endObject();
         }
 
@@ -168,51 +222,123 @@ public class SingleValueQuery extends Query {
         }
 
         @Override
-        protected org.apache.lucene.search.Query doToQuery(SearchExecutionContext context) throws IOException {
-            MappedFieldType ft = context.getFieldType(field);
+        protected final org.apache.lucene.search.Query doToQuery(SearchExecutionContext context) throws IOException {
+            MappedFieldType ft = context.getFieldType(field());
             if (ft == null) {
-                return new MatchNoDocsQuery("missing field [" + field + "]");
+                return new MatchNoDocsQuery("missing field [" + field() + "]");
             }
             SingleValueMatchQuery singleValueQuery = new SingleValueMatchQuery(
                 context.getForField(ft, MappedFieldType.FielddataOperation.SEARCH),
                 Warnings.createWarnings(
                     DriverContext.WarningsMode.COLLECT,
-                    source.source().getLineNumber(),
-                    source.source().getColumnNumber(),
-                    source.text()
+                    source().source().getLineNumber(),
+                    source().source().getColumnNumber(),
+                    source().text()
                 )
             );
             org.apache.lucene.search.Query rewrite = singleValueQuery.rewrite(context.searcher());
             if (rewrite instanceof MatchAllDocsQuery) {
                 // nothing to filter
-                return next.toQuery(context);
+                return next().toQuery(context);
             }
             BooleanQuery.Builder builder = new BooleanQuery.Builder();
-            builder.add(next.toQuery(context), BooleanClause.Occur.FILTER);
+            builder.add(next().toQuery(context), BooleanClause.Occur.FILTER);
             builder.add(rewrite, BooleanClause.Occur.FILTER);
             return builder.build();
         }
 
         @Override
-        protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
-            QueryBuilder rewritten = next.rewrite(queryRewriteContext);
-            if (rewritten instanceof MatchNoneQueryBuilder) {
-                return rewritten;
-            }
-            if (rewritten == next) {
-                return this;
-            }
-            return new Builder(rewritten, field, source);
+        protected AbstractBuilder rewrite(QueryBuilder next) {
+            return new Builder(next, field(), source());
+        }
+    }
+
+    /**
+     * Builds a {@code bool} query combining the "next" query, a {@link SingleValueMatchQuery},
+     * and a {@link TermQuery} making sure we didn't ignore any values. Three total queries.
+     * This is only used if the "next" query matches fields that would not be ignored. Read all
+     * the paragraphs below to understand it. It's tricky!
+     * <p>
+     *     This is used in the case when you do {@code text_field == "foo"} and {@code text_field}
+     *     has a {@code keyword} sub-field. See, {@code text} typed fields can't do our equality -
+     *     they only do matching. But {@code keyword} fields *can* do the equality. In this case
+     *     the "next" query is a {@link TermQuery} like {@code text_field.raw:foo}.
+     * </p>
+     * <p>
+     *     But there's a big wrinkle! If you index a field longer than {@code ignore_above} into
+     *     {@code text_field.raw} field then it'll drop its value on the floor. So the
+     *     {@link SingleValueMatchQuery} isn't enough to emulate {@code ==}. You have to remove
+     *     any matches that ignored a field. Luckily we have {@link IgnoredFieldMapper}! We can
+     *     do a {@link TermQuery} like {@code NOT(_ignored:text_field.raw)} to filter those out.
+     * </p>
+     * <p>
+     *     You may be asking, "how would the first {@code text_field.raw:foo} query work if the
+     *     value we're searching for is very long?" In that case we never use this query at all.
+     *     We have to delegate the filtering to the compute engine. No fancy lucene searches in
+     *     that case.
+     * </p>
+     */
+    public static class SyntheticSourceDelegateBuilder extends AbstractBuilder {
+        SyntheticSourceDelegateBuilder(QueryBuilder next, String field, Source source) {
+            super(next, field, source);
         }
 
         @Override
-        protected boolean doEquals(Builder other) {
-            return next.equals(other.next) && field.equals(other.field);
+        public String getWriteableName() {
+            throw new UnsupportedOperationException("Not serialized");
         }
 
         @Override
-        protected int doHashCode() {
-            return Objects.hash(next, field);
+        protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject(ENTRY.name);
+            builder.field("field", field() + ":synthetic_source_delegate");
+            builder.field("next", next(), params);
+            builder.field("source", source().toString());
+            builder.endObject();
+        }
+
+        @Override
+        public TransportVersion getMinimalSupportedVersion() {
+            throw new UnsupportedOperationException("Not serialized");
+        }
+
+        @Override
+        protected final org.apache.lucene.search.Query doToQuery(SearchExecutionContext context) throws IOException {
+            MappedFieldType ft = context.getFieldType(field());
+            if (ft == null) {
+                return new MatchNoDocsQuery("missing field [" + field() + "]");
+            }
+            ft = ((TextFieldMapper.TextFieldType) ft).syntheticSourceDelegate();
+
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.add(next().toQuery(context), BooleanClause.Occur.FILTER);
+
+            org.apache.lucene.search.Query singleValueQuery = new SingleValueMatchQuery(
+                context.getForField(ft, MappedFieldType.FielddataOperation.SEARCH),
+                Warnings.createWarnings(
+                    DriverContext.WarningsMode.COLLECT,
+                    source().source().getLineNumber(),
+                    source().source().getColumnNumber(),
+                    source().text()
+                )
+            );
+            singleValueQuery = singleValueQuery.rewrite(context.searcher());
+            if (singleValueQuery instanceof MatchAllDocsQuery == false) {
+                builder.add(singleValueQuery, BooleanClause.Occur.FILTER);
+            }
+
+            org.apache.lucene.search.Query ignored = new TermQuery(new org.apache.lucene.index.Term(IgnoredFieldMapper.NAME, ft.name()));
+            ignored = ignored.rewrite(context.searcher());
+            if (ignored instanceof MatchNoDocsQuery == false) {
+                builder.add(ignored, BooleanClause.Occur.MUST_NOT);
+            }
+
+            return builder.build();
+        }
+
+        @Override
+        protected AbstractBuilder rewrite(QueryBuilder next) {
+            return new Builder(next, field(), source());
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
@@ -17,7 +17,9 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.lucene.LuceneSourceOperator;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.FilterOperator;
 import org.elasticsearch.compute.operator.Warnings;
 import org.elasticsearch.compute.querydsl.query.SingleValueMatchQuery;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
@@ -50,6 +52,9 @@ import java.util.Objects;
  *     for now we're going to always wrap so we can always push. When we find cases
  *     where double checking is better we'll try that.
  * </p>
+ * <p>
+ *     NOTE: This will only work with {@code text} fields.
+ * </p>
  */
 public class SingleValueQuery extends Query {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
@@ -60,7 +65,7 @@ public class SingleValueQuery extends Query {
 
     private final Query next;
     private final String field;
-    private final boolean useSyntheticSourceDelegate;
+    private final UseSyntheticSourceDelegate useSyntheticSourceDelegate;
 
     /**
      * Build.
@@ -71,6 +76,10 @@ public class SingleValueQuery extends Query {
      *                                   we often want to use its delegate.
      */
     public SingleValueQuery(Query next, String field, boolean useSyntheticSourceDelegate) {
+        this(next, field, useSyntheticSourceDelegate ? UseSyntheticSourceDelegate.YES : UseSyntheticSourceDelegate.NO);
+    }
+
+    public SingleValueQuery(Query next, String field, UseSyntheticSourceDelegate useSyntheticSourceDelegate) {
         super(next.source());
         this.next = next;
         this.field = field;
@@ -79,9 +88,11 @@ public class SingleValueQuery extends Query {
 
     @Override
     protected AbstractBuilder asBuilder() {
-        return useSyntheticSourceDelegate
-            ? new SyntheticSourceDelegateBuilder(next.toQueryBuilder(), field, next.source())
-            : new Builder(next.toQueryBuilder(), field, next.source());
+        return switch (useSyntheticSourceDelegate) {
+            case NO -> new Builder(next.toQueryBuilder(), field, next.source());
+            case YES -> new SyntheticSourceDelegateBuilder(next.toQueryBuilder(), field, next.source());
+            case YES_NEGATED -> new NegatedSyntheticSourceDelegateBuilder(next.toQueryBuilder(), field, next.source());
+        };
     }
 
     @Override
@@ -91,7 +102,11 @@ public class SingleValueQuery extends Query {
 
     @Override
     public SingleValueQuery negate(Source source) {
-        return new SingleValueQuery(next.negate(source), field, useSyntheticSourceDelegate);
+        return new SingleValueQuery(next.negate(source), field, switch (useSyntheticSourceDelegate) {
+            case NO -> UseSyntheticSourceDelegate.NO;
+            case YES -> UseSyntheticSourceDelegate.YES_NEGATED;
+            case YES_NEGATED -> UseSyntheticSourceDelegate.YES;
+        });
     }
 
     @Override
@@ -188,6 +203,27 @@ public class SingleValueQuery extends Query {
         protected final int doHashCode() {
             return Objects.hash(next, field);
         }
+
+        protected final org.apache.lucene.search.Query simple(MappedFieldType ft, SearchExecutionContext context) throws IOException {
+            SingleValueMatchQuery singleValueQuery = new SingleValueMatchQuery(
+                context.getForField(ft, MappedFieldType.FielddataOperation.SEARCH),
+                Warnings.createWarnings(
+                    DriverContext.WarningsMode.COLLECT,
+                    source().source().getLineNumber(),
+                    source().source().getColumnNumber(),
+                    source().text()
+                )
+            );
+            org.apache.lucene.search.Query rewrite = singleValueQuery.rewrite(context.searcher());
+            if (rewrite instanceof MatchAllDocsQuery) {
+                // nothing to filter
+                return next().toQuery(context);
+            }
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.add(next().toQuery(context), BooleanClause.Occur.FILTER);
+            builder.add(rewrite, BooleanClause.Occur.FILTER);
+            return builder.build();
+        }
     }
 
     /**
@@ -227,24 +263,7 @@ public class SingleValueQuery extends Query {
             if (ft == null) {
                 return new MatchNoDocsQuery("missing field [" + field() + "]");
             }
-            SingleValueMatchQuery singleValueQuery = new SingleValueMatchQuery(
-                context.getForField(ft, MappedFieldType.FielddataOperation.SEARCH),
-                Warnings.createWarnings(
-                    DriverContext.WarningsMode.COLLECT,
-                    source().source().getLineNumber(),
-                    source().source().getColumnNumber(),
-                    source().text()
-                )
-            );
-            org.apache.lucene.search.Query rewrite = singleValueQuery.rewrite(context.searcher());
-            if (rewrite instanceof MatchAllDocsQuery) {
-                // nothing to filter
-                return next().toQuery(context);
-            }
-            BooleanQuery.Builder builder = new BooleanQuery.Builder();
-            builder.add(next().toQuery(context), BooleanClause.Occur.FILTER);
-            builder.add(rewrite, BooleanClause.Occur.FILTER);
-            return builder.build();
+            return simple(ft, context);
         }
 
         @Override
@@ -254,7 +273,7 @@ public class SingleValueQuery extends Query {
     }
 
     /**
-     * Builds a {@code bool} query combining the "next" query, a {@link SingleValueMatchQuery},
+     * Builds a {@code bool} query ANDing the "next" query, a {@link SingleValueMatchQuery},
      * and a {@link TermQuery} making sure we didn't ignore any values. Three total queries.
      * This is only used if the "next" query matches fields that would not be ignored. Read all
      * the paragraphs below to understand it. It's tricky!
@@ -343,6 +362,92 @@ public class SingleValueQuery extends Query {
     }
 
     /**
+     * Builds a query matching either ignored values OR the union of {@code next} query
+     * and {@link SingleValueMatchQuery}. Three total queries. This is used to generate
+     * candidate matches for queries like {@code NOT(a == "b")} where some values of {@code a}
+     * are not indexed. In fact, let's use that as an example.
+     * <p>
+     *     In that case you use a query for {@code a != "b"} as the "next" query. Then
+     *     this query will find all documents where {@code a} is single valued and
+     *     {@code == "b"} AND all documents that have ignored some values of {@code a}.
+     *     This produces <strong>candidate</strong> matches for {@code NOT(a == "b")}.
+     *     It'll find documents like:
+     * </p>
+     * <ul>
+     *     <li>"a"</li>
+     *     <li>ignored_value</li>
+     *     <li>["a", ignored_value]</li>
+     *     <li>[ignored_value1, ignored_value2]</li>
+     *     <li>["b", ignored_field]</li>
+     * </ul>
+     * <p>
+     *     The first and second of those <strong>should</strong> match {@code NOT(a == "b")}.
+     *     The last three should be rejected. So! When using this query you <strong>must</strong>
+     *     push this query to the {@link LuceneSourceOperator} <strong>and</strong>
+     *     retain it in the {@link FilterOperator}.
+     * </p>
+     * <p>
+     *     This will not find:
+     * </p>
+     * <ul>
+     *     <li>"b"</li>
+     * </ul>
+     * <p>
+     *     And that's also great! These can't match {@code NOT(a == "b")}
+     * </p>
+     */
+    public static class NegatedSyntheticSourceDelegateBuilder extends AbstractBuilder {
+        NegatedSyntheticSourceDelegateBuilder(QueryBuilder next, String field, Source source) {
+            super(next, field, source);
+        }
+
+        @Override
+        public String getWriteableName() {
+            throw new UnsupportedOperationException("Not serialized");
+        }
+
+        @Override
+        protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject("negated_" + ENTRY.name);
+            builder.field("field", field() + ":synthetic_source_delegate");
+            builder.field("next", next(), params);
+            builder.field("source", source().toString());
+            builder.endObject();
+        }
+
+        @Override
+        public TransportVersion getMinimalSupportedVersion() {
+            throw new UnsupportedOperationException("Not serialized");
+        }
+
+        @Override
+        protected final org.apache.lucene.search.Query doToQuery(SearchExecutionContext context) throws IOException {
+            MappedFieldType ft = context.getFieldType(field());
+            if (ft == null) {
+                return new MatchNoDocsQuery("missing field [" + field() + "]");
+            }
+            ft = ((TextFieldMapper.TextFieldType) ft).syntheticSourceDelegate();
+            org.apache.lucene.search.Query svNext = simple(ft, context);
+
+            org.apache.lucene.search.Query ignored = new TermQuery(new org.apache.lucene.index.Term(IgnoredFieldMapper.NAME, ft.name()));
+            ignored = ignored.rewrite(context.searcher());
+            if (ignored instanceof MatchNoDocsQuery) {
+                return svNext;
+            }
+
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.add(svNext, BooleanClause.Occur.SHOULD);
+            builder.add(ignored, BooleanClause.Occur.SHOULD);
+            return builder.build();
+        }
+
+        @Override
+        protected AbstractBuilder rewrite(QueryBuilder next) {
+            return new Builder(next, field(), source());
+        }
+    }
+
+    /**
      * Write a {@link Source} including the text in it.
      */
     static void writeOldSource(StreamOutput out, Source source) throws IOException {
@@ -361,5 +466,11 @@ public class SingleValueQuery extends Query {
 
         String text = in.readString();
         return new Source(new Location(line, charPositionInLine), text);
+    }
+
+    public enum UseSyntheticSourceDelegate {
+        NO,
+        YES,
+        YES_NEGATED;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
@@ -287,6 +287,24 @@ public class SearchContextStats implements SearchStats {
         return false;
     }
 
+    @Override
+    public boolean canUseEqualityOnSyntheticSourceDelegate(String name, String value) {
+        for (SearchExecutionContext ctx : contexts) {
+            MappedFieldType type = ctx.getFieldType(name);
+            if (type == null) {
+                return false;
+            }
+            if (type instanceof TextFieldMapper.TextFieldType t) {
+                if (t.canUseSyntheticSourceDelegateForQueryingEquality(value) == false) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private interface DocCountTester {
         Boolean test(LeafReader leafReader) throws IOException;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
@@ -37,6 +37,8 @@ public interface SearchStats {
 
     boolean isSingleValue(String field);
 
+    boolean canUseEqualityOnSyntheticSourceDelegate(String name, String value);
+
     /**
      * When there are no search stats available, for example when there are no search contexts, we have static results.
      */
@@ -92,5 +94,9 @@ public interface SearchStats {
             return true;
         }
 
+        @Override
+        public boolean canUseEqualityOnSyntheticSourceDelegate(String name, String value) {
+            return false;
+        }
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchErrorTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase
 import org.elasticsearch.xpack.esql.expression.function.ErrorsForCasesWithoutExamplesTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.hamcrest.Matcher;
 
 import java.util.List;
@@ -40,7 +41,7 @@ public class MatchErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
         // We need to add the QueryBuilder to the match expression, as it is used to implement equals() and hashCode() and
         // thus test the serialization methods. But we can only do this if the parameters make sense .
         if (args.get(0) instanceof FieldAttribute && args.get(1).foldable()) {
-            QueryBuilder queryBuilder = TRANSLATOR_HANDLER.asQuery(match).toQueryBuilder();
+            QueryBuilder queryBuilder = TRANSLATOR_HANDLER.asQuery(LucenePushdownPredicates.DEFAULT, match).toQueryBuilder();
             match.replaceQueryBuilder(queryBuilder);
         }
         return match;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.FunctionName;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -80,7 +81,7 @@ public class MatchTests extends AbstractMatchFullTextFunctionTests {
         // We need to add the QueryBuilder to the match expression, as it is used to implement equals() and hashCode() and
         // thus test the serialization methods. But we can only do this if the parameters make sense .
         if (args.get(0) instanceof FieldAttribute && args.get(1).foldable()) {
-            QueryBuilder queryBuilder = TRANSLATOR_HANDLER.asQuery(match).toQueryBuilder();
+            QueryBuilder queryBuilder = TRANSLATOR_HANDLER.asQuery(LucenePushdownPredicates.DEFAULT, match).toQueryBuilder();
             match.replaceQueryBuilder(queryBuilder);
         }
         return match;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryStringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryStringTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.FunctionName;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -79,7 +80,7 @@ public class QueryStringTests extends NoneFieldFullTextFunctionTestCase {
         // We need to add the QueryBuilder to the match expression, as it is used to implement equals() and hashCode() and
         // thus test the serialization methods. But we can only do this if the parameters make sense .
         if (args.get(0).foldable()) {
-            QueryBuilder queryBuilder = TRANSLATOR_HANDLER.asQuery(qstr).toQueryBuilder();
+            QueryBuilder queryBuilder = TRANSLATOR_HANDLER.asQuery(LucenePushdownPredicates.DEFAULT, qstr).toQueryBuilder();
             qstr.replaceQueryBuilder(queryBuilder);
         }
         return qstr;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithTests.java
@@ -11,6 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
@@ -113,7 +114,7 @@ public class EndsWithTests extends AbstractScalarFunctionTestCase {
             new Literal(Source.EMPTY, "test", DataType.KEYWORD)
         );
 
-        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(false));
+        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(TranslationAware.Translatable.NO));
     }
 
     public void testLuceneQuery_NonFoldableSuffix_NonTranslatable() {
@@ -123,7 +124,7 @@ public class EndsWithTests extends AbstractScalarFunctionTestCase {
             new FieldAttribute(Source.EMPTY, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true))
         );
 
-        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(false));
+        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(TranslationAware.Translatable.NO));
     }
 
     public void testLuceneQuery_NonFoldableSuffix_Translatable() {
@@ -133,7 +134,7 @@ public class EndsWithTests extends AbstractScalarFunctionTestCase {
             new Literal(Source.EMPTY, "a*b?c\\", DataType.KEYWORD)
         );
 
-        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(true));
+        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(TranslationAware.Translatable.YES));
 
         var query = function.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithTests.java
@@ -135,7 +135,7 @@ public class EndsWithTests extends AbstractScalarFunctionTestCase {
 
         assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(true));
 
-        var query = function.asQuery(TranslatorHandler.TRANSLATOR_HANDLER);
+        var query = function.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
 
         assertThat(query, equalTo(new WildcardQuery(Source.EMPTY, "field", "*a\\*b\\?c\\\\")));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithTests.java
@@ -11,6 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
@@ -73,7 +74,7 @@ public class StartsWithTests extends AbstractScalarFunctionTestCase {
             new Literal(Source.EMPTY, "test", DataType.KEYWORD)
         );
 
-        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(false));
+        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(TranslationAware.Translatable.NO));
     }
 
     public void testLuceneQuery_NonFoldablePrefix_NonTranslatable() {
@@ -83,7 +84,7 @@ public class StartsWithTests extends AbstractScalarFunctionTestCase {
             new FieldAttribute(Source.EMPTY, "field", new EsField("prefix", DataType.KEYWORD, Map.of(), true))
         );
 
-        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(false));
+        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(TranslationAware.Translatable.NO));
     }
 
     public void testLuceneQuery_NonFoldablePrefix_Translatable() {
@@ -93,7 +94,7 @@ public class StartsWithTests extends AbstractScalarFunctionTestCase {
             new Literal(Source.EMPTY, "a*b?c\\", DataType.KEYWORD)
         );
 
-        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(true));
+        assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(TranslationAware.Translatable.YES));
 
         var query = function.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithTests.java
@@ -95,7 +95,7 @@ public class StartsWithTests extends AbstractScalarFunctionTestCase {
 
         assertThat(function.translatable(LucenePushdownPredicates.DEFAULT), equalTo(true));
 
-        var query = function.asQuery(TranslatorHandler.TRANSLATOR_HANDLER);
+        var query = function.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
 
         assertThat(query, equalTo(new WildcardQuery(Source.EMPTY, "field", "a\\*b\\?c\\\\*")));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.WildcardLikeTests;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
 import org.junit.AfterClass;
 
@@ -91,7 +92,7 @@ public class InTests extends AbstractFunctionTestCase {
             new FieldAttribute(Source.EMPTY, "field", new EsField("suffix", DataType.KEYWORD, Map.of(), true)),
             Arrays.asList(ONE, new Literal(Source.EMPTY, null, randomFrom(DataType.types())), THREE)
         );
-        var query = in.asQuery(TranslatorHandler.TRANSLATOR_HANDLER);
+        var query = in.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
         assertEquals(new TermsQuery(EMPTY, "field", Set.of(1, 3)), query);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -134,6 +134,7 @@ import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.elasticsearch.xpack.esql.querydsl.query.EqualsSyntheticSourceDelegate;
 import org.elasticsearch.xpack.esql.querydsl.query.SingleValueQuery;
 import org.elasticsearch.xpack.esql.querydsl.query.SpatialRelatesQuery;
 import org.elasticsearch.xpack.esql.session.Configuration;
@@ -215,6 +216,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     private PhysicalPlanOptimizer physicalPlanOptimizer;
     private Mapper mapper;
     private TestDataSource testData;
+    private TestDataSource testDataLimitedRaw;
     private int allFieldRowSize;    // TODO: Move this into testDataSource so tests that load other indexes can also assert on this
     private TestDataSource airports;
     private TestDataSource airportsNoDocValues; // Test when spatial field is indexed but has no doc values
@@ -235,7 +237,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     private record TestDataSource(Map<String, EsField> mapping, EsIndex index, Analyzer analyzer, SearchStats stats) {}
 
     @ParametersFactory(argumentFormatting = PARAM_FORMATTING)
-    public static List<Object[]> readScriptSpec() {
+    public static List<Object[]> params() {
         return settings().stream().map(t -> {
             var settings = Settings.builder().loadFromMap(t.v2()).build();
             return new Object[] { t.v1(), configuration(new QueryPragmas(settings)) };
@@ -260,6 +262,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         var enrichResolution = setupEnrichResolution();
         // Most tests used data from the test index, so we load it here, and use it in the plan() function.
         this.testData = makeTestDataSource("test", "mapping-basic.json", functionRegistry, enrichResolution);
+        this.testDataLimitedRaw = makeTestDataSource("test", "mapping-basic-limited-raw.json", functionRegistry, enrichResolution);
         allFieldRowSize = testData.mapping.values()
             .stream()
             .mapToInt(
@@ -7692,6 +7695,35 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         assertThat(reductionAggs.estimatedRowSize(), equalTo(58)); // double and keyword
     }
 
+    public void testEqualsPushdownToDelegate() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM test
+            | WHERE job == "v"
+            """, testDataLimitedRaw), SEARCH_STATS_SHORT_DELEGATES);
+        var limit = as(optimized, LimitExec.class);
+        var exchange = as(limit.child(), ExchangeExec.class);
+        var project = as(exchange.child(), ProjectExec.class);
+        var extract = as(project.child(), FieldExtractExec.class);
+        var query = as(extract.child(), EsQueryExec.class);
+        assertThat(
+            query.query(),
+            equalTo(new SingleValueQuery(new EqualsSyntheticSourceDelegate(Source.EMPTY, "job", "v"), "job", true).toQueryBuilder())
+        );
+    }
+
+    public void testEqualsPushdownToDelegateTooBig() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM test
+            | WHERE job == "too_long"
+            """, testDataLimitedRaw), SEARCH_STATS_SHORT_DELEGATES);
+        var limit = as(optimized, LimitExec.class);
+        var exchange = as(limit.child(), ExchangeExec.class);
+        var project = as(exchange.child(), ProjectExec.class);
+        var extract = as(project.child(), FieldExtractExec.class);
+        var limit2 = as(extract.child(), LimitExec.class);
+        as(limit2.child(), FilterExec.class);
+    }
+
     @SuppressWarnings("SameParameterValue")
     private static void assertFilterCondition(
         Filter filter,
@@ -7905,4 +7937,16 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     protected List<String> filteredWarnings() {
         return withDefaultLimitWarning(super.filteredWarnings());
     }
+
+    private static final SearchStats SEARCH_STATS_SHORT_DELEGATES = new EsqlTestUtils.TestSearchStats() {
+        @Override
+        public boolean hasExactSubfield(String field) {
+            return false;
+        }
+
+        @Override
+        public boolean canUseEqualityOnSyntheticSourceDelegate(String name, String value) {
+            return value.length() < 4;
+        }
+    };
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -58,6 +58,7 @@ import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
+import org.elasticsearch.xpack.esql.core.querydsl.query.NotQuery;
 import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -7696,7 +7697,6 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     }
 
     public void testEqualsPushdownToDelegate() {
-        assumeFalse("disabled from bug", true);
         var optimized = optimizedPlan(physicalPlan("""
             FROM test
             | WHERE job == "v"
@@ -7723,6 +7723,33 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         var extract = as(project.child(), FieldExtractExec.class);
         var limit2 = as(extract.child(), LimitExec.class);
         as(limit2.child(), FilterExec.class);
+    }
+
+    public void testNotEqualsPushdownToDelegate() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM test
+            | WHERE job != "v"
+            """, testDataLimitedRaw), SEARCH_STATS_SHORT_DELEGATES);
+        var limit = as(optimized, LimitExec.class);
+        var exchange = as(limit.child(), ExchangeExec.class);
+        var project = as(exchange.child(), ProjectExec.class);
+        var extract = as(project.child(), FieldExtractExec.class);
+        var limit2 = as(extract.child(), LimitExec.class);
+        var filter = as(limit2.child(), FilterExec.class);
+        var extract2 = as(filter.child(), FieldExtractExec.class);
+        var query = as(extract2.child(), EsQueryExec.class);
+        assertThat(
+            query.query(),
+            equalTo(
+                new BoolQueryBuilder().filter(
+                    new SingleValueQuery(
+                        new NotQuery(Source.EMPTY, new EqualsSyntheticSourceDelegate(Source.EMPTY, "job", "v")),
+                        "job",
+                        SingleValueQuery.UseSyntheticSourceDelegate.YES_NEGATED
+                    ).toQueryBuilder()
+                )
+            )
+        );
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -7696,6 +7696,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     }
 
     public void testEqualsPushdownToDelegate() {
+        assumeFalse("disabled from bug", true);
         var optimized = optimizedPlan(physicalPlan("""
             FROM test
             | WHERE job == "v"

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryNegateTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryNegateTests.java
@@ -25,7 +25,15 @@ public class SingleValueQueryNegateTests extends ESTestCase {
         var sv = new SingleValueQuery(new MatchAll(Source.EMPTY), "foo", useSyntheticSourceDelegate);
         assertThat(
             sv.negate(Source.EMPTY),
-            equalTo(new SingleValueQuery(new NotQuery(Source.EMPTY, new MatchAll(Source.EMPTY)), "foo", useSyntheticSourceDelegate))
+            equalTo(
+                new SingleValueQuery(
+                    new NotQuery(Source.EMPTY, new MatchAll(Source.EMPTY)),
+                    "foo",
+                    useSyntheticSourceDelegate
+                        ? SingleValueQuery.UseSyntheticSourceDelegate.YES_NEGATED
+                        : SingleValueQuery.UseSyntheticSourceDelegate.NO
+                )
+            )
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryNegateTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryNegateTests.java
@@ -21,12 +21,16 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class SingleValueQueryNegateTests extends ESTestCase {
     public void testNot() {
-        var sv = new SingleValueQuery(new MatchAll(Source.EMPTY), "foo");
-        assertThat(sv.negate(Source.EMPTY), equalTo(new SingleValueQuery(new NotQuery(Source.EMPTY, new MatchAll(Source.EMPTY)), "foo")));
+        boolean useSyntheticSourceDelegate = randomBoolean();
+        var sv = new SingleValueQuery(new MatchAll(Source.EMPTY), "foo", useSyntheticSourceDelegate);
+        assertThat(
+            sv.negate(Source.EMPTY),
+            equalTo(new SingleValueQuery(new NotQuery(Source.EMPTY, new MatchAll(Source.EMPTY)), "foo", useSyntheticSourceDelegate))
+        );
     }
 
     public void testNotNot() {
-        var sv = new SingleValueQuery(new MatchAll(Source.EMPTY), "foo");
+        var sv = new SingleValueQuery(new MatchAll(Source.EMPTY), "foo", randomBoolean());
         assertThat(sv.negate(Source.EMPTY).negate(Source.EMPTY), equalTo(sv));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
@@ -22,15 +22,13 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
-import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.MatchPhraseQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
-import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.esql.core.querydsl.query.MatchAll;
 import org.elasticsearch.xpack.esql.core.querydsl.query.RangeQuery;
+import org.elasticsearch.xpack.esql.core.querydsl.query.TermQuery;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.io.IOException;
@@ -46,12 +44,14 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
         XContentBuilder mapping(XContentBuilder builder) throws IOException;
 
         List<List<Object>> build(RandomIndexWriter iw) throws IOException;
+
+        boolean useSyntheticSourceDelegate();
     }
 
     @ParametersFactory
     public static List<Object[]> params() {
         List<Object[]> params = new ArrayList<>();
-        for (String fieldType : new String[] { "long", "integer", "short", "byte", "double", "float", "keyword" }) {
+        for (String fieldType : new String[] { "long", "integer", "short", "byte", "double", "float", "keyword", "text" }) {
             for (boolean multivaluedField : new boolean[] { true, false }) {
                 for (boolean allowEmpty : new boolean[] { true, false }) {
                     params.add(new Object[] { new StandardSetup(fieldType, multivaluedField, allowEmpty, 100) });
@@ -69,45 +69,54 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
     }
 
     public void testMatchAll() throws IOException {
-        testCase(new SingleValueQuery(new MatchAll(Source.EMPTY), "foo").asBuilder(), this::runCase);
+        testCase(new SingleValueQuery(new MatchAll(Source.EMPTY), "foo", setup.useSyntheticSourceDelegate()).asBuilder(), this::runCase);
     }
 
     public void testMatchSome() throws IOException {
         int max = between(1, 100);
         testCase(
-            new SingleValueQuery.Builder(new RangeQueryBuilder("i").lt(max), "foo", Source.EMPTY),
+            new SingleValueQuery(
+                new RangeQuery(Source.EMPTY, "i", null, false, max, false, randomZone()),
+                "foo",
+                setup.useSyntheticSourceDelegate()
+            ).asBuilder(),
             (fieldValues, count) -> runCase(fieldValues, count, null, max)
         );
     }
 
     public void testSubPhrase() throws IOException {
-        testCase(new SingleValueQuery.Builder(new MatchPhraseQueryBuilder("str", "fox jumped"), "foo", Source.EMPTY), this::runCase);
+        SingleValueQuery.AbstractBuilder builder = setup.useSyntheticSourceDelegate()
+            ? new SingleValueQuery.SyntheticSourceDelegateBuilder(new MatchPhraseQueryBuilder("str", "fox jumped"), "foo", Source.EMPTY)
+            : new SingleValueQuery.Builder(new MatchPhraseQueryBuilder("str", "fox jumped"), "foo", Source.EMPTY);
+        testCase(builder, this::runCase);
     }
 
     public void testMatchNone() throws IOException {
         testCase(
-            new SingleValueQuery.Builder(new MatchNoneQueryBuilder(), "foo", Source.EMPTY),
+            new SingleValueQuery(new MatchAll(Source.EMPTY).negate(Source.EMPTY), "foo", setup.useSyntheticSourceDelegate()).asBuilder(),
             (fieldValues, count) -> assertThat(count, equalTo(0))
         );
     }
 
     public void testRewritesToMatchNone() throws IOException {
         testCase(
-            new SingleValueQuery.Builder(new TermQueryBuilder("missing", 0), "foo", Source.EMPTY),
+            new SingleValueQuery(new TermQuery(Source.EMPTY, "missing", 0), "foo", setup.useSyntheticSourceDelegate()).asBuilder(),
             (fieldValues, count) -> assertThat(count, equalTo(0))
         );
     }
 
     public void testNotMatchAll() throws IOException {
         testCase(
-            new SingleValueQuery(new MatchAll(Source.EMPTY), "foo").negate(Source.EMPTY).asBuilder(),
+            new SingleValueQuery(new MatchAll(Source.EMPTY), "foo", setup.useSyntheticSourceDelegate()).negate(Source.EMPTY).asBuilder(),
             (fieldValues, count) -> assertThat(count, equalTo(0))
         );
     }
 
     public void testNotMatchNone() throws IOException {
         testCase(
-            new SingleValueQuery(new MatchAll(Source.EMPTY).negate(Source.EMPTY), "foo").negate(Source.EMPTY).asBuilder(),
+            new SingleValueQuery(new MatchAll(Source.EMPTY).negate(Source.EMPTY), "foo", setup.useSyntheticSourceDelegate()).negate(
+                Source.EMPTY
+            ).asBuilder(),
             this::runCase
         );
     }
@@ -115,7 +124,11 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
     public void testNotMatchSome() throws IOException {
         int max = between(1, 100);
         testCase(
-            new SingleValueQuery(new RangeQuery(Source.EMPTY, "i", null, false, max, false, null), "foo").negate(Source.EMPTY).asBuilder(),
+            new SingleValueQuery(
+                new RangeQuery(Source.EMPTY, "i", null, false, max, false, null),
+                "foo",
+                setup.useSyntheticSourceDelegate()
+            ).negate(Source.EMPTY).asBuilder(),
             (fieldValues, count) -> runCase(fieldValues, count, max, 100)
         );
     }
@@ -161,7 +174,7 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
         runCase(fieldValues, count, null, null);
     }
 
-    private void testCase(SingleValueQuery.Builder builder, TestCase testCase) throws IOException {
+    private void testCase(SingleValueQuery.AbstractBuilder builder, TestCase testCase) throws IOException {
         MapperService mapper = createMapperService(mapping(setup::mapping));
         try (Directory d = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), d)) {
             List<List<Object>> fieldValues = setup.build(iw);
@@ -185,7 +198,13 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
         public XContentBuilder mapping(XContentBuilder builder) throws IOException {
             builder.startObject("i").field("type", "long").endObject();
             builder.startObject("str").field("type", "text").endObject();
-            return builder.startObject("foo").field("type", fieldType).endObject();
+            builder.startObject("foo").field("type", fieldType);
+            if (fieldType.equals("text")) {
+                builder.startObject("fields");
+                builder.startObject("raw").field("type", "keyword").field("ignore_above", 256).endObject();
+                builder.endObject();
+            }
+            return builder.endObject();
         }
 
         @Override
@@ -197,6 +216,11 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
                 iw.addDocument(docFor(i, values));
             }
             return fieldValues;
+        }
+
+        @Override
+        public boolean useSyntheticSourceDelegate() {
+            return fieldType.equals("text");
         }
 
         private List<Object> values(int i) {
@@ -225,7 +249,7 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
                 case "byte" -> randomByte();
                 case "double" -> randomDouble();
                 case "float" -> randomFloat();
-                case "keyword" -> randomAlphaOfLength(5);
+                case "keyword", "text" -> randomAlphaOfLength(5);
                 default -> throw new UnsupportedOperationException();
             };
         }
@@ -252,6 +276,12 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
                         fields.add(new KeywordField("foo", v.toString(), Field.Store.NO));
                     }
                 }
+                case "text" -> {
+                    for (Object v : values) {
+                        fields.add(new TextField("foo", v.toString(), Field.Store.NO));
+                        fields.add(new KeywordField("foo.raw", v.toString(), Field.Store.NO));
+                    }
+                }
                 default -> throw new UnsupportedOperationException();
             }
             return fields;
@@ -275,6 +305,11 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
                 fieldValues.add(List.of());
             }
             return fieldValues;
+        }
+
+        @Override
+        public boolean useSyntheticSourceDelegate() {
+            return randomBoolean();
         }
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/DisabledSearchStats.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/DisabledSearchStats.java
@@ -61,4 +61,9 @@ public class DisabledSearchStats implements SearchStats {
     public boolean isSingleValue(String field) {
         return false;
     }
+
+    @Override
+    public boolean canUseEqualityOnSyntheticSourceDelegate(String name, String value) {
+        return false;
+    }
 }


### PR DESCRIPTION
If you do:
```
| WHERE text_field == "cat"
```
we can't push to the text field because it's search index is for
individual words. But most text fields have a `.keyword` sub field and
we *can* query it's index. EXCEPT! It's normal for these fields to have
`ignore_above` in their mapping. In that case we don't push to the
field. Very sad.

With this change we can push down `==`, but only when the right hand
side is shorter than the `ignore_above`.

This has pretty much infinite speed gain. An example using a million
documents:
```
Before:  "took" : 391,
 After:  "took" :   4,
```

But this is going from totally un-indexed linear scans to totally
indexed. You can make the "Before" number as high as you want by loading
more data.



Reenables `text ==` pushdown and adds support for `text !=` pushdown.

It does so by making `TranslationAware#translatable` return something
we can turn into a tri-valued function. It has these values:
* `YES`
* `NO`
* `RECHECK`

`YES` means the `Expression` is entirely pushable into Lucene. They will
be pushed into Lucene and removed from the plan.

`NO` means the `Expression` can't be pushed to Lucene at all and will stay
in the plan.

`RECHECK` mean the `Expression` can push a query that makes *candidate*
matches but must be rechecked. Documents that don't match the query won't
match the expression, but documents that match the query might not match
the expression. These are pushed to Lucene *and* left in the plan.

This is required because `txt != "b"` can build a *candidate* query
against the `txt.keyword` subfield but it can't be sure of the match
without loading the `_source` - which we do in the compute engine.

I haven't plugged rally into this, but here's some basic
performance tests:
```
Before:
not text eq {"took":460,"documents_found":1000000}
    text eq {"took":432,"documents_found":1000000}

After:
    text eq {"took":5,"documents_found":1}
not text eq {"took":351,"documents_found":800000}
```

This comes from:
```
rm -f /tmp/bulk*
for a in {1..1000}; do
    echo '{"index":{}}' >> /tmp/bulk
    echo '{"text":"text '$(printf $(($a % 5)))'"}' >> /tmp/bulk
done
ls -l /tmp/bulk*

passwd="redacted"
curl -sk -uelastic:$passwd -HContent-Type:application/json -XDELETE https://localhost:9200/test
curl -sk -uelastic:$passwd -HContent-Type:application/json -XPUT https://localhost:9200/test -d'{
    "settings": {
        "index.codec": "best_compression",
        "index.refresh_interval": -1
    },
    "mappings": {
        "properties": {
            "many": {
                "enabled": false
            }
        }
    }
}'
for a in {1..1000}; do
    printf %04d: $a
    curl -sk -uelastic:$passwd -HContent-Type:application/json -XPOST https://localhost:9200/test/_bulk?pretty --data-binary @/tmp/bulk | grep errors
done
curl -sk -uelastic:$passwd -HContent-Type:application/json -XPOST https://localhost:9200/test/_forcemerge?max_num_segments=1
curl -sk -uelastic:$passwd -HContent-Type:application/json -XPOST https://localhost:9200/test/_refresh
echo
curl -sk -uelastic:$passwd https://localhost:9200/_cat/indices?v

text_eq() {
    echo -n "    text eq "
    curl -sk -uelastic:$passwd -HContent-Type:application/json -XPOST 'https://localhost:9200/_query?pretty' -d'{
        "query": "FROM test | WHERE text == \"text 1\" | STATS COUNT(*)",
        "pragma": {
            "data_partitioning": "shard"
        }
    }' | jq -c '{took, documents_found}'
}

not_text_eq() {
    echo -n "not text eq "
    curl -sk -uelastic:$passwd -HContent-Type:application/json -XPOST 'https://localhost:9200/_query?pretty' -d'{
        "query": "FROM test | WHERE NOT text == \"text 1\" | STATS COUNT(*)",
        "pragma": {
            "data_partitioning": "shard"
        }
    }' | jq -c '{took, documents_found}'
}

for a in {1..100}; do
    text_eq
    not_text_eq
done
```