### PR TITLE
Fix the Text class package change in example plugins

### DIFF
--- a/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggester.java
+++ b/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggester.java
@@ -11,7 +11,7 @@ package org.elasticsearch.example.customsuggester;
 
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.util.CharsRefBuilder;
-import org.elasticsearch.common.text.Text;
+import org.elasticsearch.xcontent.Text;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.search.suggest.Suggester;
 

--- a/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggestion.java
+++ b/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggestion.java
@@ -11,7 +11,7 @@ package org.elasticsearch.example.customsuggester;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.text.Text;
+import org.elasticsearch.xcontent.Text;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/127666 we changed the package for the Text class; example plugins however are not part of the source folders in Intellij and are not built as part of the normal CI process, so changes in example plugins were not done.

This PR updates the missing changes to the package.

I don't know if the CI will pick up this and build them, but anyway I run the build locally and it passes (build scan here): https://gradle-enterprise.elastic.co/s/nlajrzz3gpzoe 
