### PR TITLE
ES|QL: Split JOIN yaml tests so that non-alias queries run also on bwc

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -507,18 +507,6 @@ tests:
 - class: org.elasticsearch.index.store.DirectIOIT
   method: testDirectIOUsed
   issue: https://github.com/elastic/elasticsearch/issues/128829
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/190_lookup_join/alias-repeated-index}
-  issue: https://github.com/elastic/elasticsearch/issues/128849
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/190_lookup_join/alias-repeated-alias}
-  issue: https://github.com/elastic/elasticsearch/issues/128850
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/190_lookup_join/alias-pattern-single}
-  issue: https://github.com/elastic/elasticsearch/issues/128855
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/191_lookup_join_on_datastreams/data streams supported in LOOKUP JOIN}
-  issue: https://github.com/elastic/elasticsearch/issues/128856
 - class: org.elasticsearch.upgrades.IndexSortUpgradeIT
   method: testIndexSortForNumericTypes {upgradedNodes=3}
   issue: https://github.com/elastic/elasticsearch/issues/128861

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1164,7 +1164,7 @@ public class EsqlCapabilities {
         /**
          * Enable support for index aliases in lookup joins
          */
-        ENABLE_LOOKUP_JOIN_ON_ALIASES(JOIN_LOOKUP_V12.isEnabled());
+        ENABLE_LOOKUP_JOIN_ON_ALIASES;
 
         private final boolean enabled;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexService.java
@@ -203,7 +203,7 @@ public class LookupFromIndexService extends AbstractLookupService<LookupFromInde
                 || out.getTransportVersion().isPatchFrom(TransportVersions.JOIN_ON_ALIASES_8_19)) {
                 out.writeString(indexPattern);
             } else if (indexPattern.equals(shardId.getIndexName()) == false) {
-                throw new EsqlIllegalArgumentException("Aliases and index patterns are not allowed for LOOKUP JOIN []", indexPattern);
+                throw new EsqlIllegalArgumentException("Aliases and index patterns are not allowed for LOOKUP JOIN [{}]", indexPattern);
             }
 
             out.writeString(inputDataType.typeName());

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/192_lookup_join_on_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/192_lookup_join_on_aliases.yml
@@ -6,8 +6,8 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [join_lookup_v12]
-      reason: "uses LOOKUP JOIN"
+          capabilities: [enable_lookup_join_on_aliases]
+      reason: "uses LOOKUP JOIN on aliases"
   - do:
       indices.create:
         index: test
@@ -81,6 +81,19 @@ setup:
               color:
                 type: keyword
   - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - add:
+                index: test-lookup-1
+                alias: test-lookup-alias
+            - add:
+                index: test-lookup-*
+                alias: test-lookup-alias-pattern-multiple
+            - add:
+                index: test-lookup-1*
+                alias: test-lookup-alias-pattern-single
+  - do:
       bulk:
         index: "test"
         refresh: true
@@ -131,11 +144,11 @@ setup:
           - { "no-key": 2, "color": "yellow" }
 
 ---
-basic:
+alias-as-lookup-index:
   - do:
       esql.query:
         body:
-          query: 'FROM test | SORT key | LOOKUP JOIN test-lookup-1 ON key | LIMIT 3'
+          query: 'FROM test | SORT key | LOOKUP JOIN test-lookup-alias ON key | LIMIT 3'
 
   - match: {columns.0.name: "key"}
   - match: {columns.0.type: "long"}
@@ -145,48 +158,11 @@ basic:
   - match: {values.1: [2, "yellow"]}
 
 ---
-non-lookup index:
+alias-repeated-alias:
   - do:
       esql.query:
         body:
