### PR TITLE
[docs] Add `products` to `docset.yml`

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,4 +1,6 @@
 project: 'Elasticsearch'
+products:
+  - id: elasticsearch
 max_toc_depth: 2
 exclude:
   - README.md

--- a/docs/reference/scripting-languages/painless/brief-painless-walkthrough.md
+++ b/docs/reference/scripting-languages/painless/brief-painless-walkthrough.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-walkthrough.html
+products:
+  - id: painless
 ---
 
 # A brief painless walkthrough [painless-walkthrough]

--- a/docs/reference/scripting-languages/painless/how-painless-dispatches-function.md
+++ b/docs/reference/scripting-languages/painless/how-painless-dispatches-function.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/modules-scripting-painless-dispatch.html
+products:
+  - id: painless
 ---
 
 # How painless dispatches function [modules-scripting-painless-dispatch]

--- a/docs/reference/scripting-languages/painless/painless-analysis-predicate-context.md
+++ b/docs/reference/scripting-languages/painless/painless-analysis-predicate-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-analysis-predicate-context.html
+products:
+  - id: painless
 ---
 
 # Analysis Predicate Context [painless-analysis-predicate-context]

--- a/docs/reference/scripting-languages/painless/painless-api-examples.md
+++ b/docs/reference/scripting-languages/painless/painless-api-examples.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-execute-api.html
+products:
+  - id: painless
 ---
 
 # Painless API examples [painless-execute-api]

--- a/docs/reference/scripting-languages/painless/painless-bucket-script-agg-context.md
+++ b/docs/reference/scripting-languages/painless/painless-bucket-script-agg-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-bucket-script-agg-context.html
+products:
+  - id: painless
 ---
 
 # Bucket script aggregation context [painless-bucket-script-agg-context]

--- a/docs/reference/scripting-languages/painless/painless-bucket-selector-agg-context.md
+++ b/docs/reference/scripting-languages/painless/painless-bucket-selector-agg-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-bucket-selector-agg-context.html
+products:
+  - id: painless
 ---
 
 # Bucket selector aggregation context [painless-bucket-selector-agg-context]

--- a/docs/reference/scripting-languages/painless/painless-casting.md
+++ b/docs/reference/scripting-languages/painless/painless-casting.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-casting.html
+products:
+  - id: painless
 ---
 
 # Casting [painless-casting]

--- a/docs/reference/scripting-languages/painless/painless-comments.md
+++ b/docs/reference/scripting-languages/painless/painless-comments.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-comments.html
+products:
+  - id: painless
 ---
 
 # Comments [painless-comments]

--- a/docs/reference/scripting-languages/painless/painless-context-examples.md
+++ b/docs/reference/scripting-languages/painless/painless-context-examples.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-context-examples.html
+products:
+  - id: painless
 ---
 
 # Context example data [painless-context-examples]

--- a/docs/reference/scripting-languages/painless/painless-contexts.md
+++ b/docs/reference/scripting-languages/painless/painless-contexts.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-contexts.html
+products:
+  - id: painless
 ---
 
 # Painless contexts [painless-contexts]

--- a/docs/reference/scripting-languages/painless/painless-debugging.md
+++ b/docs/reference/scripting-languages/painless/painless-debugging.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-debugging.html
+products:
+  - id: painless
 ---
 
 # Painless debugging [painless-debugging]

--- a/docs/reference/scripting-languages/painless/painless-field-context.md
+++ b/docs/reference/scripting-languages/painless/painless-field-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-field-context.html
+products:
+  - id: painless
 ---
 
 # Field context [painless-field-context]

--- a/docs/reference/scripting-languages/painless/painless-filter-context.md
+++ b/docs/reference/scripting-languages/painless/painless-filter-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-filter-context.html
+products:
+  - id: painless
 ---
 
 # Filter context [painless-filter-context]

--- a/docs/reference/scripting-languages/painless/painless-functions.md
+++ b/docs/reference/scripting-languages/painless/painless-functions.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-functions.html
+products:
+  - id: painless
 ---
 
 # Functions [painless-functions]

--- a/docs/reference/scripting-languages/painless/painless-identifiers.md
+++ b/docs/reference/scripting-languages/painless/painless-identifiers.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-identifiers.html
+products:
+  - id: painless
 ---
 
 # Identifiers [painless-identifiers]

--- a/docs/reference/scripting-languages/painless/painless-ingest-processor-context.md
+++ b/docs/reference/scripting-languages/painless/painless-ingest-processor-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-ingest-processor-context.html
+products:
+  - id: painless
 ---
 
 # Ingest processor context [painless-ingest-processor-context]

--- a/docs/reference/scripting-languages/painless/painless-keywords.md
+++ b/docs/reference/scripting-languages/painless/painless-keywords.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-keywords.html
+products:
+  - id: painless
 ---
 
 # Keywords [painless-keywords]

