### PR TITLE
[ML][8.19] Unmute Azure testCreateRequest_WithEntraIdDefined that should be fixed

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -404,9 +404,6 @@ tests:
     method: "builds distribution from branches via archives extractedAssemble [bwcDistVersion: 8.3.0, bwcProject: staged, expectedAssembleTaskName:
     extractedAssemble, #1]"
     issue: https://github.com/elastic/elasticsearch/issues/119870
-  - class: org.elasticsearch.xpack.inference.external.request.azureopenai.embeddings.AzureOpenAiEmbeddingsRequestTests
-    method: testCreateRequest_WithEntraIdDefined
-    issue: https://github.com/elastic/elasticsearch/issues/125061
   - class: org.elasticsearch.qa.verify_version_constants.VerifyVersionConstantsIT
     method: testLuceneVersionConstant
     issue: https://github.com/elastic/elasticsearch/issues/125638


### PR DESCRIPTION
This unmutes `testCreateRequest_WithEntraIdDefined` from `AzureOpenAiEmbeddingsRequestTests` which was fixed in this PR: https://github.com/elastic/elasticsearch/pull/125152

I think what happened is the PR was merged and CI was in the process of muting the test.

The original issue: https://github.com/elastic/elasticsearch/issues/125061