### PR TITLE
[Gradle] Use variant aware resolution for deps on hfds-fixture

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -7,15 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import org.elasticsearch.gradle.internal.test.RestIntegTestTask
+
 import org.elasticsearch.gradle.OS
+import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 esplugin {
   description = 'The HDFS repository plugin adds support for Hadoop Distributed File-System (HDFS) repositories.'
-  classname ='org.elasticsearch.repositories.hdfs.HdfsPlugin'
+  classname = 'org.elasticsearch.repositories.hdfs.HdfsPlugin'
 }
 
 versions << [
@@ -23,10 +24,19 @@ versions << [
 ]
 
 def patched = Attribute.of('patched', Boolean)
+def hdfsVersionAttr = Attribute.of('hdfs.major.version', Integer)
 
 configurations {
-  hdfsFixture2
-  hdfsFixture3
+  hdfsFixture2 {
+    attributes {
+      attribute(hdfsVersionAttr, 2)
+    }
+  }
+  hdfsFixture3 {
+    attributes {
+      attribute(hdfsVersionAttr, 3)
+    }
+  }
   compileClasspath {
     attributes {
       attribute(patched, true)
@@ -82,8 +92,8 @@ dependencies {
   yamlRestTestRuntimeOnly "commons-cli:commons-cli:1.5.0"
   yamlRestTestRuntimeOnly "org.apache.logging.log4j:log4j-1.2-api:${versions.log4j}"
 
-  hdfsFixture2 project(path: ':test:fixtures:hdfs-fixture', configuration: 'shadowedHdfs2')
-  hdfsFixture3 project(path: ':test:fixtures:hdfs-fixture', configuration: 'shadow')
+  hdfsFixture2 project(':test:fixtures:hdfs-fixture')
+  hdfsFixture3 project(':test:fixtures:hdfs-fixture')
 
   attributesSchema {
     attribute(patched)

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -15,6 +15,8 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 def hdfs2patched = Attribute.of('hdfs2-patched', Boolean)
 def hdfs3patched = Attribute.of('hdfs3-patched', Boolean)
+def hdfsVersionAttr = Attribute.of('hdfs.major.version', Integer)
+
 configurations {
   hdfs2 {
     attributes {
@@ -26,7 +28,16 @@ configurations {
       attribute(hdfs3patched, true)
     }
   }
-  consumable("shadowedHdfs2")
+  consumable("shadowedHdfs2") {
+    attributes {
+      attribute(hdfsVersionAttr, 2)
+    }
+  }
+  consumable("shadowedHdfs3") {
+    attributes {
+      attribute(hdfsVersionAttr, 3)
+    }
+  }
 }
 
 dependencies {
@@ -165,4 +176,5 @@ tasks.withType(ShadowJar).configureEach {
 
 artifacts {
   shadowedHdfs2(hdfs2Jar)
+  shadowedHdfs3(tasks.named("shadowJar"))
 }

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -31,11 +31,21 @@ configurations {
   consumable("shadowedHdfs2") {
     attributes {
       attribute(hdfsVersionAttr, 2)
+      attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+      attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+      attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(buildParams.minimumRuntimeVersion.getMajorVersion()))
+      attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+      attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
     }
   }
   consumable("shadowedHdfs3") {
     attributes {
       attribute(hdfsVersionAttr, 3)
+      attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+      attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+      attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(buildParams.minimumRuntimeVersion.getMajorVersion()))
+      attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+      attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
     }
   }
 }

--- a/test/fixtures/krb5kdc-fixture/build.gradle
+++ b/test/fixtures/krb5kdc-fixture/build.gradle
@@ -25,14 +25,6 @@ configurations {
   all {
     exclude group: 'org.hamcrest', module: 'hamcrest-core'
   }
-  krb5ConfHdfsFile {
-    canBeConsumed = true
-    canBeResolved = false
-  }
-  krb5KeytabsHdfsDir {
-    canBeConsumed = true
-    canBeResolved = false
-  }
 }
 
 dependencies {

--- a/x-pack/plugin/searchable-snapshots/qa/hdfs/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/hdfs/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'elasticsearch.internal-available-ports'
 configurations {
   javaRestTestRuntimeClasspath {
     attributes {
-      attribute(Attribute.of('hdfs.major.version', Integer), 3)
+      attribute(Attribute.of('hdfs.major.version', Integer), 2)
     }
   }
 }
@@ -21,7 +21,7 @@ dependencies {
   clusterPlugins project(':plugins:repository-hdfs')
   javaRestTestImplementation(testArtifact(project(xpackModule('searchable-snapshots'))))
   javaRestTestCompileOnly project(path: ':test:fixtures:hdfs-fixture')
-  javaRestTestRuntimeOnly project(path: ':test:fixtures:hdfs-fixture', configuration:"shadowedHdfs2")
+  javaRestTestRuntimeOnly project(path: ':test:fixtures:hdfs-fixture')
   javaRestTestImplementation project(':test:fixtures:krb5kdc-fixture')
   javaRestTestRuntimeOnly "com.google.guava:guava:16.0.1"
   javaRestTestRuntimeOnly "commons-cli:commons-cli:1.2"

--- a/x-pack/plugin/searchable-snapshots/qa/hdfs/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/hdfs/build.gradle
@@ -9,6 +9,14 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 apply plugin: 'elasticsearch.internal-available-ports'
 
+configurations {
+  javaRestTestRuntimeClasspath {
+    attributes {
+      attribute(Attribute.of('hdfs.major.version', Integer), 3)
+    }
+  }
+}
+
 dependencies {
   clusterPlugins project(':plugins:repository-hdfs')
   javaRestTestImplementation(testArtifact(project(xpackModule('searchable-snapshots'))))

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/hdfs/build.gradle
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/hdfs/build.gradle
@@ -19,7 +19,7 @@ configurations {
 dependencies {
   javaRestTestImplementation testArtifact(project(xpackModule('snapshot-repo-test-kit')))
   javaRestTestCompileOnly project(path: ':test:fixtures:hdfs-fixture')
-  javaRestTestRuntimeOnly project(path: ':test:fixtures:hdfs-fixture', configuration: "shadow")
+  javaRestTestRuntimeOnly project(path: ':test:fixtures:hdfs-fixture')
   javaRestTestImplementation project(':test:fixtures:krb5kdc-fixture')
   javaRestTestImplementation "org.slf4j:slf4j-api:${versions.slf4j}"
   javaRestTestImplementation "org.slf4j:slf4j-simple:${versions.slf4j}"

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/hdfs/build.gradle
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/hdfs/build.gradle
@@ -8,10 +8,18 @@
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 
+configurations {
+  javaRestTestRuntimeClasspath {
+    attributes {
+      attribute(Attribute.of('hdfs.major.version', Integer), 3)
+    }
+  }
+}
+
 dependencies {
   javaRestTestImplementation testArtifact(project(xpackModule('snapshot-repo-test-kit')))
   javaRestTestCompileOnly project(path: ':test:fixtures:hdfs-fixture')
-  javaRestTestRuntimeOnly project(path: ':test:fixtures:hdfs-fixture', configuration:"shadow")
+  javaRestTestRuntimeOnly project(path: ':test:fixtures:hdfs-fixture', configuration: "shadow")
   javaRestTestImplementation project(':test:fixtures:krb5kdc-fixture')
   javaRestTestImplementation "org.slf4j:slf4j-api:${versions.slf4j}"
   javaRestTestImplementation "org.slf4j:slf4j-simple:${versions.slf4j}"


### PR DESCRIPTION
This reworks the dependency resolution for hdfs fixture dependencies to use gradles variant aware dependency resolution instead of relying on outgoing configuration names. 

See https://docs.gradle.org/current/userguide/how_to_share_outputs_between_projects.html for details 