### PR TITLE
Investigate using doc values for logsdb _id

### DIFF
--- a/.idea/runConfigurations/Debug_Elasticsearch.xml
+++ b/.idea/runConfigurations/Debug_Elasticsearch.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Debug Elasticsearch" type="Remote">
+    <module name="elasticsearch" />
     <option name="USE_SOCKET_TRANSPORT" value="true" />
     <option name="SERVER_MODE" value="true" />
     <option name="SHMEM_ADDRESS" />

--- a/.idea/runConfigurations/Debug_Elasticsearch__node_2_.xml
+++ b/.idea/runConfigurations/Debug_Elasticsearch__node_2_.xml
@@ -6,6 +6,10 @@
     <option name="HOST" value="localhost" />
     <option name="PORT" value="5008" />
     <option name="AUTO_RESTART" value="true" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5008" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
     <method v="2" />
   </configuration>
 </component>

--- a/.idea/runConfigurations/Debug_Elasticsearch__node_3_.xml
+++ b/.idea/runConfigurations/Debug_Elasticsearch__node_3_.xml
@@ -6,6 +6,10 @@
     <option name="HOST" value="localhost" />
     <option name="PORT" value="5009" />
     <option name="AUTO_RESTART" value="true" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5009" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
     <method v="2" />
   </configuration>
 </component>

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
@@ -182,6 +182,7 @@ final class PerThreadIDVersionAndSeqNoLookup {
 
             final Bits liveDocs = context.reader().getLiveDocs();
             int docID = DocIdSetIterator.NO_MORE_DOCS;
+            // TODO can we use skippers here?
             // there may be more than one matching docID, in the case of nested docs, so we want the last one:
             for (int doc = idDocValues.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = idDocValues.nextDoc()) {
                 if (liveDocs != null && liveDocs.get(doc) == false) {

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
@@ -18,7 +18,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.PostingsEnum;
-import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -30,7 +29,6 @@ import org.elasticsearch.common.lucene.uid.VersionsAndSeqNoResolver.DocIdAndSeqN
 import org.elasticsearch.common.lucene.uid.VersionsAndSeqNoResolver.DocIdAndVersion;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
-import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.VersionFieldMapper;
 
 import java.io.IOException;

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.LogsdbIdFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.MappingParserContext;
@@ -264,12 +265,12 @@ public enum IndexMode {
 
         @Override
         public IdFieldMapper buildIdFieldMapper(BooleanSupplier fieldDataEnabled) {
-            return new ProvidedIdFieldMapper(fieldDataEnabled);
+            return new LogsdbIdFieldMapper();
         }
 
         @Override
         public IdFieldMapper idFieldMapperWithoutFieldData() {
-            return ProvidedIdFieldMapper.NO_FIELD_DATA;
+            return new LogsdbIdFieldMapper();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1825,7 +1825,7 @@ public class InternalEngine extends Engine {
             } else {
                 // TODO
                 indexWriter.softUpdateDocument(new Term(IdFieldMapper.NAME, delete.uid()), doc, softDeletesField);
-                
+
             }
             return new DeleteResult(
                 plan.versionOfDeletion,

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1591,6 +1591,7 @@ public class InternalEngine extends Engine {
     }
 
     private void updateDocs(final BytesRef uid, final List<LuceneDocument> docs, final IndexWriter indexWriter) throws IOException {
+        // TODO
         final Term uidTerm = new Term(IdFieldMapper.NAME, uid);
         if (docs.size() > 1) {
             indexWriter.softUpdateDocuments(uidTerm, docs, softDeletesField);
@@ -1822,7 +1823,9 @@ public class InternalEngine extends Engine {
             if (plan.addStaleOpToLucene || plan.currentlyDeleted) {
                 indexWriter.addDocument(doc);
             } else {
+                // TODO
                 indexWriter.softUpdateDocument(new Term(IdFieldMapper.NAME, delete.uid()), doc, softDeletesField);
+                
             }
             return new DeleteResult(
                 plan.versionOfDeletion,
@@ -3460,6 +3463,7 @@ public class InternalEngine extends Engine {
                 continue;
             }
             final CombinedDocValues dv = new CombinedDocValues(leaf.reader());
+            // TODO
             final IdStoredFieldLoader idFieldLoader = new IdStoredFieldLoader(leaf.reader());
             final DocIdSetIterator iterator = scorer.iterator();
             int docId;

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
@@ -552,7 +552,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
     public static class IdDocValuesBlockLoader extends DocValuesBlockLoader {
         private final String fieldName;
 
-        public IdDocValuesBlockLoader (String fieldName) {
+        public IdDocValuesBlockLoader(String fieldName) {
             this.fieldName = fieldName;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -719,7 +719,7 @@ public abstract class DocumentParserContext {
         IndexableField idField = doc.getParent().getField(IdFieldMapper.NAME);
         if (idField != null) {
             if (indexSettings().getMode() == IndexMode.LOGSDB) {
-                doc.add(new SortedDocValuesField(IdFieldMapper.NAME, idField.binaryValue()));
+                doc.add(SortedDocValuesField.indexedField(IdFieldMapper.NAME, idField.binaryValue()));
             } else {
                 // We just need to store the id as indexed field, so that IndexWriter#deleteDocuments(term) can then
                 // delete it when the root document is deleted too.

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
@@ -142,7 +142,7 @@ public sealed interface IdLoader permits IdLoader.LogsdbLoader, IdLoader.TsIdLoa
                 boolean found = idDocValues.advanceExact(docId);
                 assert found;
                 BytesRef id = idDocValues.lookupOrd(idDocValues.ordValue());
-                ids[i] = id.utf8ToString();
+                ids[i] = Uid.decodeId(id.bytes, id.offset, id.length);
             }
             return new DocValueLeaf(docIdsInLeaf, ids);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
@@ -17,7 +17,6 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.routing.IndexRouting;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.fieldvisitor.LeafStoredFieldLoader;
 
 import java.io.IOException;

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
@@ -74,8 +74,8 @@ public sealed interface IdLoader permits IdLoader.LogsdbLoader, IdLoader.TsIdLoa
             this.indexRouting = indexRouting;
         }
 
-        public IdLoader.Leaf leaf(
-            SourceLoader.Leaf leafSourceLoader, LeafStoredFieldLoader loader, LeafReader reader, int[] docIdsInLeaf) throws IOException {
+        public IdLoader.Leaf leaf(SourceLoader.Leaf leafSourceLoader, LeafStoredFieldLoader loader, LeafReader reader, int[] docIdsInLeaf)
+            throws IOException {
             IndexRouting.ExtractFromSource.Builder[] builders = null;
             if (indexRouting != null) {
                 builders = new IndexRouting.ExtractFromSource.Builder[docIdsInLeaf.length];
@@ -134,9 +134,8 @@ public sealed interface IdLoader permits IdLoader.LogsdbLoader, IdLoader.TsIdLoa
     }
 
     final class LogsdbLoader implements IdLoader {
-        public IdLoader.Leaf leaf(
-            SourceLoader.Leaf leafSourceLoader, LeafStoredFieldLoader loader, LeafReader reader, int[] docIdsInLeaf
-        ) throws IOException {
+        public IdLoader.Leaf leaf(SourceLoader.Leaf leafSourceLoader, LeafStoredFieldLoader loader, LeafReader reader, int[] docIdsInLeaf)
+            throws IOException {
             try {
                 SortedDocValues idDocValues = DocValues.getSorted(reader, IdFieldMapper.NAME);
                 return loadDocValues(idDocValues, docIdsInLeaf);
@@ -164,8 +163,8 @@ public sealed interface IdLoader permits IdLoader.LogsdbLoader, IdLoader.TsIdLoa
         public StoredIdLoader() {}
 
         @Override
-        public Leaf leaf(
-            SourceLoader.Leaf leafSourceLoader, LeafStoredFieldLoader loader, LeafReader reader, int[] docIdsInLeaf) throws IOException {
+        public Leaf leaf(SourceLoader.Leaf leafSourceLoader, LeafStoredFieldLoader loader, LeafReader reader, int[] docIdsInLeaf)
+            throws IOException {
             return new StoredLeaf(loader);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
@@ -88,7 +88,7 @@ public class LogsdbIdFieldMapper extends IdFieldMapper {
 
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
-            return new BlockDocValuesReader.BytesRefsFromOrdsBlockLoader(IdFieldMapper.NAME);
+            return new BlockDocValuesReader.IdDocValuesBlockLoader(IdFieldMapper.NAME);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
@@ -9,81 +9,57 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.document.Field;
-import org.apache.lucene.document.StringField;
-import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 /**
  * A mapper for the _id field.
  */
-public abstract class LogsdbIdFieldMapper extends MetadataFieldMapper {
+public class LogsdbIdFieldMapper extends IdFieldMapper {
     // here
     public static final String NAME = "_id";
 
     public static final String CONTENT_TYPE = "_id";
 
-    public static final TypeParser PARSER = new FixedTypeParser(MappingParserContext::idFieldMapper);
-
-    private static final Map<String, NamedAnalyzer> ANALYZERS = Map.of(NAME, Lucene.KEYWORD_ANALYZER);
-
     public static final LogsdbIdFieldMapper INSTANCE = new LogsdbIdFieldMapper();
 
-    protected LogsdbIdFieldMapper(MappedFieldType mappedFieldType) {
-        super(mappedFieldType);
-        assert mappedFieldType.isSearchable();
+    public LogsdbIdFieldMapper() {
+        super(new LogsdbIdFieldType());
     }
 
     @Override
-    public Map<String, NamedAnalyzer> indexAnalyzers() {
-        return ANALYZERS;
+    public void preParse(DocumentParserContext context) {
+        if (context.sourceToParse().id() == null) {
+            throw new IllegalStateException("_id should have been set on the coordinating node");
+        }
+        context.id(context.sourceToParse().id());
+        context.doc().add(new SortedDocValuesField(fieldType().name(), new BytesRef(context.id())));
     }
 
     @Override
-    protected final String contentType() {
-        return CONTENT_TYPE;
+    public String documentDescription(DocumentParserContext context) {
+        return "logsdb document with id '" + context.sourceToParse().id() + "'";
     }
 
-    /**
-     * Description of the document being parsed used in error messages. Not
-     * called unless there is an error.
-     */
-    public abstract String documentDescription(DocumentParserContext context);
-
-    /**
-     * Description of the document being indexed used after parsing for things
-     * like version conflicts.
-     */
-    public abstract String documentDescription(ParsedDocument parsedDocument);
-
-    /**
-     * Build the {@code _id} to use on requests reindexing into indices using
-     * this {@code _id}.
-     */
-    public abstract String reindexId(String id);
-
-    /**
-     * Create a {@link Field} to store the provided {@code _id} that "stores"
-     * the {@code _id} so it can be fetched easily from the index.
-     */
-    public static Field standardIdField(String id) {
-        return new StringField(NAME, Uid.encodeId(id), Field.Store.NO);
+    @Override
+    public String documentDescription(ParsedDocument parsedDocument) {
+        return "[" + parsedDocument.id() + "]";
     }
 
-    protected abstract static class AbstractIdFieldType extends TermBasedFieldType {
+    @Override
+    public String reindexId(String id) {
+        return id;
+    }
 
-        public AbstractIdFieldType() {
+    protected static class LogsdbIdFieldType extends TermBasedFieldType {
+
+        public LogsdbIdFieldType() {
             super(NAME, false, false, true, TextSearchInfo.SIMPLE_MATCH_ONLY, Collections.emptyMap());
         }
 
@@ -94,41 +70,30 @@ public abstract class LogsdbIdFieldMapper extends MetadataFieldMapper {
 
         @Override
         public boolean isSearchable() {
-            // The _id field is always searchable.
+            // searchable, but probably not fast
             return true;
         }
 
         @Override
         public Query termsQuery(Collection<?> values, SearchExecutionContext context) {
-            failIfNotIndexed();
-            List<BytesRef> bytesRefs = values.stream().map(v -> {
-                Object idObject = v;
-                if (idObject instanceof BytesRef) {
-                    idObject = ((BytesRef) idObject).utf8ToString();
-                }
-                return Uid.encodeId(idObject.toString());
-            }).toList();
-            return new TermInSetQuery(name(), bytesRefs);
+            var bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
+            return SortedSetDocValuesField.newSlowSetQuery(name(), bytesRefs);
         }
 
         @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
-            return termsQuery(Arrays.asList(value), context);
-        }
-
-        @Override
-        public Query existsQuery(SearchExecutionContext context) {
-            return new MatchAllDocsQuery();
+            return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
         }
 
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
-            return new BlockStoredFieldsReader.IdBlockLoader();
+            return new BlockDocValuesReader.BytesRefsFromOrdsBlockLoader(NAME);
         }
 
         @Override
         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
-            return new StoredValueFetcher(context.lookup(), NAME);
+            // TODO can this be done somehow?
+            throw new UnsupportedOperationException("logsdb id cannot be fetched by values since only using doc values");
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
@@ -17,7 +17,6 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
 /**
  * A mapper for the _id field.
@@ -73,9 +72,7 @@ public class LogsdbIdFieldMapper extends IdFieldMapper {
 
         @Override
         public Query termsQuery(Collection<?> values, SearchExecutionContext context) {
-            var bytesRefs = values.stream()
-                .map(LogsdbIdFieldType::encode)
-                .map(this::indexedValueForSearch).toList();
+            var bytesRefs = values.stream().map(LogsdbIdFieldType::encode).map(this::indexedValueForSearch).toList();
             return SortedDocValuesField.newSlowSetQuery(name(), bytesRefs);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
@@ -39,7 +39,8 @@ public class LogsdbIdFieldMapper extends IdFieldMapper {
             throw new IllegalStateException("_id should have been set on the coordinating node");
         }
         context.id(context.sourceToParse().id());
-        context.doc().add(new SortedDocValuesField(fieldType().name(), new BytesRef(context.id())));
+        BytesRef uidEncoded = Uid.encodeId(context.id());
+        context.doc().add(new SortedDocValuesField(fieldType().name(), uidEncoded));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
@@ -71,6 +71,11 @@ public class LogsdbIdFieldMapper extends IdFieldMapper {
         }
 
         @Override
+        public boolean isAggregatable() {
+            return false;
+        }
+
+        @Override
         public Query termsQuery(Collection<?> values, SearchExecutionContext context) {
             var bytesRefs = values.stream().map(LogsdbIdFieldType::encode).map(this::indexedValueForSearch).toList();
             return SortedDocValuesField.newSlowSetQuery(name(), bytesRefs);

--- a/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
@@ -78,12 +78,12 @@ public class LogsdbIdFieldMapper extends IdFieldMapper {
         @Override
         public Query termsQuery(Collection<?> values, SearchExecutionContext context) {
             var bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
-            return SortedSetDocValuesField.newSlowSetQuery(name(), bytesRefs);
+            return SortedDocValuesField.newSlowSetQuery(name(), bytesRefs);
         }
 
         @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
-            return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+            return SortedDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermInSetQuery;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.query.SearchExecutionContext;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A mapper for the _id field.
+ */
+public abstract class LogsdbIdFieldMapper extends MetadataFieldMapper {
+    // here
+    public static final String NAME = "_id";
+
+    public static final String CONTENT_TYPE = "_id";
+
+    public static final TypeParser PARSER = new FixedTypeParser(MappingParserContext::idFieldMapper);
+
+    private static final Map<String, NamedAnalyzer> ANALYZERS = Map.of(NAME, Lucene.KEYWORD_ANALYZER);
+
+    public static final LogsdbIdFieldMapper INSTANCE = new LogsdbIdFieldMapper();
+
+    protected LogsdbIdFieldMapper(MappedFieldType mappedFieldType) {
+        super(mappedFieldType);
+        assert mappedFieldType.isSearchable();
+    }
+
+    @Override
+    public Map<String, NamedAnalyzer> indexAnalyzers() {
+        return ANALYZERS;
+    }
+
+    @Override
+    protected final String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    /**
+     * Description of the document being parsed used in error messages. Not
+     * called unless there is an error.
+     */
+    public abstract String documentDescription(DocumentParserContext context);
+
+    /**
+     * Description of the document being indexed used after parsing for things
+     * like version conflicts.
+     */
+    public abstract String documentDescription(ParsedDocument parsedDocument);
+
+    /**
+     * Build the {@code _id} to use on requests reindexing into indices using
+     * this {@code _id}.
+     */
+    public abstract String reindexId(String id);
+
+    /**
+     * Create a {@link Field} to store the provided {@code _id} that "stores"
+     * the {@code _id} so it can be fetched easily from the index.
+     */
+    public static Field standardIdField(String id) {
+        return new StringField(NAME, Uid.encodeId(id), Field.Store.NO);
+    }
+
+    protected abstract static class AbstractIdFieldType extends TermBasedFieldType {
+
+        public AbstractIdFieldType() {
+            super(NAME, false, false, true, TextSearchInfo.SIMPLE_MATCH_ONLY, Collections.emptyMap());
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public boolean isSearchable() {
+            // The _id field is always searchable.
+            return true;
+        }
+
+        @Override
+        public Query termsQuery(Collection<?> values, SearchExecutionContext context) {
+            failIfNotIndexed();
+            List<BytesRef> bytesRefs = values.stream().map(v -> {
+                Object idObject = v;
+                if (idObject instanceof BytesRef) {
+                    idObject = ((BytesRef) idObject).utf8ToString();
+                }
+                return Uid.encodeId(idObject.toString());
+            }).toList();
+            return new TermInSetQuery(name(), bytesRefs);
+        }
+
+        @Override
+        public Query termQuery(Object value, SearchExecutionContext context) {
+            return termsQuery(Arrays.asList(value), context);
+        }
+
+        @Override
+        public Query existsQuery(SearchExecutionContext context) {
+            return new MatchAllDocsQuery();
+        }
+
+        @Override
+        public BlockLoader blockLoader(BlockLoaderContext blContext) {
+            return new BlockStoredFieldsReader.IdBlockLoader();
+        }
+
+        @Override
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+            return new StoredValueFetcher(context.lookup(), NAME);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LogsdbIdFieldMapper.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.SortedDocValuesField;
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.query.SearchExecutionContext;

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
@@ -78,6 +78,7 @@ public class ParsedDocument {
         seqIdFields.addFields(document);
         Field versionField = VersionFieldMapper.versionField();
         document.add(versionField);
+        // TODO
         document.add(IdFieldMapper.standardIdField(id));
         return new ParsedDocument(
             versionField,

--- a/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -143,6 +143,7 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
         if (idField == null || ids.isEmpty()) {
             throw new IllegalStateException("Rewrite first");
         }
+        // TODO
         return idField.termsQuery(new ArrayList<>(ids), context);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -972,6 +972,8 @@ final class DefaultSearchContext extends SearchContext {
                 }
             }
             return IdLoader.createTsIdLoader(indexRouting, routingPaths);
+        } else if (indexService.getIndexSettings().getMode() == IndexMode.LOGSDB) {
+            return IdLoader.createDocValueIdLoader();
         } else {
             return IdLoader.fromLeafStoredFieldLoader();
         }

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -153,7 +153,7 @@ public final class FetchPhase {
                 this.leafNestedDocuments = nestedDocuments.getLeafNestedDocuments(ctx);
                 this.leafStoredFieldLoader = storedFieldLoader.getLoader(ctx, docsInLeaf);
                 this.leafSourceLoader = sourceLoader.leaf(ctx.reader(), docsInLeaf);
-                this.leafIdLoader = idLoader.leaf(leafStoredFieldLoader, ctx.reader(), docsInLeaf);
+                this.leafIdLoader = idLoader.leaf(leafSourceLoader, leafStoredFieldLoader, ctx.reader(), docsInLeaf);
                 fieldLookupProvider.setNextReader(ctx);
                 for (FetchSubPhaseProcessor processor : processors) {
                     processor.setNextReader(ctx);

--- a/server/src/test/java/org/elasticsearch/index/mapper/IdLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IdLoaderTests.java
@@ -58,7 +58,7 @@ public class IdLoaderTests extends ESTestCase {
             assertThat(indexReader.leaves(), hasSize(1));
             LeafReader leafReader = indexReader.leaves().get(0).reader();
             assertThat(leafReader.numDocs(), equalTo(3));
-            var leaf = idLoader.leaf(null, leafReader, new int[] { 0, 1, 2 });
+            var leaf = idLoader.leaf(null, null, leafReader, new int[] { 0, 1, 2 });
             // NOTE: time series data is ordered by (tsid, timestamp)
             assertThat(leaf.getId(0), equalTo(expectedId(docs.get(2), routingHash)));
             assertThat(leaf.getId(1), equalTo(expectedId(docs.get(0), routingHash)));
@@ -108,7 +108,7 @@ public class IdLoaderTests extends ESTestCase {
             {
                 LeafReader leafReader = indexReader.leaves().get(0).reader();
                 assertThat(leafReader.numDocs(), equalTo(docs1.size()));
-                var leaf = idLoader.leaf(null, leafReader, IntStream.range(0, docs1.size()).toArray());
+                var leaf = idLoader.leaf(null, null, leafReader, IntStream.range(0, docs1.size()).toArray());
                 for (int i = 0; i < docs1.size(); i++) {
                     assertThat(leaf.getId(i), equalTo(expectedId(docs1.get(i), routingHash)));
                 }
@@ -116,21 +116,21 @@ public class IdLoaderTests extends ESTestCase {
             {
                 LeafReader leafReader = indexReader.leaves().get(1).reader();
                 assertThat(leafReader.numDocs(), equalTo(docs2.size()));
-                var leaf = idLoader.leaf(null, leafReader, new int[] { 0, 3 });
+                var leaf = idLoader.leaf(null, null, leafReader, new int[] { 0, 3 });
                 assertThat(leaf.getId(0), equalTo(expectedId(docs2.get(0), routingHash)));
                 assertThat(leaf.getId(3), equalTo(expectedId(docs2.get(3), routingHash)));
             }
             {
                 LeafReader leafReader = indexReader.leaves().get(2).reader();
                 assertThat(leafReader.numDocs(), equalTo(docs3.size()));
-                var leaf = idLoader.leaf(null, leafReader, new int[] { 1, 2 });
+                var leaf = idLoader.leaf(null, null, leafReader, new int[] { 1, 2 });
                 assertThat(leaf.getId(1), equalTo(expectedId(docs3.get(1), routingHash)));
                 assertThat(leaf.getId(2), equalTo(expectedId(docs3.get(2), routingHash)));
             }
             {
                 LeafReader leafReader = indexReader.leaves().get(2).reader();
                 assertThat(leafReader.numDocs(), equalTo(docs3.size()));
-                var leaf = idLoader.leaf(null, leafReader, new int[] { 3 });
+                var leaf = idLoader.leaf(null, null, leafReader, new int[] { 3 });
                 expectThrows(IllegalArgumentException.class, () -> leaf.getId(0));
             }
         };
@@ -168,7 +168,7 @@ public class IdLoaderTests extends ESTestCase {
             assertThat(indexReader.leaves(), hasSize(1));
             LeafReader leafReader = indexReader.leaves().get(0).reader();
             assertThat(leafReader.numDocs(), equalTo(randomDocs.size()));
-            var leaf = idLoader.leaf(null, leafReader, IntStream.range(0, randomDocs.size()).toArray());
+            var leaf = idLoader.leaf(null, null, leafReader, IntStream.range(0, randomDocs.size()).toArray());
             for (int i = 0; i < randomDocs.size(); i++) {
                 String actualId = leaf.getId(i);
                 assertTrue("docId=" + i + " id=" + actualId, expectedIDs.remove(actualId));

--- a/x-pack/plugin/logsdb/src/internalClusterTest/java/org/elasticsearch/xpack/logsdb/LogsIdIT.java
+++ b/x-pack/plugin/logsdb/src/internalClusterTest/java/org/elasticsearch/xpack/logsdb/LogsIdIT.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.FormatNames;
+import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.license.LicenseSettings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.XPackPlugin;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.hamcrest.Matchers.*;
+
+public class LogsIdIT extends ESSingleNodeTestCase {
+
+    public static final String MAPPING_TEMPLATE = """
+        {
+          "_doc":{
+            "properties": {
+              "@timestamp" : {
+                "type": "date"
+              },
+              "message": {
+                "type": "keyword"
+              },
+              "k8s": {
+                "properties": {
+                  "pod": {
+                    "properties": {
+                      "uid": {
+                        "type": "keyword"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }""";
+
+    private static final String DOC = """
+        {
+            "@timestamp": "$time",
+            "message": "$pod",
+            "k8s": {
+                "pod": {
+                    "name": "dog",
+                    "uid":"$uuid",
+                    "ip": "10.10.55.3",
+                    "network": {
+                        "tx": 1434595272,
+                        "rx": 530605511
+                    }
+                }
+            }
+        }
+        """;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return List.of(InternalSettingsPlugin.class, XPackPlugin.class, LogsDBPlugin.class, DataStreamsPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder()
+            .put(super.nodeSettings())
+            .put("cluster.logsdb.enabled", "true")
+            .put(LicenseSettings.SELF_GENERATED_LICENSE_TYPE.getKey(), "trial")
+            .build();
+    }
+
+    public void testStandard() throws Exception {
+        String dataStreamName = "k8s";
+        createTemplate(dataStreamName);
+        checkIndexSearchAndRetrieval(dataStreamName, false);
+    }
+
+
+    public void testGetByGeneratedId() throws Exception {
+        String dataStreamName = "k8s";
+        createTemplate(dataStreamName);
+
+        Instant time = Instant.now();
+        BulkRequest bulkRequest = new BulkRequest(dataStreamName);
+        int numDocs = randomIntBetween(16, 256);
+        for (int j = 0; j < numDocs; j++) {
+            var indexRequest = new IndexRequest(dataStreamName).opType(DocWriteRequest.OpType.CREATE);
+            indexRequest.source(
+                DOC.replace("$time", formatInstant(time))
+                    .replace("$uuid", UUID.randomUUID().toString())
+                    .replace("$pod", "pod-" + randomIntBetween(0, 10)),
+                XContentType.JSON
+            );
+            bulkRequest.add(indexRequest);
+            time = time.plusMillis(1);
+        }
+        var bulkResponse = client().bulk(bulkRequest).actionGet();
+        assertThat(bulkResponse.hasFailures(), is(false));
+        var indexName = bulkResponse.getItems()[0].getIndex();
+        client().admin().indices().refresh(new RefreshRequest(dataStreamName)).actionGet();
+
+        // Check the search api can synthesize _id
+        var searchRequest = new SearchRequest(dataStreamName);
+        searchRequest.source().trackTotalHits(true);
+        assertResponse(client().search(searchRequest), searchResponse -> {
+            assertThat(searchResponse.getHits().getTotalHits().value(), equalTo((long) numDocs));
+
+            for (int i = 0; i < searchResponse.getHits().getHits().length; i++) {
+                String id = searchResponse.getHits().getHits()[i].getId();
+                assertThat(id, notNullValue());
+
+                // Check that the _id is gettable:
+                var getResponse = client().get(new GetRequest(indexName).id(id)).actionGet();
+                assertThat(getResponse.isExists(), is(true));
+                assertThat(getResponse.getId(), equalTo(id));
+            }
+        });
+    }
+
+    public void testGetByProvidedID() throws Exception {
+        var indexName = "test-name";
+        createIndex(indexName, Settings.builder().put("index.mode", "logsdb").build());
+        Instant time = Instant.now();
+        BulkRequest bulkRequest = new BulkRequest(indexName);
+        int numDocs = randomIntBetween(16, 256);
+        for (int j = 0; j < numDocs; j++) {
+            var indexRequest = new IndexRequest(indexName)
+                .opType(DocWriteRequest.OpType.INDEX)
+                .id("some-id-" + j);
+            indexRequest.source(
+                DOC.replace("$time", formatInstant(time))
+                    .replace("$uuid", UUID.randomUUID().toString())
+                    .replace("$pod", "pod-" + randomIntBetween(0, 10)),
+                XContentType.JSON
+            );
+            bulkRequest.add(indexRequest);
+            time = time.plusMillis(1);
+        }
+        var bulkResponse = client().bulk(bulkRequest).actionGet();
+        assertThat(bulkResponse.hasFailures(), is(false));
+        client().admin().indices().refresh(new RefreshRequest(indexName)).actionGet();
+
+        if (randomBoolean()) {
+            flush(indexName, randomBoolean());
+        }
+
+        // Check the search api can synthesize _id
+        var searchRequest = new SearchRequest(indexName);
+        searchRequest.source().trackTotalHits(true);
+        assertResponse(client().search(searchRequest), searchResponse -> {
+            assertThat(searchResponse.getHits().getTotalHits().value(), equalTo((long) numDocs));
+
+            for (int i = 0; i < searchResponse.getHits().getHits().length; i++) {
+                String id = searchResponse.getHits().getHits()[i].getId();
+                assertThat(id, notNullValue());
+
+                // test get with the IDs from search response
+                var getResponse = client().get(new GetRequest(indexName).id(id)).actionGet();
+                assertThat(getResponse.isExists(), is(true));
+                assertThat(getResponse.getId(), equalTo(id));
+            }
+        });
+
+        // test get with the provided IDs
+        for (int i = 0; i < numDocs; i++) {
+            String id = "some-id-" + i;
+            var getResponse = client().get(new GetRequest(indexName).id(id)).actionGet();
+            assertThat(getResponse.isExists(), is(true));
+            assertThat(getResponse.getId(), equalTo(id));
+        }
+    }
+
+    public void testMatchByProvidedID() throws Exception {
+        var indexName = "test-name";
+        createIndex(indexName, Settings.builder().put("index.mode", "logsdb").build());
+        Instant time = Instant.now();
+        BulkRequest bulkRequest = new BulkRequest(indexName);
+        int numDocs = randomIntBetween(16, 256);
+        for (int j = 0; j < numDocs; j++) {
+            var indexRequest = new IndexRequest(indexName)
+                .opType(DocWriteRequest.OpType.INDEX)
+                .id("some-id-" + j);
+            indexRequest.source(
+                DOC.replace("$time", formatInstant(time))
+                    .replace("$uuid", UUID.randomUUID().toString())
+                    .replace("$pod", "pod-" + j),
+                XContentType.JSON
+            );
+            bulkRequest.add(indexRequest);
+            time = time.plusMillis(1);
+        }
+        var bulkResponse = client().bulk(bulkRequest).actionGet();
+        assertThat(bulkResponse.hasFailures(), is(false));
+        client().admin().indices().refresh(new RefreshRequest(indexName)).actionGet();
+
+        for (int i = 0; i < numDocs; i++) {
+            String id = "some-id-" + i;
+            var searchRequest = new SearchRequest(indexName);
+            searchRequest.source(new SearchSourceBuilder().query(new TermQueryBuilder("_id", id)).size(10));
+            var searchResponse = client().search(searchRequest).actionGet();
+            assertThat(searchResponse.getHits().getTotalHits().value(), equalTo((long) 1));
+            assertThat(searchResponse.getHits().getAt(0).field("message"), equalTo("pod-" + i));
+        }
+    }
+
+    private void createTemplate(String dataStreamName) throws IOException {
+        var putTemplateRequest = new TransportPutComposableIndexTemplateAction.Request("id");
+        putTemplateRequest.indexTemplate(
+            ComposableIndexTemplate.builder()
+                .indexPatterns(List.of(dataStreamName + "*"))
+                .template(
+                    new Template(
+                        indexSettings(4, 0).put("index.mode", "logsdb").put("index.sort.field", "message,k8s.pod.uid,@timestamp").build(),
+                        new CompressedXContent(MAPPING_TEMPLATE),
+                        null
+                    )
+                )
+                .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate(false, false))
+                .build()
+        );
+        client().execute(TransportPutComposableIndexTemplateAction.TYPE, putTemplateRequest).actionGet();
+    }
+
+
+    private void checkIndexSearchAndRetrieval(String dataStreamName, boolean routeOnSortFields) throws Exception {
+        String[] uuis = {
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString() };
+        int numBulkRequests = randomIntBetween(128, 1024);
+        int numDocsPerBulk = randomIntBetween(16, 256);
+        String indexName = null;
+        {
+            Instant time = Instant.now();
+            for (int i = 0; i < numBulkRequests; i++) {
+                BulkRequest bulkRequest = new BulkRequest(dataStreamName);
+                for (int j = 0; j < numDocsPerBulk; j++) {
+                    var indexRequest = new IndexRequest(dataStreamName).opType(DocWriteRequest.OpType.CREATE);
+                    indexRequest.source(
+                        DOC.replace("$time", formatInstant(time))
+                            .replace("$uuid", uuis[j % uuis.length])
+                            .replace("$pod", "pod-" + randomIntBetween(0, 10)),
+                        XContentType.JSON
+                    );
+                    bulkRequest.add(indexRequest);
+                    time = time.plusMillis(1);
+                }
+                var bulkResponse = client().bulk(bulkRequest).actionGet();
+                assertThat(bulkResponse.hasFailures(), is(false));
+                indexName = bulkResponse.getItems()[0].getIndex();
+            }
+            client().admin().indices().refresh(new RefreshRequest(dataStreamName)).actionGet();
+        }
+
+        // Verify settings.
+        final GetSettingsResponse getSettingsResponse = indicesAdmin().getSettings(
+            new GetSettingsRequest(TEST_REQUEST_TIMEOUT).indices(indexName).includeDefaults(false)
+        ).actionGet();
+        final Settings settings = getSettingsResponse.getIndexToSettings().get(indexName);
+        assertEquals("message,k8s.pod.uid,@timestamp", settings.get("index.sort.field"));
+        if (routeOnSortFields) {
+            assertEquals("[message, k8s.pod.uid]", settings.get("index.routing_path"));
+            assertEquals("true", settings.get("index.logsdb.route_on_sort_fields"));
+        } else {
+            assertNull(settings.get("index.routing_path"));
+            assertNull(settings.get("index.logsdb.route_on_sort_fields"));
+        }
+
+        // Check the search api can synthesize _id
+        final String idxName = indexName;
+        var searchRequest = new SearchRequest(dataStreamName);
+        searchRequest.source().trackTotalHits(true);
+        assertResponse(client().search(searchRequest), searchResponse -> {
+            assertThat(searchResponse.getHits().getTotalHits().value(), equalTo((long) numBulkRequests * numDocsPerBulk));
+
+            for (int i = 0; i < searchResponse.getHits().getHits().length; i++) {
+                String id = searchResponse.getHits().getHits()[i].getId();
+                assertThat(id, notNullValue());
+
+                // Check that the _id is gettable:
+                var getResponse = client().get(new GetRequest(idxName).id(id)).actionGet();
+                assertThat(getResponse.isExists(), is(true));
+                assertThat(getResponse.getId(), equalTo(id));
+            }
+        });
+    }
+
+    static String formatInstant(Instant instant) {
+        return DateFormatter.forPattern(FormatNames.STRICT_DATE_OPTIONAL_TIME.getName()).format(instant);
+    }
+
+    public void flush(String index, boolean force) throws IOException, ExecutionException, InterruptedException {
+        logger.info("flushing index {} force={}", index, force);
+        FlushRequest flushRequest = new FlushRequest(index).force(force);
+        assertResponse(client().admin().indices().flush(flushRequest), response -> {
+            assertEquals(0, response.getFailedShards());
+        });
+    }
+
+}

--- a/x-pack/plugin/logsdb/src/internalClusterTest/java/org/elasticsearch/xpack/logsdb/LogsIdIT.java
+++ b/x-pack/plugin/logsdb/src/internalClusterTest/java/org/elasticsearch/xpack/logsdb/LogsIdIT.java
@@ -17,8 +17,6 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.Request;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -26,7 +24,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
-import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.license.LicenseSettings;
 import org.elasticsearch.plugins.Plugin;
@@ -40,14 +37,11 @@ import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.*;
 
@@ -120,9 +114,7 @@ public class LogsIdIT extends ESSingleNodeTestCase {
         for (int j = 0; j < numDocs; j++) {
             var indexRequest = new IndexRequest(dataStreamName).opType(DocWriteRequest.OpType.CREATE);
             indexRequest.source(
-                DOC.replace("$time", formatInstant(time))
-                    .replace("$uuid", UUID.randomUUID().toString())
-                    .replace("$pod", "pod-" + j),
+                DOC.replace("$time", formatInstant(time)).replace("$uuid", UUID.randomUUID().toString()).replace("$pod", "pod-" + j),
                 XContentType.JSON
             );
             bulkRequest.add(indexRequest);
@@ -160,13 +152,9 @@ public class LogsIdIT extends ESSingleNodeTestCase {
         BulkRequest bulkRequest = new BulkRequest(indexName);
         int numDocs = randomIntBetween(16, 256);
         for (int j = 0; j < numDocs; j++) {
-            var indexRequest = new IndexRequest(indexName)
-                .opType(DocWriteRequest.OpType.INDEX)
-                .id("id-" + j);
+            var indexRequest = new IndexRequest(indexName).opType(DocWriteRequest.OpType.INDEX).id("id-" + j);
             indexRequest.source(
-                DOC.replace("$time", formatInstant(time))
-                    .replace("$uuid", UUID.randomUUID().toString())
-                    .replace("$pod", "pod-" + j),
+                DOC.replace("$time", formatInstant(time)).replace("$uuid", UUID.randomUUID().toString()).replace("$pod", "pod-" + j),
                 XContentType.JSON
             );
             bulkRequest.add(indexRequest);
@@ -215,13 +203,9 @@ public class LogsIdIT extends ESSingleNodeTestCase {
         BulkRequest bulkRequest = new BulkRequest(indexName);
         int numDocs = randomIntBetween(16, 256);
         for (int j = 0; j < numDocs; j++) {
-            var indexRequest = new IndexRequest(indexName)
-                .opType(DocWriteRequest.OpType.INDEX)
-                .id("id-" + j);
+            var indexRequest = new IndexRequest(indexName).opType(DocWriteRequest.OpType.INDEX).id("id-" + j);
             indexRequest.source(
-                DOC.replace("$time", formatInstant(time))
-                    .replace("$uuid", UUID.randomUUID().toString())
-                    .replace("$pod", "pod-" + j),
+                DOC.replace("$time", formatInstant(time)).replace("$uuid", UUID.randomUUID().toString()).replace("$pod", "pod-" + j),
                 XContentType.JSON
             );
             bulkRequest.add(indexRequest);
@@ -258,7 +242,6 @@ public class LogsIdIT extends ESSingleNodeTestCase {
         );
         client().execute(TransportPutComposableIndexTemplateAction.TYPE, putTemplateRequest).actionGet();
     }
-
 
     private void checkIndexSearchAndRetrieval(String dataStreamName, boolean routeOnSortFields) throws Exception {
         String[] uuis = {
@@ -331,9 +314,7 @@ public class LogsIdIT extends ESSingleNodeTestCase {
     public void flush(String index, boolean force) throws IOException, ExecutionException, InterruptedException {
         logger.info("flushing index {} force={}", index, force);
         FlushRequest flushRequest = new FlushRequest(index).force(force);
-        assertResponse(client().admin().indices().flush(flushRequest), response -> {
-            assertEquals(0, response.getFailedShards());
-        });
+        assertResponse(client().admin().indices().flush(flushRequest), response -> { assertEquals(0, response.getFailedShards()); });
     }
 
 }

--- a/x-pack/plugin/logsdb/src/internalClusterTest/java/org/elasticsearch/xpack/logsdb/LogsIdIT.java
+++ b/x-pack/plugin/logsdb/src/internalClusterTest/java/org/elasticsearch/xpack/logsdb/LogsIdIT.java
@@ -234,13 +234,9 @@ public class LogsIdIT extends ESSingleNodeTestCase {
         BulkRequest bulkRequest = new BulkRequest(indexName);
         int numDocs = randomIntBetween(16, 256);
         for (int j = 0; j < numDocs; j++) {
-            var indexRequest = new IndexRequest(indexName)
-                .opType(DocWriteRequest.OpType.INDEX)
-                .id("id-" + j);
+            var indexRequest = new IndexRequest(indexName).opType(DocWriteRequest.OpType.INDEX).id("id-" + j);
             indexRequest.source(
-                DOC.replace("$time", formatInstant(time))
-                    .replace("$uuid", UUID.randomUUID().toString())
-                    .replace("$pod", "pod-" + j),
+                DOC.replace("$time", formatInstant(time)).replace("$uuid", UUID.randomUUID().toString()).replace("$pod", "pod-" + j),
                 XContentType.JSON
             );
             bulkRequest.add(indexRequest);
@@ -254,7 +250,6 @@ public class LogsIdIT extends ESSingleNodeTestCase {
             flush(indexName, randomBoolean());
         }
 
-
         var searchRequest = new SearchRequest(indexName);
         searchRequest.source().trackTotalHits(true);
         assertResponse(client().search(searchRequest), searchResponse -> {
@@ -267,10 +262,7 @@ public class LogsIdIT extends ESSingleNodeTestCase {
             assertThat(deleteResponse.status(), equalTo(RestStatus.OK));
         }
 
-        assertThat(
-            client().prepareSearch(indexName).get().getHits().getTotalHits().value(),
-            equalTo(0)
-        );
+        assertThat(client().prepareSearch(indexName).get().getHits().getTotalHits().value(), equalTo(0));
     }
 
     private void createTemplate(String dataStreamName) throws IOException {

--- a/x-pack/plugin/logsdb/src/internalClusterTest/java/org/elasticsearch/xpack/logsdb/LogsIdIT.java
+++ b/x-pack/plugin/logsdb/src/internalClusterTest/java/org/elasticsearch/xpack/logsdb/LogsIdIT.java
@@ -10,11 +10,8 @@ package org.elasticsearch.xpack.logsdb;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
-import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
-import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
 import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -28,7 +25,6 @@ import org.elasticsearch.datastreams.DataStreamsPlugin;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.license.LicenseSettings;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
@@ -45,7 +41,8 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class LogsIdIT extends ESSingleNodeTestCase {
 
@@ -123,7 +120,7 @@ public class LogsIdIT extends ESSingleNodeTestCase {
             time = time.plusMillis(1);
         }
         var bulkResponse = client().bulk(bulkRequest).actionGet();
-        assertThat(bulkResponse.hasFailures(), is(false));
+        assertThat(bulkResponse.hasFailures(), equalTo(false));
         var indexName = bulkResponse.getItems()[0].getIndex();
         client().admin().indices().refresh(new RefreshRequest(dataStreamName)).actionGet();
 
@@ -141,7 +138,7 @@ public class LogsIdIT extends ESSingleNodeTestCase {
                 // Check that the _id is gettable:
                 var getRequest = new GetRequest(indexName).id(id);
                 var getResponse = client().get(getRequest).actionGet();
-                assertThat(getResponse.isExists(), is(true));
+                assertThat(getResponse.isExists(), equalTo(true));
                 assertThat(getResponse.getId(), equalTo(id));
             }
         });
@@ -163,7 +160,7 @@ public class LogsIdIT extends ESSingleNodeTestCase {
             time = time.plusMillis(1);
         }
         var bulkResponse = client().bulk(bulkRequest).actionGet();
-        assertThat(bulkResponse.hasFailures(), is(false));
+        assertThat(bulkResponse.hasFailures(), equalTo(false));
         client().admin().indices().refresh(new RefreshRequest(indexName)).actionGet();
 
         if (randomBoolean()) {
@@ -192,7 +189,7 @@ public class LogsIdIT extends ESSingleNodeTestCase {
             String id = "id-" + i;
             var getRequest = new GetRequest(indexName).id(id).fetchSourceContext(FetchSourceContext.FETCH_SOURCE);
             var getResponse = client().get(getRequest).actionGet();
-            assertThat(getResponse.isExists(), is(true));
+            assertThat(getResponse.isExists(), equalTo(true));
             assertThat(getResponse.getId(), equalTo(id));
             assertThat(getResponse.getSourceAsMap().get("message"), equalTo("pod-" + i));
         }
@@ -214,7 +211,7 @@ public class LogsIdIT extends ESSingleNodeTestCase {
             time = time.plusMillis(1);
         }
         var bulkResponse = client().bulk(bulkRequest).actionGet();
-        assertThat(bulkResponse.hasFailures(), is(false));
+        assertThat(bulkResponse.hasFailures(), equalTo(false));
         client().admin().indices().refresh(new RefreshRequest(indexName)).actionGet();
 
         for (int i = 0; i < numDocs; i++) {
@@ -227,43 +224,43 @@ public class LogsIdIT extends ESSingleNodeTestCase {
         }
     }
 
-    public void testDeleteByProvidedID() throws Exception {
-        var indexName = "test-name";
-        createIndex(indexName, Settings.builder().put("index.mode", "logsdb").build());
-        Instant time = Instant.now();
-        BulkRequest bulkRequest = new BulkRequest(indexName);
-        int numDocs = randomIntBetween(16, 256);
-        for (int j = 0; j < numDocs; j++) {
-            var indexRequest = new IndexRequest(indexName).opType(DocWriteRequest.OpType.INDEX).id("id-" + j);
-            indexRequest.source(
-                DOC.replace("$time", formatInstant(time)).replace("$uuid", UUID.randomUUID().toString()).replace("$pod", "pod-" + j),
-                XContentType.JSON
-            );
-            bulkRequest.add(indexRequest);
-            time = time.plusMillis(1);
-        }
-        var bulkResponse = client().bulk(bulkRequest).actionGet();
-        assertThat(bulkResponse.hasFailures(), is(false));
-        client().admin().indices().refresh(new RefreshRequest(indexName)).actionGet();
-
-        if (randomBoolean()) {
-            flush(indexName, randomBoolean());
-        }
-
-        var searchRequest = new SearchRequest(indexName);
-        searchRequest.source().trackTotalHits(true);
-        assertResponse(client().search(searchRequest), searchResponse -> {
-            assertThat(searchResponse.getHits().getTotalHits().value(), equalTo((long) numDocs));
-        });
-
-        // test get with the provided IDs
-        for (int i = 0; i < numDocs; i++) {
-            DeleteResponse deleteResponse = client().prepareDelete(indexName, "id-" + i).get();
-            assertThat(deleteResponse.status(), equalTo(RestStatus.OK));
-        }
-
-        assertThat(client().prepareSearch(indexName).get().getHits().getTotalHits().value(), equalTo(0));
-    }
+//    public void testDeleteByProvidedID() throws Exception {
+//        var indexName = "test-name";
+//        createIndex(indexName, Settings.builder().put("index.mode", "logsdb").build());
+//        Instant time = Instant.now();
+//        BulkRequest bulkRequest = new BulkRequest(indexName);
+//        int numDocs = randomIntBetween(16, 256);
+//        for (int j = 0; j < numDocs; j++) {
+//            var indexRequest = new IndexRequest(indexName).opType(DocWriteRequest.OpType.INDEX).id("id-" + j);
+//            indexRequest.source(
+//                DOC.replace("$time", formatInstant(time)).replace("$uuid", UUID.randomUUID().toString()).replace("$pod", "pod-" + j),
+//                XContentType.JSON
+//            );
+//            bulkRequest.add(indexRequest);
+//            time = time.plusMillis(1);
+//        }
+//        var bulkResponse = client().bulk(bulkRequest).actionGet();
+//        assertThat(bulkResponse.hasFailures(), is(false));
+//        client().admin().indices().refresh(new RefreshRequest(indexName)).actionGet();
+//
+//        if (randomBoolean()) {
+//            flush(indexName, randomBoolean());
+//        }
+//
+//        var searchRequest = new SearchRequest(indexName);
+//        searchRequest.source().trackTotalHits(true);
+//        assertResponse(client().search(searchRequest), searchResponse -> {
+//            assertThat(searchResponse.getHits().getTotalHits().value(), equalTo((long) numDocs));
+//        });
+//
+//        // test get with the provided IDs
+//        for (int i = 0; i < numDocs; i++) {
+//            DeleteResponse deleteResponse = client().prepareDelete(indexName, "id-" + i).get();
+//            assertThat(deleteResponse.status(), equalTo(RestStatus.OK));
+//        }
+//
+//        assertThat(client().prepareSearch(indexName).get().getHits().getTotalHits().value(), equalTo(0));
+//    }
 
     private void createTemplate(String dataStreamName) throws IOException {
         var putTemplateRequest = new TransportPutComposableIndexTemplateAction.Request("id");
@@ -281,70 +278,6 @@ public class LogsIdIT extends ESSingleNodeTestCase {
                 .build()
         );
         client().execute(TransportPutComposableIndexTemplateAction.TYPE, putTemplateRequest).actionGet();
-    }
-
-    private void checkIndexSearchAndRetrieval(String dataStreamName, boolean routeOnSortFields) throws Exception {
-        String[] uuis = {
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString() };
-        int numBulkRequests = randomIntBetween(128, 1024);
-        int numDocsPerBulk = randomIntBetween(16, 256);
-        String indexName = null;
-        {
-            Instant time = Instant.now();
-            for (int i = 0; i < numBulkRequests; i++) {
-                BulkRequest bulkRequest = new BulkRequest(dataStreamName);
-                for (int j = 0; j < numDocsPerBulk; j++) {
-                    var indexRequest = new IndexRequest(dataStreamName).opType(DocWriteRequest.OpType.CREATE);
-                    indexRequest.source(
-                        DOC.replace("$time", formatInstant(time))
-                            .replace("$uuid", uuis[j % uuis.length])
-                            .replace("$pod", "pod-" + randomIntBetween(0, 10)),
-                        XContentType.JSON
-                    );
-                    bulkRequest.add(indexRequest);
-                    time = time.plusMillis(1);
-                }
-                var bulkResponse = client().bulk(bulkRequest).actionGet();
-                assertThat(bulkResponse.hasFailures(), is(false));
-                indexName = bulkResponse.getItems()[0].getIndex();
-            }
-            client().admin().indices().refresh(new RefreshRequest(dataStreamName)).actionGet();
-        }
-
-        // Verify settings.
-        final GetSettingsResponse getSettingsResponse = indicesAdmin().getSettings(
-            new GetSettingsRequest(TEST_REQUEST_TIMEOUT).indices(indexName).includeDefaults(false)
-        ).actionGet();
-        final Settings settings = getSettingsResponse.getIndexToSettings().get(indexName);
-        assertEquals("message,k8s.pod.uid,@timestamp", settings.get("index.sort.field"));
-        if (routeOnSortFields) {
-            assertEquals("[message, k8s.pod.uid]", settings.get("index.routing_path"));
-            assertEquals("true", settings.get("index.logsdb.route_on_sort_fields"));
-        } else {
-            assertNull(settings.get("index.routing_path"));
-            assertNull(settings.get("index.logsdb.route_on_sort_fields"));
-        }
-
-        // Check the search api can synthesize _id
-        final String idxName = indexName;
-        var searchRequest = new SearchRequest(dataStreamName);
-        searchRequest.source().trackTotalHits(true);
-        assertResponse(client().search(searchRequest), searchResponse -> {
-            assertThat(searchResponse.getHits().getTotalHits().value(), equalTo((long) numBulkRequests * numDocsPerBulk));
-
-            for (int i = 0; i < searchResponse.getHits().getHits().length; i++) {
-                String id = searchResponse.getHits().getHits()[i].getId();
-                assertThat(id, notNullValue());
-
-                // Check that the _id is gettable:
-                var getResponse = client().get(new GetRequest(idxName).id(id)).actionGet();
-                assertThat(getResponse.isExists(), is(true));
-                assertThat(getResponse.getId(), equalTo(id));
-            }
-        });
     }
 
     static String formatInstant(Instant instant) {

--- a/x-pack/plugin/logsdb/src/internalClusterTest/java/org/elasticsearch/xpack/logsdb/LogsIdIT.java
+++ b/x-pack/plugin/logsdb/src/internalClusterTest/java/org/elasticsearch/xpack/logsdb/LogsIdIT.java
@@ -224,43 +224,43 @@ public class LogsIdIT extends ESSingleNodeTestCase {
         }
     }
 
-//    public void testDeleteByProvidedID() throws Exception {
-//        var indexName = "test-name";
-//        createIndex(indexName, Settings.builder().put("index.mode", "logsdb").build());
-//        Instant time = Instant.now();
-//        BulkRequest bulkRequest = new BulkRequest(indexName);
-//        int numDocs = randomIntBetween(16, 256);
-//        for (int j = 0; j < numDocs; j++) {
-//            var indexRequest = new IndexRequest(indexName).opType(DocWriteRequest.OpType.INDEX).id("id-" + j);
-//            indexRequest.source(
-//                DOC.replace("$time", formatInstant(time)).replace("$uuid", UUID.randomUUID().toString()).replace("$pod", "pod-" + j),
-//                XContentType.JSON
-//            );
-//            bulkRequest.add(indexRequest);
-//            time = time.plusMillis(1);
-//        }
-//        var bulkResponse = client().bulk(bulkRequest).actionGet();
-//        assertThat(bulkResponse.hasFailures(), is(false));
-//        client().admin().indices().refresh(new RefreshRequest(indexName)).actionGet();
-//
-//        if (randomBoolean()) {
-//            flush(indexName, randomBoolean());
-//        }
-//
-//        var searchRequest = new SearchRequest(indexName);
-//        searchRequest.source().trackTotalHits(true);
-//        assertResponse(client().search(searchRequest), searchResponse -> {
-//            assertThat(searchResponse.getHits().getTotalHits().value(), equalTo((long) numDocs));
-//        });
-//
-//        // test get with the provided IDs
-//        for (int i = 0; i < numDocs; i++) {
-//            DeleteResponse deleteResponse = client().prepareDelete(indexName, "id-" + i).get();
-//            assertThat(deleteResponse.status(), equalTo(RestStatus.OK));
-//        }
-//
-//        assertThat(client().prepareSearch(indexName).get().getHits().getTotalHits().value(), equalTo(0));
-//    }
+    // public void testDeleteByProvidedID() throws Exception {
+    // var indexName = "test-name";
+    // createIndex(indexName, Settings.builder().put("index.mode", "logsdb").build());
+    // Instant time = Instant.now();
+    // BulkRequest bulkRequest = new BulkRequest(indexName);
+    // int numDocs = randomIntBetween(16, 256);
+    // for (int j = 0; j < numDocs; j++) {
+    // var indexRequest = new IndexRequest(indexName).opType(DocWriteRequest.OpType.INDEX).id("id-" + j);
+    // indexRequest.source(
+    // DOC.replace("$time", formatInstant(time)).replace("$uuid", UUID.randomUUID().toString()).replace("$pod", "pod-" + j),
+    // XContentType.JSON
+    // );
+    // bulkRequest.add(indexRequest);
+    // time = time.plusMillis(1);
+    // }
+    // var bulkResponse = client().bulk(bulkRequest).actionGet();
+    // assertThat(bulkResponse.hasFailures(), is(false));
+    // client().admin().indices().refresh(new RefreshRequest(indexName)).actionGet();
+    //
+    // if (randomBoolean()) {
+    // flush(indexName, randomBoolean());
+    // }
+    //
+    // var searchRequest = new SearchRequest(indexName);
+    // searchRequest.source().trackTotalHits(true);
+    // assertResponse(client().search(searchRequest), searchResponse -> {
+    // assertThat(searchResponse.getHits().getTotalHits().value(), equalTo((long) numDocs));
+    // });
+    //
+    // // test get with the provided IDs
+    // for (int i = 0; i < numDocs; i++) {
+    // DeleteResponse deleteResponse = client().prepareDelete(indexName, "id-" + i).get();
+    // assertThat(deleteResponse.status(), equalTo(RestStatus.OK));
+    // }
+    //
+    // assertThat(client().prepareSearch(indexName).get().getHits().getTotalHits().value(), equalTo(0));
+    // }
 
     private void createTemplate(String dataStreamName) throws IOException {
         var putTemplateRequest = new TransportPutComposableIndexTemplateAction.Request("id");

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
@@ -12,7 +12,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.FormatNames;
-import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
@@ -421,37 +420,27 @@ public class LogsdbRestIT extends ESRestTestCase {
         var forceMergeResponse = client().performRequest(forceMergeRequest);
         assertOK(forceMergeResponse);
 
-
         var getRequest = new Request("GET", "/" + indexName + "/_doc/" + "some_id_4");
-       var getResponse = client().performRequest(getRequest);
+        var getResponse = client().performRequest(getRequest);
         logger.info(getRequest);
         assertOK(getResponse);
 
-
-
-
-
-
-
-
-
-
-//        var searchRequest = new Request("POST", "/" + indexName + "/_search");
-//
-//        searchRequest.setJsonEntity("""
-//            {
-//                "query": {
-//                    "match": {
-//                        "_id": "some_id_5"
-//                    }
-//                }
-//            }
-//            """);
-//        var searchResponse = client().performRequest(searchRequest);
-//        assertOK(searchResponse);
-//        var searchResponseBody = responseAsMap(searchResponse);
-//        int totalHits = (int) XContentMapValues.extractValue("hits.total.value", searchResponseBody);
-//        assertThat(totalHits, equalTo(1));
+        // var searchRequest = new Request("POST", "/" + indexName + "/_search");
+        //
+        // searchRequest.setJsonEntity("""
+        // {
+        // "query": {
+        // "match": {
+        // "_id": "some_id_5"
+        // }
+        // }
+        // }
+        // """);
+        // var searchResponse = client().performRequest(searchRequest);
+        // assertOK(searchResponse);
+        // var searchResponseBody = responseAsMap(searchResponse);
+        // int totalHits = (int) XContentMapValues.extractValue("hits.total.value", searchResponseBody);
+        // assertThat(totalHits, equalTo(1));
     }
 
 }


### PR DESCRIPTION
Remove `_id` stored field and inverted index from logsdb, replacing with a doc value. Investigate effects of change on storage size.