### PR TITLE
Remove use_default_lucene_postings_format feature flag

### DIFF
--- a/docs/changelog/128509.yaml
+++ b/docs/changelog/128509.yaml
@@ -1,5 +1,5 @@
 pr: 128509
-summary: Remove `use_default_lucene_postings_format` feature flag
+summary: Use default Lucene postings format when index mode is standard.
 area: Codec
 type: enhancement
 issues: []

--- a/docs/changelog/128509.yaml
+++ b/docs/changelog/128509.yaml
@@ -1,0 +1,5 @@
+pr: 128509
+summary: Remove `use_default_lucene_postings_format` feature flag
+area: Codec
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -129,6 +129,11 @@ public enum IndexMode {
         public SourceFieldMapper.Mode defaultSourceMode() {
             return SourceFieldMapper.Mode.STORED;
         }
+
+        @Override
+        public boolean useDefaultPostingsFormat() {
+            return true;
+        }
     },
     TIME_SERIES("time_series") {
         @Override
@@ -550,6 +555,13 @@ public enum IndexMode {
 
     public String getDefaultCodec() {
         return CodecService.DEFAULT_CODEC;
+    }
+
+    /**
+     * Whether the default posting format (for inverted indices) from Lucene should be used.
+     */
+    public boolean useDefaultPostingsFormat() {
+        return false;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -15,7 +15,6 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersions;
@@ -33,7 +32,6 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
  * vectors.
  */
 public class PerFieldFormatSupplier {
-    public static final FeatureFlag USE_DEFAULT_LUCENE_POSTINGS_FORMAT = new FeatureFlag("use_default_lucene_postings_format");
 
     private static final DocValuesFormat docValuesFormat = new Lucene90DocValuesFormat();
     private static final KnnVectorsFormat knnVectorsFormat = new Lucene99HnswVectorsFormat();
@@ -51,9 +49,8 @@ public class PerFieldFormatSupplier {
         this.bloomFilterPostingsFormat = new ES87BloomFilterPostingsFormat(bigArrays, this::internalGetPostingsFormatForField);
 
         if (mapperService != null
-            && USE_DEFAULT_LUCENE_POSTINGS_FORMAT.isEnabled()
             && mapperService.getIndexSettings().getIndexVersionCreated().onOrAfter(IndexVersions.USE_LUCENE101_POSTINGS_FORMAT)
-            && mapperService.getIndexSettings().getMode() == IndexMode.STANDARD) {
+            && mapperService.getIndexSettings().getMode().useDefaultPostingsFormat()) {
             defaultPostingsFormat = Elasticsearch900Lucene101Codec.DEFAULT_POSTINGS_FORMAT;
         } else {
             // our own posting format using PFOR

--- a/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
@@ -94,8 +94,7 @@ public class PerFieldMapperCodecTests extends ESTestCase {
         assertThat(perFieldMapperCodec.getPostingsFormatForField("_id"), instanceOf(ES87BloomFilterPostingsFormat.class));
         assertThat(perFieldMapperCodec.useBloomFilter("another_field"), is(false));
 
-        Class<? extends PostingsFormat> expectedPostingsFormat = PerFieldFormatSupplier.USE_DEFAULT_LUCENE_POSTINGS_FORMAT.isEnabled()
-            && timeSeries == false ? Lucene101PostingsFormat.class : ES812PostingsFormat.class;
+        Class<? extends PostingsFormat> expectedPostingsFormat = timeSeries ? ES812PostingsFormat.class : Lucene101PostingsFormat.class;
         assertThat(perFieldMapperCodec.getPostingsFormatForField("another_field"), instanceOf(expectedPostingsFormat));
     }
 
@@ -110,10 +109,7 @@ public class PerFieldMapperCodecTests extends ESTestCase {
     public void testUseBloomFilterWithTimestampFieldEnabled_noTimeSeriesMode() throws IOException {
         PerFieldFormatSupplier perFieldMapperCodec = createFormatSupplier(true, false, false);
         assertThat(perFieldMapperCodec.useBloomFilter("_id"), is(false));
-        Class<? extends PostingsFormat> expectedPostingsFormat = PerFieldFormatSupplier.USE_DEFAULT_LUCENE_POSTINGS_FORMAT.isEnabled()
-            ? Lucene101PostingsFormat.class
-            : ES812PostingsFormat.class;
-        assertThat(perFieldMapperCodec.getPostingsFormatForField("_id"), instanceOf(expectedPostingsFormat));
+        assertThat(perFieldMapperCodec.getPostingsFormatForField("_id"), instanceOf(Lucene101PostingsFormat.class));
     }
 
     public void testUseBloomFilterWithTimestampFieldEnabled_disableBloomFilter() throws IOException {


### PR DESCRIPTION
Also let the IndexMode decide whether to default lucene postings instead of checking for standard index mode.

The `Lucene101PostingsFormat` is now used for a while behind a feature flag. Regressions were found by were fixed via apache/lucene#14511. The `Lucene101PostingsFormat` is now a better trade off when the index mode is standard.