### PR TITLE
[DOCS] Add missing index setting link

### DIFF
--- a/docs/reference/elasticsearch/index-settings/index.md
+++ b/docs/reference/elasticsearch/index-settings/index.md
@@ -34,3 +34,5 @@ Settings are available for the following modules:
   Configure the backing indices in a time series data stream (TSDS).
 * [Translog](translog.md)
   Control the transaction log and background flush operations.
+
+There are also index settings associated with [text analysis](docs-content://manage-data/data-store/text-analysis.md), which define analyzers, tokenizers, token filters, and character filters.


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/4435

While adding a link from the "update index settings" API to the [index settings reference](https://www.elastic.co/docs/reference/elasticsearch/index-settings/), I noticed that in the 
[V8 docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.18/index-modules.html#_settings_in_other_index_modules) there was mention of additional "analyzer" settings.

This PR adds a similar link to the appropriate section of the docs for V9. In the long-term it might be a good idea to explicitly include those settings in the index settings reference.

### Preview

https://docs-v3-preview.elastic.dev/elastic/elasticsearch/pull/128794/reference/elasticsearch/index-settings/