### PR TITLE
Don't close indices that are being resharded

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexReshardService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexReshardService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index;
+
+import org.elasticsearch.cluster.ProjectState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Resharding is currently only implemented in Serverless. This service only exposes minimal metadata about resharding
+ * needed by other services.
+ */
+public class IndexReshardService {
+    /**
+     * Returns the indices from the provided set that are currently being resharded.
+     */
+    public static Set<Index> reshardingIndices(final ProjectState projectState, final Set<Index> indicesToCheck) {
+        final Set<Index> indices = new HashSet<>();
+        for (Index index : indicesToCheck) {
+            IndexMetadata indexMetadata = projectState.metadata().index(index);
+
+            if (indexMetadata != null && indexMetadata.getReshardingMetadata() != null) {
+                indices.add(index);
+            }
+        }
+        return indices;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/IndexReshardServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexReshardServiceTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index;
+
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexReshardingMetadata;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class IndexReshardServiceTests extends ESTestCase {
+    public void testReshardingIndices() {
+        var indexMetadata1 = IndexMetadata.builder(randomAlphaOfLength(5)).settings(indexSettings(IndexVersion.current(), 1, 0)).build();
+        var indexMetadata2 = IndexMetadata.builder(indexMetadata1.getIndex().getName() + "2")
+            .settings(indexSettings(IndexVersion.current(), 1, 0))
+            .reshardingMetadata(IndexReshardingMetadata.newSplitByMultiple(1, 2))
+            .build();
+
+        var projectId = randomProjectIdOrDefault();
+
+        var projectMetadataBuilder = ProjectMetadata.builder(projectId);
+        projectMetadataBuilder.put(indexMetadata1, false);
+        projectMetadataBuilder.put(indexMetadata2, false);
+
+        final ClusterState clusterState = ClusterState.builder(new ClusterName("testReshardingIndices"))
+            .putProjectMetadata(projectMetadataBuilder)
+            .build();
+
+        Set<Index> indicesToCheck = new HashSet<>();
+        indicesToCheck.add(indexMetadata1.getIndex());
+        indicesToCheck.add(indexMetadata2.getIndex());
+
+        Set<Index> reshardingIndices = IndexReshardService.reshardingIndices(clusterState.projectState(projectId), indicesToCheck);
+
+        assertEquals(1, reshardingIndices.size());
+        assertTrue(reshardingIndices.contains(indexMetadata2.getIndex()));
+    }
+}


### PR DESCRIPTION
Closing an index with ongoing resharding operation may be problematic. Until the implications of this are tested and understood we'll prevent this from happening. This PR does that.