### PR TITLE
Fix ChangePointOperatorTests.testSimpleFinishClose

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -458,9 +458,6 @@ tests:
   - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
     method: testSearchWhileRelocating
     issue: https://github.com/elastic/elasticsearch/issues/127188
-  - class: org.elasticsearch.compute.operator.ChangePointOperatorTests
-    method: testSimpleFinishClose
-    issue: https://github.com/elastic/elasticsearch/issues/127106
   - class: org.elasticsearch.search.CCSDuelIT
     method: testTerminateAfter
     issue: https://github.com/elastic/elasticsearch/issues/126085

--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/OperatorTestCase.java
@@ -241,16 +241,16 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
      * Tests that finish then close without calling {@link Operator#getOutput} to
      * retrieve a potential last page, releases all memory.
      */
-    public void testSimpleFinishClose() throws Exception {
+    public void testSimpleFinishClose() {
         DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(driverContext.blockFactory(), 1));
-        assert input.size() == 1 : "Expected single page, got: " + input;
         // eventually, when driverContext always returns a tracking factory, we can enable this assertion
         // assertThat(driverContext.blockFactory().breaker().getUsed(), greaterThan(0L));
-        Page page = input.get(0);
         try (var operator = simple().get(driverContext)) {
             assert operator.needsInput();
-            operator.addInput(page);
+            for (Page page : input) {
+                operator.addInput(page);
+            }
             operator.finish();
         }
     }


### PR DESCRIPTION
This PR:
- fixes `ChangePointOperatorTests.testSimpleFinishClose` (by backporting https://github.com/elastic/elasticsearch/pull/122245)
- unmutes the test

Fixes https://github.com/elastic/elasticsearch/issues/127106