### PR TITLE
[8.19] Conditionally force sequential reading in LuceneSyntheticSourceChangesSnapshot (#128473)

### DIFF
--- a/docs/changelog/128473.yaml
+++ b/docs/changelog/128473.yaml
@@ -1,0 +1,5 @@
+pr: 128473
+summary: Conditionally force sequential reading in `LuceneSyntheticSourceChangesSnapshot`
+area: Logs
+type: enhancement
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Conditionally force sequential reading in LuceneSyntheticSourceChangesSnapshot (#128473)