### PR TITLE
[8.19] ES|QL: Make skip_unavailable catch all errors (#128163)

### DIFF
--- a/docs/changelog/128163.yaml
+++ b/docs/changelog/128163.yaml
@@ -1,0 +1,17 @@
+pr: 128163
+summary: Make `skip_unavailable` catch all errors
+area: ES|QL
+type: breaking
+issues: [ ]
+breaking:
+  title: Cluster setting "skip_unavailable" catches all runtime errors
+  area: ES|QL
+  details: "If `skip_unavailable` is set to `true`, the runtime errors from this cluster\
+    \ do not lead to a failure of the query. Instead, the cluster is set to `skipped`\
+    \ or `partial` status, and the query execution continues. This is a breaking change\
+    \ from previous versions, where `skip_unavailable` only applied to errors related\
+    \ to a cluster being unavailable."
+  impact: "The errors on remote clusters, e.g. missing indices, will not lead to a\
+    \ failure of the query. Instead, the cluster is set to `skipped` or `partial` status\
+    \ in the response metadata."
+  notable: false

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
@@ -325,6 +325,7 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
             XContentHelper.toXContent(snapshot, XContentType.JSON, randomBoolean()),
             XContentType.JSON
         );
+        assertToXContentEquivalent(new BytesArray(expectedJson), new BytesArray(snapshot.toString()), XContentType.JSON);
     }
 
     private String readJSONFromResource(String fileName) throws IOException {

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationIT.java
@@ -81,6 +81,22 @@ public class EsqlRestValidationIT extends EsqlRestValidationTestCase {
         return remoteClient;
     }
 
+    protected boolean isSkipUnavailable() {
+        return true;
+    }
+
+    @Override
+    public void testAlias() throws IOException {
+        assumeFalse("expecting skip_unavailable to be false", isSkipUnavailable());
+        super.testAlias();
+    }
+
+    @Override
+    public void testExistentIndexWithoutWildcard() throws IOException {
+        assumeFalse("expecting skip_unavailable to be false", isSkipUnavailable());
+        super.testExistentIndexWithoutWildcard();
+    }
+
     @Before
     public void skipTestOnOldVersions() {
         assumeTrue("skip on old versions", Clusters.localClusterVersion().equals(Version.V_8_19_0));

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationSkipUnFalseIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationSkipUnFalseIT.java
@@ -27,4 +27,9 @@ public class EsqlRestValidationSkipUnFalseIT extends EsqlRestValidationIT {
     protected String getTestRestCluster() {
         return localCluster.getHttpAddresses();
     }
+
+    @Override
+    protected boolean isSkipUnavailable() {
+        return false;
+    }
 }

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/RequestIndexFilteringIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/RequestIndexFilteringIT.java
@@ -148,9 +148,8 @@ public class RequestIndexFilteringIT extends RequestIndexFilteringTestCase {
     }
 
     private static boolean checkVersion(org.elasticsearch.Version version) {
-        return version.onOrAfter(Version.fromString("9.1.0"));
-        // TODO: enable this when ported to 8.x
-        // || (version.onOrAfter(Version.fromString("8.19.0")) && version.before(Version.fromString("9.0.0")));
+        return version.onOrAfter(Version.fromString("9.1.0"))
+            || (version.onOrAfter(Version.fromString("8.19.0")) && version.before(Version.fromString("9.0.0")));
     }
 
     // We need a separate test since remote missing indices and local missing indices now work differently

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/RequestIndexFilteringIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/RequestIndexFilteringIT.java
@@ -33,9 +33,11 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
@@ -145,4 +147,33 @@ public class RequestIndexFilteringIT extends RequestIndexFilteringTestCase {
         assertMap(result, matcher);
     }
 
+    private static boolean checkVersion(org.elasticsearch.Version version) {
+        return version.onOrAfter(Version.fromString("9.1.0"));
+        // TODO: enable this when ported to 8.x
+        // || (version.onOrAfter(Version.fromString("8.19.0")) && version.before(Version.fromString("9.0.0")));
+    }
+
+    // We need a separate test since remote missing indices and local missing indices now work differently
+    public void testIndicesDontExistRemote() throws IOException {
+        // Exclude old versions
+        assumeTrue("Only works with latest support_unavailable logic", checkVersion(Clusters.localClusterVersion()));
+        int docsTest1 = randomIntBetween(1, 5);
+        indexTimestampData(docsTest1, "test1", "2024-11-26", "id1");
+
+        Map<String, Object> result = runEsql(
+            timestampFilter("gte", "2020-01-01").query("FROM *:foo,*:test1 METADATA _index | SORT id1 | KEEP _index, id*")
+        );
+        @SuppressWarnings("unchecked")
+        var columns = (List<List<Object>>) result.get("columns");
+        assertThat(
+            columns,
+            matchesList().item(matchesMap().entry("name", "_index").entry("type", "keyword"))
+                .item(matchesMap().entry("name", "id1").entry("type", "integer"))
+        );
+        @SuppressWarnings("unchecked")
+        var values = (List<List<Object>>) result.get("values");
+        // TODO: for now, we return empty result, but eventually it should return records from test1
+        assertThat(values, hasSize(0));
+
+    }
 }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RequestIndexFilteringTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RequestIndexFilteringTestCase.java
@@ -195,7 +195,7 @@ public abstract class RequestIndexFilteringTestCase extends ESRestTestCase {
     }
 
     public void testIndicesDontExist() throws IOException {
-        int docsTest1 = 0; // we are interested only in the created index, not necessarily that it has data
+        int docsTest1 = randomIntBetween(1, 5);
         indexTimestampData(docsTest1, "test1", "2024-11-26", "id1");
 
         ResponseException e = expectThrows(ResponseException.class, () -> runEsql(timestampFilter("gte", "2020-01-01").query(from("foo"))));
@@ -208,7 +208,7 @@ public abstract class RequestIndexFilteringTestCase extends ESRestTestCase {
         assertThat(e.getMessage(), containsString("verification_exception"));
         assertThat(e.getMessage(), anyOf(containsString("Unknown index [foo*]"), containsString("Unknown index [remote_cluster:foo*]")));
 
-        e = expectThrows(ResponseException.class, () -> runEsql(timestampFilter("gte", "2020-01-01").query(from("foo", "test1"))));
+        e = expectThrows(ResponseException.class, () -> runEsql(timestampFilter("gte", "2020-01-01").query("FROM foo, test1")));
         assertEquals(404, e.getResponse().getStatusLine().getStatusCode());
         assertThat(e.getMessage(), containsString("index_not_found_exception"));
         assertThat(e.getMessage(), anyOf(containsString("no such index [foo]"), containsString("no such index [remote_cluster:foo]")));
@@ -231,7 +231,7 @@ public abstract class RequestIndexFilteringTestCase extends ESRestTestCase {
         }
     }
 
-    private static RestEsqlTestCase.RequestObjectBuilder timestampFilter(String op, String date) throws IOException {
+    protected static RestEsqlTestCase.RequestObjectBuilder timestampFilter(String op, String date) throws IOException {
         return requestObjectBuilder().filter(b -> {
             b.startObject("range");
             {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryIT.java
@@ -29,7 +29,6 @@ import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
-import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
@@ -260,6 +259,7 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
         Map<String, Object> testClusterInfo = setupClusters(numClusters);
         int localNumShards = (Integer) testClusterInfo.get("local.num_shards");
         int remote1NumShards = (Integer) testClusterInfo.get("remote1.num_shards");
+        int remote2NumShards = (Integer) testClusterInfo.get("remote2.num_shards");
         String localIndex = (String) testClusterInfo.get("local.index");
         String remote1Index = (String) testClusterInfo.get("remote1.index");
         String remote2Index = (String) testClusterInfo.get("remote2.index");
@@ -281,7 +281,23 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
         {
             String q = "FROM logs*,cluster-a:nomatch";
             String expectedError = "Unknown index [cluster-a:nomatch]";
+            setSkipUnavailable(REMOTE_CLUSTER_1, false);
             expectVerificationExceptionForQuery(q, expectedError, requestIncludeMeta);
+            setSkipUnavailable(REMOTE_CLUSTER_1, true);
+            try (EsqlQueryResponse resp = runQuery(q, requestIncludeMeta)) {
+                assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(1));
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                assertExpectedClustersForMissingIndicesTests(
+                    executionInfo,
+                    List.of(
+                        new ExpectedCluster(LOCAL_CLUSTER, "logs*", EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, localNumShards),
+                        new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0)
+                    )
+                );
+
+            }
         }
 
         // No error since local non-matching index has wildcard and the remote cluster index expression matches
@@ -411,7 +427,34 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
             String remote2IndexName = randomFrom(remote2Index, IDX_ALIAS, FILTERED_IDX_ALIAS);
             String q = Strings.format("FROM %s*,cluster-a:nomatch,%s:%s*", localIndexName, REMOTE_CLUSTER_2, remote2IndexName);
             String expectedError = "Unknown index [cluster-a:nomatch]";
+            setSkipUnavailable(REMOTE_CLUSTER_1, false);
             expectVerificationExceptionForQuery(q, expectedError, requestIncludeMeta);
+            setSkipUnavailable(REMOTE_CLUSTER_1, true);
+            try (EsqlQueryResponse resp = runQuery(q, requestIncludeMeta)) {
+                assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(1));
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                assertExpectedClustersForMissingIndicesTests(
+                    executionInfo,
+                    List.of(
+                        new ExpectedCluster(
+                            LOCAL_CLUSTER,
+                            localIndexName + "*",
+                            EsqlExecutionInfo.Cluster.Status.SUCCESSFUL,
+                            localNumShards
+                        ),
+                        new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0),
+                        new ExpectedCluster(
+                            REMOTE_CLUSTER_2,
+                            remote2IndexName + "*",
+                            EsqlExecutionInfo.Cluster.Status.SUCCESSFUL,
+                            remote2NumShards
+                        )
+                    )
+                );
+
+            }
         }
     }
 
@@ -454,8 +497,8 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
                 assertThat(msg, cluster.getSkippedShards(), equalTo(expectedCluster.totalShards()));
                 assertThat(msg, cluster.getFailures().size(), equalTo(1));
                 assertThat(msg, cluster.getFailures().get(0).getCause(), instanceOf(VerificationException.class));
-                String expectedMsg = "Unknown index [" + expectedCluster.indexExpression() + "]";
-                assertThat(msg, cluster.getFailures().get(0).getCause().getMessage(), containsString(expectedMsg));
+                assertThat(msg, cluster.getFailures().get(0).getCause().getMessage(), containsString("Unknown index"));
+                assertThat(msg, cluster.getFailures().get(0).getCause().getMessage(), containsString(expectedCluster.indexExpression()));
                 hasSkipped = true;
             }
             // currently failed shards is always zero - change this once we start allowing partial data for individual shard failures
