### PR TITLE
Temporarily disable use_default_lucene_postings_format feature flag.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -50,8 +50,10 @@ public class PerFieldFormatSupplier {
         this.mapperService = mapperService;
         this.bloomFilterPostingsFormat = new ES87BloomFilterPostingsFormat(bigArrays, this::internalGetPostingsFormatForField);
 
+        // TODO: temporarily disable feature flag for a few days to see effect in benchmarks
+        boolean useDefaultLucenePostingsFormat = USE_DEFAULT_LUCENE_POSTINGS_FORMAT.isEnabled() && false;
         if (mapperService != null
-            && USE_DEFAULT_LUCENE_POSTINGS_FORMAT.isEnabled()
+            && useDefaultLucenePostingsFormat
             && mapperService.getIndexSettings().getIndexVersionCreated().onOrAfter(IndexVersions.USE_LUCENE101_POSTINGS_FORMAT)
             && mapperService.getIndexSettings().getMode() == IndexMode.STANDARD) {
             defaultPostingsFormat = Elasticsearch900Lucene101Codec.DEFAULT_POSTINGS_FORMAT;

--- a/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.index.codec;
 
 import org.apache.lucene.codecs.PostingsFormat;
-import org.apache.lucene.codecs.lucene101.Lucene101PostingsFormat;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -94,8 +93,7 @@ public class PerFieldMapperCodecTests extends ESTestCase {
         assertThat(perFieldMapperCodec.getPostingsFormatForField("_id"), instanceOf(ES87BloomFilterPostingsFormat.class));
         assertThat(perFieldMapperCodec.useBloomFilter("another_field"), is(false));
 
-        Class<? extends PostingsFormat> expectedPostingsFormat = PerFieldFormatSupplier.USE_DEFAULT_LUCENE_POSTINGS_FORMAT.isEnabled()
-            && timeSeries == false ? Lucene101PostingsFormat.class : ES812PostingsFormat.class;
+        Class<? extends PostingsFormat> expectedPostingsFormat = ES812PostingsFormat.class;
         assertThat(perFieldMapperCodec.getPostingsFormatForField("another_field"), instanceOf(expectedPostingsFormat));
     }
 
@@ -110,9 +108,7 @@ public class PerFieldMapperCodecTests extends ESTestCase {
     public void testUseBloomFilterWithTimestampFieldEnabled_noTimeSeriesMode() throws IOException {
         PerFieldFormatSupplier perFieldMapperCodec = createFormatSupplier(true, false, false);
         assertThat(perFieldMapperCodec.useBloomFilter("_id"), is(false));
-        Class<? extends PostingsFormat> expectedPostingsFormat = PerFieldFormatSupplier.USE_DEFAULT_LUCENE_POSTINGS_FORMAT.isEnabled()
-            ? Lucene101PostingsFormat.class
-            : ES812PostingsFormat.class;
+        Class<? extends PostingsFormat> expectedPostingsFormat = ES812PostingsFormat.class;
         assertThat(perFieldMapperCodec.getPostingsFormatForField("_id"), instanceOf(expectedPostingsFormat));
     }
 


### PR DESCRIPTION
When the feature flag was enabled, there were many changes happening at the same time. Upgrade to Lucene 10.2 and enabling logsdb by default. The new default codec did have a regression, that was fixed in Lucene with the next bugfix release (apache/lucene#14445).

However, there's been still some noise in the benchmark since standard index mode started to use the default lucene posting format. By temporarily disabling and then enabling after a few days, we hope to get more clarity about whether there is still a regression. I plan to revert this change Monday morning.