### PR TITLE
Allow for mark == bytes.length in SlicedInputStreamTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
@@ -178,7 +178,8 @@ public class SlicedInputStreamTests extends ESTestCase {
         // Reset
         input.reset();
         int slicesOpenedAfterReset = streamsOpened.size();
-        assert moreBytes > 0 || mark == 0 || slicesOpenedAfterReset == slicesOpenedAtMark : "Reset at mark should not re-open slices";
+        assert moreBytes > 0 || mark == 0 || mark == bytes.length || slicesOpenedAfterReset == slicesOpenedAtMark
+            : "Reset at mark should not re-open slices";
 
         // Read all remaining bytes, which should be the bytes from mark up to the end
         final int remainingBytes = bytes.length - mark;


### PR DESCRIPTION
### Background

I saw this error on a build on commit 4faef7272172525700ddd878876a612184536b95:

```
REPRODUCE WITH: gradlew ":server:test" --tests "org.elasticsearch.index.snapshots.blobstore.SlicedInputStreamTests.testRandomMarkReset" -Dtests.seed=57395327998DD7F4 -Dtests.locale=ast-Latn-ES -Dtests.timezone=Asia/Yekaterinburg -Druntime.java=24
SlicedInputStreamTests > testRandomMarkReset FAILED
    java.lang.AssertionError: Reset at mark should not re-open slices
        at __randomizedtesting.SeedInfo.seed([57395327998DD7F4:57FCBCBA4A77F350]:0)
        at org.elasticsearch.index.snapshots.blobstore.SlicedInputStreamTests.testRandomMarkReset(SlicedInputStreamTests.java:181)
```

### Hypothesis

In the case that the mark is at the very end of the stream, the slice's stream could already be closed by the time we call `reset()`, and so the stream must be reopened.

### Test fix

Change the test so the above assertion passes whenever the `mark` is right at the end of the input.