### PR TITLE
Mark `repository_verify_integrity` API as `public`

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_verify_integrity.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_verify_integrity.json
@@ -5,7 +5,7 @@
       "description":"Verifies the integrity of the contents of a snapshot repository"
     },
     "stability":"experimental",
-    "visibility":"private",
+    "visibility":"public",
     "headers": {
       "accept": [
         "application/json"


### PR DESCRIPTION
Not sure why this was defined as `private` in #112348, it should have
been `public`. This commit fixes the visibility so we generate docs for
this API.