@@ -809,18 +852,30 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
         assertTrue(latch.await(30, TimeUnit.SECONDS));
     }
 
-    // Non-disconnect remote failures still fail the request even if skip_unavailable is true
+    // Non-disconnect remote failures lead to skipping if skip_unavailable is true
     public void testRemoteFailureSkipUnavailableTrue() throws IOException {
         Map<String, Object> testClusterInfo = setupFailClusters();
         String localIndex = (String) testClusterInfo.get("local.index");
         String remote1Index = (String) testClusterInfo.get("remote.index");
         String q = Strings.format("FROM %s,cluster-a:%s*", localIndex, remote1Index);
 
-        Exception error = expectThrows(Exception.class, () -> runQuery(q, false));
-        error = EsqlTestUtils.unwrapIfWrappedInRemoteException(error);
+        try (EsqlQueryResponse resp = runQuery(q, randomBoolean())) {
+            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+            assertNotNull(executionInfo);
+            assertThat(executionInfo.isCrossClusterSearch(), is(true));
+            assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
 
-        assertThat(error, instanceOf(IllegalStateException.class));
-        assertThat(error.getMessage(), containsString("Accessing failing field"));
+            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
+            assertThat(remoteCluster.getIndexExpression(), equalTo("logs-2*"));
+            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
+            assertThat(remoteCluster.getTotalShards(), equalTo(0));
+            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
+            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
+            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertThat(remoteCluster.getFailures(), hasSize(1));
+            assertThat(remoteCluster.getFailures().getFirst().reason(), containsString("Accessing failing field"));
+        }
     }
 
     private static void assertClusterMetadataInResponse(EsqlQueryResponse resp, boolean responseExpectMeta) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryIT.java
