### PR TITLE
[9.0] Docs: Fix match_phrase docs for zero_terms_query (#128387)

### DIFF
--- a/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-match-query-phrase.md
@@ -34,13 +34,10 @@ GET /_search
 
 `zero_terms_query`
 :   (Optional, string) Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter. Valid values are:
-
-`none` (Default)
-:   No documents are returned if the `analyzer` removes all tokens.
-
-`all`
-:   Returns all documents, similar to a [`match_all`](/reference/query-languages/query-dsl/query-dsl-match-all-query.md) query.
-
+  - `none` (Default)
+  No documents are returned if the `analyzer` removes all tokens.
+  - `all`
+  Returns all documents, similar to a [`match_all`](/reference/query-languages/query-dsl/query-dsl-match-all-query.md) query.
 
 A phrase query matches terms up to a configurable `slop` (which defaults to 0) in any order. Transposed terms have a slop of 2.
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Docs: Fix match_phrase docs for zero_terms_query (#128387)