### PR TITLE
[8.19] More efficient sort in `tryRelocateShard` (#128063)

### DIFF
--- a/docs/changelog/128063.yaml
+++ b/docs/changelog/128063.yaml
@@ -1,0 +1,5 @@
+pr: 128063
+summary: More efficient sort in `tryRelocateShard`
+area: Allocation
+type: enhancement
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.19:
 - More efficient sort in `tryRelocateShard` (#128063)