### PR TITLE
Re-enable and fix the EsqlRestValidationIT test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -486,8 +486,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
   method: testSearchWhileRelocating
   issue: https://github.com/elastic/elasticsearch/issues/128500
-- class: org.elasticsearch.xpack.esql.ccq.EsqlRestValidationIT
-  issue: https://github.com/elastic/elasticsearch/issues/128543
 - class: org.elasticsearch.xpack.ccr.index.engine.FollowingEngineTests
   method: testProcessOnceOnPrimary
   issue: https://github.com/elastic/elasticsearch/issues/128541

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationIT.java
@@ -97,7 +97,7 @@ public class EsqlRestValidationIT extends EsqlRestValidationTestCase {
         super.testExistentIndexWithoutWildcard();
     }
 
-    private static boolean checkVersion(org.elasticsearch.Version version) {
+    private static boolean checkVersion(Version version) {
         return version.onOrAfter(Version.fromString("9.1.0"))
             || (version.onOrAfter(Version.fromString("8.19.0")) && version.before(Version.fromString("9.0.0")));
     }

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationIT.java
@@ -81,8 +81,29 @@ public class EsqlRestValidationIT extends EsqlRestValidationTestCase {
         return remoteClient;
     }
 
+    protected boolean isSkipUnavailable() {
+        return true;
+    }
+
+    @Override
+    public void testAlias() throws IOException {
+        assumeFalse("expecting skip_unavailable to be false", isSkipUnavailable());
+        super.testAlias();
+    }
+
+    @Override
+    public void testExistentIndexWithoutWildcard() throws IOException {
+        assumeFalse("expecting skip_unavailable to be false", isSkipUnavailable());
+        super.testExistentIndexWithoutWildcard();
+    }
+
+    private static boolean checkVersion(org.elasticsearch.Version version) {
+        return version.onOrAfter(Version.fromString("9.1.0"))
+            || (version.onOrAfter(Version.fromString("8.19.0")) && version.before(Version.fromString("9.0.0")));
+    }
+
     @Before
     public void skipTestOnOldVersions() {
-        assumeTrue("skip on old versions", Clusters.localClusterVersion().equals(Version.V_8_19_0));
+        assumeTrue("skip on old versions", checkVersion(Clusters.localClusterVersion()));
     }
 }

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationIT.java
@@ -97,13 +97,13 @@ public class EsqlRestValidationIT extends EsqlRestValidationTestCase {
         super.testExistentIndexWithoutWildcard();
     }
 
-    private static boolean checkVersion(Version version) {
-        return version.onOrAfter(Version.fromString("9.1.0"))
-            || (version.onOrAfter(Version.fromString("8.19.0")) && version.before(Version.fromString("9.0.0")));
-    }
-
     @Before
     public void skipTestOnOldVersions() {
-        assumeTrue("skip on old versions", checkVersion(Clusters.localClusterVersion()));
+        Version version = Clusters.localClusterVersion();
+        assumeTrue(
+            "skip on old versions",
+            version.onOrAfter(Version.fromString("9.1.0"))
+                || (version.onOrAfter(Version.fromString("8.19.0")) && version.before(Version.fromString("9.0.0")))
+        );
     }
 }

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationSkipUnFalseIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/EsqlRestValidationSkipUnFalseIT.java
@@ -27,4 +27,9 @@ public class EsqlRestValidationSkipUnFalseIT extends EsqlRestValidationIT {
     protected String getTestRestCluster() {
         return localCluster.getHttpAddresses();
     }
+
+    @Override
+    protected boolean isSkipUnavailable() {
+        return false;
+    }
 }

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/RequestIndexFilteringIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/RequestIndexFilteringIT.java
@@ -142,9 +142,8 @@ public class RequestIndexFilteringIT extends RequestIndexFilteringTestCase {
     }
 
     private static boolean checkVersion(org.elasticsearch.Version version) {
-        return version.onOrAfter(Version.fromString("9.1.0"));
-        // TODO: enable this when ported to 8.x
-        // || (version.onOrAfter(Version.fromString("8.19.0")) && version.before(Version.fromString("9.0.0")));
+        return version.onOrAfter(Version.fromString("9.1.0"))
+            || (version.onOrAfter(Version.fromString("8.19.0")) && version.before(Version.fromString("9.0.0")));
     }
 
     // We need a separate test since remote missing indices and local missing indices now work differently


### PR DESCRIPTION
This test seems to be unintentionally disabled in 9.x branch. 

Fixes https://github.com/elastic/elasticsearch/issues/128543