### PR TITLE
[8.19] Use StringBuilder instead of StringBuffer (#128665)

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -456,10 +456,10 @@ public class Augmentation {
     public static String replaceAll(CharSequence receiver, Pattern pattern, Function<Matcher, String> replacementBuilder) {
         Matcher m = pattern.matcher(receiver);
         if (false == m.find()) {
-            // CharSequqence's toString is *supposed* to always return the characters in the sequence as a String
+            // CharSequence's toString is *supposed* to always return the characters in the sequence as a String
             return receiver.toString();
         }
-        StringBuffer result = new StringBuffer(initialBufferForReplaceWith(receiver));
+        StringBuilder result = new StringBuilder(initialBufferForReplaceWith(receiver));
         do {
             m.appendReplacement(result, Matcher.quoteReplacement(replacementBuilder.apply(m)));
         } while (m.find());
@@ -477,7 +477,7 @@ public class Augmentation {
             // CharSequqence's toString is *supposed* to always return the characters in the sequence as a String
             return receiver.toString();
         }
-        StringBuffer result = new StringBuffer(initialBufferForReplaceWith(receiver));
+        StringBuilder result = new StringBuilder(initialBufferForReplaceWith(receiver));
         m.appendReplacement(result, Matcher.quoteReplacement(replacementBuilder.apply(m)));
         m.appendTail(result);
         return result.toString();

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/Stash.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/Stash.java
@@ -92,7 +92,7 @@ public class Stash implements ToXContentFragment {
          * modern versions of java the uncontended synchronization is very,
          * very cheap so that should not be a problem.
          */
-        StringBuffer result = new StringBuffer(key.length());
+        StringBuilder result = new StringBuilder(key.length());
         if (false == matcher.find()) {
             throw new IllegalArgumentException("Doesn't contain any stash keys [" + key + "]");
         }
@@ -189,7 +189,7 @@ public class Stash implements ToXContentFragment {
             }
         }
         String builtPath = Matcher.quoteReplacement(pathBuilder.toString());
-        StringBuffer newKey = new StringBuffer(key.length());
+        StringBuilder newKey = new StringBuilder(key.length());
         do {
             matcher.appendReplacement(newKey, builtPath);
         } while (matcher.find());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/BCrypt.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/BCrypt.java
@@ -1337,7 +1337,7 @@ public class BCrypt {
      */
     private static String encode_base64(byte d[], int len) throws IllegalArgumentException {
         int off = 0;
-        StringBuffer rs = new StringBuffer();
+        StringBuilder rs = new StringBuilder();
         int c1, c2;
 
         if (len <= 0 || len > d.length) throw new IllegalArgumentException("Invalid len");
@@ -1387,7 +1387,7 @@ public class BCrypt {
      * @throws          IllegalArgumentException if maxolen is invalid
      */
     private static byte[] decode_base64(String s, int maxolen) throws IllegalArgumentException {
-        StringBuffer rs = new StringBuffer();
+        StringBuilder rs = new StringBuilder();
         int off = 0, slen = s.length(), olen = 0;
         byte ret[];
         byte c1, c2, c3, c4, o;
@@ -1599,7 +1599,7 @@ public class BCrypt {
         byte passwordb[], saltb[], hashed[];
         char minor = (char) 0;
         int rounds, off = 0;
-        StringBuffer rs = new StringBuffer();
+        StringBuilder rs = new StringBuilder();
 
         if (salt.charAt(0) != '$' || salt.charAt(1) != '2') throw new IllegalArgumentException("Invalid salt version");
         if (salt.charAt(2) == '$') off = 3;
@@ -1674,7 +1674,7 @@ public class BCrypt {
      * @return            an encoded salt value
      */
     public static String gensalt(int log_rounds, SecureRandom random) {
-        StringBuffer rs = new StringBuffer();
+        StringBuilder rs = new StringBuilder();
         byte rnd[] = new byte[BCRYPT_SALT_LEN];
 
         random.nextBytes(rnd);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RequestXContent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RequestXContent.java
@@ -54,7 +54,7 @@ final class RequestXContent {
         }
 
         String fields() {
-            StringBuffer s = new StringBuffer();
+            StringBuilder s = new StringBuilder();
             for (Map.Entry<?, ?> entry : fields.entrySet()) {
                 if (s.length() > 0) {
                     s.append(", ");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatTests.java
@@ -161,7 +161,7 @@ public class TextFormatTests extends ESTestCase {
         List<String> expectedTerms = terms.stream()
             .map(x -> x.contains(String.valueOf(delim)) ? '"' + x + '"' : x)
             .collect(Collectors.toList());
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         do {
             sb.append(expectedTerms.remove(0));
             sb.append(delim);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySIDUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySIDUtil.java
@@ -51,7 +51,7 @@ public class ActiveDirectorySIDUtil {
         }
 
         char[] hex = Hex.encodeHex(bytes);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
         // start with 'S'
         sb.append('S');
@@ -76,7 +76,7 @@ public class ActiveDirectorySIDUtil {
 
         // sub-authorities, little-endian
         for (int i = 0; i < count; i++) {
-            StringBuffer rid = new StringBuffer();
+            StringBuilder rid = new StringBuilder();
 
             for (int k = 3; k >= 0; k--) {
                 rid.append(hex[16 + (i * 8) + (k * 2)]);

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/StringUtils.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/StringUtils.java
@@ -305,7 +305,7 @@ public abstract class StringUtils {
         if (count < 0) {
             throw new IllegalArgumentException("negative count: " + count);
         }
-        StringBuffer sb = new StringBuffer(in.length() * count);
+        StringBuilder sb = new StringBuilder(in.length() * count);
         for (int i = 0; i < count; i++) {
             sb.append(in);
         }

--- a/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/VersionTests.java
+++ b/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/VersionTests.java
@@ -35,7 +35,7 @@ public class VersionTests extends ESTestCase {
     private static final String JAR_PATH_SEPARATOR = "!/";
 
     private static String versionString(byte[] parts) {
-        StringBuffer version = new StringBuffer();
+        StringBuilder version = new StringBuilder();
         for (byte part : parts) {
             version.append(".");
             version.append(part);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/TextFormatTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/TextFormatTests.java
@@ -97,7 +97,7 @@ public class TextFormatTests extends ESTestCase {
         List<String> expectedTerms = terms.stream()
             .map(x -> x.contains(String.valueOf(delim)) ? '"' + x + '"' : x)
             .collect(Collectors.toList());
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         do {
             sb.append(expectedTerms.remove(0));
             sb.append(delim);


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Use StringBuilder instead of StringBuffer (#128665)