@@ -874,7 +874,7 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
             assertThat(remoteCluster.getSkippedShards(), equalTo(0));
             assertThat(remoteCluster.getFailedShards(), equalTo(0));
             assertThat(remoteCluster.getFailures(), hasSize(1));
-            assertThat(remoteCluster.getFailures().getFirst().reason(), containsString("Accessing failing field"));
+            assertThat(remoteCluster.getFailures().get(0).reason(), containsString("Accessing failing field"));
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithPartialResultsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithPartialResultsIT.java
@@ -227,6 +227,7 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
                 assertNotNull(unwrapped);
                 assertThat(unwrapped.getMessage(), equalTo(simulatedFailure.getMessage()));
             }
+            // The failure leads to skipped regardless of allowPartialResults
             request.allowPartialResults(true);
             try (var resp = runQuery(request)) {
                 assertTrue(resp.isPartial());
@@ -289,7 +290,7 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
                 assertThat(returnedIds, equalTo(local.okIds));
                 assertClusterSuccess(resp, LOCAL_CLUSTER, local.okShards);
                 EsqlExecutionInfo.Cluster remoteInfo = resp.getExecutionInfo().getCluster(REMOTE_CLUSTER_1);
-                assertThat(remoteInfo.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.PARTIAL));
+                assertThat(remoteInfo.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
                 assertClusterFailure(resp, REMOTE_CLUSTER_1, simulatedFailure.getMessage());
             }
         } finally {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterUsageTelemetryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterUsageTelemetryIT.java
@@ -118,24 +118,23 @@ public class CrossClusterUsageTelemetryIT extends AbstractCrossClusterUsageTelem
 
         assertThat(telemetry.getTotalCount(), equalTo(1L));
         assertThat(telemetry.getSuccessCount(), equalTo(0L));
-        assertThat(telemetry.getByRemoteCluster().size(), equalTo(0));
+        assertThat(telemetry.getByRemoteCluster().size(), equalTo(1));
         assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(2.0));
         assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
