### PR TITLE
Add transport version support for IDP_CUSTOM_SAML_ATTRIBUTES_ADDED_8_19

### DIFF
--- a/docs/changelog/128798.yaml
+++ b/docs/changelog/128798.yaml
@@ -1,0 +1,5 @@
+pr: 128798
+summary: Add transport version support for IDP_CUSTOM_SAML_ATTRIBUTES_ADDED_8_19
+area: IdentityProvider
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -184,6 +184,7 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_SAGEMAKER_CHAT_COMPLETION_8_19 = def(8_841_0_37);
     public static final TransportVersion ML_INFERENCE_VERTEXAI_CHATCOMPLETION_ADDED_8_19 = def(8_841_0_38);
     public static final TransportVersion INFERENCE_CUSTOM_SERVICE_ADDED_8_19 = def(8_841_0_39);
+    public static final TransportVersion IDP_CUSTOM_SAML_ATTRIBUTES_ADDED_8_19 = def(8_841_0_40);
     public static final TransportVersion V_9_0_0 = def(9_000_0_09);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0_1 = def(9_000_0_10);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0_2 = def(9_000_0_11);

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/SamlInitiateSingleSignOnRequest.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/SamlInitiateSingleSignOnRequest.java
@@ -31,7 +31,8 @@ public class SamlInitiateSingleSignOnRequest extends LegacyActionRequest {
         spEntityId = in.readString();
         assertionConsumerService = in.readString();
         samlAuthenticationState = in.readOptionalWriteable(SamlAuthenticationState::new);
-        if (in.getTransportVersion().onOrAfter(TransportVersions.IDP_CUSTOM_SAML_ATTRIBUTES)) {
+        if (in.getTransportVersion().isPatchFrom(TransportVersions.IDP_CUSTOM_SAML_ATTRIBUTES_ADDED_8_19)
+            || in.getTransportVersion().onOrAfter(TransportVersions.IDP_CUSTOM_SAML_ATTRIBUTES)) {
             attributes = in.readOptionalWriteable(SamlInitiateSingleSignOnAttributes::new);
         }
     }
@@ -99,7 +100,8 @@ public class SamlInitiateSingleSignOnRequest extends LegacyActionRequest {
         out.writeString(spEntityId);
         out.writeString(assertionConsumerService);
         out.writeOptionalWriteable(samlAuthenticationState);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.IDP_CUSTOM_SAML_ATTRIBUTES)) {
+        if (out.getTransportVersion().isPatchFrom(TransportVersions.IDP_CUSTOM_SAML_ATTRIBUTES_ADDED_8_19)
+            || out.getTransportVersion().onOrAfter(TransportVersions.IDP_CUSTOM_SAML_ATTRIBUTES)) {
             out.writeOptionalWriteable(attributes);
         }
     }

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/SamlInitiateSingleSignOnRequestTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/SamlInitiateSingleSignOnRequestTests.java
@@ -79,13 +79,7 @@ public class SamlInitiateSingleSignOnRequestTests extends ESTestCase {
         }
         assertThat("An invalid request is not guaranteed to serialize correctly", request.validate(), nullValue());
         final BytesStreamOutput out = new BytesStreamOutput();
-        out.setTransportVersion(
-            TransportVersionUtils.randomVersionBetween(
-                random(),
-                TransportVersions.IDP_CUSTOM_SAML_ATTRIBUTES_ADDED_8_19,
-                TransportVersionUtils.getPreviousVersion(TransportVersions.IDP_CUSTOM_SAML_ATTRIBUTES)
-            )
-        );
+        out.setTransportVersion(TransportVersions.IDP_CUSTOM_SAML_ATTRIBUTES_ADDED_8_19);
         request.writeTo(out);
 
         try (StreamInput in = out.bytes().streamInput()) {


### PR DESCRIPTION
Adds `IDP_CUSTOM_SAML_ATTRIBUTES_ADDED_8_19` and uses it on serdes.

Also adds a UT and adjusts existing ones.

Related to:
* https://github.com/elastic/elasticsearch/pull/128796
* https://github.com/elastic/elasticsearch/pull/128176
