### PR TITLE
[9.0] Remove stale synthetic source preview note (#128981)

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/aggregate-metric-double.md
+++ b/docs/reference/elasticsearch/mapping-reference/aggregate-metric-double.md
@@ -202,11 +202,6 @@ The search returns the following hit. The value of the `default_metric` field, `
 
 ## Synthetic `_source` [aggregate-metric-double-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 For example:
 
 $$$synthetic-source-aggregate-metric-double-example$$$

--- a/docs/reference/elasticsearch/mapping-reference/binary.md
+++ b/docs/reference/elasticsearch/mapping-reference/binary.md
@@ -47,11 +47,6 @@ The following parameters are accepted by `binary` fields:
 
 ## Synthetic `_source` [binary-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 Synthetic source may sort `binary` values in order of their byte representation. For example:
 
 $$$synthetic-source-binary-example$$$

--- a/docs/reference/elasticsearch/mapping-reference/boolean.md
+++ b/docs/reference/elasticsearch/mapping-reference/boolean.md
@@ -126,11 +126,6 @@ The following parameters are accepted by `boolean` fields:
 
 ## Synthetic `_source` [boolean-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 `boolean` fields support [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) in their default configuration.
 
 Synthetic source may sort `boolean` field values. For example:

--- a/docs/reference/elasticsearch/mapping-reference/date.md
+++ b/docs/reference/elasticsearch/mapping-reference/date.md
@@ -186,11 +186,6 @@ Which will reply with a date like:
 
 ## Synthetic `_source` [date-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 Synthetic source may sort `date` field values. For example:
 
 $$$synthetic-source-date-example$$$

--- a/docs/reference/elasticsearch/mapping-reference/date_nanos.md
+++ b/docs/reference/elasticsearch/mapping-reference/date_nanos.md
@@ -85,11 +85,6 @@ Aggregations are still on millisecond resolution, even when using a `date_nanos`
 
 ## Synthetic `_source` [date-nanos-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 Synthetic source may sort `date_nanos` field values. For example:
 
 $$$synthetic-source-date-nanos-example$$$

--- a/docs/reference/elasticsearch/mapping-reference/dense-vector.md
+++ b/docs/reference/elasticsearch/mapping-reference/dense-vector.md
@@ -278,11 +278,6 @@ $$$dense-vector-index-options$$$
 
 ## Synthetic `_source` [dense-vector-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 `dense_vector` fields support [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) .
 
 

--- a/docs/reference/elasticsearch/mapping-reference/flattened.md
+++ b/docs/reference/elasticsearch/mapping-reference/flattened.md
@@ -236,11 +236,6 @@ The following mapping parameters are accepted:
 
 ## Synthetic `_source` [flattened-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 Flattened fields support [synthetic`_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) in their default configuration.
 
 Synthetic source may sort `flattened` field values and remove duplicates. For example:

--- a/docs/reference/elasticsearch/mapping-reference/geo-point.md
+++ b/docs/reference/elasticsearch/mapping-reference/geo-point.md
@@ -207,16 +207,6 @@ def lon      = doc['location'].lon;
 
 ## Synthetic source [geo-point-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices
-(indices that have `index.mode` set to `time_series`). For other indices
-synthetic `_source` is in technical preview. Features in technical preview may
-be changed or removed in a future release. Elastic will work to fix
-any issues, but features in technical preview are not subject to the support SLA
-of official GA features.
-::::
-
-
 Synthetic source may sort `geo_point` fields (first by latitude and then
 longitude) and reduces them to their stored precision. For example:
 

