### PR TITLE
Default tests.security.manager to false

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -152,7 +152,7 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
                 "tests.artifact",
                 project.getName(),
                 "tests.security.manager",
-                "true",
+                "false",
                 "jna.nosys",
                 "true"
             );


### PR DESCRIPTION
Since https://github.com/elastic/elasticsearch/pull/127087 has not been backported to 8.18 and 9.0, we need to default security manager to false, or some tests will run with SM enabled causing failures. 

Follows #127789 as that was not enough.

Closes #128245
Closes #128246
Closes #128247