### PR TITLE
[9.0] [CI] Add windows-2025 to windows testing (#127850)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -40,6 +40,7 @@ steps:
           setup:
             image:
               - windows-2022
+              - windows-2025
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -361,6 +361,7 @@ steps:
           setup:
             image:
               - windows-2022
+              - windows-2025
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -38,6 +38,7 @@ steps:
           setup:
             image:
               - windows-2022
+              - windows-2025
             GRADLE_TASK:
               - checkPart1
               - checkPart2

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
@@ -11,6 +11,7 @@ steps:
           setup:
             image:
               - windows-2022
+              - windows-2025
             PACKAGING_TASK:
               - default-windows-archive
         agents:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[CI] Add windows-2025 to windows testing (#127850)](https://github.com/elastic/elasticsearch/pull/127850)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)