-          query: 'FROM test-lookup-1 | SORT key | LOOKUP JOIN test ON key | LIMIT 3'
-      catch: "bad_request"
-
-  - match: { error.type: "verification_exception" }
-  - contains: { error.reason: "Found 1 problem\nline 1:45: invalid [test] resolution in lookup mode to an index in [standard] mode" }
-
----
-pattern-multiple:
-  - do:
-      esql.query:
-        body:
-          query: 'FROM test-lookup-1 | LOOKUP JOIN test-lookup-* ON key'
-      catch: "bad_request"
-
-  - match: { error.type: "parsing_exception" }
-  - contains: { error.reason: "line 1:34: invalid index pattern [test-lookup-*], * is not allowed in LOOKUP JOIN" }
-
----
-pattern-single:
-  - do:
-      esql.query:
-        body:
-          query: 'FROM test | SORT key | LOOKUP JOIN test-lookup-1* ON key | LIMIT 3'
-      catch: "bad_request"
-
-  - match: { error.type: "parsing_exception" }
-  - contains: { error.reason: "line 1:36: invalid index pattern [test-lookup-1*], * is not allowed in LOOKUP JOIN" }
-
----
-mv-on-lookup:
-  - do:
-      esql.query:
-        body:
-          query: 'FROM test | SORT key | LOOKUP JOIN test-lookup-mv ON key'
-      allowed_warnings:
-        - "No limit defined, adding default limit of [1000]"
-        - "Line 1:24: evaluation of [LOOKUP JOIN test-lookup-mv ON key] failed, treating result as null. Only first 20 failures recorded."
-        - "Line 1:24: java.lang.IllegalArgumentException: LOOKUP JOIN encountered multi-value"
+          query: 'FROM test-lookup-alias | SORT key | LOOKUP JOIN test-lookup-alias ON key | LIMIT 3'
 
   - match: {columns.0.name: "key"}
   - match: {columns.0.type: "long"}
@@ -196,30 +172,40 @@ mv-on-lookup:
   - match: {values.1: [2, "yellow"]}
 
 ---
-mv-on-query:
+alias-repeated-index:
   - do:
       esql.query:
         body:
-          query: 'FROM test-mv | SORT key | LOOKUP JOIN test-lookup-1 ON key | LIMIT 4'
-      allowed_warnings:
-        - "Line 1:27: evaluation of [LOOKUP JOIN test-lookup-1 ON key] failed, treating result as null. Only first 20 failures recorded."
-        - "Line 1:27: java.lang.IllegalArgumentException: LOOKUP JOIN encountered multi-value"
+          query: 'FROM test-lookup-1 | SORT key | LOOKUP JOIN test-lookup-alias ON key | LIMIT 3'
 
   - match: {columns.0.name: "key"}
   - match: {columns.0.type: "long"}
   - match: {columns.1.name: "color"}
   - match: {columns.1.type: "keyword"}
-  - match: {values.0: [[0, 1, 2], null]}
-  - match: {values.1: [1, "cyan"]}
-  - match: {values.2: [2, "yellow"]}
+  - match: {values.0: [1, "cyan"]}
+  - match: {values.1: [2, "yellow"]}
 
 ---
-lookup-no-key:
+alias-pattern-multiple:
   - do:
       esql.query:
-          body:
-            query: 'FROM test | LOOKUP JOIN test-lookup-no-key ON key | KEEP key, color'
+        body:
+          query: 'FROM test-lookup-1 | LOOKUP JOIN test-lookup-alias-pattern-multiple ON key'
       catch: "bad_request"
 
   - match: { error.type: "verification_exception" }
-  - contains: { error.reason: "Unknown column [key] in right side of join" }
+  - contains: { error.reason: "Found 1 problem\nline 1:34: invalid [test-lookup-alias-pattern-multiple] resolution in lookup mode to [4] indices" }
+
+---
+alias-pattern-single:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test | SORT key | LOOKUP JOIN test-lookup-alias-pattern-single ON key | LIMIT 3'
+
+  - match: {columns.0.name: "key"}
+  - match: {columns.0.type: "long"}
+  - match: {columns.1.name: "color"}
+  - match: {columns.1.type: "keyword"}
+  - match: {values.0: [1, "cyan"]}
+  - match: {values.1: [2, "yellow"]}

--- a/x-pack/qa/multi-project/xpack-rest-tests-with-multiple-projects/build.gradle
+++ b/x-pack/qa/multi-project/xpack-rest-tests-with-multiple-projects/build.gradle
@@ -46,6 +46,7 @@ tasks.named("yamlRestTest").configure {
     '^esql/190_lookup_join/*',
     '^esql/191_lookup_join_on_datastreams/*',
     '^esql/191_lookup_join_text/*',
+    '^esql/192_lookup_join_on_aliases/*',
     '^health/10_usage/*',
     '^ilm/10_basic/Test Undeletable Policy In Use',
     '^ilm/20_move_to_step/*',


### PR DESCRIPTION
Making JOIN yaml tests more granular (lookup on aliases in its own yml file), so that they keep running on bwc.
Also fixing an error message.

Fixes: https://github.com/elastic/elasticsearch/issues/128850
Fixes: https://github.com/elastic/elasticsearch/issues/128849
Fixes: https://github.com/elastic/elasticsearch/issues/128856
Fixes: https://github.com/elastic/elasticsearch/issues/128855