### PR TITLE
Improve get-snapshots behaviour for unreadable repositories

### DIFF
--- a/docs/changelog/128277.yaml
+++ b/docs/changelog/128277.yaml
@@ -1,0 +1,5 @@
+pr: 128277
+summary: Improve get-snapshots behaviour for unreadable repositories
+area: Snapshot/Restore
+type: enhancement
+issues: []


### PR DESCRIPTION
Today if the get-snapshots API cannot access one of the repositories we
return an exception with a fairly low-level message about the problem,
perhaps `Could not determine repository generation from root blobs`.
This message is shown verbatim in the Kibana UI so users need something
a little more descriptive. With this commit we wrap the exception in one
that indicates the problem in terms that users are more likely to
understand.

Moreover, if the user specifies the `?ignore_unavailable` option then we
ignore individual snapshots that are unavailable, treating them as if
they do not exist, but an unavailable repository will still cause the
API to return an exception. With this commit we extend the meaning of
this option to also ignore whole-repository unavailability, treating
unavailable repositories as if they are empty.

Relates #128208