### PR TITLE
Preserve integer-exact representation of numbers and allow conversion of floating point values to integers

### DIFF
--- a/docs/changelog/128540.yaml
+++ b/docs/changelog/128540.yaml
@@ -1,0 +1,6 @@
+pr: 128540
+summary: Preserve integer-exact representation of numbers and allow conversion of
+  floating point values to integers
+area: Ingest Node
+type: enhancement
+issues: []

--- a/docs/changelog/128540.yaml
+++ b/docs/changelog/128540.yaml
@@ -1,6 +1,7 @@
 pr: 128540
 summary: Preserve integer-exact representation of numbers and allow conversion of
-  floating point values to integers
+  floating point values to integers in the `convert` ingest processor
 area: Ingest Node
 type: enhancement
-issues: []
+issues:
+  - 128160

--- a/docs/changelog/128540.yaml
+++ b/docs/changelog/128540.yaml
@@ -3,5 +3,4 @@ summary: Preserve integer-exact representation of numbers and allow conversion o
   floating point values to integers in the `convert` ingest processor
 area: Ingest Node
 type: enhancement
-issues:
-  - 128160
+issues: []

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
@@ -102,6 +102,14 @@ public final class ConvertProcessor extends AbstractProcessor {
         STRING {
             @Override
             public Object convert(Object value) {
+                if (isExactIntegerDouble(value)) {
+                    Long l = Long.valueOf((long) ((Double) value).doubleValue());
+                    return l.toString();
+                }
+                if (isExactIntegerFloat(value)) {
+                    Long l = Long.valueOf((long) ((Float) value).floatValue());
+                    return l.toString();
+                }
                 return value.toString();
             }
         },
@@ -148,6 +156,24 @@ public final class ConvertProcessor extends AbstractProcessor {
                     "type [" + type + "] not supported, cannot convert field."
                 );
             }
+        }
+
+        private static boolean isExactIntegerFloat(Object value) {
+            final float ABS_MAX_EXACT_FLOAT = (float) 0x1p24 - 1;
+            if (value instanceof Float == false) {
+                return false;
+            }
+            float v = ((Float) value).floatValue();
+            return v == (long) v && -ABS_MAX_EXACT_FLOAT <= v && v <= ABS_MAX_EXACT_FLOAT;
+        }
+
+        private static boolean isExactIntegerDouble(Object value) {
+            final double ABS_MAX_EXACT_DOUBLE = 0x1p53 - 1;
+            if (value instanceof Double == false) {
+                return false;
+            }
+            double v = ((Double) value).doubleValue();
+            return v == (long) v && -ABS_MAX_EXACT_DOUBLE <= v && v <= ABS_MAX_EXACT_DOUBLE;
         }
     }
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
@@ -103,12 +103,10 @@ public final class ConvertProcessor extends AbstractProcessor {
             @Override
             public Object convert(Object value) {
                 if (isExactIntegerDouble(value)) {
-                    Long l = Long.valueOf((long) ((Double) value).doubleValue());
-                    return l.toString();
+                    return String.valueOf(((Double) value).longValue());
                 }
                 if (isExactIntegerFloat(value)) {
-                    Long l = Long.valueOf((long) ((Float) value).floatValue());
-                    return l.toString();
+                    return String.valueOf(((Float) value).longValue());
                 }
                 return value.toString();
             }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
@@ -34,7 +34,7 @@ public final class ConvertProcessor extends AbstractProcessor {
             @Override
             public Object convert(Object value) {
                 try {
-                    String strValue = value.toString();
+                    String strValue = (String) STRING.convert(value);
                     if (strValue.startsWith("0x") || strValue.startsWith("-0x")) {
                         return Integer.decode(strValue);
                     }
@@ -49,7 +49,7 @@ public final class ConvertProcessor extends AbstractProcessor {
             @Override
             public Object convert(Object value) {
                 try {
-                    String strValue = value.toString();
+                    String strValue = (String) STRING.convert(value);
                     if (strValue.startsWith("0x") || strValue.startsWith("-0x")) {
                         return Long.decode(strValue);
                     }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
@@ -42,7 +42,6 @@ public final class ConvertProcessor extends AbstractProcessor {
                 } catch (NumberFormatException e) {
                     throw new IllegalArgumentException("unable to convert [" + value + "] to integer", e);
                 }
-
             }
         },
         LONG {

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
@@ -118,19 +118,19 @@ public final class ConvertProcessor extends AbstractProcessor {
                 }
                 try {
                     return BOOLEAN.convert(value);
-                } catch (IllegalArgumentException e) {}
+                } catch (IllegalArgumentException ignored) {}
                 try {
                     return INTEGER.convert(value);
-                } catch (IllegalArgumentException e) {}
+                } catch (IllegalArgumentException ignored) {}
                 try {
                     return LONG.convert(value);
-                } catch (IllegalArgumentException e) {}
+                } catch (IllegalArgumentException ignored) {}
                 try {
                     return FLOAT.convert(value);
-                } catch (IllegalArgumentException e) {}
+                } catch (IllegalArgumentException ignored) {}
                 try {
                     return DOUBLE.convert(value);
-                } catch (IllegalArgumentException e) {}
+                } catch (IllegalArgumentException ignored) {}
                 return value;
             }
         };

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
@@ -155,6 +155,7 @@ public final class ConvertProcessor extends AbstractProcessor {
             }
         }
 