--- a/docs/reference/elasticsearch/mapping-reference/geo-shape.md
+++ b/docs/reference/elasticsearch/mapping-reference/geo-shape.md
@@ -365,12 +365,3 @@ Neither GeoJSON nor WKT supports a point-radius circle type. Instead, use a [cir
 ### Sorting and Retrieving index Shapes [_sorting_and_retrieving_index_shapes]
 
 Due to the complex input structure and index representation of shapes, it is not currently possible to sort shapes or retrieve their fields directly. The `geo_shape` value is only retrievable through the `_source` field.
-
-## Synthetic source [geo-shape-synthetic-source]
-
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
-

--- a/docs/reference/elasticsearch/mapping-reference/histogram.md
+++ b/docs/reference/elasticsearch/mapping-reference/histogram.md
@@ -52,11 +52,6 @@ The histogram field is "algorithm agnostic" and does not store data specific to 
 
 ## Synthetic `_source` [histogram-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 `histogram` fields support [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) in their default configuration.
 
 ::::{note}

--- a/docs/reference/elasticsearch/mapping-reference/ip.md
+++ b/docs/reference/elasticsearch/mapping-reference/ip.md
@@ -123,11 +123,6 @@ GET my-index-000001/_search
 
 ## Synthetic `_source` [ip-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 Synthetic source may sort `ip` field values and remove duplicates. For example:
 
 $$$synthetic-source-ip-example$$$

--- a/docs/reference/elasticsearch/mapping-reference/keyword.md
+++ b/docs/reference/elasticsearch/mapping-reference/keyword.md
@@ -119,11 +119,6 @@ The following parameters are accepted by `keyword` fields:
 
 ## Synthetic `_source` [keyword-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 Synthetic source may sort `keyword` fields and remove duplicates. For example:
 
 $$$synthetic-source-keyword-example-default$$$

--- a/docs/reference/elasticsearch/mapping-reference/number.md
+++ b/docs/reference/elasticsearch/mapping-reference/number.md
@@ -179,11 +179,6 @@ This can lead to unexpected results with [range queries](/reference/query-langua
 
 ## Synthetic `_source` [numeric-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 All numeric fields support [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) in their default configuration. Synthetic `_source` cannot be used together with [`copy_to`](/reference/elasticsearch/mapping-reference/copy-to.md), or with [`doc_values`](/reference/elasticsearch/mapping-reference/doc-values.md) disabled.
 
 Synthetic source may sort numeric field values. For example:

--- a/docs/reference/elasticsearch/mapping-reference/range.md
+++ b/docs/reference/elasticsearch/mapping-reference/range.md
@@ -218,11 +218,6 @@ The following parameters are accepted by range types:
 
 ## Synthetic `_source` [range-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 `range` fields support [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) in their default configuration.
 
 Synthetic source may sort `range` field values and remove duplicates for all `range` fields except `ip_range`. Ranges are sorted by their lower bound and then by upper bound. For example:

--- a/docs/reference/elasticsearch/mapping-reference/rank-vectors.md
+++ b/docs/reference/elasticsearch/mapping-reference/rank-vectors.md
@@ -109,11 +109,6 @@ $$$rank-vectors-element-type$$$
 
 ## Synthetic `_source` [rank-vectors-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 `rank_vectors` fields support [synthetic `_source`](mapping-source-field.md#synthetic-source) .
 
 

--- a/docs/reference/elasticsearch/mapping-reference/search-as-you-type.md
+++ b/docs/reference/elasticsearch/mapping-reference/search-as-you-type.md
@@ -181,11 +181,6 @@ The analyzer of the `._index_prefix` subfield slightly modifies the shingle-buil
 
 ### Synthetic `_source` [search-as-you-type-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 `search_as_you_type` fields support [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) in their default configuration.
 
 

--- a/docs/reference/elasticsearch/mapping-reference/text.md
+++ b/docs/reference/elasticsearch/mapping-reference/text.md
@@ -99,11 +99,6 @@ The following parameters are accepted by `text` fields:
 
 ## Synthetic `_source` [text-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 `text` fields support [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) if they have a [`keyword`](/reference/elasticsearch/mapping-reference/keyword.md#keyword-synthetic-source) sub-field that supports synthetic `_source` or if the `text` field sets `store` to `true`. Either way, it may not have [`copy_to`](/reference/elasticsearch/mapping-reference/copy-to.md).
 
 If using a sub-`keyword` field, then the values are sorted in the same way as a `keyword` field’s values are sorted. By default, that means sorted with duplicates removed. So:

--- a/docs/reference/elasticsearch/mapping-reference/token-count.md
+++ b/docs/reference/elasticsearch/mapping-reference/token-count.md
@@ -74,11 +74,6 @@ The following parameters are accepted by `token_count` fields:
 
 ### Synthetic `_source` [token-count-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 `token_count` fields support [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) in their default configuration.
 
 

--- a/docs/reference/elasticsearch/mapping-reference/version.md
+++ b/docs/reference/elasticsearch/mapping-reference/version.md
@@ -43,11 +43,6 @@ This field type isn’t optimized for heavy wildcard, regex, or fuzzy searches. 
 
 ## Synthetic `_source` [version-synthetic-source]
 
-::::{important}
-Synthetic `_source` is Generally Available only for TSDB indices (indices that have `index.mode` set to `time_series`). For other indices, synthetic `_source` is in technical preview. Features in technical preview may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 `version` fields support [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) in their default configuration..
 
 Synthetic source may sort `version` field values and remove duplicates. For example:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Remove stale synthetic source preview note (#128981)](https://github.com/elastic/elasticsearch/pull/128981)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)