### PR TITLE
Fix serialization issue with RunTask using Configuration Cache

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -46,7 +46,7 @@ public abstract class RunTask extends DefaultTestClustersTask {
 
     private Boolean apmServerEnabled = false;
 
-    private List<String> plugins = List.of();
+    private List<String> plugins;
 
     private Boolean preserveData = false;
 
@@ -115,7 +115,12 @@ public abstract class RunTask extends DefaultTestClustersTask {
         }
     }
 
+    public void setPlugins(List<String> plugins) {
+        this.plugins = plugins;
+    }
+
     @Input
+    @Optional
     public List<String> getPlugins() {
         return plugins;
     }


### PR DESCRIPTION
This fixes an serialization issue causing the gradle build to fail with 
```
Could not load the value of field `plugins` of task `:run` of type `org.elasticsearch.gradle.testclusters.RunTask`.
> null array

```

when running the RunTask if configuration cache is used.