### PR TITLE
[8.18] [ML] Prevent retention classes from failing when deleting documents in read-only indices (#125408)

### DIFF
--- a/docs/changelog/125408.yaml
+++ b/docs/changelog/125408.yaml
@@ -1,0 +1,6 @@
+pr: 125408
+summary: Prevent ML data retention logic from failing when deleting documents in read-only
+  indices
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -364,6 +364,7 @@ import org.elasticsearch.xpack.ml.job.process.normalizer.MultiplyingNormalizerPr
 import org.elasticsearch.xpack.ml.job.process.normalizer.NativeNormalizerProcessFactory;
 import org.elasticsearch.xpack.ml.job.process.normalizer.NormalizerFactory;
 import org.elasticsearch.xpack.ml.job.process.normalizer.NormalizerProcessFactory;
+import org.elasticsearch.xpack.ml.job.retention.WritableIndexExpander;
 import org.elasticsearch.xpack.ml.job.snapshot.upgrader.SnapshotUpgradeTaskExecutor;
 import org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
@@ -921,6 +922,9 @@ public class MachineLearning extends Plugin
         NamedXContentRegistry xContentRegistry = services.xContentRegistry();
         IndexNameExpressionResolver indexNameExpressionResolver = services.indexNameExpressionResolver();
         TelemetryProvider telemetryProvider = services.telemetryProvider();
+
+        // Initialize WritableIndexExpander
+        WritableIndexExpander.initialize(clusterService, indexNameExpressionResolver);
 
         if (enabled == false) {
             // Holders for @link(MachineLearningFeatureSetUsage) which needs access to job manager and ML extension,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataAction.java
@@ -240,6 +240,7 @@ public class TransportDeleteExpiredDataAction extends HandledTransportAction<
         TaskId parentTaskId,
         AnomalyDetectionAuditor anomalyDetectionAuditor
     ) {
+
         return Arrays.asList(
             new ExpiredResultsRemover(
                 originClient,
@@ -252,8 +253,8 @@ public class TransportDeleteExpiredDataAction extends HandledTransportAction<
             new ExpiredModelSnapshotsRemover(
                 originClient,
                 new WrappedBatchedJobsIterator(new SearchAfterJobsIterator(originClient)),
-                threadPool,
                 parentTaskId,
+                threadPool,
                 jobResultsProvider,
                 anomalyDetectionAuditor
             ),
@@ -277,8 +278,8 @@ public class TransportDeleteExpiredDataAction extends HandledTransportAction<
             new ExpiredModelSnapshotsRemover(
                 client,
                 new VolatileCursorIterator<>(jobs),
-                threadPool,
                 parentTaskId,
+                threadPool,
                 jobResultsProvider,
                 anomalyDetectionAuditor
             ),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
@@ -65,7 +65,6 @@ import org.elasticsearch.xpack.core.ml.job.results.ModelPlot;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.security.user.InternalUsers;
-import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.job.retention.WritableIndexExpander;
 import org.elasticsearch.xpack.ml.utils.MlIndicesUtils;
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
@@ -65,6 +65,8 @@ import org.elasticsearch.xpack.core.ml.job.results.ModelPlot;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.security.user.InternalUsers;
+import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.job.retention.WritableIndexExpander;
 import org.elasticsearch.xpack.ml.utils.MlIndicesUtils;
 
 import java.util.ArrayList;
@@ -131,7 +133,10 @@ public class JobDataDeleter {
             indices.add(AnomalyDetectorsIndex.jobResultsAliasedName(modelSnapshot.getJobId()));
         }
 
-        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(indices.toArray(new String[0])).setRefresh(true)
+        String[] indicesToQuery = removeReadOnlyIndices(new ArrayList<>(indices), listener, "model snapshots", null);
+        if (indicesToQuery.length == 0) return;
+
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(indicesToQuery).setRefresh(true)
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
             .setQuery(QueryBuilders.idsQuery().addIds(idsToDelete.toArray(new String[0])));
 
@@ -179,7 +184,16 @@ public class JobDataDeleter {
             boolQuery.filter(QueryBuilders.termsQuery(Annotation.EVENT.getPreferredName(), eventsToDelete));
         }
         QueryBuilder query = QueryBuilders.constantScoreQuery(boolQuery);
-        DeleteByQueryRequest dbqRequest = new DeleteByQueryRequest(AnnotationIndex.READ_ALIAS_NAME).setQuery(query)
+
+        String[] indicesToQuery = removeReadOnlyIndices(
+            List.of(AnnotationIndex.READ_ALIAS_NAME),
+            listener,
+            "annotations",
+            () -> listener.onResponse(true)
+        );
+        if (indicesToQuery.length == 0) return;
+
+        DeleteByQueryRequest dbqRequest = new DeleteByQueryRequest(indicesToQuery).setQuery(query)
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
             .setAbortOnVersionConflict(false)
             .setRefresh(true)
@@ -195,6 +209,28 @@ public class JobDataDeleter {
             dbqRequest,
             ActionListener.wrap(r -> listener.onResponse(true), listener::onFailure)
         );
+    }
+
+    private <T> String[] removeReadOnlyIndices(
+        List<String> indicesToQuery,
+        ActionListener<T> listener,
+        String entityType,
+        Runnable onEmpty
+    ) {
+        try {
+            indicesToQuery = WritableIndexExpander.getInstance().getWritableIndices(indicesToQuery);
+        } catch (Exception e) {
+            logger.error("Failed to get writable indices for [" + jobId + "]", e);
+            listener.onFailure(e);
+            return new String[0];
+        }
+        if (indicesToQuery.isEmpty()) {
+            logger.info("No writable {} indices found for [{}] job. No {} to remove.", entityType, jobId, entityType);
+            if (onEmpty != null) {
+                onEmpty.run();
+            }
+        }
+        return indicesToQuery.toArray(String[]::new);
     }
 
     /**
@@ -218,7 +254,14 @@ public class JobDataDeleter {
                 )
             )
             .filter(QueryBuilders.rangeQuery(Result.TIMESTAMP.getPreferredName()).gte(cutoffEpochMs));
-        DeleteByQueryRequest dbqRequest = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)).setQuery(query)
+        String[] indicesToQuery = removeReadOnlyIndices(
+            List.of(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)),
+            listener,
+            "results",
+            () -> listener.onResponse(true)
+        );
+        if (indicesToQuery.length == 0) return;
+        DeleteByQueryRequest dbqRequest = new DeleteByQueryRequest(indicesToQuery).setQuery(query)
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
             .setAbortOnVersionConflict(false)
             .setRefresh(true)
@@ -263,9 +306,14 @@ public class JobDataDeleter {
      * @param listener Response listener
      */
     public void deleteDatafeedTimingStats(ActionListener<BulkByScrollResponse> listener) {
-        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)).setRefresh(
-            true
-        )
+        String[] indicesToQuery = removeReadOnlyIndices(
+            List.of(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)),
+            listener,
+            "datafeed timing stats",
+            null
+        );
+        if (indicesToQuery.length == 0) return;
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(indicesToQuery).setRefresh(true)
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
             .setQuery(QueryBuilders.idsQuery().addIds(DatafeedTimingStats.documentId(jobId)));
 
@@ -455,7 +503,9 @@ public class JobDataDeleter {
         ActionListener<BroadcastResponse> refreshListener = ActionListener.wrap(refreshResponse -> {
             logger.info("[{}] running delete by query on [{}]", jobId, String.join(", ", indices));
             ConstantScoreQueryBuilder query = new ConstantScoreQueryBuilder(new TermQueryBuilder(Job.ID.getPreferredName(), jobId));
-            DeleteByQueryRequest request = new DeleteByQueryRequest(indices).setQuery(query)
+            String[] indicesToQuery = removeReadOnlyIndices(List.of(indices), listener, "results", null);
+            if (indicesToQuery.length == 0) return;
+            DeleteByQueryRequest request = new DeleteByQueryRequest(indicesToQuery).setQuery(query)
                 .setIndicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpenHidden()))
                 .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
                 .setAbortOnVersionConflict(false)
@@ -523,7 +573,16 @@ public class JobDataDeleter {
     private void deleteQuantiles(@SuppressWarnings("HiddenField") String jobId, ActionListener<Boolean> finishedHandler) {
         // Just use ID here, not type, as trying to delete different types spams the logs with an exception stack trace
         IdsQueryBuilder query = new IdsQueryBuilder().addIds(Quantiles.documentId(jobId));
-        DeleteByQueryRequest request = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(query)
+
+        String[] indicesToQuery = removeReadOnlyIndices(
+            List.of(AnomalyDetectorsIndex.jobStateIndexPattern()),
+            finishedHandler,
+            "quantiles",
+            () -> finishedHandler.onResponse(true)
+        );
+        if (indicesToQuery.length == 0) return;
+
+        DeleteByQueryRequest request = new DeleteByQueryRequest(indicesToQuery).setQuery(query)
             .setIndicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()))
             .setAbortOnVersionConflict(false)
             .setRefresh(true);
@@ -553,7 +612,14 @@ public class JobDataDeleter {
     ) {
         // Just use ID here, not type, as trying to delete different types spams the logs with an exception stack trace
         IdsQueryBuilder query = new IdsQueryBuilder().addIds(CategorizerState.documentId(jobId, docNum));
-        DeleteByQueryRequest request = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(query)
+        String[] indicesToQuery = removeReadOnlyIndices(
+            List.of(AnomalyDetectorsIndex.jobStateIndexPattern()),
+            finishedHandler,
+            "categorizer state",
+            () -> finishedHandler.onResponse(true)
+        );
+        if (indicesToQuery.length == 0) return;
+        DeleteByQueryRequest request = new DeleteByQueryRequest(indicesToQuery).setQuery(query)
             .setIndicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()))
             .setAbortOnVersionConflict(false)
             .setRefresh(true);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemover.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -83,7 +84,14 @@ public class ExpiredAnnotationsRemover extends AbstractExpiredJobDataRemover {
         long cutoffEpochMs,
         ActionListener<Boolean> listener
     ) {
-        DeleteByQueryRequest request = createDBQRequest(job, requestsPerSecond, cutoffEpochMs);
+        var indicesToQuery = WritableIndexExpander.getInstance().getWritableIndices(AnnotationIndex.READ_ALIAS_NAME);
+        if (indicesToQuery.isEmpty()) {
+            LOGGER.info("No writable annotation indices found for [{}] job. No expired annotations to remove.", job.getId());
+            listener.onResponse(true);
+            return;
+        }
+
+        DeleteByQueryRequest request = createDBQRequest(job, requestsPerSecond, cutoffEpochMs, indicesToQuery);
         request.setParentTask(getParentTaskId());
 
         client.execute(DeleteByQueryAction.INSTANCE, request, new ActionListener<>() {
@@ -112,12 +120,17 @@ public class ExpiredAnnotationsRemover extends AbstractExpiredJobDataRemover {
         });
     }
 
-    private static DeleteByQueryRequest createDBQRequest(Job job, float requestsPerSec, long cutoffEpochMs) {
+    private static DeleteByQueryRequest createDBQRequest(
+        Job job,
+        float requestsPerSec,
+        long cutoffEpochMs,
+        ArrayList<String> indicesToQuery
+    ) {
         QueryBuilder query = QueryBuilders.boolQuery()
             .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), job.getId()))
             .filter(QueryBuilders.rangeQuery(Annotation.TIMESTAMP.getPreferredName()).lt(cutoffEpochMs).format("epoch_millis"))
             .filter(QueryBuilders.termQuery(Annotation.CREATE_USERNAME.getPreferredName(), InternalUsers.XPACK_USER.principal()));
-        DeleteByQueryRequest request = new DeleteByQueryRequest(AnnotationIndex.READ_ALIAS_NAME).setSlices(
+        DeleteByQueryRequest request = new DeleteByQueryRequest(indicesToQuery.toArray(new String[0])).setSlices(
             AbstractBulkByScrollRequest.AUTO_SLICES
         )
             .setBatchSize(AbstractBulkByScrollRequest.DEFAULT_SCROLL_SIZE)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredForecastsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredForecastsRemover.java
@@ -125,7 +125,14 @@ public class ExpiredForecastsRemover implements MlDataRemover {
             return;
         }
 
-        DeleteByQueryRequest request = buildDeleteByQuery(forecastsToDelete).setRequestsPerSecond(requestsPerSec)
+        var indicesToQuery = WritableIndexExpander.getInstance().getWritableIndices(RESULTS_INDEX_PATTERN);
+        if (indicesToQuery.isEmpty()) {
+            LOGGER.info("No writable indices found for expired forecasts. No expired forecasts to remove.");
+            listener.onResponse(true);
+            return;
+        }
+
+        DeleteByQueryRequest request = buildDeleteByQuery(forecastsToDelete, indicesToQuery).setRequestsPerSecond(requestsPerSec)
             .setAbortOnVersionConflict(false);
         request.setParentTask(parentTaskId);
         client.execute(DeleteByQueryAction.INSTANCE, request, new ActionListener<>() {
@@ -199,12 +206,12 @@ public class ExpiredForecastsRemover implements MlDataRemover {
         return forecastsToDelete;
     }
 
-    private static DeleteByQueryRequest buildDeleteByQuery(List<JobForecastId> ids) {
+    private static DeleteByQueryRequest buildDeleteByQuery(List<JobForecastId> ids, ArrayList<String> indicesToQuery) {
         DeleteByQueryRequest request = new DeleteByQueryRequest();
         request.setSlices(AbstractBulkByScrollRequest.AUTO_SLICES);
         request.setTimeout(DEFAULT_MAX_DURATION);
 
-        request.indices(RESULTS_INDEX_PATTERN);
+        request.indices(indicesToQuery.toArray(new String[0]));
         BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().minimumShouldMatch(1);
         boolQuery.must(
             QueryBuilders.termsQuery(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
@@ -11,11 +11,14 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -26,24 +29,29 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.common.time.TimeUtils;
+import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.ml.MachineLearning;
-import org.elasticsearch.xpack.ml.job.persistence.JobDataDeleter;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.utils.MlIndicesUtils;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 /**
  * Deletes all model snapshots that have expired the configured retention time
@@ -62,9 +70,9 @@ public class ExpiredModelSnapshotsRemover extends AbstractExpiredJobDataRemover 
     private static final long MS_IN_ONE_DAY = TimeValue.timeValueDays(1).getMillis();
 
     /**
-     *  The max number of snapshots to fetch per job. It is set to 10K, the default for an index as
-     *  we don't change that in our ML indices. It should be more than enough for most cases. If not,
-     *  it will take a few iterations to delete all snapshots, which is OK.
+     * The max number of snapshots to fetch per job. It is set to 10K, the default for an index as
+     * we don't change that in our ML indices. It should be more than enough for most cases. If not,
+     * it will take a few iterations to delete all snapshots, which is OK.
      */
     private static final int MODEL_SNAPSHOT_SEARCH_SIZE = 10000;
 
@@ -75,8 +83,8 @@ public class ExpiredModelSnapshotsRemover extends AbstractExpiredJobDataRemover 
     public ExpiredModelSnapshotsRemover(
         OriginSettingClient client,
         Iterator<Job> jobIterator,
-        ThreadPool threadPool,
         TaskId parentTaskId,
+        ThreadPool threadPool,
         JobResultsProvider jobResultsProvider,
         AnomalyDetectionAuditor auditor
     ) {
@@ -247,19 +255,59 @@ public class ExpiredModelSnapshotsRemover extends AbstractExpiredJobDataRemover 
             listener.onResponse(true);
             return;
         }
-        JobDataDeleter deleter = new JobDataDeleter(client, jobId);
-        deleter.deleteModelSnapshots(modelSnapshots, listener.delegateFailureAndWrap((l, bulkResponse) -> {
-            auditor.info(jobId, Messages.getMessage(Messages.JOB_AUDIT_SNAPSHOTS_DELETED, modelSnapshots.size()));
-            LOGGER.debug(
-                () -> format(
-                    "[%s] deleted model snapshots %s with descriptions %s",
-                    jobId,
-                    modelSnapshots.stream().map(ModelSnapshot::getSnapshotId).collect(toList()),
-                    modelSnapshots.stream().map(ModelSnapshot::getDescription).collect(toList())
-                )
-            );
-            l.onResponse(true);
-        }));
-    }
 
+        String stateIndexName = AnomalyDetectorsIndex.jobStateIndexPattern();
+
+        List<String> idsToDelete = new ArrayList<>();
+        Set<String> indices = new HashSet<>();
+        indices.add(stateIndexName);
+        indices.add(AnnotationIndex.READ_ALIAS_NAME);
+        for (ModelSnapshot modelSnapshot : modelSnapshots) {
+            idsToDelete.addAll(modelSnapshot.stateDocumentIds());
+            idsToDelete.add(ModelSnapshot.documentId(modelSnapshot));
+            idsToDelete.add(ModelSnapshot.annotationDocumentId(modelSnapshot));
+            indices.add(AnomalyDetectorsIndex.jobResultsAliasedName(modelSnapshot.getJobId()));
+        }
+
+        // Remove read-only indices
+        List<String> indicesToQuery;
+        try {
+            indicesToQuery = WritableIndexExpander.getInstance().getWritableIndices(indices);
+        } catch (Exception e) {
+            LOGGER.error("Failed to get writable indices for [" + jobId + "]", e);
+            listener.onFailure(e);
+            return;
+        }
+        if (indicesToQuery.isEmpty()) {
+            LOGGER.info("No writable model snapshot indices found for [{}] job. No expired model snapshots to remove.", jobId);
+            listener.onResponse(true);
+            return;
+        }
+
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(indicesToQuery.toArray(new String[0])).setRefresh(true)
+            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+            .setQuery(QueryBuilders.idsQuery().addIds(idsToDelete.toArray(new String[0])));
+
+        // _doc is the most efficient sort order and will also disable scoring
+        deleteByQueryRequest.getSearchRequest().source().sort(ElasticsearchMappings.ES_DOC);
+
+        executeAsyncWithOrigin(
+            client,
+            ML_ORIGIN,
+            DeleteByQueryAction.INSTANCE,
+            deleteByQueryRequest,
+            listener.delegateFailureAndWrap((l, bulkResponse) -> {
+                auditor.info(jobId, Messages.getMessage(Messages.JOB_AUDIT_SNAPSHOTS_DELETED, modelSnapshots.size()));
+                LOGGER.debug(
+                    () -> format(
+                        "[%s] deleted model snapshots %s with descriptions %s",
+                        jobId,
+                        modelSnapshots.stream().map(ModelSnapshot::getSnapshotId).collect(toList()),
+                        modelSnapshots.stream().map(ModelSnapshot::getDescription).collect(toList())
+                    )
+                );
+                l.onResponse(true);
+            })
+        );
+    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/UnusedStateRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/UnusedStateRemover.java
@@ -137,8 +137,18 @@ public class UnusedStateRemover implements MlDataRemover {
 
     private void executeDeleteUnusedStateDocs(List<String> unusedDocIds, float requestsPerSec, ActionListener<Boolean> listener) {
         LOGGER.info("Found [{}] unused state documents; attempting to delete", unusedDocIds.size());
-        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobStateIndexPattern())
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+
+        var indicesToQuery = WritableIndexExpander.getInstance().getWritableIndices(AnomalyDetectorsIndex.jobStateIndexPattern());
+
+        if (indicesToQuery.isEmpty()) {
+            LOGGER.info("No writable indices found for unused state documents");
+            listener.onResponse(true);
+            return;
+        }
+
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(indicesToQuery.toArray(new String[0])).setIndicesOptions(
+            IndicesOptions.lenientExpandOpen()
+        )
             .setAbortOnVersionConflict(false)
             .setRequestsPerSecond(requestsPerSec)
             .setTimeout(DEFAULT_MAX_DURATION)
@@ -149,7 +159,7 @@ public class UnusedStateRemover implements MlDataRemover {
         deleteByQueryRequest.setParentTask(parentTaskId);
 
         client.execute(DeleteByQueryAction.INSTANCE, deleteByQueryRequest, ActionListener.wrap(response -> {
-            if (response.getBulkFailures().size() > 0 || response.getSearchFailures().size() > 0) {
+            if (response.getBulkFailures().isEmpty() == false || response.getSearchFailures().isEmpty() == false) {
                 LOGGER.error(
                     "Some unused state documents could not be deleted due to failures: {}",
                     Strings.collectionToCommaDelimitedString(response.getBulkFailures())

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/WritableIndexExpander.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/WritableIndexExpander.java
@@ -66,7 +66,7 @@ public class WritableIndexExpander {
     }
 
     private Boolean isIndexReadOnly(String indexName) {
-        IndexMetadata indexMetadata = clusterService.state().metadata().getProject().index(indexName);
+        IndexMetadata indexMetadata = clusterService.state().metadata().index(indexName);
         if (indexMetadata == null) {
             throw new IllegalArgumentException("Failed to identify if index is read-only: index [" + indexName + "] not found");
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/WritableIndexExpander.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/WritableIndexExpander.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.retention;
+
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * This class is used to expand index patterns and filter out read-only indices.
+ * It is used in the context of machine learning jobs retention to ensure that only writable indices are considered.
+ */
+public class WritableIndexExpander {
+
+    private final ClusterService clusterService;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private static WritableIndexExpander INSTANCE;
+
+    public static void initialize(ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver) {
+        INSTANCE = new WritableIndexExpander(clusterService, indexNameExpressionResolver);
+    }
+
+    public static void initialize(WritableIndexExpander newInstance) {
+        INSTANCE = newInstance;
+    }
+
+    public static WritableIndexExpander getInstance() {
+        if (INSTANCE == null) {
+            throw new IllegalStateException("WritableIndexExpander is not initialized");
+        }
+        return INSTANCE;
+    }
+
+    protected WritableIndexExpander(ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver) {
+        this.clusterService = Objects.requireNonNull(clusterService);
+        this.indexNameExpressionResolver = Objects.requireNonNull(indexNameExpressionResolver);
+    }
+
+    public ArrayList<String> getWritableIndices(String indexPattern) {
+        return getWritableIndices(List.of(indexPattern));
+    }
+
+    public ArrayList<String> getWritableIndices(Collection<String> indices) {
+        if (indices == null || indices.isEmpty()) {
+            return new ArrayList<>();
+        }
+        var clusterState = clusterService.state();
+        return indices.stream()
+            .map(index -> indexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN, index))
+            .flatMap(Arrays::stream)
+            .filter(index -> (isIndexReadOnly(index) == false))
+            .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private Boolean isIndexReadOnly(String indexName) {
+        IndexMetadata indexMetadata = clusterService.state().metadata().getProject().index(indexName);
+        if (indexMetadata == null) {
+            throw new IllegalArgumentException("Failed to identify if index is read-only: index [" + indexName + "] not found");
+        }
+        if (indexMetadata.getSettings() == null) {
+            throw new IllegalStateException("Settings for index [" + indexName + "] are unavailable");
+        }
+        return IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.get(indexMetadata.getSettings());
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataActionTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -20,6 +21,7 @@ import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.job.retention.MlDataRemover;
+import org.elasticsearch.xpack.ml.job.retention.WritableIndexExpander;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.junit.After;
 import org.junit.Before;
@@ -61,6 +63,7 @@ public class TransportDeleteExpiredDataActionTests extends ESTestCase {
         threadPool = new TestThreadPool("TransportDeleteExpiredDataActionTests thread pool");
         Client client = mock(Client.class);
         ClusterService clusterService = mock(ClusterService.class);
+        WritableIndexExpander.initialize(clusterService, TestIndexNameExpressionResolver.newInstance());
         auditor = mock(AnomalyDetectionAuditor.class);
         transportDeleteExpiredDataAction = new TransportDeleteExpiredDataAction(
             threadPool,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemoverTests.java
@@ -11,8 +11,10 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.tasks.TaskId;
@@ -84,6 +86,7 @@ public class AbstractExpiredJobDataRemoverTests extends ESTestCase {
     public void setUpTests() {
         Client client = mock(Client.class);
         originSettingClient = MockOriginSettingClient.mockOriginSettingClient(client, ClientHelper.ML_ORIGIN);
+        WritableIndexExpander.initialize(mock(ClusterService.class), TestIndexNameExpressionResolver.newInstance());
     }
 
     static SearchResponse createSearchResponse(List<? extends ToXContent> toXContents) throws IOException {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/MockWritableIndexExpander.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/MockWritableIndexExpander.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.retention;
+
+import org.mockito.ArgumentMatchers;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MockWritableIndexExpander {
+    public static WritableIndexExpander create(boolean stateIndexWritable) {
+        WritableIndexExpander.initialize(mock(WritableIndexExpander.class));
+        WritableIndexExpander writableIndexExpander = WritableIndexExpander.getInstance();
+        if (stateIndexWritable) {
+            mockWhenIndicesAreWritable(writableIndexExpander);
+        } else {
+            mockWhenIndicesAreNotWritable(writableIndexExpander);
+        }
+        return writableIndexExpander;
+    }
+
+    private static void mockWhenIndicesAreNotWritable(WritableIndexExpander writableIndexExpander) {
+        when(writableIndexExpander.getWritableIndices(anyString()))
+            .thenReturn(new ArrayList<>());
+        when(writableIndexExpander.getWritableIndices(ArgumentMatchers.<Collection<String>>any()))
+            .thenReturn(new ArrayList<>());
+    }
+
+    private static void mockWhenIndicesAreWritable(WritableIndexExpander writableIndexExpander) {
+        when(writableIndexExpander.getWritableIndices(anyString())).thenAnswer(invocation -> {
+            String input = invocation.getArgument(0);
+            return new ArrayList<>(List.of(input));
+        });
+        when(writableIndexExpander.getWritableIndices(ArgumentMatchers.<Collection<String>>any())).thenAnswer(
+            invocation -> new ArrayList<>(invocation.getArgument(0))
+        );
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ML] Prevent retention classes from failing when deleting documents in read-only indices (#125408)](https://github.com/elastic/elasticsearch/pull/125408)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)