### PR TITLE
[DOCS] Document that `join` field type not supported on serverless currently

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/parent-join.md
+++ b/docs/reference/elasticsearch/mapping-reference/parent-join.md
@@ -1,11 +1,12 @@
 ---
+applies_to:
+  serverless: unavailable
 navigation_title: "Join"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/parent-join.html
 ---
 
 # Join field type [parent-join]
-
 
 The `join` data type is a special field that creates parent/child relation within documents of the same index. The `relations` section defines a set of possible relations within the documents, each relation being a parent name and a child name.
 


### PR DESCRIPTION
You'll see this error when trying to add a child document:


```
{
  "error": {
    "root_cause": [
      {
        "type": "status_exception",
        "reason": "Parameter validation failed for [/my_index/_doc/doc-123]: The http parameter [routing] (with value [parent-1]) is not permitted when running in serverless mode"
      }
    ],
    "type": "status_exception",
    "reason": "Parameter validation failed for [/my_index/_doc/doc-123]: The http parameter [routing] (with value [parent-1]) is not permitted when running in serverless mode"
  },
  "status": 400
}
```

