### PR TITLE
Fix concurrency issue in Text class

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/Text.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/Text.java
@@ -31,7 +31,7 @@ public final class Text implements XContentString, Comparable<Text>, ToXContentF
         return texts;
     }
 
-    private ByteBuffer bytes;
+    private volatile ByteBuffer bytes;
     private String text;
     private int hash;
     private int stringLength = -1;


### PR DESCRIPTION
After updating the Text class to use ByteBuffer in #127666 we saw test failures where similar Text instances are shared between different threads and tested for equals(). The reason is that calling bytes() lazily materializes the internal ByteBuffer. That method is what the equals method calls on both instances it tests. Apparently this can leads to race conditions when instances are shared across threads. Making the internal `bytes` representation volatile fixes the problem.

Closes #127971
Closes #128029 