### PR TITLE
[8.19] Remove include_default query param from get data stream options. (#128730)

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/rest/RestGetDataStreamOptionsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/rest/RestGetDataStreamOptionsAction.java
@@ -46,7 +46,6 @@ public class RestGetDataStreamOptionsAction extends BaseRestHandler {
             RestUtils.getMasterNodeTimeout(request),
             Strings.splitStringByCommaToArray(request.param("name"))
         );
-        getDataStreamOptionsRequest.includeDefaults(request.paramAsBoolean("include_defaults", false));
         getDataStreamOptionsRequest.indicesOptions(IndicesOptions.fromRequest(request, getDataStreamOptionsRequest.indicesOptions()));
         return channel -> client.execute(
             GetDataStreamOptionsAction.INSTANCE,

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_options.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_options.json
@@ -38,10 +38,6 @@
         "default":"open",
         "description":"Whether wildcard expressions should get expanded to open or closed indices (default: open)"
       },
-      "include_defaults":{
-        "type":"boolean",
-        "description":"Return all relevant default configurations for the data stream (default: false)"
-      },
       "master_timeout":{
         "type":"time",
         "description":"Specify timeout for connection to master"

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -230,6 +230,7 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_VERTEXAI_CHATCOMPLETION_ADDED_8_19 = def(8_841_0_38);
     public static final TransportVersion INFERENCE_CUSTOM_SERVICE_ADDED_8_19 = def(8_841_0_39);
     public static final TransportVersion IDP_CUSTOM_SAML_ATTRIBUTES_ADDED_8_19 = def(8_841_0_40);
+    public static final TransportVersion DATA_STREAM_OPTIONS_API_REMOVE_INCLUDE_DEFAULTS_8_19 = def(8_841_0_41);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Remove include_default query param from get data stream options. (#128730)](https://github.com/elastic/elasticsearch/pull/128730)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)