### PR TITLE
Run field extraction concurrently in TS

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesExtractFieldOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesExtractFieldOperator.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.lucene;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.DocBlock;
+import org.elasticsearch.compute.data.DocVector;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.AbstractPageMappingOperator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.BlockLoaderStoredFieldsFromLeafLoader;
+import org.elasticsearch.index.mapper.SourceLoader;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A variant of {@link ValuesSourceReaderOperator} for extracting fields in time-series indices. The differences are:
+ * 1. Caches all segments of the last shard instead of only the last segment, since data in time-series can come from
+ *    any segment at any time
+ * 2. Although docs do not arrive in the global order (by shard, then segment, then docId), they are still sorted
+ *    within each segment; hence, this reader does not perform sorting and regrouping, which are expensive.
+ * 3. For dimension fields, values are read only once per tsid.
+ * These changes are made purely for performance reasons. We should look into consolidating this operator with
+ * {@link ValuesSourceReaderOperator} by adding some metadata to the {@link DocVector} and handling them accordingly.
+ */
+public class TimeSeriesExtractFieldOperator extends AbstractPageMappingOperator {
+
+    public record Factory(List<ValuesSourceReaderOperator.FieldInfo> fields, List<? extends ShardContext> shardContexts)
+        implements
+            OperatorFactory {
+        @Override
+        public Operator get(DriverContext driverContext) {
+            return new TimeSeriesExtractFieldOperator(driverContext.blockFactory(), fields, shardContexts);
+        }
+
+        @Override
+        public String describe() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("TimeSeriesExtractFieldOperator[fields = [");
+            if (fields.size() < 10) {
+                boolean first = true;
+                for (var f : fields) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        sb.append(", ");
+                    }
+                    sb.append(f.name());
+                }
+            } else {
+                sb.append(fields.size()).append(" fields");
+            }
+            return sb.append("]]").toString();
+        }
+    }
+
+    private final BlockFactory blockFactory;
+    private final List<ValuesSourceReaderOperator.FieldInfo> fields;
+    private final List<? extends ShardContext> shardContexts;
+
+    private ShardLevelFieldsReader fieldsReader;
+
+    public TimeSeriesExtractFieldOperator(
+        BlockFactory blockFactory,
+        List<ValuesSourceReaderOperator.FieldInfo> fields,
+        List<? extends ShardContext> shardContexts
+    ) {
+        this.blockFactory = blockFactory;
+        this.fields = fields;
+        this.shardContexts = shardContexts;
+    }
+
+    private OrdinalBytesRefVector getTsid(Page page, int channel) {
+        BytesRefBlock block = page.getBlock(channel);
+        OrdinalBytesRefBlock ordinals = block.asOrdinals();
+        if (ordinals == null) {
+            throw new IllegalArgumentException("tsid must be an ordinals block, got: " + block.getClass().getName());
+        }
+        OrdinalBytesRefVector vector = ordinals.asVector();
+        if (vector == null) {
+            throw new IllegalArgumentException("tsid must be an ordinals vector, got: " + block.getClass().getName());
+        }
+        return vector;
+    }
+
+    private DocVector getDocVector(Page page, int channel) {
+        DocBlock docBlock = page.getBlock(channel);
+        DocVector docVector = docBlock.asVector();
+        if (docVector == null) {
+            throw new IllegalArgumentException("doc must be a doc vector, got: " + docBlock.getClass().getName());
+        }
+        return docVector;
+    }
+
+    @Override
+    protected Page process(Page page) {
+        try {
+            return processUnchecked(page);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Page processUnchecked(Page page) throws IOException {
+        DocVector docVector = getDocVector(page, 0);
+        IntVector shards = docVector.shards();
+        if (shards.isConstant() == false) {
+            throw new IllegalArgumentException("shards must be a constant vector, got: " + shards.getClass().getName());
+        }
+        OrdinalBytesRefVector tsidVector = getTsid(page, 1);
+        IntVector tsidOrdinals = tsidVector.getOrdinalsVector();
+        int shardIndex = shards.getInt(0);
+        if (fieldsReader == null || fieldsReader.shardIndex != shardIndex) {
+            Releasables.close(fieldsReader);
+            fieldsReader = new ShardLevelFieldsReader(shardIndex, blockFactory, shardContexts.get(shardIndex), fields);
+        }
+        fieldsReader.prepareForReading(page.getPositionCount());
+        IntVector docs = docVector.docs();
+        IntVector segments = docVector.segments();
+        int lastTsidOrdinal = -1;
+        for (int p = 0; p < docs.getPositionCount(); p++) {
+            int doc = docs.getInt(p);
+            int segment = segments.getInt(p);
+            int tsidOrd = tsidOrdinals.getInt(p);
+            if (tsidOrd == lastTsidOrdinal) {
+                fieldsReader.readValues(segment, doc, true);
+            } else {
+                fieldsReader.readValues(segment, doc, false);
+                lastTsidOrdinal = tsidOrd;
+            }
+        }
+        Block[] blocks = new Block[fields.size()];
+        Page result = null;
+        try {
+            fieldsReader.buildBlocks(blocks, tsidOrdinals);
+            result = page.appendBlocks(blocks);
+            return result;
+        } finally {
+            if (result == null) {
+                Releasables.close(blocks);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("TimeSeriesExtractFieldOperator[fields = [");
+        if (fields.size() < 10) {
+            boolean first = true;
+            for (var f : fields) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                sb.append(f.name());
+            }
+        } else {
+            sb.append(fields.size()).append(" fields");
+        }
+        return sb.append("]]").toString();
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(fieldsReader, super::close);
+    }
+
+    static class BlockLoaderFactory extends ValuesSourceReaderOperator.DelegatingBlockLoaderFactory {
+        BlockLoaderFactory(BlockFactory factory) {
+            super(factory);
+        }
+
+        @Override
+        public BlockLoader.Block constantNulls() {
+            throw new UnsupportedOperationException("must not be used by column readers");
+        }
+
+        @Override
+        public BlockLoader.Block constantBytes(BytesRef value) {
+            throw new UnsupportedOperationException("must not be used by column readers");
+        }
+
+        @Override
+        public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count) {
+            throw new UnsupportedOperationException("must not be used by column readers");
+        }
+    }
+
+    static final class ShardLevelFieldsReader implements Releasable {
+        final int shardIndex;
+        private final BlockLoaderFactory blockFactory;
+        private final SegmentLevelFieldsReader[] segments;
+        private final BlockLoader[] loaders;
+        private final boolean[] dimensions;
+        private final Block.Builder[] builders;
+        private final StoredFieldsSpec storedFieldsSpec;
+        private final SourceLoader sourceLoader;
+
+        ShardLevelFieldsReader(
+            int shardIndex,
+            BlockFactory blockFactory,
+            ShardContext shardContext,
+            List<ValuesSourceReaderOperator.FieldInfo> fields
+        ) {
+            this.shardIndex = shardIndex;
+            this.blockFactory = new BlockLoaderFactory(blockFactory);
+            final IndexReader indexReader = shardContext.searcher().getIndexReader();
+            this.segments = new SegmentLevelFieldsReader[indexReader.leaves().size()];
+            this.loaders = new BlockLoader[fields.size()];
+            this.builders = new Block.Builder[loaders.length];
+            StoredFieldsSpec storedFieldsSpec = StoredFieldsSpec.NO_REQUIREMENTS;
+            for (int i = 0; i < fields.size(); i++) {
+                BlockLoader loader = fields.get(i).blockLoader().apply(shardIndex);
+                storedFieldsSpec = storedFieldsSpec.merge(loader.rowStrideStoredFieldSpec());
+                loaders[i] = loader;
+            }
+            for (int i = 0; i < indexReader.leaves().size(); i++) {
+                LeafReaderContext leafReaderContext = indexReader.leaves().get(i);
+                segments[i] = new SegmentLevelFieldsReader(leafReaderContext, loaders);
+            }
+            if (storedFieldsSpec.requiresSource()) {
+                sourceLoader = shardContext.newSourceLoader();
+                storedFieldsSpec = storedFieldsSpec.merge(new StoredFieldsSpec(false, false, sourceLoader.requiredStoredFields()));
+            } else {
+                sourceLoader = null;
+            }
+            this.storedFieldsSpec = storedFieldsSpec;
+            this.dimensions = new boolean[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                dimensions[i] = shardContext.fieldType(fields.get(i).name()).isDimension();
+            }
+        }
+
+        /**
+         * For dimension fields, skips reading them when {@code nonDimensionFieldsOnly} is true,
+         * since they only need to be read once per tsid.
+         */
+        void readValues(int segment, int docID, boolean nonDimensionFieldsOnly) throws IOException {
+            segments[segment].read(docID, builders, nonDimensionFieldsOnly, dimensions);
+        }
+
+        void prepareForReading(int estimatedSize) throws IOException {
+            if (this.builders.length > 0 && this.builders[0] == null) {
+                for (int f = 0; f < builders.length; f++) {
+                    builders[f] = (Block.Builder) loaders[f].builder(blockFactory, estimatedSize);
+                }
+            }
+            for (SegmentLevelFieldsReader segment : segments) {
+                segment.reinitializeIfNeeded(sourceLoader, storedFieldsSpec);
+            }
+        }
+
+        void buildBlocks(Block[] blocks, IntVector tsidOrdinals) {
+            for (int i = 0; i < builders.length; i++) {
+                if (dimensions[i]) {
+                    blocks[i] = buildBlockForDimensionField(builders[i], tsidOrdinals);
+                } else {
+                    blocks[i] = builders[i].build();
+                }
+            }
+            Arrays.fill(builders, null);
+        }
+
+        private Block buildBlockForDimensionField(Block.Builder builder, IntVector tsidOrdinals) {
+            try (var values = builder.build()) {
+                if (values.asVector() instanceof BytesRefVector bytes) {
+                    tsidOrdinals.incRef();
+                    values.incRef();
+                    return new OrdinalBytesRefVector(tsidOrdinals, bytes).asBlock();
+                } else if (values.areAllValuesNull()) {
+                    return blockFactory.factory.newConstantNullBlock(tsidOrdinals.getPositionCount());
+                } else {
+                    final int positionCount = tsidOrdinals.getPositionCount();
+                    try (var newBuilder = values.elementType().newBlockBuilder(positionCount, blockFactory.factory)) {
+                        for (int p = 0; p < positionCount; p++) {
+                            int pos = tsidOrdinals.getInt(p);
+                            newBuilder.copyFrom(values, pos, pos + 1);
+                        }
+                        return newBuilder.build();
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.close(builders);
+        }
+    }
+
+    static final class SegmentLevelFieldsReader {
+        private final BlockLoader.RowStrideReader[] rowStride;
+        private final BlockLoader[] loaders;
+        private final LeafReaderContext leafContext;
+        private BlockLoaderStoredFieldsFromLeafLoader storedFields;
+        private Thread loadedThread = null;
+
+        SegmentLevelFieldsReader(LeafReaderContext leafContext, BlockLoader[] loaders) {
+            this.leafContext = leafContext;
+            this.loaders = loaders;
+            this.rowStride = new BlockLoader.RowStrideReader[loaders.length];
+        }
+
+        private void reinitializeIfNeeded(SourceLoader sourceLoader, StoredFieldsSpec storedFieldsSpec) throws IOException {
+            final Thread currentThread = Thread.currentThread();
+            if (loadedThread != currentThread) {
+                loadedThread = currentThread;
+                for (int f = 0; f < loaders.length; f++) {
+                    rowStride[f] = loaders[f].rowStrideReader(leafContext);
+                }
+                storedFields = new BlockLoaderStoredFieldsFromLeafLoader(
+                    StoredFieldLoader.fromSpec(storedFieldsSpec).getLoader(leafContext, null),
+                    sourceLoader != null ? sourceLoader.leaf(leafContext.reader(), null) : null
+                );
+            }
+        }
+
+        void read(int docId, Block.Builder[] builder, boolean nonDimensionFieldsOnly, boolean[] dimensions) throws IOException {
+            storedFields.advanceTo(docId);
+            if (nonDimensionFieldsOnly) {
+                for (int i = 0; i < rowStride.length; i++) {
+                    if (dimensions[i] == false) {
+                        rowStride[i].read(docId, storedFields, builder[i]);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowStride.length; i++) {
+                    rowStride[i].read(docId, storedFields, builder[i]);
+                }
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSourceOperatorFactory.java
@@ -29,13 +29,9 @@ import java.util.function.Function;
 public class TimeSeriesSourceOperatorFactory extends LuceneOperator.Factory {
 
     private final int maxPageSize;
-    private final boolean emitDocIds;
-    private final List<ValuesSourceReaderOperator.FieldInfo> fieldsToExact;
 
     private TimeSeriesSourceOperatorFactory(
         List<? extends ShardContext> contexts,
-        boolean emitDocIds,
-        List<ValuesSourceReaderOperator.FieldInfo> fieldsToExact,
         Function<ShardContext, List<LuceneSliceQueue.QueryAndTags>> queryFunction,
         int taskConcurrency,
         int maxPageSize,
@@ -52,13 +48,11 @@ public class TimeSeriesSourceOperatorFactory extends LuceneOperator.Factory {
             ScoreMode.COMPLETE_NO_SCORES
         );
         this.maxPageSize = maxPageSize;
-        this.emitDocIds = emitDocIds;
-        this.fieldsToExact = fieldsToExact;
     }
 
     @Override
     public SourceOperator get(DriverContext driverContext) {
-        return new TimeSeriesSourceOperator(driverContext.blockFactory(), emitDocIds, fieldsToExact, sliceQueue, maxPageSize, limit);
+        return new TimeSeriesSourceOperator(driverContext.blockFactory(), sliceQueue, maxPageSize, limit);
     }
 
     @Override
@@ -70,11 +64,9 @@ public class TimeSeriesSourceOperatorFactory extends LuceneOperator.Factory {
         int limit,
         int maxPageSize,
         int taskConcurrency,
-        boolean emitDocIds,
         List<? extends ShardContext> contexts,
-        List<ValuesSourceReaderOperator.FieldInfo> fieldsToExact,
         Function<ShardContext, List<LuceneSliceQueue.QueryAndTags>> queryFunction
     ) {
-        return new TimeSeriesSourceOperatorFactory(contexts, emitDocIds, fieldsToExact, queryFunction, taskConcurrency, maxPageSize, limit);
+        return new TimeSeriesSourceOperatorFactory(contexts, queryFunction, taskConcurrency, maxPageSize, limit);
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/TimeSeriesSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/TimeSeriesSourceOperatorTests.java
@@ -134,7 +134,7 @@ public class TimeSeriesSourceOperatorTests extends AnyOperatorTestCase {
         assertThat(status.tsidLoaded(), equalTo((long) numTimeSeries));
         assertThat(status.rowsEmitted(), equalTo((long) numTimeSeries * numSamplesPerTS));
         assertThat(status.documentsFound(), equalTo((long) numTimeSeries * numSamplesPerTS));
-        assertThat(status.valuesLoaded(), equalTo((long) numTimeSeries * numSamplesPerTS * 3));
+        assertThat(status.valuesLoaded(), equalTo((long) numTimeSeries * numSamplesPerTS));
 
         String expected = String.format(
             Locale.ROOT,
@@ -224,8 +224,6 @@ public class TimeSeriesSourceOperatorTests extends AnyOperatorTestCase {
         var timeSeriesFactory = createTimeSeriesSourceOperator(
             directory,
             r -> this.reader = r,
-            true,
-            List.of(new ExtractField(metricField, ElementType.LONG)),
             limit,
             maxPageSize,
             randomBoolean(),
@@ -243,7 +241,7 @@ public class TimeSeriesSourceOperatorTests extends AnyOperatorTestCase {
             TestDriverFactory.create(
                 driverContext,
                 timeSeriesFactory.get(driverContext),
-                List.of(),
+                List.of(extractFieldsFactory(reader, List.of(new ExtractField(metricField, ElementType.LONG))).get(driverContext)),
                 new TestResultPageSinkOperator(results::add)
             )
         );
@@ -307,9 +305,7 @@ public class TimeSeriesSourceOperatorTests extends AnyOperatorTestCase {
                     Integer.MAX_VALUE,
                     randomIntBetween(1, 1024),
                     1,
-                    randomBoolean(),
                     List.of(ctx),
-                    List.of(),
                     unused -> List.of(new LuceneSliceQueue.QueryAndTags(query, List.of()))
                 );
                 var driverContext = driverContext();
@@ -329,7 +325,7 @@ public class TimeSeriesSourceOperatorTests extends AnyOperatorTestCase {
 
     @Override
     protected Operator.OperatorFactory simple(SimpleOptions options) {
-        return createTimeSeriesSourceOperator(directory, r -> this.reader = r, randomBoolean(), List.of(), 1, 1, false, writer -> {
+        return createTimeSeriesSourceOperator(directory, r -> this.reader = r, 1, 1, true, writer -> {
             long timestamp = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2024-01-01T00:00:00Z");
             writeTS(writer, timestamp, new Object[] { "hostname", "host-01" }, new Object[] { "voltage", 2 });
             return 1;
@@ -372,11 +368,13 @@ public class TimeSeriesSourceOperatorTests extends AnyOperatorTestCase {
     ) {
         var voltageField = new NumberFieldMapper.NumberFieldType("voltage", NumberFieldMapper.NumberType.LONG);
         var hostnameField = new KeywordFieldMapper.KeywordFieldType("hostname");
+        var extractFields = List.of(
+            new ExtractField(voltageField, ElementType.LONG),
+            new ExtractField(hostnameField, ElementType.BYTES_REF)
+        );
         var timeSeriesFactory = createTimeSeriesSourceOperator(
             directory,
             indexReader -> this.reader = indexReader,
-            true,
-            List.of(new ExtractField(voltageField, ElementType.LONG), new ExtractField(hostnameField, ElementType.BYTES_REF)),
             limit,
             maxPageSize,
             forceMerge,
@@ -396,7 +394,7 @@ public class TimeSeriesSourceOperatorTests extends AnyOperatorTestCase {
         return TestDriverFactory.create(
             driverContext,
             timeSeriesFactory.get(driverContext),
-            List.of(),
+            List.of(extractFieldsFactory(reader, extractFields).get(driverContext)),
             new TestResultPageSinkOperator(consumer)
         );
     }
@@ -408,8 +406,6 @@ public class TimeSeriesSourceOperatorTests extends AnyOperatorTestCase {
     public static TimeSeriesSourceOperatorFactory createTimeSeriesSourceOperator(
         Directory directory,
         Consumer<IndexReader> readerConsumer,
-        boolean emitDocIds,
-        List<ExtractField> extractFields,
         int limit,
         int maxPageSize,
         boolean forceMerge,
@@ -438,32 +434,11 @@ public class TimeSeriesSourceOperatorTests extends AnyOperatorTestCase {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        var ctx = new LuceneSourceOperatorTests.MockShardContext(reader, 0) {
-            @Override
-            public MappedFieldType fieldType(String name) {
-                for (ExtractField e : extractFields) {
-                    if (e.ft.name().equals(name)) {
-                        return e.ft;
-                    }
-                }
-                throw new IllegalArgumentException("Unknown field [" + name + "]");
-            }
-        };
+        var ctx = new LuceneSourceOperatorTests.MockShardContext(reader, 0);
         Function<ShardContext, List<LuceneSliceQueue.QueryAndTags>> queryFunction = c -> List.of(
             new LuceneSliceQueue.QueryAndTags(new MatchAllDocsQuery(), List.of())
         );
-
-        var fieldInfos = extractFields.stream()
-            .map(
-                f -> new ValuesSourceReaderOperator.FieldInfo(
-                    f.ft.name(),
-                    f.elementType,
-                    n -> f.ft.blockLoader(ValuesSourceReaderOperatorTests.blContext())
-                )
-            )
-            .toList();
-
-        return TimeSeriesSourceOperatorFactory.create(limit, maxPageSize, 1, emitDocIds, List.of(ctx), fieldInfos, queryFunction);
+        return TimeSeriesSourceOperatorFactory.create(limit, maxPageSize, 1, List.of(ctx), queryFunction);
     }
 
     public static void writeTS(RandomIndexWriter iw, long timestamp, Object[] dimensions, Object[] metrics) throws IOException {
@@ -493,5 +468,29 @@ public class TimeSeriesSourceOperatorTests extends AnyOperatorTestCase {
             new SortedDocValuesField(TimeSeriesIdFieldMapper.NAME, TimeSeriesIdFieldMapper.buildLegacyTsid(routingPathFields).toBytesRef())
         );
         iw.addDocument(fields);
+    }
+
+    TimeSeriesExtractFieldOperator.Factory extractFieldsFactory(IndexReader reader, List<ExtractField> extractFields) {
+        var ctx = new LuceneSourceOperatorTests.MockShardContext(reader, 0) {
+            @Override
+            public MappedFieldType fieldType(String name) {
+                for (ExtractField e : extractFields) {
+                    if (e.ft.name().equals(name)) {
+                        return e.ft;
+                    }
+                }
+                throw new IllegalArgumentException("Unknown field [" + name + "]");
+            }
+        };
+        var fieldInfos = extractFields.stream()
+            .map(
+                f -> new ValuesSourceReaderOperator.FieldInfo(
+                    f.ft.name(),
+                    f.elementType,
+                    n -> f.ft.blockLoader(ValuesSourceReaderOperatorTests.blContext())
+                )
+            )
+            .toList();
+        return new TimeSeriesExtractFieldOperator.Factory(fieldInfos, List.of(ctx));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -11,7 +11,7 @@ import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.EnableSpatialDistancePushdown;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.InsertFieldExtraction;
-import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushDownFieldExtractionToTimeSeriesSource;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ParallelizeTimeSeriesSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushFiltersToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushLimitToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushSampleToSource;
@@ -81,7 +81,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             new InsertFieldExtraction(),
             new SpatialDocValuesExtraction(),
             new SpatialShapeBoundsExtraction(),
-            new PushDownFieldExtractionToTimeSeriesSource()
+            new ParallelizeTimeSeriesSource()
         );
         return List.of(pushdown, fieldExtraction);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
@@ -33,14 +33,14 @@ public class FieldExtractExec extends UnaryExec implements EstimatesRowSize {
         FieldExtractExec::new
     );
 
-    private final List<Attribute> attributesToExtract;
-    private final @Nullable Attribute sourceAttribute;
+    protected final List<Attribute> attributesToExtract;
+    protected final @Nullable Attribute sourceAttribute;
 
     /**
      * The default for {@link #fieldExtractPreference} if the plan doesn't require
      * a preference.
      */
-    private final MappedFieldType.FieldExtractPreference defaultPreference;
+    protected final MappedFieldType.FieldExtractPreference defaultPreference;
 
     /**
      * Attributes that may be extracted as doc values even if that makes them
@@ -51,7 +51,7 @@ public class FieldExtractExec extends UnaryExec implements EstimatesRowSize {
      *     This is never serialized between nodes and only used locally.
      * </p>
      */
-    private final Set<Attribute> docValuesAttributes;
+    protected final Set<Attribute> docValuesAttributes;
 
     /**
      * Attributes of a shape whose extent can be extracted directly from the doc-values encoded geometry.
@@ -59,7 +59,7 @@ public class FieldExtractExec extends UnaryExec implements EstimatesRowSize {
      *     This is never serialized between nodes and only used locally.
      * </p>
      */
-    private final Set<Attribute> boundsAttributes;
+    protected final Set<Attribute> boundsAttributes;
 
     private List<Attribute> lazyOutput;
 
@@ -72,7 +72,7 @@ public class FieldExtractExec extends UnaryExec implements EstimatesRowSize {
         this(source, child, attributesToExtract, defaultPreference, Set.of(), Set.of());
     }
 
-    private FieldExtractExec(
+    protected FieldExtractExec(
         Source source,
         PhysicalPlan child,
         List<Attribute> attributesToExtract,
@@ -128,7 +128,7 @@ public class FieldExtractExec extends UnaryExec implements EstimatesRowSize {
     }
 
     @Override
-    protected NodeInfo<FieldExtractExec> info() {
+    protected NodeInfo<? extends FieldExtractExec> info() {
         return NodeInfo.create(this, FieldExtractExec::new, child(), attributesToExtract, defaultPreference);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesFieldExtractExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesFieldExtractExec.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+public class TimeSeriesFieldExtractExec extends FieldExtractExec {
+    public TimeSeriesFieldExtractExec(
+        Source source,
+        PhysicalPlan child,
+        List<Attribute> attributesToExtract,
+        MappedFieldType.FieldExtractPreference defaultPreference,
+        Set<Attribute> docValuesAttributes,
+        Set<Attribute> boundsAttributes
+    ) {
+        super(source, child, attributesToExtract, defaultPreference, docValuesAttributes, boundsAttributes);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("local plan");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("local plan");
+    }
+
+    @Override
+    protected NodeInfo<TimeSeriesFieldExtractExec> info() {
+        return NodeInfo.create(
+            this,
+            TimeSeriesFieldExtractExec::new,
+            child(),
+            attributesToExtract,
+            defaultPreference,
+            docValuesAttributes,
+            boundsAttributes
+        );
+    }
+
+    @Override
+    public UnaryExec replaceChild(PhysicalPlan newChild) {
+        return new TimeSeriesFieldExtractExec(
+            source(),
+            newChild,
+            attributesToExtract,
+            defaultPreference,
+            docValuesAttributes,
+            boundsAttributes
+        );
+    }
+
+    @Override
+    public FieldExtractExec withDocValuesAttributes(Set<Attribute> docValuesAttributes) {
+        return new TimeSeriesFieldExtractExec(
+            source(),
+            child(),
+            attributesToExtract,
+            defaultPreference,
+            docValuesAttributes,
+            boundsAttributes
+        );
+    }
+
+    @Override
+    public FieldExtractExec withBoundsAttributes(Set<Attribute> boundsAttributes) {
+        return new TimeSeriesFieldExtractExec(
+            source(),
+            child(),
+            attributesToExtract,
+            defaultPreference,
+            docValuesAttributes,
+            boundsAttributes
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/TimeSeriesSourceExec.java
@@ -9,62 +9,33 @@ package org.elasticsearch.xpack.esql.plan.physical;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Similar to {@link EsQueryExec}, but this is a physical plan specifically for time series indices.
- * This plan is forked from {@link EsQueryExec} to allow field extractions, leveraging caching
- * and avoiding the cost of sorting and rebuilding blocks.
  */
 public class TimeSeriesSourceExec extends LeafExec implements EstimatesRowSize {
-
-    private final MappedFieldType.FieldExtractPreference defaultPreference;
-    private final Set<Attribute> docValuesAttributes;
-    private final Set<Attribute> boundsAttributes;
-    private final List<Attribute> attributesToExtract;
 
     private final List<Attribute> attrs;
     private final QueryBuilder query;
     private final Expression limit;
     private final Integer estimatedRowSize;
-    private List<Attribute> lazyOutput;
 
-    public TimeSeriesSourceExec(
-        Source source,
-        List<Attribute> attrs,
-        QueryBuilder query,
-        Expression limit,
-        MappedFieldType.FieldExtractPreference defaultPreference,
-        Set<Attribute> docValuesAttributes,
-        Set<Attribute> boundsAttributes,
-        List<Attribute> attributesToExtract,
-        Integer estimatedRowSize
-    ) {
+    public TimeSeriesSourceExec(Source source, List<Attribute> attrs, QueryBuilder query, Expression limit, Integer estimatedRowSize) {
         super(source);
         this.attrs = attrs;
         this.query = query;
         this.limit = limit;
-        this.defaultPreference = defaultPreference;
-        this.docValuesAttributes = docValuesAttributes;
-        this.boundsAttributes = boundsAttributes;
-        this.attributesToExtract = attributesToExtract;
         this.estimatedRowSize = estimatedRowSize;
-        if (this.attributesToExtract.isEmpty()) {
-            lazyOutput = attrs;
-        }
     }
 
     @Override
@@ -79,18 +50,7 @@ public class TimeSeriesSourceExec extends LeafExec implements EstimatesRowSize {
 
     @Override
     protected NodeInfo<TimeSeriesSourceExec> info() {
-        return NodeInfo.create(
-            this,
-            TimeSeriesSourceExec::new,
-            attrs,
-            query,
-            limit,
-            defaultPreference,
-            docValuesAttributes,
-            boundsAttributes,
-            attributesToExtract,
-            estimatedRowSize
-        );
+        return NodeInfo.create(this, TimeSeriesSourceExec::new, attrs, query, limit, estimatedRowSize);
     }
 
     public QueryBuilder query() {
@@ -103,17 +63,7 @@ public class TimeSeriesSourceExec extends LeafExec implements EstimatesRowSize {
 
     @Override
     public List<Attribute> output() {
-        if (lazyOutput == null) {
-            lazyOutput = new ArrayList<>(attrs.size() + attributesToExtract.size());
-            lazyOutput.addAll(attrs);
-            lazyOutput.addAll(attributesToExtract);
-        }
-        return lazyOutput;
-    }
-
-    @Override
-    protected AttributeSet computeReferences() {
-        return super.computeReferences();
+        return attrs;
     }
 
     public Expression limit() {
@@ -124,41 +74,16 @@ public class TimeSeriesSourceExec extends LeafExec implements EstimatesRowSize {
         return estimatedRowSize;
     }
 
-    public List<Attribute> attributesToExtract() {
-        return attributesToExtract;
-    }
-
-    public MappedFieldType.FieldExtractPreference fieldExtractPreference(Attribute attr) {
-        if (boundsAttributes.contains(attr)) {
-            return MappedFieldType.FieldExtractPreference.EXTRACT_SPATIAL_BOUNDS;
-        }
-        if (docValuesAttributes.contains(attr)) {
-            return MappedFieldType.FieldExtractPreference.DOC_VALUES;
-        }
-        return defaultPreference;
-    }
-
     @Override
     public PhysicalPlan estimateRowSize(State state) {
         state.add(false, Integer.BYTES * 2);
         state.add(false, 22); // tsid
         state.add(false, 8); // timestamp
-        state.add(false, attributesToExtract);
         int size = state.consumeAllFields(false);
         if (Objects.equals(this.estimatedRowSize, size)) {
             return this;
         } else {
-            return new TimeSeriesSourceExec(
-                source(),
-                attrs,
-                query,
-                limit,
-                defaultPreference,
-                docValuesAttributes,
-                boundsAttributes,
-                attributesToExtract,
-                size
-            );
+            return new TimeSeriesSourceExec(source(), attrs, query, limit, size);
         }
     }
 
@@ -167,10 +92,7 @@ public class TimeSeriesSourceExec extends LeafExec implements EstimatesRowSize {
         return Objects.hash(
             attrs,
             query,
-            defaultPreference,
-            docValuesAttributes,
-            boundsAttributes,
-            attributesToExtract,
+
             limit,
             estimatedRowSize
         );
@@ -188,10 +110,6 @@ public class TimeSeriesSourceExec extends LeafExec implements EstimatesRowSize {
 
         TimeSeriesSourceExec other = (TimeSeriesSourceExec) obj;
         return Objects.equals(attrs, other.attrs)
-            && Objects.equals(defaultPreference, other.defaultPreference)
-            && Objects.equals(docValuesAttributes, other.docValuesAttributes)
-            && Objects.equals(boundsAttributes, other.boundsAttributes)
-            && Objects.equals(attributesToExtract, other.attributesToExtract)
             && Objects.equals(query, other.query)
             && Objects.equals(limit, other.limit)
             && Objects.equals(estimatedRowSize, other.estimatedRowSize);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -24,6 +24,7 @@ import org.elasticsearch.compute.lucene.LuceneOperator;
 import org.elasticsearch.compute.lucene.LuceneSliceQueue;
 import org.elasticsearch.compute.lucene.LuceneSourceOperator;
 import org.elasticsearch.compute.lucene.LuceneTopNSourceOperator;
+import org.elasticsearch.compute.lucene.TimeSeriesExtractFieldOperator;
 import org.elasticsearch.compute.lucene.TimeSeriesSourceOperatorFactory;
 import org.elasticsearch.compute.lucene.ValuesSourceReaderOperator;
 import org.elasticsearch.compute.operator.Operator;
@@ -65,6 +66,7 @@ import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec.Sort;
 import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
 import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesAggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesFieldExtractExec;
 import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesSourceExec;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.DriverParallelism;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecutionPlannerContext;
@@ -140,7 +142,12 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             layout.append(attr);
         }
         var fields = extractFields(fieldExtractExec.attributesToExtract(), fieldExtractExec::fieldExtractPreference);
-        return source.with(new ValuesSourceReaderOperator.Factory(fields, readers, docChannel), layout.build());
+        if (fieldExtractExec instanceof TimeSeriesFieldExtractExec) {
+            // TODO: consolidate with ValuesSourceReaderOperator
+            return source.with(new TimeSeriesExtractFieldOperator.Factory(fields, shardContexts), layout.build());
+        } else {
+            return source.with(new ValuesSourceReaderOperator.Factory(fields, readers, docChannel), layout.build());
+        }
     }
 
     private static String getFieldName(Attribute attr) {
@@ -249,16 +256,12 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
 
     @Override
     public PhysicalOperation timeSeriesSourceOperation(TimeSeriesSourceExec ts, LocalExecutionPlannerContext context) {
-
         final int limit = ts.limit() != null ? (Integer) ts.limit().fold(context.foldCtx()) : NO_LIMIT;
-        final boolean emitDocIds = ts.attrs().stream().anyMatch(EsQueryExec::isSourceAttribute);
         LuceneOperator.Factory luceneFactory = TimeSeriesSourceOperatorFactory.create(
             limit,
             context.pageSize(ts.estimatedRowSize()),
             context.queryPragmas().taskConcurrency(),
-            emitDocIds,
             shardContexts,
-            extractFields(ts.attributesToExtract(), ts::fieldExtractPreference),
             querySupplier(ts.query())
         );
         Layout.Builder layout = new Layout.Builder();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -2033,9 +2033,9 @@ public class LocalPhysicalPlanOptimizerTests extends MapperServiceTestCase {
         assertThat(esQuery.query().toString(), equalTo(expected.toString()));
     }
 
-    public void testPushDownFieldExtractToTimeSeriesSource() {
+    public void testParallelizeTimeSeriesPlan() {
         assumeTrue("requires snapshot builds", Build.current().isSnapshot());
-        var query = "TS k8s | STATS max(rate(network.total_bytes_in))";
+        var query = "TS k8s | STATS max(rate(network.total_bytes_in)) BY bucket(@timestamp, 1h)";
         var optimizer = new TestPlannerOptimizer(config, timeSeriesAnalyzer);
         PhysicalPlan plan = optimizer.plan(query);
         var limit = as(plan, LimitExec.class);
@@ -2044,13 +2044,11 @@ public class LocalPhysicalPlanOptimizerTests extends MapperServiceTestCase {
         var timeSeriesFinalAgg = as(partialAgg.child(), TimeSeriesAggregateExec.class);
         var exchange = as(timeSeriesFinalAgg.child(), ExchangeExec.class);
         var timeSeriesPartialAgg = as(exchange.child(), TimeSeriesAggregateExec.class);
-        var parallel = as(timeSeriesPartialAgg.child(), ParallelExec.class);
-        var timeSeriesSource = as(parallel.child(), TimeSeriesSourceExec.class);
-        assertThat(timeSeriesSource.attributesToExtract(), hasSize(1));
-        FieldAttribute field = as(timeSeriesSource.attributesToExtract().getFirst(), FieldAttribute.class);
-        assertThat(field.name(), equalTo("network.total_bytes_in"));
-        assertThat(timeSeriesSource.attrs(), hasSize(2));
-        assertTrue(timeSeriesSource.attrs().stream().noneMatch(EsQueryExec::isSourceAttribute));
+        var parallel1 = as(timeSeriesPartialAgg.child(), ParallelExec.class);
+        var eval = as(parallel1.child(), EvalExec.class);
+        var fieldExtract = as(eval.child(), FieldExtractExec.class);
+        var parallel2 = as(fieldExtract.child(), ParallelExec.class);
+        as(parallel2.child(), TimeSeriesSourceExec.class);
     }
 
     /**


### PR DESCRIPTION
This change extracts the field extraction logic previously run inside `TimeSeriesSourceOperator` into a separate operator, executed in a separate driver. We should consider consolidating this operator with `ValuesSourceReaderOperator`. I tried to extend `ValuesSourceReaderOperator` to support this, but it may take some time to complete. Our current goal is to move quickly with experimental support for querying time-series data in ES|QL, so I am proceeding with a separate operator. I will spend more time on combining these two operators later.

With #128419 and this PR, the query time for the example below decreased from 41ms to 27ms.

```
POST /_query
{
    "profile": true,
    "query": "TS metrics-hostmetricsreceiver.otel-default 
        | WHERE @timestamp >= \"2025-05-08T18:00:08.001Z\"
        | STATS cpu = avg(rate(`metrics.process.cpu.time`)) BY host.name, BUCKET(@timestamp, 5 minute)"
}
```