### PR TITLE
[8.19] Unit test to validate copy_to for semantic_text field in esql (#128795)

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/SemanticMatchTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/SemanticMatchTestCase.java
@@ -16,8 +16,11 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.test.ListMatcher.matchesList;
+import static org.elasticsearch.test.MapMatcher.matchesMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
 
@@ -47,6 +50,27 @@ public abstract class SemanticMatchTestCase extends ESRestTestCase {
 
         assertThat(re.getMessage(), containsString("Inference endpoint not found"));
         assertEquals(404, re.getResponse().getStatusLine().getStatusCode());
+    }
+
+    public void testCopyToWithSemanticText() throws IOException {
+        assumeTrue("semantic text capability not available", EsqlCapabilities.Cap.SEMANTIC_TEXT_FIELD_CAPS.isEnabled());
+
+        var request = new Request("POST", "/test-semantic4/_doc/id-1");
+        request.addParameter("refresh", "true");
+        request.setJsonEntity("{\"text_field\": \"inference test\"}");
+        assertEquals(201, adminClient().performRequest(request).getStatusLine().getStatusCode());
+
+        String query = """
+            from test-semantic4
+            """;
+        Map<String, Object> result = runEsqlQuery(query);
+
+        assertResultMap(
+            result,
+            matchesList().item(matchesMap().entry("name", "semantic_text_field").entry("type", "text"))
+                .item(matchesMap().entry("name", "text_field").entry("type", "text")),
+            List.of(List.of("inference test", "inference test"))
+        );
     }
 
     @Before
@@ -82,6 +106,20 @@ public abstract class SemanticMatchTestCase extends ESRestTestCase {
                  }
             """;
         createIndex(adminClient(), "test-semantic3", settings, mapping3);
+
+        String mapping4 = """
+                "properties": {
+                  "semantic_text_field": {
+                   "type": "semantic_text",
+                   "inference_id": "test_dense_inference"
+                  },
+                  "text_field": {
+                   "type": "text",
+                   "copy_to": "semantic_text_field"
+                  }
+                }
+            """;
+        createIndex(adminClient(), "test-semantic4", settings, mapping4);
     }
 
     @Before


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Unit test to validate copy_to for semantic_text field in esql (#128795)