### PR TITLE
Docs: Fix match_phrase docs for zero_terms_query

### DIFF
--- a/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase.md
@@ -36,10 +36,9 @@ GET /_search
 :   (Optional, string) Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter. Valid values are:
 
   - `none` (Default)
-  :   No documents are returned if the `analyzer` removes all tokens.
+  No documents are returned if the `analyzer` removes all tokens.
   - `all`
-  :   Returns all documents, similar to a [`match_all`](/reference/query-languages/query-dsl/query-dsl-match-all-query.md) query.
-
+  Returns all documents, similar to a [`match_all`](/reference/query-languages/query-dsl/query-dsl-match-all-query.md) query.
 
 A phrase query matches terms up to a configurable `slop` (which defaults to 0) in any order. Transposed terms have a slop of 2.
 

--- a/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase.md
@@ -35,11 +35,11 @@ GET /_search
 `zero_terms_query`
 :   (Optional, string) Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter. Valid values are:
 
-`none` (Default)
-:   No documents are returned if the `analyzer` removes all tokens.
+  - `none` (Default)
+  :   No documents are returned if the `analyzer` removes all tokens.
 
-`all`
-:   Returns all documents, similar to a [`match_all`](/reference/query-languages/query-dsl/query-dsl-match-all-query.md) query.
+  - `all`
+  :   Returns all documents, similar to a [`match_all`](/reference/query-languages/query-dsl/query-dsl-match-all-query.md) query.
 
 
 A phrase query matches terms up to a configurable `slop` (which defaults to 0) in any order. Transposed terms have a slop of 2.

--- a/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase.md
@@ -34,7 +34,6 @@ GET /_search
 
 `zero_terms_query`
 :   (Optional, string) Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter. Valid values are:
-
   - `none` (Default)
   No documents are returned if the `analyzer` removes all tokens.
   - `all`

--- a/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase.md
@@ -37,7 +37,6 @@ GET /_search
 
   - `none` (Default)
   :   No documents are returned if the `analyzer` removes all tokens.
-
   - `all`
   :   Returns all documents, similar to a [`match_all`](/reference/query-languages/query-dsl/query-dsl-match-all-query.md) query.
 


### PR DESCRIPTION
This fixes an issue in the [`match_phrase` docs](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase), where there's no break and no indentation for the valid values of `zero_terms_query` option. `none` and `all` appear to be options of `match_phrase`, when they are actually valid values of `zero_terms_query`.

<img width="831" alt="Screenshot 2025-05-23 at 16 28 19" src="https://github.com/user-attachments/assets/33b21707-1385-4af9-a846-942d3291a5eb" />
