### PR TITLE
[9.0] [Test] More accurate pattern matching for testWatchdogLogging (#128648)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -3359,7 +3359,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         MockLog.assertThatLogger(
             deterministicTaskQueue::runAllRunnableTasks,
             ThreadWatchdog.class,
-            new MockLog.UnseenEventExpectation("no logging", ThreadWatchdog.class.getCanonicalName(), Level.WARN, "*")
+            new MockLog.UnseenEventExpectation("no logging", ThreadWatchdog.class.getCanonicalName(), Level.WARN, "*" + threadName + "*")
         );
         deterministicTaskQueue.advanceTime();
         MockLog.assertThatLogger(


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [Test] More accurate pattern matching for testWatchdogLogging (#128648)