### PR TITLE
Fix computation of last block size in Azure concurrent multipart uploads

### DIFF
--- a/docs/changelog/128746.yaml
+++ b/docs/changelog/128746.yaml
@@ -1,0 +1,5 @@
+pr: 128746
+summary: Fix computation of last block size in Azure concurrent multipart uploads
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -533,8 +533,9 @@ public class AzureBlobStore implements BlobStore {
             return List.of(new MultiPart(0, makeMultipartBlockId(), 0L, totalSize, true));
         }
 
-        long lastPartSize = totalSize % partSize;
-        int parts = Math.toIntExact(totalSize / partSize) + (0L < lastPartSize ? 1 : 0);
+        long remaining = totalSize % partSize;
+        int parts = Math.toIntExact(totalSize / partSize) + (0L < remaining ? 1 : 0);
+        long lastPartSize = 0L < remaining ? remaining : partSize;
 
         long blockOffset = 0L;
         var list = new ArrayList<MultiPart>(parts);


### PR DESCRIPTION
Last part size is wrongly computed to 0 when the last part's length is exactly equal to the size of a part. Would have probably be caught by an existing assertion.

Relates ES-11815