### PR TITLE
[9.0] Support DATE_NANOS in LOOKUP JOIN (#127962)

### DIFF
--- a/docs/changelog/127962.yaml
+++ b/docs/changelog/127962.yaml
@@ -1,0 +1,6 @@
+pr: 127962
+summary: Support DATE_NANOS in LOOKUP JOIN
+area: ES|QL
+type: bug
+issues:
+ - 127249

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -472,7 +472,7 @@ public final class DateFieldMapper extends FieldMapper {
             this(name, true, true, false, true, DEFAULT_DATE_TIME_FORMATTER, Resolution.MILLISECONDS, null, null, Collections.emptyMap());
         }
 
-        public DateFieldType(String name, boolean isIndexed) {
+        public DateFieldType(String name, boolean isIndexed, Resolution resolution) {
             this(
                 name,
                 isIndexed,
@@ -480,11 +480,15 @@ public final class DateFieldMapper extends FieldMapper {
                 false,
                 true,
                 DEFAULT_DATE_TIME_FORMATTER,
-                Resolution.MILLISECONDS,
+                resolution,
                 null,
                 null,
                 Collections.emptyMap()
             );
+        }
+
+        public DateFieldType(String name, boolean isIndexed) {
+            this(name, isIndexed, Resolution.MILLISECONDS);
         }
 
         public DateFieldType(String name, DateFormatter dateFormatter) {
@@ -696,6 +700,54 @@ public final class DateFieldMapper extends FieldMapper {
             Resolution resolution
         ) {
             return resolution.convert(dateParser.parse(BytesRefs.toString(value), now, roundUp, zone));
+        }
+
+        /**
+         * Similar to the {@link DateFieldType#termQuery} method, but works on dates that are already parsed to a long
+         * in the same precision as the field mapper.
+         */
+        public Query equalityQuery(Long value, @Nullable SearchExecutionContext context) {
+            return rangeQuery(value, value, true, true, context);
+        }
+
+        /**
+         * Similar to the existing
+         * {@link DateFieldType#rangeQuery(Object, Object, boolean, boolean, ShapeRelation, ZoneId, DateMathParser, SearchExecutionContext)}
+         * method, but works on dates that are already parsed to a long in the same precision as the field mapper.
+         */
+        public Query rangeQuery(
+            Long lowerTerm,
+            Long upperTerm,
+            boolean includeLower,
+            boolean includeUpper,
+            SearchExecutionContext context
+        ) {
+            failIfNotIndexedNorDocValuesFallback(context);
+            long l, u;
+            if (lowerTerm == null) {
+                l = Long.MIN_VALUE;
+            } else {
+                l = (includeLower == false) ? lowerTerm + 1 : lowerTerm;
+            }
+            if (upperTerm == null) {
+                u = Long.MAX_VALUE;
+            } else {
+                u = (includeUpper == false) ? upperTerm - 1 : upperTerm;
+            }
+            Query query;
+            if (isIndexed()) {
+                query = LongPoint.newRangeQuery(name(), l, u);
+                if (hasDocValues()) {
+                    Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
+                    query = new IndexOrDocValuesQuery(query, dvQuery);
+                }
+            } else {
+                query = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
+            }
+            if (hasDocValues() && context.indexSortedOnField(name())) {
+                query = new XIndexSortSortedNumericDocValuesRangeQuery(name(), l, u, query);
+            }
+            return query;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -473,18 +473,7 @@ public final class DateFieldMapper extends FieldMapper {
         }
 
         public DateFieldType(String name, boolean isIndexed, Resolution resolution) {
-            this(
-                name,
-                isIndexed,
-                isIndexed,
-                false,
-                true,
-                DEFAULT_DATE_TIME_FORMATTER,
-                resolution,
-                null,
-                null,
-                Collections.emptyMap()
-            );
+            this(name, isIndexed, isIndexed, false, true, DEFAULT_DATE_TIME_FORMATTER, resolution, null, null, Collections.emptyMap());
         }
 
         public DateFieldType(String name, boolean isIndexed) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
@@ -252,9 +252,9 @@ public abstract class QueryList {
             MappedFieldType field,
             SearchExecutionContext searchExecutionContext,
             LongBlock block,
-            boolean onlySingleValueParams
+            boolean onlySingleValues
         ) {
-            super(field, searchExecutionContext, block, onlySingleValueParams);
+            super(field, searchExecutionContext, block, onlySingleValues);
             if (field instanceof RangeFieldMapper.RangeFieldType rangeFieldType) {
                 // TODO: do this validation earlier
                 throw new IllegalArgumentException(

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
@@ -11,6 +11,7 @@ import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
@@ -30,6 +31,7 @@ import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeQueryable;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
@@ -37,7 +39,9 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.IntFunction;
 
 /**
@@ -190,6 +194,14 @@ public abstract class QueryList {
     }
 
     /**
+     * Returns a list of term queries for the given field and the input block of
+     * {@code date_nanos} field values.
+     */
+    public static QueryList dateNanosTermQueryList(MappedFieldType field, SearchExecutionContext searchExecutionContext, LongBlock block) {
+        return new DateNanosQueryList(field, searchExecutionContext, block, false);
+    }
+
+    /**
      * Returns a list of geo_shape queries for the given field and the input block.
      */
     public static QueryList geoShapeQueryList(MappedFieldType field, SearchExecutionContext searchExecutionContext, Block block) {
@@ -227,6 +239,68 @@ public abstract class QueryList {
                         terms.add(value);
                     }
                     yield field.termsQuery(terms, searchExecutionContext);
+                }
+            };
+        }
+    }
+
+    private static class DateNanosQueryList extends QueryList {
+        protected final IntFunction<Long> blockValueReader;
+        private final DateFieldMapper.DateFieldType dateFieldType;
+
+        private DateNanosQueryList(
+            MappedFieldType field,
+            SearchExecutionContext searchExecutionContext,
+            LongBlock block,
+            boolean onlySingleValueParams
+        ) {
+            super(field, searchExecutionContext, block, onlySingleValueParams);
+            if (field instanceof RangeFieldMapper.RangeFieldType rangeFieldType) {
+                // TODO: do this validation earlier
+                throw new IllegalArgumentException(
+                    "DateNanosQueryList does not support range fields [" + rangeFieldType + "]: " + field.name()
+                );
+            }
+            this.blockValueReader = block::getLong;
+            if (field instanceof DateFieldMapper.DateFieldType dateFieldType) {
+                // Validate that the field is a date_nanos field
+                // TODO: Consider allowing date_nanos to match normal datetime fields
+                if (dateFieldType.resolution() != DateFieldMapper.Resolution.NANOSECONDS) {
+                    throw new IllegalArgumentException(
+                        "DateNanosQueryList only supports date_nanos fields, but got: " + field.typeName() + " for field: " + field.name()
+                    );
+                }
+                this.dateFieldType = dateFieldType;
+            } else {
+                throw new IllegalArgumentException(
+                    "DateNanosQueryList only supports date_nanos fields, but got: " + field.typeName() + " for field: " + field.name()
+                );
+            }
+        }
+
+        @Override
+        public DateNanosQueryList onlySingleValues() {
+            return new DateNanosQueryList(field, searchExecutionContext, (LongBlock) block, true);
+        }
+
+        @Override
+        Query doGetQuery(int position, int firstValueIndex, int valueCount) {
+            return switch (valueCount) {
+                case 0 -> null;
+                case 1 -> dateFieldType.equalityQuery(blockValueReader.apply(firstValueIndex), searchExecutionContext);
+                default -> {
+                    // The following code is a slight simplification of the DateFieldMapper.termsQuery method
+                    final Set<Long> values = new HashSet<>(valueCount);
+                    BooleanQuery.Builder builder = new BooleanQuery.Builder();
+                    for (int i = 0; i < valueCount; i++) {
+                        final Long value = blockValueReader.apply(firstValueIndex + i);
+                        if (values.contains(value)) {
+                            continue; // Skip duplicates
+                        }
+                        values.add(value);
+                        builder.add(dateFieldType.equalityQuery(value, searchExecutionContext), BooleanClause.Occur.SHOULD);
+                    }
+                    yield new ConstantScoreQuery(builder.build());
                 }
             };
         }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -278,7 +278,7 @@ public final class CsvAssert {
         fail(description + System.lineSeparator() + describeFailures(dataFailures) + actual + expected);
     }
 
-    private static final int MAX_ROWS = 25;
+    private static final int MAX_ROWS = 50;
 
     private static String pipeTable(
         String description,

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -83,6 +83,8 @@ public class CsvTestsDataLoader {
     private static final TestDataset SAMPLE_DATA_TS_NANOS = SAMPLE_DATA.withIndex("sample_data_ts_nanos")
         .withData("sample_data_ts_nanos.csv")
         .withTypeMapping(Map.of("@timestamp", "date_nanos"));
+    private static final TestDataset LOOKUP_SAMPLE_DATA_TS_NANOS = SAMPLE_DATA_TS_NANOS.withIndex("lookup_sample_data_ts_nanos")
+        .withSetting("lookup-settings.json");
     private static final TestDataset MISSING_IP_SAMPLE_DATA = new TestDataset("missing_ip_sample_data");
     private static final TestDataset SAMPLE_DATA_PARTIAL_MAPPING = new TestDataset("partial_mapping_sample_data");
     private static final TestDataset SAMPLE_DATA_NO_MAPPING = new TestDataset(
@@ -160,6 +162,7 @@ public class CsvTestsDataLoader {
         Map.entry(SAMPLE_DATA_STR.indexName, SAMPLE_DATA_STR),
         Map.entry(SAMPLE_DATA_TS_LONG.indexName, SAMPLE_DATA_TS_LONG),
         Map.entry(SAMPLE_DATA_TS_NANOS.indexName, SAMPLE_DATA_TS_NANOS),
+        Map.entry(LOOKUP_SAMPLE_DATA_TS_NANOS.indexName, LOOKUP_SAMPLE_DATA_TS_NANOS),
         Map.entry(MISSING_IP_SAMPLE_DATA.indexName, MISSING_IP_SAMPLE_DATA),
         Map.entry(CLIENT_IPS.indexName, CLIENT_IPS),
         Map.entry(CLIENT_IPS_LOOKUP.indexName, CLIENT_IPS_LOOKUP),

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -1661,3 +1661,27 @@ max:long
 3450233
 8268153
 ;
+
+###############################################
+# LOOKUP JOIN on date_nanos field
+###############################################
+
+joinDateNanos
+required_capability: join_lookup_v12
+required_capability: date_nanos_lookup_join
+
+FROM sample_data_ts_nanos
+| LOOKUP JOIN lookup_sample_data_ts_nanos ON @timestamp
+| KEEP @timestamp, client_ip, event_duration, message
+| SORT @timestamp DESC
+;
+
+@timestamp:date_nanos | client_ip:ip | event_duration:long | message:keyword
+2023-10-23T13:55:01.543123456Z | 172.21.3.15 | 1756467 | Connected to 10.1.0.1
+2023-10-23T13:53:55.832123456Z | 172.21.3.15 | 5033755 | Connection error
+2023-10-23T13:52:55.015123456Z | 172.21.3.15 | 8268153 | Connection error
+2023-10-23T13:51:54.732123456Z | 172.21.3.15 | 725448 | Connection error
+2023-10-23T13:33:34.937123456Z | 172.21.0.5 | 1232382 | Disconnected
+2023-10-23T12:27:28.948123456Z | 172.21.2.113 | 2764889 | Connected to 10.1.0.2
+2023-10-23T12:15:03.360123456Z | 172.21.2.162 | 3450233 | Connected to 10.1.0.3
+;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupJoinTypesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupJoinTypesIT.java
@@ -40,6 +40,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.AGGREGATE_METRIC_D
 import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
 import static org.elasticsearch.xpack.esql.core.type.DataType.BYTE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_NANOS;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOC_DATA_TYPE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.FLOAT;
@@ -175,6 +176,19 @@ public class LookupJoinTypesIT extends ESIntegTestCase {
             }
         }
 
+        // Tests for mixed-date/time types
+        var dateTypes = List.of(DATETIME, DATE_NANOS);
+        {
+            TestConfigs configs = testConfigurations.computeIfAbsent("mixed-temporal", TestConfigs::new);
+            for (DataType mainType : dateTypes) {
+                for (DataType lookupType : dateTypes) {
+                    if (mainType != lookupType) {
+                        configs.addFails(mainType, lookupType);
+                    }
+                }
+            }
+        }
+
         // Tests for all unsupported types
         DataType[] unsupported = Join.UNSUPPORTED_TYPES;
         {
@@ -201,7 +215,20 @@ public class LookupJoinTypesIT extends ESIntegTestCase {
         }
 
         // Tests for all types where left and right are the same type
-        DataType[] supported = { BOOLEAN, LONG, INTEGER, DOUBLE, SHORT, BYTE, FLOAT, HALF_FLOAT, DATETIME, IP, KEYWORD, SCALED_FLOAT };
+        DataType[] supported = {
+            BOOLEAN,
+            LONG,
+            INTEGER,
+            DOUBLE,
+            SHORT,
+            BYTE,
+            FLOAT,
+            HALF_FLOAT,
+            DATETIME,
+            DATE_NANOS,
+            IP,
+            KEYWORD,
+            SCALED_FLOAT };
         {
             Collection<TestConfigs> existing = testConfigurations.values();
             TestConfigs configs = testConfigurations.computeIfAbsent("same", TestConfigs::new);
@@ -275,6 +302,10 @@ public class LookupJoinTypesIT extends ESIntegTestCase {
 
     public void testLookupJoinMixedNumerical() {
         testLookupJoinTypes("mixed-numerical");
+    }
+
+    public void testLookupJoinMixedTemporal() {
+        testLookupJoinTypes("mixed-temporal");
     }
 
     public void testLookupJoinSame() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -553,6 +553,12 @@ public class EsqlCapabilities {
          * e.g. {@code WHERE millis > to_datenanos("2023-10-23T12:15:03.360103847") AND millis < to_datetime("2023-10-23T13:53:55.832")}
          */
         FIX_DATE_NANOS_MIXED_RANGE_PUSHDOWN_BUG(),
+
+        /**
+         * Support for date nanos in lookup join. Done in #127962
+         */
+        DATE_NANOS_LOOKUP_JOIN,
+
         /**
          * DATE_PARSE supports reading timezones
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
@@ -198,6 +198,7 @@ public abstract class AbstractLookupService<R extends AbstractLookupService.Requ
         return switch (inputDataType) {
             case IP -> QueryList.ipTermQueryList(field, searchExecutionContext, (BytesRefBlock) block);
             case DATETIME -> QueryList.dateTermQueryList(field, searchExecutionContext, (LongBlock) block);
+            case DATE_NANOS -> QueryList.dateNanosTermQueryList(field, searchExecutionContext, (LongBlock) block);
             case null, default -> QueryList.rawTermQueryList(field, searchExecutionContext, block);
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/Join.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/Join.java
@@ -37,7 +37,6 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.COUNTER_DOUBLE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.COUNTER_INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.COUNTER_LONG;
-import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_NANOS;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_PERIOD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOC_DATA_TYPE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
@@ -71,7 +70,6 @@ public class Join extends BinaryPlan implements PostAnalysisVerificationAware, S
         COUNTER_LONG,
         COUNTER_INTEGER,
         COUNTER_DOUBLE,
-        DATE_NANOS,
         OBJECT,
         SOURCE,
         DATE_PERIOD,


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/127962