--- a/docs/reference/scripting-languages/painless/painless-lambdas.md
+++ b/docs/reference/scripting-languages/painless/painless-lambdas.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-lambdas.html
+products:
+  - id: painless
 ---
 
 # Lambdas [painless-lambdas]

--- a/docs/reference/scripting-languages/painless/painless-language-specification.md
+++ b/docs/reference/scripting-languages/painless/painless-language-specification.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-lang-spec.html
+products:
+  - id: painless
 ---
 
 # Painless language specification [painless-lang-spec]

--- a/docs/reference/scripting-languages/painless/painless-literals.md
+++ b/docs/reference/scripting-languages/painless/painless-literals.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-literals.html
+products:
+  - id: painless
 ---
 
 # Literals [painless-literals]

--- a/docs/reference/scripting-languages/painless/painless-metric-agg-combine-context.md
+++ b/docs/reference/scripting-languages/painless/painless-metric-agg-combine-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-metric-agg-combine-context.html
+products:
+  - id: painless
 ---
 
 # Metric aggregation combine context [painless-metric-agg-combine-context]

--- a/docs/reference/scripting-languages/painless/painless-metric-agg-init-context.md
+++ b/docs/reference/scripting-languages/painless/painless-metric-agg-init-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-metric-agg-init-context.html
+products:
+  - id: painless
 ---
 
 # Metric aggregation initialization context [painless-metric-agg-init-context]

--- a/docs/reference/scripting-languages/painless/painless-metric-agg-map-context.md
+++ b/docs/reference/scripting-languages/painless/painless-metric-agg-map-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-metric-agg-map-context.html
+products:
+  - id: painless
 ---
 
 # Metric aggregation map context [painless-metric-agg-map-context]

--- a/docs/reference/scripting-languages/painless/painless-metric-agg-reduce-context.md
+++ b/docs/reference/scripting-languages/painless/painless-metric-agg-reduce-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-metric-agg-reduce-context.html
+products:
+  - id: painless
 ---
 
 # Metric aggregation reduce context [painless-metric-agg-reduce-context]

--- a/docs/reference/scripting-languages/painless/painless-min-should-match-context.md
+++ b/docs/reference/scripting-languages/painless/painless-min-should-match-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-min-should-match-context.html
+products:
+  - id: painless
 ---
 
 # Minimum should match context [painless-min-should-match-context]

--- a/docs/reference/scripting-languages/painless/painless-operators-array.md
+++ b/docs/reference/scripting-languages/painless/painless-operators-array.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-operators-array.html
+products:
+  - id: painless
 ---
 
 # Operators: Array [painless-operators-array]

--- a/docs/reference/scripting-languages/painless/painless-operators-boolean.md
+++ b/docs/reference/scripting-languages/painless/painless-operators-boolean.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-operators-boolean.html
+products:
+  - id: painless
 ---
 
 # Operators: Boolean [painless-operators-boolean]

--- a/docs/reference/scripting-languages/painless/painless-operators-general.md
+++ b/docs/reference/scripting-languages/painless/painless-operators-general.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-operators-general.html
+products:
+  - id: painless
 ---
 
 # Operators: General [painless-operators-general]

--- a/docs/reference/scripting-languages/painless/painless-operators-numeric.md
+++ b/docs/reference/scripting-languages/painless/painless-operators-numeric.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-operators-numeric.html
+products:
+  - id: painless
 ---
 
 # Operators: Numeric [painless-operators-numeric]

--- a/docs/reference/scripting-languages/painless/painless-operators-reference.md
+++ b/docs/reference/scripting-languages/painless/painless-operators-reference.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-operators-reference.html
+products:
+  - id: painless
 ---
 
 # Operators: Reference [painless-operators-reference]

--- a/docs/reference/scripting-languages/painless/painless-operators.md
+++ b/docs/reference/scripting-languages/painless/painless-operators.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-operators.html
+products:
+  - id: painless
 ---
 
 # Operators [painless-operators]

--- a/docs/reference/scripting-languages/painless/painless-regexes.md
+++ b/docs/reference/scripting-languages/painless/painless-regexes.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-regexes.html
+products:
+  - id: painless
 ---
 
 # Regexes [painless-regexes]

--- a/docs/reference/scripting-languages/painless/painless-reindex-context.md
+++ b/docs/reference/scripting-languages/painless/painless-reindex-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-reindex-context.html
+products:
+  - id: painless
 ---
 
 # Reindex context [painless-reindex-context]

--- a/docs/reference/scripting-languages/painless/painless-runtime-fields-context.md
+++ b/docs/reference/scripting-languages/painless/painless-runtime-fields-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-runtime-fields-context.html
+products:
+  - id: painless
 ---
 
 # Runtime fields context [painless-runtime-fields-context]

