### PR TITLE
from needs to less than to in float range

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/FloatRangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FloatRangeFieldMapperTests.java
@@ -42,10 +42,11 @@ public class FloatRangeFieldMapperTests extends RangeFieldMapperTests {
 
     @Override
     protected TestRange<Float> randomRangeForSyntheticSourceTest() {
-        var includeFrom = randomBoolean();
         Float from = (float) randomDoubleBetween(-Float.MAX_VALUE, Float.MAX_VALUE - Math.ulp(Float.MAX_VALUE), true);
-        var includeTo = randomBoolean();
         Float to = (float) randomDoubleBetween(from + Math.ulp(from), Float.MAX_VALUE, true);
+        boolean valuesAdjacent = Math.nextUp(from) > Math.nextDown(to);
+        var includeFrom = valuesAdjacent || randomBoolean();
+        var includeTo = valuesAdjacent || randomBoolean();
 
         if (rarely()) {
             from = null;


### PR DESCRIPTION
When testing float range, the from and to values are generated then it is decided whether or not to include the bounds within the range. If the values are not included in the range, the min value is calculated as the next higher float value than from and to as the next lower float value. If from and to are immediately adjacent to each other, and bounds are not included, the lower end of the range will be larger than the upper.