### PR TITLE
Prevent concurrent access to local breaker in rerank (#128162)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/indices/CrankyCircuitBreakerService.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/CrankyCircuitBreakerService.java
@@ -29,7 +29,7 @@ public class CrankyCircuitBreakerService extends CircuitBreakerService {
      */
     public static final String ERROR_MESSAGE = "cranky breaker";
 
-    private final CircuitBreaker breaker = new CircuitBreaker() {
+    public static final class CrankyCircuitBreaker implements CircuitBreaker {
         private final AtomicLong used = new AtomicLong();
 
         @Override
@@ -82,7 +82,9 @@ public class CrankyCircuitBreakerService extends CircuitBreakerService {
         public void setLimitAndOverhead(long limit, double overhead) {
 
         }
-    };
+    }
+
+    private final CrankyCircuitBreaker breaker = new CrankyCircuitBreaker();
 
     @Override
     public CircuitBreaker getBreaker(String name) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
@@ -211,10 +211,13 @@ public class Driver implements Releasable, Describable {
         while (true) {
             IsBlockedResult isBlocked = Operator.NOT_BLOCKED;
             try {
+                assert driverContext.assertBeginRunLoop();
                 isBlocked = runSingleLoopIteration();
             } catch (DriverEarlyTerminationException unused) {
                 closeEarlyFinishedOperators();
                 assert isFinished() : "not finished after early termination";
+            } finally {
+                assert driverContext.assertEndRunLoop();
             }
             totalIterationsThisRun++;
             iterationsSinceLastStatusUpdate++;


### PR DESCRIPTION
When an async operator receives a response, we can't create new blocks on the responding thread because multiple threads may adjust the local breaker simultaneously, leading to a data race. To address this, we can either use the global breaker or delay block creation in getOutput. While using the global block factory is simpler, I prefer the second option to use the local breaker when possible. Therefore, I opted to keep the results in the queue and create new blocks in getOutput. Our tests didn't catch this issue because: (1) only one block is created in the test, and (2) there is no delay when simulating the inference service.

Closes #127638
Closes #127051