### PR TITLE
Refactor TestBuildInfoPluginFuncTest for clarity

### DIFF
--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/TestBuildInfoPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/TestBuildInfoPluginFuncTest.groovy
@@ -39,17 +39,6 @@ class TestBuildInfoPluginFuncTest extends AbstractGradleFuncTest {
         }
         """
 
-        when:
-        def result = gradleRunner('generateTestBuildInfo').build()
-        def task = result.task(":generateTestBuildInfo")
-
-
-        then:
-        task.outcome == TaskOutcome.SUCCESS
-
-        def output = file("build/generated-build-info/plugin-test-build-info.json")
-        output.exists() == true
-
         def location = Map.of(
             "module", "com.example",
             "representative_class", "com/example/Example.class"
@@ -58,6 +47,16 @@ class TestBuildInfoPluginFuncTest extends AbstractGradleFuncTest {
             "component", "example-component",
             "locations", List.of(location)
         )
+
+        def output = file("build/generated-build-info/plugin-test-build-info.json")
+
+        when:
+        def result = gradleRunner('generateTestBuildInfo').build()
+        def task = result.task(":generateTestBuildInfo")
+
+        then:
+        task.outcome == TaskOutcome.SUCCESS
+        output.exists() == true
         new ObjectMapper().readValue(output, Map.class) == expectedOutput
     }
 
@@ -87,16 +86,7 @@ class TestBuildInfoPluginFuncTest extends AbstractGradleFuncTest {
         }
         """
 
-        when:
-        def result = gradleRunner('generateTestBuildInfo').build()
-        def task = result.task(":generateTestBuildInfo")
-
-
-        then:
-        task.outcome == TaskOutcome.SUCCESS
-
         def output = file("build/generated-build-info/plugin-test-build-info.json")
-        output.exists() == true
 
         def locationFromModuleInfo = Map.of(
             "module", "org.objectweb.asm",
@@ -115,7 +105,13 @@ class TestBuildInfoPluginFuncTest extends AbstractGradleFuncTest {
             "locations", List.of(locationFromModuleInfo, locationFromManifest, locationFromJarFileName)
         )
 
-        def value = new ObjectMapper().readValue(output, Map.class)
-        value == expectedOutput
+        when:
+        def result = gradleRunner('generateTestBuildInfo').build()
+        def task = result.task(":generateTestBuildInfo")
+
+        then:
+        task.outcome == TaskOutcome.SUCCESS
+        output.exists() == true
+        new ObjectMapper().readValue(output, Map.class) == expectedOutput
     }
 }

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/TestBuildInfoPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/TestBuildInfoPluginFuncTest.groovy
@@ -52,10 +52,9 @@ class TestBuildInfoPluginFuncTest extends AbstractGradleFuncTest {
 
         when:
         def result = gradleRunner('generateTestBuildInfo').build()
-        def task = result.task(":generateTestBuildInfo")
 
         then:
-        task.outcome == TaskOutcome.SUCCESS
+        result.task(":generateTestBuildInfo").outcome == TaskOutcome.SUCCESS
         output.exists() == true
         new ObjectMapper().readValue(output, Map.class) == expectedOutput
     }
@@ -107,10 +106,9 @@ class TestBuildInfoPluginFuncTest extends AbstractGradleFuncTest {
 
         when:
         def result = gradleRunner('generateTestBuildInfo').build()
-        def task = result.task(":generateTestBuildInfo")
 
         then:
-        task.outcome == TaskOutcome.SUCCESS
+        result.task(":generateTestBuildInfo").outcome == TaskOutcome.SUCCESS
         output.exists() == true
         new ObjectMapper().readValue(output, Map.class) == expectedOutput
     }


### PR DESCRIPTION
When I wrote this test, I was a bit careless of what went into the `given` and `then` clauses. I'm not sure, but I think this change is more in the spirit of what is supposed to be in each clause.

After this change:
- `when` contains only the code that runs the gradle task and fetches its output
- `then` contains only assertions covering the expected conditions
- `given` contains everything else, and can be referred to as needed to understand the other clauses