### PR TITLE
Deserialize geojson coordinate arrays to double arrays instead of List of Doubles.

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
@@ -223,7 +223,7 @@ public final class GeoJson {
             @Override
             public Void visit(Circle circle) {
                 root.put(FIELD_RADIUS.getPreferredName(), DistanceUnit.METERS.toString(circle.getRadiusMeters()));
-                root.put(FIELD_COORDINATES.getPreferredName(), coordinatesToList(circle.getY(), circle.getX(), circle.getZ()));
+                root.put(FIELD_COORDINATES.getPreferredName(), coordinatesToArray(circle.getX(), circle.getY(), circle.getZ()));
                 return null;
             }
 
@@ -264,13 +264,7 @@ public final class GeoJson {
                 List<Object> points = new ArrayList<>(multiPoint.size());
                 for (int i = 0; i < multiPoint.size(); i++) {
                     Point p = multiPoint.get(i);
-                    List<Object> point = new ArrayList<>();
-                    point.add(p.getX());
-                    point.add(p.getY());
-                    if (p.hasZ()) {
-                        point.add(p.getZ());
-                    }
-                    points.add(point);
+                    points.add(coordinatesToArray(p.getX(), p.getY(), p.getZ()));
                 }
                 root.put(FIELD_COORDINATES.getPreferredName(), points);
                 return null;
@@ -288,7 +282,7 @@ public final class GeoJson {
 
             @Override
             public Void visit(Point point) {
-                root.put(FIELD_COORDINATES.getPreferredName(), coordinatesToList(point.getY(), point.getX(), point.getZ()));
+                root.put(FIELD_COORDINATES.getPreferredName(), coordinatesToArray(point.getX(), point.getY(), point.getZ()));
                 return null;
             }
 
@@ -306,34 +300,26 @@ public final class GeoJson {
             @Override
             public Void visit(Rectangle rectangle) {
                 List<Object> coords = new ArrayList<>(2);
-                coords.add(coordinatesToList(rectangle.getMaxY(), rectangle.getMinX(), rectangle.getMinZ())); // top left
-                coords.add(coordinatesToList(rectangle.getMinY(), rectangle.getMaxX(), rectangle.getMaxZ())); // bottom right
+                coords.add(coordinatesToArray(rectangle.getMinX(), rectangle.getMaxY(), rectangle.getMinZ())); // top left
+                coords.add(coordinatesToArray(rectangle.getMaxX(), rectangle.getMinY(), rectangle.getMaxZ())); // bottom right
                 root.put(FIELD_COORDINATES.getPreferredName(), coords);
                 return null;
             }
 
-            private static List<Object> coordinatesToList(double lat, double lon, double alt) {
-                List<Object> coords = new ArrayList<>(3);
-                coords.add(lon);
-                coords.add(lat);
-                if (Double.isNaN(alt) == false) {
-                    coords.add(alt);
+            private static double[] coordinatesToArray(double lon, double lat, double alt) {
+                if (Double.isNaN(alt)) {
+                    return new double[] { lon, lat };
+                } else {
+                    return new double[] { lon, lat, alt };
                 }
-                return coords;
             }
 
             private static List<Object> coordinatesToList(Line line) {
-                List<Object> lines = new ArrayList<>(line.length());
+                List<Object> coords = new ArrayList<>(line.length());
                 for (int i = 0; i < line.length(); i++) {
-                    List<Object> coords = new ArrayList<>(3);
-                    coords.add(line.getX(i));
-                    coords.add(line.getY(i));
-                    if (line.hasZ()) {
-                        coords.add(line.getZ(i));
-                    }
-                    lines.add(coords);
+                    coords.add(coordinatesToArray(line.getX(i), line.getY(i), line.getZ(i)));
                 }
-                return lines;
+                return coords;
             }
 
             private static List<Object> coordinatesToList(Polygon polygon) {

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoJsonSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoJsonSerializationTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.common.geo;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.utils.GeographyValidator;
@@ -23,6 +24,7 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
@@ -133,7 +135,7 @@ public class GeoJsonSerializationTests extends ESTestCase {
                     .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, input)
             ) {
                 Map<String, Object> map = GeoJson.toMap(geometry);
-                assertThat(parser.map(), equalTo(map));
+                assertThat(parser.map(), equalTo(XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, map).map()));
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointScriptFieldTypeTests.java
@@ -117,6 +117,7 @@ public class GeoPointScriptFieldTypeTests extends AbstractNonTextScriptFieldType
         assertThat(e.getMessage(), equalTo("can't sort on geo_point field without using specific sorting feature, like geo_distance"));
     }
 
+    @SuppressWarnings("unchecked")
     public void testFetch() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
             addDocument(iw, List.of(new StoredField("_source", new BytesRef("""
@@ -126,10 +127,12 @@ public class GeoPointScriptFieldTypeTests extends AbstractNonTextScriptFieldType
                 Source source = searchContext.lookup().getSource(reader.leaves().get(0), 0);
                 ValueFetcher fetcher = simpleMappedFieldType().valueFetcher(searchContext, randomBoolean() ? null : "geojson");
                 fetcher.setNextReader(reader.leaves().get(0));
-                assertThat(
-                    fetcher.fetchValues(source, 0, null),
-                    equalTo(List.of(Map.of("type", "Point", "coordinates", List.of(45.0, 45.0))))
-                );
+                // we need to check manually the map as the assertion methods do not like arrays inside the map
+                Map<String, Object> fetchValue = (Map<String, Object>) fetcher.fetchValues(source, 0, null).get(0);
+                assertThat(fetchValue.size(), equalTo(2));
+                assertThat(fetchValue.get("type"), equalTo("Point"));
+                double[] coordinates = (double[]) fetchValue.get("coordinates");
+                assertThat(coordinates, equalTo(new double[] { 45.0, 45.0 }));
                 fetcher = simpleMappedFieldType().valueFetcher(searchContext, "wkt");
                 fetcher.setNextReader(reader.leaves().get(0));
                 assertThat(fetcher.fetchValues(source, 0, null), equalTo(List.of("POINT (45.0 45.0)")));

--- a/test/framework/src/main/java/org/elasticsearch/geo/GeometryFieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/geo/GeometryFieldTypeTestCase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.geo;
+
+import org.elasticsearch.index.mapper.FieldTypeTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public abstract class GeometryFieldTypeTestCase extends FieldTypeTestCase {
+
+    @SuppressWarnings("unchecked")
+    public static void assertGeoJsonFetch(List<?> expected, List<?> actual) {
+        assertThat(actual.size(), equalTo(expected.size()));
+        for (int i = 0; i < expected.size(); i++) {
+            Object o = expected.get(i);
+            if (o instanceof Map<?, ?> m) {
+                assertGeoJsonFetch(m, (Map<?, ?>) actual.get(i));
+            } else if (o instanceof List<?> l) {
+                assertGeoJsonFetch(l, (List<?>) actual.get(i));
+            } else {
+                assertThat(o, equalTo(actual.get(i)));
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static void assertGeoJsonFetch(Map<?, ?> expected, Map<?, ?> actual) {
+        assertThat(actual.size(), equalTo(expected.size()));
+        for (Map.Entry<?, ?> e : expected.entrySet()) {
+            assertTrue(actual.containsKey(e.getKey()));
+            Object o = e.getValue();
+            if (o instanceof Map<?, ?> m) {
+                assertGeoJsonFetch(m, (Map<String, Object>) actual.get(e.getKey()));
+            } else if (o instanceof List<?> l) {
+                assertGeoJsonFetch(l, (List<?>) actual.get(e.getKey()));
+            } else {
+                assertThat(o, equalTo(actual.get(e.getKey())));
+            }
+        }
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeFieldBlockLoaderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeFieldBlockLoaderTests.java
@@ -11,7 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.geo.GeometryNormalizer;
 import org.elasticsearch.common.geo.Orientation;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.utils.GeographyValidator;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
@@ -19,8 +19,7 @@ import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.mapper.BlockLoaderTestCase;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xcontent.support.MapXContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 import org.elasticsearch.xpack.spatial.datageneration.GeoShapeDataSourceHandler;
 
@@ -80,12 +79,7 @@ public class GeoShapeFieldBlockLoaderTests extends BlockLoaderTestCase {
     @SuppressWarnings("unchecked")
     private Geometry fromGeoJson(Map<?, ?> map) {
         try {
-            var parser = new MapXContentParser(
-                xContentRegistry(),
-                LoggingDeprecationHandler.INSTANCE,
-                (Map<String, Object>) map,
-                XContentType.JSON
-            );
+            var parser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, (Map<String, ?>) map);
             parser.nextToken();
 
             var geometry = GeoJson.fromXContent(GeographyValidator.instance(true), false, true, parser);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldTypeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldTypeTests.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.spatial.index.mapper;
 
+import org.elasticsearch.geo.GeometryFieldTypeTestCase;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
-import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 
@@ -20,29 +20,29 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class PointFieldTypeTests extends FieldTypeTestCase {
+public class PointFieldTypeTests extends GeometryFieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         MappedFieldType mapper = new PointFieldMapper.Builder("field", false).build(MapperBuilderContext.root(false, false)).fieldType();
 
-        Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(42.0, 27.1));
+        Map<String, Object> mapPoint = Map.of("type", "Point", "coordinates", new double[] { 42.0, 27.1 });
         String wktPoint = "POINT (42.0 27.1)";
-        Map<String, Object> otherJsonPoint = Map.of("type", "Point", "coordinates", List.of(30.0, 50.0));
+        Map<String, Object> otherMapPoint = Map.of("type", "Point", "coordinates", new double[] { 30.0, 50.0 });
         String otherWktPoint = "POINT (30.0 50.0)";
         byte[] wkbPoint = WellKnownBinary.toWKB(new Point(42.0, 27.1), ByteOrder.LITTLE_ENDIAN);
         byte[] otherWkbPoint = WellKnownBinary.toWKB(new Point(30.0, 50.0), ByteOrder.LITTLE_ENDIAN);
 
         // Test a single point in [x, y] array format.
         Object sourceValue = List.of(42.0, 27.1);
-        assertEquals(List.of(jsonPoint), fetchSourceValue(mapper, sourceValue, null));
-        assertEquals(List.of(wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+        assertGeoJsonFetch(List.of(mapPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertGeoJsonFetch(List.of(wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
         List<?> wkb = fetchSourceValue(mapper, sourceValue, "wkb");
         assertThat(wkb.size(), equalTo(1));
         assertThat(wkb.get(0), equalTo(wkbPoint));
 
         // Test a single point in "x, y" string format.
         sourceValue = "42.0,27.1";
-        assertEquals(List.of(jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertGeoJsonFetch(List.of(mapPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(List.of(wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
         wkb = fetchSourceValue(mapper, sourceValue, "wkb");
         assertThat(wkb.size(), equalTo(1));
@@ -56,7 +56,7 @@ public class PointFieldTypeTests extends FieldTypeTestCase {
 
         // Test a list of points in [x, y] array format.
         sourceValue = List.of(List.of(42.0, 27.1), List.of(30.0, 50.0));
-        assertEquals(List.of(jsonPoint, otherJsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertGeoJsonFetch(List.of(mapPoint, otherMapPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(List.of(wktPoint, otherWktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
         wkb = fetchSourceValue(mapper, sourceValue, "wkb");
         assertThat(wkb.size(), equalTo(2));
@@ -65,12 +65,12 @@ public class PointFieldTypeTests extends FieldTypeTestCase {
 
         // Test a single point in well-known text format.
         sourceValue = "POINT (42.0 27.1)";
-        assertEquals(List.of(jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertGeoJsonFetch(List.of(mapPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(List.of(wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a list of points in [x, y] array format with a malformed entry
         sourceValue = List.of(List.of(42.0, 27.1), List.of("a", "b"), List.of(30.0, 50.0));
-        assertEquals(List.of(jsonPoint, otherJsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertGeoJsonFetch(List.of(mapPoint, otherMapPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(List.of(wktPoint, otherWktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
     }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldBlockLoaderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldBlockLoaderTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.spatial.index.mapper;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.GeoJson;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
@@ -17,8 +17,7 @@ import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.mapper.BlockLoaderTestCase;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xcontent.support.MapXContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 import org.elasticsearch.xpack.spatial.datageneration.ShapeDataSourceHandler;
 
@@ -77,12 +76,7 @@ public class ShapeFieldBlockLoaderTests extends BlockLoaderTestCase {
     @SuppressWarnings("unchecked")
     private Geometry fromGeoJson(Map<?, ?> map) {
         try {
-            var parser = new MapXContentParser(
-                xContentRegistry(),
-                LoggingDeprecationHandler.INSTANCE,
-                (Map<String, Object>) map,
-                XContentType.JSON
-            );
+            var parser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, (Map<String, ?>) map);
             parser.nextToken();
 
             return GeoJson.fromXContent(StandardValidator.instance(true), false, true, parser);


### PR DESCRIPTION
This should save quite a bit of heap when serializing geojson as a map of maps. The change is pretty straight forward but the testing is more challenging as the current tooling does not work well for asserting equality of maps containing primitive arrays.