### PR TITLE
Removing the data stream settings feature flag

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.datastreams.lifecycle.ExplainDataStreamLifecycle
 import org.elasticsearch.action.datastreams.lifecycle.GetDataStreamLifecycleAction;
 import org.elasticsearch.action.datastreams.lifecycle.PutDataStreamLifecycleAction;
 import org.elasticsearch.client.internal.OriginSettingClient;
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -283,8 +282,8 @@ public class DataStreamsPlugin extends Plugin implements ActionPlugin, HealthPlu
         handlers.add(new RestGetDataStreamOptionsAction());
         handlers.add(new RestPutDataStreamOptionsAction());
         handlers.add(new RestDeleteDataStreamOptionsAction());
-            handlers.add(new RestGetDataStreamSettingsAction());
-            handlers.add(new RestUpdateDataStreamSettingsAction());
+        handlers.add(new RestGetDataStreamSettingsAction());
+        handlers.add(new RestUpdateDataStreamSettingsAction());
         return handlers;
     }
 

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
@@ -283,10 +283,8 @@ public class DataStreamsPlugin extends Plugin implements ActionPlugin, HealthPlu
         handlers.add(new RestGetDataStreamOptionsAction());
         handlers.add(new RestPutDataStreamOptionsAction());
         handlers.add(new RestDeleteDataStreamOptionsAction());
-        if (DataStream.LOGS_STREAM_FEATURE_FLAG) {
             handlers.add(new RestGetDataStreamSettingsAction());
             handlers.add(new RestUpdateDataStreamSettingsAction());
-        }
         return handlers;
     }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_settings.json
@@ -5,8 +5,7 @@
       "description":"Gets a data stream's settings"
     },
     "stability":"stable",
-    "visibility": "feature_flag",
-    "feature_flag": "logs_stream",
+    "visibility": "public",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_settings.json
@@ -5,8 +5,7 @@
       "description":"Updates a data stream's settings"
     },
     "stability":"stable",
-    "visibility": "feature_flag",
-    "feature_flag": "logs_stream",
+    "visibility": "public",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
@@ -418,9 +418,9 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
                     builder.endArray();
                     builder.endObject();
                 }
-                    builder.startObject(SETTINGS_FIELD.getPreferredName());
-                    dataStream.getSettings().toXContent(builder, params);
-                    builder.endObject();
+                builder.startObject(SETTINGS_FIELD.getPreferredName());
+                dataStream.getSettings().toXContent(builder, params);
+                builder.endObject();
 
                 builder.startObject(DataStream.FAILURE_STORE_FIELD.getPreferredName());
                 builder.field(FAILURE_STORE_ENABLED.getPreferredName(), failureStoreEffectivelyEnabled);

--- a/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
@@ -418,11 +418,9 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
                     builder.endArray();
                     builder.endObject();
                 }
-                if (DataStream.LOGS_STREAM_FEATURE_FLAG) {
                     builder.startObject(SETTINGS_FIELD.getPreferredName());
                     dataStream.getSettings().toXContent(builder, params);
                     builder.endObject();
-                }
 
                 builder.startObject(DataStream.FAILURE_STORE_FIELD.getPreferredName());
                 builder.field(FAILURE_STORE_ENABLED.getPreferredName(), failureStoreEffectivelyEnabled);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -80,7 +80,6 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
     private static final Logger LOGGER = LogManager.getLogger(DataStream.class);
 
     public static final NodeFeature DATA_STREAM_FAILURE_STORE_FEATURE = new NodeFeature("data_stream.failure_store");
-    public static final boolean LOGS_STREAM_FEATURE_FLAG = new FeatureFlag("logs_stream").isEnabled();
     public static final TransportVersion ADDED_FAILURE_STORE_TRANSPORT_VERSION = TransportVersions.V_8_12_0;
     public static final TransportVersion ADDED_AUTO_SHARDING_EVENT_VERSION = TransportVersions.V_8_14_0;
     public static final TransportVersion ADD_DATA_STREAM_OPTIONS_VERSION = TransportVersions.V_8_16_0;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -34,7 +34,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
-import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.core.Nullable;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
+import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.core.Nullable;
@@ -79,6 +80,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
     private static final Logger LOGGER = LogManager.getLogger(DataStream.class);
 
     public static final NodeFeature DATA_STREAM_FAILURE_STORE_FEATURE = new NodeFeature("data_stream.failure_store");
+    public static final boolean LOGS_STREAM_FEATURE_FLAG = new FeatureFlag("logs_stream").isEnabled();
     public static final TransportVersion ADDED_FAILURE_STORE_TRANSPORT_VERSION = TransportVersions.V_8_12_0;
     public static final TransportVersion ADDED_AUTO_SHARDING_EVENT_VERSION = TransportVersions.V_8_14_0;
     public static final TransportVersion ADD_DATA_STREAM_OPTIONS_VERSION = TransportVersions.V_8_16_0;


### PR DESCRIPTION
This removes the feature flag that was introduced in #127858, making the data stream settings APIs available without having to pass a flag..