### PR TITLE
Add temporary LegacyActionRequest (#128107)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
@@ -10,10 +10,10 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -43,11 +43,11 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class GrokProcessorGetAction {
 
-    static final ActionType<GrokProcessorGetAction.Response> INSTANCE = new ActionType<>("cluster:admin/ingest/processor/grok/get");
+    static final ActionType<Response> INSTANCE = new ActionType<>("cluster:admin/ingest/processor/grok/get");
 
     private GrokProcessorGetAction() {/* no instances */}
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         private final boolean sorted;
         private final String ecsCompatibility;

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.script.mustache;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -30,7 +30,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class MultiSearchTemplateRequest extends ActionRequest implements CompositeIndicesRequest {
+public class MultiSearchTemplateRequest extends LegacyActionRequest implements CompositeIndicesRequest {
 
     private int maxConcurrentSearchRequests = 0;
     private List<SearchTemplateRequest> requests = new ArrayList<>();

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateRequest.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateRequest.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.script.mustache;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
@@ -34,7 +34,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A request to execute a search based on a search template.
  */
-public class SearchTemplateRequest extends ActionRequest implements CompositeIndicesRequest, ToXContentObject {
+public class SearchTemplateRequest extends LegacyActionRequest implements CompositeIndicesRequest, ToXContentObject {
 
     private SearchRequest request;
     private boolean simulate = false;
@@ -171,6 +171,7 @@ public class SearchTemplateRequest extends ActionRequest implements CompositeInd
     private static final ParseField PROFILE_FIELD = new ParseField("profile");
 
     private static final ObjectParser<SearchTemplateRequest, Void> PARSER;
+
     static {
         PARSER = new ObjectParser<>("search_template");
         PARSER.declareField((parser, request, s) -> request.setScriptParams(parser.map()), PARAMS_FIELD, ObjectParser.ValueType.OBJECT);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextAction.java
@@ -10,10 +10,10 @@
 package org.elasticsearch.painless.action;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -61,7 +61,7 @@ public class PainlessContextAction {
 
     private PainlessContextAction() {/* no instances */}
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         private String scriptContextName;
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalRequest.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalRequest.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.index.rankeval;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * Request to perform a search ranking evaluation.
  */
-public final class RankEvalRequest extends ActionRequest implements IndicesRequest.Replaceable {
+public final class RankEvalRequest extends LegacyActionRequest implements IndicesRequest.Replaceable {
 
     private RankEvalSpec rankingEvaluationSpec;
 

--- a/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainRequest.java
+++ b/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainRequest.java
@@ -9,14 +9,14 @@
 
 package org.elasticsearch.rest.root;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public class MainRequest extends ActionRequest {
+public class MainRequest extends LegacyActionRequest {
     @Override
     public ActionRequestValidationException validate() {
         return null;

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedContinuationsIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedContinuationsIT.java
@@ -15,6 +15,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ESNetty4IntegTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionRunnable;

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedContinuationsIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedContinuationsIT.java
@@ -15,11 +15,11 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ESNetty4IntegTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.CountDownActionListener;
 import org.elasticsearch.action.support.SubscribableListener;
@@ -337,14 +337,14 @@ public class Netty4ChunkedContinuationsIT extends ESNetty4IntegTestCase {
         static final String ROUTE = "/_test/yields_continuations";
         static final String FAIL_INDEX_PARAM = "fail_index";
 
-        private static final ActionType<YieldsContinuationsPlugin.Response> TYPE = new ActionType<>("test:yields_continuations");
+        private static final ActionType<Response> TYPE = new ActionType<>("test:yields_continuations");
 
         @Override
         public Collection<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
             return List.of(new ActionHandler<>(TYPE, TransportYieldsContinuationsAction.class));
         }
 
-        public static class Request extends ActionRequest {
+        public static class Request extends LegacyActionRequest {
             final int failIndex;
 
             public Request(int failIndex) {
@@ -525,7 +525,7 @@ public class Netty4ChunkedContinuationsIT extends ESNetty4IntegTestCase {
             return List.of(new ActionHandler<>(TYPE, TransportInfiniteContinuationsAction.class));
         }
 
-        public static class Request extends ActionRequest {
+        public static class Request extends LegacyActionRequest {
             @Override
             public ActionRequestValidationException validate() {
                 return null;

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -14,11 +14,11 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.GroupedActionListener;
@@ -118,6 +118,7 @@ public class CancellableTasksIT extends ESIntegTestCase {
 
     /**
      * Allow some parts of the request to be completed
+     *
      * @return a pending child requests
      */
     static Set<TestRequest> allowPartialRequest(TestRequest request) throws Exception {
@@ -418,7 +419,7 @@ public class CancellableTasksIT extends ESIntegTestCase {
         }
     }
 
-    static class TestRequest extends ActionRequest {
+    static class TestRequest extends LegacyActionRequest {
         final int id;
         final DiscoveryNode node;
         final List<TestRequest> subRequests;

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/tasks/ListTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/tasks/ListTasksIT.java
@@ -10,11 +10,11 @@
 package org.elasticsearch.action.admin.cluster.tasks;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -142,7 +142,7 @@ public class ListTasksIT extends ESSingleNodeTestCase {
         }
     }
 
-    public static class TestRequest extends ActionRequest {
+    public static class TestRequest extends LegacyActionRequest {
         @Override
         public ActionRequestValidationException validate() {
             return null;

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/tasks/ListTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/tasks/ListTasksIT.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.action.admin.cluster.tasks;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionRunnable;

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/rank/MockedRequestActionBasedRerankerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/rank/MockedRequestActionBasedRerankerIT.java
@@ -16,10 +16,10 @@ import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.search.SearchPhaseController;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -142,7 +142,7 @@ public class MockedRequestActionBasedRerankerIT extends AbstractRerankerIT {
         }
     }
 
-    public static class TestRerankingActionRequest extends ActionRequest {
+    public static class TestRerankingActionRequest extends LegacyActionRequest {
 
         private final List<String> docFeatures;
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/rank/MockedRequestActionBasedRerankerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/rank/MockedRequestActionBasedRerankerIT.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;

--- a/server/src/main/java/org/elasticsearch/action/LegacyActionRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/LegacyActionRequest.java
@@ -6,30 +6,25 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-package org.elasticsearch.action.admin.cluster.storedscripts;
 
-import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.LegacyActionRequest;
+package org.elasticsearch.action;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
 
-public class GetScriptContextRequest extends LegacyActionRequest {
-    public GetScriptContextRequest() {
+/**
+ * An action request with an unspecified response type.
+ *
+ * @deprecated Use {@link ActionRequest} with a specific {@link ActionResponse} type.
+ */
+@Deprecated
+public abstract class LegacyActionRequest extends ActionRequest {
+    public LegacyActionRequest() {
         super();
     }
 
-    GetScriptContextRequest(StreamInput in) throws IOException {
+    public LegacyActionRequest(StreamInput in) throws IOException {
         super(in);
-    }
-
-    @Override
-    public ActionRequestValidationException validate() {
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return "get script context";
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/ClusterFormationInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/ClusterFormationInfoAction.java
@@ -10,10 +10,10 @@
 package org.elasticsearch.action.admin.cluster.coordination;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.coordination.ClusterFormationFailureHelper;
@@ -41,7 +41,7 @@ public class ClusterFormationInfoAction extends ActionType<ClusterFormationInfoA
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         public Request() {}
 
@@ -106,7 +106,7 @@ public class ClusterFormationInfoAction extends ActionType<ClusterFormationInfoA
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            ClusterFormationInfoAction.Response response = (ClusterFormationInfoAction.Response) o;
+            Response response = (Response) o;
             return clusterFormationState.equals(response.clusterFormationState);
         }
 
@@ -119,9 +119,7 @@ public class ClusterFormationInfoAction extends ActionType<ClusterFormationInfoA
     /**
      * This transport action fetches the ClusterFormationState from a remote node.
      */
-    public static class TransportAction extends HandledTransportAction<
-        ClusterFormationInfoAction.Request,
-        ClusterFormationInfoAction.Response> {
+    public static class TransportAction extends HandledTransportAction<Request, Response> {
         private final Coordinator coordinator;
 
         @Inject
@@ -130,19 +128,15 @@ public class ClusterFormationInfoAction extends ActionType<ClusterFormationInfoA
                 ClusterFormationInfoAction.NAME,
                 transportService,
                 actionFilters,
-                ClusterFormationInfoAction.Request::new,
+                Request::new,
                 transportService.getThreadPool().executor(ThreadPool.Names.CLUSTER_COORDINATION)
             );
             this.coordinator = coordinator;
         }
 
         @Override
-        protected void doExecute(
-            Task task,
-            ClusterFormationInfoAction.Request request,
-            ActionListener<ClusterFormationInfoAction.Response> listener
-        ) {
-            listener.onResponse(new ClusterFormationInfoAction.Response(coordinator.getClusterFormationState()));
+        protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
+            listener.onResponse(new Response(coordinator.getClusterFormationState()));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/CoordinationDiagnosticsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/CoordinationDiagnosticsAction.java
@@ -10,10 +10,10 @@
 package org.elasticsearch.action.admin.cluster.coordination;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.coordination.CoordinationDiagnosticsService;
@@ -42,7 +42,7 @@ public class CoordinationDiagnosticsAction extends ActionType<CoordinationDiagno
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         final boolean explain; // Non-private for testing
 
         public Request(boolean explain) {
@@ -105,7 +105,7 @@ public class CoordinationDiagnosticsAction extends ActionType<CoordinationDiagno
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            CoordinationDiagnosticsAction.Response response = (CoordinationDiagnosticsAction.Response) o;
+            Response response = (Response) o;
             return result.equals(response.result);
         }
 
@@ -131,14 +131,14 @@ public class CoordinationDiagnosticsAction extends ActionType<CoordinationDiagno
                 CoordinationDiagnosticsAction.NAME,
                 transportService,
                 actionFilters,
-                CoordinationDiagnosticsAction.Request::new,
+                Request::new,
                 transportService.getThreadPool().executor(ThreadPool.Names.CLUSTER_COORDINATION)
             );
             this.coordinationDiagnosticsService = coordinationDiagnosticsService;
         }
 
         @Override
-        protected void doExecute(Task task, CoordinationDiagnosticsAction.Request request, ActionListener<Response> listener) {
+        protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
             listener.onResponse(new Response(coordinationDiagnosticsService.diagnoseMasterStability(request.explain)));
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/MasterHistoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/MasterHistoryAction.java
@@ -10,10 +10,10 @@
 package org.elasticsearch.action.admin.cluster.coordination;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.coordination.MasterHistoryService;
@@ -42,7 +42,7 @@ public class MasterHistoryAction extends ActionType<MasterHistoryAction.Response
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         public Request() {}
 
@@ -94,6 +94,7 @@ public class MasterHistoryAction extends ActionType<MasterHistoryAction.Response
         /**
          * Returns an ordered list of DiscoveryNodes that the node responding has seen to be master nodes over the last 30 minutes, ordered
          * oldest first. Note that these DiscoveryNodes can be null.
+         *
          * @return a list of DiscoveryNodes that the node responding has seen to be master nodes over the last 30 minutes, ordered oldest
          * first
          */
@@ -113,7 +114,7 @@ public class MasterHistoryAction extends ActionType<MasterHistoryAction.Response
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            MasterHistoryAction.Response response = (MasterHistoryAction.Response) o;
+            Response response = (Response) o;
             return masterHistory.equals(response.masterHistory);
         }
 
@@ -136,8 +137,8 @@ public class MasterHistoryAction extends ActionType<MasterHistoryAction.Response
         }
 
         @Override
-        protected void doExecute(Task task, MasterHistoryAction.Request request, ActionListener<Response> listener) {
-            listener.onResponse(new MasterHistoryAction.Response(masterHistoryService.getLocalMasterHistory().getRawNodes()));
+        protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
+            listener.onResponse(new Response(masterHistoryService.getLocalMasterHistory().getRawNodes()));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/GetTaskRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/GetTaskRequest.java
@@ -9,8 +9,8 @@
 
 package org.elasticsearch.action.admin.cluster.node.tasks.get;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -23,7 +23,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A request to get node tasks
  */
-public class GetTaskRequest extends ActionRequest {
+public class GetTaskRequest extends LegacyActionRequest {
     private TaskId taskId = TaskId.EMPTY_TASK_ID;
     private boolean waitForCompletion = false;
     private TimeValue timeout = null;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesAction.java
@@ -10,10 +10,10 @@
 package org.elasticsearch.action.admin.cluster.remote;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.RemoteClusterActionType;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
@@ -40,13 +40,10 @@ import java.util.Objects;
 public class RemoteClusterNodesAction {
 
     public static final String NAME = "cluster:internal/remote_cluster/nodes";
-    public static final ActionType<RemoteClusterNodesAction.Response> TYPE = new ActionType<>(NAME);
-    public static final RemoteClusterActionType<Response> REMOTE_TYPE = new RemoteClusterActionType<>(
-        NAME,
-        RemoteClusterNodesAction.Response::new
-    );
+    public static final ActionType<Response> TYPE = new ActionType<>(NAME);
+    public static final RemoteClusterActionType<Response> REMOTE_TYPE = new RemoteClusterActionType<>(NAME, Response::new);
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         public static final Request ALL_NODES = new Request(false);
         public static final Request REMOTE_CLUSTER_SERVER_NODES = new Request(true);
         private final boolean remoteClusterServer;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteInfoRequest.java
@@ -9,13 +9,13 @@
 
 package org.elasticsearch.action.admin.cluster.remote;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
 
-public final class RemoteInfoRequest extends ActionRequest {
+public final class RemoteInfoRequest extends LegacyActionRequest {
 
     public RemoteInfoRequest() {}
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/RemoteClusterStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/RemoteClusterStatsRequest.java
@@ -10,8 +10,8 @@
 package org.elasticsearch.action.admin.cluster.stats;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -20,7 +20,7 @@ import java.io.IOException;
 /**
  * A request to get cluster level stats from the remote cluster.
  */
-public class RemoteClusterStatsRequest extends ActionRequest {
+public class RemoteClusterStatsRequest extends LegacyActionRequest {
     public RemoteClusterStatsRequest(StreamInput in) throws IOException {
         super(in);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/GetScriptLanguageRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/GetScriptLanguageRequest.java
@@ -9,13 +9,13 @@
 
 package org.elasticsearch.action.admin.cluster.storedscripts;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
 
-public class GetScriptLanguageRequest extends ActionRequest {
+public class GetScriptLanguageRequest extends LegacyActionRequest {
     public GetScriptLanguageRequest() {
         super();
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequest.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.action.admin.indices.mapping.get;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -23,11 +23,11 @@ import java.util.Arrays;
 
 /**
  * Request the mappings of specific fields
- *
+ * <p>
  * Note: there is a new class with the same name for the Java HLRC that uses a typeless format.
  * Any changes done to this class should go to that client class as well.
  */
-public class GetFieldMappingsRequest extends ActionRequest implements IndicesRequest.Replaceable {
+public class GetFieldMappingsRequest extends LegacyActionRequest implements IndicesRequest.Replaceable {
 
     private String[] fields = Strings.EMPTY_ARRAY;
 
@@ -84,7 +84,9 @@ public class GetFieldMappingsRequest extends ActionRequest implements IndicesReq
         return true;
     }
 
-    /** @param fields a list of fields to retrieve the mapping for */
+    /**
+     * @param fields a list of fields to retrieve the mapping for
+     */
     public GetFieldMappingsRequest fields(String... fields) {
         this.fields = fields;
         return this;
@@ -98,7 +100,9 @@ public class GetFieldMappingsRequest extends ActionRequest implements IndicesReq
         return includeDefaults;
     }
 
-    /** Indicates whether default mapping settings should be returned */
+    /**
+     * Indicates whether default mapping settings should be returned
+     */
     public GetFieldMappingsRequest includeDefaults(boolean includeDefaults) {
         this.includeDefaults = includeDefaults;
         return this;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
@@ -11,9 +11,9 @@ package org.elasticsearch.action.admin.indices.resolve;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 
-public class ResolveClusterActionRequest extends ActionRequest implements IndicesRequest.Replaceable {
+public class ResolveClusterActionRequest extends LegacyActionRequest implements IndicesRequest.Replaceable {
 
     public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
     public static final String TRANSPORT_VERSION_ERROR_MESSAGE_PREFIX = "ResolveClusterAction requires at least version";

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -10,11 +10,11 @@
 package org.elasticsearch.action.admin.indices.resolve;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.RemoteClusterActionType;
 import org.elasticsearch.action.support.ActionFilters;
@@ -73,7 +73,7 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest.Replaceable {
+    public static class Request extends LegacyActionRequest implements IndicesRequest.Replaceable {
 
         public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
@@ -56,7 +57,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * Note that we only support refresh on the bulk request not per item.
  * @see org.elasticsearch.client.internal.Client#bulk(BulkRequest)
  */
-public class BulkRequest extends ActionRequest
+public class BulkRequest extends LegacyActionRequest
     implements
         CompositeIndicesRequest,
         WriteRequest<BulkRequest>,

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.action.fieldcaps;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-class FieldCapabilitiesNodeRequest extends ActionRequest implements IndicesRequest {
+class FieldCapabilitiesNodeRequest extends LegacyActionRequest implements IndicesRequest {
 
     private final List<ShardId> shardIds;
     private final String[] fields;

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.action.fieldcaps;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-public final class FieldCapabilitiesRequest extends ActionRequest implements IndicesRequest.Replaceable, ToXContentObject {
+public final class FieldCapabilitiesRequest extends LegacyActionRequest implements IndicesRequest.Replaceable, ToXContentObject {
     public static final String NAME = "field_caps_request";
     public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpenAndForbidClosed();
 

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -11,10 +11,10 @@ package org.elasticsearch.action.get;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.RealtimeRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -48,7 +48,7 @@ import java.util.Locale;
 
 // It's not possible to suppress teh warning at #realtime(boolean) at a method-level.
 @SuppressWarnings("unchecked")
-public class MultiGetRequest extends ActionRequest
+public class MultiGetRequest extends LegacyActionRequest
     implements
         Iterable<MultiGetRequest.Item>,
         CompositeIndicesRequest,

--- a/server/src/main/java/org/elasticsearch/action/get/TransportGetFromTranslogAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportGetFromTranslogAction.java
@@ -13,10 +13,10 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -87,7 +87,7 @@ public class TransportGetFromTranslogAction extends HandledTransportAction<
         });
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest {
+    public static class Request extends LegacyActionRequest implements IndicesRequest {
 
         private final GetRequest getRequest;
         private final ShardId shardId;

--- a/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetFomTranslogAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetFomTranslogAction.java
@@ -12,9 +12,9 @@ package org.elasticsearch.action.get;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.TransportActions;
@@ -108,7 +108,7 @@ public class TransportShardMultiGetFomTranslogAction extends HandledTransportAct
         });
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         private final MultiGetShardRequest multiGetShardRequest;
         private final ShardId shardId;

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -9,8 +9,8 @@
 
 package org.elasticsearch.action.ingest;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class SimulatePipelineRequest extends ActionRequest implements ToXContentObject {
+public class SimulatePipelineRequest extends LegacyActionRequest implements ToXContentObject {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(SimulatePipelineRequest.class);
     private String id;
     private boolean verbose;

--- a/server/src/main/java/org/elasticsearch/action/search/ClearScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClearScrollRequest.java
@@ -9,8 +9,8 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -24,7 +24,7 @@ import java.util.List;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class ClearScrollRequest extends ActionRequest implements ToXContentObject {
+public class ClearScrollRequest extends LegacyActionRequest implements ToXContentObject {
 
     private List<String> scrollIds;
 

--- a/server/src/main/java/org/elasticsearch/action/search/ClosePointInTimeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClosePointInTimeRequest.java
@@ -9,8 +9,8 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -24,7 +24,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Base64;
 
-public class ClosePointInTimeRequest extends ActionRequest implements ToXContentObject {
+public class ClosePointInTimeRequest extends LegacyActionRequest implements ToXContentObject {
     private static final ParseField ID = new ParseField("id");
 
     private final BytesReference id;

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.TriFunction;
@@ -50,7 +50,7 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeSt
 /**
  * A multi search API request.
  */
-public class MultiSearchRequest extends ActionRequest implements CompositeIndicesRequest {
+public class MultiSearchRequest extends LegacyActionRequest implements CompositeIndicesRequest {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestSearchAction.class);
     public static final String FIRST_LINE_EMPTY_DEPRECATION_MESSAGE =
         "support for empty first line before any action metadata in msearch API is deprecated "

--- a/server/src/main/java/org/elasticsearch/action/search/OpenPointInTimeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/OpenPointInTimeRequest.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -29,7 +29,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public final class OpenPointInTimeRequest extends ActionRequest implements IndicesRequest.Replaceable {
+public final class OpenPointInTimeRequest extends LegacyActionRequest implements IndicesRequest.Replaceable {
 
     private String[] indices;
     private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -11,10 +11,11 @@ package org.elasticsearch.action.search;
 
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -46,14 +47,14 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A request to execute search against one or more indices (or all).
  * <p>
- * Note, the search {@link #source(org.elasticsearch.search.builder.SearchSourceBuilder)}
+ * Note, the search {@link #source(SearchSourceBuilder)}
  * is required. The search source is the different search options, including aggregations and such.
  * </p>
  *
- * @see org.elasticsearch.client.internal.Client#search(SearchRequest)
+ * @see Client#search(SearchRequest)
  * @see SearchResponse
  */
-public class SearchRequest extends ActionRequest implements IndicesRequest.Replaceable, Rewriteable<SearchRequest> {
+public class SearchRequest extends LegacyActionRequest implements IndicesRequest.Replaceable, Rewriteable<SearchRequest> {
 
     public static final ToXContent.Params FORMAT_PARAMS = new ToXContent.MapParams(Collections.singletonMap("pretty", "false"));
 
@@ -169,12 +170,12 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
      * Used when a {@link SearchRequest} is created and executed as part of a cross-cluster search request
      * performing reduction on each cluster in order to minimize network round-trips between the coordinating node and the remote clusters.
      *
-     * @param parentTaskId the parent taskId of the original search request
+     * @param parentTaskId          the parent taskId of the original search request
      * @param originalSearchRequest the original search request
-     * @param indices the indices to search against
-     * @param clusterAlias the alias to prefix index names with in the returned search results
-     * @param absoluteStartMillis the absolute start time to be used on the remote clusters to ensure that the same value is used
-     * @param finalReduce whether the reduction should be final or not
+     * @param indices               the indices to search against
+     * @param clusterAlias          the alias to prefix index names with in the returned search results
+     * @param absoluteStartMillis   the absolute start time to be used on the remote clusters to ensure that the same value is used
+     * @param finalReduce           whether the reduction should be final or not
      */
     static SearchRequest subSearchRequest(
         TaskId parentTaskId,
@@ -664,7 +665,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
      * the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for
      * instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard
      * bounds and the query are disjoint.
-     *
+     * <p>
      * When unspecified, the pre-filter phase is executed if any of these conditions is met:
      * <ul>
      * <li>The request targets more than 128 shards</li>
@@ -685,7 +686,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
      * This filter roundtrip can limit the number of shards significantly if for
      * instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard
      * bounds and the query are disjoint.
-     *
+     * <p>
      * When unspecified, the pre-filter phase is executed if any of these conditions is met:
      * <ul>
      * <li>The request targets more than 128 shards</li>

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollRequest.java
@@ -9,8 +9,8 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class SearchScrollRequest extends ActionRequest implements ToXContentObject {
+public class SearchScrollRequest extends LegacyActionRequest implements ToXContentObject {
 
     private String scrollId;
     private Scroll scroll;

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardsRequest.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -28,7 +28,7 @@ import java.util.Objects;
 /**
  * A request to find the list of target shards that might match the query for the given target indices.
  */
-public final class SearchShardsRequest extends ActionRequest implements IndicesRequest.Replaceable {
+public final class SearchShardsRequest extends LegacyActionRequest implements IndicesRequest.Replaceable {
     private String[] indices;
     private final IndicesOptions indicesOptions;
     @Nullable

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.action.support.broadcast;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -20,7 +20,7 @@ import org.elasticsearch.core.TimeValue;
 
 import java.io.IOException;
 
-public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends ActionRequest implements IndicesRequest.Replaceable {
+public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends LegacyActionRequest implements IndicesRequest.Replaceable {
 
     public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpenAndForbidClosed();
 

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/BroadcastUnpromotableRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/BroadcastUnpromotableRequest.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.action.support.broadcast.unpromotable;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -29,7 +29,7 @@ import static org.elasticsearch.action.support.IndicesOptions.strictSingleIndexN
 /**
  * A request that is broadcast to the unpromotable assigned replicas of a primary.
  */
-public class BroadcastUnpromotableRequest extends ActionRequest implements IndicesRequest {
+public class BroadcastUnpromotableRequest extends LegacyActionRequest implements IndicesRequest {
 
     /**
      * Holds the index shard routing table that will be used by {@link TransportBroadcastUnpromotableAction} to broadcast the requests to

--- a/server/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
@@ -11,10 +11,11 @@ package org.elasticsearch.action.support.master;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.RestUtils;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -22,7 +23,7 @@ import java.util.Objects;
 /**
  * A based request for master based operation.
  */
-public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Request>> extends ActionRequest {
+public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Request>> extends LegacyActionRequest {
 
     /**
      * The default timeout for master-node requests. It's super-trappy to have such a default, because it makes it all too easy to forget
@@ -30,7 +31,7 @@ public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Reques
      * that is struggling to process cluster state updates fast enough, and it's a disaster if we cannot extend the master-node timeout in
      * those cases. We shouldn't use this any more and should work towards removing it.
      * <p>
-     * For requests which originate in the REST layer, use {@link org.elasticsearch.rest.RestUtils#getMasterNodeTimeout} to determine the
+     * For requests which originate in the REST layer, use {@link RestUtils#getMasterNodeTimeout} to determine the
      * timeout.
      * <p>
      * For internally-generated requests, choose an appropriate timeout. Often this will be {@link TimeValue#MAX_VALUE} (or {@link
@@ -58,7 +59,7 @@ public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Reques
      *                          <ul>
      *                          <li>
      *                              For requests which originate in the REST layer, use
-     *                              {@link org.elasticsearch.rest.RestUtils#getMasterNodeTimeout} to determine the timeout.
+     *                              {@link RestUtils#getMasterNodeTimeout} to determine the timeout.
      *                          </li>
      *                          <li>
      *                              For internally-generated requests, choose an appropriate timeout. Often this will be an infinite
@@ -107,7 +108,7 @@ public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Reques
      * Specifies how long to wait when the master has not been discovered yet, or is disconnected, or is busy processing other tasks. The
      * value {@link TimeValue#MINUS_ONE} means to wait forever in 8.15.0 onwards.
      * <p>
-     * For requests which originate in the REST layer, use {@link org.elasticsearch.rest.RestUtils#getMasterNodeTimeout} to determine the
+     * For requests which originate in the REST layer, use {@link RestUtils#getMasterNodeTimeout} to determine the
      * timeout.
      * <p>
      * For internally-generated requests, choose an appropriate timeout. Often this will be {@link TimeValue#MAX_VALUE} (or {@link

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
@@ -1,53 +1,47 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.action.support.nodes;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.LegacyActionRequest;
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
 
 public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>> extends LegacyActionRequest {
 
     /**
-     * the list of nodesIds that will be used to resolve this request and {@link #concreteNodes}
-     * will be populated. Note that if {@link #concreteNodes} is not null, it will be used and nodeIds
-     * will be ignored.
-     *
-     * See {@link DiscoveryNodes#resolveNodes} for a full description of the options.
-     *
-     * TODO: we can get rid of this and resolve it to concrete nodes in the rest layer
+     * Sequence of node specifications that describe the nodes that this request should target. See {@link DiscoveryNodes#resolveNodes} for
+     * a full description of the options. If set, {@link #concreteNodes} is {@code null} and ignored.
      **/
-    private String[] nodesIds;
+    private final String[] nodesIds;
 
     /**
-     * once {@link #nodesIds} are resolved this will contain the concrete nodes that are part of this request. If set, {@link #nodesIds}
-     * will be ignored and this will be used.
-     * */
-    private DiscoveryNode[] concreteNodes;
+     * The exact nodes that this request should target. If set, {@link #nodesIds} is {@code null} and ignored.
+     **/
+    private final DiscoveryNode[] concreteNodes;
 
+    @Nullable // if no timeout
     private TimeValue timeout;
 
-    protected BaseNodesRequest(StreamInput in) throws IOException {
-        super(in);
-        nodesIds = in.readStringArray();
-        concreteNodes = in.readOptionalArray(DiscoveryNode::new, DiscoveryNode[]::new);
-        timeout = in.readOptionalTimeValue();
-    }
-
-    protected BaseNodesRequest(String... nodesIds) {
+    protected BaseNodesRequest(String[] nodesIds) {
         this.nodesIds = nodesIds;
+        this.concreteNodes = null;
     }
 
     protected BaseNodesRequest(DiscoveryNode... concreteNodes) {
@@ -57,12 +51,6 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
 
     public final String[] nodesIds() {
         return nodesIds;
-    }
-
-    @SuppressWarnings("unchecked")
-    public final Request nodesIds(String... nodesIds) {
-        this.nodesIds = nodesIds;
-        return (Request) this;
     }
 
     public TimeValue timeout() {
@@ -75,30 +63,26 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
         return (Request) this;
     }
 
-    @SuppressWarnings("unchecked")
-    public final Request timeout(String timeout) {
-        this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
-        return (Request) this;
-    }
-
-    public DiscoveryNode[] concreteNodes() {
-        return concreteNodes;
-    }
-
-    public void setConcreteNodes(DiscoveryNode[] concreteNodes) {
-        this.concreteNodes = concreteNodes;
-    }
-
     @Override
     public ActionRequestValidationException validate() {
         return null;
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeStringArrayNullable(nodesIds);
-        out.writeOptionalArray(concreteNodes);
-        out.writeOptionalTimeValue(timeout);
+    public final void writeTo(StreamOutput out) throws IOException {
+        // `BaseNodesRequest` is rather heavyweight, especially all those `DiscoveryNodes` objects in larger clusters, and there is no need
+        // to send it out over the wire. Use a dedicated transport request just for the bits you need.
+        TransportAction.localOnly();
+    }
+
+    /**
+     * @return the nodes to which this request should fan out.
+     */
+    DiscoveryNode[] resolveNodes(ClusterState clusterState) {
+        assert nodesIds == null || concreteNodes == null;
+        return Objects.requireNonNullElseGet(
+            concreteNodes,
+            () -> Arrays.stream(clusterState.nodes().resolveNodes(nodesIds)).map(clusterState.nodes()::get).toArray(DiscoveryNode[]::new)
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
@@ -1,47 +1,53 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
  */
 
 package org.elasticsearch.action.support.nodes;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.TransportAction;
-import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Objects;
 
-public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>> extends ActionRequest {
+public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>> extends LegacyActionRequest {
 
     /**
-     * Sequence of node specifications that describe the nodes that this request should target. See {@link DiscoveryNodes#resolveNodes} for
-     * a full description of the options. If set, {@link #concreteNodes} is {@code null} and ignored.
+     * the list of nodesIds that will be used to resolve this request and {@link #concreteNodes}
+     * will be populated. Note that if {@link #concreteNodes} is not null, it will be used and nodeIds
+     * will be ignored.
+     *
+     * See {@link DiscoveryNodes#resolveNodes} for a full description of the options.
+     *
+     * TODO: we can get rid of this and resolve it to concrete nodes in the rest layer
      **/
-    private final String[] nodesIds;
+    private String[] nodesIds;
 
     /**
-     * The exact nodes that this request should target. If set, {@link #nodesIds} is {@code null} and ignored.
-     **/
-    private final DiscoveryNode[] concreteNodes;
+     * once {@link #nodesIds} are resolved this will contain the concrete nodes that are part of this request. If set, {@link #nodesIds}
+     * will be ignored and this will be used.
+     * */
+    private DiscoveryNode[] concreteNodes;
 
-    @Nullable // if no timeout
     private TimeValue timeout;
 
-    protected BaseNodesRequest(String[] nodesIds) {
+    protected BaseNodesRequest(StreamInput in) throws IOException {
+        super(in);
+        nodesIds = in.readStringArray();
+        concreteNodes = in.readOptionalArray(DiscoveryNode::new, DiscoveryNode[]::new);
+        timeout = in.readOptionalTimeValue();
+    }
+
+    protected BaseNodesRequest(String... nodesIds) {
         this.nodesIds = nodesIds;
-        this.concreteNodes = null;
     }
 
     protected BaseNodesRequest(DiscoveryNode... concreteNodes) {
@@ -51,6 +57,12 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
 
     public final String[] nodesIds() {
         return nodesIds;
+    }
+
+    @SuppressWarnings("unchecked")
+    public final Request nodesIds(String... nodesIds) {
+        this.nodesIds = nodesIds;
+        return (Request) this;
     }
 
     public TimeValue timeout() {
@@ -63,26 +75,30 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
         return (Request) this;
     }
 
+    @SuppressWarnings("unchecked")
+    public final Request timeout(String timeout) {
+        this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
+        return (Request) this;
+    }
+
+    public DiscoveryNode[] concreteNodes() {
+        return concreteNodes;
+    }
+
+    public void setConcreteNodes(DiscoveryNode[] concreteNodes) {
+        this.concreteNodes = concreteNodes;
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         return null;
     }
 
     @Override
-    public final void writeTo(StreamOutput out) throws IOException {
-        // `BaseNodesRequest` is rather heavyweight, especially all those `DiscoveryNodes` objects in larger clusters, and there is no need
-        // to send it out over the wire. Use a dedicated transport request just for the bits you need.
-        TransportAction.localOnly();
-    }
-
-    /**
-     * @return the nodes to which this request should fan out.
-     */
-    DiscoveryNode[] resolveNodes(ClusterState clusterState) {
-        assert nodesIds == null || concreteNodes == null;
-        return Objects.requireNonNullElseGet(
-            concreteNodes,
-            () -> Arrays.stream(clusterState.nodes().resolveNodes(nodesIds)).map(clusterState.nodes()::get).toArray(DiscoveryNode[]::new)
-        );
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeStringArrayNullable(nodesIds);
+        out.writeOptionalArray(concreteNodes);
+        out.writeOptionalTimeValue(timeout);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.action.support.replication;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.admin.indices.refresh.TransportShardRefreshAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
@@ -33,7 +33,9 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * Requests that are run on a particular replica, first on the primary and then on the replicas like {@link IndexRequest} or
  * {@link TransportShardRefreshAction}.
  */
-public abstract class ReplicationRequest<Request extends ReplicationRequest<Request>> extends ActionRequest implements IndicesRequest {
+public abstract class ReplicationRequest<Request extends ReplicationRequest<Request>> extends LegacyActionRequest
+    implements
+        IndicesRequest {
 
     public static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueMinutes(1);
 

--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.action.support.single.instance;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -24,7 +24,7 @@ import java.io.IOException;
 
 // TODO: This request and its associated transport action can be folded into UpdateRequest which is its only concrete production code
 //       implementation
-public abstract class InstanceShardOperationRequest<Request extends InstanceShardOperationRequest<Request>> extends ActionRequest
+public abstract class InstanceShardOperationRequest<Request extends InstanceShardOperationRequest<Request>> extends LegacyActionRequest
     implements
         IndicesRequest {
 

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.action.support.single.shard;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-public abstract class SingleShardRequest<Request extends SingleShardRequest<Request>> extends ActionRequest
+public abstract class SingleShardRequest<Request extends SingleShardRequest<Request>> extends LegacyActionRequest
     implements
         IndicesRequest.RemoteClusterShardRequest {
 
@@ -31,7 +31,7 @@ public abstract class SingleShardRequest<Request extends SingleShardRequest<Requ
 
     /**
      * The concrete index name
-     *
+     * <p>
      * Whether index property is optional depends on the concrete implementation. If index property is required the
      * concrete implementation should use {@link #validateNonNullIndex()} to check if the index property has been set
      */
@@ -67,9 +67,9 @@ public abstract class SingleShardRequest<Request extends SingleShardRequest<Requ
 
     /**
      * @return The concrete index this request is targeted for or <code>null</code> if index is optional.
-     *         Whether index property is optional depends on the concrete implementation. If index property
-     *         is required the concrete implementation should use {@link #validateNonNullIndex()} to check
-     *         if the index property has been set
+     * Whether index property is optional depends on the concrete implementation. If index property
+     * is required the concrete implementation should use {@link #validateNonNullIndex()} to check
+     * if the index property has been set
      */
     @Nullable
     public String index() {

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
@@ -9,8 +9,8 @@
 
 package org.elasticsearch.action.support.tasks;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -27,7 +27,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A base class for task requests
  */
-public class BaseTasksRequest<Request extends BaseTasksRequest<Request>> extends ActionRequest {
+public class BaseTasksRequest<Request extends BaseTasksRequest<Request>> extends LegacyActionRequest {
 
     public static final String[] ALL_ACTIONS = Strings.EMPTY_ARRAY;
 
@@ -103,7 +103,7 @@ public class BaseTasksRequest<Request extends BaseTasksRequest<Request>> extends
 
     /**
      * Returns the id of the task that should be processed.
-     *
+     * <p>
      * By default tasks with any ids are returned.
      */
     public TaskId getTargetTaskId() {

--- a/server/src/main/java/org/elasticsearch/action/synonyms/AbstractSynonymsPagedResultAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/AbstractSynonymsPagedResultAction.java
@@ -9,10 +9,10 @@
 
 package org.elasticsearch.action.synonyms;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -42,7 +42,7 @@ public abstract class AbstractSynonymsPagedResultAction<T extends ActionResponse
     /**
      * Base request class that includes support for pagination parameters
      */
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         private static final int MAX_SYNONYMS_RESULTS = 10_000;
         private final int from;
         private final int size;

--- a/server/src/main/java/org/elasticsearch/action/synonyms/DeleteSynonymRuleAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/DeleteSynonymRuleAction.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.action.synonyms;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -29,7 +29,7 @@ public class DeleteSynonymRuleAction extends ActionType<SynonymUpdateResponse> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         private final String synonymsSetId;
 
         private final String synonymRuleId;

--- a/server/src/main/java/org/elasticsearch/action/synonyms/DeleteSynonymsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/DeleteSynonymsAction.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.action.synonyms;
 
 import org.apache.logging.log4j.util.Strings;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -29,7 +29,7 @@ public class DeleteSynonymsAction extends ActionType<AcknowledgedResponse> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         private final String synonymsSetId;
 
         public Request(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/synonyms/GetSynonymRuleAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/GetSynonymRuleAction.java
@@ -9,10 +9,10 @@
 
 package org.elasticsearch.action.synonyms;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -33,7 +33,7 @@ public class GetSynonymRuleAction extends ActionType<GetSynonymRuleAction.Respon
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         private final String synonymsSetId;
 
         private final String synonymRuleId;

--- a/server/src/main/java/org/elasticsearch/action/synonyms/PutSynonymRuleAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/PutSynonymRuleAction.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.action.synonyms;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -38,7 +38,7 @@ public class PutSynonymRuleAction extends ActionType<SynonymUpdateResponse> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         private final String synonymsSetId;
 
         private final SynonymRule synonymRule;

--- a/server/src/main/java/org/elasticsearch/action/synonyms/PutSynonymsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/PutSynonymsAction.java
@@ -9,9 +9,9 @@
 
 package org.elasticsearch.action.synonyms;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -40,7 +40,7 @@ public class PutSynonymsAction extends ActionType<SynonymUpdateResponse> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         private final String synonymsSetId;
         private final SynonymRule[] synonymRules;
 

--- a/server/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequest.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.action.termvectors;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.RealtimeRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -30,7 +30,7 @@ import java.util.Set;
 
 // It's not possible to suppress teh warning at #realtime(boolean) at a method-level.
 @SuppressWarnings("unchecked")
-public class MultiTermVectorsRequest extends ActionRequest
+public class MultiTermVectorsRequest extends LegacyActionRequest
     implements
         Iterable<TermVectorsRequest>,
         CompositeIndicesRequest,

--- a/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
@@ -10,10 +10,10 @@
 package org.elasticsearch.health;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
@@ -150,7 +150,7 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
         }
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         private final String indicatorName;
         private final boolean verbose;
         private final int size;

--- a/server/src/main/java/org/elasticsearch/health/node/action/HealthNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/health/node/action/HealthNodeRequest.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.health.node.action;
 
-import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
@@ -21,7 +21,7 @@ import java.util.Map;
 /**
  * This is a base class for all the requests that will be sent to the health node.
  */
-public abstract class HealthNodeRequest extends ActionRequest {
+public abstract class HealthNodeRequest extends LegacyActionRequest {
 
     public HealthNodeRequest() {}
 

--- a/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -9,8 +9,8 @@
 
 package org.elasticsearch.index.reindex;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
@@ -31,7 +31,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.core.TimeValue.timeValueMillis;
 import static org.elasticsearch.core.TimeValue.timeValueMinutes;
 
-public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScrollRequest<Self>> extends ActionRequest {
+public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScrollRequest<Self>> extends LegacyActionRequest {
 
     public static final int MAX_DOCS_ALL_MATCHES = -1;
     public static final TimeValue DEFAULT_SCROLL_TIMEOUT = timeValueMinutes(5);
@@ -118,8 +118,8 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
      * Constructor for actual use.
      *
      * @param searchRequest the search request to execute to get the documents to process
-     * @param setDefaults should this request set the defaults on the search request? Usually set to true but leave it false to support
-     *        request slicing
+     * @param setDefaults   should this request set the defaults on the search request? Usually set to true but leave it false to support
+     *                      request slicing
      */
     public AbstractBulkByScrollRequest(SearchRequest searchRequest, boolean setDefaults) {
         this.searchRequest = searchRequest;

--- a/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
@@ -11,8 +11,8 @@ package org.elasticsearch.index.shard;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.resync.ResyncReplicationRequest;
 import org.elasticsearch.action.resync.ResyncReplicationResponse;
 import org.elasticsearch.action.resync.TransportResyncReplicationAction;
@@ -374,7 +374,7 @@ public class PrimaryReplicaSyncer {
         }
     }
 
-    public static class ResyncRequest extends ActionRequest {
+    public static class ResyncRequest extends LegacyActionRequest {
 
         private final ShardId shardId;
         private final String allocationId;
@@ -463,8 +463,8 @@ public class PrimaryReplicaSyncer {
         }
 
         @Override
-        public ResyncTask.Status getStatus() {
-            return new ResyncTask.Status(phase, totalOperations, resyncedOperations, skippedOperations);
+        public Status getStatus() {
+            return new Status(phase, totalOperations, resyncedOperations, skippedOperations);
         }
 
         public static class Status implements Task.Status {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/StatelessPrimaryRelocationAction.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/StatelessPrimaryRelocationAction.java
@@ -9,10 +9,10 @@
 
 package org.elasticsearch.indices.recovery;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -27,7 +27,7 @@ public class StatelessPrimaryRelocationAction {
         "internal:index/shard/recovery/stateless_primary_relocation"
     );
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         private final long recoveryId;
         private final ShardId shardId;

--- a/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
@@ -10,10 +10,10 @@
 package org.elasticsearch.repositories;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -67,7 +67,7 @@ public class VerifyNodeRepositoryAction {
         }
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         protected final String repository;
         protected final String verificationToken;

--- a/server/src/test/java/org/elasticsearch/action/ActionModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ActionModuleTests.java
@@ -83,7 +83,7 @@ public class ActionModuleTests extends ESTestCase {
     }
 
     public void testPluginCanRegisterAction() {
-        class FakeRequest extends ActionRequest {
+        class FakeRequest extends LegacyActionRequest {
             @Override
             public ActionRequestValidationException validate() {
                 return null;

--- a/server/src/test/java/org/elasticsearch/action/support/MappedActionFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/MappedActionFiltersTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
@@ -25,7 +26,7 @@ import static org.hamcrest.Matchers.is;
 
 public class MappedActionFiltersTests extends ESTestCase {
 
-    static class DummyRequest extends ActionRequest {
+    static class DummyRequest extends LegacyActionRequest {
         @Override
         public ActionRequestValidationException validate() {
             return null;

--- a/server/src/test/java/org/elasticsearch/action/support/ReservedStateAwareHandledTransportActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ReservedStateAwareHandledTransportActionTests.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.action.support;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -115,7 +115,7 @@ public class ReservedStateAwareHandledTransportActionTests extends ESTestCase {
         }
     }
 
-    static class DummyRequest extends ActionRequest {
+    static class DummyRequest extends LegacyActionRequest {
         @Override
         public ActionRequestValidationException validate() {
             return null;

--- a/server/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainRefCountingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainRefCountingTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -167,7 +168,7 @@ public class TransportActionFilterChainRefCountingTests extends ESSingleNodeTest
         }
     }
 
-    private static class Request extends ActionRequest {
+    private static class Request extends LegacyActionRequest {
         private final SubscribableListener<Void> closeListeners = new SubscribableListener<>();
         private final RefCounted refs = LeakTracker.wrap(AbstractRefCounted.of(() -> closeListeners.onResponse(null)));
 

--- a/server/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -288,7 +289,7 @@ public class TransportActionFilterChainTests extends ESTestCase {
         );
     }
 
-    public static class TestRequest extends ActionRequest {
+    public static class TestRequest extends LegacyActionRequest {
         @Override
         public ActionRequestValidationException validate() {
             return null;

--- a/server/src/test/java/org/elasticsearch/action/support/TransportActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/TransportActionTests.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.action.support;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -147,7 +147,7 @@ public class TransportActionTests extends ESTestCase {
         return transportAction;
     }
 
-    private static class TestRequest extends ActionRequest {
+    private static class TestRequest extends LegacyActionRequest {
         @Override
         public ActionRequestValidationException validate() {
             return null;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/ClearCcrRestoreSessionRequest.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/ClearCcrRestoreSessionRequest.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.ccr.action.repositories;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -21,7 +21,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.xpack.ccr.Ccr.TRANSPORT_VERSION_ACTION_WITH_SHARD_ID;
 
-public class ClearCcrRestoreSessionRequest extends ActionRequest implements RemoteClusterAwareRequest, IndicesRequest {
+public class ClearCcrRestoreSessionRequest extends LegacyActionRequest implements RemoteClusterAwareRequest, IndicesRequest {
 
     private DiscoveryNode node;
     private final String sessionUUID;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/DeleteInternalCcrRepositoryRequest.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/DeleteInternalCcrRepositoryRequest.java
@@ -7,15 +7,15 @@
 
 package org.elasticsearch.xpack.ccr.action.repositories;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class DeleteInternalCcrRepositoryRequest extends ActionRequest {
+public class DeleteInternalCcrRepositoryRequest extends LegacyActionRequest {
 
     private final String name;
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkRequest.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkRequest.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.ccr.action.repositories;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -21,7 +21,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.xpack.ccr.Ccr.TRANSPORT_VERSION_ACTION_WITH_SHARD_ID;
 
-public class GetCcrRestoreFileChunkRequest extends ActionRequest implements RemoteClusterAwareRequest, IndicesRequest {
+public class GetCcrRestoreFileChunkRequest extends LegacyActionRequest implements RemoteClusterAwareRequest, IndicesRequest {
 
     private final DiscoveryNode node;
     private final String sessionUUID;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutInternalCcrRepositoryRequest.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutInternalCcrRepositoryRequest.java
@@ -7,15 +7,15 @@
 
 package org.elasticsearch.xpack.ccr.action.repositories;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class PutInternalCcrRepositoryRequest extends ActionRequest {
+public class PutInternalCcrRepositoryRequest extends LegacyActionRequest {
 
     private final String name;
     private final String type;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetFeatureUsageRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetFeatureUsageRequest.java
@@ -7,13 +7,13 @@
 
 package org.elasticsearch.license;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
 
-public class GetFeatureUsageRequest extends ActionRequest {
+public class GetFeatureUsageRequest extends LegacyActionRequest {
 
     public GetFeatureUsageRequest() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoRequest.java
@@ -8,8 +8,8 @@ package org.elasticsearch.protocol.xpack;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.license.License;
@@ -21,7 +21,7 @@ import java.util.Locale;
 /**
  * Fetch information about X-Pack from the cluster.
  */
-public class XPackInfoRequest extends ActionRequest {
+public class XPackInfoRequest extends LegacyActionRequest {
 
     public enum Category {
         BUILD,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreRequest.java
@@ -7,9 +7,9 @@
 package org.elasticsearch.protocol.xpack.graph;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
@@ -33,7 +33,7 @@ import java.util.List;
  * Holds the criteria required to guide the exploration of connected terms which
  * can be returned as a graph.
  */
-public class GraphExploreRequest extends ActionRequest implements IndicesRequest.Replaceable, ToXContentObject {
+public class GraphExploreRequest extends LegacyActionRequest implements IndicesRequest.Replaceable, ToXContentObject {
 
     public static final String NO_HOPS_ERROR_MESSAGE = "Graph explore request must have at least one hop";
     public static final String NO_VERTICES_ERROR_MESSAGE = "Graph explore hop must have at least one VertexRequest";
@@ -158,9 +158,8 @@ public class GraphExploreRequest extends ActionRequest implements IndicesRequest
      * available but can still overrun due to the nature of their "best efforts"
      * timeout support. When a timeout occurs partial results are returned.
      *
-     * @param timeout
-     *            a {@link TimeValue} object which determines the maximum length
-     *            of time to spend exploring
+     * @param timeout a {@link TimeValue} object which determines the maximum length
+     *                of time to spend exploring
      */
     public GraphExploreRequest timeout(TimeValue timeout) {
         if (timeout == null) {
@@ -212,8 +211,7 @@ public class GraphExploreRequest extends ActionRequest implements IndicesRequest
      * background frequencies of terms found in the documents
      * </p>
      *
-     * @param maxNumberOfDocsPerHop
-     *            shard-level sample size in documents
+     * @param maxNumberOfDocsPerHop shard-level sample size in documents
      */
     public void sampleSize(int maxNumberOfDocsPerHop) {
         sampleSize = maxNumberOfDocsPerHop;
@@ -253,8 +251,7 @@ public class GraphExploreRequest extends ActionRequest implements IndicesRequest
      * significance (see the {@link SignificantTerms} aggregation) rather than
      * popularity (using the {@link TermsAggregator}).
      *
-     * @param value
-     *            true if the significant_terms algorithm should be used.
+     * @param value true if the significant_terms algorithm should be used.
      */
     public void useSignificance(boolean value) {
         this.useSignificance = value;
@@ -268,8 +265,7 @@ public class GraphExploreRequest extends ActionRequest implements IndicesRequest
      * Return detailed information about vertex frequencies as part of JSON
      * results - defaults to false
      *
-     * @param value
-     *            true if detailed information is required in JSON responses
+     * @param value true if detailed information is required in JSON responses
      */
     public void returnDetailedInfo(boolean value) {
         this.returnDetailedInfo = value;
@@ -284,11 +280,10 @@ public class GraphExploreRequest extends ActionRequest implements IndicesRequest
      * querying elasticsearch to identify terms which can then be connnected to
      * other terms in a subsequent hop.
      *
-     * @param guidingQuery
-     *            optional choice of query which influences which documents are
-     *            considered in this stage
+     * @param guidingQuery optional choice of query which influences which documents are
+     *                     considered in this stage
      * @return a {@link Hop} object that holds settings for a stage in the graph
-     *         exploration
+     * exploration
      */
     public Hop createNextHop(QueryBuilder guidingQuery) {
         Hop parent = null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/watcher/DeleteWatchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/watcher/DeleteWatchRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.protocol.xpack.watcher;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -18,7 +18,7 @@ import java.io.IOException;
 /**
  * A delete watch request to delete an watch by name (id)
  */
-public class DeleteWatchRequest extends ActionRequest {
+public class DeleteWatchRequest extends LegacyActionRequest {
 
     private String id;
     private long version = Versions.MATCH_ANY;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/watcher/PutWatchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/watcher/PutWatchRequest.java
@@ -6,15 +6,15 @@
  */
 package org.elasticsearch.protocol.xpack.watcher;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
@@ -28,7 +28,7 @@ import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
  * This request class contains the data needed to create a watch along with the name of the watch.
  * The name of the watch will become the ID of the indexed document.
  */
-public final class PutWatchRequest extends ActionRequest {
+public final class PutWatchRequest extends LegacyActionRequest {
 
     private static final Pattern NO_WS_PATTERN = Pattern.compile("\\S+");
 
@@ -38,7 +38,7 @@ public final class PutWatchRequest extends ActionRequest {
     private boolean active = true;
     private long version = Versions.MATCH_ANY;
 
-    private long ifSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
+    private long ifSeqNo = UNASSIGNED_SEQ_NO;
     private long ifPrimaryTerm = UNASSIGNED_PRIMARY_TERM;
 
     public PutWatchRequest() {}
@@ -135,9 +135,9 @@ public final class PutWatchRequest extends ActionRequest {
     /**
      * only performs this put request if the watch's last modification was assigned the given
      * sequence number. Must be used in combination with {@link #setIfPrimaryTerm(long)}
-     *
+     * <p>
      * If the watch's last modification was assigned a different sequence number a
-     * {@link org.elasticsearch.index.engine.VersionConflictEngineException} will be thrown.
+     * {@link VersionConflictEngineException} will be thrown.
      */
     public PutWatchRequest setIfSeqNo(long seqNo) {
         if (seqNo < 0 && seqNo != UNASSIGNED_SEQ_NO) {
@@ -150,9 +150,9 @@ public final class PutWatchRequest extends ActionRequest {
     /**
      * only performs this put request if the watch's last modification was assigned the given
      * primary term. Must be used in combination with {@link #setIfSeqNo(long)}
-     *
+     * <p>
      * If the watch last modification was assigned a different term a
-     * {@link org.elasticsearch.index.engine.VersionConflictEngineException} will be thrown.
+     * {@link VersionConflictEngineException} will be thrown.
      */
     public PutWatchRequest setIfPrimaryTerm(long term) {
         if (term < 0) {
@@ -165,7 +165,7 @@ public final class PutWatchRequest extends ActionRequest {
     /**
      * If set, only perform this put watch request if the watch's last modification was assigned this sequence number.
      * If the watch last last modification was assigned a different sequence number a
-     * {@link org.elasticsearch.index.engine.VersionConflictEngineException} will be thrown.
+     * {@link VersionConflictEngineException} will be thrown.
      */
     public long getIfSeqNo() {
         return ifSeqNo;
@@ -173,9 +173,9 @@ public final class PutWatchRequest extends ActionRequest {
 
     /**
      * If set, only perform this put watch request if the watch's last modification was assigned this primary term.
-     *
+     * <p>
      * If the watch's last modification was assigned a different term a
-     * {@link org.elasticsearch.index.engine.VersionConflictEngineException} will be thrown.
+     * {@link VersionConflictEngineException} will be thrown.
      */
     public long getIfPrimaryTerm() {
         return ifPrimaryTerm;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractGetResourcesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractGetResourcesRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.CancellableTask;
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-public abstract class AbstractGetResourcesRequest extends ActionRequest {
+public abstract class AbstractGetResourcesRequest extends LegacyActionRequest {
 
     private String resourceId;
     private PageParams pageParams = PageParams.defaultParams();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncStopRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncStopRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.async;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -17,7 +17,7 @@ import java.util.Objects;
 /**
  * Request for TransportEsqlAsyncStopAction action.
  */
-public class AsyncStopRequest extends ActionRequest {
+public class AsyncStopRequest extends LegacyActionRequest {
     private final String id;
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/DeleteAsyncResultRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/DeleteAsyncResultRequest.java
@@ -7,15 +7,15 @@
 
 package org.elasticsearch.xpack.core.async;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class DeleteAsyncResultRequest extends ActionRequest {
+public class DeleteAsyncResultRequest extends LegacyActionRequest {
     private final String id;
 
     public DeleteAsyncResultRequest(String id) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/GetAsyncResultRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/GetAsyncResultRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.async;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -15,7 +15,7 @@ import org.elasticsearch.core.TimeValue;
 import java.io.IOException;
 import java.util.Objects;
 
-public class GetAsyncResultRequest extends ActionRequest {
+public class GetAsyncResultRequest extends LegacyActionRequest {
     private final String id;
     private TimeValue waitForCompletionTimeout = TimeValue.MINUS_ONE;
     private TimeValue keepAlive = TimeValue.MINUS_ONE;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/GetAsyncStatusRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/GetAsyncStatusRequest.java
@@ -7,8 +7,8 @@
 package org.elasticsearch.xpack.core.async;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -19,12 +19,13 @@ import java.util.Objects;
 /**
  * A request class to get a status update of the async search request
  */
-public class GetAsyncStatusRequest extends ActionRequest {
+public class GetAsyncStatusRequest extends LegacyActionRequest {
     private final String id;
     private TimeValue keepAlive = TimeValue.MINUS_ONE;
 
     /**
      * Creates a new request
+     *
      * @param id The id of the search progress request.
      */
     public GetAsyncStatusRequest(String id) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/esql/action/EsqlQueryRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/esql/action/EsqlQueryRequest.java
@@ -7,13 +7,13 @@
 
 package org.elasticsearch.xpack.core.esql.action;
 
-import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
 
-public abstract class EsqlQueryRequest extends ActionRequest {
+public abstract class EsqlQueryRequest extends LegacyActionRequest {
 
     protected EsqlQueryRequest() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/BaseInferenceActionRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/BaseInferenceActionRequest.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.xpack.core.inference.action;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.inference.TaskType;
@@ -21,7 +21,7 @@ import java.util.Objects;
  * Base class for inference action requests. Tracks request routing state to prevent potential routing loops
  * and supports both streaming and non-streaming inference operations.
  */
-public abstract class BaseInferenceActionRequest extends ActionRequest {
+public abstract class BaseInferenceActionRequest extends LegacyActionRequest {
 
     private boolean hasBeenRerouted;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceActionProxy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceActionProxy.java
@@ -8,9 +8,9 @@
 package org.elasticsearch.xpack.core.inference.action;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -38,7 +38,7 @@ public class InferenceActionProxy extends ActionType<InferenceAction.Response> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         private final TaskType taskType;
         private final String inferenceEntityId;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/AuditMlNotificationAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/AuditMlNotificationAction.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -40,7 +40,7 @@ public class AuditMlNotificationAction extends ActionType<AcknowledgedResponse> 
         SYSTEM
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         private final AuditType auditType;
         private final String id;
         private final String message;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CancelJobModelSnapshotUpgradeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CancelJobModelSnapshotUpgradeAction.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -43,7 +43,7 @@ public class CancelJobModelSnapshotUpgradeAction extends ActionType<CancelJobMod
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static final String ALL = "_all";
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CoordinatedInferenceAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CoordinatedInferenceAction.java
@@ -8,9 +8,9 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -33,7 +33,7 @@ public class CoordinatedInferenceAction extends ActionType<InferModelAction.Resp
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         public enum RequestModelType {
             INFERENCE_SERVICE_MODEL,
@@ -41,7 +41,7 @@ public class CoordinatedInferenceAction extends ActionType<InferModelAction.Resp
             BOOSTED_TREE_MODEL,
             NLP_MODEL,  // Either an inference service model or ml pytorch model but not a boosted tree model
             UNKNOWN
-        };
+        }
 
         public static Request forTextInput(
             String modelId,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -33,7 +33,7 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         public static final ParseField REQUESTS_PER_SECOND = new ParseField("requests_per_second");
         public static final ParseField TIMEOUT = new ParseField("timeout");
@@ -103,6 +103,7 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
         /**
          * Not serialized, the expanded job Ids should only be used
          * on the executing node.
+         *
          * @return The expanded Ids in the case where {@code jobId} is not `_all`
          * otherwise null.
          */

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteModelSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteModelSnapshotAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -27,7 +27,7 @@ public class DeleteModelSnapshotAction extends ActionType<AcknowledgedResponse> 
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         private String jobId;
         private String snapshotId;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateModelMemoryAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateModelMemoryAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -37,13 +37,13 @@ public class EstimateModelMemoryAction extends ActionType<EstimateModelMemoryAct
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         public static final ParseField ANALYSIS_CONFIG = Job.ANALYSIS_CONFIG;
         public static final ParseField OVERALL_CARDINALITY = new ParseField("overall_cardinality");
         public static final ParseField MAX_BUCKET_CARDINALITY = new ParseField("max_bucket_cardinality");
 
-        public static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, EstimateModelMemoryAction.Request::new);
+        public static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
 
         static {
             PARSER.declareObject(Request::setAnalysisConfig, (p, c) -> AnalysisConfig.STRICT_PARSER.apply(p, c).build(), ANALYSIS_CONFIG);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -49,7 +49,7 @@ public class EvaluateDataFrameAction extends ActionType<EvaluateDataFrameAction.
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         private static final ParseField INDEX = new ParseField("index");
         private static final ParseField QUERY = new ParseField("query");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetBucketsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetBucketsAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -36,7 +36,7 @@ public class GetBucketsAction extends ActionType<GetBucketsAction.Response> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static final ParseField EXPAND = new ParseField("expand");
         public static final ParseField EXCLUDE_INTERIM = new ParseField("exclude_interim");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCalendarEventsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCalendarEventsAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -37,7 +37,7 @@ public class GetCalendarEventsAction extends ActionType<GetCalendarEventsAction.
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static final ParseField START = new ParseField("start");
         public static final ParseField END = new ParseField("end");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCalendarsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCalendarsAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -34,7 +34,7 @@ public class GetCalendarsAction extends ActionType<GetCalendarsAction.Response> 
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static final String ALL = "_all";
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCategoriesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCategoriesAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.CancellableTask;
@@ -42,7 +42,7 @@ public class GetCategoriesAction extends ActionType<GetCategoriesAction.Response
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static final ParseField CATEGORY_ID = CategoryDefinition.CATEGORY_ID;
         public static final ParseField FROM = new ParseField("from");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
@@ -336,9 +336,7 @@ public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.
             private GetDatafeedRunningStateAction.Response datafeedRuntimeState;
 
             public Builder setDatafeedIds(Collection<String> datafeedIds) {
-                this.statsBuilders = datafeedIds.stream()
-                    .map(GetDatafeedsStatsAction.Response.DatafeedStats::builder)
-                    .collect(Collectors.toList());
+                this.statsBuilders = datafeedIds.stream().map(DatafeedStats::builder).collect(Collectors.toList());
                 return this;
             }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetInfluencersAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetInfluencersAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -35,7 +35,7 @@ public class GetInfluencersAction extends ActionType<GetInfluencersAction.Respon
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static final ParseField START = new ParseField("start");
         public static final ParseField END = new ParseField("end");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetModelSnapshotsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetModelSnapshotsAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -42,7 +42,7 @@ public class GetModelSnapshotsAction extends ActionType<GetModelSnapshotsAction.
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static final ParseField SNAPSHOT_ID = new ParseField("snapshot_id");
         public static final ParseField SORT = new ParseField("sort");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsAction.java
@@ -7,9 +7,9 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.time.DateMathParser;
@@ -59,7 +59,7 @@ public class GetOverallBucketsAction extends ActionType<GetOverallBucketsAction.
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static final ParseField TOP_N = new ParseField("top_n");
         public static final ParseField BUCKET_SPAN = new ParseField("bucket_span");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetRecordsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetRecordsAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -35,7 +35,7 @@ public class GetRecordsAction extends ActionType<GetRecordsAction.Response> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static final ParseField START = new ParseField("start");
         public static final ParseField END = new ParseField("end");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -7,10 +7,10 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -48,7 +48,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         super(name);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         public static final ParseField ID = new ParseField("id");
         public static final ParseField DEPLOYMENT_ID = new ParseField("deployment_id");
@@ -57,6 +57,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         public static final ParseField INFERENCE_CONFIG = new ParseField("inference_config");
 
         static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>(NAME, Builder::new);
+
         static {
             PARSER.declareString(Builder::setId, ID);
             PARSER.declareObjectArray(Builder::setDocs, (p, c) -> p.mapOrdered(), DOCS);
@@ -94,21 +95,14 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
 
         /**
          * Build a request from a list of documents as maps.
-         * The inference timeout (how long the request waits in
-         * the inference queue for) is set to a high value {@code #DEFAULT_TIMEOUT_FOR_INGEST}
-         * to prefer slow ingest over dropping documents.
-         */
-
-        /**
-         * Build a request from a list of documents as maps.
          *
-         * @param id The model Id
-         * @param docs List of document maps
-         * @param update Inference config update
+         * @param id                 The model Id
+         * @param docs               List of document maps
+         * @param update             Inference config update
          * @param previouslyLicensed License has been checked previously
          *                           and can now be skipped
-         * @param inferenceTimeout The inference timeout (how long the
-         *                         request waits in the inference queue for)
+         * @param inferenceTimeout   The inference timeout (how long the
+         *                           request waits in the inference queue for)
          * @return the new Request
          */
         public static Request forIngestDocs(
@@ -119,7 +113,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             TimeValue inferenceTimeout
         ) {
             return new Request(
-                ExceptionsHelper.requireNonNull(id, InferModelAction.Request.ID),
+                ExceptionsHelper.requireNonNull(id, Request.ID),
                 update,
                 ExceptionsHelper.requireNonNull(Collections.unmodifiableList(docs), DOCS),
                 null,
@@ -132,13 +126,13 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
          * Build a request from a list of strings, each string
          * is one evaluation of the model.
          *
-         * @param id The model Id
-         * @param update Inference config update
-         * @param textInput Inference input
+         * @param id                 The model Id
+         * @param update             Inference config update
+         * @param textInput          Inference input
          * @param previouslyLicensed License has been checked previously
          *                           and can now be skipped
-         * @param inferenceTimeout The inference timeout (how long the
-         *                         request waits in the inference queue for)
+         * @param inferenceTimeout   The inference timeout (how long the
+         *                           request waits in the inference queue for)
          * @return the new Request
          */
         public static Request forTextInput(
@@ -294,7 +288,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            InferModelAction.Request that = (InferModelAction.Request) o;
+            Request that = (Request) o;
             return Objects.equals(id, that.id)
                 && Objects.equals(update, that.update)
                 && Objects.equals(previouslyLicensed, that.previouslyLicensed)
@@ -413,7 +407,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            InferModelAction.Response that = (InferModelAction.Response) o;
+            Response that = (Response) o;
             return isLicensed == that.isLicensed && Objects.equals(inferenceResults, that.inferenceResults) && Objects.equals(id, that.id);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlInfoAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -29,7 +29,7 @@ public class MlInfoAction extends ActionType<MlInfoAction.Response> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         public Request() {
             super();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventsAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -38,7 +38,7 @@ public class PostCalendarEventsAction extends ActionType<PostCalendarEventsActio
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         private static final ObjectParser<List<ScheduledEvent.Builder>, Void> PARSER = new ObjectParser<>(NAME, ArrayList::new);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDataFrameAnalyticsAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.CancellableTask;
@@ -40,18 +40,19 @@ public class PreviewDataFrameAnalyticsAction extends ActionType<PreviewDataFrame
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         public static final ParseField CONFIG = new ParseField("config");
 
         private final DataFrameAnalyticsConfig config;
 
-        static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("preview_data_frame_analytics_response", Request.Builder::new);
+        static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("preview_data_frame_analytics_response", Builder::new);
+
         static {
-            PARSER.declareObject(Request.Builder::setConfig, DataFrameAnalyticsConfig.STRICT_PARSER::apply, CONFIG);
+            PARSER.declareObject(Builder::setConfig, DataFrameAnalyticsConfig.STRICT_PARSER::apply, CONFIG);
         }
 
-        public static Request.Builder fromXContent(XContentParser parser) {
+        public static Builder fromXContent(XContentParser parser) {
             return PARSER.apply(parser, null);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
@@ -7,10 +7,10 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -50,14 +50,15 @@ public class PreviewDatafeedAction extends ActionType<PreviewDatafeedAction.Resp
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         private static final String BLANK_ID = "";
 
         public static final ParseField DATAFEED_CONFIG = new ParseField("datafeed_config");
         public static final ParseField JOB_CONFIG = new ParseField("job_config");
 
-        private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("preview_datafeed_action", Request.Builder::new);
+        private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("preview_datafeed_action", Builder::new);
+
         static {
             PARSER.declareObject(Builder::setDatafeedBuilder, DatafeedConfig.STRICT_PARSER, DATAFEED_CONFIG);
             PARSER.declareObject(Builder::setJobBuilder, Job.REST_REQUEST_PARSER, JOB_CONFIG);
@@ -65,7 +66,7 @@ public class PreviewDatafeedAction extends ActionType<PreviewDatafeedAction.Resp
             PARSER.declareString(Builder::setEnd, END_TIME);
         }
 
-        public static Request.Builder fromXContent(XContentParser parser, @Nullable String datafeedId) {
+        public static Builder fromXContent(XContentParser parser, @Nullable String datafeedId) {
             Builder builder = PARSER.apply(parser, null);
             // We don't need to check for "inconsistent ids" as we don't parse an ID from the body
             if (datafeedId != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutCalendarAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutCalendarAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -34,7 +34,7 @@ public class PutCalendarAction extends ActionType<PutCalendarAction.Response> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static Request parseRequest(String calendarId, XContentParser parser) {
             Calendar.Builder builder = Calendar.STRICT_PARSER.apply(parser, null);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutFilterAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutFilterAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,7 +32,7 @@ public class PutFilterAction extends ActionType<PutFilterAction.Response> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static Request parseRequest(String filterId, XContentParser parser) {
             MlFilter.Builder filter = MlFilter.STRICT_PARSER.apply(parser, null);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateCalendarJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateCalendarJobAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.core.ml.calendars.Calendar;
@@ -25,7 +25,7 @@ public class UpdateCalendarJobAction extends ActionType<PutCalendarAction.Respon
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         private String calendarId;
         private String jobIdsToAddExpression;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -39,7 +39,7 @@ public class UpdateFilterAction extends ActionType<PutFilterAction.Response> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static final ParseField ADD_ITEMS = new ParseField("add_items");
         public static final ParseField REMOVE_ITEMS = new ParseField("remove_items");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateModelSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateModelSnapshotAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,7 +35,7 @@ public class UpdateModelSnapshotAction extends ActionType<UpdateModelSnapshotAct
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         private static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ValidateDetectorAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ValidateDetectorAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -29,7 +29,7 @@ public class ValidateDetectorAction extends ActionType<AcknowledgedResponse> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         private Detector detector;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ValidateJobConfigAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ValidateJobConfigAction.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -28,7 +28,7 @@ public class ValidateJobConfigAction extends ActionType<AcknowledgedResponse> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         private final Job job;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringBulkRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringBulkRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.monitoring.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.bulk.BulkRequestParser;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -30,7 +30,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * Every monitoring document added to the request is associated to a {@link MonitoredSystem}. The monitored system is used
  * to resolve the index name in which the document will be indexed into.
  */
-public class MonitoringBulkRequest extends ActionRequest {
+public class MonitoringBulkRequest extends LegacyActionRequest {
 
     private final List<MonitoringBulkDoc> docs = new ArrayList<>();
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.rollup.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -37,7 +37,7 @@ public class GetRollupCapsAction extends ActionType<GetRollupCapsAction.Response
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentFragment {
+    public static class Request extends LegacyActionRequest implements ToXContentFragment {
         private String indexPattern;
 
         public Request(String indexPattern) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
@@ -6,11 +6,11 @@
  */
 package org.elasticsearch.xpack.core.rollup.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -40,7 +40,7 @@ public class GetRollupIndexCapsAction extends ActionType<GetRollupIndexCapsActio
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest.Replaceable, ToXContentFragment {
+    public static class Request extends LegacyActionRequest implements IndicesRequest.Replaceable, ToXContentFragment {
         private String[] indices;
         private IndicesOptions options;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.search.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -28,7 +28,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  *
  * @see AsyncSearchResponse
  */
-public class SubmitAsyncSearchRequest extends ActionRequest {
+public class SubmitAsyncSearchRequest extends LegacyActionRequest {
     public static long MIN_KEEP_ALIVE = TimeValue.timeValueSeconds(1).millis();
 
     private TimeValue waitForCompletionTimeout = TimeValue.timeValueSeconds(1);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/DelegatePkiAuthenticationRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/DelegatePkiAuthenticationRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -37,7 +37,7 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  * The request object for {@code TransportDelegatePkiAuthenticationAction} containing the certificate chain for the target subject
  * distinguished name to be granted an access token.
  */
-public final class DelegatePkiAuthenticationRequest extends ActionRequest implements ToXContentObject {
+public final class DelegatePkiAuthenticationRequest extends LegacyActionRequest implements ToXContentObject {
 
     private static final ParseField X509_CERTIFICATE_CHAIN_FIELD = new ParseField("x509_certificate_chain");
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/GrantRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/GrantRequest.java
@@ -7,14 +7,14 @@
 
 package org.elasticsearch.xpack.core.security.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public abstract class GrantRequest extends ActionRequest {
+public abstract class GrantRequest extends LegacyActionRequest {
     protected final Grant grant;
 
     public GrantRequest() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/AbstractCreateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/AbstractCreateApiKeyRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.apikey;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Strings;
@@ -26,7 +26,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public abstract class AbstractCreateApiKeyRequest extends ActionRequest {
+public abstract class AbstractCreateApiKeyRequest extends LegacyActionRequest {
     protected final String id;
     protected String name;
     protected TimeValue expiration;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BaseUpdateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BaseUpdateApiKeyRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.apikey;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public abstract class BaseUpdateApiKeyRequest extends ActionRequest {
+public abstract class BaseUpdateApiKeyRequest extends LegacyActionRequest {
 
     @Nullable
     protected final List<RoleDescriptor> roleDescriptors;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/GetApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/GetApiKeyRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.apikey;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -22,7 +22,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Request for get API key
  */
-public final class GetApiKeyRequest extends ActionRequest {
+public final class GetApiKeyRequest extends LegacyActionRequest {
 
     private final String realmName;
     private final String userName;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/InvalidateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/InvalidateApiKeyRequest.java
@@ -8,8 +8,8 @@
 package org.elasticsearch.xpack.core.security.action.apikey;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -25,7 +25,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Request for invalidating API key(s) so that it can no longer be used
  */
-public final class InvalidateApiKeyRequest extends ActionRequest {
+public final class InvalidateApiKeyRequest extends LegacyActionRequest {
 
     private final String realmName;
     private final String userName;
@@ -129,9 +129,9 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
     /**
      * Creates invalidate API key request for given api key ids
      *
-     * @param id api key id
+     * @param id                       api key id
      * @param ownedByAuthenticatedUser set {@code true} if the request is only for the API keys owned by current authenticated user else
-     * {@code false}
+     *                                 {@code false}
      * @return {@link InvalidateApiKeyRequest}
      */
     public static InvalidateApiKeyRequest usingApiKeyId(String id, boolean ownedByAuthenticatedUser) {
@@ -141,9 +141,9 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
     /**
      * Creates invalidate API key request for given api key id
      *
-     * @param ids array of api key ids
+     * @param ids                      array of api key ids
      * @param ownedByAuthenticatedUser set {@code true} if the request is only for the API keys owned by current authenticated user else
-     * {@code false}
+     *                                 {@code false}
      * @return {@link InvalidateApiKeyRequest}
      */
     public static InvalidateApiKeyRequest usingApiKeyIds(String[] ids, boolean ownedByAuthenticatedUser) {
@@ -153,9 +153,9 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
     /**
      * Creates invalidate api key request for given api key name
      *
-     * @param name api key name
+     * @param name                     api key name
      * @param ownedByAuthenticatedUser set {@code true} if the request is only for the API keys owned by current authenticated user else
-     * {@code false}
+     *                                 {@code false}
      * @return {@link InvalidateApiKeyRequest}
      */
     public static InvalidateApiKeyRequest usingApiKeyName(String name, boolean ownedByAuthenticatedUser) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.apikey;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public final class QueryApiKeyRequest extends ActionRequest {
+public final class QueryApiKeyRequest extends LegacyActionRequest {
 
     @Nullable
     private final QueryBuilder queryBuilder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/enrollment/KibanaEnrollmentRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/enrollment/KibanaEnrollmentRequest.java
@@ -7,13 +7,13 @@
 
 package org.elasticsearch.xpack.core.security.action.enrollment;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
 
-public final class KibanaEnrollmentRequest extends ActionRequest {
+public final class KibanaEnrollmentRequest extends LegacyActionRequest {
 
     public KibanaEnrollmentRequest() {
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/enrollment/NodeEnrollmentRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/enrollment/NodeEnrollmentRequest.java
@@ -7,13 +7,13 @@
 
 package org.elasticsearch.xpack.core.security.action.enrollment;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
 
-public final class NodeEnrollmentRequest extends ActionRequest {
+public final class NodeEnrollmentRequest extends LegacyActionRequest {
 
     public NodeEnrollmentRequest() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/oidc/OpenIdConnectAuthenticateRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/oidc/OpenIdConnectAuthenticateRequest.java
@@ -7,8 +7,8 @@
 package org.elasticsearch.xpack.core.security.action.oidc;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -20,7 +20,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Represents a request for authentication using OpenID Connect
  */
-public class OpenIdConnectAuthenticateRequest extends ActionRequest {
+public class OpenIdConnectAuthenticateRequest extends LegacyActionRequest {
 
     /**
      * The URI where the OP redirected the browser after the authentication attempt. This is passed as is from the

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/oidc/OpenIdConnectLogoutRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/oidc/OpenIdConnectLogoutRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.oidc;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public final class OpenIdConnectLogoutRequest extends ActionRequest {
+public final class OpenIdConnectLogoutRequest extends LegacyActionRequest {
 
     private String token;
     @Nullable

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/oidc/OpenIdConnectPrepareAuthenticationRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/oidc/OpenIdConnectPrepareAuthenticationRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.oidc;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -19,7 +19,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Represents a request to prepare an OAuth 2.0 authorization request
  */
-public class OpenIdConnectPrepareAuthenticationRequest extends ActionRequest {
+public class OpenIdConnectPrepareAuthenticationRequest extends LegacyActionRequest {
 
     /**
      * The name of the OpenID Connect realm in the configuration that should be used for authentication

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.privilege;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -23,7 +23,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A request to delete an application privilege.
  */
-public final class DeletePrivilegesRequest extends ActionRequest
+public final class DeletePrivilegesRequest extends LegacyActionRequest
     implements
         ApplicationPrivilegesRequest,
         WriteRequest<DeletePrivilegesRequest> {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetBuiltinPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetBuiltinPrivilegesRequest.java
@@ -6,13 +6,13 @@
  */
 package org.elasticsearch.xpack.core.security.action.privilege;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 
 /**
  * Request to retrieve built-in (cluster/index) privileges.
  */
-public final class GetBuiltinPrivilegesRequest extends ActionRequest {
+public final class GetBuiltinPrivilegesRequest extends LegacyActionRequest {
 
     public GetBuiltinPrivilegesRequest() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.privilege;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -22,7 +22,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Request to retrieve one or more application privileges.
  */
-public final class GetPrivilegesRequest extends ActionRequest implements ApplicationPrivilegesRequest {
+public final class GetPrivilegesRequest extends LegacyActionRequest implements ApplicationPrivilegesRequest {
 
     @Nullable
     private String application;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.privilege;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -27,7 +27,10 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Request object to put a one or more application privileges.
  */
-public final class PutPrivilegesRequest extends ActionRequest implements ApplicationPrivilegesRequest, WriteRequest<PutPrivilegesRequest> {
+public final class PutPrivilegesRequest extends LegacyActionRequest
+    implements
+        ApplicationPrivilegesRequest,
+        WriteRequest<PutPrivilegesRequest> {
 
     private List<ApplicationPrivilegeDescriptor> privileges;
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.profile;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -20,7 +20,7 @@ import java.util.Set;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class GetProfilesRequest extends ActionRequest {
+public class GetProfilesRequest extends LegacyActionRequest {
 
     private final List<String> uids;
     private final Set<String> dataKeys;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/SetProfileEnabledRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/SetProfileEnabledRequest.java
@@ -7,15 +7,15 @@
 
 package org.elasticsearch.xpack.core.security.action.profile;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public class SetProfileEnabledRequest extends ActionRequest {
+public class SetProfileEnabledRequest extends LegacyActionRequest {
 
     private final String uid;
     private final boolean enabled;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/SuggestProfilesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/SuggestProfilesRequest.java
@@ -8,8 +8,8 @@
 package org.elasticsearch.xpack.core.security.action.profile;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,7 +30,7 @@ import java.util.Set;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class SuggestProfilesRequest extends ActionRequest {
+public class SuggestProfilesRequest extends LegacyActionRequest {
 
     private final Set<String> dataKeys;
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/UpdateProfileDataRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/UpdateProfileDataRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.profile;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class UpdateProfileDataRequest extends ActionRequest {
+public class UpdateProfileDataRequest extends LegacyActionRequest {
 
     private final String uid;
     private final Map<String, Object> labels;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/BulkDeleteRolesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/BulkDeleteRolesRequest.java
@@ -7,14 +7,14 @@
 
 package org.elasticsearch.xpack.core.security.action.role;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 
 import java.util.List;
 import java.util.Objects;
 
-public class BulkDeleteRolesRequest extends ActionRequest {
+public class BulkDeleteRolesRequest extends LegacyActionRequest {
 
     private List<String> roleNames;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/BulkPutRolesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/BulkPutRolesRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.role;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class BulkPutRolesRequest extends ActionRequest {
+public class BulkPutRolesRequest extends LegacyActionRequest {
 
     private List<RoleDescriptor> roles;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/DeleteRoleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/DeleteRoleRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.role;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -20,7 +20,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A request delete a role from the security index
  */
-public class DeleteRoleRequest extends ActionRequest {
+public class DeleteRoleRequest extends LegacyActionRequest {
 
     private String name;
     private WriteRequest.RefreshPolicy refreshPolicy = WriteRequest.RefreshPolicy.IMMEDIATE;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetRolesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetRolesRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.role;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -19,7 +19,7 @@ import static org.elasticsearch.action.support.TransportAction.localOnly;
 /**
  * Request to retrieve roles from the security index
  */
-public class GetRolesRequest extends ActionRequest {
+public class GetRolesRequest extends LegacyActionRequest {
 
     private String[] names = Strings.EMPTY_ARRAY;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.role;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Strings;
@@ -33,7 +33,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Request object for adding a role to the security index
  */
-public class PutRoleRequest extends ActionRequest {
+public class PutRoleRequest extends LegacyActionRequest {
 
     private String name;
     private String[] clusterPrivileges = Strings.EMPTY_ARRAY;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/QueryRoleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/QueryRoleRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.role;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -21,7 +21,7 @@ import java.util.List;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public final class QueryRoleRequest extends ActionRequest {
+public final class QueryRoleRequest extends LegacyActionRequest {
 
     @Nullable
     private final QueryBuilder queryBuilder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/DeleteRoleMappingRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/DeleteRoleMappingRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.rolemapping;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -19,7 +19,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A request delete a role-mapping from the org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore
  */
-public class DeleteRoleMappingRequest extends ActionRequest implements WriteRequest<DeleteRoleMappingRequest> {
+public class DeleteRoleMappingRequest extends LegacyActionRequest implements WriteRequest<DeleteRoleMappingRequest> {
 
     private String name;
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/GetRoleMappingsRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/GetRoleMappingsRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.rolemapping;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -19,10 +19,10 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
  * Request to retrieve role-mappings from X-Pack security
- *
+ * <p>
  * see org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore
  */
-public class GetRoleMappingsRequest extends ActionRequest {
+public class GetRoleMappingsRequest extends LegacyActionRequest {
 
     private String[] names = Strings.EMPTY_ARRAY;
 
@@ -44,6 +44,7 @@ public class GetRoleMappingsRequest extends ActionRequest {
 
     /**
      * Specify (by name) which role-mappings to delete.
+     *
      * @see ExpressionRoleMapping#getName()
      */
     public void setNames(String... names) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingRequest.java
@@ -7,8 +7,8 @@
 package org.elasticsearch.xpack.core.security.action.rolemapping;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,10 +30,10 @@ import static org.elasticsearch.xpack.core.security.authc.support.mapper.Express
 
 /**
  * Request object for adding/updating a role-mapping to the native store
- *
+ * <p>
  * see org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore
  */
-public class PutRoleMappingRequest extends ActionRequest implements WriteRequest<PutRoleMappingRequest> {
+public class PutRoleMappingRequest extends LegacyActionRequest implements WriteRequest<PutRoleMappingRequest> {
 
     private String name = null;
     private boolean enabled = true;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.saml;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.core.Nullable;
 
@@ -17,7 +17,7 @@ import java.util.List;
 /**
  * Represents a request to authenticate using SAML assertions.
  */
-public final class SamlAuthenticateRequest extends ActionRequest {
+public final class SamlAuthenticateRequest extends LegacyActionRequest {
 
     private byte[] saml;
     private List<String> validRequestIds;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlCompleteLogoutRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlCompleteLogoutRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.saml;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.core.Nullable;
@@ -20,7 +20,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Represents a request to complete SAML LogoutResponse
  */
-public final class SamlCompleteLogoutRequest extends ActionRequest {
+public final class SamlCompleteLogoutRequest extends LegacyActionRequest {
 
     @Nullable
     private String queryString;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlInvalidateSessionRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlInvalidateSessionRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.saml;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.core.Nullable;
@@ -19,7 +19,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Represents a request to invalidate a SAML session using a {@code LogoutRequest}.
  */
-public final class SamlInvalidateSessionRequest extends ActionRequest {
+public final class SamlInvalidateSessionRequest extends LegacyActionRequest {
 
     @Nullable
     private String realmName;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlLogoutRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlLogoutRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.saml;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.core.Nullable;
@@ -19,7 +19,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Represents a request to prepare a SAML {@code &lt;LogoutRequest&gt;}.
  */
-public final class SamlLogoutRequest extends ActionRequest {
+public final class SamlLogoutRequest extends LegacyActionRequest {
 
     private String token;
     @Nullable

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlPrepareAuthenticationRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlPrepareAuthenticationRequest.java
@@ -7,8 +7,8 @@
 package org.elasticsearch.xpack.core.security.action.saml;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -18,7 +18,7 @@ import java.io.IOException;
 /**
  * Represents a request to prepare a SAML {@code &lt;AuthnRequest&gt;}.
  */
-public final class SamlPrepareAuthenticationRequest extends ActionRequest {
+public final class SamlPrepareAuthenticationRequest extends LegacyActionRequest {
 
     @Nullable
     private String realmName;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlSpMetadataRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlSpMetadataRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.saml;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class SamlSpMetadataRequest extends ActionRequest {
+public class SamlSpMetadataRequest extends LegacyActionRequest {
 
     private String realmName;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/CreateServiceAccountTokenRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/CreateServiceAccountTokenRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.service;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -20,7 +20,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class CreateServiceAccountTokenRequest extends ActionRequest {
+public class CreateServiceAccountTokenRequest extends LegacyActionRequest {
 
     private final String namespace;
     private final String serviceName;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.service;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -20,7 +20,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class DeleteServiceAccountTokenRequest extends ActionRequest {
+public class DeleteServiceAccountTokenRequest extends LegacyActionRequest {
 
     private final String namespace;
     private final String serviceName;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.service;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -18,7 +18,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class GetServiceAccountCredentialsRequest extends ActionRequest {
+public class GetServiceAccountCredentialsRequest extends LegacyActionRequest {
 
     private final String namespace;
     private final String serviceName;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.service;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -16,7 +16,7 @@ import org.elasticsearch.core.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
-public class GetServiceAccountRequest extends ActionRequest {
+public class GetServiceAccountRequest extends LegacyActionRequest {
 
     @Nullable
     private final String namespace;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.token;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -28,7 +28,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * fields for an OAuth 2.0 access token request that uses the <code>password</code> grant type or the
  * <code>refresh_token</code> grant type.
  */
-public final class CreateTokenRequest extends ActionRequest {
+public final class CreateTokenRequest extends LegacyActionRequest {
 
     public enum GrantType {
         PASSWORD("password"),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/InvalidateTokenRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/InvalidateTokenRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.token;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -20,7 +20,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Request for invalidating a token so that it can no longer be used
  */
-public final class InvalidateTokenRequest extends ActionRequest {
+public final class InvalidateTokenRequest extends LegacyActionRequest {
 
     public enum Type {
         ACCESS_TOKEN("token"),
@@ -66,9 +66,9 @@ public final class InvalidateTokenRequest extends ActionRequest {
 
     /**
      * @param tokenString the string representation of the token to be invalidated
-     * @param tokenType the type of the token to be invalidated
-     * @param realmName the name of the realm for which all tokens will be invalidated
-     * @param userName the principal of the user for which all tokens will be invalidated
+     * @param tokenType   the type of the token to be invalidated
+     * @param realmName   the name of the realm for which all tokens will be invalidated
+     * @param userName    the principal of the user for which all tokens will be invalidated
      */
     public InvalidateTokenRequest(
         @Nullable String tokenString,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateRequest.java
@@ -7,14 +7,14 @@
 package org.elasticsearch.xpack.core.security.action.user;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public class AuthenticateRequest extends ActionRequest {
+public class AuthenticateRequest extends LegacyActionRequest {
 
     public static final AuthenticateRequest INSTANCE = new AuthenticateRequest();
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ChangePasswordRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ChangePasswordRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -22,7 +22,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Request to change a user's password.
  */
-public class ChangePasswordRequest extends ActionRequest implements UserRequest, WriteRequest<ChangePasswordRequest> {
+public class ChangePasswordRequest extends LegacyActionRequest implements UserRequest, WriteRequest<ChangePasswordRequest> {
 
     private String username;
     private char[] passwordHash;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/DeleteUserRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/DeleteUserRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -19,7 +19,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * A request to delete a native user.
  */
-public class DeleteUserRequest extends ActionRequest implements UserRequest, WriteRequest<DeleteUserRequest> {
+public class DeleteUserRequest extends LegacyActionRequest implements UserRequest, WriteRequest<DeleteUserRequest> {
 
     private String username;
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -16,7 +16,7 @@ import java.io.IOException;
 /**
  * A request for checking a user's privileges
  */
-public final class GetUserPrivilegesRequest extends ActionRequest implements UserRequest {
+public final class GetUserPrivilegesRequest extends LegacyActionRequest implements UserRequest {
 
     private String username;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersRequest.java
@@ -7,8 +7,8 @@
 package org.elasticsearch.xpack.core.security.action.user;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -20,7 +20,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Request to retrieve a native user.
  */
-public class GetUsersRequest extends ActionRequest implements UserRequest {
+public class GetUsersRequest extends LegacyActionRequest implements UserRequest {
 
     private String[] usernames;
     private boolean withProfileUid;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine;
@@ -19,7 +19,7 @@ import java.io.IOException;
 /**
  * A request for checking a user's privileges
  */
-public class HasPrivilegesRequest extends ActionRequest implements UserRequest {
+public class HasPrivilegesRequest extends LegacyActionRequest implements UserRequest {
 
     private String username;
     private String[] clusterPrivileges;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ProfileHasPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ProfileHasPrivilegesRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.CancellableTask;
@@ -28,7 +28,7 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class ProfileHasPrivilegesRequest extends ActionRequest {
+public class ProfileHasPrivilegesRequest extends LegacyActionRequest {
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<ProfileHasPrivilegesRequest, Void> PARSER = new ConstructingObjectParser<>(
@@ -36,6 +36,7 @@ public class ProfileHasPrivilegesRequest extends ActionRequest {
         false,
         argv -> new ProfileHasPrivilegesRequest((List<String>) argv[0], (PrivilegesToCheck) argv[1])
     );
+
     static {
         PARSER.declareStringArray(constructorArg(), Fields.UIDS);
         PARSER.declareField(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -26,7 +26,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Request object to put a native user.
  */
-public class PutUserRequest extends ActionRequest implements UserRequest, WriteRequest<PutUserRequest> {
+public class PutUserRequest extends LegacyActionRequest implements UserRequest, WriteRequest<PutUserRequest> {
 
     private String username;
     private String[] roles;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/QueryUserRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/QueryUserRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -25,7 +25,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * Request for the query Users API. <br>
  * Model for API requests to the query users API
  */
-public final class QueryUserRequest extends ActionRequest {
+public final class QueryUserRequest extends LegacyActionRequest {
 
     @Nullable
     private final QueryBuilder queryBuilder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/SetEnabledRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/SetEnabledRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -22,7 +22,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * The request that allows to set a user as enabled or disabled
  */
-public class SetEnabledRequest extends ActionRequest implements UserRequest, WriteRequest<SetEnabledRequest> {
+public class SetEnabledRequest extends LegacyActionRequest implements UserRequest, WriteRequest<SetEnabledRequest> {
 
     private Boolean enabled;
     private String username;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/action/GetCertificateInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/action/GetCertificateInfoAction.java
@@ -6,11 +6,11 @@
  */
 package org.elasticsearch.xpack.core.ssl.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -34,7 +34,7 @@ public class GetCertificateInfoAction extends ActionType<GetCertificateInfoActio
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         Request() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/AbstractFindStructureRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/AbstractFindStructureRequest.java
@@ -8,8 +8,8 @@
 package org.elasticsearch.xpack.core.textstructure.action;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public abstract class AbstractFindStructureRequest extends ActionRequest {
+public abstract class AbstractFindStructureRequest extends LegacyActionRequest {
 
     public static final int MIN_SAMPLE_LINE_COUNT = 2;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/TestGrokPatternAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/TestGrokPatternAction.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.core.textstructure.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,22 +30,20 @@ import java.util.Objects;
 
 public class TestGrokPatternAction {
 
-    public static final ActionType<TestGrokPatternAction.Response> INSTANCE = new ActionType<>(
-        "cluster:monitor/text_structure/test_grok_pattern"
-    );
+    public static final ActionType<Response> INSTANCE = new ActionType<>("cluster:monitor/text_structure/test_grok_pattern");
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         public static final ParseField GROK_PATTERN = new ParseField("grok_pattern");
         public static final ParseField TEXT = new ParseField("text");
         public static final ParseField ECS_COMPATIBILITY = new ParseField("ecs_compatibility");
 
-        private static final ObjectParser<Request.Builder, Void> PARSER = createParser();
+        private static final ObjectParser<Builder, Void> PARSER = createParser();
 
-        private static ObjectParser<Request.Builder, Void> createParser() {
-            ObjectParser<Request.Builder, Void> parser = new ObjectParser<>("textstructure/testgrokpattern", false, Request.Builder::new);
-            parser.declareString(Request.Builder::grokPattern, GROK_PATTERN);
-            parser.declareStringArray(Request.Builder::text, TEXT);
+        private static ObjectParser<Builder, Void> createParser() {
+            ObjectParser<Builder, Void> parser = new ObjectParser<>("textstructure/testgrokpattern", false, Builder::new);
+            parser.declareString(Builder::grokPattern, GROK_PATTERN);
+            parser.declareStringArray(Builder::text, TEXT);
             return parser;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetCheckpointAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetCheckpointAction.java
@@ -8,11 +8,11 @@
 package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.RemoteClusterActionType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
@@ -47,7 +47,7 @@ public class GetCheckpointAction extends ActionType<GetCheckpointAction.Response
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest.Replaceable {
+    public static class Request extends LegacyActionRequest implements IndicesRequest.Replaceable {
 
         private String[] indices;
         private final IndicesOptions indicesOptions;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetCheckpointNodeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetCheckpointNodeAction.java
@@ -8,11 +8,11 @@
 package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -88,7 +88,7 @@ public class GetCheckpointNodeAction extends ActionType<GetCheckpointNodeAction.
         }
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest {
+    public static class Request extends LegacyActionRequest implements IndicesRequest {
 
         private final Set<ShardId> shards;
         private final OriginalIndices originalIndices;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/QueryWatchesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/QueryWatchesAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -19,7 +19,6 @@ import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -44,7 +43,7 @@ public class QueryWatchesAction extends ActionType<QueryWatchesAction.Response> 
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         public static final ParseField FROM_FIELD = new ParseField("from");
         public static final ParseField SIZE_FIELD = new ParseField("size");
@@ -162,7 +161,7 @@ public class QueryWatchesAction extends ActionType<QueryWatchesAction.Response> 
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             if (from != null) {
                 builder.field(FROM_FIELD.getPreferredName(), from);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/ack/AckWatchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/ack/AckWatchRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions.ack;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -20,7 +20,7 @@ import java.util.Locale;
 /**
  * A ack watch request to ack a watch by name (id)
  */
-public class AckWatchRequest extends ActionRequest {
+public class AckWatchRequest extends LegacyActionRequest {
 
     private String watchId;
     private String[] actionIds = Strings.EMPTY_ARRAY;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/activate/ActivateWatchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/activate/ActivateWatchRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions.activate;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -18,7 +18,7 @@ import java.io.IOException;
 /**
  * A ack watch request to ack a watch by name (id)
  */
-public class ActivateWatchRequest extends ActionRequest {
+public class ActivateWatchRequest extends LegacyActionRequest {
 
     private String watchId;
     private boolean activate;
@@ -54,7 +54,7 @@ public class ActivateWatchRequest extends ActionRequest {
 
     /**
      * @return {@code true} if the request is for activating the watch, {@code false} if its
-     *         for deactivating it.
+     * for deactivating it.
      */
     public boolean isActivate() {
         return activate;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/execute/ExecuteWatchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/execute/ExecuteWatchRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions.execute;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -28,7 +28,7 @@ import java.util.Map;
 /**
  * A request to execute a watch by id
  */
-public class ExecuteWatchRequest extends ActionRequest {
+public class ExecuteWatchRequest extends LegacyActionRequest {
 
     public static final String INLINE_WATCH_ID = "_inlined_";
 
@@ -200,8 +200,8 @@ public class ExecuteWatchRequest extends ActionRequest {
     }
 
     /**
-     * @return  the execution modes for the actions. These modes determine the nature of the execution
-     *          of the watch actions while the watch is executing.
+     * @return the execution modes for the actions. These modes determine the nature of the execution
+     * of the watch actions while the watch is executing.
      */
     public Map<String, ActionExecutionMode> getActionModes() {
         return actionModes;
@@ -210,8 +210,8 @@ public class ExecuteWatchRequest extends ActionRequest {
     /**
      * Sets the action execution mode for the give action (identified by its id).
      *
-     * @param actionId      the action id.
-     * @param actionMode    the execution mode of the action.
+     * @param actionId   the action id.
+     * @param actionMode the execution mode of the action.
      */
     public void setActionMode(String actionId, ActionExecutionMode actionMode) {
         actionModes.put(actionId, actionMode);
@@ -219,7 +219,7 @@ public class ExecuteWatchRequest extends ActionRequest {
 
     /**
      * @return whether the watch should execute in debug mode. In debug mode the execution {@code vars}
-     *         will be returned as part of the watch record.
+     * will be returned as part of the watch record.
      */
     public boolean isDebug() {
         return debug;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/get/GetWatchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/get/GetWatchRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions.get;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -18,7 +18,7 @@ import java.io.IOException;
 /**
  * The request to get the watch by name (id)
  */
-public class GetWatchRequest extends ActionRequest {
+public class GetWatchRequest extends LegacyActionRequest {
 
     private String id;
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/action/MockIndicesRequest.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/action/MockIndicesRequest.java
@@ -8,7 +8,7 @@ package org.elasticsearch.action;
 
 import org.elasticsearch.action.support.IndicesOptions;
 
-public class MockIndicesRequest extends ActionRequest implements IndicesRequest, CompositeIndicesRequest {
+public class MockIndicesRequest extends LegacyActionRequest implements IndicesRequest, CompositeIndicesRequest {
 
     private final String[] indices;
     private final IndicesOptions indicesOptions;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilterTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilterTests.java
@@ -8,9 +8,9 @@
 package org.elasticsearch.xpack.core.api.filtering;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -127,7 +127,7 @@ public class ApiFilteringActionFilterTests extends ESTestCase {
         return new ThreadContext(settings);
     }
 
-    private static class TestRequest extends ActionRequest {
+    private static class TestRequest extends LegacyActionRequest {
         @Override
         public ActionRequestValidationException validate() {
             return null;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/InvalidateApiKeyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/InvalidateApiKeyRequestTests.java
@@ -9,8 +9,8 @@ package org.elasticsearch.xpack.core.security.action.apikey;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
@@ -95,7 +95,7 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
     }
 
     public void testRequestValidationFailureScenarios() throws IOException {
-        class Dummy extends ActionRequest {
+        class Dummy extends LegacyActionRequest {
             String realm;
             String user;
             String apiKeyId;

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutor.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutor.java
@@ -11,11 +11,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -263,7 +263,7 @@ public class DownsampleShardPersistentTaskExecutor extends PersistentTasksExecut
             super(NAME);
         }
 
-        public static class Request extends ActionRequest implements IndicesRequest.RemoteClusterShardRequest {
+        public static class Request extends LegacyActionRequest implements IndicesRequest.RemoteClusterShardRequest {
 
             private final DownsampleShardTask task;
             private final BytesRef lastDownsampleTsid;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.application.analytics.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -39,11 +39,11 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 public class PostAnalyticsEventAction {
 
     public static final String NAME = "cluster:admin/xpack/application/analytics/post_event";
-    public static final ActionType<PostAnalyticsEventAction.Response> INSTANCE = new ActionType<>(NAME);
+    public static final ActionType<Response> INSTANCE = new ActionType<>(NAME);
 
     private PostAnalyticsEventAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements AnalyticsEvent.Context, ToXContentObject {
+    public static class Request extends LegacyActionRequest implements AnalyticsEvent.Context, ToXContentObject {
 
         private final String eventCollectionName;
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ConnectorActionRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ConnectorActionRequest.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.application.connector.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -24,7 +24,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * Abstract base class for action requests targeting the connectors index. Implements {@link org.elasticsearch.action.IndicesRequest}
  * to ensure index-level privilege support. This class defines the connectors index as the target for all derived action requests.
  */
-public abstract class ConnectorActionRequest extends ActionRequest implements IndicesRequest {
+public abstract class ConnectorActionRequest extends LegacyActionRequest implements IndicesRequest {
 
     public ConnectorActionRequest() {
         super();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.application.connector.secrets.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -19,7 +19,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class DeleteConnectorSecretRequest extends ActionRequest {
+public class DeleteConnectorSecretRequest extends LegacyActionRequest {
 
     private final String id;
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/GetConnectorSecretRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/GetConnectorSecretRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.application.connector.secrets.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -19,7 +19,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class GetConnectorSecretRequest extends ActionRequest {
+public class GetConnectorSecretRequest extends LegacyActionRequest {
 
     private final String id;
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/PostConnectorSecretRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/PostConnectorSecretRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.application.connector.secrets.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -23,7 +23,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class PostConnectorSecretRequest extends ActionRequest {
+public class PostConnectorSecretRequest extends LegacyActionRequest {
 
     private static final ParseField VALUE_FIELD = new ParseField("value");
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/PutConnectorSecretRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/PutConnectorSecretRequest.java
@@ -8,8 +8,8 @@
 package org.elasticsearch.xpack.application.connector.secrets.action;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -17,7 +17,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -30,7 +29,7 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class PutConnectorSecretRequest extends ActionRequest implements ToXContentObject {
+public class PutConnectorSecretRequest extends LegacyActionRequest implements ToXContentObject {
 
     private final String id;
     private final String value;
@@ -68,7 +67,7 @@ public class PutConnectorSecretRequest extends ActionRequest implements ToXConte
         return PARSER.parse(parser, id);
     }
 
-    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field("value", value);
         builder.endObject();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ConnectorSyncJobActionRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ConnectorSyncJobActionRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.application.connector.syncjob.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry;
@@ -20,7 +20,7 @@ import java.io.IOException;
  * Implements {@link org.elasticsearch.action.IndicesRequest} to ensure index-level privilege support.
  * This class defines the connectors sync job index as the target for all derived action requests.
  */
-public abstract class ConnectorSyncJobActionRequest extends ActionRequest implements IndicesRequest {
+public abstract class ConnectorSyncJobActionRequest extends LegacyActionRequest implements IndicesRequest {
 
     public ConnectorSyncJobActionRequest() {
         super();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/DeleteQueryRuleAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/DeleteQueryRuleAction.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.application.rules.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -33,7 +33,7 @@ public class DeleteQueryRuleAction {
 
     private DeleteQueryRuleAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
         private final String rulesetId;
         private final String ruleId;
 
@@ -108,6 +108,7 @@ public class DeleteQueryRuleAction {
             false,
             (p) -> new Request((String) p[0], (String) p[1])
         );
+
         static {
             PARSER.declareString(constructorArg(), RULESET_ID_FIELD);
             PARSER.declareString(constructorArg(), RULE_ID_FIELD);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/DeleteQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/DeleteQueryRulesetAction.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.application.rules.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -33,7 +33,7 @@ public class DeleteQueryRulesetAction {
 
     private DeleteQueryRulesetAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
         private final String rulesetId;
 
         private static final ParseField RULESET_ID_FIELD = new ParseField("ruleset_id");
@@ -96,6 +96,7 @@ public class DeleteQueryRulesetAction {
                 return new Request((String) p[0]);
             }
         );
+
         static {
             PARSER.declareString(constructorArg(), RULESET_ID_FIELD);
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/GetQueryRuleAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/GetQueryRuleAction.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.application.rules.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,11 +30,11 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 public class GetQueryRuleAction {
 
     public static final String NAME = "cluster:admin/xpack/query_rules/rule/get";
-    public static final ActionType<GetQueryRuleAction.Response> INSTANCE = new ActionType<>(NAME);
+    public static final ActionType<Response> INSTANCE = new ActionType<>(NAME);
 
     private GetQueryRuleAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
         private final String rulesetId;
         private final String ruleId;
 
@@ -110,6 +110,7 @@ public class GetQueryRuleAction {
             (p) -> new Request((String) p[0], (String) p[1])
 
         );
+
         static {
             PARSER.declareString(constructorArg(), RULESET_ID_FIELD);
             PARSER.declareString(constructorArg(), RULE_ID_FIELD);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetAction.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.application.rules.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -31,13 +31,13 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 
 public class GetQueryRulesetAction {
 
-    public static final ActionType<GetQueryRulesetAction.Response> TYPE = new ActionType<>("cluster:admin/xpack/query_rules/get");
+    public static final ActionType<Response> TYPE = new ActionType<>("cluster:admin/xpack/query_rules/get");
     public static final String NAME = TYPE.name();
-    public static final ActionType<GetQueryRulesetAction.Response> INSTANCE = new ActionType<>(NAME);
+    public static final ActionType<Response> INSTANCE = new ActionType<>(NAME);
 
     private GetQueryRulesetAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
         private final String rulesetId;
         private static final ParseField RULESET_ID_FIELD = new ParseField("ruleset_id");
 
@@ -100,6 +100,7 @@ public class GetQueryRulesetAction {
             }
 
         );
+
         static {
             PARSER.declareString(constructorArg(), RULESET_ID_FIELD);
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/ListQueryRulesetsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/ListQueryRulesetsAction.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.application.rules.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.features.NodeFeature;
@@ -32,13 +32,13 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 public class ListQueryRulesetsAction {
 
     public static final String NAME = "cluster:admin/xpack/query_rules/list";
-    public static final ActionType<ListQueryRulesetsAction.Response> INSTANCE = new ActionType<>(NAME);
+    public static final ActionType<Response> INSTANCE = new ActionType<>(NAME);
 
     public static final NodeFeature QUERY_RULE_LIST_TYPES = new NodeFeature("query_rule_list_types", true);
 
     private ListQueryRulesetsAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
         private final PageParams pageParams;
 
         private static final ParseField PAGE_PARAMS_FIELD = new ParseField("pageParams");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/PutQueryRuleAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/PutQueryRuleAction.java
@@ -7,11 +7,11 @@
 
 package org.elasticsearch.xpack.application.rules.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -34,11 +34,11 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 public class PutQueryRuleAction {
 
     public static final String NAME = "cluster:admin/xpack/query_rules/rule/put";
-    public static final ActionType<PutQueryRuleAction.Response> INSTANCE = new ActionType<>(NAME);
+    public static final ActionType<Response> INSTANCE = new ActionType<>(NAME);
 
     private PutQueryRuleAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         private final String queryRulesetId;
         private final QueryRule queryRule;
@@ -131,12 +131,12 @@ public class PutQueryRuleAction {
             PARSER.declareObject(constructorArg(), (p, c) -> QueryRule.fromXContent(p), QUERY_RULE_FIELD);
         }
 
-        public static PutQueryRuleAction.Request parse(XContentParser parser, String resourceName) {
+        public static Request parse(XContentParser parser, String resourceName) {
             return PARSER.apply(parser, resourceName);
         }
 
-        public static PutQueryRuleAction.Request fromXContent(String queryRulesetId, XContentParser parser) throws IOException {
-            return new PutQueryRuleAction.Request(queryRulesetId, QueryRule.fromXContent(parser));
+        public static Request fromXContent(String queryRulesetId, XContentParser parser) throws IOException {
+            return new Request(queryRulesetId, QueryRule.fromXContent(parser));
         }
 
         @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetAction.java
@@ -7,11 +7,11 @@
 
 package org.elasticsearch.xpack.application.rules.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -36,11 +36,11 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 public class PutQueryRulesetAction {
 
     public static final String NAME = "cluster:admin/xpack/query_rules/put";
-    public static final ActionType<PutQueryRulesetAction.Response> INSTANCE = new ActionType<>(NAME);
+    public static final ActionType<Response> INSTANCE = new ActionType<>(NAME);
 
     private PutQueryRulesetAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         private final QueryRuleset queryRuleset;
         private static final ParseField QUERY_RULESET_FIELD = new ParseField("queryRuleset");
@@ -120,8 +120,8 @@ public class PutQueryRulesetAction {
             PARSER.declareObject(constructorArg(), (p, c) -> QueryRuleset.fromXContent(c, p), QUERY_RULESET_FIELD);
         }
 
-        public static PutQueryRulesetAction.Request fromXContent(String id, XContentParser parser) throws IOException {
-            return new PutQueryRulesetAction.Request(QueryRuleset.fromXContent(id, parser));
+        public static Request fromXContent(String id, XContentParser parser) throws IOException {
+            return new Request(QueryRuleset.fromXContent(id, parser));
         }
 
         @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/TestQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/TestQueryRulesetAction.java
@@ -7,11 +7,11 @@
 
 package org.elasticsearch.xpack.application.rules.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -38,14 +38,14 @@ public class TestQueryRulesetAction {
     public static final NodeFeature QUERY_RULES_TEST_API = new NodeFeature("query_rules.test", true);
 
     // TODO - We'd like to transition this to require less stringent permissions
-    public static final ActionType<TestQueryRulesetAction.Response> TYPE = new ActionType<>("cluster:admin/xpack/query_rules/test");
+    public static final ActionType<Response> TYPE = new ActionType<>("cluster:admin/xpack/query_rules/test");
 
     public static final String NAME = TYPE.name();
-    public static final ActionType<TestQueryRulesetAction.Response> INSTANCE = new ActionType<>(NAME);
+    public static final ActionType<Response> INSTANCE = new ActionType<>(NAME);
 
     private TestQueryRulesetAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject, IndicesRequest {
+    public static class Request extends LegacyActionRequest implements ToXContentObject, IndicesRequest {
         private final String rulesetId;
         private final Map<String, Object> matchCriteria;
 
@@ -123,6 +123,7 @@ public class TestQueryRulesetAction {
             }
 
         );
+
         static {
             PARSER.declareObject(constructorArg(), (p, c) -> p.map(), MATCH_CRITERIA_FIELD);
             PARSER.declareString(optionalConstructorArg(), RULESET_ID_FIELD); // Required for parsing

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/DeleteSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/DeleteSearchApplicationAction.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.application.search.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,7 +32,7 @@ public class DeleteSearchApplicationAction {
 
     private DeleteSearchApplicationAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
         private final String name;
 
         public static ParseField NAME_FIELD = new ParseField("name");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/GetSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/GetSearchApplicationAction.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.application.search.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -30,11 +30,11 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 public class GetSearchApplicationAction {
 
     public static final String NAME = "cluster:admin/xpack/application/search_application/get";
-    public static final ActionType<GetSearchApplicationAction.Response> INSTANCE = new ActionType<>(NAME);
+    public static final ActionType<Response> INSTANCE = new ActionType<>(NAME);
 
     private GetSearchApplicationAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
         private final String name;
 
         public static final ParseField NAME_FIELD = new ParseField("name");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/ListSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/ListSearchApplicationAction.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.application.search.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -35,11 +35,11 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 public class ListSearchApplicationAction {
 
     public static final String NAME = "cluster:admin/xpack/application/search_application/list";
-    public static final ActionType<ListSearchApplicationAction.Response> INSTANCE = new ActionType<>(NAME);
+    public static final ActionType<Response> INSTANCE = new ActionType<>(NAME);
 
     private ListSearchApplicationAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         private static final String DEFAULT_QUERY = "*";
         public static final ParseField QUERY = new ParseField("query");
@@ -110,6 +110,7 @@ public class ListSearchApplicationAction {
             "list_search_application_request",
             p -> new Request((String) p[0], (PageParams) p[1])
         );
+
         static {
             PARSER.declareString(optionalConstructorArg(), QUERY);
             PARSER.declareObject(constructorArg(), (p, c) -> PageParams.fromXContent(p), PAGE_PARAMS);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/PutSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/PutSearchApplicationAction.java
@@ -7,11 +7,11 @@
 
 package org.elasticsearch.xpack.application.search.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -33,11 +33,11 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 public class PutSearchApplicationAction {
 
     public static final String NAME = "cluster:admin/xpack/application/search_application/put";
-    public static final ActionType<PutSearchApplicationAction.Response> INSTANCE = new ActionType<>(NAME);
+    public static final ActionType<Response> INSTANCE = new ActionType<>(NAME);
 
     private PutSearchApplicationAction() {/* no instances */}
 
-    public static class Request extends ActionRequest implements ToXContentObject {
+    public static class Request extends LegacyActionRequest implements ToXContentObject {
 
         private final SearchApplication searchApp;
         private final boolean create;
@@ -110,6 +110,7 @@ public class PutSearchApplicationAction {
             false,
             (params) -> new Request((SearchApplication) params[0], (boolean) params[1])
         );
+
         static {
             PARSER.declareObject(constructorArg(), (p, c) -> SearchApplication.fromXContent(c, p), SEARCH_APPLICATION);
             PARSER.declareBoolean(constructorArg(), CREATE);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationSearchRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationSearchRequest.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.application.search.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -31,7 +31,7 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public class SearchApplicationSearchRequest extends ActionRequest implements IndicesRequest, ToXContentObject {
+public class SearchApplicationSearchRequest extends LegacyActionRequest implements IndicesRequest, ToXContentObject {
 
     private static final ParseField QUERY_PARAMS_FIELD = new ParseField("params");
     private static final ParseField NAME_FIELD = new ParseField("name");

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -7,9 +7,9 @@
 package org.elasticsearch.xpack.eql.action;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -42,7 +42,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xpack.eql.action.RequestDefaults.FIELD_EVENT_CATEGORY;
 import static org.elasticsearch.xpack.eql.action.RequestDefaults.FIELD_TIMESTAMP;
 
-public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Replaceable, ToXContent {
+public class EqlSearchRequest extends LegacyActionRequest implements IndicesRequest.Replaceable, ToXContent {
 
     public static long MIN_KEEP_ALIVE = TimeValue.timeValueMinutes(1).millis();
     public static TimeValue DEFAULT_KEEP_ALIVE = TimeValue.timeValueDays(5);
@@ -281,13 +281,13 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
             EqlSearchRequest::waitForCompletionTimeout,
             (p, c) -> TimeValue.parseTimeValue(p.text(), KEY_WAIT_FOR_COMPLETION_TIMEOUT),
             WAIT_FOR_COMPLETION_TIMEOUT,
-            ObjectParser.ValueType.VALUE
+            ValueType.VALUE
         );
         parser.declareField(
             EqlSearchRequest::keepAlive,
             (p, c) -> TimeValue.parseTimeValue(p.text(), KEY_KEEP_ALIVE),
             KEEP_ALIVE,
-            ObjectParser.ValueType.VALUE
+            ValueType.VALUE
         );
         parser.declareBoolean(EqlSearchRequest::keepOnCompletion, KEEP_ON_COMPLETION);
         parser.declareString(EqlSearchRequest::resultPosition, RESULT_POSITION);
@@ -467,7 +467,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         Token token = parser.currentToken();
 
         if (token == Token.START_ARRAY) {
-            while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+            while ((token = parser.nextToken()) != Token.END_ARRAY) {
                 result.add(FieldAndFormat.fromXContent(parser));
             }
         }

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/async/AsyncTaskManagementServiceTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/async/AsyncTaskManagementServiceTests.java
@@ -7,9 +7,9 @@
 package org.elasticsearch.xpack.esql.core.async;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -50,7 +50,7 @@ public class AsyncTaskManagementServiceTests extends ESSingleNodeTestCase {
 
     private final ExecutorService executorService = Executors.newFixedThreadPool(1);
 
-    public static class TestRequest extends ActionRequest {
+    public static class TestRequest extends LegacyActionRequest {
         private final String string;
 
         public TestRequest(String string) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverTaskRunner.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverTaskRunner.java
@@ -8,10 +8,10 @@
 package org.elasticsearch.compute.operator;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.CompositeIndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ChannelActionListener;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -65,7 +65,7 @@ public class DriverTaskRunner {
         runner.runToCompletion(drivers, listener);
     }
 
-    private static class DriverRequest extends ActionRequest implements CompositeIndicesRequest {
+    private static class DriverRequest extends LegacyActionRequest implements CompositeIndicesRequest {
         private final Driver driver;
         private final Executor executor;
 

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/DeleteSecretRequest.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/DeleteSecretRequest.java
@@ -7,15 +7,15 @@
 
 package org.elasticsearch.xpack.fleet.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class DeleteSecretRequest extends ActionRequest {
+public class DeleteSecretRequest extends LegacyActionRequest {
 
     private final String id;
 

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsAction.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsAction.java
@@ -9,12 +9,12 @@ package org.elasticsearch.xpack.fleet.action;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -41,7 +41,6 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -82,7 +81,7 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field("timed_out", timedOut);
             builder.array("global_checkpoints", globalCheckpoints);
@@ -90,7 +89,7 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
         }
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest {
+    public static class Request extends LegacyActionRequest implements IndicesRequest {
 
         private final String index;
         private final boolean waitForAdvance;

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/GetSecretRequest.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/GetSecretRequest.java
@@ -7,15 +7,15 @@
 
 package org.elasticsearch.xpack.fleet.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class GetSecretRequest extends ActionRequest {
+public class GetSecretRequest extends LegacyActionRequest {
 
     private final String id;
 

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/PostSecretRequest.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/PostSecretRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.fleet.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -20,7 +20,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Objects;
 
-public class PostSecretRequest extends ActionRequest {
+public class PostSecretRequest extends LegacyActionRequest {
 
     public static final ParseField VALUE_FIELD = new ParseField("value");
 

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/DeleteSamlServiceProviderRequest.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/DeleteSamlServiceProviderRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.idp.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -22,7 +22,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Request object to remove a service provider (by Entity ID) from the IdP.
  */
-public class DeleteSamlServiceProviderRequest extends ActionRequest {
+public class DeleteSamlServiceProviderRequest extends LegacyActionRequest {
 
     private final String entityId;
     private final WriteRequest.RefreshPolicy refreshPolicy;

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/PutSamlServiceProviderRequest.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/PutSamlServiceProviderRequest.java
@@ -8,8 +8,8 @@
 package org.elasticsearch.xpack.idp.action;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class PutSamlServiceProviderRequest extends ActionRequest {
+public class PutSamlServiceProviderRequest extends LegacyActionRequest {
     public static final WriteRequest.RefreshPolicy DEFAULT_REFRESH_POLICY = WriteRequest.RefreshPolicy.NONE;
 
     private final SamlServiceProviderDocument document;

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/SamlInitiateSingleSignOnRequest.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/SamlInitiateSingleSignOnRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.idp.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class SamlInitiateSingleSignOnRequest extends ActionRequest {
+public class SamlInitiateSingleSignOnRequest extends LegacyActionRequest {
 
     private String spEntityId;
     private String assertionConsumerService;

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/SamlMetadataRequest.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/SamlMetadataRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.idp.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -15,7 +15,7 @@ import org.elasticsearch.core.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
-public class SamlMetadataRequest extends ActionRequest {
+public class SamlMetadataRequest extends LegacyActionRequest {
 
     private String spEntityId;
     private String assertionConsumerService;

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/SamlValidateAuthnRequestRequest.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/SamlValidateAuthnRequestRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.idp.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -16,7 +16,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class SamlValidateAuthnRequestRequest extends ActionRequest {
+public class SamlValidateAuthnRequestRequest extends LegacyActionRequest {
 
     private String queryString;
 

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/DeletePipelineRequest.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/DeletePipelineRequest.java
@@ -7,15 +7,15 @@
 
 package org.elasticsearch.xpack.logstash.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class DeletePipelineRequest extends ActionRequest {
+public class DeletePipelineRequest extends LegacyActionRequest {
 
     private final String id;
 

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/GetPipelineRequest.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/GetPipelineRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.logstash.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class GetPipelineRequest extends ActionRequest {
+public class GetPipelineRequest extends LegacyActionRequest {
 
     private final List<String> ids;
 

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/PutPipelineRequest.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/PutPipelineRequest.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.logstash.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -17,7 +17,7 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.IOException;
 import java.util.Objects;
 
-public class PutPipelineRequest extends ActionRequest {
+public class PutPipelineRequest extends LegacyActionRequest {
 
     private final String id;
     private final String source;

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CancelReindexDataStreamAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CancelReindexDataStreamAction.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.migrate.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -28,7 +28,7 @@ public class CancelReindexDataStreamAction extends ActionType<AcknowledgedRespon
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest {
+    public static class Request extends LegacyActionRequest implements IndicesRequest {
         private final String index;
 
         public Request(String index) {

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceAction.java
@@ -6,10 +6,10 @@
  */
 package org.elasticsearch.xpack.migrate.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -38,7 +38,7 @@ public class CreateIndexFromSourceAction extends ActionType<AcknowledgedResponse
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest, ToXContent {
+    public static class Request extends LegacyActionRequest implements IndicesRequest, ToXContent {
         private final String sourceIndex;
         private final String destIndex;
         private Settings settingsOverride;
@@ -152,7 +152,7 @@ public class CreateIndexFromSourceAction extends ActionType<AcknowledgedResponse
          * This only exists for the sake of testing the xcontent parser
          */
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             if (mappingsOverride.containsKey("_doc")) {
                 builder.field(MAPPINGS_OVERRIDE_FIELD.getPreferredName(), mappingsOverride.get("_doc"));
             }

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/GetMigrationReindexStatusAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/GetMigrationReindexStatusAction.java
@@ -7,11 +7,11 @@
 
 package org.elasticsearch.xpack.migrate.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -82,7 +82,7 @@ public class GetMigrationReindexStatusAction extends ActionType<GetMigrationRein
 
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest {
+    public static class Request extends LegacyActionRequest implements IndicesRequest {
         private final String index;
 
         public Request(String index) {

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamAction.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.migrate.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -48,7 +48,7 @@ public class ReindexDataStreamAction extends ActionType<AcknowledgedResponse> {
         UPGRADE
     }
 
-    public static class ReindexDataStreamRequest extends ActionRequest implements IndicesRequest, ToXContent {
+    public static class ReindexDataStreamRequest extends LegacyActionRequest implements IndicesRequest, ToXContent {
         private final Mode mode;
         private final String sourceDataStream;
 

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexAction.java
@@ -6,11 +6,11 @@
  */
 package org.elasticsearch.xpack.migrate.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,7 +32,7 @@ public class ReindexDataStreamIndexAction extends ActionType<ReindexDataStreamIn
         super(NAME);
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest {
+    public static class Request extends LegacyActionRequest implements IndicesRequest {
 
         private final String sourceIndex;
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetStackTracesRequest.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetStackTracesRequest.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.profiling.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.ParsingException;
@@ -36,7 +36,7 @@ import static org.elasticsearch.index.query.AbstractQueryBuilder.parseTopLevelQu
 /**
  * A request to get profiling details
  */
-public class GetStackTracesRequest extends ActionRequest implements IndicesRequest.Replaceable {
+public class GetStackTracesRequest extends LegacyActionRequest implements IndicesRequest.Replaceable {
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField SAMPLE_SIZE_FIELD = new ParseField("sample_size");
     public static final ParseField LIMIT_FIELD = new ParseField("limit");

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementServiceTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementServiceTests.java
@@ -7,9 +7,9 @@
 package org.elasticsearch.xpack.ql.async;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -50,7 +50,7 @@ public class AsyncTaskManagementServiceTests extends ESSingleNodeTestCase {
 
     private final ExecutorService executorService = Executors.newFixedThreadPool(1);
 
-    public static class TestRequest extends ActionRequest {
+    public static class TestRequest extends LegacyActionRequest {
         private final String string;
 
         public TestRequest(String string) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/FrozenCacheInfoAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/FrozenCacheInfoAction.java
@@ -9,9 +9,9 @@ package org.elasticsearch.xpack.searchablesnapshots.action.cache;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -34,7 +34,7 @@ public class FrozenCacheInfoAction extends ActionType<FrozenCacheInfoResponse> {
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         private final DiscoveryNode discoveryNode;
 
@@ -58,14 +58,14 @@ public class FrozenCacheInfoAction extends ActionType<FrozenCacheInfoResponse> {
         }
     }
 
-    public static class TransportAction extends HandledTransportAction<FrozenCacheInfoAction.Request, FrozenCacheInfoResponse> {
+    public static class TransportAction extends HandledTransportAction<Request, FrozenCacheInfoResponse> {
 
         private final FrozenCacheInfoNodeAction.Request nodeRequest = new FrozenCacheInfoNodeAction.Request();
         private final TransportService transportService;
 
         @Inject
         public TransportAction(TransportService transportService, ActionFilters actionFilters) {
-            super(NAME, transportService, actionFilters, FrozenCacheInfoAction.Request::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
+            super(NAME, transportService, actionFilters, Request::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
             this.transportService = transportService;
         }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/FrozenCacheInfoNodeAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/FrozenCacheInfoNodeAction.java
@@ -8,9 +8,9 @@
 package org.elasticsearch.xpack.searchablesnapshots.action.cache;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -33,7 +33,7 @@ public class FrozenCacheInfoNodeAction extends ActionType<FrozenCacheInfoRespons
         super(NAME);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         public Request() {}
 

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.RemoteClusterActionType;
 import org.elasticsearch.action.admin.cluster.remote.RemoteClusterNodesAction;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
@@ -632,7 +633,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
         return service;
     }
 
-    private static class MalformedGetRequest extends ActionRequest {
+    private static class MalformedGetRequest extends LegacyActionRequest {
         private final String otherIndexId;
 
         MalformedGetRequest(String otherIndexId) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1579,7 +1579,7 @@ public class Security extends Plugin
             return Arrays.asList(usageAction, infoAction);
         }
 
-        return Stream.of(
+        return List.of(
             new ActionHandler<>(ClearRealmCacheAction.INSTANCE, TransportClearRealmCacheAction.class),
             new ActionHandler<>(ClearRolesCacheAction.INSTANCE, TransportClearRolesCacheAction.class),
             new ActionHandler<>(ClearPrivilegesCacheAction.INSTANCE, TransportClearPrivilegesCacheAction.class),
@@ -1648,7 +1648,7 @@ public class Security extends Plugin
             new ActionHandler<>(UpdateIndexMigrationVersionAction.INSTANCE, UpdateIndexMigrationVersionAction.TransportAction.class),
             usageAction,
             infoAction
-        ).filter(Objects::nonNull).toList();
+        );
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/settings/TransportReloadRemoteClusterCredentialsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/settings/TransportReloadRemoteClusterCredentialsAction.java
@@ -8,9 +8,9 @@
 package org.elasticsearch.xpack.security.action.settings;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterState;
@@ -21,6 +21,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.rest.action.admin.cluster.RestReloadSecureSettingsAction;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.TransportService;
@@ -33,10 +34,10 @@ import java.util.function.Supplier;
 
 /**
  * This is a local-only action which updates remote cluster credentials for remote cluster connections, from keystore settings reloaded via
- * a call to {@link org.elasticsearch.rest.action.admin.cluster.RestReloadSecureSettingsAction}.
- *
+ * a call to {@link RestReloadSecureSettingsAction}.
+ * <p>
  * It's invoked as part of the {@link Security#reload(Settings)} call.
- *
+ * <p>
  * This action is largely an implementation detail to work around the fact that Security is a plugin without direct access to many core
  * classes, including the {@link RemoteClusterService} which is required for a credentials reload. A transport action gives us access to
  * the {@link RemoteClusterService} which is injectable but not part of the plugin contract.
@@ -85,7 +86,7 @@ public class TransportReloadRemoteClusterCredentialsAction extends TransportActi
         return clusterState.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         private final Settings settings;
 
         public Request(Settings settings) {

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/TransportSLMGetExpiredSnapshotsAction.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/TransportSLMGetExpiredSnapshotsAction.java
@@ -10,11 +10,11 @@ package org.elasticsearch.xpack.slm;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.action.support.SubscribableListener;
@@ -249,7 +249,7 @@ public class TransportSLMGetExpiredSnapshotsAction extends TransportAction<
         }).toList();
     }
 
-    public static final class Request extends ActionRequest {
+    public static final class Request extends LegacyActionRequest {
         private final Collection<String> repositories;
         private final Map<String, SnapshotLifecyclePolicy> policies;
 

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/BlobAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/BlobAnalyzeAction.java
@@ -13,9 +13,9 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -145,7 +145,6 @@ import static org.elasticsearch.repositories.blobstore.testkit.SnapshotRepositor
  *
  * On success, details of how long everything took are returned. On failure, cancels the remote read tasks to try and avoid consuming
  * unnecessary resources.
- *
  */
 class BlobAnalyzeAction extends HandledTransportAction<BlobAnalyzeAction.Request, BlobAnalyzeAction.Response> {
 
@@ -193,10 +192,10 @@ class BlobAnalyzeAction extends HandledTransportAction<BlobAnalyzeAction.Request
     private static class BlobAnalysis {
         private final TransportService transportService;
         private final CancellableTask task;
-        private final BlobAnalyzeAction.Request request;
+        private final Request request;
         private final BlobStoreRepository repository;
         private final BlobContainer blobContainer;
-        private final ActionListener<BlobAnalyzeAction.Response> listener;
+        private final ActionListener<Response> listener;
         private final Random random;
         private final boolean checksumWholeBlob;
         private final long checksumStart;
@@ -211,10 +210,10 @@ class BlobAnalyzeAction extends HandledTransportAction<BlobAnalyzeAction.Request
         BlobAnalysis(
             TransportService transportService,
             CancellableTask task,
-            BlobAnalyzeAction.Request request,
+            Request request,
             BlobStoreRepository repository,
             BlobContainer blobContainer,
-            ActionListener<BlobAnalyzeAction.Response> listener
+            ActionListener<Response> listener
         ) {
             this.transportService = transportService;
             this.task = task;
@@ -643,7 +642,7 @@ class BlobAnalyzeAction extends HandledTransportAction<BlobAnalyzeAction.Request
         }
     }
 
-    static class Request extends ActionRequest {
+    static class Request extends LegacyActionRequest {
         private final String repositoryName;
         private final String blobPath;
         private final String blobName;

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/ContendedRegisterAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/ContendedRegisterAnalyzeAction.java
@@ -11,10 +11,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.Strings;
@@ -176,7 +176,7 @@ class ContendedRegisterAnalyzeAction extends HandledTransportAction<ContendedReg
         }
     }
 
-    static class Request extends ActionRequest {
+    static class Request extends LegacyActionRequest {
         private final String repositoryName;
         private final String containerPath;
         private final String registerName;

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/GetBlobChecksumAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/GetBlobChecksumAction.java
@@ -10,9 +10,9 @@ package org.elasticsearch.repositories.blobstore.testkit.analyze;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.blobstore.BlobContainer;
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.CRC32;
 
 /**
- * Action which instructs a node to read a range of a blob from a {@link org.elasticsearch.repositories.blobstore.BlobStoreRepository}
+ * Action which instructs a node to read a range of a blob from a {@link BlobStoreRepository}
  * (possibly the entire blob) and compute its checksum. It is acceptable if the blob is not found but we do not accept the blob being
  * otherwise unreadable.
  */
@@ -176,7 +176,7 @@ class GetBlobChecksumAction extends HandledTransportAction<GetBlobChecksumAction
         listener.onResponse(response);
     }
 
-    static class Request extends ActionRequest {
+    static class Request extends LegacyActionRequest {
 
         private final String repositoryName;
         private final String blobPath;

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalyzeAction.java
@@ -15,11 +15,11 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.RefCountingRunnable;
@@ -97,7 +97,7 @@ public class RepositoryAnalyzeAction extends HandledTransportAction<RepositoryAn
 
     private static final Logger logger = LogManager.getLogger(RepositoryAnalyzeAction.class);
 
-    public static final ActionType<RepositoryAnalyzeAction.Response> INSTANCE = new ActionType<>("cluster:admin/repository/analyze");
+    public static final ActionType<Response> INSTANCE = new ActionType<>("cluster:admin/repository/analyze");
 
     static final String UNCONTENDED_REGISTER_NAME_PREFIX = "test-register-uncontended-";
     static final String CONTENDED_REGISTER_NAME_PREFIX = "test-register-contended-";
@@ -113,7 +113,7 @@ public class RepositoryAnalyzeAction extends HandledTransportAction<RepositoryAn
         ClusterService clusterService,
         RepositoriesService repositoriesService
     ) {
-        super(INSTANCE.name(), transportService, actionFilters, RepositoryAnalyzeAction.Request::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        super(INSTANCE.name(), transportService, actionFilters, Request::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.repositoriesService = repositoriesService;
@@ -890,7 +890,7 @@ public class RepositoryAnalyzeAction extends HandledTransportAction<RepositoryAn
         }
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
 
         private final String repositoryName;
 

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/UncontendedRegisterAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/UncontendedRegisterAnalyzeAction.java
@@ -11,9 +11,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.Strings;
@@ -135,7 +135,7 @@ class UncontendedRegisterAnalyzeAction extends HandledTransportAction<Uncontende
         );
     }
 
-    static class Request extends ActionRequest {
+    static class Request extends LegacyActionRequest {
         private final String repositoryName;
         private final String containerPath;
         private final String registerName;

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/TransportRepositoryVerifyIntegrityAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/TransportRepositoryVerifyIntegrityAction.java
@@ -9,9 +9,9 @@ package org.elasticsearch.repositories.blobstore.testkit.integrity;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.SubscribableListener;
@@ -57,13 +57,13 @@ class TransportRepositoryVerifyIntegrityAction extends HandledTransportAction<
         ActionFilters actionFilters,
         Executor executor
     ) {
-        super(ACTION_NAME, transportService, actionFilters, TransportRepositoryVerifyIntegrityAction.Request::new, executor);
+        super(ACTION_NAME, transportService, actionFilters, Request::new, executor);
         this.repositoriesService = repositoriesService;
         this.transportService = transportService;
         this.executor = executor;
     }
 
-    static class Request extends ActionRequest {
+    static class Request extends LegacyActionRequest {
         private final DiscoveryNode coordinatingNode;
         private final long coordinatingTaskId;
         private final RepositoryVerifyIntegrityParams requestParams;

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/TransportRepositoryVerifyIntegrityCoordinationAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/TransportRepositoryVerifyIntegrityCoordinationAction.java
@@ -9,9 +9,9 @@ package org.elasticsearch.repositories.blobstore.testkit.integrity;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -98,7 +98,7 @@ public class TransportRepositoryVerifyIntegrityCoordinationAction extends Transp
     private final ClusterService clusterService;
     private final Executor managementExecutor;
 
-    public static class Request extends ActionRequest {
+    public static class Request extends LegacyActionRequest {
         private final RepositoryVerifyIntegrityParams requestParams;
         private final RepositoryVerifyIntegrityResponseStream responseStream;
 

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/TransportRepositoryVerifyIntegrityResponseChunkAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/TransportRepositoryVerifyIntegrityResponseChunkAction.java
@@ -8,9 +8,9 @@
 package org.elasticsearch.repositories.blobstore.testkit.integrity;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -43,7 +43,7 @@ class TransportRepositoryVerifyIntegrityResponseChunkAction extends HandledTrans
         this.activeRepositoryVerifyIntegrityTasks = activeRepositoryVerifyIntegrityTasks;
     }
 
-    static class Request extends ActionRequest {
+    static class Request extends LegacyActionRequest {
         private final long coordinatingTaskId;
         private final RepositoryVerifyIntegrityResponseChunk chunkContents;
 

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlRequest.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.sql.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.sql.proto.Mode;
@@ -24,7 +24,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * <p>
  * Contains information about the client mode that can be used to generate different responses based on the caller type.
  */
-public abstract class AbstractSqlRequest extends ActionRequest {
+public abstract class AbstractSqlRequest extends LegacyActionRequest {
 
     private RequestInfo requestInfo;
 


### PR DESCRIPTION
In order to remove ActionType, ActionRequest will become strongly typed, referring to the ActionResponse type. As a precursor to that, this commit adds a LegacyActionRequest which all existing ActionRequest implementations now inherit from. This will allow adding the ActionResponse type to ActionRequest in a future commit without modifying every implementation at once.