### PR TITLE
[8.19] [ML] Pass timeout to chat completion (#128338)

### DIFF
--- a/docs/changelog/128338.yaml
+++ b/docs/changelog/128338.yaml
@@ -1,0 +1,5 @@
+pr: 128338
+summary: Pass timeout to chat completion
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUnifiedCompletionInferenceAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUnifiedCompletionInferenceAction.java
@@ -89,7 +89,7 @@ public class TransportUnifiedCompletionInferenceAction extends BaseTransportInfe
         InferenceService service,
         ActionListener<InferenceServiceResults> listener
     ) {
-        service.unifiedCompletionInfer(model, request.getUnifiedCompletionRequest(), null, listener);
+        service.unifiedCompletionInfer(model, request.getUnifiedCompletionRequest(), request.getTimeout(), listener);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ML] Pass timeout to chat completion (#128338)