### PR TITLE
Add initial bcUpgradeTask

### DIFF
--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-java-rest-test'
@@ -22,6 +23,18 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
+  }
+}
+
+tasks.register("bcUpgradeTest", StandaloneRestIntegTestTask) {
+  // We use a phony version here as the real version is provided via `tests.bwc.main.version` system property
+  usesBwcDistribution(Version.fromString("0.0.0"))
+  systemProperty("tests.old_cluster_version", "0.0.0")
+  onlyIf("tests.bwc.main.version system property exists") { System.getProperty("tests.bwc.main.version") != null }
+  filter {
+    // filter tests initially for quicker iterations
+    // TODO remove once expanding the test set to other modules
+    includeTestsMatching("org.elasticsearch.upgrades.IndexingIT")
   }
 }
 


### PR DESCRIPTION
This can be run as follows until the incompatibility check is removed from TransportService
```
gradle -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.main.version=9.1.0 -Dtests.bwc.refspec.main=e5cdc581cf7c03903a99eb2adec567294be9ad43 bcUpgradeTest -Dtests.jvm.argline="-Des.serverless_transport=true"
```

However, this sometimes failed unexpectedly on the upgrade due to an ML issue. When later trying to reproduce to see the actual exception, it didn't reproduce anymore :(

```
Failure running machine learning native code. This could be due to running on an unsupported OS or distribution, missing OS libraries, or a problem with the temp directory. To bypass this problem by running Elasticsearch without machine learning functionality set [xpack.ml.enabled: false].
```
Relates to ES-11870