### PR TITLE
[8.18] Default tests.security.manager to false (#128252)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -152,7 +152,7 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
                 "tests.artifact",
                 project.getName(),
                 "tests.security.manager",
-                "true",
+                "false",
                 "jna.nosys",
                 "true"
             );


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Default tests.security.manager to false (#128252)