### PR TITLE
Adjust generated pushdown query for IndexOrDocValuesQuery

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,491 +1,491 @@
 tests:
-  - class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
-    issue: "https://github.com/elastic/elasticsearch/issues/102717"
-    method: "testRequestResetAndAbort"
-  - class: org.elasticsearch.smoketest.WatcherYamlRestIT
-    method: test {p0=watcher/usage/10_basic/Test watcher usage stats output}
-    issue: https://github.com/elastic/elasticsearch/issues/112189
-  - class: org.elasticsearch.ingest.geoip.IngestGeoIpClientYamlTestSuiteIT
-    issue: https://github.com/elastic/elasticsearch/issues/111497
-  - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
-    method: test20SecurityNotAutoConfiguredOnReInstallation
-    issue: https://github.com/elastic/elasticsearch/issues/112635
-  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-    method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
-    issue: https://github.com/elastic/elasticsearch/issues/112642
-  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-    method: test {case-functions.testUcaseInline1}
-    issue: https://github.com/elastic/elasticsearch/issues/112641
-  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-    method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
-    issue: https://github.com/elastic/elasticsearch/issues/112640
-  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-    method: test {case-functions.testUcaseInline3}
-    issue: https://github.com/elastic/elasticsearch/issues/112643
-  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-    method: test {case-functions.testUcaseInline1}
-    issue: https://github.com/elastic/elasticsearch/issues/112641
-  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-    method: test {case-functions.testUcaseInline3}
-    issue: https://github.com/elastic/elasticsearch/issues/112643
-  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-    method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
-    issue: https://github.com/elastic/elasticsearch/issues/112640
-  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-    method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
-    issue: https://github.com/elastic/elasticsearch/issues/112642
-  - class: org.elasticsearch.packaging.test.WindowsServiceTests
-    method: test30StartStop
-    issue: https://github.com/elastic/elasticsearch/issues/113160
-  - class: org.elasticsearch.packaging.test.WindowsServiceTests
-    method: test33JavaChanged
-    issue: https://github.com/elastic/elasticsearch/issues/113177
-  - class: org.elasticsearch.packaging.test.WindowsServiceTests
-    method: test80JavaOptsInEnvVar
-    issue: https://github.com/elastic/elasticsearch/issues/113219
-  - class: org.elasticsearch.packaging.test.WindowsServiceTests
-    method: test81JavaOptsInJvmOptions
-    issue: https://github.com/elastic/elasticsearch/issues/113313
-  - class: org.elasticsearch.xpack.transform.integration.TransformIT
-    method: testStopWaitForCheckpoint
-    issue: https://github.com/elastic/elasticsearch/issues/106113
-  - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
-    method: testTracingCrossCluster
-    issue: https://github.com/elastic/elasticsearch/issues/112731
-  - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-    method: testDeploymentSurvivesRestart {cluster=UPGRADED}
-    issue: https://github.com/elastic/elasticsearch/issues/115528
-  - class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
-    method: testStalledShardMigrationProperlyDetected
-    issue: https://github.com/elastic/elasticsearch/issues/115697
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
-    issue: https://github.com/elastic/elasticsearch/issues/115808
-  - class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
-    issue: https://github.com/elastic/elasticsearch/issues/116087
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start already started transform}
-    issue: https://github.com/elastic/elasticsearch/issues/98802
-  - class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
-    method: testAllocationPreventedForRemoval
-    issue: https://github.com/elastic/elasticsearch/issues/116363
-  - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectoryGroupsResolverTests
-    issue: https://github.com/elastic/elasticsearch/issues/116182
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
-    issue: https://github.com/elastic/elasticsearch/issues/116775
-  - class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
-    method: testRandomDirectoryIOExceptions
-    issue: https://github.com/elastic/elasticsearch/issues/114824
-  - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
-    method: test {yaml=/10_apm/Test template reinstallation}
-    issue: https://github.com/elastic/elasticsearch/issues/116445
-  - class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
-    method: testSeqNoCASLinearizability
-    issue: https://github.com/elastic/elasticsearch/issues/117249
-  - class: org.elasticsearch.discovery.ClusterDisruptionIT
-    method: testAckedIndexing
-    issue: https://github.com/elastic/elasticsearch/issues/117024
-  - class: org.elasticsearch.xpack.inference.InferenceRestIT
-    method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
-    issue: https://github.com/elastic/elasticsearch/issues/117027
-  - class: org.elasticsearch.xpack.inference.InferenceRestIT
-    method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
-    issue: https://github.com/elastic/elasticsearch/issues/117349
-  - class: org.elasticsearch.xpack.inference.InferenceRestIT
-    method: test {p0=inference/30_semantic_text_inference_bwc/Calculates embeddings using the default ELSER 2 endpoint}
-    issue: https://github.com/elastic/elasticsearch/issues/117349
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_reset/Test reset running transform}
-    issue: https://github.com/elastic/elasticsearch/issues/117473
-  - class: org.elasticsearch.xpack.ml.integration.RegressionIT
-    method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
-    issue: https://github.com/elastic/elasticsearch/issues/117805
-  - class: org.elasticsearch.packaging.test.ArchiveTests
-    method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
-    issue: https://github.com/elastic/elasticsearch/issues/118208
-  - class: org.elasticsearch.packaging.test.ArchiveTests
-    method: test51AutoConfigurationWithPasswordProtectedKeystore
-    issue: https://github.com/elastic/elasticsearch/issues/118212
-  - class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
-    method: test {p0=data_stream/120_data_streams_stats/Multiple data stream}
-    issue: https://github.com/elastic/elasticsearch/issues/118217
-  - class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
-    method: testShardChangesNoOperation
-    issue: https://github.com/elastic/elasticsearch/issues/118800
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
-    issue: https://github.com/elastic/elasticsearch/issues/119508
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
-    issue: https://github.com/elastic/elasticsearch/issues/119548
-  - class: org.elasticsearch.xpack.ml.integration.ForecastIT
-    method: testOverflowToDisk
-    issue: https://github.com/elastic/elasticsearch/issues/117740
-  - class: org.elasticsearch.xpack.security.authc.ldap.MultiGroupMappingIT
-    issue: https://github.com/elastic/elasticsearch/issues/119599
-  - class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
-    issue: https://github.com/elastic/elasticsearch/issues/119983
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_unattended/Test unattended put and start}
-    issue: https://github.com/elastic/elasticsearch/issues/120019
-  - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
-    method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
-    issue: https://github.com/elastic/elasticsearch/issues/120127
-  - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-    method: testOldRepoAccess
-    issue: https://github.com/elastic/elasticsearch/issues/120148
-  - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-    method: testOldSourceOnlyRepoAccess
-    issue: https://github.com/elastic/elasticsearch/issues/120080
-  - class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
-    method: testCleanShardFollowTaskAfterDeleteFollower
-    issue: https://github.com/elastic/elasticsearch/issues/120339
-  - class: org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeToCharProcessorTests
-    issue: https://github.com/elastic/elasticsearch/issues/120575
-  - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
-    method: testMultipleInferencesTriggeringDownloadAndDeploy
-    issue: https://github.com/elastic/elasticsearch/issues/120668
-  - class: org.elasticsearch.xpack.security.authc.ldap.ADLdapUserSearchSessionFactoryTests
-    issue: https://github.com/elastic/elasticsearch/issues/119882
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
-    issue: https://github.com/elastic/elasticsearch/issues/120810
-  - class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
-    method: testAuthenticateShouldNotFallThroughInCaseOfFailure
-    issue: https://github.com/elastic/elasticsearch/issues/120902
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test050BasicApiTests
-    issue: https://github.com/elastic/elasticsearch/issues/120911
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test140CgroupOsStatsAreAvailable
-    issue: https://github.com/elastic/elasticsearch/issues/120914
-  - class: org.elasticsearch.xpack.security.FileSettingsRoleMappingsRestartIT
-    method: testReservedStatePersistsOnRestart
-    issue: https://github.com/elastic/elasticsearch/issues/120923
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test070BindMountCustomPathConfAndJvmOptions
-    issue: https://github.com/elastic/elasticsearch/issues/120910
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test071BindMountCustomPathWithDifferentUID
-    issue: https://github.com/elastic/elasticsearch/issues/120918
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test171AdditionalCliOptionsAreForwarded
-    issue: https://github.com/elastic/elasticsearch/issues/120925
-  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-    method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
-    issue: https://github.com/elastic/elasticsearch/issues/120950
-  - class: org.elasticsearch.xpack.security.FileSettingsRoleMappingsRestartIT
-    method: testFileSettingsReprocessedOnRestartWithoutVersionChange
-    issue: https://github.com/elastic/elasticsearch/issues/120964
-  - class: org.elasticsearch.xpack.ml.integration.PyTorchModelIT
-    issue: https://github.com/elastic/elasticsearch/issues/121165
-  - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectorySessionFactoryTests
-    issue: https://github.com/elastic/elasticsearch/issues/121285
-  - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
-    issue: https://github.com/elastic/elasticsearch/issues/121407
-  - class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
-    method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
-    issue: https://github.com/elastic/elasticsearch/issues/121625
-  - class: org.elasticsearch.xpack.application.CohereServiceUpgradeIT
-    issue: https://github.com/elastic/elasticsearch/issues/121537
-  - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-    method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
-    issue: https://github.com/elastic/elasticsearch/issues/122102
-  - class: org.elasticsearch.smoketest.SmokeTestMonitoringWithSecurityIT
-    method: testHTTPExporterWithSSL
-    issue: https://github.com/elastic/elasticsearch/issues/122220
-  - class: org.elasticsearch.blocks.SimpleBlocksIT
-    method: testConcurrentAddBlock
-    issue: https://github.com/elastic/elasticsearch/issues/122324
-  - class: org.elasticsearch.xpack.ilm.TimeSeriesLifecycleActionsIT
-    method: testHistoryIsWrittenWithFailure
-    issue: https://github.com/elastic/elasticsearch/issues/123203
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test151MachineDependentHeapWithSizeOverride
-    issue: https://github.com/elastic/elasticsearch/issues/123437
-  - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
-    method: testChildrenTasksCancelledOnTimeout
-    issue: https://github.com/elastic/elasticsearch/issues/123568
-  - class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
-    method: testCreateAndRestorePartialSearchableSnapshot
-    issue: https://github.com/elastic/elasticsearch/issues/123773
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
-    issue: https://github.com/elastic/elasticsearch/issues/122755
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/data_frame_analytics_crud/Test get stats given multiple analytics}
-    issue: https://github.com/elastic/elasticsearch/issues/123034
-  - class: org.elasticsearch.indices.recovery.IndexRecoveryIT
-    method: testSourceThrottling
-    issue: https://github.com/elastic/elasticsearch/issues/123680
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
-    issue: https://github.com/elastic/elasticsearch/issues/120814
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable is missing}
-    issue: https://github.com/elastic/elasticsearch/issues/124168
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/3rd_party_deployment/Test start and stop multiple deployments}
-    issue: https://github.com/elastic/elasticsearch/issues/124315
-  - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-    method: test {yaml=data_stream/190_failure_store_redirection/Redirect ingest failure in data stream to failure store}
-    issue: https://github.com/elastic/elasticsearch/issues/124518
-  - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-    method: test {yaml=data_stream/150_tsdb/created the data stream}
-    issue: https://github.com/elastic/elasticsearch/issues/124575
-  - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-    method: testDeploymentSurvivesRestart {cluster=OLD}
-    issue: https://github.com/elastic/elasticsearch/issues/124160
-  - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-    method: test {yaml=search.vectors/41_knn_search_byte_quantized/kNN search plus query}
-    issue: https://github.com/elastic/elasticsearch/issues/124687
-  - class: org.elasticsearch.packaging.test.BootstrapCheckTests
-    method: test20RunWithBootstrapChecks
-    issue: https://github.com/elastic/elasticsearch/issues/124940
-  - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
-    method: testStopQueryLocal
-    issue: https://github.com/elastic/elasticsearch/issues/121672
-  - class: org.elasticsearch.packaging.test.BootstrapCheckTests
-    method: test10Install
-    issue: https://github.com/elastic/elasticsearch/issues/124957
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test011SecurityEnabledStatus
-    issue: https://github.com/elastic/elasticsearch/issues/124990
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test012SecurityCanBeDisabled
-    issue: https://github.com/elastic/elasticsearch/issues/116636
-  - class: org.elasticsearch.index.shard.StoreRecoveryTests
-    method: testAddIndices
-    issue: https://github.com/elastic/elasticsearch/issues/124104
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/data_frame_analytics_crud/Test get stats on newly created config}
-    issue: https://github.com/elastic/elasticsearch/issues/121726
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/data_frame_analytics_cat_apis/Test cat data frame analytics all jobs with header and column selection}
-    issue: https://github.com/elastic/elasticsearch/issues/125641
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/data_frame_analytics_cat_apis/Test cat data frame analytics single job with header}
-    issue: https://github.com/elastic/elasticsearch/issues/125642
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test010Install
-    issue: https://github.com/elastic/elasticsearch/issues/125680
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
-    issue: https://github.com/elastic/elasticsearch/issues/120720
-  - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceTests
-    method: testIORateIsAdjustedForRunningMergeTasks
-    issue: https://github.com/elastic/elasticsearch/issues/125842
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
-    issue: https://github.com/elastic/elasticsearch/issues/125854
-  - class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
-    method: testRecreateTemplateWhenDeleted
-    issue: https://github.com/elastic/elasticsearch/issues/123232
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=ml/start_data_frame_analytics/Test start given dest index is not empty}
-    issue: https://github.com/elastic/elasticsearch/issues/125909
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_stats/Test get transform stats with timeout}
-    issue: https://github.com/elastic/elasticsearch/issues/125975
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test021InstallPlugin
-    issue: https://github.com/elastic/elasticsearch/issues/116147
-  - class: org.elasticsearch.action.RejectionActionIT
-    method: testSimulatedSearchRejectionLoad
-    issue: https://github.com/elastic/elasticsearch/issues/125901
-  - class: org.elasticsearch.search.CCSDuelIT
-    method: testTerminateAfter
-    issue: https://github.com/elastic/elasticsearch/issues/126085
-  - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-    method: testSearchWithRandomDisconnects
-    issue: https://github.com/elastic/elasticsearch/issues/122707
-  - class: org.elasticsearch.xpack.esql.inference.RerankOperatorTests
-    method: testSimpleCircuitBreaking
-    issue: https://github.com/elastic/elasticsearch/issues/124337
-  - class: org.elasticsearch.index.engine.ThreadPoolMergeSchedulerTests
-    method: testSchedulerCloseWaitsForRunningMerge
-    issue: https://github.com/elastic/elasticsearch/issues/125236
-  - class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
-    method: testUpdatingFileBasedRoleAffectsAllProjects
-    issue: https://github.com/elastic/elasticsearch/issues/126223
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test020PluginsListWithNoPlugins
-    issue: https://github.com/elastic/elasticsearch/issues/126232
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_reset/Test force reseting a running transform}
-    issue: https://github.com/elastic/elasticsearch/issues/126240
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_stats/Test get transform stats}
-    issue: https://github.com/elastic/elasticsearch/issues/126270
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
-    issue: https://github.com/elastic/elasticsearch/issues/126299
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test023InstallPluginUsingConfigFile
-    issue: https://github.com/elastic/elasticsearch/issues/126145
-  - class: org.elasticsearch.search.SearchWithRejectionsIT
-    method: testOpenContextsAfterRejections
-    issue: https://github.com/elastic/elasticsearch/issues/126340
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
-    issue: https://github.com/elastic/elasticsearch/issues/123200
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test022InstallPluginsFromLocalArchive
-    issue: https://github.com/elastic/elasticsearch/issues/116866
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/trained_model_cat_apis/Test cat trained models}
-    issue: https://github.com/elastic/elasticsearch/issues/125750
-  - class: org.elasticsearch.ingest.geoip.EnterpriseGeoIpDownloaderIT
-    method: testEnterpriseDownloaderTask
-    issue: https://github.com/elastic/elasticsearch/issues/126124
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
-    issue: https://github.com/elastic/elasticsearch/issues/126466
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/get_trained_model_stats/Test get stats given trained models}
-    issue: https://github.com/elastic/elasticsearch/issues/126510
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_stats/Test get multiple transform stats}
-    issue: https://github.com/elastic/elasticsearch/issues/126567
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_stats/Test get single transform stats when it does not have a task}
-    issue: https://github.com/elastic/elasticsearch/issues/126568
-  - class: org.elasticsearch.repositories.blobstore.testkit.rest.SnapshotRepoTestKitClientYamlTestSuiteIT
-    method: test {p0=/10_analyze/Analysis without details}
-    issue: https://github.com/elastic/elasticsearch/issues/126569
-  - class: org.elasticsearch.xpack.esql.action.EsqlActionIT
-    method: testQueryOnEmptyDataIndex
-    issue: https://github.com/elastic/elasticsearch/issues/126580
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
-    issue: https://github.com/elastic/elasticsearch/issues/126755
-  - class: org.elasticsearch.search.SearchServiceSingleNodeTests
-    method: testBeforeShardLockDuringShardCreate
-    issue: https://github.com/elastic/elasticsearch/issues/126812
-  - class: org.elasticsearch.search.SearchServiceSingleNodeTests
-    method: testLookUpSearchContext
-    issue: https://github.com/elastic/elasticsearch/issues/126813
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_stats/Test get multiple transform stats where one does not have a task}
-    issue: https://github.com/elastic/elasticsearch/issues/126863
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=ml/inference_crud/Test delete given unused trained model}
-    issue: https://github.com/elastic/elasticsearch/issues/126881
-  - class: org.elasticsearch.index.engine.CompletionStatsCacheTests
-    method: testCompletionStatsCache
-    issue: https://github.com/elastic/elasticsearch/issues/126910
-  - class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
-    method: testFeatureImportanceValues
-    issue: https://github.com/elastic/elasticsearch/issues/124341
-  - class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
-    method: testStdinWithMultipleValues
-    issue: https://github.com/elastic/elasticsearch/issues/126882
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test024InstallPluginFromArchiveUsingConfigFile
-    issue: https://github.com/elastic/elasticsearch/issues/126936
-  - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-    method: test {rerank.Reranker before a limit ASYNC}
-    issue: https://github.com/elastic/elasticsearch/issues/127051
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test026InstallBundledRepositoryPlugins
-    issue: https://github.com/elastic/elasticsearch/issues/127081
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test026InstallBundledRepositoryPluginsViaConfigFile
-    issue: https://github.com/elastic/elasticsearch/issues/127158
-  - class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS2EnrichUnavailableRemotesIT
-    method: testEsqlEnrichWithSkipUnavailable
-    issue: https://github.com/elastic/elasticsearch/issues/127368
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=ml/data_frame_analytics_cat_apis/Test cat data frame analytics all jobs with header}
-    issue: https://github.com/elastic/elasticsearch/issues/127625
-  - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-    method: test {rerank.Reranker using another sort order ASYNC}
-    issue: https://github.com/elastic/elasticsearch/issues/127638
-  - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-    method: testCancellationViaTimeoutWithAllowPartialResultsSetToFalse
-    issue: https://github.com/elastic/elasticsearch/issues/127096
-  - class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
-    method: testChangeFollowerHistoryUUID
-    issue: https://github.com/elastic/elasticsearch/issues/127680
-  - class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
-    method: testKnnVectors
-    issue: https://github.com/elastic/elasticsearch/issues/127689
-  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-    method: test {p0=search/350_point_in_time/point-in-time with index filter}
-    issue: https://github.com/elastic/elasticsearch/issues/127741
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test025SyncPluginsUsingProxy
-    issue: https://github.com/elastic/elasticsearch/issues/127138
-  - class: org.elasticsearch.indices.stats.IndexStatsIT
-    method: testThrottleStats
-    issue: https://github.com/elastic/elasticsearch/issues/126359
-  - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityRestIT
-    method: testTaskCancellation
-    issue: https://github.com/elastic/elasticsearch/issues/128009
-  - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
-    method: testOneRemoteClusterPartial
-    issue: https://github.com/elastic/elasticsearch/issues/124055
-  - class: org.elasticsearch.compute.aggregation.SampleDoubleAggregatorFunctionTests
-    method: testSimpleWithCranky
-    issue: https://github.com/elastic/elasticsearch/issues/128024
-  - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-    method: test {lookup-join.MvJoinKeyOnTheLookupIndex ASYNC}
-    issue: https://github.com/elastic/elasticsearch/issues/128030
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test042KeystorePermissionsAreCorrect
-    issue: https://github.com/elastic/elasticsearch/issues/128018
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test072RunEsAsDifferentUserAndGroup
-    issue: https://github.com/elastic/elasticsearch/issues/128031
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test122CanUseDockerLoggingConfig
-    issue: https://github.com/elastic/elasticsearch/issues/128110
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test041AmazonCaCertsAreInTheKeystore
-    issue: https://github.com/elastic/elasticsearch/issues/128006
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test130JavaHasCorrectOwnership
-    issue: https://github.com/elastic/elasticsearch/issues/128174
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test600Interrupt
-    issue: https://github.com/elastic/elasticsearch/issues/128144
-  - class: org.elasticsearch.packaging.test.EnrollmentProcessTests
-    method: test20DockerAutoFormCluster
-    issue: https://github.com/elastic/elasticsearch/issues/128113
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test121CanUseStackLoggingConfig
-    issue: https://github.com/elastic/elasticsearch/issues/128165
-  - class: org.elasticsearch.xpack.esql.session.IndexResolverFieldNamesTests
-    method: testForkFieldsWithKeepAfterFork
-    issue: https://github.com/elastic/elasticsearch/issues/128271
-  - class: org.elasticsearch.xpack.esql.session.IndexResolverFieldNamesTests
-    method: testForkWithStatsInAllBranches
-    issue: https://github.com/elastic/elasticsearch/issues/128272
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test080ConfigurePasswordThroughEnvironmentVariableFile
-    issue: https://github.com/elastic/elasticsearch/issues/128075
-  - class: org.elasticsearch.ingest.geoip.GeoIpDownloaderCliIT
-    method: testInvalidTimestamp
-    issue: https://github.com/elastic/elasticsearch/issues/128284
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test120DockerLogsIncludeElasticsearchLogs
-    issue: https://github.com/elastic/elasticsearch/issues/128117
-  - class: org.elasticsearch.packaging.test.TemporaryDirectoryConfigTests
-    method: test21AcceptsCustomPathInDocker
-    issue: https://github.com/elastic/elasticsearch/issues/128114
-  - class: org.elasticsearch.xpack.ml.integration.InferenceIngestIT
-    method: testPipelineIngestWithModelAliases
-    issue: https://github.com/elastic/elasticsearch/issues/128417
-  - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-    method: testCCSClusterDetailsWhereAllShardsSkippedInCanMatch
-    issue: https://github.com/elastic/elasticsearch/issues/128418
-  - class: org.elasticsearch.xpack.esql.action.ForkIT
-    method: testProfile
-    issue: https://github.com/elastic/elasticsearch/issues/128377
-  - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithFiltersIT
-    method: testTimestampFilterFromQuery
-    issue: https://github.com/elastic/elasticsearch/issues/127332
+- class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
+  issue: "https://github.com/elastic/elasticsearch/issues/102717"
+  method: "testRequestResetAndAbort"
+- class: org.elasticsearch.smoketest.WatcherYamlRestIT
+  method: test {p0=watcher/usage/10_basic/Test watcher usage stats output}
+  issue: https://github.com/elastic/elasticsearch/issues/112189
+- class: org.elasticsearch.ingest.geoip.IngestGeoIpClientYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/111497
+- class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
+  method: test20SecurityNotAutoConfiguredOnReInstallation
+  issue: https://github.com/elastic/elasticsearch/issues/112635
+- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+  method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
+  issue: https://github.com/elastic/elasticsearch/issues/112642
+- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+  method: test {case-functions.testUcaseInline1}
+  issue: https://github.com/elastic/elasticsearch/issues/112641
+- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+  method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
+  issue: https://github.com/elastic/elasticsearch/issues/112640
+- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+  method: test {case-functions.testUcaseInline3}
+  issue: https://github.com/elastic/elasticsearch/issues/112643
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testUcaseInline1}
+  issue: https://github.com/elastic/elasticsearch/issues/112641
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testUcaseInline3}
+  issue: https://github.com/elastic/elasticsearch/issues/112643
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
+  issue: https://github.com/elastic/elasticsearch/issues/112640
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
+  issue: https://github.com/elastic/elasticsearch/issues/112642
+- class: org.elasticsearch.packaging.test.WindowsServiceTests
+  method: test30StartStop
+  issue: https://github.com/elastic/elasticsearch/issues/113160
+- class: org.elasticsearch.packaging.test.WindowsServiceTests
+  method: test33JavaChanged
+  issue: https://github.com/elastic/elasticsearch/issues/113177
+- class: org.elasticsearch.packaging.test.WindowsServiceTests
+  method: test80JavaOptsInEnvVar
+  issue: https://github.com/elastic/elasticsearch/issues/113219
+- class: org.elasticsearch.packaging.test.WindowsServiceTests
+  method: test81JavaOptsInJvmOptions
+  issue: https://github.com/elastic/elasticsearch/issues/113313
+- class: org.elasticsearch.xpack.transform.integration.TransformIT
+  method: testStopWaitForCheckpoint
+  issue: https://github.com/elastic/elasticsearch/issues/106113
+- class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
+  method: testTracingCrossCluster
+  issue: https://github.com/elastic/elasticsearch/issues/112731
+- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
+  issue: https://github.com/elastic/elasticsearch/issues/115528
+- class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
+  method: testStalledShardMigrationProperlyDetected
+  issue: https://github.com/elastic/elasticsearch/issues/115697
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
+  issue: https://github.com/elastic/elasticsearch/issues/115808
+- class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
+  issue: https://github.com/elastic/elasticsearch/issues/116087
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start already started transform}
+  issue: https://github.com/elastic/elasticsearch/issues/98802
+- class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
+  method: testAllocationPreventedForRemoval
+  issue: https://github.com/elastic/elasticsearch/issues/116363
+- class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectoryGroupsResolverTests
+  issue: https://github.com/elastic/elasticsearch/issues/116182
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
+  issue: https://github.com/elastic/elasticsearch/issues/116775
+- class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
+  method: testRandomDirectoryIOExceptions
+  issue: https://github.com/elastic/elasticsearch/issues/114824
+- class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
+  method: test {yaml=/10_apm/Test template reinstallation}
+  issue: https://github.com/elastic/elasticsearch/issues/116445
+- class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
+  method: testSeqNoCASLinearizability
+  issue: https://github.com/elastic/elasticsearch/issues/117249
+- class: org.elasticsearch.discovery.ClusterDisruptionIT
+  method: testAckedIndexing
+  issue: https://github.com/elastic/elasticsearch/issues/117024
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/117027
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/117349
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/30_semantic_text_inference_bwc/Calculates embeddings using the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/117349
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_reset/Test reset running transform}
+  issue: https://github.com/elastic/elasticsearch/issues/117473
+- class: org.elasticsearch.xpack.ml.integration.RegressionIT
+  method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
+  issue: https://github.com/elastic/elasticsearch/issues/117805
+- class: org.elasticsearch.packaging.test.ArchiveTests
+  method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
+  issue: https://github.com/elastic/elasticsearch/issues/118208
+- class: org.elasticsearch.packaging.test.ArchiveTests
+  method: test51AutoConfigurationWithPasswordProtectedKeystore
+  issue: https://github.com/elastic/elasticsearch/issues/118212
+- class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
+  method: test {p0=data_stream/120_data_streams_stats/Multiple data stream}
+  issue: https://github.com/elastic/elasticsearch/issues/118217
+- class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
+  method: testShardChangesNoOperation
+  issue: https://github.com/elastic/elasticsearch/issues/118800
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
+  issue: https://github.com/elastic/elasticsearch/issues/119508
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
+  issue: https://github.com/elastic/elasticsearch/issues/119548
+- class: org.elasticsearch.xpack.ml.integration.ForecastIT
+  method: testOverflowToDisk
+  issue: https://github.com/elastic/elasticsearch/issues/117740
+- class: org.elasticsearch.xpack.security.authc.ldap.MultiGroupMappingIT
+  issue: https://github.com/elastic/elasticsearch/issues/119599
+- class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/119983
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_unattended/Test unattended put and start}
+  issue: https://github.com/elastic/elasticsearch/issues/120019
+- class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
+  method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
+  issue: https://github.com/elastic/elasticsearch/issues/120127
+- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
+  method: testOldRepoAccess
+  issue: https://github.com/elastic/elasticsearch/issues/120148
+- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
+  method: testOldSourceOnlyRepoAccess
+  issue: https://github.com/elastic/elasticsearch/issues/120080
+- class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
+  method: testCleanShardFollowTaskAfterDeleteFollower
+  issue: https://github.com/elastic/elasticsearch/issues/120339
+- class: org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeToCharProcessorTests
+  issue: https://github.com/elastic/elasticsearch/issues/120575
+- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
+  method: testMultipleInferencesTriggeringDownloadAndDeploy
+  issue: https://github.com/elastic/elasticsearch/issues/120668
+- class: org.elasticsearch.xpack.security.authc.ldap.ADLdapUserSearchSessionFactoryTests
+  issue: https://github.com/elastic/elasticsearch/issues/119882
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
+  issue: https://github.com/elastic/elasticsearch/issues/120810
+- class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
+  method: testAuthenticateShouldNotFallThroughInCaseOfFailure
+  issue: https://github.com/elastic/elasticsearch/issues/120902
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test050BasicApiTests
+  issue: https://github.com/elastic/elasticsearch/issues/120911
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test140CgroupOsStatsAreAvailable
+  issue: https://github.com/elastic/elasticsearch/issues/120914
+- class: org.elasticsearch.xpack.security.FileSettingsRoleMappingsRestartIT
+  method: testReservedStatePersistsOnRestart
+  issue: https://github.com/elastic/elasticsearch/issues/120923
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test070BindMountCustomPathConfAndJvmOptions
+  issue: https://github.com/elastic/elasticsearch/issues/120910
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test071BindMountCustomPathWithDifferentUID
+  issue: https://github.com/elastic/elasticsearch/issues/120918
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test171AdditionalCliOptionsAreForwarded
+  issue: https://github.com/elastic/elasticsearch/issues/120925
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
+  issue: https://github.com/elastic/elasticsearch/issues/120950
+- class: org.elasticsearch.xpack.security.FileSettingsRoleMappingsRestartIT
+  method: testFileSettingsReprocessedOnRestartWithoutVersionChange
+  issue: https://github.com/elastic/elasticsearch/issues/120964
+- class: org.elasticsearch.xpack.ml.integration.PyTorchModelIT
+  issue: https://github.com/elastic/elasticsearch/issues/121165
+- class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectorySessionFactoryTests
+  issue: https://github.com/elastic/elasticsearch/issues/121285
+- class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/121407
+- class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
+  method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
+  issue: https://github.com/elastic/elasticsearch/issues/121625
+- class: org.elasticsearch.xpack.application.CohereServiceUpgradeIT
+  issue: https://github.com/elastic/elasticsearch/issues/121537
+- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
+  method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
+  issue: https://github.com/elastic/elasticsearch/issues/122102
+- class: org.elasticsearch.smoketest.SmokeTestMonitoringWithSecurityIT
+  method: testHTTPExporterWithSSL
+  issue: https://github.com/elastic/elasticsearch/issues/122220
+- class: org.elasticsearch.blocks.SimpleBlocksIT
+  method: testConcurrentAddBlock
+  issue: https://github.com/elastic/elasticsearch/issues/122324
+- class: org.elasticsearch.xpack.ilm.TimeSeriesLifecycleActionsIT
+  method: testHistoryIsWrittenWithFailure
+  issue: https://github.com/elastic/elasticsearch/issues/123203
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test151MachineDependentHeapWithSizeOverride
+  issue: https://github.com/elastic/elasticsearch/issues/123437
+- class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
+  method: testChildrenTasksCancelledOnTimeout
+  issue: https://github.com/elastic/elasticsearch/issues/123568
+- class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
+  method: testCreateAndRestorePartialSearchableSnapshot
+  issue: https://github.com/elastic/elasticsearch/issues/123773
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
+  issue: https://github.com/elastic/elasticsearch/issues/122755
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/data_frame_analytics_crud/Test get stats given multiple analytics}
+  issue: https://github.com/elastic/elasticsearch/issues/123034
+- class: org.elasticsearch.indices.recovery.IndexRecoveryIT
+  method: testSourceThrottling
+  issue: https://github.com/elastic/elasticsearch/issues/123680
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
+  issue: https://github.com/elastic/elasticsearch/issues/120814
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable is missing}
+  issue: https://github.com/elastic/elasticsearch/issues/124168
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/3rd_party_deployment/Test start and stop multiple deployments}
+  issue: https://github.com/elastic/elasticsearch/issues/124315
+- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=data_stream/190_failure_store_redirection/Redirect ingest failure in data stream to failure store}
+  issue: https://github.com/elastic/elasticsearch/issues/124518
+- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=data_stream/150_tsdb/created the data stream}
+  issue: https://github.com/elastic/elasticsearch/issues/124575
+- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+  method: testDeploymentSurvivesRestart {cluster=OLD}
+  issue: https://github.com/elastic/elasticsearch/issues/124160
+- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=search.vectors/41_knn_search_byte_quantized/kNN search plus query}
+  issue: https://github.com/elastic/elasticsearch/issues/124687
+- class: org.elasticsearch.packaging.test.BootstrapCheckTests
+  method: test20RunWithBootstrapChecks
+  issue: https://github.com/elastic/elasticsearch/issues/124940
+- class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
+  method: testStopQueryLocal
+  issue: https://github.com/elastic/elasticsearch/issues/121672
+- class: org.elasticsearch.packaging.test.BootstrapCheckTests
+  method: test10Install
+  issue: https://github.com/elastic/elasticsearch/issues/124957
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test011SecurityEnabledStatus
+  issue: https://github.com/elastic/elasticsearch/issues/124990
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test012SecurityCanBeDisabled
+  issue: https://github.com/elastic/elasticsearch/issues/116636
+- class: org.elasticsearch.index.shard.StoreRecoveryTests
+  method: testAddIndices
+  issue: https://github.com/elastic/elasticsearch/issues/124104
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/data_frame_analytics_crud/Test get stats on newly created config}
+  issue: https://github.com/elastic/elasticsearch/issues/121726
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/data_frame_analytics_cat_apis/Test cat data frame analytics all jobs with header and column selection}
+  issue: https://github.com/elastic/elasticsearch/issues/125641
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/data_frame_analytics_cat_apis/Test cat data frame analytics single job with header}
+  issue: https://github.com/elastic/elasticsearch/issues/125642
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test010Install
+  issue: https://github.com/elastic/elasticsearch/issues/125680
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
+  issue: https://github.com/elastic/elasticsearch/issues/120720
+- class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceTests
+  method: testIORateIsAdjustedForRunningMergeTasks
+  issue: https://github.com/elastic/elasticsearch/issues/125842
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
+  issue: https://github.com/elastic/elasticsearch/issues/125854
+- class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
+  method: testRecreateTemplateWhenDeleted
+  issue: https://github.com/elastic/elasticsearch/issues/123232
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=ml/start_data_frame_analytics/Test start given dest index is not empty}
+  issue: https://github.com/elastic/elasticsearch/issues/125909
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_stats/Test get transform stats with timeout}
+  issue: https://github.com/elastic/elasticsearch/issues/125975
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test021InstallPlugin
+  issue: https://github.com/elastic/elasticsearch/issues/116147
+- class: org.elasticsearch.action.RejectionActionIT
+  method: testSimulatedSearchRejectionLoad
+  issue: https://github.com/elastic/elasticsearch/issues/125901
+- class: org.elasticsearch.search.CCSDuelIT
+  method: testTerminateAfter
+  issue: https://github.com/elastic/elasticsearch/issues/126085
+- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
+  method: testSearchWithRandomDisconnects
+  issue: https://github.com/elastic/elasticsearch/issues/122707
+- class: org.elasticsearch.xpack.esql.inference.RerankOperatorTests
+  method: testSimpleCircuitBreaking
+  issue: https://github.com/elastic/elasticsearch/issues/124337
+- class: org.elasticsearch.index.engine.ThreadPoolMergeSchedulerTests
+  method: testSchedulerCloseWaitsForRunningMerge
+  issue: https://github.com/elastic/elasticsearch/issues/125236
+- class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
+  method: testUpdatingFileBasedRoleAffectsAllProjects
+  issue: https://github.com/elastic/elasticsearch/issues/126223
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test020PluginsListWithNoPlugins
+  issue: https://github.com/elastic/elasticsearch/issues/126232
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_reset/Test force reseting a running transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126240
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_stats/Test get transform stats}
+  issue: https://github.com/elastic/elasticsearch/issues/126270
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
+  issue: https://github.com/elastic/elasticsearch/issues/126299
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test023InstallPluginUsingConfigFile
+  issue: https://github.com/elastic/elasticsearch/issues/126145
+- class: org.elasticsearch.search.SearchWithRejectionsIT
+  method: testOpenContextsAfterRejections
+  issue: https://github.com/elastic/elasticsearch/issues/126340
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
+  issue: https://github.com/elastic/elasticsearch/issues/123200
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test022InstallPluginsFromLocalArchive
+  issue: https://github.com/elastic/elasticsearch/issues/116866
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/trained_model_cat_apis/Test cat trained models}
+  issue: https://github.com/elastic/elasticsearch/issues/125750
+- class: org.elasticsearch.ingest.geoip.EnterpriseGeoIpDownloaderIT
+  method: testEnterpriseDownloaderTask
+  issue: https://github.com/elastic/elasticsearch/issues/126124
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126466
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/get_trained_model_stats/Test get stats given trained models}
+  issue: https://github.com/elastic/elasticsearch/issues/126510
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_stats/Test get multiple transform stats}
+  issue: https://github.com/elastic/elasticsearch/issues/126567
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_stats/Test get single transform stats when it does not have a task}
+  issue: https://github.com/elastic/elasticsearch/issues/126568
+- class: org.elasticsearch.repositories.blobstore.testkit.rest.SnapshotRepoTestKitClientYamlTestSuiteIT
+  method: test {p0=/10_analyze/Analysis without details}
+  issue: https://github.com/elastic/elasticsearch/issues/126569
+- class: org.elasticsearch.xpack.esql.action.EsqlActionIT
+  method: testQueryOnEmptyDataIndex
+  issue: https://github.com/elastic/elasticsearch/issues/126580
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126755
+- class: org.elasticsearch.search.SearchServiceSingleNodeTests
+  method: testBeforeShardLockDuringShardCreate
+  issue: https://github.com/elastic/elasticsearch/issues/126812
+- class: org.elasticsearch.search.SearchServiceSingleNodeTests
+  method: testLookUpSearchContext
+  issue: https://github.com/elastic/elasticsearch/issues/126813
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_stats/Test get multiple transform stats where one does not have a task}
+  issue: https://github.com/elastic/elasticsearch/issues/126863
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=ml/inference_crud/Test delete given unused trained model}
+  issue: https://github.com/elastic/elasticsearch/issues/126881
+- class: org.elasticsearch.index.engine.CompletionStatsCacheTests
+  method: testCompletionStatsCache
+  issue: https://github.com/elastic/elasticsearch/issues/126910
+- class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
+  method: testFeatureImportanceValues
+  issue: https://github.com/elastic/elasticsearch/issues/124341
+- class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
+  method: testStdinWithMultipleValues
+  issue: https://github.com/elastic/elasticsearch/issues/126882
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test024InstallPluginFromArchiveUsingConfigFile
+  issue: https://github.com/elastic/elasticsearch/issues/126936
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+  method: test {rerank.Reranker before a limit ASYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/127051
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test026InstallBundledRepositoryPlugins
+  issue: https://github.com/elastic/elasticsearch/issues/127081
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test026InstallBundledRepositoryPluginsViaConfigFile
+  issue: https://github.com/elastic/elasticsearch/issues/127158
+- class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS2EnrichUnavailableRemotesIT
+  method: testEsqlEnrichWithSkipUnavailable
+  issue: https://github.com/elastic/elasticsearch/issues/127368
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=ml/data_frame_analytics_cat_apis/Test cat data frame analytics all jobs with header}
+  issue: https://github.com/elastic/elasticsearch/issues/127625
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+  method: test {rerank.Reranker using another sort order ASYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/127638
+- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
+  method: testCancellationViaTimeoutWithAllowPartialResultsSetToFalse
+  issue: https://github.com/elastic/elasticsearch/issues/127096
+- class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
+  method: testChangeFollowerHistoryUUID
+  issue: https://github.com/elastic/elasticsearch/issues/127680
+- class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
+  method: testKnnVectors
+  issue: https://github.com/elastic/elasticsearch/issues/127689
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=search/350_point_in_time/point-in-time with index filter}
+  issue: https://github.com/elastic/elasticsearch/issues/127741
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test025SyncPluginsUsingProxy
+  issue: https://github.com/elastic/elasticsearch/issues/127138
+- class: org.elasticsearch.indices.stats.IndexStatsIT
+  method: testThrottleStats
+  issue: https://github.com/elastic/elasticsearch/issues/126359
+- class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityRestIT
+  method: testTaskCancellation
+  issue: https://github.com/elastic/elasticsearch/issues/128009
+- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
+  method: testOneRemoteClusterPartial
+  issue: https://github.com/elastic/elasticsearch/issues/124055
+- class: org.elasticsearch.compute.aggregation.SampleDoubleAggregatorFunctionTests
+  method: testSimpleWithCranky
+  issue: https://github.com/elastic/elasticsearch/issues/128024
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+  method: test {lookup-join.MvJoinKeyOnTheLookupIndex ASYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/128030
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test042KeystorePermissionsAreCorrect
+  issue: https://github.com/elastic/elasticsearch/issues/128018
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test072RunEsAsDifferentUserAndGroup
+  issue: https://github.com/elastic/elasticsearch/issues/128031
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test122CanUseDockerLoggingConfig
+  issue: https://github.com/elastic/elasticsearch/issues/128110
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test041AmazonCaCertsAreInTheKeystore
+  issue: https://github.com/elastic/elasticsearch/issues/128006
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test130JavaHasCorrectOwnership
+  issue: https://github.com/elastic/elasticsearch/issues/128174
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test600Interrupt
+  issue: https://github.com/elastic/elasticsearch/issues/128144
+- class: org.elasticsearch.packaging.test.EnrollmentProcessTests
+  method: test20DockerAutoFormCluster
+  issue: https://github.com/elastic/elasticsearch/issues/128113
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test121CanUseStackLoggingConfig
+  issue: https://github.com/elastic/elasticsearch/issues/128165
+- class: org.elasticsearch.xpack.esql.session.IndexResolverFieldNamesTests
+  method: testForkFieldsWithKeepAfterFork
+  issue: https://github.com/elastic/elasticsearch/issues/128271
+- class: org.elasticsearch.xpack.esql.session.IndexResolverFieldNamesTests
+  method: testForkWithStatsInAllBranches
+  issue: https://github.com/elastic/elasticsearch/issues/128272
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test080ConfigurePasswordThroughEnvironmentVariableFile
+  issue: https://github.com/elastic/elasticsearch/issues/128075
+- class: org.elasticsearch.ingest.geoip.GeoIpDownloaderCliIT
+  method: testInvalidTimestamp
+  issue: https://github.com/elastic/elasticsearch/issues/128284
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test120DockerLogsIncludeElasticsearchLogs
+  issue: https://github.com/elastic/elasticsearch/issues/128117
+- class: org.elasticsearch.packaging.test.TemporaryDirectoryConfigTests
+  method: test21AcceptsCustomPathInDocker
+  issue: https://github.com/elastic/elasticsearch/issues/128114
+- class: org.elasticsearch.xpack.ml.integration.InferenceIngestIT
+  method: testPipelineIngestWithModelAliases
+  issue: https://github.com/elastic/elasticsearch/issues/128417
+- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
+  method: testCCSClusterDetailsWhereAllShardsSkippedInCanMatch
+  issue: https://github.com/elastic/elasticsearch/issues/128418
+- class: org.elasticsearch.xpack.esql.action.ForkIT
+  method: testProfile
+  issue: https://github.com/elastic/elasticsearch/issues/128377
+- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithFiltersIT
+  method: testTimestampFilterFromQuery
+  issue: https://github.com/elastic/elasticsearch/issues/127332
 
 # Examples:
 #
@@ -525,3 +525,4 @@ tests:
 #  - class: "org.elasticsearch.xpack.esql.**"
 #    method: "test {union_types.MultiIndexIpStringStatsInline *}"
 #    issue: "https://github.com/elastic/elasticsearch/..."
+

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -525,4 +525,3 @@ tests:
 #  - class: "org.elasticsearch.xpack.esql.**"
 #    method: "test {union_types.MultiIndexIpStringStatsInline *}"
 #    issue: "https://github.com/elastic/elasticsearch/..."
-

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -477,9 +477,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceIT
   method: testSymlinkUpdateTriggerReload
   issue: https://github.com/elastic/elasticsearch/issues/128369
-- class: org.elasticsearch.xpack.esql.qa.single_node.PushQueriesIT
-  method: testEqualityAndOther {semantic_text}
-  issue: https://github.com/elastic/elasticsearch/issues/128414
 - class: org.elasticsearch.index.query.MultiMatchQueryBuilderTests
   method: testToQuery
   issue: https://github.com/elastic/elasticsearch/issues/128416

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -151,7 +151,10 @@ public class PushQueriesIT extends ESRestTestCase {
                  * single_value_match is here because there are extra documents hiding in the index
                  * that don't have the `foo` field.
                  */
-                List.of("#foo:[1 TO 1] #single_value_match(foo) #FieldExistsQuery [field=_primary_term]", "foo:[1 TO 1]");
+                List.of(
+                    "#foo:[1 TO 1] #single_value_match(foo) #FieldExistsQuery [field=_primary_term]",
+                    "#foo:[1 TO 1] #FieldExistsQuery [field=_primary_term]"
+                );
             default -> throw new UnsupportedOperationException("unknown type [" + type + "]");
         };
         boolean filterInCompute = switch (type) {


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/128293 we change the query generated by a TermQuery over a numeric field for a PointQuery to an IndexOrDocValuesQuery whenever possible. This had a sode effect on this test, so we are adjusting it here. 

fixes https://github.com/elastic/elasticsearch/issues/128414