### PR TITLE
Update 8.18.0.asciidoc

### DIFF
--- a/docs/reference/release-notes/8.18.0.asciidoc
+++ b/docs/reference/release-notes/8.18.0.asciidoc
@@ -488,7 +488,7 @@ authentication to perform outbound network connections. This issue will be fixed
 +
 As a workaround, you can temporarily patch the policy using a JVM option:
 
-1. Create a file called `${ES_CONF_PATH}/jvm_options.d/workaround-127061.options`.
+1. Create a file called `${ES_CONF_PATH}/jvm.options.d/workaround-127061.options`.
 2. Add the following line to the new file:
 +
      -Des.entitlements.policy.x-pack-core=dmVyc2lvbnM6CiAgLSA4LjE4LjAKICAtIDkuMC4wCnBvbGljeToKICB1bmJvdW5kaWQubGRhcHNkazoKICAgIC0gc2V0X2h0dHBzX2Nvbm5lY3Rpb25fcHJvcGVydGllcwogICAgLSBvdXRib3VuZF9uZXR3b3Jr


### PR DESCRIPTION
fixed a different typo for "jvm.options.d"

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