-        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(0L));
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(1L));
         Map<String, Long> expectedFailure = Map.of(CCSUsageTelemetry.Result.NOT_FOUND.getName(), 1L);
         assertThat(telemetry.getFailureReasons(), equalTo(expectedFailure));
 
-        // this is only for cluster-a so no skipped remotes
+        // this is only for cluster-a now
         telemetry = getTelemetryFromFailedQuery("from logs-*,cluster-a:no_such_index | stats sum (v)");
         assertThat(telemetry.getTotalCount(), equalTo(2L));
         assertThat(telemetry.getSuccessCount(), equalTo(0L));
-        assertThat(telemetry.getByRemoteCluster().size(), equalTo(0));
+        assertThat(telemetry.getByRemoteCluster().size(), equalTo(1));
         assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(2.0));
         assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
-        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(0L));
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(1L));
         expectedFailure = Map.of(CCSUsageTelemetry.Result.NOT_FOUND.getName(), 2L);
         assertThat(telemetry.getFailureReasons(), equalTo(expectedFailure));
-        assertThat(telemetry.getByRemoteCluster().size(), equalTo(0));
     }
 
     public void testRemoteOnly() throws Exception {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
@@ -403,7 +403,7 @@ public class EsqlCCSUtilsTests extends ESTestCase {
             assertThat(remote2Cluster.getSkippedShards(), equalTo(0));
             assertThat(remote2Cluster.getFailedShards(), equalTo(0));
             assertThat(remote2Cluster.getFailures(), hasSize(1));
-            assertThat(remote2Cluster.getFailures().getFirst().reason(), containsString("Unknown index [remote2:mylogs1,mylogs2*]"));
+            assertThat(remote2Cluster.getFailures().get(0).reason(), containsString("Unknown index [remote2:mylogs1,mylogs2*]"));
         }
 
         // test where remote2 is already marked as SKIPPED so no modifications or exceptions should be thrown

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.transport.NoSeedNodeLeftException;
 import org.elasticsearch.transport.NoSuchRemoteClusterException;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.RemoteTransportException;
-import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.analysis.TableInfo;
 import org.elasticsearch.xpack.esql.core.type.EsField;
@@ -54,6 +53,7 @@ import static org.elasticsearch.xpack.esql.session.EsqlCCSUtils.shouldIgnoreRunt
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 public class EsqlCCSUtilsTests extends ESTestCase {
@@ -365,18 +365,18 @@ public class EsqlCCSUtilsTests extends ESTestCase {
         }
 
         // No remotes had matching indices from field-caps call: 1) remote1 because it was unavailable, 2) remote2 was available,
-        // but had no matching indices and since a concrete index was requested, a VerificationException is thrown
+        // but had no matching indices. remote2 is set to skipped since it has skip_unavailable by default.
         {
             EsqlExecutionInfo executionInfo = new EsqlExecutionInfo(true);
             executionInfo.swapCluster(LOCAL_CLUSTER_ALIAS, (k, v) -> new EsqlExecutionInfo.Cluster(LOCAL_CLUSTER_ALIAS, "logs*"));
             executionInfo.swapCluster(REMOTE1_ALIAS, (k, v) -> new EsqlExecutionInfo.Cluster(REMOTE1_ALIAS, "*", randomBoolean()));
             executionInfo.swapCluster(
                 REMOTE2_ALIAS,
-                (k, v) -> new EsqlExecutionInfo.Cluster(REMOTE2_ALIAS, "mylogs1,mylogs2,logs*", randomBoolean())
+                (k, v) -> new EsqlExecutionInfo.Cluster(REMOTE2_ALIAS, "mylogs1,mylogs2*", randomBoolean())
             );
 
             EsIndex esIndex = new EsIndex(
-                "logs*,remote2:mylogs1,remote2:mylogs2,remote2:logs*",  // original user-provided index expression
+                "logs*,remote2:mylogs1,remote2:mylogs2*,remote1:logs*",  // original user-provided index expression
                 randomMapping(),
                 Map.of("logs-a", IndexMode.STANDARD)  // resolved indices from field-caps (none from either remote)
             );
@@ -384,11 +384,26 @@ public class EsqlCCSUtilsTests extends ESTestCase {
             var failure = new FieldCapabilitiesFailure(new String[] { "logs-a" }, new NoSeedNodeLeftException("unable to connect"));
             Map<String, FieldCapabilitiesFailure> unavailableClusters = Map.of(REMOTE1_ALIAS, failure);
             IndexResolution indexResolution = IndexResolution.valid(esIndex, esIndex.concreteIndices(), Set.of(), unavailableClusters);
-            VerificationException ve = expectThrows(
-                VerificationException.class,
-                () -> EsqlCCSUtils.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution)
-            );
-            assertThat(ve.getDetailedMessage(), containsString("Unknown index [remote2:mylogs1,mylogs2,logs*]"));
+            EsqlCCSUtils.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution);
+
+            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER_ALIAS);
+            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
+            assertClusterStatusAndShardCounts(localCluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+
+            EsqlExecutionInfo.Cluster remote1Cluster = executionInfo.getCluster(REMOTE1_ALIAS);
+            // since remote1 is in the unavailable Map (passed to IndexResolution.valid), it's status will not be changed
+            // by updateExecutionInfoWithClustersWithNoMatchingIndices (it is handled in updateExecutionInfoWithUnavailableClusters)
+            assertThat(remote1Cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.RUNNING));
+
+            EsqlExecutionInfo.Cluster remote2Cluster = executionInfo.getCluster(REMOTE2_ALIAS);
+            assertThat(remote2Cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+            assertThat(remote2Cluster.getTook().millis(), greaterThanOrEqualTo(0L));
+            assertThat(remote2Cluster.getTotalShards(), equalTo(0));
+            assertThat(remote2Cluster.getSuccessfulShards(), equalTo(0));
+            assertThat(remote2Cluster.getSkippedShards(), equalTo(0));
+            assertThat(remote2Cluster.getFailedShards(), equalTo(0));
+            assertThat(remote2Cluster.getFailures(), hasSize(1));
+            assertThat(remote2Cluster.getFailures().getFirst().reason(), containsString("Unknown index [remote2:mylogs1,mylogs2*]"));
         }
 
         // test where remote2 is already marked as SKIPPED so no modifications or exceptions should be thrown
@@ -779,8 +794,8 @@ public class EsqlCCSUtilsTests extends ESTestCase {
             shouldIgnoreRuntimeError(executionInfo, REMOTE1_ALIAS, new IllegalStateException("Unable to open any connections")),
             is(true)
         );
-        assertThat(shouldIgnoreRuntimeError(executionInfo, REMOTE1_ALIAS, new TaskCancelledException("task cancelled")), is(false));
-        assertThat(shouldIgnoreRuntimeError(executionInfo, REMOTE1_ALIAS, new ElasticsearchException("something is wrong")), is(false));
+        assertThat(shouldIgnoreRuntimeError(executionInfo, REMOTE1_ALIAS, new TaskCancelledException("task cancelled")), is(true));
+        assertThat(shouldIgnoreRuntimeError(executionInfo, REMOTE1_ALIAS, new ElasticsearchException("something is wrong")), is(true));
         // remote2: skip_unavailable=false, so should not ignore any errors
         assertThat(
             shouldIgnoreRuntimeError(executionInfo, REMOTE2_ALIAS, new IllegalStateException("Unable to open any connections")),

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.TriConsumer;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
@@ -37,6 +38,7 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -1098,17 +1100,51 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
         {
             String q = "FROM employees,my_remote_cluster:employees_nomatch";
 
+            CheckedBiConsumer<Response, Boolean, Exception> verifier = (resp, limit0) -> {
+                assertOK(resp);
+                Map<String, Object> map = responseAsMap(resp);
+                assertThat(((List<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+                assertThat(((List<?>) map.get("values")).size(), limit0 ? equalTo(0) : greaterThanOrEqualTo(1));
+                assertExpectedClustersForMissingIndicesTests(
+                    map,
+                    List.of(
+                        new ExpectedCluster("(local)", "employees", "successful", limit0 ? 0 : null),
+                        new ExpectedCluster(
+                            REMOTE_CLUSTER_ALIAS,
+                            "employees_nomatch",
+                            "skipped",
+                            0,
+                            new ExpectedFailure("verification_exception", List.of("Unknown index", "my_remote_cluster:employees_nomatch"))
+                        )
+                    )
+                );
+            };
+
             Request limit1 = esqlRequest(q + " | LIMIT 1");
-            ResponseException e = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUser(limit1));
-            assertThat(e.getMessage(), containsString("Unknown index [my_remote_cluster:employees_nomatch]"));
-            e = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUserViaAPIKey(limit1, remoteSearchUserAPIKey));
-            assertThat(e.getMessage(), containsString("Unknown index [my_remote_cluster:employees_nomatch]"));
+            if (skipUnavailable == false) {
+                ResponseException e = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUser(limit1));
+                assertThat(e.getMessage(), containsString("Unknown index [my_remote_cluster:employees_nomatch]"));
+                e = expectThrows(
+                    ResponseException.class,
+                    () -> performRequestWithRemoteSearchUserViaAPIKey(limit1, remoteSearchUserAPIKey)
+                );
+                assertThat(e.getMessage(), containsString("Unknown index [my_remote_cluster:employees_nomatch]"));
+            } else {
+                verifier.accept(performRequestWithRemoteSearchUser(limit1), false);
+            }
 
             Request limit0 = esqlRequest(q + " | LIMIT 0");
-            e = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUser(limit0));
-            assertThat(e.getMessage(), containsString("Unknown index [my_remote_cluster:employees_nomatch]"));
-            e = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUserViaAPIKey(limit0, remoteSearchUserAPIKey));
-            assertThat(e.getMessage(), containsString("Unknown index [my_remote_cluster:employees_nomatch]"));
+            if (skipUnavailable == false) {
+                ResponseException e = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUser(limit0));
+                assertThat(e.getMessage(), containsString("Unknown index [my_remote_cluster:employees_nomatch]"));
+                e = expectThrows(
+                    ResponseException.class,
+                    () -> performRequestWithRemoteSearchUserViaAPIKey(limit0, remoteSearchUserAPIKey)
+                );
+                assertThat(e.getMessage(), containsString("Unknown index [my_remote_cluster:employees_nomatch]"));
+            } else {
+                verifier.accept(performRequestWithRemoteSearchUser(limit0), true);
+            }
         }
 
         // since there is at least one matching index in the query, the missing wildcarded local index is not an error
