### PR TITLE
[8.19] Query hot indices first (#122928)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.search.SearchShardsResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.Maps;
@@ -38,10 +39,12 @@ import org.elasticsearch.xpack.esql.action.EsqlSearchShardsAction;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -59,6 +62,19 @@ import static org.elasticsearch.core.TimeValue.timeValueNanos;
  * and executing these computes on the data nodes.
  */
 abstract class DataNodeRequestSender {
+
+    /**
+     * Query order according to the
+     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/node-roles-overview.html">node roles</a>.
+     */
+    private static final List<String> NODE_QUERY_ORDER = List.of(
+        DiscoveryNodeRole.SEARCH_ROLE.roleName(),
+        DiscoveryNodeRole.DATA_CONTENT_NODE_ROLE.roleName(),
+        DiscoveryNodeRole.DATA_HOT_NODE_ROLE.roleName(),
+        DiscoveryNodeRole.DATA_WARM_NODE_ROLE.roleName(),
+        DiscoveryNodeRole.DATA_COLD_NODE_ROLE.roleName(),
+        DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE.roleName()
+    );
 
     private final ClusterService clusterService;
     private final TransportService transportService;
@@ -126,10 +142,37 @@ abstract class DataNodeRequestSender {
                     )
                 )
             ) {
-                pendingShardIds.addAll(targetShards.shards.keySet());
+                pendingShardIds.addAll(order(targetShards));
                 trySendingRequestsForPendingShards(targetShards, computeListener);
             }
         }, listener::onFailure));
+    }
+
+    private static List<ShardId> order(TargetShards targetShards) {
+        var computedNodeOrder = new HashMap<DiscoveryNode, Integer>();
+        var ordered = new ArrayList<>(targetShards.shards.keySet());
+        ordered.sort(Comparator.comparingInt(shardId -> nodesOrder(targetShards.getShard(shardId).remainingNodes, computedNodeOrder)));
+        return ordered;
+    }
+
+    private static int nodesOrder(List<DiscoveryNode> nodes, Map<DiscoveryNode, Integer> computedNodeOrder) {
+        if (nodes.isEmpty()) {
+            return Integer.MAX_VALUE;
+        }
+        var order = 0;
+        for (var node : nodes) {
+            order = Math.max(order, computedNodeOrder.computeIfAbsent(node, DataNodeRequestSender::nodeOrder));
+        }
+        return order;
+    }
+
+    private static int nodeOrder(DiscoveryNode node) {
+        for (int i = 0; i < NODE_QUERY_ORDER.size(); i++) {
+            if (node.hasRole(NODE_QUERY_ORDER.get(i))) {
+                return i;
+            }
+        }
+        return Integer.MAX_VALUE;
     }
 
     private void trySendingRequestsForPendingShards(TargetShards targetShards, ComputeListener computeListener) {
@@ -338,7 +381,7 @@ abstract class DataNodeRequestSender {
      */
     private List<NodeRequest> selectNodeRequests(TargetShards targetShards) {
         assert sendingLock.isHeldByCurrentThread();
-        final Map<DiscoveryNode, List<ShardId>> nodeToShardIds = new HashMap<>();
+        final Map<DiscoveryNode, List<ShardId>> nodeToShardIds = new LinkedHashMap<>();
         final Iterator<ShardId> shardsIt = pendingShardIds.iterator();
 
         while (shardsIt.hasNext()) {


### PR DESCRIPTION
This backports following changes to 8.19:

* #122928