### PR TITLE
Updating score assertions to use close_to instead of match for linear_retriever yml tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -531,9 +531,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test040JavaUsesTheOsProvidedKeystore
   issue: https://github.com/elastic/elasticsearch/issues/128230
-- class: org.elasticsearch.xpack.rank.rrf.LinearRankClientYamlTestSuiteIT
-  method: test {yaml=linear/10_linear_retriever/should normalize initial scores with l2_norm}
-  issue: https://github.com/elastic/elasticsearch/issues/128774
 - class: org.elasticsearch.index.codec.vectors.es818.ES818HnswBinaryQuantizedVectorsFormatTests
   method: testSimpleOffHeapSizeFSDir
   issue: https://github.com/elastic/elasticsearch/issues/128799

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/10_linear_retriever.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/linear/10_linear_retriever.yml
@@ -81,9 +81,9 @@ setup:
 
   - match: { hits.total.value: 2 }
   - match: { hits.hits.0._id: "1" }
-  - match: { hits.hits.0._score: 5.0 }
+  - close_to: { hits.hits.0._score: { value: 5.0, error: 0.001} }
   - match: { hits.hits.1._id: "4" }
-  - match: { hits.hits.1._score: 2.0 }
+  - close_to: { hits.hits.1._score: { value: 2.0, error: 0.001} }
 
 ---
 "basic linear weighted combination - interleaved results":
@@ -174,13 +174,13 @@ setup:
 
   - match: { hits.total.value: 4 }
   - match: { hits.hits.0._id: "1" }
-  - match: { hits.hits.0._score: 20.0 }
+  - close_to: { hits.hits.0._score: { value: 20.0, error: 0.001} }
   - match: { hits.hits.1._id: "3" }
-  - match: { hits.hits.1._score: 15.0 }
+  - close_to: { hits.hits.1._score: { value: 15.0, error: 0.001} }
   - match: { hits.hits.2._id: "4" }
-  - match: { hits.hits.2._score: 12.0 }
+  - close_to: { hits.hits.2._score: { value: 12.0, error: 0.001} }
   - match: { hits.hits.3._id: "2" }
-  - match: { hits.hits.3._score: 10.0 }
+  - close_to: { hits.hits.3._score: { value: 10.0, error: 0.001} }
 
 ---
 "should normalize initial scores":
@@ -256,12 +256,11 @@ setup:
 
   - match: { hits.total.value: 4 }
   - match: { hits.hits.0._id: "1" }
-  - match: {hits.hits.0._score: 10.0}
+  - close_to: { hits.hits.0._score: { value: 10.0, error: 0.001} }
   - match: { hits.hits.1._id: "2" }
-  - match: {hits.hits.1._score: 8.0}
+  - close_to: { hits.hits.1._score: { value: 8.0, error: 0.001} }
   - match: { hits.hits.2._id: "4" }
-  - match: {hits.hits.2._score: 2.0}
-  - match: { hits.hits.2._score: 2.0 }
+  - close_to: { hits.hits.2._score: { value: 2.0, error: 0.001} }
   - match: { hits.hits.3._id: "3" }
   - close_to: { hits.hits.3._score: { value: 0.0, error: 0.001 } }
 
@@ -310,13 +309,13 @@ setup:
 
   - match: { hits.total.value: 4 }
   - match: { hits.hits.0._id: "2" }
-  - match: { hits.hits.0._score: 8.0 }
+  - close_to: { hits.hits.0._score: { value: 8.0, error: 0.001} }
   - match: { hits.hits.1._id: "1" }
-  - match: { hits.hits.1._score: 6.0 }
+  - close_to: { hits.hits.1._score: { value: 6.0, error: 0.001} }
   - match: { hits.hits.2._id: "4" }
   - close_to: { hits.hits.2._score: { value: 1.6, error: 0.001 } }
   - match: { hits.hits.3._id: "3" }
-  - match: { hits.hits.3._score: 1.2 }
+  - close_to: { hits.hits.3._score: { value: 1.2, error: 0.001} }
 
 ---
 "should handle all zero scores in normalization":
@@ -514,7 +513,7 @@ setup:
   - match: { hits.total.value: 4 }
   - length: { hits.hits: 1 }
   - match: { hits.hits.0._id: "4" }
-  - match: { hits.hits.0._score: 2.0 }
+  - close_to: { hits.hits.0._score: { value: 2.0, error: 0.001} }
 
   - do:
       search:
@@ -703,9 +702,9 @@ setup:
 
   - match: { hits.total.value: 4 }
   - match: { hits.hits.0._id: "4" }
-  - match: { hits.hits.0._score: 2.0 }
+  - close_to: { hits.hits.0._score: { value: 2.0, error: 0.001} }
   - match: { hits.hits.1._id: "1" }
-  - match: { hits.hits.1._score: 1.0 }
+  - close_to: { hits.hits.1._score: { value: 1.0, error: 0.001} }
 
 ---
 "explain should provide info on weights and inner retrievers":
@@ -908,11 +907,11 @@ setup:
 
   - match: { hits.total.value: 3 }
   - match: { hits.hits.0._id: "2" }
-  - match: { hits.hits.0._score: 40.0 }
+  - close_to: { hits.hits.0._score: { value: 40.0, error: 0.001} }
   - match: { hits.hits.1._id: "1" }
-  - match: { hits.hits.1._score: 5.0 }
+  - close_to: { hits.hits.1._score: { value: 5.0, error: 0.001} }
   - match: { hits.hits.2._id: "4" }
-  - match: { hits.hits.2._score: 2.0 }
+  - close_to: { hits.hits.2._score: { value: 2.0, error: 0.001} }
 
 ---
 "linear retriever with filters":
@@ -962,7 +961,7 @@ setup:
   - match: { hits.total.value: 1 }
   - length: {hits.hits: 1}
   - match: { hits.hits.0._id: "4" }
-  - match: { hits.hits.0._score: 2.0 }
+  - close_to: { hits.hits.0._score: { value: 2.0, error: 0.001} }
 
 ---
 "linear retriever with filters on nested retrievers":
@@ -1013,7 +1012,7 @@ setup:
   - match: { hits.total.value: 1 }
   - length: {hits.hits: 1}
   - match: { hits.hits.0._id: "4" }
-  - match: { hits.hits.0._score: 2.0 }
+  - close_to: { hits.hits.0._score: { value: 2.0, error: 0.001} }
 
 
 ---
@@ -1150,7 +1149,7 @@ setup:
   - match: { hits.hits.0._id: "2" }
   - close_to: { hits.hits.0._score: { value: 1.5, error: 0.001 } }
   - match: { hits.hits.1._id: "1" }
-  - match: { hits.hits.1._score: 1 }
+  - close_to: { hits.hits.1._score: { value: 1, error: 0.001} }
 
 ---
 "should throw when rank_window_size is negative":
@@ -1222,4 +1221,4 @@ setup:
 
   - match: { hits.total.value: 1 }
   - match: { hits.hits.0._id: "1" }
-  - match: { hits.hits.0._score: 1.0 }
+  - close_to: { hits.hits.0._score: { value: 1.0, error: 0.001} }


### PR DESCRIPTION
This PR changes the score validation in linear retriever yaml tests from `match` to `close_to` to avoid arithmetic errors like the following: 
```
java.lang.AssertionError: Failure at [linear/10_linear_retriever:319]: field [hits.hits.3._score] doesn't match the expected value
Expected: <1.2>
     but: was <1.2000000476837158>
```

Closes https://github.com/elastic/elasticsearch/issues/128774