### PR TITLE
ES|QL: Return columns for unsupported field types in FORK

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
@@ -46,7 +46,7 @@ import static org.elasticsearch.xpack.esql.CsvSpecReader.specParser;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.isEnabled;
 import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.ENRICH_SOURCE_INDICES;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.classpathResources;
-import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.FORK_V4;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.FORK_V5;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.INLINESTATS;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.INLINESTATS_V2;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.INLINESTATS_V7;
@@ -132,7 +132,7 @@ public class MultiClusterSpecIT extends EsqlSpecTestCase {
         assumeFalse("LOOKUP JOIN not yet supported in CCS", testCase.requiredCapabilities.contains(JOIN_LOOKUP_V12.capabilityName()));
         // Unmapped fields require a coorect capability response from every cluster, which isn't currently implemented.
         assumeFalse("UNMAPPED FIELDS not yet supported in CCS", testCase.requiredCapabilities.contains(UNMAPPED_FIELDS.capabilityName()));
-        assumeFalse("FORK not yet supported in CCS", testCase.requiredCapabilities.contains(FORK_V4.capabilityName()));
+        assumeFalse("FORK not yet supported in CCS", testCase.requiredCapabilities.contains(FORK_V5.capabilityName()));
     }
 
     @Override

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
@@ -3,7 +3,7 @@
 //
 
 simpleFork
-required_capability: fork_v4
+required_capability: fork_v5
 
 FROM employees
 | FORK ( WHERE emp_no == 10001 )
@@ -18,7 +18,7 @@ emp_no:integer | _fork:keyword
 ;
 
 forkWithWhereSortAndLimit
-required_capability: fork_v4
+required_capability: fork_v5
 
 FROM employees
 | FORK ( WHERE hire_date < "1985-03-01T00:00:00Z" | SORT first_name | LIMIT 5 )
@@ -38,7 +38,7 @@ emp_no:integer | first_name:keyword | _fork:keyword
 ;
 
 fiveFork
-required_capability: fork_v4
+required_capability: fork_v5
 
 FROM employees
 | FORK ( WHERE emp_no == 10005 )
@@ -59,7 +59,7 @@ fork5         | 10001
 ;
 
 forkWithWhereSortDescAndLimit
-required_capability: fork_v4
+required_capability: fork_v5
 
 FROM employees
 | FORK ( WHERE hire_date < "1985-03-01T00:00:00Z" | SORT first_name DESC | LIMIT 2 )
@@ -76,7 +76,7 @@ fork2         | 10087          | Xinglin
 ;
 
 forkWithCommonPrefilter
-required_capability: fork_v4
+required_capability: fork_v5
 
 FROM employees
 | WHERE emp_no > 10050
@@ -94,7 +94,7 @@ fork2         | 10100
 ;
 
 forkWithSemanticSearchAndScore
-required_capability: fork_v4
+required_capability: fork_v5
 required_capability: semantic_text_field_caps
 required_capability: metadata_score
 
@@ -114,7 +114,7 @@ fork2         | 6.093784261960139E18  | 2           | all we have to decide is w
 ;
 
 forkWithEvals
-required_capability: fork_v4
+required_capability: fork_v5
 
 FROM employees
 | FORK (WHERE emp_no == 10048 OR emp_no == 10081 | EVAL x = "abc" | EVAL y = 1)
@@ -131,7 +131,7 @@ fork2         | 10087          | def       | null      | 2
 ;
 
 forkWithStats
-required_capability: fork_v4
+required_capability: fork_v5
 
 FROM employees
 | FORK (WHERE emp_no == 10048 OR emp_no == 10081)
@@ -152,7 +152,7 @@ fork4         | null           | 100    | 10001     | null
 ;
 
 forkWithDissect
-required_capability: fork_v4
+required_capability: fork_v5
 
 FROM employees
 | WHERE emp_no == 10048 OR emp_no == 10081
@@ -172,7 +172,7 @@ fork2         | 10081          | Rosen     | 10081     | null      | Zhongwei
 ;
 
 forkWithMixOfCommands
-required_capability: fork_v4
+required_capability: fork_v5
 
 FROM employees
 | WHERE emp_no == 10048 OR emp_no == 10081
@@ -197,7 +197,7 @@ fork4         | 10081          | abc       | aaa       | null      | null
 ;
 
 forkWithFiltersOnConstantValues
-required_capability: fork_v4
+required_capability: fork_v5
 
 FROM employees
 | EVAL z = 1
@@ -215,4 +215,18 @@ _fork:keyword | emp_no:integer | x:long | y:integer | z:integer
 fork2         | 10081          | null   | null      | 1
 fork2         | 10087          | null   | null      | 1
 fork3         | null           | 100    | 10100     | 10001
