### PR TITLE
Pass PolicyManager into entitlements bootstrap

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
@@ -35,6 +35,11 @@ import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Main entry point for firing up the Entitlements system.
+ * Called by ES {@code initPhase2} to load the agent after setting up its prerequisites,
+ * such as {@link BootstrapArgs} and some special module exports.
+ */
 public class EntitlementBootstrap {
 
     public record BootstrapArgs(
@@ -63,9 +68,11 @@ public class EntitlementBootstrap {
     /**
      * Activates entitlement checking. Once this method returns, calls to methods protected by Entitlements from classes without a valid
      * policy will throw {@link org.elasticsearch.entitlement.runtime.api.NotEntitledException}.
+     * <p>
+     * (Note: when we reference Elasticsearch "plugins" here, we generally also include Elasticsearch "modules".)
      *
      * @param serverPolicyPatch a policy with additional entitlements to patch the embedded server layer policy
-     * @param pluginPolicies a map holding policies for plugins (and modules), by plugin (or module) name.
+     * @param pluginPolicies a map holding policies for plugins, by plugin name.
      * @param scopeResolver a functor to map a Java Class to the component and module it belongs to.
      * @param settingResolver a functor to resolve a setting name pattern for one or more Elasticsearch settings.
      * @param dataDirs       data directories for Elasticsearch
@@ -74,7 +81,7 @@ public class EntitlementBootstrap {
      * @param libDir         the lib directory for Elasticsearch
      * @param modulesDir     the directory where Elasticsearch modules are
      * @param pluginsDir     the directory where plugins are installed for Elasticsearch
-     * @param sourcePaths    a map holding the path to each plugin or module jars, by plugin (or module) name.
+     * @param sourcePaths    a map holding the path to each plugin or module jars, by plugin name.
      * @param tempDir        the temp directory for Elasticsearch
      * @param logsDir        the log directory for Elasticsearch
      * @param pidFile        path to a pid file for Elasticsearch, or {@code null} if one was not specified

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlements.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlements.java
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.entitlement.initialization;
+package org.elasticsearch.entitlement.bootstrap;
 
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.entitlement.runtime.policy.Policy;
@@ -42,7 +42,7 @@ import static org.elasticsearch.entitlement.runtime.policy.Platform.LINUX;
 import static org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement.Mode.READ;
 import static org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement.Mode.READ_WRITE;
 
-class HardcodedEntitlements {
+public class HardcodedEntitlements {
 
     private static List<Scope> createServerEntitlements(Path pidFile) {
 
@@ -179,7 +179,7 @@ class HardcodedEntitlements {
         return serverScopes;
     }
 
-    static Policy serverPolicy(Path pidFile, Policy serverPolicyPatch) {
+    public static Policy serverPolicy(Path pidFile, Policy serverPolicyPatch) {
         var serverScopes = createServerEntitlements(pidFile);
         return new Policy(
             "server",
@@ -190,7 +190,7 @@ class HardcodedEntitlements {
     // agents run without a module, so this is a special hack for the apm agent
     // this should be removed once https://github.com/elastic/elasticsearch/issues/109335 is completed
     // See also modules/apm/src/main/plugin-metadata/entitlement-policy.yaml
-    static List<Entitlement> agentEntitlements() {
+    public static List<Entitlement> agentEntitlements() {
         return List.of(
             new CreateClassLoaderEntitlement(),
             new ManageThreadsEntitlement(),

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -11,7 +11,6 @@ package org.elasticsearch.entitlement.initialization;
 
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.entitlement.bootstrap.EntitlementBootstrap;
-import org.elasticsearch.entitlement.bootstrap.HardcodedEntitlements;
 import org.elasticsearch.entitlement.bridge.EntitlementChecker;
 import org.elasticsearch.entitlement.runtime.api.ElasticsearchEntitlementChecker;
 import org.elasticsearch.entitlement.runtime.policy.PathLookup;
@@ -124,19 +123,11 @@ public class EntitlementInitialization {
 
         FilesEntitlementsValidation.validate(pluginPolicies, pathLookup);
 
-        PolicyManager policyManager = new PolicyManager(
-            HardcodedEntitlements.serverPolicy(pathLookup.pidFile(), bootstrapArgs.serverPolicyPatch()),
-            HardcodedEntitlements.agentEntitlements(),
-            pluginPolicies,
-            EntitlementBootstrap.bootstrapArgs().scopeResolver(),
-            EntitlementBootstrap.bootstrapArgs().sourcePaths(),
-            pathLookup
-        );
         return new PolicyCheckerImpl(
             bootstrapArgs.suppressFailureLogPackages(),
             ENTITLEMENTS_MODULE,
-            policyManager,
-            bootstrapArgs.pathLookup()
+            bootstrapArgs.policyManager(),
+            pathLookup
         );
     }
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -36,11 +36,11 @@ public class EntitlementInitialization {
 
     private static final Module ENTITLEMENTS_MODULE = PolicyManager.class.getModule();
 
-    private static ElasticsearchEntitlementChecker manager;
+    private static ElasticsearchEntitlementChecker checker;
 
     // Note: referenced by bridge reflectively
     public static EntitlementChecker checker() {
-        return manager;
+        return checker;
     }
 
     /**
@@ -63,7 +63,7 @@ public class EntitlementInitialization {
      * @param inst the JVM instrumentation class instance
      */
     public static void initialize(Instrumentation inst) throws Exception {
-        manager = initChecker();
+        checker = initEntitlementChecker();
 
         var verifyBytecode = Booleans.parseBoolean(System.getProperty("es.entitlements.verify_bytecode", "false"));
         if (verifyBytecode) {
@@ -95,7 +95,7 @@ public class EntitlementInitialization {
         }
     }
 
-    private static ElasticsearchEntitlementChecker initChecker() {
+    private static ElasticsearchEntitlementChecker initEntitlementChecker() {
         final PolicyChecker policyChecker = createPolicyChecker();
 
         final Class<?> clazz = EntitlementCheckerUtils.getVersionSpecificCheckerClass(

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -11,6 +11,7 @@ package org.elasticsearch.entitlement.initialization;
 
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.entitlement.bootstrap.EntitlementBootstrap;
+import org.elasticsearch.entitlement.bootstrap.HardcodedEntitlements;
 import org.elasticsearch.entitlement.bridge.EntitlementChecker;
 import org.elasticsearch.entitlement.runtime.api.ElasticsearchEntitlementChecker;
 import org.elasticsearch.entitlement.runtime.policy.PathLookup;


### PR DESCRIPTION
_Reviewers: review commit-by-commit._

Refactor so the complete `PolicyManager` is created by `initPhase2` and passed in to the entitlements bootstrap process.

This will open the door to passing in a different `TestPolicyManager` for unit tests.

(I think there are opportunities for additional simplification here, but I'm struggling to keep these PRs bite-sized, so let's just start with this.)

See ES-11597.