### PR TITLE
[8.19] Fix: Allow non-score sorts in pinned retriever sub-retrievers (#128323)

### DIFF
--- a/docs/changelog/128323.yaml
+++ b/docs/changelog/128323.yaml
@@ -1,0 +1,5 @@
+pr: 128323
+summary: "Fix: Allow non-score secondary sorts in pinned retriever sub-retrievers"
+area: Relevance
+type: bug
+issues: []

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/retriever/PinnedRetrieverBuilder.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/retriever/PinnedRetrieverBuilder.java
@@ -18,9 +18,7 @@ import org.elasticsearch.search.retriever.CompoundRetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverBuilderWrapper;
 import org.elasticsearch.search.retriever.RetrieverParserContext;
-import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.ScoreSortBuilder;
-import org.elasticsearch.search.sort.ShardDocSortField;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -106,16 +104,9 @@ public final class PinnedRetrieverBuilder extends CompoundRetrieverBuilder<Pinne
         if (sorts == null || sorts.isEmpty()) {
             return;
         }
-        for (SortBuilder<?> sort : sorts) {
-            if (sort instanceof ScoreSortBuilder) {
-                continue;
-            }
-            if (sort instanceof FieldSortBuilder) {
-                FieldSortBuilder fieldSort = (FieldSortBuilder) sort;
-                if (ShardDocSortField.NAME.equals(fieldSort.getFieldName())) {
-                    continue;
-                }
-            }
+
+        SortBuilder<?> sort = sorts.get(0);
+        if (sort instanceof ScoreSortBuilder == false) {
             throw new IllegalArgumentException(
                 "[" + NAME + "] retriever only supports sorting by score, invalid sort criterion: " + sort.toString()
             );


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix: Allow non-score sorts in pinned retriever sub-retrievers (#128323)