### PR TITLE
[ML] Use internal user for internal inference action

### DIFF
--- a/docs/changelog/128327.yaml
+++ b/docs/changelog/128327.yaml
@@ -1,0 +1,5 @@
+pr: 128327
+summary: Use internal user for internal inference action
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceRunner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceRunner.java
@@ -76,12 +76,6 @@ public class InferenceRunner {
     }
 
     public void doInference(InferenceAction.Request request, ActionListener<InferenceAction.Response> listener) {
-        executeAsyncWithOrigin(
-            client,
-            INFERENCE_ORIGIN,
-            InferenceAction.INSTANCE,
-            request,
-            listener
-        );
+        executeAsyncWithOrigin(client, INFERENCE_ORIGIN, InferenceAction.INSTANCE, request, listener);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceRunner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceRunner.java
@@ -21,6 +21,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.xpack.core.ClientHelper.INFERENCE_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
 public class InferenceRunner {
 
     private final Client client;
@@ -73,6 +76,12 @@ public class InferenceRunner {
     }
 
     public void doInference(InferenceAction.Request request, ActionListener<InferenceAction.Response> listener) {
-        client.execute(InferenceAction.INSTANCE, request, listener);
+        executeAsyncWithOrigin(
+            client,
+            INFERENCE_ORIGIN,
+            InferenceAction.INSTANCE,
+            request,
+            listener
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
@@ -25,6 +25,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.core.ClientHelper.INFERENCE_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
 /**
  * A {@code RankFeaturePhaseRankCoordinatorContext} that performs a rerank inference call to determine relevance scores for documents within
  * the provided rank window.
@@ -114,7 +117,7 @@ public class TextSimilarityRankFeaturePhaseRankCoordinatorContext extends RankFe
                 List<String> featureData = Arrays.stream(featureDocs).map(x -> x.featureData).toList();
                 InferenceAction.Request inferenceRequest = generateRequest(featureData);
                 try {
-                    client.execute(InferenceAction.INSTANCE, inferenceRequest, inferenceListener);
+                    executeAsyncWithOrigin(client, INFERENCE_ORIGIN, InferenceAction.INSTANCE, inferenceRequest, inferenceListener);
                 } finally {
                     inferenceRequest.decRef();
                 }


### PR DESCRIPTION
When we added the proxy action it caused a bug because we moved the `InferenceAction.Request` to an internal action instead of `monitor`([here](https://github.com/elastic/elasticsearch/pull/121804/files#diff-04e56a3c6bb2c08146b9ab94d337fa65880dab05ad41345d8c3c9f43f631ab1eR50)). There are a few places where we're using the `InferenceAction.Request` directly. In these situations we need to execute the client using the `INFERENCE_ORIGIN` to indicate that we're acting as the internal user. Otherwise we'd get an error when a read only user (with only `monitor_inference` privileges) attempts to make inference requests.

## Reproducing the issue

<details>

The issue can be reproduced like the following:

```
PUT _inference/rerank/coherererank
{
    "service": "cohere",
    "service_settings": {
        "api_key": "api_key",
        "model_id": "rerank-v3.5"
    }
}

PUT jon/_doc/1?pretty
{
    "title": "The Terminator",
    "overview": "A cyborg is sent back in time to kill Sarah Connor."
}

PUT jon/_doc/2?pretty
{
    "title": "Terminator 2: Judgment Day",
    "overview": "A cyborg is sent back in time to protect John Connor."
}
PUT jon/_doc/3?pretty
{
    "title": "Terminator Genisys",
    "overview": "A cyborg is sent back in time to protect Sarah Connor."
}

GET jon/_search <-- This should result in a permissions error
{
    "_source": [
        "title"
    ],
    "retriever": {
        "text_similarity_reranker": {
            "retriever": {
                "standard": {
                    "query": {
                        "multi_match": {
                            "fields": [
                                "title",
                                "overview"
                            ],
                            "query": "terminator arnold"
                        }
                    }
                }
            },
            "field": "title",
            "inference_text": "terminator arnold",
            "inference_id": "coherererank"
        }
    }
}

POST /_query?format=txt <--- this should also fail
{
    "query": "FROM jon | KEEP title, overview | SORT title DESC | LIMIT 10 | RERANK \"terminator arnold\" ON title WITH coherererank"
}

```

### Error
```
{
    "error": {
        "root_cause": [
            {
                "type": "status_exception",
                "reason": "[text_similarity_reranker] search failed - retrievers '[standard]' returned errors. All failures are attached as suppressed exceptions.",
                "suppressed": [
                    {
                        "type": "search_phase_execution_exception",
                        "reason": "Computing updated ranks for results failed",
                        "phase": "rank-feature",
                        "grouped": true,
                        "failed_shards": []
                    }
                ]
            }
        ],
        "type": "status_exception",
        "reason": "[text_similarity_reranker] search failed - retrievers '[standard]' returned errors. All failures are attached as suppressed exceptions.",
        "suppressed": [
            {
                "type": "search_phase_execution_exception",
                "reason": "Computing updated ranks for results failed",
                "phase": "rank-feature",
                "grouped": true,
                "failed_shards": [],
                "caused_by": {
                    "type": "security_exception",
                    "reason": "action [cluster:internal/xpack/inference] is unauthorized for user [test_read_user] with effective roles [test_read], this action is granted by the cluster privileges [manage,all]"
                }
            }
        ]
    },
    "status": 403
}
```

</details>

## Testing that it works correctly

To ensure the fix works we can do the following

<details>


### Create a role with only monitor_inference

```
POST _security/role/test_read?pretty
{
    "cluster": ["monitor_inference"],
    "indices": [
      {
        "names": [
          "jon*"
        ],
        "privileges": [
          "read"
        ],
        "allow_restricted_indices": false
      }
    ]
}
```

### Create a user that uses the role

```
POST _security/user/test_read_user?pretty
{
    "password": "password",
    "roles": [
      "test_read"
    ]
}
```

### Perform the request with the test_read_user

```
GET jon/_search
{
    "_source": [
        "title"
    ],
    "retriever": {
        "text_similarity_reranker": {
            "retriever": {
                "standard": {
                    "query": {
                        "multi_match": {
                            "fields": [
                                "title",
                                "overview"
                            ],
                            "query": "terminator arnold"
                        }
                    }
                }
            },
            "field": "title",
            "inference_text": "terminator arnold",
            "inference_id": "coherererank"
        }
    }
}
```

```
POST /_query?format=txt
{
    "query": "FROM jon | KEEP title, overview | SORT title DESC | LIMIT 10 | RERANK \"terminator arnold\" ON title WITH coherererank"
}
```

</details>