### PR TITLE
ESQL: Forward port 8.19 RegexMatch serialization change version

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -189,7 +189,7 @@ public class TransportVersions {
     public static final TransportVersion DATA_STREAM_OPTIONS_API_REMOVE_INCLUDE_DEFAULTS_8_19 = def(8_841_0_41);
     public static final TransportVersion JOIN_ON_ALIASES_8_19 = def(8_841_0_42);
     public static final TransportVersion ILM_ADD_SKIP_SETTING_8_19 = def(8_841_0_43);
-    public static final TransportVersion ML_INFERENCE_MISTRAL_CHAT_COMPLETION_ADDED_8_19 = def(8_841_0_44);
+    public static final TransportVersion ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19 = def(8_841_0_44);
     public static final TransportVersion V_9_0_0 = def(9_000_0_09);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0_1 = def(9_000_0_10);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0_2 = def(9_000_0_11);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
@@ -24,7 +24,6 @@ import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdow
 
 import java.io.IOException;
 
-import static org.elasticsearch.TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
 
@@ -75,14 +74,15 @@ abstract class RegexMatch<P extends AbstractStringPattern> extends org.elasticse
     void serializeCaseInsensitivity(StreamOutput out) throws IOException {
         var transportVersion = out.getTransportVersion();
         if (transportVersion.onOrAfter(TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY)
-            || transportVersion.isPatchFrom(ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19)) {
+            || transportVersion.isPatchFrom(TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19)) {
             out.writeBoolean(caseInsensitive());
         } else if (caseInsensitive()) {
             // The plan has been optimized to run a case-insensitive match, which the remote peer cannot be notified of. Simply avoiding
             // the serialization of the boolean would result in wrong results.
             throw new EsqlIllegalArgumentException(
-                name() + " with case insensitivity is not supported in peer node's version [{}]. Upgrade to version [{}] or newer.",
+                name() + " with case insensitivity is not supported in peer node's version [{}]. Upgrade to version [{}, {}] or newer.",
                 out.getTransportVersion(),
+                TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19,
                 TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY
             );
         } // else: write nothing, the remote peer can execute the case-sensitive query
@@ -91,6 +91,6 @@ abstract class RegexMatch<P extends AbstractStringPattern> extends org.elasticse
     static boolean deserializeCaseInsensitivity(StreamInput in) throws IOException {
         var transportVersion = in.getTransportVersion();
         return (transportVersion.onOrAfter(TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY)
-            || transportVersion.isPatchFrom(ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19)) && in.readBoolean();
+            || transportVersion.isPatchFrom(TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19)) && in.readBoolean();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
@@ -81,7 +81,7 @@ abstract class RegexMatch<P extends AbstractStringPattern> extends org.elasticse
             // the serialization of the boolean would result in wrong results.
             throw new EsqlIllegalArgumentException(
                 name() + " with case insensitivity is not supported in peer node's version [{}]. Upgrade to version [{}, {}] or newer.",
-                out.getTransportVersion(),
+                transportVersion,
                 TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19,
                 TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY
             );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdow
 
 import java.io.IOException;
 
+import static org.elasticsearch.TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
 
@@ -72,22 +73,24 @@ abstract class RegexMatch<P extends AbstractStringPattern> extends org.elasticse
     }
 
     void serializeCaseInsensitivity(StreamOutput out) throws IOException {
-        if (out.getTransportVersion().before(TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY)) {
-            if (caseInsensitive()) {
-                // The plan has been optimized to run a case-insensitive match, which the remote peer cannot be notified of. Simply avoiding
-                // the serialization of the boolean would result in wrong results.
-                throw new EsqlIllegalArgumentException(
-                    name() + " with case insensitivity is not supported in peer node's version [{}]. Upgrade to version [{}] or newer.",
-                    out.getTransportVersion(),
-                    TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY
-                );
-            } // else: write nothing, the remote peer can execute the case-sensitive query
-        } else {
+        var transportVersion = out.getTransportVersion();
+        if (transportVersion.onOrAfter(TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY)
+            || transportVersion.isPatchFrom(ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19)) {
             out.writeBoolean(caseInsensitive());
-        }
+        } else if (caseInsensitive()) {
+            // The plan has been optimized to run a case-insensitive match, which the remote peer cannot be notified of. Simply avoiding
+            // the serialization of the boolean would result in wrong results.
+            throw new EsqlIllegalArgumentException(
+                name() + " with case insensitivity is not supported in peer node's version [{}]. Upgrade to version [{}] or newer.",
+                out.getTransportVersion(),
+                TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY
+            );
+        } // else: write nothing, the remote peer can execute the case-sensitive query
     }
 
     static boolean deserializeCaseInsensitivity(StreamInput in) throws IOException {
-        return in.getTransportVersion().onOrAfter(TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY) && in.readBoolean();
+        var transportVersion = in.getTransportVersion();
+        return (transportVersion.onOrAfter(TransportVersions.ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY)
+            || transportVersion.isPatchFrom(ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19)) && in.readBoolean();
     }
 }


### PR DESCRIPTION
Fwd port `ESQL_REGEX_MATCH_WITH_CASE_INSENSITIVITY_8_19`.

Related: #128919.