--- a/docs/reference/scripting-languages/painless/painless-score-context.md
+++ b/docs/reference/scripting-languages/painless/painless-score-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-score-context.html
+products:
+  - id: painless
 ---
 
 # Score context [painless-score-context]

--- a/docs/reference/scripting-languages/painless/painless-scripts.md
+++ b/docs/reference/scripting-languages/painless/painless-scripts.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-scripts.html
+products:
+  - id: painless
 ---
 
 # Scripts [painless-scripts]

--- a/docs/reference/scripting-languages/painless/painless-similarity-context.md
+++ b/docs/reference/scripting-languages/painless/painless-similarity-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-similarity-context.html
+products:
+  - id: painless
 ---
 
 # Similarity context [painless-similarity-context]

--- a/docs/reference/scripting-languages/painless/painless-sort-context.md
+++ b/docs/reference/scripting-languages/painless/painless-sort-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-sort-context.html
+products:
+  - id: painless
 ---
 
 # Sort context [painless-sort-context]

--- a/docs/reference/scripting-languages/painless/painless-statements.md
+++ b/docs/reference/scripting-languages/painless/painless-statements.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-statements.html
+products:
+  - id: painless
 ---
 
 # Statements [painless-statements]

--- a/docs/reference/scripting-languages/painless/painless-types.md
+++ b/docs/reference/scripting-languages/painless/painless-types.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-types.html
+products:
+  - id: painless
 ---
 
 # Types [painless-types]

--- a/docs/reference/scripting-languages/painless/painless-update-by-query-context.md
+++ b/docs/reference/scripting-languages/painless/painless-update-by-query-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-update-by-query-context.html
+products:
+  - id: painless
 ---
 
 # Update by query context [painless-update-by-query-context]

--- a/docs/reference/scripting-languages/painless/painless-update-context.md
+++ b/docs/reference/scripting-languages/painless/painless-update-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-update-context.html
+products:
+  - id: painless
 ---
 
 # Update context [painless-update-context]

--- a/docs/reference/scripting-languages/painless/painless-variables.md
+++ b/docs/reference/scripting-languages/painless/painless-variables.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-variables.html
+products:
+  - id: painless
 ---
 
 # Variables [painless-variables]

--- a/docs/reference/scripting-languages/painless/painless-watcher-condition-context.md
+++ b/docs/reference/scripting-languages/painless/painless-watcher-condition-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-watcher-condition-context.html
+products:
+  - id: painless
 ---
 
 # Watcher condition context [painless-watcher-condition-context]

--- a/docs/reference/scripting-languages/painless/painless-watcher-transform-context.md
+++ b/docs/reference/scripting-languages/painless/painless-watcher-transform-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-watcher-transform-context.html
+products:
+  - id: painless
 ---
 
 # Watcher transform context [painless-watcher-transform-context]

--- a/docs/reference/scripting-languages/painless/painless-weight-context.md
+++ b/docs/reference/scripting-languages/painless/painless-weight-context.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-weight-context.html
+products:
+  - id: painless
 ---
 
 # Weight context [painless-weight-context]

--- a/docs/reference/scripting-languages/painless/painless.md
+++ b/docs/reference/scripting-languages/painless/painless.md
@@ -2,6 +2,8 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-guide.html
+products:
+  - id: painless
 ---
 
 # Painless [painless-guide]

--- a/docs/reference/scripting-languages/painless/use-painless-scripts-in-runtime-fields.md
+++ b/docs/reference/scripting-languages/painless/use-painless-scripts-in-runtime-fields.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-runtime-fields.html
+products:
+  - id: painless
 ---
 
 # Use painless scripts in runtime fields [painless-runtime-fields]

--- a/docs/reference/scripting-languages/painless/using-datetime-in-painless.md
+++ b/docs/reference/scripting-languages/painless/using-datetime-in-painless.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-datetime.html
+products:
+  - id: painless
 ---
 
 # Using datetime in Painless [painless-datetime]

--- a/docs/reference/scripting-languages/painless/using-ingest-processors-in-painless.md
+++ b/docs/reference/scripting-languages/painless/using-ingest-processors-in-painless.md
@@ -1,6 +1,8 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-ingest.html
+products:
+  - id: painless
 ---
 
 # Using ingest processors in Painless [painless-ingest]


### PR DESCRIPTION
Related to https://github.com/elastic/docs-builder/issues/1200

Add `products` to `docset.yml` to be used in the search experience.

Note: This should result in both `elasticsearch` and `painless` product tags for [Painless pages](https://www.elastic.co/docs/reference/scripting-languages/painless/painless) and just `elasticsearch` product tags for all other pages.

cc @KOTungseth 