### PR TITLE
[8.19] Readd `index.lifecycle.skip` setting (#128736)

### DIFF
--- a/docs/changelog/128736.yaml
+++ b/docs/changelog/128736.yaml
@@ -1,0 +1,5 @@
+pr: 128736
+summary: Add `index.lifecycle.skip` index-scoped setting to instruct ILM to skip processing specific indices
+area: ILM+SLM
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -233,6 +233,7 @@ public class TransportVersions {
     public static final TransportVersion IDP_CUSTOM_SAML_ATTRIBUTES_ADDED_8_19 = def(8_841_0_40);
     public static final TransportVersion DATA_STREAM_OPTIONS_API_REMOVE_INCLUDE_DEFAULTS_8_19 = def(8_841_0_41);
     public static final TransportVersion JOIN_ON_ALIASES_8_19 = def(8_841_0_42);
+    public static final TransportVersion ILM_ADD_SKIP_SETTING_8_19 = def(8_841_0_43);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleSettings.java
@@ -23,6 +23,7 @@ public class LifecycleSettings {
     public static final String LIFECYCLE_STEP_MASTER_TIMEOUT = "indices.lifecycle.step.master_timeout";
     public static final String LIFECYCLE_STEP_WAIT_TIME_THRESHOLD = "index.lifecycle.step.wait_time_threshold";
     public static final String LIFECYCLE_ROLLOVER_ONLY_IF_HAS_DOCUMENTS = "indices.lifecycle.rollover.only_if_has_documents";
+    public static final String LIFECYCLE_SKIP = "index.lifecycle.skip";
 
     public static final String SLM_HISTORY_INDEX_ENABLED = "slm.history_index_enabled";
     public static final String SLM_RETENTION_SCHEDULE = "slm.retention_schedule";
@@ -81,6 +82,12 @@ public class LifecycleSettings {
         Setting.Property.Dynamic,
         Setting.Property.NodeScope,
         Setting.Property.DeprecatedWarning
+    );
+    public static final Setting<Boolean> LIFECYCLE_SKIP_SETTING = Setting.boolSetting(
+        LIFECYCLE_SKIP,
+        false,
+        Setting.Property.Dynamic,
+        Setting.Property.IndexScope
     );
 
     public static final Setting<Boolean> SLM_HISTORY_INDEX_ENABLED_SETTING = Setting.boolSetting(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponseTests.java
@@ -74,7 +74,8 @@ public class IndexLifecycleExplainResponseTests extends AbstractXContentSerializ
             stepNull ? null : randomAlphaOfLength(10),
             randomBoolean() ? null : new BytesArray(new RandomStepInfo(() -> randomAlphaOfLength(10)).toString()),
             randomBoolean() ? null : new BytesArray(new RandomStepInfo(() -> randomAlphaOfLength(10)).toString()),
-            randomBoolean() ? null : PhaseExecutionInfoTests.randomPhaseExecutionInfo("")
+            randomBoolean() ? null : PhaseExecutionInfoTests.randomPhaseExecutionInfo(""),
+            randomBoolean()
         );
     }
 
@@ -101,7 +102,8 @@ public class IndexLifecycleExplainResponseTests extends AbstractXContentSerializ
                 randomBoolean() ? null : randomAlphaOfLength(10),
                 randomBoolean() ? null : new BytesArray(new RandomStepInfo(() -> randomAlphaOfLength(10)).toString()),
                 randomBoolean() ? null : new BytesArray(new RandomStepInfo(() -> randomAlphaOfLength(10)).toString()),
-                randomBoolean() ? null : PhaseExecutionInfoTests.randomPhaseExecutionInfo("")
+                randomBoolean() ? null : PhaseExecutionInfoTests.randomPhaseExecutionInfo(""),
+                randomBoolean()
             )
         );
         assertThat(exception.getMessage(), startsWith("managed index response must have complete step details"));
@@ -135,7 +137,8 @@ public class IndexLifecycleExplainResponseTests extends AbstractXContentSerializ
             null,
             null,
             null,
