### PR TITLE
Making the data stream settngs rest-api-spec consistent with the elasticsearch-specification repository

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_settings.json
@@ -20,20 +20,16 @@
           "parts":{
             "name":{
               "type":"string",
-              "description":"The name of the data stream or data stream pattern"
+              "description":"Comma-separated list of data streams or data stream patterns"
             }
           }
         }
       ]
     },
     "params":{
-      "timeout":{
-        "type":"time",
-        "description":"Specify timeout for acknowledging the cluster state update"
-      },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Period to wait for a connection to the master node"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_settings.json
@@ -20,7 +20,7 @@
           "parts":{
             "name":{
               "type":"string",
-              "description":"The name of the data stream or data stream pattern"
+              "description":"Comma-separated list of data streams or data stream patterns"
             }
           }
         }
@@ -29,16 +29,16 @@
     "params":{
       "dry_run":{
         "type":"boolean",
-        "description":"Perform a dry run but do not actually change any settings",
+        "description":"Whether this request should only be a dry run rather than actually applying settings",
         "default":false
       },
       "timeout":{
         "type":"time",
-        "description":"Specify timeout for acknowledging the cluster state update"
+        "description":"Period to wait for a response"
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Period to wait for a connection to the master node"
       }
     },
     "body":{


### PR DESCRIPTION
This PR makes the data stream settings rest-api-spec files consistent with what is in https://github.com/elastic/elasticsearch-specification/pull/4416, after some slight improvements in that PR.