### PR TITLE
[8.19] [ML] Ensure EIS auth response exists before executing tests (#128640)

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/BaseMockEISAuthServerTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/BaseMockEISAuthServerTest.java
@@ -24,17 +24,15 @@ import org.junit.rules.TestRule;
 
 public class BaseMockEISAuthServerTest extends ESRestTestCase {
 
-    // The reason we're retrying is there's a race condition between the node retrieving the
-    // authorization response and running the test. Retrieving the authorization should be very fast since
-    // we're hosting a local mock server but it's possible it could respond slower. So in the even of a test failure
-    // we'll automatically retry after waiting a second.
-    @Rule
-    public RetryRule retry = new RetryRule(3, TimeValue.timeValueSeconds(1));
+    protected static final MockElasticInferenceServiceAuthorizationServer mockEISServer =
+        new MockElasticInferenceServiceAuthorizationServer();
 
-    private static final MockElasticInferenceServiceAuthorizationServer mockEISServer = MockElasticInferenceServiceAuthorizationServer
-        .enabledWithRainbowSprinklesAndElser();
+    static {
+        // Ensure that the mock EIS server has an authorized response prior to the cluster starting
+        mockEISServer.enqueueAuthorizeAllModelsResponse();
+    }
 
-    private static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+    private static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "true")
@@ -52,8 +50,17 @@ public class BaseMockEISAuthServerTest extends ESRestTestCase {
 
     // The reason we're doing this is to make sure the mock server is initialized first so we can get the address before communicating
     // it to the cluster as a setting.
+    // Note: @ClassRule is executed once for the entire test class
     @ClassRule
     public static TestRule ruleChain = RuleChain.outerRule(mockEISServer).around(cluster);
+
+    // The reason we're retrying is there's a race condition between the node retrieving the
+    // authorization response and running the test. Retrieving the authorization should be very fast since
+    // we're hosting a local mock server but it's possible it could respond slower. So in the even of a test failure
+    // we'll automatically retry after waiting a second.
+    // Note: @Rule is executed for each test
+    @Rule
+    public RetryRule retry = new RetryRule(3, TimeValue.timeValueSeconds(1));
 
     @Override
     protected String getTestRestCluster() {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetModelsWithElasticInferenceServiceIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetModelsWithElasticInferenceServiceIT.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.xpack.inference;
 
 import org.elasticsearch.inference.TaskType;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.List;
@@ -21,6 +22,12 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 public class InferenceGetModelsWithElasticInferenceServiceIT extends BaseMockEISAuthServerTest {
+
+    @BeforeClass
+    public static void init() {
+        // Ensure the mock EIS server has an authorized response ready
+        mockEISServer.enqueueAuthorizeAllModelsResponse();
+    }
 
     public void testGetDefaultEndpoints() throws IOException {
         var allModels = getAllModels();

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetServicesIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetServicesIT.java
@@ -12,6 +12,7 @@ package org.elasticsearch.xpack.inference;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.List;
@@ -22,6 +23,12 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 
 public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
+
+    @BeforeClass
+    public static void init() {
+        // Ensure the mock EIS server has an authorized response ready
+        mockEISServer.enqueueAuthorizeAllModelsResponse();
+    }
 
     public void testGetServicesWithoutTaskType() throws IOException {
         List<Object> services = getAllServices();

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockElasticInferenceServiceAuthorizationServer.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockElasticInferenceServiceAuthorizationServer.java
@@ -26,6 +26,11 @@ public class MockElasticInferenceServiceAuthorizationServer implements TestRule 
     public static MockElasticInferenceServiceAuthorizationServer enabledWithRainbowSprinklesAndElser() {
         var server = new MockElasticInferenceServiceAuthorizationServer();
 
+        server.enqueueAuthorizeAllModelsResponse();
+        return server;
+    }
+
+    public void enqueueAuthorizeAllModelsResponse() {
         String responseJson = """
             {
                 "models": [
@@ -41,21 +46,7 @@ public class MockElasticInferenceServiceAuthorizationServer implements TestRule 
             }
             """;
 
-        server.webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
-        return server;
-    }
-
-    public static MockElasticInferenceServiceAuthorizationServer disabled() {
-        var server = new MockElasticInferenceServiceAuthorizationServer();
-
-        String responseJson = """
-            {
-                "models": []
-            }
-            """;
-
-        server.webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
-        return server;
+        webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
     }
 
     public String getUrl() {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ML] Ensure EIS auth response exists before executing tests (#128640)