### PR TITLE
[8.19] Simplify testSearchWhileRelocating (#128095)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ManyShardsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ManyShardsIT.java
@@ -123,7 +123,7 @@ public class ManyShardsIT extends AbstractEsqlIntegTestCase {
                     logger.warn("Query failed with exception", e);
                     throw e;
                 }
-            }, "testConcurrentQueries");
+            }, "testConcurrentQueries-" + q);
         }
         for (Thread thread : threads) {
             thread.start();


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Simplify testSearchWhileRelocating (#128095)