### PR TITLE
Remove doPrivileged uses from server (#127781)

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoader.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoader.java
@@ -23,10 +23,8 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
 import java.security.CodeSigner;
 import java.security.CodeSource;
-import java.security.PrivilegedAction;
 import java.security.SecureClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -96,8 +94,7 @@ public final class EmbeddedImplClassLoader extends SecureClassLoader {
     private final ClassLoader parent;
 
     static EmbeddedImplClassLoader getInstance(ClassLoader parent, String providerName) {
-        PrivilegedAction<EmbeddedImplClassLoader> pa = () -> new EmbeddedImplClassLoader(parent, getProviderPrefixes(parent, providerName));
-        return AccessController.doPrivileged(pa);
+        return new EmbeddedImplClassLoader(parent, getProviderPrefixes(parent, providerName));
     }
 
     private EmbeddedImplClassLoader(ClassLoader parent, Map<JarMeta, CodeSource> prefixToCodeBase) {
@@ -120,14 +117,12 @@ public final class EmbeddedImplClassLoader extends SecureClassLoader {
     record Resource(InputStream inputStream, CodeSource codeSource) {}
 
     /** Searches for the named resource. Iterates over all prefixes. */
-    private Resource privilegedGetResourceOrNull(JarMeta jarMeta, String pkg, String filepath) {
-        return AccessController.doPrivileged((PrivilegedAction<Resource>) () -> {
-            InputStream is = findResourceInLoaderPkgOrNull(jarMeta, pkg, filepath, parent::getResourceAsStream);
-            if (is != null) {
-                return new Resource(is, prefixToCodeBase.get(jarMeta.prefix()));
-            }
-            return null;
-        });
+    private Resource getResourceOrNull(JarMeta jarMeta, String pkg, String filepath) {
+        InputStream is = findResourceInLoaderPkgOrNull(jarMeta, pkg, filepath, parent::getResourceAsStream);
+        if (is != null) {
+            return new Resource(is, prefixToCodeBase.get(jarMeta.prefix()));
+        }
+        return null;
     }
 
     @Override
@@ -148,7 +143,7 @@ public final class EmbeddedImplClassLoader extends SecureClassLoader {
         String pkg = toPackageName(filepath);
         JarMeta jarMeta = packageToJarMeta.get(pkg);
         if (jarMeta != null) {
-            Resource res = privilegedGetResourceOrNull(jarMeta, pkg, filepath);
+            Resource res = getResourceOrNull(jarMeta, pkg, filepath);
             if (res != null) {
                 try (InputStream in = res.inputStream()) {
                     byte[] bytes = in.readAllBytes();

--- a/libs/core/src/main/java/org/elasticsearch/core/internal/provider/ProviderLocator.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/internal/provider/ProviderLocator.java
@@ -15,9 +15,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.module.Configuration;
 import java.lang.module.ModuleFinder;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.ServiceConfigurationError;
@@ -97,10 +94,9 @@ public final class ProviderLocator<T> implements Supplier<T> {
     @Override
     public T get() {
         try {
-            PrivilegedExceptionAction<T> pa = this::load;
-            return AccessController.doPrivileged(pa);
-        } catch (PrivilegedActionException e) {
-            throw new UncheckedIOException((IOException) e.getCause());
+            return load();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -174,7 +174,7 @@ public class EvilLoggerTests extends ESTestCase {
             assertLogLine(
                 deprecationEvents.get(i),
                 DeprecationLogger.CRITICAL,
-                "org.elasticsearch.common.logging.DeprecationLogger.lambda\\$doPrivilegedLog\\$0",
+                "org.elasticsearch.common.logging.DeprecationLogger.logDeprecation",
                 ".*This is a maybe logged deprecation message" + i + ".*"
             );
         }
@@ -207,7 +207,7 @@ public class EvilLoggerTests extends ESTestCase {
             assertLogLine(
                 deprecationEvents.get(0),
                 DeprecationLogger.CRITICAL,
-                "org.elasticsearch.common.logging.DeprecationLogger.lambda\\$doPrivilegedLog\\$0",
+                "org.elasticsearch.common.logging.DeprecationLogger.logDeprecation",
                 ".*\\[deprecated.foo\\] setting was deprecated in Elasticsearch and will be removed in a future release..*"
             );
         }

--- a/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
@@ -14,8 +14,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.SuppressForbidden;
 
 import java.io.IOError;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 class ElasticsearchUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
     private static final Logger logger = LogManager.getLogger(ElasticsearchUncaughtExceptionHandler.class);
@@ -53,41 +51,17 @@ class ElasticsearchUncaughtExceptionHandler implements Thread.UncaughtExceptionH
 
     void onFatalUncaught(final String threadName, final Throwable t) {
         final String message = "fatal error in thread [" + threadName + "], exiting";
-        logErrorMessage(t, message);
+        logger.error(message, t);
     }
 
     void onNonFatalUncaught(final String threadName, final Throwable t) {
         final String message = "uncaught exception in thread [" + threadName + "]";
-        logErrorMessage(t, message);
+        logger.error(message, t);
     }
 
-    private static void logErrorMessage(Throwable t, String message) {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            logger.error(message, t);
-            return null;
-        });
-    }
-
+    @SuppressForbidden(reason = "intentionally halting")
     void halt(int status) {
-        AccessController.doPrivileged(new PrivilegedHaltAction(status));
+        // we halt to prevent shutdown hooks from running
+        Runtime.getRuntime().halt(status);
     }
-
-    static class PrivilegedHaltAction implements PrivilegedAction<Void> {
-
-        private final int status;
-
-        private PrivilegedHaltAction(final int status) {
-            this.status = status;
-        }
-
-        @SuppressForbidden(reason = "halt")
-        @Override
-        public Void run() {
-            // we halt to prevent shutdown hooks from running
-            Runtime.getRuntime().halt(status);
-            return null;
-        }
-
-    }
-
 }

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
@@ -18,8 +18,6 @@ import org.elasticsearch.core.IOUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Iterator;
 import java.util.List;
 
@@ -57,14 +55,11 @@ public class FsBlobStore implements BlobStore {
     public BlobContainer blobContainer(BlobPath path) {
         Path f = buildPath(path);
         if (readOnly == false) {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                try {
-                    Files.createDirectories(f);
-                } catch (IOException ex) {
-                    throw new ElasticsearchException("failed to create blob container", ex);
-                }
-                return null;
-            });
+            try {
+                Files.createDirectories(f);
+            } catch (IOException ex) {
+                throw new ElasticsearchException("failed to create blob container", ex);
+            }
         }
         return new FsBlobContainer(this, path, f);
     }

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -15,8 +15,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.List;
 
@@ -119,16 +117,9 @@ public class DeprecationLogger {
             String opaqueId = HeaderWarning.getXOpaqueId();
             String productOrigin = HeaderWarning.getProductOrigin();
             ESLogMessage deprecationMessage = DeprecatedMessage.of(category, key, opaqueId, productOrigin, msg, params);
-            doPrivilegedLog(level, deprecationMessage);
+            logger.log(level, deprecationMessage);
         }
         return this;
-    }
-
-    private void doPrivilegedLog(Level level, ESLogMessage deprecationMessage) {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            logger.log(level, deprecationMessage);
-            return null;
-        });
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -17,8 +17,6 @@ import org.elasticsearch.common.unit.Processors;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.node.Node;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.AbstractExecutorService;
@@ -393,11 +391,9 @@ public class EsExecutors {
 
         @Override
         public Thread newThread(Runnable r) {
-            return AccessController.doPrivileged((PrivilegedAction<Thread>) () -> {
-                Thread t = new EsThread(group, r, namePrefix + "[T#" + threadNumber.getAndIncrement() + "]", 0, isSystem);
-                t.setDaemon(true);
-                return t;
-            });
+            Thread t = new EsThread(group, r, namePrefix + "[T#" + threadNumber.getAndIncrement() + "]", 0, isSystem);
+            t.setDaemon(true);
+            return t;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/plugins/ExtendedPluginsClassLoader.java
+++ b/server/src/main/java/org/elasticsearch/plugins/ExtendedPluginsClassLoader.java
@@ -9,8 +9,6 @@
 
 package org.elasticsearch.plugins;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.List;
 
@@ -43,8 +41,6 @@ class ExtendedPluginsClassLoader extends ClassLoader {
      * Return a new classloader across the parent and extended loaders.
      */
     public static ExtendedPluginsClassLoader create(ClassLoader parent, List<ClassLoader> extendedLoaders) {
-        return AccessController.doPrivileged(
-            (PrivilegedAction<ExtendedPluginsClassLoader>) () -> new ExtendedPluginsClassLoader(parent, extendedLoaders)
-        );
+        return new ExtendedPluginsClassLoader(parent, extendedLoaders);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
@@ -19,8 +19,6 @@ import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
 import org.elasticsearch.script.field.Field;
 
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -42,23 +40,18 @@ public class LeafDocLookup implements Map<String, ScriptDocValues<?>> {
      */
     class FieldFactoryWrapper {
         final DocValuesScriptFieldFactory factory;
-        private final PrivilegedAction<Void> advancer;
 
         FieldFactoryWrapper(DocValuesScriptFieldFactory factory) {
             this.factory = factory;
-            this.advancer = () -> {
-                try {
-                    factory.setNextDocId(docId);
-                } catch (IOException ioe) {
-                    throw ExceptionsHelper.convertToElastic(ioe);
-                }
-                return null;
-            };
         }
 
         // advances the factory to the current docid for the enclosing LeafDocLookup
         void advanceToDoc() {
-            AccessController.doPrivileged(this.advancer);
+            try {
+                factory.setNextDocId(docId);
+            } catch (IOException ioe) {
+                throw ExceptionsHelper.convertToElastic(ioe);
+            }
         }
     }
 
@@ -101,30 +94,26 @@ public class LeafDocLookup implements Map<String, ScriptDocValues<?>> {
             throw new IllegalArgumentException("No field found for [" + fieldName + "] in mapping");
         }
 
-        // Load the field data on behalf of the script. Otherwise, it would require
-        // additional permissions to deal with pagedbytes/ramusagestimator/etc.
-        return AccessController.doPrivileged((PrivilegedAction<FieldFactoryWrapper>) () -> {
-            IndexFieldData<?> indexFieldData = fieldDataLookup.apply(fieldType, SCRIPT);
+        IndexFieldData<?> indexFieldData = fieldDataLookup.apply(fieldType, SCRIPT);
 
-            FieldFactoryWrapper docFactory = null;
+        FieldFactoryWrapper docFactory = null;
 
-            if (docFactoryCache.isEmpty() == false) {
-                docFactory = docFactoryCache.get(fieldName);
-            }
+        if (docFactoryCache.isEmpty() == false) {
+            docFactory = docFactoryCache.get(fieldName);
+        }
 
-            // if this field has already been accessed via the doc-access API and the field-access API
-            // uses doc values then we share to avoid double-loading
-            FieldFactoryWrapper fieldFactory;
-            if (docFactory != null && indexFieldData instanceof SourceValueFetcherIndexFieldData == false) {
-                fieldFactory = docFactory;
-            } else {
-                fieldFactory = new FieldFactoryWrapper(indexFieldData.load(reader).getScriptFieldFactory(fieldName));
-            }
+        // if this field has already been accessed via the doc-access API and the field-access API
+        // uses doc values then we share to avoid double-loading
+        FieldFactoryWrapper fieldFactory;
+        if (docFactory != null && indexFieldData instanceof SourceValueFetcherIndexFieldData == false) {
+            fieldFactory = docFactory;
+        } else {
+            fieldFactory = new FieldFactoryWrapper(indexFieldData.load(reader).getScriptFieldFactory(fieldName));
+        }
 
-            fieldFactoryCache.put(fieldName, fieldFactory);
+        fieldFactoryCache.put(fieldName, fieldFactory);
 
-            return fieldFactory;
-        });
+        return fieldFactory;
     }
 
     public Field<?> getScriptField(String fieldName) {
@@ -146,35 +135,31 @@ public class LeafDocLookup implements Map<String, ScriptDocValues<?>> {
             throw new IllegalArgumentException("No field found for [" + fieldName + "] in mapping");
         }
 
-        // Load the field data on behalf of the script. Otherwise, it would require
-        // additional permissions to deal with pagedbytes/ramusagestimator/etc.
-        return AccessController.doPrivileged((PrivilegedAction<FieldFactoryWrapper>) () -> {
-            FieldFactoryWrapper docFactory = null;
-            FieldFactoryWrapper fieldFactory = null;
+        FieldFactoryWrapper docFactory = null;
+        FieldFactoryWrapper fieldFactory = null;
 
-            if (fieldFactoryCache.isEmpty() == false) {
-                fieldFactory = fieldFactoryCache.get(fieldName);
+        if (fieldFactoryCache.isEmpty() == false) {
+            fieldFactory = fieldFactoryCache.get(fieldName);
+        }
+
+        if (fieldFactory != null) {
+            IndexFieldData<?> fieldIndexFieldData = fieldDataLookup.apply(fieldType, SCRIPT);
+
+            // if this field has already been accessed via the field-access API and the field-access API
+            // uses doc values then we share to avoid double-loading
+            if (fieldIndexFieldData instanceof SourceValueFetcherIndexFieldData == false) {
+                docFactory = fieldFactory;
             }
+        }
 
-            if (fieldFactory != null) {
-                IndexFieldData<?> fieldIndexFieldData = fieldDataLookup.apply(fieldType, SCRIPT);
+        if (docFactory == null) {
+            IndexFieldData<?> indexFieldData = fieldDataLookup.apply(fieldType, SEARCH);
+            docFactory = new FieldFactoryWrapper(indexFieldData.load(reader).getScriptFieldFactory(fieldName));
+        }
 
-                // if this field has already been accessed via the field-access API and the field-access API
-                // uses doc values then we share to avoid double-loading
-                if (fieldIndexFieldData instanceof SourceValueFetcherIndexFieldData == false) {
-                    docFactory = fieldFactory;
-                }
-            }
+        docFactoryCache.put(fieldName, docFactory);
 
-            if (docFactory == null) {
-                IndexFieldData<?> indexFieldData = fieldDataLookup.apply(fieldType, SEARCH);
-                docFactory = new FieldFactoryWrapper(indexFieldData.load(reader).getScriptFieldFactory(fieldName));
-            }
-
-            docFactoryCache.put(fieldName, docFactory);
-
-            return docFactory;
-        });
+        return docFactory;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
@@ -17,11 +17,6 @@ import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.mockito.Mockito;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.Permissions;
-import java.security.PrivilegedAction;
-import java.security.ProtectionDomain;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -75,13 +70,7 @@ public class DeprecationLoggerTests extends ESTestCase {
 
             DeprecationLogger deprecationLogger = DeprecationLogger.getLogger("name");
 
-            AccessControlContext noPermissionsAcc = new AccessControlContext(
-                new ProtectionDomain[] { new ProtectionDomain(null, new Permissions()) }
-            );
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                deprecationLogger.warn(DeprecationCategory.API, "key", "foo", "bar");
-                return null;
-            }, noPermissionsAcc);
+            deprecationLogger.warn(DeprecationCategory.API, "key", "foo", "bar");
             assertThat("supplier called", supplierCalled.get(), is(true));
         } finally {
             LogManager.setFactory(originalFactory);

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
@@ -24,10 +24,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.ProtectionDomain;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -427,12 +423,7 @@ public class LeafDocLookupTests extends ESTestCase {
     public void testLookupPrivilegesAdvanceDoc() {
         nextDocCallback = i -> SpecialPermission.check();
 
-        // mimic the untrusted codebase, which gets no permissions
-        var restrictedContext = new AccessControlContext(new ProtectionDomain[] { new ProtectionDomain(null, null) });
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            ScriptDocValues<?> fetchedDocValues = docLookup.get("field");
-            assertEquals(docValues, fetchedDocValues);
-            return null;
-        }, restrictedContext);
+        ScriptDocValues<?> fetchedDocValues = docLookup.get("field");
+        assertEquals(docValues, fetchedDocValues);
     }
 }

--- a/server/src/test/java/org/elasticsearch/transport/TransportHandshakerRawMessageTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportHandshakerRawMessageTests.java
@@ -26,8 +26,6 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThan;
@@ -239,8 +237,6 @@ public class TransportHandshakerRawMessageTests extends ESSingleNodeTestCase {
 
     private Socket openTransportConnection() throws Exception {
         final var transportAddress = randomFrom(getInstanceFromNode(TransportService.class).boundAddress().boundAddresses()).address();
-        return AccessController.doPrivileged(
-            (PrivilegedExceptionAction<Socket>) (() -> new Socket(transportAddress.getAddress(), transportAddress.getPort()))
-        );
+        return new Socket(transportAddress.getAddress(), transportAddress.getPort());
     }
 }


### PR DESCRIPTION
Now that SecurityManager is no longer used, doPrivileged is no longer necessary. This commit removes uses of it from core and server