### PR TITLE
[9.0] Cleanup renovate config after default in branch name (#128817)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,19 +19,5 @@
     "9.0",
     "8.18",
     "8.17"
-  ],
-  "packageRules": [
-    {
-      "groupName": "wolfi (versioned)",
-      "groupSlug": "wolfi-versioned",
-      "description": "Override the `groupSlug` to create a non-special-character branch name",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "/^docker.elastic.co/wolfi/chainguard-base$/",
-        "/^docker.elastic.co/wolfi/chainguard-base-fips$/"
-      ]
-    }
   ]
 }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Cleanup renovate config after default in branch name (#128817)