### PR TITLE
ESQL: Remove test mute

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -423,9 +423,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test025SyncPluginsUsingProxy
   issue: https://github.com/elastic/elasticsearch/issues/127138
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/120_profile/avg 8.14 or after}
-  issue: https://github.com/elastic/elasticsearch/issues/127879
 - class: org.elasticsearch.indices.stats.IndexStatsIT
   method: testThrottleStats
   issue: https://github.com/elastic/elasticsearch/issues/126359


### PR DESCRIPTION
Closes #127879

This was caused by a backport problem that has since been fixed.
