### PR TITLE
[9.0] [ML] Use internal user for internal inference action (#128327)

### DIFF
--- a/docs/changelog/128327.yaml
+++ b/docs/changelog/128327.yaml
@@ -1,0 +1,5 @@
+pr: 128327
+summary: Use internal user for internal inference action
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
@@ -25,6 +25,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.core.ClientHelper.INFERENCE_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
 /**
  * A {@code RankFeaturePhaseRankCoordinatorContext} that performs a rerank inference call to determine relevance scores for documents within
  * the provided rank window.
@@ -113,7 +116,7 @@ public class TextSimilarityRankFeaturePhaseRankCoordinatorContext extends RankFe
                 List<String> featureData = Arrays.stream(featureDocs).map(x -> x.featureData).toList();
                 InferenceAction.Request inferenceRequest = generateRequest(featureData);
                 try {
-                    client.execute(InferenceAction.INSTANCE, inferenceRequest, inferenceListener);
+                    executeAsyncWithOrigin(client, INFERENCE_ORIGIN, InferenceAction.INSTANCE, inferenceRequest, inferenceListener);
                 } finally {
                     inferenceRequest.decRef();
                 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[ML] Use internal user for internal inference action (#128327)](https://github.com/elastic/elasticsearch/pull/128327)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)