+;
+
+forkWithUnsupportedAttributes
+required_capability: fork_v5
+
+FROM heights
+| FORK (SORT description DESC | LIMIT 1 | EVAL x = length(description) )
+       (SORT description ASC | LIMIT 1)
+| SORT _fork
+;
+
+description:keyword | height_range:unsupported | x:integer | _fork:keyword
+Very Tall           | null                     | 9         | fork1
+Medium Height       | null                     | null      | fork2
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1019,7 +1019,7 @@ public class EsqlCapabilities {
         /**
          * Support streaming of sub plan results
          */
-        FORK_V4(Build.current().isSnapshot()),
+        FORK_V5(Build.current().isSnapshot()),
 
         /**
          * Support for the {@code leading_zeros} named parameter.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1052,12 +1052,18 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                     final int priority;
                     if (proj instanceof UnresolvedStar) {
                         resolved = childOutput;
-                        priority = 2;
+                        priority = 4;
                     } else if (proj instanceof UnresolvedNamePattern up) {
                         resolved = resolveAgainstList(up, childOutput);
-                        priority = 1;
+                        priority = 3;
+                    } else if (proj instanceof UnsupportedAttribute) {
+                        resolved = List.of(proj.toAttribute());
+                        priority = 2;
                     } else if (proj instanceof UnresolvedAttribute ua) {
                         resolved = resolveAgainstList(ua, childOutput);
+                        priority = 1;
+                    } else if (proj.resolved()) {
+                        resolved = List.of(proj.toAttribute());
                         priority = 0;
                     } else {
                         throw new EsqlIllegalArgumentException("unexpected projection: " + proj);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -310,7 +310,7 @@ public class CsvTests extends ESTestCase {
             );
             assumeFalse(
                 "CSV tests cannot currently handle FORK",
-                testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.FORK_V4.capabilityName())
+                testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.FORK_V5.capabilityName())
             );
             assumeFalse(
                 "CSV tests cannot currently handle multi_match function that depends on Lucene",


### PR DESCRIPTION
When querying indices that have field types that are unsupported in ES|QL (e.g. `ip_range`, `sparse_vector` etc) with `FORK`, the query returns an error.

### Steps to replicate:

Create an index with an unsupported field type
```
PUT my-index
{
    "mappings": {
        "properties": {
            "abc": {
                "type": "date_range"
            },
            "x": {
                "type": "keyword"
            }
        }
    }
}

```

Issue a query using FORK

```
POST /_query
{
    "query": """
        FROM my-index
        | FORK (limit 1) (limit 1)
        """
}
```

See error response:

```
{
  "error": {
    "root_cause": [
      {
        "type": "esql_illegal_argument_exception",
        "reason": "unexpected projection: !abc"
      }
    ],
    "type": "esql_illegal_argument_exception",
    "reason": "unexpected projection: !abc"
  },
  "status": 500
}
```

Stacktrace:

```
[2025-05-27T14:19:56,091][WARN ][r.suppressed             ] [runTask-0] path: /_query, params: {pretty=true}, status: 500 org.elasticsearch.xpack.esql.EsqlIllegalArgumentException: unexpected projection: !abc
        at org.elasticsearch.xpack.esql.analysis.Analyzer$ResolveRefs.resolveKeep(Analyzer.java:1063)
        at org.elasticsearch.xpack.esql.analysis.Analyzer$ResolveRefs.rule(Analyzer.java:502)
        at org.elasticsearch.xpack.esql.analysis.Analyzer$ResolveRefs.rule(Analyzer.java:470)
        at org.elasticsearch.xpack.esql.analysis.AnalyzerRules$ParameterizedAnalyzerRule.lambda$apply$0(AnalyzerRules.java:49)
        at org.elasticsearch.xpack.esql.core.tree.Node.lambda$transformUp$10(Node.java:209)
        at org.elasticsearch.xpack.esql.core.tree.Node.transformUp(Node.java:204)
        at org.elasticsearch.xpack.esql.core.tree.Node.lambda$transformUp$9(Node.java:202)
        at org.elasticsearch.xpack.esql.core.tree.Node.transformChildren(Node.java:227)
        at org.elasticsearch.xpack.esql.core.tree.Node.transformUp(Node.java:202)
        at org.elasticsearch.xpack.esql.core.tree.Node.transformUp(Node.java:209)
        at org.elasticsearch.xpack.esql.analysis.AnalyzerRules$ParameterizedAnalyzerRule.apply(AnalyzerRules.java:49)
        at org.elasticsearch.xpack.esql.analysis.AnalyzerRules$ParameterizedAnalyzerRule.apply(AnalyzerRules.java:41)
        at org.elasticsearch.xpack.esql.rule.ParameterizedRuleExecutor.lambda$transform$0(ParameterizedRuleExecutor.java:29)
        at org.elasticsearch.xpack.esql.rule.RuleExecutor$Transformation.<init>(RuleExecutor.java:92)
        at org.elasticsearch.xpack.esql.rule.RuleExecutor.executeWithInfo(RuleExecutor.java:171)
        at org.elasticsearch.xpack.esql.rule.RuleExecutor.execute(RuleExecutor.java:140)
        at org.elasticsearch.xpack.esql.analysis.Analyzer.analyze(Analyzer.java:192)
        at org.elasticsearch.xpack.esql.session.EsqlSession.lambda$analyzedPlan$7(EsqlSession.java:325)
        at org.elasticsearch.xpack.esql.session.EsqlSession.analyzeAndMaybeRetry(EsqlSession.java:524)
        at org.elasticsearch.xpack.esql.session.EsqlSession.lambda$analyzedPlan$15(EsqlSession.java:367)

```


## Cause

The problem is that when we resolve `FORK` during analysis, we add `KEEP` plans to align the output of FORK branches.
If the output contains `UnsupportedAttribute`, these are not correctly handled when we resolve the `Keep` projections (in `Analyzer.resolveKeep`).
