### PR TITLE
[8.18] Fix: Add NamedWriteable for RuleQueryRankDoc (#128153)

### DIFF
--- a/docs/changelog/128153.yaml
+++ b/docs/changelog/128153.yaml
@@ -1,0 +1,6 @@
+pr: 128153
+summary: "Fix: Add `NamedWriteable` for `RuleQueryRankDoc`"
+area: Relevance
+type: bug
+issues:
+ - 126071

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -30,6 +30,7 @@ import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.search.rank.RankDoc;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry;
 import org.elasticsearch.xpack.application.analytics.action.DeleteAnalyticsCollectionAction;
@@ -179,6 +180,7 @@ import org.elasticsearch.xpack.application.rules.action.TransportPutQueryRuleAct
 import org.elasticsearch.xpack.application.rules.action.TransportPutQueryRulesetAction;
 import org.elasticsearch.xpack.application.rules.action.TransportTestQueryRulesetAction;
 import org.elasticsearch.xpack.application.rules.retriever.QueryRuleRetrieverBuilder;
+import org.elasticsearch.xpack.application.rules.retriever.RuleQueryRankDoc;
 import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.search.action.DeleteSearchApplicationAction;
 import org.elasticsearch.xpack.application.search.action.GetSearchApplicationAction;
@@ -345,6 +347,11 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         }
 
         return Collections.unmodifiableList(actionHandlers);
+    }
+
+    @Override
+    public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return List.of(new NamedWriteableRegistry.Entry(RankDoc.class, RuleQueryRankDoc.NAME, RuleQueryRankDoc::new));
     }
 
     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Fix: Add NamedWriteable for RuleQueryRankDoc (#128153)](https://github.com/elastic/elasticsearch/pull/128153)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)