+        private final float ABS_MAX_EXACT_FLOAT = 0x1p24f - 1;
         private static boolean isExactIntegerFloat(Object value) {
             if (value instanceof Float == false) {
                 return false;
@@ -163,6 +164,7 @@ public final class ConvertProcessor extends AbstractProcessor {
             return v == (long) v && -ABS_MAX_EXACT_FLOAT <= v && v <= ABS_MAX_EXACT_FLOAT;
         }
 
+        private final double ABS_MAX_EXACT_DOUBLE = 0x1p53 - 1;
         private static boolean isExactIntegerDouble(Object value) {
             if (value instanceof Double == false) {
                 return false;
@@ -178,9 +180,6 @@ public final class ConvertProcessor extends AbstractProcessor {
     private final String targetField;
     private final Type convertType;
     private final boolean ignoreMissing;
-
-    private final float ABS_MAX_EXACT_FLOAT = 0x1p24f - 1;
-    private final double ABS_MAX_EXACT_DOUBLE = 0x1p53 - 1;
 
     ConvertProcessor(String tag, String description, String field, String targetField, Type convertType, boolean ignoreMissing) {
         super(tag, description);

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
@@ -156,20 +156,18 @@ public final class ConvertProcessor extends AbstractProcessor {
         }
 
         private static boolean isExactIntegerFloat(Object value) {
-            final float ABS_MAX_EXACT_FLOAT = (float) 0x1p24 - 1;
             if (value instanceof Float == false) {
                 return false;
             }
-            float v = ((Float) value).floatValue();
+            float v = (Float) value;
             return v == (long) v && -ABS_MAX_EXACT_FLOAT <= v && v <= ABS_MAX_EXACT_FLOAT;
         }
 
         private static boolean isExactIntegerDouble(Object value) {
-            final double ABS_MAX_EXACT_DOUBLE = 0x1p53 - 1;
             if (value instanceof Double == false) {
                 return false;
             }
-            double v = ((Double) value).doubleValue();
+            double v = (Double) value;
             return v == (long) v && -ABS_MAX_EXACT_DOUBLE <= v && v <= ABS_MAX_EXACT_DOUBLE;
         }
     }
@@ -180,6 +178,9 @@ public final class ConvertProcessor extends AbstractProcessor {
     private final String targetField;
     private final Type convertType;
     private final boolean ignoreMissing;
+
+    private final float ABS_MAX_EXACT_FLOAT = 0x1p24f - 1;
+    private final double ABS_MAX_EXACT_DOUBLE = 0x1p53 - 1;
 
     ConvertProcessor(String tag, String description, String field, String targetField, Type convertType, boolean ignoreMissing) {
         super(tag, description);

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ConvertProcessor.java
@@ -155,8 +155,8 @@ public final class ConvertProcessor extends AbstractProcessor {
             }
         }
 
-        private final float ABS_MAX_EXACT_FLOAT = 0x1p24f - 1;
         private static boolean isExactIntegerFloat(Object value) {
+            final float ABS_MAX_EXACT_FLOAT = 0x1p24f - 1;
             if (value instanceof Float == false) {
                 return false;
             }
@@ -164,8 +164,8 @@ public final class ConvertProcessor extends AbstractProcessor {
             return v == (long) v && -ABS_MAX_EXACT_FLOAT <= v && v <= ABS_MAX_EXACT_FLOAT;
         }
 
-        private final double ABS_MAX_EXACT_DOUBLE = 0x1p53 - 1;
         private static boolean isExactIntegerDouble(Object value) {
+            final double ABS_MAX_EXACT_DOUBLE = 0x1p53 - 1;
             if (value instanceof Double == false) {
                 return false;
             }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
@@ -466,6 +466,30 @@ public class ConvertProcessorTests extends ESTestCase {
         assertThat(ingestDocument.getFieldValue(fieldName, List.class), equalTo(expectedList));
     }
 
+    public void testConvertStringIntegralDoubleBillion() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        Map<String, Double> expectedResult = new HashMap<>();
+        double billion = 1e9;
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, billion);
+        expectedResult.put(fieldName, billion);
+
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), null, fieldName, fieldName, Type.STRING, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue(fieldName, String.class), equalTo("1000000000"));
+    }
+
+    public void testConvertStringIntegralFloatTenMillion() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        Map<String, Float> expectedResult = new HashMap<>();
+        float tenMillion = (float) 1e7;
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, tenMillion);
+        expectedResult.put(fieldName, tenMillion);
+
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), null, fieldName, fieldName, Type.STRING, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue(fieldName, String.class), equalTo("10000000"));
+    }
+
     public void testConvertNonExistingField() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
