### PR TITLE
ES|QL: Split JOIN yaml tests so that non-alias queries run also on bwc

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -904,7 +904,7 @@ public class EsqlCapabilities {
         /**
          * Enable support for index aliases in lookup joins
          */
-        ENABLE_LOOKUP_JOIN_ON_ALIASES(JOIN_LOOKUP_V12.isEnabled()),
+        ENABLE_LOOKUP_JOIN_ON_ALIASES,
 
         /**
          * Allow lookup join on mixed numeric fields, among byte, short, int, long, half_float, scaled_float, float and double.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexService.java
@@ -190,7 +190,7 @@ public class LookupFromIndexService extends AbstractLookupService<LookupFromInde
             if (out.getTransportVersion().onOrAfter(TransportVersions.JOIN_ON_ALIASES_8_19)) {
                 out.writeString(indexPattern);
             } else if (indexPattern.equals(shardId.getIndexName()) == false) {
-                throw new EsqlIllegalArgumentException("Aliases and index patterns are not allowed for LOOKUP JOIN []", indexPattern);
+                throw new EsqlIllegalArgumentException("Aliases and index patterns are not allowed for LOOKUP JOIN [{}]", indexPattern);
             }
 
             out.writeString(inputDataType.typeName());

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
@@ -6,7 +6,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [join_lookup_v12, enable_lookup_join_on_aliases]
+          capabilities: [join_lookup_v12]
       reason: "uses LOOKUP JOIN"
   - do:
       indices.create:
@@ -44,19 +44,6 @@ setup:
                 type: long
               color:
                 type: keyword
-  - do:
-      indices.update_aliases:
-        body:
-          actions:
-            - add:
-                index: test-lookup-1
-                alias: test-lookup-alias
-            - add:
-                index: test-lookup-*
-                alias: test-lookup-alias-pattern-multiple
-            - add:
-                index: test-lookup-1*
-                alias: test-lookup-alias-pattern-single
   - do:
       bulk:
         index: "test"
@@ -100,76 +87,6 @@ non-lookup index:
 
   - match: { error.type: "verification_exception" }
   - contains: { error.reason: "Found 1 problem\nline 1:45: invalid [test] resolution in lookup mode to an index in [standard] mode" }
-
----
-
-"Alias as lookup index":
-  - skip:
-      awaits_fix: "LOOKUP JOIN does not support index aliases for now"
-  - do:
-      esql.query:
-        body:
-          query: 'FROM test | SORT key | LOOKUP JOIN test-lookup-alias ON key | LIMIT 3'
-
-  - match: {columns.0.name: "key"}
-  - match: {columns.0.type: "long"}
-  - match: {columns.1.name: "color"}
-  - match: {columns.1.type: "keyword"}
-  - match: {values.0: [1, "cyan"]}
-  - match: {values.1: [2, "yellow"]}
-
----
-alias-repeated-alias:
-  - do:
-      esql.query:
-        body:
-          query: 'FROM test-lookup-alias | SORT key | LOOKUP JOIN test-lookup-alias ON key | LIMIT 3'
-
-  - match: {columns.0.name: "key"}
-  - match: {columns.0.type: "long"}
-  - match: {columns.1.name: "color"}
-  - match: {columns.1.type: "keyword"}
-  - match: {values.0: [1, "cyan"]}
-  - match: {values.1: [2, "yellow"]}
-
----
-alias-repeated-index:
-  - do:
-      esql.query:
-        body:
-          query: 'FROM test-lookup-1 | SORT key | LOOKUP JOIN test-lookup-alias ON key | LIMIT 3'
-
-  - match: {columns.0.name: "key"}
-  - match: {columns.0.type: "long"}
-  - match: {columns.1.name: "color"}
-  - match: {columns.1.type: "keyword"}
-  - match: {values.0: [1, "cyan"]}
-  - match: {values.1: [2, "yellow"]}
-
----
-alias-pattern-multiple:
-  - do:
-      esql.query:
-        body:
-          query: 'FROM test-lookup-1 | LOOKUP JOIN test-lookup-alias-pattern-multiple ON key'
-      catch: "bad_request"
-
-  - match: { error.type: "verification_exception" }
-  - contains: { error.reason: "Found 1 problem\nline 1:34: invalid [test-lookup-alias-pattern-multiple] resolution in lookup mode to [2] indices" }
-
----
-alias-pattern-single:
-  - do:
-      esql.query:
-        body:
-          query: 'FROM test | SORT key | LOOKUP JOIN test-lookup-alias-pattern-single ON key | LIMIT 3'
-
-  - match: {columns.0.name: "key"}
-  - match: {columns.0.type: "long"}
-  - match: {columns.1.name: "color"}
-  - match: {columns.1.type: "keyword"}
-  - match: {values.0: [1, "cyan"]}
-  - match: {values.1: [2, "yellow"]}
 
 ---
 pattern-multiple:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/192_lookup_join_on_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/192_lookup_join_on_aliases.yml
@@ -194,7 +194,7 @@ alias-pattern-multiple:
       catch: "bad_request"
 
   - match: { error.type: "verification_exception" }
-  - contains: { error.reason: "Found 1 problem\nline 1:34: invalid [test-lookup-alias-pattern-multiple] resolution in lookup mode to [2] indices" }
+  - contains: { error.reason: "Found 1 problem\nline 1:34: invalid [test-lookup-alias-pattern-multiple] resolution in lookup mode to [4] indices" }
 
 ---
 alias-pattern-single:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/192_lookup_join_on_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/192_lookup_join_on_aliases.yml
@@ -1,0 +1,211 @@
+---
+setup:
+  - requires:
+      test_runner_features: [capabilities, contains, allowed_warnings]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [enable_lookup_join_on_aliases]
+      reason: "uses LOOKUP JOIN on aliases"
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              key:
+                type: long
+              color:
+                type: keyword
+  - do:
+      indices.create:
+        index: test-mv
+        body:
+          mappings:
+            properties:
+              key:
+                type: long
+              color:
+                type: keyword
+  - do:
+      indices.create:
+        index: test-lookup-1
+        body:
+          settings:
+            index:
+              mode: lookup
+          mappings:
+            properties:
+              key:
+                type: long
+              color:
+                type: keyword
+  - do:
+      indices.create:
+        index: test-lookup-2
+        body:
+          settings:
+            index:
+              mode: lookup
+          mappings:
+            properties:
+              key:
+                type: long
+              color:
+                type: keyword
+  - do:
+      indices.create:
+        index: test-lookup-mv
+        body:
+          settings:
+            index:
+              mode: lookup
+          mappings:
+            properties:
+              key:
+                type: long
+              color:
+                type: keyword
+  - do:
+      indices.create:
+        index: test-lookup-no-key
+        body:
+          settings:
+            index:
+              mode: lookup
+          mappings:
+            properties:
+              no-key:
+                type: long
+              color:
+                type: keyword
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - add:
+                index: test-lookup-1
+                alias: test-lookup-alias
+            - add:
+                index: test-lookup-*
+                alias: test-lookup-alias-pattern-multiple
+            - add:
+                index: test-lookup-1*
+                alias: test-lookup-alias-pattern-single
+  - do:
+      bulk:
+        index: "test"
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "key": 1, "color": "red" }
+          - { "index": { } }
+          - { "key": 2, "color": "blue" }
+  - do:
+      bulk:
+        index: "test-lookup-1"
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "key": 1, "color": "cyan" }
+          - { "index": { } }
+          - { "key": 2, "color": "yellow" }
+  - do:
+      bulk:
+        index: "test-mv"
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "key": 1, "color": "red" }
+          - { "index": { } }
+          - { "key": 2, "color": "blue" }
+          - { "index": { } }
+          - { "key": [0, 1, 2], "color": null }
+  - do:
+      bulk:
+        index: "test-lookup-mv"
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "key": 1, "color": "cyan" }
+          - { "index": { } }
+          - { "key": 2, "color": "yellow" }
+          - { "index": { } }
+          - { "key": [0, 1, 2], "color": "green" }
+  - do:
+      bulk:
+        index: "test-lookup-no-key"
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "no-key": 1, "color": "cyan" }
+          - { "index": { } }
+          - { "no-key": 2, "color": "yellow" }
+
+---
+alias-as-lookup-index:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test | SORT key | LOOKUP JOIN test-lookup-alias ON key | LIMIT 3'
+
+  - match: {columns.0.name: "key"}
+  - match: {columns.0.type: "long"}
+  - match: {columns.1.name: "color"}
+  - match: {columns.1.type: "keyword"}
+  - match: {values.0: [1, "cyan"]}
+  - match: {values.1: [2, "yellow"]}
+
+---
+alias-repeated-alias:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test-lookup-alias | SORT key | LOOKUP JOIN test-lookup-alias ON key | LIMIT 3'
+
+  - match: {columns.0.name: "key"}
+  - match: {columns.0.type: "long"}
+  - match: {columns.1.name: "color"}
+  - match: {columns.1.type: "keyword"}
+  - match: {values.0: [1, "cyan"]}
+  - match: {values.1: [2, "yellow"]}
+
+---
+alias-repeated-index:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test-lookup-1 | SORT key | LOOKUP JOIN test-lookup-alias ON key | LIMIT 3'
+
+  - match: {columns.0.name: "key"}
+  - match: {columns.0.type: "long"}
+  - match: {columns.1.name: "color"}
+  - match: {columns.1.type: "keyword"}
+  - match: {values.0: [1, "cyan"]}
+  - match: {values.1: [2, "yellow"]}
+
+---
+alias-pattern-multiple:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test-lookup-1 | LOOKUP JOIN test-lookup-alias-pattern-multiple ON key'
+      catch: "bad_request"
+
+  - match: { error.type: "verification_exception" }
+  - contains: { error.reason: "Found 1 problem\nline 1:34: invalid [test-lookup-alias-pattern-multiple] resolution in lookup mode to [2] indices" }
+
+---
+alias-pattern-single:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test | SORT key | LOOKUP JOIN test-lookup-alias-pattern-single ON key | LIMIT 3'
+
+  - match: {columns.0.name: "key"}
+  - match: {columns.0.type: "long"}
+  - match: {columns.1.name: "color"}
+  - match: {columns.1.type: "keyword"}
+  - match: {values.0: [1, "cyan"]}
+  - match: {values.1: [2, "yellow"]}


### PR DESCRIPTION
Manual backport of #128884