@@ -1189,7 +1225,8 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
             String q = "FROM employees,my_remote_cluster:employees_nomatch,my_remote_cluster:employees*";
 
             Request limit1 = esqlRequest(q + " | LIMIT 1");
-            ResponseException e = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUser(limit1));
+            Request limit0 = esqlRequest(q + " | LIMIT 0");
+
             /* Example error:
              *{"error":{"root_cause":[{"type":"security_exception","reason":"action [indices:data/read/esql/cluster] towards
              * remote cluster is unauthorized for user [remote_search_user] with assigned roles [remote_search] authenticated by
@@ -1199,11 +1236,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
              * by API key id [zaeMK5MBeGk5jCIiFtqB] of user [test_user] on indices [employees_nomatch], this action is granted by the
              * index privileges [read,all]"},"status":403}"
              */
-            assertThat(e.getMessage(), containsString("unauthorized for user [remote_search_user]"));
-            assertThat(e.getMessage(), containsString("on indices [employees_nomatch]"));
-            assertThat(e.getMessage(), containsString("security_exception"));
-
-            e = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUserViaAPIKey(limit1, remoteSearchUserAPIKey));
+            var userErrors = List.of("unauthorized for user [remote_search_user]", "of user [test_user]", "on indices [employees_nomatch]");
             /* Example error:
              * {"error":{"root_cause":[{"type":"security_exception","reason":"action [indices:data/read/esql/cluster] towards
              * remote cluster is unauthorized for API key id [sxuSK5MBSfGSGj4YFLyv] of user [remote_search_user] authenticated by
@@ -1213,15 +1246,66 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
              * by API key id [cUiRK5MB5j18U5stsvQj] of user [test_user] on indices [employees_nomatch], this action is granted by the
              * index privileges [read,all]"},"status":403}"
              */
