### PR TITLE
[8.19] Update docker default base to Ubuntu 24.04

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
@@ -13,7 +13,7 @@ package org.elasticsearch.gradle.internal;
  * This class models the different Docker base images that are used to build Docker distributions of Elasticsearch.
  */
 public enum DockerBase {
-    DEFAULT("ubuntu:20.04", "", "apt-get", "dockerfiles/default/Dockerfile"),
+    DEFAULT("ubuntu:24.04", "", "apt-get", "dockerfiles/default/Dockerfile"),
 
     // "latest" here is intentional, since the image name specifies "8"
     UBI("docker.elastic.co/ubi8/ubi-minimal:latest", "-ubi8", "microdnf", "Dockerfile"),

--- a/distribution/docker/src/docker/dockerfiles/default/Dockerfile
+++ b/distribution/docker/src/docker/dockerfiles/default/Dockerfile
@@ -92,7 +92,7 @@ package_manager,
   "      ${package_manager} update && \n" +
   "      ${package_manager} upgrade -y && \n" +
   "      ${package_manager} install -y --no-install-recommends \n" +
-  "        ca-certificates curl netcat p11-kit unzip zip ${docker_base == 'cloud' ? 'wget' : '' } && \n" +
+  "        ca-certificates curl netcat-openbsd p11-kit unzip zip ${docker_base == 'cloud' ? 'wget' : '' } && \n" +
   "      ${package_manager} clean && \n" +
   "      rm -rf /var/lib/apt/lists/*"
 ) %>

--- a/distribution/docker/src/docker/dockerfiles/default/Dockerfile
+++ b/distribution/docker/src/docker/dockerfiles/default/Dockerfile
@@ -97,9 +97,10 @@ package_manager,
   "      rm -rf /var/lib/apt/lists/*"
 ) %>
 
-RUN groupadd -g 1000 elasticsearch && \\
-    adduser --uid 1000 --gid 1000 --home /usr/share/elasticsearch elasticsearch && \\
-    adduser elasticsearch root && \\
+RUN userdel -r ubuntu && \\
+    groupadd -g 1000 elasticsearch && \\
+    useradd --uid 1000 --gid 1000 --home-dir /usr/share/elasticsearch --create-home elasticsearch && \\
+    usermod -aG root elasticsearch && \\
     chown -R 0:0 /usr/share/elasticsearch
 
 ENV ELASTIC_CONTAINER=true

--- a/docs/changelog/128534.yaml
+++ b/docs/changelog/128534.yaml
@@ -1,0 +1,5 @@
+pr: 128534
+summary: "Update default docker base image to Ubuntu 24.04"
+area: Packaging
+type: upgrade
+issues: []


### PR DESCRIPTION
This PR is related to https://github.com/elastic/elasticsearch/issues/118866 and not a committment yet we provide an ubuntu update (tbd.) but evaluating basic compatibility by running packaging test suites.