### PR TITLE
Renamed the feature flag that controls when default Lucene posting format is used

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/Elasticsearch900Lucene101Codec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/Elasticsearch900Lucene101Codec.java
@@ -28,6 +28,8 @@ import org.elasticsearch.index.codec.zstd.Zstd814StoredFieldsFormat;
  */
 public class Elasticsearch900Lucene101Codec extends CodecService.DeduplicateFieldInfosCodec {
 
+    public static final PostingsFormat DEFAULT_POSTINGS_FORMAT = new Lucene101PostingsFormat();
+
     private final StoredFieldsFormat storedFieldsFormat;
 
     private final PostingsFormat defaultPostingsFormat;
@@ -66,7 +68,7 @@ public class Elasticsearch900Lucene101Codec extends CodecService.DeduplicateFiel
     public Elasticsearch900Lucene101Codec(Zstd814StoredFieldsFormat.Mode mode) {
         super("Elasticsearch900Lucene101", new Lucene101Codec());
         this.storedFieldsFormat = mode.getFormat();
-        this.defaultPostingsFormat = new Lucene101PostingsFormat();
+        this.defaultPostingsFormat = DEFAULT_POSTINGS_FORMAT;
         this.defaultDVFormat = new Lucene90DocValuesFormat();
         this.defaultKnnVectorsFormat = new Lucene99HnswVectorsFormat();
     }

--- a/server/src/main/java/org/elasticsearch/index/codec/Elasticsearch900Lucene101Codec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/Elasticsearch900Lucene101Codec.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.codec.zstd.Zstd814StoredFieldsFormat;
  */
 public class Elasticsearch900Lucene101Codec extends CodecService.DeduplicateFieldInfosCodec {
 
-    public static final PostingsFormat DEFAULT_POSTINGS_FORMAT = new Lucene101PostingsFormat();
+    static final PostingsFormat DEFAULT_POSTINGS_FORMAT = new Lucene101PostingsFormat();
 
     private final StoredFieldsFormat storedFieldsFormat;
 

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -12,7 +12,6 @@ package org.elasticsearch.index.codec;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.PostingsFormat;
-import org.apache.lucene.codecs.lucene101.Lucene101PostingsFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.elasticsearch.common.util.BigArrays;
@@ -34,13 +33,12 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
  * vectors.
  */
 public class PerFieldFormatSupplier {
-    public static final FeatureFlag USE_LUCENE101_POSTINGS_FORMAT = new FeatureFlag("use_lucene101_postings_format");
+    public static final FeatureFlag USE_DEFAULT_LUCENE_POSTINGS_FORMAT = new FeatureFlag("use_default_lucene_postings_format");
 
     private static final DocValuesFormat docValuesFormat = new Lucene90DocValuesFormat();
     private static final KnnVectorsFormat knnVectorsFormat = new Lucene99HnswVectorsFormat();
     private static final ES819TSDBDocValuesFormat tsdbDocValuesFormat = new ES819TSDBDocValuesFormat();
     private static final ES812PostingsFormat es812PostingsFormat = new ES812PostingsFormat();
-    private static final Lucene101PostingsFormat lucene101PostingsFormat = new Lucene101PostingsFormat();
     private static final PostingsFormat completionPostingsFormat = PostingsFormat.forName("Completion101");
 
     private final ES87BloomFilterPostingsFormat bloomFilterPostingsFormat;
@@ -53,10 +51,10 @@ public class PerFieldFormatSupplier {
         this.bloomFilterPostingsFormat = new ES87BloomFilterPostingsFormat(bigArrays, this::internalGetPostingsFormatForField);
 
         if (mapperService != null
-            && USE_LUCENE101_POSTINGS_FORMAT.isEnabled()
+            && USE_DEFAULT_LUCENE_POSTINGS_FORMAT.isEnabled()
             && mapperService.getIndexSettings().getIndexVersionCreated().onOrAfter(IndexVersions.USE_LUCENE101_POSTINGS_FORMAT)
             && mapperService.getIndexSettings().getMode() == IndexMode.STANDARD) {
-            defaultPostingsFormat = lucene101PostingsFormat;
+            defaultPostingsFormat = Elasticsearch900Lucene101Codec.DEFAULT_POSTINGS_FORMAT;
         } else {
             // our own posting format using PFOR
             defaultPostingsFormat = es812PostingsFormat;

--- a/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
@@ -94,7 +94,7 @@ public class PerFieldMapperCodecTests extends ESTestCase {
         assertThat(perFieldMapperCodec.getPostingsFormatForField("_id"), instanceOf(ES87BloomFilterPostingsFormat.class));
         assertThat(perFieldMapperCodec.useBloomFilter("another_field"), is(false));
 
-        Class<? extends PostingsFormat> expectedPostingsFormat = PerFieldFormatSupplier.USE_LUCENE101_POSTINGS_FORMAT.isEnabled()
+        Class<? extends PostingsFormat> expectedPostingsFormat = PerFieldFormatSupplier.USE_DEFAULT_LUCENE_POSTINGS_FORMAT.isEnabled()
             && timeSeries == false ? Lucene101PostingsFormat.class : ES812PostingsFormat.class;
         assertThat(perFieldMapperCodec.getPostingsFormatForField("another_field"), instanceOf(expectedPostingsFormat));
     }
@@ -110,7 +110,7 @@ public class PerFieldMapperCodecTests extends ESTestCase {
     public void testUseBloomFilterWithTimestampFieldEnabled_noTimeSeriesMode() throws IOException {
         PerFieldFormatSupplier perFieldMapperCodec = createFormatSupplier(true, false, false);
         assertThat(perFieldMapperCodec.useBloomFilter("_id"), is(false));
-        Class<? extends PostingsFormat> expectedPostingsFormat = PerFieldFormatSupplier.USE_LUCENE101_POSTINGS_FORMAT.isEnabled()
+        Class<? extends PostingsFormat> expectedPostingsFormat = PerFieldFormatSupplier.USE_DEFAULT_LUCENE_POSTINGS_FORMAT.isEnabled()
             ? Lucene101PostingsFormat.class
             : ES812PostingsFormat.class;
         assertThat(perFieldMapperCodec.getPostingsFormatForField("_id"), instanceOf(expectedPostingsFormat));


### PR DESCRIPTION
Renamed the feature flag that controls when default Lucene posting format is used.
And moved replaced `lucene101PostingsFormat` from `PerFieldFormatSupplier` constant to `Elasticsearch900Lucene101Codec`.

Addressed comment from #126080