### PR TITLE
[9.0] Add initial bcUpgradeTask (#128588)

### DIFF
--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-java-rest-test'
@@ -22,6 +23,18 @@ buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
+  }
+}
+
+tasks.register("bcUpgradeTest", StandaloneRestIntegTestTask) {
+  // We use a phony version here as the real version is provided via `tests.bwc.main.version` system property
+  usesBwcDistribution(Version.fromString("0.0.0"))
+  systemProperty("tests.old_cluster_version", "0.0.0")
+  onlyIf("tests.bwc.main.version system property exists") { System.getProperty("tests.bwc.main.version") != null }
+  filter {
+    // filter tests initially for quicker iterations
+    // TODO remove once expanding the test set to other modules
+    includeTestsMatching("org.elasticsearch.upgrades.IndexingIT")
   }
 }
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Add initial bcUpgradeTask (#128588)