### PR TITLE
[8.19] Inject an unfollow action before executing a downsample action in ILM (#128788)

### DIFF
--- a/docs/changelog/128788.yaml
+++ b/docs/changelog/128788.yaml
@@ -1,0 +1,6 @@
+pr: 105773
+summary: Inject an unfollow action before executing a downsample action in ILM
+area: ILM+SLM
+type: bug
+issues:
+ - 105773

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
@@ -132,7 +132,8 @@ public class TimeseriesLifecycleType implements LifecycleType {
                 if (actions.containsKey(UnfollowAction.NAME) == false
                     && (actions.containsKey(RolloverAction.NAME)
                         || actions.containsKey(ShrinkAction.NAME)
-                        || actions.containsKey(SearchableSnapshotAction.NAME))) {
+                        || actions.containsKey(SearchableSnapshotAction.NAME)
+                        || actions.containsKey(DownsampleAction.NAME))) {
                     Map<String, LifecycleAction> actionMap = new HashMap<>(phase.getActions());
                     actionMap.put(UnfollowAction.NAME, UnfollowAction.INSTANCE);
                     phase = new Phase(phase.getName(), phase.getMinimumAge(), actionMap);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -476,6 +476,9 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
         assertTrue(isUnfollowInjected("cold", SearchableSnapshotAction.NAME));
         assertTrue(isUnfollowInjected("frozen", SearchableSnapshotAction.NAME));
 
+        assertTrue(isUnfollowInjected("warm", DownsampleAction.NAME));
+        assertTrue(isUnfollowInjected("cold", DownsampleAction.NAME));
+
         assertFalse(isUnfollowInjected("hot", SetPriorityAction.NAME));
         assertFalse(isUnfollowInjected("warm", SetPriorityAction.NAME));
         assertFalse(isUnfollowInjected("warm", AllocateAction.NAME));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Inject an unfollow action before executing a downsample action in ILM (#128788)](https://github.com/elastic/elasticsearch/pull/128788)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)