-            null
+            null,
+            false
         );
         assertThat(managedExplainResponse.getLifecycleDate(), is(notNullValue()));
         Long now = 1_000_000L;
@@ -196,9 +199,10 @@ public class IndexLifecycleExplainResponseTests extends AbstractXContentSerializ
         BytesReference stepInfo = instance.getStepInfo();
         BytesReference previousStepInfo = instance.getPreviousStepInfo();
         PhaseExecutionInfo phaseExecutionInfo = instance.getPhaseExecutionInfo();
+        boolean skip = instance.getSkip();
 
         if (managed) {
-            switch (between(0, 15)) {
+            switch (between(0, 16)) {
                 case 0 -> index += randomAlphaOfLengthBetween(1, 5);
                 case 1 -> policy += randomAlphaOfLengthBetween(1, 5);
                 case 2 -> {
@@ -257,6 +261,7 @@ public class IndexLifecycleExplainResponseTests extends AbstractXContentSerializ
                 case 13 -> repositoryName = randomValueOtherThan(repositoryName, () -> randomAlphaOfLengthBetween(5, 10));
                 case 14 -> snapshotName = randomValueOtherThan(snapshotName, () -> randomAlphaOfLengthBetween(5, 10));
                 case 15 -> shrinkIndexName = randomValueOtherThan(shrinkIndexName, () -> randomAlphaOfLengthBetween(5, 10));
+                case 16 -> skip = skip == false;
                 default -> throw new AssertionError("Illegal randomisation branch");
             }
 
@@ -279,7 +284,8 @@ public class IndexLifecycleExplainResponseTests extends AbstractXContentSerializ
                 shrinkIndexName,
                 stepInfo,
                 previousStepInfo,
-                phaseExecutionInfo
+                phaseExecutionInfo,
+                skip
             );
         } else {
             return switch (between(0, 1)) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -128,6 +128,7 @@ public class IndexLifecycle extends Plugin implements ActionPlugin, HealthPlugin
             LifecycleSettings.LIFECYCLE_STEP_MASTER_TIMEOUT_SETTING,
             LifecycleSettings.LIFECYCLE_STEP_WAIT_TIME_THRESHOLD_SETTING,
             LifecycleSettings.LIFECYCLE_ROLLOVER_ONLY_IF_HAS_DOCUMENTS_SETTING,
+            LifecycleSettings.LIFECYCLE_SKIP_SETTING,
             RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING,
             IlmHealthIndicatorService.MAX_TIME_ON_ACTION_SETTING,
             IlmHealthIndicatorService.MAX_TIME_ON_STEP_SETTING,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.core.ilm.AsyncWaitStep;
 import org.elasticsearch.xpack.core.ilm.ClusterStateActionStep;
 import org.elasticsearch.xpack.core.ilm.ClusterStateWaitStep;
 import org.elasticsearch.xpack.core.ilm.ErrorStep;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.PhaseCompleteStep;
 import org.elasticsearch.xpack.core.ilm.Step;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
@@ -176,6 +177,10 @@ class IndexLifecycleRunner {
      */
     void runPeriodicStep(String policy, Metadata metadata, IndexMetadata indexMetadata) {
         String index = indexMetadata.getIndex().getName();
+        if (LifecycleSettings.LIFECYCLE_SKIP_SETTING.get(indexMetadata.getSettings())) {
+            logger.info("[{}] skipping policy [{}] because [{}] is true", index, policy, LifecycleSettings.LIFECYCLE_SKIP);
+            return;
+        }
         LifecycleExecutionState lifecycleState = indexMetadata.getLifecycleExecutionState();
         final Step currentStep;
         try {
@@ -303,6 +308,10 @@ class IndexLifecycleRunner {
      */
     void maybeRunAsyncAction(ClusterState currentState, IndexMetadata indexMetadata, String policy, StepKey expectedStepKey) {
         String index = indexMetadata.getIndex().getName();
+        if (LifecycleSettings.LIFECYCLE_SKIP_SETTING.get(indexMetadata.getSettings())) {
+            logger.info("[{}] skipping policy [{}] because [{}] is true", index, policy, LifecycleSettings.LIFECYCLE_SKIP);
+            return;
+        }
         LifecycleExecutionState lifecycleState = indexMetadata.getLifecycleExecutionState();
         final Step currentStep;
         try {
@@ -383,6 +392,10 @@ class IndexLifecycleRunner {
      */
     void runPolicyAfterStateChange(String policy, IndexMetadata indexMetadata) {
         String index = indexMetadata.getIndex().getName();
+        if (LifecycleSettings.LIFECYCLE_SKIP_SETTING.get(indexMetadata.getSettings())) {
+            logger.info("[{}] skipping policy [{}] because [{}] is true", index, policy, LifecycleSettings.LIFECYCLE_SKIP);
+            return;
+        }
         LifecycleExecutionState lifecycleState = indexMetadata.getLifecycleExecutionState();
         final StepKey currentStepKey = Step.getCurrentStepKey(lifecycleState);
         if (busyIndices.contains(Tuple.tuple(indexMetadata.getIndex(), currentStepKey))) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
@@ -477,6 +477,7 @@ public final class IndexLifecycleTransition {
 
         notChanged &= Strings.isNullOrEmpty(newSettings.remove(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()));
         notChanged &= Strings.isNullOrEmpty(newSettings.remove(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE_SETTING.getKey()));
+        notChanged &= Strings.isNullOrEmpty(newSettings.remove(LifecycleSettings.LIFECYCLE_SKIP_SETTING.getKey()));
         notChanged &= Strings.isNullOrEmpty(newSettings.remove(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING.getKey()));
         long newSettingsVersion = notChanged ? indexMetadata.getSettingsVersion() : 1 + indexMetadata.getSettingsVersion();
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
@@ -188,7 +188,8 @@ public class TransportExplainLifecycleAction extends TransportClusterInfoAction<
                     lifecycleState.shrinkIndexName(),
                     stepInfoBytes,
                     previousStepInfoBytes,
-                    phaseExecutionInfo
+                    phaseExecutionInfo,
+                    LifecycleSettings.LIFECYCLE_SKIP_SETTING.get(idxSettings)
                 );
             } else {
                 indexResponse = null;

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -137,11 +137,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         PolicyStepsRegistry stepRegistry = createOneStepPolicyStepRegistry(policyName, step);
         ClusterService clusterService = mock(ClusterService.class);
         IndexLifecycleRunner runner = new IndexLifecycleRunner(stepRegistry, historyStore, clusterService, threadPool, () -> 0L);
-        IndexMetadata indexMetadata = IndexMetadata.builder("my_index")
-            .settings(settings(IndexVersion.current()))
-            .numberOfShards(randomIntBetween(1, 5))
-            .numberOfReplicas(randomIntBetween(0, 5))
-            .build();
+        IndexMetadata indexMetadata = createIndex("my_index");
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
 
@@ -155,11 +151,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         PolicyStepsRegistry stepRegistry = createOneStepPolicyStepRegistry(policyName, step);
         ClusterService clusterService = mock(ClusterService.class);
         IndexLifecycleRunner runner = new IndexLifecycleRunner(stepRegistry, historyStore, clusterService, threadPool, () -> 0L);
-        IndexMetadata indexMetadata = IndexMetadata.builder("my_index")
-            .settings(settings(IndexVersion.current()))
-            .numberOfShards(randomIntBetween(1, 5))
-            .numberOfReplicas(randomIntBetween(0, 5))
-            .build();
+        IndexMetadata indexMetadata = createIndex("my_index");
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
         runner.runPeriodicStep(policyName, Metadata.builder().put(indexMetadata, true).build(), indexMetadata);
@@ -185,11 +177,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         ClusterService clusterService = mock(ClusterService.class);
         MasterServiceTaskQueue<IndexLifecycleClusterStateUpdateTask> taskQueue = newMockTaskQueue(clusterService);
         IndexLifecycleRunner runner = new IndexLifecycleRunner(stepRegistry, historyStore, clusterService, threadPool, () -> 0L);
-        IndexMetadata indexMetadata = IndexMetadata.builder("my_index")
-            .settings(settings(IndexVersion.current()))
-            .numberOfShards(randomIntBetween(1, 5))
-            .numberOfReplicas(randomIntBetween(0, 5))
-            .build();
+        IndexMetadata indexMetadata = createIndex("my_index");
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
         runner.runPeriodicStep(policyName, Metadata.builder().put(indexMetadata, true).build(), indexMetadata);
@@ -219,13 +207,53 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         newState.setStep(ErrorStep.NAME);
         newState.setPhaseDefinition(phaseJson);
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
-            .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .settings(randomIndexSettings())
             .putCustom(ILM_CUSTOM_METADATA_KEY, newState.build().asMap())
-            .numberOfShards(randomIntBetween(1, 5))
-            .numberOfReplicas(randomIntBetween(0, 5))
             .build();
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
+
+        Mockito.verify(clusterService).createTaskQueue(anyString(), any(Priority.class), any());
+        Mockito.verifyNoMoreInteractions(clusterService);
+    }
+
+    public void testSkip_afterStateChange() {
+        final var policyName = randomAlphaOfLength(10);
+        ClusterService clusterService = mock(ClusterService.class);
+        final var runner = new IndexLifecycleRunner(null, null, clusterService, null, () -> 0L);
+        final var index = IndexMetadata.builder(randomAlphaOfLength(5))
+            .settings(randomIndexSettings().put(LifecycleSettings.LIFECYCLE_SKIP, true))
+            .build();
+
+        runner.runPolicyAfterStateChange(policyName, index);
+
+        Mockito.verify(clusterService).createTaskQueue(anyString(), any(Priority.class), any());
+        Mockito.verifyNoMoreInteractions(clusterService);
+    }
+
+    public void testSkip_periodicRun() {
+        final var policyName = randomAlphaOfLength(10);
+        ClusterService clusterService = mock(ClusterService.class);
+        final var runner = new IndexLifecycleRunner(null, null, clusterService, null, () -> 0L);
+        final var index = IndexMetadata.builder(randomAlphaOfLength(5))
+            .settings(randomIndexSettings().put(LifecycleSettings.LIFECYCLE_SKIP, true))
+            .build();
+
+        runner.runPeriodicStep(policyName, null, index);
+
+        Mockito.verify(clusterService).createTaskQueue(anyString(), any(Priority.class), any());
+        Mockito.verifyNoMoreInteractions(clusterService);
+    }
+
+    public void testSkip_asyncAction() {
+        final var policyName = randomAlphaOfLength(10);
+        ClusterService clusterService = mock(ClusterService.class);
+        final var runner = new IndexLifecycleRunner(null, null, clusterService, null, () -> 0L);
+        final var index = IndexMetadata.builder(randomAlphaOfLength(5))
+            .settings(randomIndexSettings().put(LifecycleSettings.LIFECYCLE_SKIP, true))
+            .build();
+
+        runner.maybeRunAsyncAction(null, index, policyName, null);
 
         Mockito.verify(clusterService).createTaskQueue(anyString(), any(Priority.class), any());
         Mockito.verifyNoMoreInteractions(clusterService);
@@ -263,10 +291,8 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         newState.setStep(ErrorStep.NAME);
         newState.setPhaseDefinition(phaseJson);
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
-            .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .settings(randomIndexSettings().put(LifecycleSettings.LIFECYCLE_NAME, policyName))
             .putCustom(ILM_CUSTOM_METADATA_KEY, newState.build().asMap())
-            .numberOfShards(randomIntBetween(1, 5))
-            .numberOfReplicas(randomIntBetween(0, 5))
             .build();
 
         runner.runPeriodicStep(policyName, Metadata.builder().put(indexMetadata, true).build(), indexMetadata);
@@ -281,7 +307,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         PolicyStepsRegistry stepRegistry = createOneStepPolicyStepRegistry(policyName, step);
         ThreadPool threadPool = new TestThreadPool("name");
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
-            .settings(indexSettings(IndexVersion.current(), 1, 1).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .settings(randomIndexSettings().put(LifecycleSettings.LIFECYCLE_NAME, policyName))
             .build();
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
         DiscoveryNode node = clusterService.localNode();
@@ -332,7 +358,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             .setStep("cluster_state_action_step")
             .build();
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
-            .settings(indexSettings(IndexVersion.current(), 1, 1).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .settings(randomIndexSettings().put(LifecycleSettings.LIFECYCLE_NAME, policyName))
             .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, les.asMap())
             .build();
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
@@ -419,7 +445,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             .setStep("cluster_state_action_step")
             .build();
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
-            .settings(indexSettings(IndexVersion.current(), 1, 1).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .settings(randomIndexSettings().put(LifecycleSettings.LIFECYCLE_NAME, policyName))
             .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, les.asMap())
             .build();
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
@@ -469,7 +495,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         PolicyStepsRegistry stepRegistry = createOneStepPolicyStepRegistry(policyName, step);
         ThreadPool threadPool = new TestThreadPool("name");
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
-            .settings(indexSettings(IndexVersion.current(), 1, 1).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .settings(randomIndexSettings().put(LifecycleSettings.LIFECYCLE_NAME, policyName))
             .build();
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
         DiscoveryNode node = clusterService.localNode();
@@ -518,7 +544,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             .setStep("cluster_state_action_step")
             .build();
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
-            .settings(indexSettings(IndexVersion.current(), 1, 1).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .settings(randomIndexSettings().put(LifecycleSettings.LIFECYCLE_NAME, policyName))
             .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, les.asMap())
             .build();
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
@@ -595,7 +621,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             .setStep("cluster_state_action_step")
             .build();
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
-            .settings(indexSettings(IndexVersion.current(), 1, 1).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .settings(randomIndexSettings().put(LifecycleSettings.LIFECYCLE_NAME, policyName))
             .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, les.asMap())
             .build();
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
@@ -633,11 +659,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         ClusterService clusterService = mock(ClusterService.class);
         MasterServiceTaskQueue<IndexLifecycleClusterStateUpdateTask> taskQueue = newMockTaskQueue(clusterService);
         IndexLifecycleRunner runner = new IndexLifecycleRunner(stepRegistry, historyStore, clusterService, threadPool, () -> 0L);
-        IndexMetadata indexMetadata = IndexMetadata.builder("my_index")
-            .settings(settings(IndexVersion.current()))
-            .numberOfShards(randomIntBetween(1, 5))
-            .numberOfReplicas(randomIntBetween(0, 5))
-            .build();
+        IndexMetadata indexMetadata = createIndex("my_index");
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
 
@@ -662,11 +684,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         ClusterService clusterService = mock(ClusterService.class);
         MasterServiceTaskQueue<IndexLifecycleClusterStateUpdateTask> taskQueue = newMockTaskQueue(clusterService);
         IndexLifecycleRunner runner = new IndexLifecycleRunner(stepRegistry, historyStore, clusterService, threadPool, () -> 0L);
-        IndexMetadata indexMetadata = IndexMetadata.builder("my_index")
-            .settings(settings(IndexVersion.current()))
-            .numberOfShards(randomIntBetween(1, 5))
-            .numberOfReplicas(randomIntBetween(0, 5))
-            .build();
+        IndexMetadata indexMetadata = createIndex("my_index");
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
 
@@ -692,11 +710,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         PolicyStepsRegistry stepRegistry = createOneStepPolicyStepRegistry(policyName, step);
         ClusterService clusterService = mock(ClusterService.class);
         IndexLifecycleRunner runner = new IndexLifecycleRunner(stepRegistry, historyStore, clusterService, threadPool, () -> 0L);
-        IndexMetadata indexMetadata = IndexMetadata.builder("my_index")
-            .settings(settings(IndexVersion.current()))
-            .numberOfShards(randomIntBetween(1, 5))
-            .numberOfReplicas(randomIntBetween(0, 5))
-            .build();
+        IndexMetadata indexMetadata = createIndex("my_index");
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
 
@@ -714,11 +728,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         PolicyStepsRegistry stepRegistry = createOneStepPolicyStepRegistry(policyName, step);
         ClusterService clusterService = mock(ClusterService.class);
         IndexLifecycleRunner runner = new IndexLifecycleRunner(stepRegistry, historyStore, clusterService, threadPool, () -> 0L);
-        IndexMetadata indexMetadata = IndexMetadata.builder("my_index")
-            .settings(settings(IndexVersion.current()))
-            .numberOfShards(randomIntBetween(1, 5))
-            .numberOfReplicas(randomIntBetween(0, 5))
-            .build();
+        IndexMetadata indexMetadata = createIndex("my_index");
 
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
 
@@ -738,11 +748,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             threadPool,
             () -> 0L
         );
-        IndexMetadata indexMetadata = IndexMetadata.builder("my_index")
-            .settings(settings(IndexVersion.current()))
-            .numberOfShards(randomIntBetween(1, 5))
-            .numberOfReplicas(randomIntBetween(0, 5))
-            .build();
+        IndexMetadata indexMetadata = createIndex("my_index");
         // verify that no exception is thrown
         runner.runPolicyAfterStateChange(policyName, indexMetadata);
         final SetStepInfoUpdateTaskMatcher taskMatcher = new SetStepInfoUpdateTaskMatcher(
@@ -789,7 +795,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         String phaseJson = Strings.toString(pei);
         LifecycleAction action = randomValueOtherThan(MigrateAction.DISABLED, () -> randomFrom(phase.getActions().values()));
         Step step = randomFrom(action.toSteps(client, phaseName, MOCK_STEP_KEY, null));
-        Settings indexSettings = indexSettings(IndexVersion.current(), 1, 0).put(LifecycleSettings.LIFECYCLE_NAME, policyName).build();
+        Settings indexSettings = randomIndexSettings().put(LifecycleSettings.LIFECYCLE_NAME, policyName).build();
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setPhaseDefinition(phaseJson);
         lifecycleState.setPhase(step.getKey().phase());
@@ -845,11 +851,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         ClusterService clusterService = mock(ClusterService.class);
         final AtomicLong now = new AtomicLong(5);
         IndexLifecycleRunner runner = new IndexLifecycleRunner(policyStepsRegistry, historyStore, clusterService, threadPool, now::get);
-        IndexMetadata indexMetadata = IndexMetadata.builder("my_index")
-            .settings(settings(IndexVersion.current()))
-            .numberOfShards(randomIntBetween(1, 5))
-            .numberOfReplicas(randomIntBetween(0, 5))
-            .build();
+        IndexMetadata indexMetadata = createIndex("my_index");
         // With no time, always transition
         assertTrue(
             "index should be able to transition with no creation date",
@@ -944,6 +946,14 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         assertEquals(now, newLifecycleState.stepTime().longValue());
         assertEquals(null, newLifecycleState.failedStep());
         assertEquals(null, newLifecycleState.stepInfo());
+    }
+
+    private static IndexMetadata createIndex(String name) {
+        return IndexMetadata.builder(name).settings(randomIndexSettings()).build();
+    }
+
+    private static Settings.Builder randomIndexSettings() {
+        return indexSettings(IndexVersion.current(), randomIntBetween(1, 5), randomIntBetween(0, 5));
     }
 
     static class MockAsyncActionStep extends AsyncActionStep {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
@@ -1307,6 +1307,7 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         assertFalse(LifecycleSettings.LIFECYCLE_NAME_SETTING.exists(indexSettings));
         assertFalse(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING.exists(indexSettings));
         assertFalse(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE_SETTING.exists(indexSettings));
+        assertFalse(LifecycleSettings.LIFECYCLE_SKIP_SETTING.exists(indexSettings));
     }
 
     public static void assertClusterStateOnNextStep(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Readd `index.lifecycle.skip` setting (#128736)](https://github.com/elastic/elasticsearch/pull/128736)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)