### PR TITLE
ESQL: Throw ISE instead of IAE for illegal block in page

### DIFF
--- a/docs/changelog/128960.yaml
+++ b/docs/changelog/128960.yaml
@@ -1,0 +1,5 @@
+pr: 128960
+summary: Throw ISE instead of IAE for illegal block in page
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
@@ -84,7 +84,7 @@ public final class Page implements Writeable, Releasable {
     private Page(Page prev, Block[] toAdd) {
         for (Block block : toAdd) {
             if (prev.positionCount != block.getPositionCount()) {
-                throw new IllegalArgumentException(
+                throw new IllegalStateException(
                     "Block [" + block + "] does not have same position count: " + block.getPositionCount() + " != " + prev.positionCount
                 );
             }


### PR DESCRIPTION
relates https://github.com/elastic/elasticsearch/issues/128963

IAE gets reported as a 400 status code, but that's inappropriate when inconsistent pages are always bugs, and should be reported with a 500. Throw ISE instead.

This is relevant for Serverless as 500 status codes indicate bugs that require our attention.