-            assertThat(e.getMessage(), containsString("unauthorized for API key id"));
-            assertThat(e.getMessage(), containsString("of user [remote_search_user]"));
-            assertThat(e.getMessage(), containsString("on indices [employees_nomatch]"));
-            assertThat(e.getMessage(), containsString("security_exception"));
+            var keyErrors = List.of("unauthorized for API key id", "of user [remote_search_user]", "on indices [employees_nomatch]");
 
-            // TODO: in follow on PR, add support for throwing a VerificationException for this scenario - no exception is currently thrown
-            // Request limit0 = esqlRequest(q + " | LIMIT 0");
-            // e = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUser(limit0));
-            // assertThat(e.getMessage(), containsString("Unknown index [my_remote_cluster:employees_nomatch]"));
+            if (skipUnavailable == false) {
+                ResponseException e = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUser(limit1));
+                assertThat(e.getMessage(), containsString("security_exception"));
+                for (String error : userErrors) {
+                    assertThat(e.getMessage(), containsString(error));
+                }
+
+                e = expectThrows(
+                    ResponseException.class,
+                    () -> performRequestWithRemoteSearchUserViaAPIKey(limit1, remoteSearchUserAPIKey)
+                );
+                assertThat(e.getMessage(), containsString("security_exception"));
+                for (String error : keyErrors) {
+                    assertThat(e.getMessage(), containsString(error));
+                }
+
+                // TODO: in follow on PR, add support for throwing a VerificationException for this scenario - no exception is currently
+                // thrown
+                // Request limit0 = esqlRequest(q + " | LIMIT 0");
+                // e = expectThrows(ResponseException.class, () -> performRequestWithRemoteSearchUser(limit0));
+                // assertThat(e.getMessage(), containsString("Unknown index [my_remote_cluster:employees_nomatch]"));
+            } else {
+                TriConsumer<Response, Boolean, Collection<String>> verifier = (response, isLimit0, errors) -> {
+                    assertOK(response);
+                    Map<String, Object> map;
+                    try {
+                        map = responseAsMap(response);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    assertThat(((List<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+                    if (isLimit0) {
+                        assertThat(((List<?>) map.get("values")).size(), equalTo(0));
+                    } else {
+                        assertThat(((List<?>) map.get("values")).size(), greaterThanOrEqualTo(1));
+                    }
+                    assertExpectedClustersForMissingIndicesTests(
+                        map,
+                        List.of(
+                            new ExpectedCluster("(local)", "employees", "successful", isLimit0 ? 0 : null),
+                            // FIXME: this actually should produce SUCCESS since "employees" exists, but not implemented yet
+                            new ExpectedCluster(
+                                REMOTE_CLUSTER_ALIAS,
+                                "employees_nomatch,employees*",
+                                // TODO: LIMIT 0 produces "successful" here since no runtime check is performed. This is probably wrong.
+                                isLimit0 ? "successful" : "skipped",
+                                0,
+                                isLimit0 ? null : new ExpectedFailure("security_exception", errors)
+                            )
+                        )
+                    );
+                };
+                verifier.apply(performRequestWithRemoteSearchUser(limit1), false, userErrors);
+                verifier.apply(performRequestWithRemoteSearchUser(limit0), true, userErrors);
+                verifier.apply(performRequestWithRemoteSearchUserViaAPIKey(limit1, remoteSearchUserAPIKey), false, keyErrors);
+                verifier.apply(performRequestWithRemoteSearchUserViaAPIKey(limit0, remoteSearchUserAPIKey), true, keyErrors);
+            }
+
         }
     }
 
@@ -1527,7 +1611,13 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
         assertThat(flatList, containsInAnyOrder(2, 3, "usa", "canada"));
     }
 
-    record ExpectedCluster(String clusterAlias, String indexExpression, String status, Integer totalShards) {}
+    record ExpectedFailure(String type, Collection<String> messages) {}
+
+    record ExpectedCluster(String clusterAlias, String indexExpression, String status, Integer totalShards, ExpectedFailure failure) {
+        ExpectedCluster(String clusterAlias, String indexExpression, String status, Integer totalShards) {
+            this(clusterAlias, indexExpression, status, totalShards, null);
+        }
+    }
 
     @SuppressWarnings("unchecked")
     void assertExpectedClustersForMissingIndicesTests(Map<String, Object> responseMap, List<ExpectedCluster> expected) {
@@ -1566,10 +1656,12 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
                 assertThat(failures.size(), is(1));
                 Map<String, ?> failure1 = (Map<String, ?>) failures.get(0);
                 Map<String, ?> innerReason = (Map<String, ?>) failure1.get("reason");
-                String expectedMsg = "Unknown index [" + expectedCluster.indexExpression() + "]";
-                assertThat(innerReason.get("reason").toString(), containsString(expectedMsg));
-                assertThat(innerReason.get("type").toString(), containsString("verification_exception"));
-
+                if (expectedCluster.failure() != null) {
+                    for (var f : expectedCluster.failure().messages()) {
+                        assertThat(innerReason.get("reason").toString(), containsString(f));
+                    }
+                    assertThat(innerReason.get("type").toString(), containsString(expectedCluster.failure().type()));
+                }
             } else {
                 fail(msg + "; Unexpected status: " + expectedCluster.status());
             }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [ES|QL: Make skip_unavailable catch all errors (#128163)](https://github.com/elastic/elasticsearch/pull/128163)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)