### PR TITLE
Fully initialize policy checker before instrumenting

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -138,7 +138,6 @@ public class EntitlementInitialization {
             throw new AssertionError(e);
         }
 
-
         return checker;
     }
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -63,6 +63,7 @@ public class EntitlementInitialization {
      * @param inst the JVM instrumentation class instance
      */
     public static void initialize(Instrumentation inst) throws Exception {
+        // the checker _MUST_ be set before _any_ instrumentation is done
         checker = initChecker(createPolicyManager());
         initInstrumentation(inst);
     }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -63,7 +63,8 @@ public class EntitlementInitialization {
      * @param inst the JVM instrumentation class instance
      */
     public static void initialize(Instrumentation inst) throws Exception {
-        checker = initChecker(inst, createPolicyManager());
+        checker = initChecker(createPolicyManager());
+        initInstrumentation(inst);
     }
 
     private static PolicyCheckerImpl createPolicyChecker(PolicyManager policyManager) {
@@ -115,7 +116,7 @@ public class EntitlementInitialization {
         }
     }
 
-    static ElasticsearchEntitlementChecker initChecker(Instrumentation inst, PolicyManager policyManager) throws Exception {
+    static ElasticsearchEntitlementChecker initChecker(PolicyManager policyManager) {
         final PolicyChecker policyChecker = createPolicyChecker(policyManager);
         final Class<?> clazz = EntitlementCheckerUtils.getVersionSpecificCheckerClass(
             ElasticsearchEntitlementChecker.class,
@@ -136,17 +137,21 @@ public class EntitlementInitialization {
             throw new AssertionError(e);
         }
 
+
+        return checker;
+    }
+
+    static void initInstrumentation(Instrumentation instrumentation) throws Exception {
         var verifyBytecode = Booleans.parseBoolean(System.getProperty("es.entitlements.verify_bytecode", "false"));
         if (verifyBytecode) {
             ensureClassesSensitiveToVerificationAreInitialized();
         }
 
         DynamicInstrumentation.initialize(
-            inst,
+            instrumentation,
             EntitlementCheckerUtils.getVersionSpecificCheckerClass(EntitlementChecker.class, Runtime.version().feature()),
             verifyBytecode
         );
 
-        return checker;
     }
 }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -501,9 +501,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.string.WildcardLikeTests
   method: testEvaluateInManyThreads {TestCase=100 random code points matches self case insensitive with text}
   issue: https://github.com/elastic/elasticsearch/issues/128677
-- class: org.elasticsearch.test.apmintegration.MetricsApmIT
-  method: testApmIntegration
-  issue: https://github.com/elastic/elasticsearch/issues/128678
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -492,9 +492,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test085EnvironmentVariablesAreRespectedUnderDockerExec
   issue: https://github.com/elastic/elasticsearch/issues/128115
-- class: org.elasticsearch.test.apmintegration.TracesApmIT
-  method: testApmIntegration
-  issue: https://github.com/elastic/elasticsearch/issues/128651
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.string.WildcardLikeTests
   method: testEvaluateInManyThreads {TestCase=100 random code points matches self case insensitive with keyword}
   issue: https://github.com/elastic/elasticsearch/issues/128676

--- a/test/framework/src/main/java/org/elasticsearch/entitlement/initialization/TestEntitlementInitialization.java
+++ b/test/framework/src/main/java/org/elasticsearch/entitlement/initialization/TestEntitlementInitialization.java
@@ -32,6 +32,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.entitlement.initialization.EntitlementInitialization.initInstrumentation;
+
 /**
  * Test-specific version of {@code EntitlementInitialization}
  */
@@ -46,7 +48,8 @@ public class TestEntitlementInitialization {
 
     public static void initialize(Instrumentation inst) throws Exception {
         TestEntitlementBootstrap.BootstrapArgs bootstrapArgs = TestEntitlementBootstrap.bootstrapArgs();
-        checker = EntitlementInitialization.initChecker(inst, createPolicyManager(bootstrapArgs.pathLookup()));
+        checker = EntitlementInitialization.initChecker(createPolicyManager(bootstrapArgs.pathLookup()));
+        initInstrumentation(inst);
     }
 
     private record TestPluginData(String pluginName, boolean isModular, boolean isExternalPlugin) {}


### PR DESCRIPTION
Entitlement instrumentation works by reflectively calling back into the entitlements lib to grab the checker. It must be fully in place before any classes are instrumented. This commit fixes a bug that was introduced by refactoring which caused the checker to not be set until after all classes were instrumented. In some situations this could lead the checker to being null when it is grabbed (and statically cached) by the entitlement bridge.