### PR TITLE
[8.18] [CI] Add windows-2025 to windows testing (#127850)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -45,6 +45,7 @@ steps:
             image:
               - windows-2019
               - windows-2022
+              - windows-2025
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -638,6 +638,7 @@ steps:
             image:
               - windows-2019
               - windows-2022
+              - windows-2025
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -44,6 +44,7 @@ steps:
             image:
               - windows-2019
               - windows-2022
+              - windows-2025
             GRADLE_TASK:
               - checkPart1
               - checkPart2

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
@@ -12,6 +12,7 @@ steps:
             image:
               - windows-2019
               - windows-2022
+              - windows-2025
             PACKAGING_TASK:
               - default-windows-archive
         agents:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[CI] Add windows-2025 to windows testing (#127850)](https://github.com/elastic/elasticsearch/pull/127850)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)