@@ -468,10 +468,8 @@ public class ConvertProcessorTests extends ESTestCase {
 
     public void testConvertStringIntegralDoubleBillion() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
-        Map<String, Double> expectedResult = new HashMap<>();
         double billion = 1e9;
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, billion);
-        expectedResult.put(fieldName, billion);
 
         Processor processor = new ConvertProcessor(randomAlphaOfLength(10), null, fieldName, fieldName, Type.STRING, false);
         processor.execute(ingestDocument);
@@ -480,10 +478,8 @@ public class ConvertProcessorTests extends ESTestCase {
 
     public void testConvertStringIntegralFloatTenMillion() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
-        Map<String, Float> expectedResult = new HashMap<>();
         float tenMillion = (float) 1e7;
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, tenMillion);
-        expectedResult.put(fieldName, tenMillion);
 
         Processor processor = new ConvertProcessor(randomAlphaOfLength(10), null, fieldName, fieldName, Type.STRING, false);
         processor.execute(ingestDocument);

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
@@ -83,6 +83,26 @@ public class ConvertProcessorTests extends ESTestCase {
         assertThat(ingestDocument.getFieldValue(fieldName, List.class), equalTo(expectedList));
     }
 
+    public void testConvertIntFromDouble() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        double tenMillion = 1e7;
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, tenMillion);
+
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), null, fieldName, fieldName, Type.INTEGER, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue(fieldName, Integer.class), equalTo((int) tenMillion));
+    }
+
+    public void testConvertIntFromFloat() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        float tenMillion = (float) 1e7;
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, tenMillion);
+
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), null, fieldName, fieldName, Type.INTEGER, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue(fieldName, Integer.class), equalTo((int) tenMillion));
+    }
+
     public void testConvertIntError() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
@@ -151,6 +171,26 @@ public class ConvertProcessorTests extends ESTestCase {
         Processor processor = new ConvertProcessor(randomAlphaOfLength(10), null, fieldName, fieldName, Type.LONG, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, List.class), equalTo(expectedList));
+    }
+
+    public void testConvertLongFromDouble() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        double billion = 1e9;
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, billion);
+
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), null, fieldName, fieldName, Type.LONG, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue(fieldName, Long.class), equalTo((long) billion));
+    }
+
+    public void testConvertLongFromFloat() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        float tenMillion = (float) 1e7;
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, tenMillion);
+
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), null, fieldName, fieldName, Type.LONG, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue(fieldName, Long.class), equalTo((long) tenMillion));
     }
 
     public void testConvertLongError() throws Exception {


### PR DESCRIPTION
This differentiates integral floating point values that are within the range of exact integer correspondence and renders them as integers rather than using the default java toString method which formats floating point values in E-notation when the absolute value is at least 1e7.

The new formatting is used as the input string for the INTEGER and LONG convert methods enabling conversion from floating point to integer numbers.

ref: elastic/beats#43659

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? :white_check_mark:
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)? :white_check_mark:
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. :white_check_mark:
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? :white_check_mark:
- ~If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.~

### Questions

Currently only successful `convert` operations are tested for the new change. Do we want tests for long/int converts from floating point inputs that have fractional parts or are outside the exact integer representation range? These are expected (intended) to error out. For the string convert from the same floating point values, we just expect the string to either include a decimal or be in E-notation respectively.