### PR TITLE
lucene_snapshot: Fix ScriptedSimilarityTests by allowing for BulkScoreBulkScorer calling TermScorer::nextDocsAndScores

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/similarity/ScriptedSimilarityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/similarity/ScriptedSimilarityTests.java
@@ -152,7 +152,6 @@ public class ScriptedSimilarityTests extends ESTestCase {
         dir.close();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/128502")
     public void testInitScript() throws IOException {
         final AtomicBoolean initCalled = new AtomicBoolean();
         SimilarityWeightScript.Factory weightScriptFactory = () -> {
@@ -189,7 +188,8 @@ public class ScriptedSimilarityTests extends ESTestCase {
 
                     StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
                     if (Arrays.stream(stackTraceElements).anyMatch(ste -> {
-                        return ste.getClassName().endsWith(".TermScorer") && ste.getMethodName().equals("score");
+                        return ste.getClassName().endsWith(".TermScorer")
+                            && (ste.getMethodName().equals("score") || ste.getMethodName().equals("nextDocsAndScores"));
                     }) == false) {
                         // this might happen when computing max scores
                         return Float.MAX_VALUE;


### PR DESCRIPTION
Fix ScriptedSimilarityTests by allowing for BulkScoreBulkScorer calling TermScorer::nextDocsAndScores.

closes #128502