### PR TITLE
Change exceptions to IllegalArgumentException in GroupingDocValuesSelector

### DIFF
--- a/server/src/main/java/org/elasticsearch/lucene/grouping/GroupingDocValuesSelector.java
+++ b/server/src/main/java/org/elasticsearch/lucene/grouping/GroupingDocValuesSelector.java
@@ -100,7 +100,7 @@ abstract class GroupingDocValuesSelector<T> extends GroupSelector<T> {
                             public boolean advanceExact(int target) throws IOException {
                                 if (sorted.advanceExact(target)) {
                                     if (sorted.docValueCount() > 1) {
-                                        throw new IllegalStateException(
+                                        throw new IllegalArgumentException(
                                             "failed to extract doc:" + target + ", the grouping field must be single valued"
                                         );
                                     }
@@ -124,7 +124,7 @@ abstract class GroupingDocValuesSelector<T> extends GroupSelector<T> {
                         };
                     }
                 }
-                default -> throw new IllegalStateException("unexpected doc values type " + type + "` for field `" + field + "`");
+                default -> throw new IllegalArgumentException("unexpected doc values type " + type + "` for field `" + field + "`");
             }
         }
 
@@ -200,7 +200,7 @@ abstract class GroupingDocValuesSelector<T> extends GroupSelector<T> {
                             public boolean advanceExact(int target) throws IOException {
                                 if (sorted.advanceExact(target)) {
                                     if (sorted.docValueCount() > 1) {
-                                        throw new IllegalStateException(
+                                        throw new IllegalArgumentException(
                                             "failed to extract doc:" + target + ", the grouping field must be single valued"
                                         );
                                     }
@@ -233,7 +233,7 @@ abstract class GroupingDocValuesSelector<T> extends GroupSelector<T> {
                         };
                     }
                 }
-                default -> throw new IllegalStateException("unexpected doc values type " + type + "` for field `" + field + "`");
+                default -> throw new IllegalArgumentException("unexpected doc values type " + type + "` for field `" + field + "`");
             }
         }
 


### PR DESCRIPTION
The exceptions happens when user provides unsupported doc value types (either the type is wrong or it is multi-valued) so the rest status code should be 400 instead of 500. 

Current error:

```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_state_exception",
        "reason": "failed to extract doc:0, the grouping field must be single valued"
      }
    ],
    "type": "search_phase_execution_exception",
    "reason": "all shards failed",
    "phase": "query",
    "grouped": true,
    "failed_shards": [
      {
        "shard": 0,
        "index": "test",
        "node": "6lqb2ehXRrOdVMeXe_7PHg",
        "reason": {
          "type": "illegal_state_exception",
          "reason": "failed to extract doc:0, the grouping field must be single valued"
        }
      }
    ],
    "caused_by": {
      "type": "illegal_state_exception",
      "reason": "failed to extract doc:0, the grouping field must be single valued",
      "caused_by": {
        "type": "illegal_state_exception",
        "reason": "failed to extract doc:0, the grouping field must be single valued"
      }
    }
  },
  "status": 500
}
```