### PR TITLE
[8.19] Skip bootstrap checks on snapshot builds (#128448)

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -12,6 +12,7 @@ package org.elasticsearch.bootstrap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
+import org.elasticsearch.Build;
 import org.elasticsearch.cluster.coordination.ClusterBootstrapService;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.settings.Setting;
@@ -39,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -77,7 +79,11 @@ final class BootstrapChecks {
         combinedChecks.addAll(additionalChecks);
         check(
             context,
-            enforceLimits(boundTransportAddress, DiscoveryModule.DISCOVERY_TYPE_SETTING.get(context.settings())),
+            enforceLimits(
+                boundTransportAddress,
+                DiscoveryModule.DISCOVERY_TYPE_SETTING.get(context.settings()),
+                Build.current()::isSnapshot
+            ),
             Collections.unmodifiableList(combinedChecks)
         );
     }
@@ -174,17 +180,23 @@ final class BootstrapChecks {
     }
 
     /**
-     * Tests if the checks should be enforced.
+     * Tests if the checks should be enforced. \
+     * Bootstrap checks are enforced (in production builds) if a non-loopback address is configured and a non-snapshot build is used.
      *
      * @param boundTransportAddress the node network bindings
      * @param discoveryType the discovery type
+     * @param isSnapshot provider to test if this build is snapshot or not
      * @return {@code true} if the checks should be enforced
      */
-    static boolean enforceLimits(final BoundTransportAddress boundTransportAddress, final String discoveryType) {
+    static boolean enforceLimits(
+        final BoundTransportAddress boundTransportAddress,
+        final String discoveryType,
+        final BooleanSupplier isSnapshot
+    ) {
         final Predicate<TransportAddress> isLoopbackAddress = t -> t.address().getAddress().isLoopbackAddress();
         final boolean bound = (Arrays.stream(boundTransportAddress.boundAddresses()).allMatch(isLoopbackAddress)
             && isLoopbackAddress.test(boundTransportAddress.publishAddress())) == false;
-        return bound && SINGLE_NODE_DISCOVERY_TYPE.equals(discoveryType) == false;
+        return bound && isSnapshot.getAsBoolean() == false && SINGLE_NODE_DISCOVERY_TYPE.equals(discoveryType) == false;
     }
 
     // the list of checks to execute

--- a/server/src/main/java/org/elasticsearch/plugins/internal/SettingsExtension.java
+++ b/server/src/main/java/org/elasticsearch/plugins/internal/SettingsExtension.java
@@ -25,7 +25,7 @@ public interface SettingsExtension {
     List<Setting<?>> getSettings();
 
     /**
-     * Loads a single BuildExtension, or returns {@code null} if none are found.
+     * Loads a single SettingsExtension, or returns {@code null} if none are found.
      */
     static List<SettingsExtension> load() {
         var loader = ServiceLoader.load(SettingsExtension.class);

--- a/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
@@ -36,6 +36,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static org.elasticsearch.discovery.DiscoveryModule.MULTI_NODE_DISCOVERY_TYPE;
 import static org.elasticsearch.discovery.DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -43,6 +45,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -103,7 +106,7 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
         final String discoveryType = randomFrom(MULTI_NODE_DISCOVERY_TYPE, SINGLE_NODE_DISCOVERY_TYPE);
 
         assertEquals(
-            BootstrapChecks.enforceLimits(boundTransportAddress, discoveryType),
+            BootstrapChecks.enforceLimits(boundTransportAddress, discoveryType, FALSE::booleanValue),
             SINGLE_NODE_DISCOVERY_TYPE.equals(discoveryType) == false
         );
     }
@@ -124,9 +127,25 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
         final String discoveryType = randomFrom(MULTI_NODE_DISCOVERY_TYPE, SINGLE_NODE_DISCOVERY_TYPE);
 
         assertEquals(
-            BootstrapChecks.enforceLimits(boundTransportAddress, discoveryType),
+            BootstrapChecks.enforceLimits(boundTransportAddress, discoveryType, FALSE::booleanValue),
             SINGLE_NODE_DISCOVERY_TYPE.equals(discoveryType) == false
         );
+    }
+
+    public void testDoNotEnforceLimitsWhenSnapshotBuild() {
+        final List<TransportAddress> transportAddresses = new ArrayList<>();
+
+        for (int i = 0; i < randomIntBetween(1, 8); i++) {
+            final TransportAddress randomTransportAddress = buildNewFakeTransportAddress();
+            transportAddresses.add(randomTransportAddress);
+        }
+
+        final TransportAddress publishAddress = new TransportAddress(InetAddress.getLoopbackAddress(), 0);
+        final BoundTransportAddress boundTransportAddress = mock(BoundTransportAddress.class);
+        when(boundTransportAddress.boundAddresses()).thenReturn(transportAddresses.toArray(new TransportAddress[0]));
+        when(boundTransportAddress.publishAddress()).thenReturn(publishAddress);
+
+        assertThat(BootstrapChecks.enforceLimits(boundTransportAddress, MULTI_NODE_DISCOVERY_TYPE, TRUE::booleanValue), is(false));
     }
 
     public void testExceptionAggregation() {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Skip bootstrap checks on snapshot builds (#128448)