### PR TITLE
Create a pipeline to run micro-benchmarks periodically

### DIFF
--- a/.buildkite/pipelines/periodic-micro-benchmarks.yml
+++ b/.buildkite/pipelines/periodic-micro-benchmarks.yml
@@ -1,0 +1,10 @@
+steps:
+  - label: periodic-micro-benchmarks
+    command: |
+      .ci/scripts/run-gradle.sh -p benchmarks/ run --args 'org.elasticsearch.benchmark._nightly -rf json -rff build/result.json'
+    timeout_in_minutes: 300
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2004
+      machineType: custom-32-98304
+      buildDirectory: /dev/shm/bk

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -263,3 +263,41 @@ spec:
         Daily:
           branch: main
           cronline: "0 12 * * * America/New_York"
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elasticsearch-periodic-micro-benchmarks
+  description: Runs periodic micro benchmarks fom the main branch
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elasticsearch-periodic-micro-benchmarks
+spec:
+  type: buildkite-pipeline
+  system: buildkite
+  owner: group:elasticsearch-team
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: ":elasticsearch: Runs nightly micro benchmarks fom the main branch"
+      name: elasticsearch / periodic / micro-benchmarks
+    spec:
+      repository: elastic/elasticsearch
+      pipeline_file: .buildkite/pipelines/periodic-micro-benchmarks.yml
+      branch_configuration: main
+      teams:
+        elasticsearch-team: {}
+        ml-core: {}
+        everyone:
+          access_level: BUILD_AND_READ
+      provider_settings:
+        build_branches: false
+        build_pull_requests: false
+        publish_commit_status: false
+        trigger_mode: none
+      schedules:
+        Daily:
+          branch: main
+          cronline: "@daily"


### PR DESCRIPTION
This change registers job to run subset of benchmarks (added to `_nightly` package) daily.
The run should result in a json report:

<details>
  <summary>Sample report</summary>
    
  ```
[
    {
        "jmhVersion" : "1.37",
        "benchmark" : "org.elasticsearch.benchmark._nightly.esql.QueryPlanningBenchmark.manyFields",
        "mode" : "avgt",
        "threads" : 1,
        "forks" : 1,
        "jvm" : "/home/idegtiarenko/.gradle/jdks/oracle_corporation-24-amd64-linux.2/bin/java",
        "jvmArgs" : [
            "-Des.nativelibs.path=/home/idegtiarenko/Projects/elastic/elasticsearch/libs/native/libraries/build/platform/linux-x64",
            "-Dfile.encoding=UTF-8",
            "-Duser.country=US",
            "-Duser.language=en",
            "-Duser.variant"
        ],
        "jdkVersion" : "24",
        "vmName" : "OpenJDK 64-Bit Server VM",
        "vmVersion" : "24+36-3646",
        "warmupIterations" : 5,
        "warmupTime" : "10 s",
        "warmupBatchSize" : 1,
        "measurementIterations" : 10,
        "measurementTime" : "10 s",
        "measurementBatchSize" : 1,
        "primaryMetric" : {
            "score" : 2.5501854536845863,
            "scoreError" : 0.12476065476761453,
            "scoreConfidence" : [
                2.4254247989169717,
                2.674946108452201
            ],
            "scorePercentiles" : {
                "0.0" : 2.4942035827930176,
                "50.0" : 2.5238861528406904,
                "90.0" : 2.7509016220596325,
                "95.0" : 2.7684760226958205,
                "99.0" : 2.7684760226958205,
                "99.9" : 2.7684760226958205,
                "99.99" : 2.7684760226958205,
                "99.999" : 2.7684760226958205,
                "99.9999" : 2.7684760226958205,
                "100.0" : 2.7684760226958205
            },
            "scoreUnit" : "ms/op",
            "rawData" : [
                [
                    2.4942035827930176,
                    2.5476331044053984,
                    2.5927320163339385,
                    2.7684760226958205,
                    2.5265088297549885,
                    2.503548321151439,
                    2.4987187072195853,
                    2.5212634759263928,
                    2.50056901975,
                    2.5482014568152866
                ]
            ]
        },
        "secondaryMetrics" : {
        }
    },
    {
        "jmhVersion" : "1.37",
        "benchmark" : "org.elasticsearch.benchmark._nightly.esql.QueryPlanningBenchmark.manyFieldsNoLimit",
        "mode" : "avgt",
        "threads" : 1,
        "forks" : 1,
        "jvm" : "/home/idegtiarenko/.gradle/jdks/oracle_corporation-24-amd64-linux.2/bin/java",
        "jvmArgs" : [
            "-Des.nativelibs.path=/home/idegtiarenko/Projects/elastic/elasticsearch/libs/native/libraries/build/platform/linux-x64",
            "-Dfile.encoding=UTF-8",
            "-Duser.country=US",
            "-Duser.language=en",
            "-Duser.variant"
        ],
        "jdkVersion" : "24",
        "vmName" : "OpenJDK 64-Bit Server VM",
        "vmVersion" : "24+36-3646",
        "warmupIterations" : 5,
        "warmupTime" : "10 s",
        "warmupBatchSize" : 1,
        "measurementIterations" : 10,
        "measurementTime" : "10 s",
        "measurementBatchSize" : 1,
        "primaryMetric" : {
            "score" : 2.4431926029403432,
            "scoreError" : 0.2634269444906417,
            "scoreConfidence" : [
                2.1797656584497016,
                2.706619547430985
            ],
            "scorePercentiles" : {
                "0.0" : 2.2387473962390865,
                "50.0" : 2.425221952605737,
                "90.0" : 2.8242164666793643,
                "95.0" : 2.855264660291179,
                "99.0" : 2.855264660291179,
                "99.9" : 2.855264660291179,
                "99.99" : 2.855264660291179,
                "99.999" : 2.855264660291179,
                "99.9999" : 2.855264660291179,
                "100.0" : 2.855264660291179
            },
            "scoreUnit" : "ms/op",
            "rawData" : [
                [
                    2.285977825142857,
                    2.2387473962390865,
                    2.293294572345792,
                    2.4258984986660197,
                    2.4552520346182174,
                    2.414704606470304,
                    2.4245454065454544,
                    2.544782724173028,
                    2.855264660291179,
                    2.4934583049114933
                ]
            ]
        },
        "secondaryMetrics" : {
        }
    }
]

  ```
  
</details>

This change leaves publishing the report out of scope for now. It will be handled separately after this pipeline is registered.

