### PR TITLE
[8.19] ESQL: Limit Replace function memory usage (#127924)

### DIFF
--- a/docs/changelog/127924.yaml
+++ b/docs/changelog/127924.yaml
@@ -1,0 +1,5 @@
+pr: 127924
+summary: Limit Replace function memory usage
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/ScalarFunction.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/ScalarFunction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.common.unit.ByteSizeUnit.MB;
 
 /**
  * A {@code ScalarFunction} is a {@code Function} that takes values from some
@@ -21,6 +22,14 @@ import static java.util.Collections.emptyList;
  * value (abs) and returns a new value.
  */
 public abstract class ScalarFunction extends Function {
+
+    /**
+     * Limit for the BytesRef return of functions.
+     * <p>
+     *     To be used when there's no CircuitBreaking, as an arbitrary measure to limit memory usage.
+     * </p>
+     */
+    public static final long MAX_BYTES_REF_RESULT_SIZE = MB.toBytes(1);
 
     protected ScalarFunction(Source source) {
         super(source, emptyList());

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceConstantEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceConstantEvaluator.java
@@ -8,7 +8,6 @@ import java.lang.IllegalArgumentException;
 import java.lang.Override;
 import java.lang.String;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -92,7 +91,7 @@ public final class ReplaceConstantEvaluator implements EvalOperator.ExpressionEv
         }
         try {
           result.appendBytesRef(Replace.process(strBlock.getBytesRef(strBlock.getFirstValueIndex(p), strScratch), this.regex, newStrBlock.getBytesRef(newStrBlock.getFirstValueIndex(p), newStrScratch)));
-        } catch (PatternSyntaxException e) {
+        } catch (IllegalArgumentException e) {
           warnings().registerException(e);
           result.appendNull();
         }
@@ -109,7 +108,7 @@ public final class ReplaceConstantEvaluator implements EvalOperator.ExpressionEv
       position: for (int p = 0; p < positionCount; p++) {
         try {
           result.appendBytesRef(Replace.process(strVector.getBytesRef(p, strScratch), this.regex, newStrVector.getBytesRef(p, newStrScratch)));
-        } catch (PatternSyntaxException e) {
+        } catch (IllegalArgumentException e) {
           warnings().registerException(e);
           result.appendNull();
         }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceEvaluator.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 import java.lang.IllegalArgumentException;
 import java.lang.Override;
 import java.lang.String;
-import java.util.regex.PatternSyntaxException;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -111,7 +110,7 @@ public final class ReplaceEvaluator implements EvalOperator.ExpressionEvaluator 
         }
         try {
           result.appendBytesRef(Replace.process(strBlock.getBytesRef(strBlock.getFirstValueIndex(p), strScratch), regexBlock.getBytesRef(regexBlock.getFirstValueIndex(p), regexScratch), newStrBlock.getBytesRef(newStrBlock.getFirstValueIndex(p), newStrScratch)));
-        } catch (PatternSyntaxException e) {
+        } catch (IllegalArgumentException e) {
           warnings().registerException(e);
           result.appendNull();
         }
@@ -129,7 +128,7 @@ public final class ReplaceEvaluator implements EvalOperator.ExpressionEvaluator 
       position: for (int p = 0; p < positionCount; p++) {
         try {
           result.appendBytesRef(Replace.process(strVector.getBytesRef(p, strScratch), regexVector.getBytesRef(p, regexScratch), newStrVector.getBytesRef(p, newStrScratch)));
-        } catch (PatternSyntaxException e) {
+        } catch (IllegalArgumentException e) {
           warnings().registerException(e);
           result.appendNull();
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Repeat.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Repeat.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.elasticsearch.common.unit.ByteSizeUnit.MB;
 import static org.elasticsearch.compute.ann.Fixed.Scope.THREAD_LOCAL;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
@@ -39,8 +38,6 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isTyp
 
 public class Repeat extends EsqlScalarFunction implements OptionalArgument {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Repeat", Repeat::new);
-
-    static final long MAX_REPEATED_LENGTH = MB.toBytes(1);
 
     private final Expression str;
     private final Expression number;
@@ -123,9 +120,9 @@ public class Repeat extends EsqlScalarFunction implements OptionalArgument {
 
     static BytesRef processInner(BreakingBytesRefBuilder scratch, BytesRef str, int number) {
         int repeatedLen = str.length * number;
-        if (repeatedLen > MAX_REPEATED_LENGTH) {
+        if (repeatedLen > MAX_BYTES_REF_RESULT_SIZE) {
             throw new IllegalArgumentException(
-                "Creating repeated strings with more than [" + MAX_REPEATED_LENGTH + "] bytes is not supported"
+                "Creating repeated strings with more than [" + MAX_BYTES_REF_RESULT_SIZE + "] bytes is not supported"
             );
         }
         scratch.grow(repeatedLen);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractScalarFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractScalarFunctionTestCase.java
@@ -303,6 +303,7 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
         if (testCase.getExpectedBuildEvaluatorWarnings() != null) {
             assertWarnings(testCase.getExpectedBuildEvaluatorWarnings());
         }
+
         ExecutorService exec = Executors.newFixedThreadPool(threads);
         try {
             List<Future<?>> futures = new ArrayList<>();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceStaticTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceStaticTests.java
@@ -42,32 +42,69 @@ import static org.hamcrest.Matchers.equalTo;
  * limited memory, and instantiating many copies of these
  * tests with large rows causes out of memory.
  */
-public class RepeatStaticTests extends ESTestCase {
+public class ReplaceStaticTests extends ESTestCase {
 
-    public void testAlmostTooBig() {
-        String str = randomAlphaOfLength(1);
-        int number = (int) ScalarFunction.MAX_BYTES_REF_RESULT_SIZE;
-        String repeated = process(str, number);
-        assertThat(repeated, equalTo(str.repeat(number)));
+    public void testLimit() {
+        int textLength = (int) ScalarFunction.MAX_BYTES_REF_RESULT_SIZE / 10;
+        String text = randomAlphaOfLength((int) ScalarFunction.MAX_BYTES_REF_RESULT_SIZE / 10);
+        String regex = "^(.+)$";
+
+        // 10 times the original text + the remainder
+        String extraString = "a".repeat((int) ScalarFunction.MAX_BYTES_REF_RESULT_SIZE % 10);
+        assert textLength * 10 + extraString.length() == ScalarFunction.MAX_BYTES_REF_RESULT_SIZE;
+        String newStr = "$0$0$0$0$0$0$0$0$0$0" + extraString;
+
+        String result = process(text, regex, newStr);
+        assertThat(result, equalTo(newStr.replaceAll("\\$\\d", text)));
     }
 
     public void testTooBig() {
-        String str = randomAlphaOfLength(1);
-        int number = (int) ScalarFunction.MAX_BYTES_REF_RESULT_SIZE + 1;
-        String repeated = process(str, number);
-        assertNull(repeated);
+        String textAndNewStr = randomAlphaOfLength((int) (ScalarFunction.MAX_BYTES_REF_RESULT_SIZE / 10));
+        String regex = ".";
+
+        String result = process(textAndNewStr, regex, textAndNewStr);
+        assertNull(result);
         assertWarnings(
-            "Line -1:-1: java.lang.IllegalArgumentException: Creating repeated strings with more than [1048576] bytes is not supported",
-            "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded."
+            "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+            "Line -1:-1: java.lang.IllegalArgumentException: "
+                + "Creating strings with more than ["
+                + ScalarFunction.MAX_BYTES_REF_RESULT_SIZE
+                + "] bytes is not supported"
         );
     }
 
-    public String process(String str, int number) {
+    public void testTooBigWithGroups() {
+        int textLength = (int) ScalarFunction.MAX_BYTES_REF_RESULT_SIZE / 10;
+        String text = randomAlphaOfLength(textLength);
+        String regex = "(.+)";
+
+        // 10 times the original text + the remainder + 1
+        String extraString = "a".repeat(1 + (int) ScalarFunction.MAX_BYTES_REF_RESULT_SIZE % 10);
+        assert textLength * 10 + extraString.length() == ScalarFunction.MAX_BYTES_REF_RESULT_SIZE + 1;
+        String newStr = "$0$1$0$1$0$1$0$1$0$1" + extraString;
+
+        String result = process(text, regex, newStr);
+        assertNull(result);
+        assertWarnings(
+            "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+            "Line -1:-1: java.lang.IllegalArgumentException: "
+                + "Creating strings with more than ["
+                + ScalarFunction.MAX_BYTES_REF_RESULT_SIZE
+                + "] bytes is not supported"
+        );
+    }
+
+    public String process(String text, String regex, String newStr) {
         try (
             var eval = AbstractScalarFunctionTestCase.evaluator(
-                new Repeat(Source.EMPTY, field("string", DataType.KEYWORD), field("number", DataType.INTEGER))
+                new Replace(
+                    Source.EMPTY,
+                    field("text", DataType.KEYWORD),
+                    field("regex", DataType.KEYWORD),
+                    field("newStr", DataType.KEYWORD)
+                )
             ).get(driverContext());
-            Block block = eval.eval(row(List.of(new BytesRef(str), number)));
+            Block block = eval.eval(row(List.of(new BytesRef(text), new BytesRef(regex), new BytesRef(newStr))));
         ) {
             return block.isNull(0) ? null : ((BytesRef) BlockUtils.toJavaObject(block, 0)).utf8ToString();
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceTests.java
@@ -78,6 +78,22 @@ public class ReplaceTests extends AbstractScalarFunctionTestCase {
             )
         );
 
+        // Groups
+        suppliers.add(fixedCase("Full group", "Cats are awesome", ".+", "<$0>", "<Cats are awesome>"));
+        suppliers.add(
+            fixedCase("Nested groups", "A cat is great, a cat is awesome", "\\b([Aa] (\\w+)) is (\\w+)\\b", "$1$2", "A catcat, a catcat")
+        );
+        suppliers.add(
+            fixedCase(
+                "Multiple groups",
+                "Cats are awesome",
+                "(\\w+) (.+)",
+                "$0 -> $1 and dogs $2",
+                "Cats are awesome -> Cats and dogs are awesome"
+            )
+        );
+
+        // Errors
         suppliers.add(new TestCaseSupplier("syntax error", List.of(DataType.KEYWORD, DataType.KEYWORD, DataType.KEYWORD), () -> {
             String text = randomAlphaOfLength(10);
             String invalidRegex = "[";
@@ -85,7 +101,7 @@ public class ReplaceTests extends AbstractScalarFunctionTestCase {
             return new TestCaseSupplier.TestCase(
                 List.of(
                     new TestCaseSupplier.TypedData(new BytesRef(text), DataType.KEYWORD, "str"),
-                    new TestCaseSupplier.TypedData(new BytesRef(invalidRegex), DataType.KEYWORD, "oldStr"),
+                    new TestCaseSupplier.TypedData(new BytesRef(invalidRegex), DataType.KEYWORD, "regex"),
                     new TestCaseSupplier.TypedData(new BytesRef(newStr), DataType.KEYWORD, "newStr")
                 ),
                 "ReplaceEvaluator[str=Attribute[channel=0], regex=Attribute[channel=1], newStr=Attribute[channel=2]]",


### PR DESCRIPTION
Backports the following commits to 8.19:
 - ESQL: Limit Replace function memory usage (#127924)