### PR TITLE
ESQL: Speed up semantic_text tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -9,9 +9,7 @@ package org.elasticsearch.xpack.esql.qa.single_node;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
-import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
-import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -25,6 +23,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.esql.AssertWarnings;
 import org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase;
 import org.hamcrest.Matcher;
+import org.junit.Before;
 import org.junit.ClassRule;
 
 import java.io.IOException;
@@ -52,10 +51,9 @@ import static org.hamcrest.Matchers.startsWith;
  * Tests for pushing queries to lucene.
  */
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
-@TimeoutSuite(millis = 10 * TimeUnits.MINUTE) // semantic_text can take a long, long time to start in CI
 public class PushQueriesIT extends ESRestTestCase {
     @ClassRule
-    public static ElasticsearchCluster cluster = Clusters.testCluster();
+    public static ElasticsearchCluster cluster = Clusters.testCluster(spec -> spec.plugin("inference-service-test"));
 
     @ParametersFactory(argumentFormatting = "%1s")
     public static List<Object[]> args() {
@@ -294,13 +292,30 @@ public class PushQueriesIT extends ESRestTestCase {
                   "number_of_shards": 1
                 }
               }""";
-        if (false == "auto".equals(type)) {
-            json += """
+        json += switch (type) {
+            case "auto" -> "";
+            case "semantic_text" -> """
                 ,
                 "mappings": {
                   "properties": {
                     "test": {
-                      "type": "%type",
+                      "type": "semantic_text",
+                      "inference_id": "test",
+                      "fields": {
+                        "keyword": {
+                          "type": "keyword",
+                          "ignore_above": 256
+                        }
+                      }
+                    }
+                  }
+                }""";
+            default -> """
+                  ,
+                  "mappings": {
+                    "properties": {
+                      "test": {
+                        "type": "%type",
                         "fields": {
                           "keyword": {
                             "type": "keyword",
@@ -311,7 +326,7 @@ public class PushQueriesIT extends ESRestTestCase {
                     }
                   }
                 }""".replace("%type", type);
-        }
+        };
         json += "}";
         createIndex.setJsonEntity(json);
         Response createResponse = client().performRequest(createIndex);
@@ -352,5 +367,29 @@ public class PushQueriesIT extends ESRestTestCase {
     protected boolean preserveClusterUponCompletion() {
         // Preserve the cluser to speed up the semantic_text tests
         return true;
+    }
+
+    private static boolean setupEmbeddings = false;
+
+    @Before
+    public void setUpTextEmbeddingInferenceEndpoint() throws IOException {
+        if (type.equals("semantic_text") == false || setupEmbeddings) {
+            return;
+        }
+        setupEmbeddings = true;
+        Request request = new Request("PUT", "_inference/text_embedding/test");
+        request.setJsonEntity("""
+                  {
+                   "service": "text_embedding_test_service",
+                   "service_settings": {
+                     "model": "my_model",
+                     "api_key": "abc64",
+                     "dimensions": 128
+                   },
+                   "task_settings": {
+                   }
+                 }
+            """);
+        adminClient().performRequest(request);
     }
 }


### PR DESCRIPTION
Speeds up the semantic_text tests by using a test inference plugin. That skips downloading the normal inference setup.

Closes #128511
Closes #128513
Closes #128571
Closes #128572
Closes #128573
Closes #128574
