### PR TITLE
Fix thread leak in ManyShardsIT

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/iterable/Iterables.java
+++ b/server/src/main/java/org/elasticsearch/common/util/iterable/Iterables.java
@@ -79,6 +79,6 @@ public class Iterables {
     }
 
     public static long size(Iterable<?> iterable) {
-        return StreamSupport.stream(iterable.spliterator(), true).count();
+        return StreamSupport.stream(iterable.spliterator(), false).count();
     }
 }


### PR DESCRIPTION
Today `Iterables.size` is implemented as following:
```
    public static long size(Iterable<?> iterable) {
        return StreamSupport.stream(iterable.spliterator(), true).count();
    }
```
please note the second parameter passed to `stream` call: `parallel=true`.
A parallel stream starts a fork join ForkJoinPool. It is never closed here as stream is not closed explicitly nor used in try block.

This results in a thread leak that was detected in #127196. Surprisingly it was only happening on JDK 21.

I do not think there is any benefit of counting number of entries concurrently so I am changing the call to use non-parallel stream.

This method is also used in prod, so I am adding core/infra to this review.

Closes: #127196
