### PR TITLE
[8.19] ESQL: Speed up semantic_text tests (#128591)

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -9,9 +9,7 @@ package org.elasticsearch.xpack.esql.qa.single_node;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
-import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
-import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -25,6 +23,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.esql.AssertWarnings;
 import org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase;
 import org.hamcrest.Matcher;
+import org.junit.Before;
 import org.junit.ClassRule;
 
 import java.io.IOException;
@@ -51,10 +50,9 @@ import static org.hamcrest.Matchers.startsWith;
  * Tests for pushing queries to lucene.
  */
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
-@TimeoutSuite(millis = 10 * TimeUnits.MINUTE) // semantic_text can take a long, long time to start in CI
 public class PushQueriesIT extends ESRestTestCase {
     @ClassRule
-    public static ElasticsearchCluster cluster = Clusters.testCluster();
+    public static ElasticsearchCluster cluster = Clusters.testCluster(spec -> spec.plugin("inference-service-test"));
 
     @ParametersFactory(argumentFormatting = "%1s")
     public static List<Object[]> args() {
@@ -288,13 +286,30 @@ public class PushQueriesIT extends ESRestTestCase {
                   "number_of_shards": 1
                 }
               }""";
-        if (false == "auto".equals(type)) {
-            json += """
+        json += switch (type) {
+            case "auto" -> "";
+            case "semantic_text" -> """
                 ,
                 "mappings": {
                   "properties": {
                     "test": {
-                      "type": "%type",
+                      "type": "semantic_text",
+                      "inference_id": "test",
+                      "fields": {
+                        "keyword": {
+                          "type": "keyword",
+                          "ignore_above": 256
+                        }
+                      }
+                    }
+                  }
+                }""";
+            default -> """
+                  ,
+                  "mappings": {
+                    "properties": {
+                      "test": {
+                        "type": "%type",
                         "fields": {
                           "keyword": {
                             "type": "keyword",
@@ -305,7 +320,7 @@ public class PushQueriesIT extends ESRestTestCase {
                     }
                   }
                 }""".replace("%type", type);
-        }
+        };
         json += "}";
         createIndex.setJsonEntity(json);
         Response createResponse = client().performRequest(createIndex);
@@ -346,5 +361,29 @@ public class PushQueriesIT extends ESRestTestCase {
     protected boolean preserveClusterUponCompletion() {
         // Preserve the cluser to speed up the semantic_text tests
         return true;
+    }
+
+    private static boolean setupEmbeddings = false;
+
+    @Before
+    public void setUpTextEmbeddingInferenceEndpoint() throws IOException {
+        if (type.equals("semantic_text") == false || setupEmbeddings) {
+            return;
+        }
+        setupEmbeddings = true;
+        Request request = new Request("PUT", "_inference/text_embedding/test");
+        request.setJsonEntity("""
+                  {
+                   "service": "text_embedding_test_service",
+                   "service_settings": {
+                     "model": "my_model",
+                     "api_key": "abc64",
+                     "dimensions": 128
+                   },
+                   "task_settings": {
+                   }
+                 }
+            """);
+        adminClient().performRequest(request);
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - ESQL: Speed up semantic_text tests (#128591)