### PR TITLE
[9.0] [DOCS] Make ESQL functions/operators/commands overview accordions open by default (#128197)

### DIFF
--- a/docs/reference/query-languages/esql/esql-functions-operators.md
+++ b/docs/reference/query-languages/esql/esql-functions-operators.md
@@ -12,56 +12,67 @@ mapped_pages:
 ## Functions overview [esql-functions]
 
 ::::{dropdown} Aggregate functions
+:open:
 :::{include} _snippets/lists/aggregation-functions.md
 :::
 ::::
 
 ::::{dropdown} Grouping functions
+:open:
 :::{include} _snippets/lists/grouping-functions.md
 :::
 ::::
 
 ::::{dropdown} Conditional functions and expressions
+:open:
 :::{include} _snippets/lists/conditional-functions-and-expressions.md
 :::
 ::::
 
 ::::{dropdown} Date and time functions
+:open:
 :::{include} _snippets/lists/date-time-functions.md
 :::
 ::::
 
 ::::{dropdown} IP functions
+:open:
 :::{include} _snippets/lists/ip-functions.md
 :::
 ::::
 
 ::::{dropdown} Math functions
+:open:
 :::{include} _snippets/lists/math-functions.md
 :::
 ::::
 
 ::::{dropdown} Search functions
+:open:
 :::{include} _snippets/lists/search-functions.md
 :::
 ::::
 
 ::::{dropdown} Spatial functions
+:open:
 :::{include} _snippets/lists/spatial-functions.md
 :::
 ::::
 
 ::::{dropdown} String functions
+:open:
 :::{include} _snippets/lists/string-functions.md
 :::
 ::::
 
 ::::{dropdown} Type conversion functions
+:open:
 :::{include} _snippets/lists/type-conversion-functions.md
 :::
 ::::
 
 ::::{dropdown} Multi value functions
+:open:
 :::{include} _snippets/lists/mv-functions.md
 :::
 ::::
@@ -70,6 +81,7 @@ mapped_pages:
 ## Operators overview [esql-operators-overview]
 
 ::::{dropdown} Operators
+:open:
 :::{include} _snippets/lists/operators.md
 :::
 ::::


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [DOCS] Make ESQL functions/operators/commands overview accordions open by default (#128197)