### PR TITLE
[9.0] [DOCS] Document &#x60;join&#x60; field type not available on serverless currently (#128496)

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/parent-join.md
+++ b/docs/reference/elasticsearch/mapping-reference/parent-join.md
@@ -1,11 +1,12 @@
 ---
+applies_to:
+  serverless: unavailable
 navigation_title: "Join"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/parent-join.html
 ---
 
 # Join field type [parent-join]
-
 
 The `join` data type is a special field that creates parent/child relation within documents of the same index. The `relations` section defines a set of possible relations within the documents, each relation being a parent name and a child name.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[DOCS] Document &#x60;join&#x60; field type not available on serverless currently (#128496)](https://github.com/elastic/elasticsearch/pull/128496)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)