### PR TITLE
[8.18., 8.19] Adds ml-ccp release notes to elasticsearch release notes for 8.18

### DIFF
--- a/docs/reference/release-notes/8.18.0.asciidoc
+++ b/docs/reference/release-notes/8.18.0.asciidoc
@@ -126,6 +126,10 @@ Machine Learning::
 * Set default similarity for Cohere model to cosine {es-pull}125370[#125370] (issue: {es-issue}122878[#122878])
 * Updating Inference Update API documentation to have the correct PUT method {es-pull}121048[#121048]
 * [Inference API] Fix output stream ordering in `InferenceActionProxy` {es-pull}124225[#124225]
+* Restrict file system access for PyTorch models {ml-pull}2851[#2851]
+* Update the PyTorch library to version 2.5.1. {ml-pull}2783[#2798], {ml-pull}2799[#2799]
+* Upgrade Boost libraries to version 1.86. {ml-pull}2780[#2780], {ml-pull}2779[#2779]
+
 
 Mapping::
 * Avoid serializing empty `_source` fields in mappings {es-pull}122606[#122606]


### PR DESCRIPTION
As title states.