### PR TITLE
[release-notes] Fix tests and make it easy to regenerate output after changes

### DIFF
--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.java
@@ -20,9 +20,13 @@ import java.util.Objects;
 
 import static org.elasticsearch.gradle.internal.release.GenerateReleaseNotesTask.getSortedBundlesWithUniqueChangelogs;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
 public class ReleaseNotesGeneratorTest {
+
+    // Temporarily set this to `true` to regenerate test output files when they need to be updated
+    private final boolean UPDATE_EXPECTED_OUTPUT = false;
 
     private static final List<String> CHANGE_TYPES = List.of(
         "breaking",
@@ -78,8 +82,9 @@ public class ReleaseNotesGeneratorTest {
 
     public void testTemplate(String templateFilename, String outputFilename, List<ChangelogBundle> bundles) throws Exception {
         // given:
+        final String outputFile = "/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest." + outputFilename;
         final String template = getResource("/templates/" + templateFilename);
-        final String expectedOutput = getResource("/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest." + outputFilename);
+        final String expectedOutput = getResource(outputFile);
 
         if (bundles == null) {
             bundles = getBundles();
@@ -91,7 +96,12 @@ public class ReleaseNotesGeneratorTest {
         final String actualOutput = ReleaseNotesGenerator.generateFile(template, bundles);
 
         // then:
-        assertThat(actualOutput, equalTo(expectedOutput));
+        if (UPDATE_EXPECTED_OUTPUT) {
+            writeResource(outputFile, actualOutput);
+            assertFalse("UPDATE_EXPECTED_OUTPUT should be set back to false after updating output", UPDATE_EXPECTED_OUTPUT);
+        } else {
+            assertThat(actualOutput, equalTo(expectedOutput));
+        }
     }
 
     private List<ChangelogBundle> getBundles() {
@@ -175,5 +185,10 @@ public class ReleaseNotesGeneratorTest {
 
     private String getResource(String name) throws Exception {
         return Files.readString(Paths.get(Objects.requireNonNull(this.getClass().getResource(name)).toURI()), StandardCharsets.UTF_8);
+    }
+
+    private void writeResource(String name, String contents) throws Exception {
+        String path = "src/test/resources" + name;
+        Files.writeString(Paths.get(path), contents);
     }
 }

--- a/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.index.md
+++ b/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.index.md
@@ -20,10 +20,10 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [elasticsearch-next-fixes]
 % *
 
+## 9.1.0 [elasticsearch-9.1.0-release-notes]
 ```{applies_to}
 stack: coming 9.1.0
 ```
-## 9.1.0 [elasticsearch-9.1.0-release-notes]
 
 ### Highlights [elasticsearch-9.1.0-highlights]
 
@@ -47,10 +47,10 @@ Search:
 *  [#52](https://github.com/elastic/elasticsearch/pull/52)
 
 
+## 9.0.10 [elasticsearch-9.0.10-release-notes]
 ```{applies_to}
 stack: coming 9.0.10
 ```
-## 9.0.10 [elasticsearch-9.0.10-release-notes]
 
 ### Features and enhancements [elasticsearch-9.0.10-features-enhancements]
 

--- a/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.index.no-highlights.md
+++ b/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.index.no-highlights.md
@@ -20,10 +20,10 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [elasticsearch-next-fixes]
 % *
 
+## 9.0.10 [elasticsearch-9.0.10-release-notes]
 ```{applies_to}
 stack: coming 9.0.10
 ```
-## 9.0.10 [elasticsearch-9.0.10-release-notes]
 
 ### Features and enhancements [elasticsearch-9.0.10-features-enhancements]
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -534,12 +534,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test040JavaUsesTheOsProvidedKeystore
   issue: https://github.com/elastic/elasticsearch/issues/128230
-- class: org.elasticsearch.gradle.internal.release.ReleaseNotesGeneratorTest
-  method: generateFile_index_rendersCorrectMarkup
-  issue: https://github.com/elastic/elasticsearch/issues/128772
-- class: org.elasticsearch.gradle.internal.release.ReleaseNotesGeneratorTest
-  method: generateFile_index_noHighlights_rendersCorrectMarkup
-  issue: https://github.com/elastic/elasticsearch/issues/128773
 - class: org.elasticsearch.xpack.rank.rrf.LinearRankClientYamlTestSuiteIT
   method: test {yaml=linear/10_linear_retriever/should normalize initial scores with l2_norm}
   issue: https://github.com/elastic/elasticsearch/issues/128774


### PR DESCRIPTION
Fixes #128772 #128773

- Update the output files in the tests to match the updated templates
- Create a flag to make it easy to update the output files
- Unmute the broken tests