### PR TITLE
Tighten up `readonly` invariants on repositories

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
@@ -171,6 +171,7 @@ public final class TransportCleanupRepositoryAction extends TransportMasterNodeA
                     @Override
                     public ClusterState execute(ClusterState currentState) {
                         SnapshotsService.ensureRepositoryExists(repositoryName, currentState);
+                        SnapshotsService.ensureNotReadOnly(currentState, repositoryName);
                         final RepositoryCleanupInProgress repositoryCleanupInProgress = RepositoryCleanupInProgress.get(currentState);
                         if (repositoryCleanupInProgress.hasCleanupInProgress()) {
                             throw new IllegalStateException(

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -49,6 +49,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.repositories.VerifyNodeRepositoryAction.Request;
+import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.repositories.blobstore.MeteredBlobStoreRepository;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -288,6 +289,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
             List<RepositoryMetadata> repositoriesMetadata = new ArrayList<>(repositories.repositories().size() + 1);
             for (RepositoryMetadata repositoryMetadata : repositories.repositories()) {
                 if (repositoryMetadata.name().equals(request.name())) {
+                    rejectInvalidReadonlyFlagChange(repositoryMetadata, request.settings());
                     final RepositoryMetadata newRepositoryMetadata = new RepositoryMetadata(
                         request.name(),
                         // Copy the UUID from the existing instance rather than resetting it back to MISSING_UUID which would force us to
@@ -600,6 +602,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
     public void applyClusterState(ClusterChangedEvent event) {
         try {
             final ClusterState state = event.state();
+            assert assertReadonlyRepositoriesNotInUseForWrites(state);
             final RepositoriesMetadata oldMetadata = RepositoriesMetadata.get(event.previousState());
             final RepositoriesMetadata newMetadata = RepositoriesMetadata.get(state);
 
@@ -884,7 +887,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
         }
     }
 
-    private static void ensureRepositoryNotInUse(ClusterState clusterState, String repository) {
+    private static void ensureRepositoryNotInUseForWrites(ClusterState clusterState, String repository) {
         if (SnapshotsInProgress.get(clusterState).forRepo(repository).isEmpty() == false) {
             throw newRepositoryConflictException(repository, "snapshot is in progress");
         }
@@ -898,10 +901,54 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                 throw newRepositoryConflictException(repository, "repository clean up is in progress");
             }
         }
+    }
+
+    private static void ensureRepositoryNotInUse(ClusterState clusterState, String repository) {
+        ensureRepositoryNotInUseForWrites(clusterState, repository);
         for (RestoreInProgress.Entry entry : RestoreInProgress.get(clusterState)) {
             if (repository.equals(entry.snapshot().getRepository())) {
                 throw newRepositoryConflictException(repository, "snapshot restore is in progress");
             }
+        }
+    }
+
+    public static boolean isReadOnly(Settings repositorySettings) {
+        return Boolean.TRUE.equals(repositorySettings.getAsBoolean(BlobStoreRepository.READONLY_SETTING_KEY, null));
+    }
+
+    /**
+     * Test-only check for the invariant that read-only repositories never have any write activities.
+     */
+    private static boolean assertReadonlyRepositoriesNotInUseForWrites(ClusterState clusterState) {
+        for (final var repositoryMetadata : RepositoriesMetadata.get(clusterState).repositories()) {
+            if (isReadOnly(repositoryMetadata.settings())) {
+                try {
+                    ensureRepositoryNotInUseForWrites(clusterState, repositoryMetadata.name());
+                } catch (Exception e) {
+                    throw new AssertionError("repository [" + repositoryMetadata + "] is readonly but still in use", e);
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Reject a change to the {@code readonly} setting if there is a pending generation change in progress, i.e. some node somewhere is
+     * updating the root {@link RepositoryData} blob.
+     */
+    private static void rejectInvalidReadonlyFlagChange(RepositoryMetadata existingRepositoryMetadata, Settings newSettings) {
+        if (isReadOnly(newSettings)
+            && isReadOnly(existingRepositoryMetadata.settings()) == false
+            && existingRepositoryMetadata.generation() >= RepositoryData.EMPTY_REPO_GEN
+            && existingRepositoryMetadata.generation() != existingRepositoryMetadata.pendingGeneration()) {
+            throw newRepositoryConflictException(
+                existingRepositoryMetadata.name(),
+                Strings.format(
+                    "currently updating root blob generation from [%d] to [%d], cannot update readonly flag",
+                    existingRepositoryMetadata.generation(),
+                    existingRepositoryMetadata.pendingGeneration()
+                )
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -337,6 +337,7 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
                 ensureRepositoryExists(repositoryName, currentState);
                 ensureSnapshotNameAvailableInRepo(repositoryData, snapshotName, repository);
                 ensureNoCleanupInProgress(currentState, repositoryName, snapshotName, "clone snapshot");
+                ensureNotReadOnly(currentState, repositoryName);
                 final SnapshotsInProgress snapshots = SnapshotsInProgress.get(currentState);
                 ensureSnapshotNameNotRunning(snapshots, repositoryName, snapshotName);
                 validate(repositoryName, snapshotName, currentState);
@@ -429,6 +430,13 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
                         .map(RepositoryCleanupInProgress.Entry::repository)
                         .collect(Collectors.toSet())
             );
+        }
+    }
+
+    public static void ensureNotReadOnly(final ClusterState currentState, final String repositoryName) {
+        final var repositoryMetadata = RepositoriesMetadata.get(currentState).repository(repositoryName);
+        if (RepositoriesService.isReadOnly(repositoryMetadata.settings())) {
+            throw new RepositoryException(repositoryMetadata.name(), "repository is readonly");
         }
     }
 
@@ -2151,6 +2159,8 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
                     snapshotIds.stream().findFirst().get().getName(),
                     "delete snapshot"
                 );
+
+                ensureNotReadOnly(currentState, repositoryName);
 
                 final SnapshotDeletionsInProgress deletionsInProgress = SnapshotDeletionsInProgress.get(currentState);
 
@@ -3991,8 +4001,13 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
             for (final var taskContext : batchExecutionContext.taskContexts()) {
                 if (taskContext.getTask() instanceof CreateSnapshotTask task) {
                     try {
-                        registeredPolicySnapshots.maybeAdd(task.createSnapshotRequest.userMetadata(), task.snapshot.getSnapshotId());
                         final var repoMeta = RepositoriesMetadata.get(state).repository(task.snapshot.getRepository());
+                        if (RepositoriesService.isReadOnly(repoMeta.settings())) {
+                            taskContext.onFailure(new RepositoryException(repoMeta.name(), "repository is readonly"));
+                            continue;
+                        }
+
+                        registeredPolicySnapshots.maybeAdd(task.createSnapshotRequest.userMetadata(), task.snapshot.getSnapshotId());
                         if (Objects.equals(task.initialRepositoryMetadata, repoMeta)) {
                             snapshotsInProgress = createSnapshot(task, taskContext, state, snapshotsInProgress);
                         } else {

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -21,12 +21,18 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRes
 import org.elasticsearch.action.admin.cluster.snapshots.create.TransportCreateSnapshotAction;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.TransportGetSnapshotsAction;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.action.support.RefCountingRunnable;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Numbers;
@@ -211,6 +217,89 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         assertEquals(ESBlobStoreRepositoryIntegTestCase.getRepositoryData(repository), repositoryData);
         assertThat(repository.latestIndexBlobId(), equalTo(expectedGeneration + 2L));
         assertThat(repository.readSnapshotIndexLatestBlob(), equalTo(expectedGeneration + 2L));
+
+        // adding more snapshots to check that writeIndexGen checks the actual repo metadata and fails on a readonly repository
+        final var newRepositoryData = addRandomSnapshotsToRepoData(ESBlobStoreRepositoryIntegTestCase.getRepositoryData(repository), true);
+        final var barrier = new CyclicBarrier(2);
+        final var setReadonlyPromise = blockAndSetRepositoryReadOnly(repository.getMetadata().name(), barrier);
+        safeAwait(barrier); // wait for set-readonly task to start executing
+        safeAwait(l -> {
+            repository.writeIndexGen(
+                newRepositoryData,
+                newRepositoryData.getGenId(),
+                IndexVersion.current(),
+                Function.identity(),
+                ActionTestUtils.assertNoSuccessListener(e -> {
+                    assertThat(
+                        asInstanceOf(RepositoryException.class, e).getMessage(),
+                        containsString("[test-repo] Failed to execute cluster state update [set pending repository generation")
+                    );
+                    assertThat(
+                        asInstanceOf(RepositoryException.class, e.getCause()).getMessage(),
+                        containsString("[test-repo] repository is readonly, cannot update root blob")
+                    );
+                    l.onResponse(null);
+                })
+            );
+            safeAwait(barrier); // allow set-readonly task to proceed now that the set-pending-generation task is enqueued
+        });
+        safeAwait(setReadonlyPromise);
+    }
+
+    /**
+     * Submits a cluster state update which blocks on the {@code barrier} twice and then marks the given repository as readonly.
+     * @return a promise that is completed when the cluster state update finishes.
+     */
+    private SubscribableListener<Void> blockAndSetRepositoryReadOnly(String repositoryName, CyclicBarrier barrier) {
+        return SubscribableListener.newForked(
+            l -> getInstanceFromNode(ClusterService.class).submitUnbatchedStateUpdateTask(
+                "update readonly flag",
+                new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        safeAwait(barrier);
+                        safeAwait(barrier);
+                        return new ClusterState.Builder(currentState).metadata(
+                            Metadata.builder(currentState.metadata())
+                                .putCustom(
+                                    RepositoriesMetadata.TYPE,
+                                    new RepositoriesMetadata(
+                                        RepositoriesMetadata.get(currentState)
+                                            .repositories()
+                                            .stream()
+                                            .map(
+                                                r -> r.name().equals(repositoryName)
+                                                    ? new RepositoryMetadata(
+                                                        r.name(),
+                                                        r.uuid(),
+                                                        r.type(),
+                                                        Settings.builder()
+                                                            .put(r.settings())
+                                                            .put(BlobStoreRepository.READONLY_SETTING_KEY, "true")
+                                                            .build(),
+                                                        r.generation(),
+                                                        r.pendingGeneration()
+                                                    )
+                                                    : r
+                                            )
+                                            .toList()
+                                    )
+                                )
+                        ).build();
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        l.onFailure(e);
+                    }
+
+                    @Override
+                    public void clusterStateProcessed(ClusterState initialState, ClusterState newState) {
+                        l.onResponse(null);
+                    }
+                }
+            )
+        );
     }
 
     public void testCorruptIndexLatestFile() throws Exception {


### PR DESCRIPTION
Today there are various mechanisms to prevent writes to readonly
repositories, but they are scattered across the snapshot codebase and do
not obviously prevent writes in all possible circumstances; it'd be easy
to add a new operation on a repository that does not check the readonly
flag in quite the right way.

This commit adds much tighter checks which cannot be circumvented:

- Do not allow to start an update of the root `index-N` blob if the
  repository is marked as readonly in the cluster state.

- Conversely, do not allow the readonly flag to be set if an update of
  the root `index-N` blob is in progress.

- Establish the invariant that we never create a
  `SnapshotsInProgress$Entry`, `SnapshotDeletionsInProgress$Entry`, or
  `RepositoryCleanupInProgress$Entry` if the repository is marked as
  readonly in the cluster state.

Closes #93575

Backport of #127964 to `8.19`