### PR TITLE
Fix and test off-heap stats when using direct IO for accessing the raw vectors

### DIFF
--- a/docs/changelog/128615.yaml
+++ b/docs/changelog/128615.yaml
@@ -1,0 +1,5 @@
+pr: 128615
+summary: Fix and test off-heap stats when using direct IO for accessing the raw vectors
+area: Vector Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/DirectIOLucene99FlatVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/DirectIOLucene99FlatVectorsReader.java
@@ -44,16 +44,18 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.SuppressForbidden;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.elasticsearch.index.codec.vectors.reflect.OffHeapStats;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Map;
 
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readSimilarityFunction;
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readVectorEncoding;
 
 /** Copied from Lucene99FlatVectorsReader in Lucene 10.2, then modified to support DirectIOIndexInputSupplier */
 @SuppressForbidden(reason = "Copied from lucene")
-public class DirectIOLucene99FlatVectorsReader extends FlatVectorsReader {
+public class DirectIOLucene99FlatVectorsReader extends FlatVectorsReader implements OffHeapStats {
 
     private static final boolean USE_DIRECT_IO = Boolean.parseBoolean(System.getProperty("vector.rescoring.directio", "true"));
 
@@ -280,6 +282,11 @@ public class DirectIOLucene99FlatVectorsReader extends FlatVectorsReader {
     @Override
     public void close() throws IOException {
         IOUtils.close(vectorData);
+    }
+
+    @Override
+    public Map<String, Long> getOffHeapByteSize(FieldInfo fieldInfo) {
+        return Map.of();  // no off-heap
     }
 
     private record FieldEntry(

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/MergeReaderWrapper.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/MergeReaderWrapper.java
@@ -11,17 +11,21 @@ package org.elasticsearch.index.codec.vectors.es818;
 
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.index.codec.vectors.reflect.OffHeapByteSizeUtils;
+import org.elasticsearch.index.codec.vectors.reflect.OffHeapStats;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
-class MergeReaderWrapper extends FlatVectorsReader {
+class MergeReaderWrapper extends FlatVectorsReader implements OffHeapStats {
 
     private final FlatVectorsReader mainReader;
     private final FlatVectorsReader mergeReader;
@@ -85,5 +89,10 @@ class MergeReaderWrapper extends FlatVectorsReader {
     @Override
     public void close() throws IOException {
         IOUtils.close(mainReader, mergeReader);
+    }
+
+    @Override
+    public Map<String, Long> getOffHeapByteSize(FieldInfo fieldInfo) {
+        return OffHeapByteSizeUtils.getOffHeapByteSize(mainReader, fieldInfo);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/reflect/OffHeapByteSizeUtils.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/reflect/OffHeapByteSizeUtils.java
@@ -19,7 +19,6 @@ import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsReader;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader;
 import org.apache.lucene.codecs.lucene99.Lucene99ScalarQuantizedVectorsReader;
 import org.apache.lucene.index.FieldInfo;
-import org.elasticsearch.index.codec.vectors.es818.DirectIOLucene99FlatVectorsReader;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -50,9 +49,6 @@ public class OffHeapByteSizeUtils {
                 return mergeOffHeapByteSizeMaps(quant, raw);
             }
             case Lucene99FlatVectorsReader flatVectorsReader -> {
-                return OffHeapReflectionUtils.getOffHeapByteSizeF99FLT(flatVectorsReader, fieldInfo);
-            }
-            case DirectIOLucene99FlatVectorsReader flatVectorsReader -> {
                 return OffHeapReflectionUtils.getOffHeapByteSizeF99FLT(flatVectorsReader, fieldInfo);
             }
             case Lucene95HnswVectorsReader lucene95HnswVectorsReader -> {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsFormatTests.java
@@ -35,12 +35,16 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.misc.store.DirectIODirectory;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 import org.apache.lucene.tests.store.MockDirectoryWrapper;
@@ -61,6 +65,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
+import java.util.OptionalLong;
 
 import static java.lang.String.format;
 import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
@@ -200,6 +205,7 @@ public class ES818BinaryQuantizedVectorsFormatTests extends BaseKnnVectorsFormat
     }
 
     public void testSimpleOffHeapSizeFSDir() throws IOException {
+        checkDirectIOSupported();
         var config = newIndexWriterConfig().setUseCompoundFile(false); // avoid compound files to allow directIO
         try (Directory dir = newFSDirectory()) {
             testSimpleOffHeapSizeImpl(dir, config, false);
@@ -259,5 +265,23 @@ public class ES818BinaryQuantizedVectorsFormatTests extends BaseKnnVectorsFormat
             dir = new MockDirectoryWrapper(random(), dir);
         }
         return dir;
+    }
+
+    static void checkDirectIOSupported() {
+        Path path = createTempDir("directIOProbe");
+        try (Directory dir = open(path); IndexOutput out = dir.createOutput("out", IOContext.DEFAULT)) {
+            out.writeString("test");
+        } catch (IOException e) {
+            assumeNoException("test requires a filesystem that supports Direct IO", e);
+        }
+    }
+
+    static DirectIODirectory open(Path path) throws IOException {
+        return new DirectIODirectory(FSDirectory.open(path)) {
+            @Override
+            protected boolean useDirectIO(String name, IOContext context, OptionalLong fileLength) {
+                return true;
+            }
+        };
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsFormatTests.java
@@ -68,7 +68,6 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 
-@com.carrotsearch.randomizedtesting.annotations.Repeat(iterations = 100)
 public class ES818BinaryQuantizedVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {


### PR DESCRIPTION
Fix and test off-heap stats when using direct IO for accessing the raw vectors. The direct IO reader is not using off-heap, so it returns an empty map to indicate that there is no off-heap requirements. I added some overloaded of tests with different directories to verify this.

Note: For 9.1 we're still using reflection to access the internals of non-ES readers, but DirectIO is an ES reader so we can use our internal OffHeapStats interface (rather than reflection). This is all replaced when we eventually get Lucene 10.3.