### PR TITLE
ESQL: Use less data in test (#128337)

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -653,7 +653,7 @@ public class HeapAttackIT extends ESRestTestCase {
     }
 
     public void testLookupExplosionNoFetch() throws IOException {
-        int sensorDataCount = 7000;
+        int sensorDataCount = 6000;
         int lookupEntries = 10000;
         Map<?, ?> map = lookupExplosionNoFetch(sensorDataCount, lookupEntries);
         assertMap(map, matchesMap().extraOk().entry("values", List.of(List.of(sensorDataCount * lookupEntries))));


### PR DESCRIPTION
This test is expected to complete a deeply abusive lookup join without circuit breaking. It was sometimes circuit breaking. This lowers the data we feed to the test so its slightly less abusive. It's still plenty abusive.

Closes #127365
