### PR TITLE
[8.19] Remove sync from `ConnectionTarget#toString` (#128656)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
@@ -342,9 +342,7 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
 
         @Override
         public String toString() {
-            synchronized (mutex) {
-                return "ConnectionTarget{" + "discoveryNode=" + discoveryNode + '}';
-            }
+            return "ConnectionTarget{discoveryNode=" + discoveryNode + '}';
         }
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Remove sync from `ConnectionTarget#toString` (#128656)