### PR TITLE
Merge open_exchange with data transport call

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -264,6 +264,7 @@ public class TransportVersions {
     public static final TransportVersion NODES_STATS_SUPPORTS_MULTI_PROJECT = def(9_079_0_00);
     public static final TransportVersion ML_INFERENCE_HUGGING_FACE_RERANK_ADDED = def(9_080_0_00);
     public static final TransportVersion SETTINGS_IN_DATA_STREAMS_DRY_RUN = def(9_081_0_00);
+    public static final TransportVersion REMOVE_OPEN_EXCHANGE = def(9_082_0_00);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeService.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeService.java
@@ -143,6 +143,16 @@ public final class ExchangeService extends AbstractLifecycleComponent {
     }
 
     /**
+     * Returns an exchange sink handler for the given id or creates a new one if it doesn't exist.
+     */
+    public ExchangeSinkHandler getOrCreateSinkHandler(String exchangeId, int maxBufferSize) {
+        return sinks.computeIfAbsent(
+            exchangeId,
+            key -> new ExchangeSinkHandler(blockFactory, maxBufferSize, threadPool.relativeTimeInMillisSupplier())
+        );
+    }
+
+    /**
      * Removes the exchange sink handler associated with the given exchange id.
      * W will abort the sink handler if the given failure is not null.
      */
@@ -232,7 +242,7 @@ public final class ExchangeService extends AbstractLifecycleComponent {
     private class OpenExchangeRequestHandler implements TransportRequestHandler<OpenExchangeRequest> {
         @Override
         public void messageReceived(OpenExchangeRequest request, TransportChannel channel, Task task) throws Exception {
-            // createSinkHandler(request.sessionId, request.exchangeBuffer);
+            createSinkHandler(request.sessionId, request.exchangeBuffer);
             channel.sendResponse(ActionResponse.Empty.INSTANCE);
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkHandler.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkHandler.java
@@ -104,7 +104,7 @@ public final class ExchangeSinkHandler {
      * @param sourceFinished if true, then this handler can finish as sources have enough pages.
      * @param listener       the listener that will be notified when pages are ready or this handler is finished
      * @see RemoteSink
-     * @see ExchangeSourceHandler#addRemoteSink(RemoteSink, boolean, Runnable, int, ActionListener)
+     * @see ExchangeSourceHandler#addAndStartRemoteSink(RemoteSink, boolean, Runnable, int, ActionListener)
      */
     public void fetchPageAsync(boolean sourceFinished, ActionListener<ExchangeResponse> listener) {
         if (sourceFinished) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
@@ -216,7 +216,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
             threadPool.relativeTimeInMillisSupplier()
         );
         ExchangeSourceHandler sourceExchanger = new ExchangeSourceHandler(randomIntBetween(1, 4), threadPool.executor(ESQL_TEST_EXECUTOR));
-        sourceExchanger.addRemoteSink(
+        sourceExchanger.addAndStartRemoteSink(
             sinkExchanger::fetchPageAsync,
             randomBoolean(),
             () -> {},

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
@@ -123,7 +123,7 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                     return completionInfo;
                 }))) {
                     var remoteSink = exchangeService.newRemoteSink(groupTask, childSessionId, transportService, cluster.connection);
-                    exchangeSource.addRemoteSink(
+                    exchangeSource.addAndStartRemoteSink(
                         remoteSink,
                         failFast,
                         () -> pagesFetched.set(true),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -249,7 +249,7 @@ public class ComputeService {
                     var childSessionId = newChildSession(sessionId);
                     ExchangeSinkHandler exchangeSink = exchangeService.createSinkHandler(childSessionId, queryPragmas.exchangeBufferSize());
                     // funnel sub plan pages into the main plan exchange source
-                    mainExchangeSource.addRemoteSink(exchangeSink::fetchPageAsync, true, () -> {}, 1, ActionListener.noop());
+                    mainExchangeSource.addAndStartRemoteSink(exchangeSink::fetchPageAsync, true, () -> {}, 1, ActionListener.noop());
                     var subPlanListener = localListener.acquireCompute();
 
                     executePlan(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -416,8 +416,10 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             var parentListener = computeListener.acquireAvoid();
             try {
                 // run compute with target shards
-                // var externalSink = exchangeService.getSinkHandler(externalId);
-                var externalSink = exchangeService.createSinkHandler(externalId, request.pragmas().exchangeBufferSize());
+
+                // if coordinating node is before TransportVersions.REMOVE_OPEN_EXCHANGE then externalSink exists already
+                // and data might be already polled from it. Create a new one otherwise.
+                var externalSink = exchangeService.getOrCreateSinkHandler(externalId, request.pragmas().exchangeBufferSize());
                 var internalSink = exchangeService.createSinkHandler(request.sessionId(), request.pragmas().exchangeBufferSize());
                 task.addListener(() -> {
                     exchangeService.finishSinkHandler(externalId, new TaskCancelledException(task.getReasonCancelled()));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -707,7 +707,7 @@ public class CsvTests extends ESTestCase {
             );
 
             var csvDataNodePhysicalPlan = PlannerUtils.localPlan(dataNodePlan, logicalTestOptimizer, physicalTestOptimizer);
-            exchangeSource.addRemoteSink(
+            exchangeSource.addAndStartRemoteSink(
                 exchangeSink::fetchPageAsync,
                 Randomness.get().nextBoolean(),
                 () -> {},


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/97ad916a-632c-4625-84cc-aa68512a137c)

According to above typical request flow is:
* open exchange on the data node (`internal:data/read/esql/open_exchange`)
* start fetching data from it (`internal:data/read/esql/exchange`)
* trigger computing data on the data node (`indices:data/read/esql/data`)

ElasticSearch relies on Netty to make transport as cheap and as performant as possible, but still each transport message has some cost associated with it.

This change:
* merges `open_exchange` with `data` call to minimize amount of remote calls required to start a query on the data node
* ensures `internal:data/read/esql/exchange` calls are started after above initialization is done to avoid making calls and receiving empty messages before actual data node computation starts