### PR TITLE
Avoiding infinite loop for invalid files in rest spec parser

### DIFF
--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
@@ -34,6 +34,12 @@ public class ClientYamlSuiteRestApiParser {
     public ClientYamlSuiteRestApi parse(String location, XContentParser parser) throws IOException {
 
         while (parser.nextToken() != XContentParser.Token.FIELD_NAME) {
+            if (parser.currentToken() == null) {
+                throw new ParsingException(
+                    parser.getTokenLocation(),
+                    "Invalid rest spec file found at [" + location + "]. No API name found in file"
+                );
+            }
             // move to first field name
         }
 


### PR DESCRIPTION
If a yaml rest spec file is empty or otherwise has no field name, the rest spec parser will get stuck in an infinite loop. This change intentionally throws an error in that loop if it can't possibly proceed.