### PR TITLE
Fix for dissect processor overeager delimiter consumption

### DIFF
--- a/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectParser.java
+++ b/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectParser.java
@@ -227,7 +227,7 @@ public final class DissectParser {
                         // jump to the end of the match
                         i += lookAheadMatches;
                         // look for consecutive delimiters (e.g. a,,,,d,e)
-                        while (i < input.length) {
+                        while (dissectPair.key.skipRightPadding() && i < input.length) {
                             lookAheadMatches = 0;
                             for (int j = 0; j < delimiter.length; j++) {
                                 if (i + j < input.length && input[i + j] == delimiter[j]) {
@@ -238,16 +238,6 @@ public final class DissectParser {
                             if (lookAheadMatches == delimiter.length) {
                                 // jump to the end of the match
                                 i += lookAheadMatches;
-                                if (key.skipRightPadding() == false) {
-                                    // progress the keys/delimiter if possible
-                                    if (it.hasNext() == false) {
-                                        break; // the while loop
-                                    }
-                                    dissectPair = it.next();
-                                    key = dissectPair.key();
-                                    // add the key with an empty value for the empty delimiter
-                                    dissectMatch.add(key, "");
-                                }
                             } else {
                                 break; // the while loop
                             }

--- a/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
+++ b/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
@@ -316,7 +316,7 @@ public class DissectParserTests extends ESTestCase {
     }
 
     public void testAppendWithConsecutiveDelimiters() {
-        assertMatch("%{+a/1},%{+a/3}-%{+a/2} %{b}", "foo,bar----baz lol", Arrays.asList("a", "b"), Arrays.asList("foobar", ""));
+        assertMatch("%{+a/1},%{+a/3}-%{+a/2} %{b}", "foo,bar----baz lol", Arrays.asList("a", "b"), Arrays.asList("foo---bazbar", "lol"));
         assertMatch("%{+a/1},%{+a/3->}-%{+a/2} %{b}", "foo,bar----baz lol", Arrays.asList("a", "b"), Arrays.asList("foobazbar", "lol"));
     }
 
@@ -474,6 +474,12 @@ public class DissectParserTests extends ESTestCase {
         assertThat(new DissectParser("%{*a} %{&a}", "").referenceKeys(), contains("a"));
         assertThat(new DissectParser("%{a} %{b} %{*c} %{&c}", "").referenceKeys(), contains("c"));
         assertThat(new DissectParser("%{a} %{b} %{*c} %{&c} %{*d} %{&d}", "").referenceKeys(), contains("c", "d"));
+    }
+
+    // Test for elasticsearch#119264
+    public void testConcurrentDelimitersAdditional() {
+        assertMatch("%{a}-%{b}", "foo------bar", Arrays.asList("a", "b"), Arrays.asList("foo", "-----bar"));
+        assertMatch("%{}|%{}|foo=%{field}", "||foo=bar", Arrays.asList("field"), Arrays.asList("bar"));
     }
 
     private DissectException assertFail(String pattern, String input) {


### PR DESCRIPTION
This PR addresses #119264 and the overly greedy consumption of delimiters by the ES implementation of the dissect processor.

This code modifies the implementation to correctly match the spec and only attempts to greedily consume repeated delimiters if the skip right padding operator is used.

In the process of this, 2 new unit tests were created to highlight the current incorrect behaviour and one tests which did not match the specification was modified to correctly reflect the desired behaviour.

To ensure our implementation aligns with the rest of the product stack, https://github.com/logstash-plugins/logstash-filter-dissect/pull/92 was merged to add the new units tests to Logstash's implimentation of Disect where it passed without the issues raised in #119264, further indicating that our current implementation is faulty.