### PR TITLE
Register mustache size limit setting (#119291)

### DIFF
--- a/docs/changelog/119291.yaml
+++ b/docs/changelog/119291.yaml
@@ -1,0 +1,5 @@
+pr: 119291
+summary: Register mustache size limit setting
+area: Infra/Scripting
+type: bug
+issues: []

--- a/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MustacheSettingsIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MustacheSettingsIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.script.mustache;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.Matchers.equalTo;
+
+public class MustacheSettingsIT extends ESSingleNodeTestCase {
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return List.of(MustachePlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder().put(MustacheScriptEngine.MUSTACHE_RESULT_SIZE_LIMIT.getKey(), "10b").build();
+    }
+
+    public void testResultSizeLimit() throws Exception {
+        createIndex("test");
+        prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("text", "value1").endObject()).get();
+        indicesAdmin().prepareRefresh().get();
+
+        String query = """
+            { "query": {"match_all": {}}, "size" : "{{my_size}}"  }""";
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.indices("test");
+        var e = expectThrows(
+            ElasticsearchParseException.class,
+            () -> new SearchTemplateRequestBuilder(client()).setRequest(searchRequest)
+                .setScript(query)
+                .setScriptType(ScriptType.INLINE)
+                .setScriptParams(Collections.singletonMap("my_size", 1))
+                .get()
+        );
+        assertThat(e.getMessage(), equalTo("Mustache script result size limit exceeded"));
+    }
+}

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.features.NodeFeature;
@@ -72,5 +73,10 @@ public class MustachePlugin extends Plugin implements ScriptPlugin, ActionPlugin
             new RestMultiSearchTemplateAction(settings),
             new RestRenderSearchTemplateAction()
         );
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(MustacheScriptEngine.MUSTACHE_RESULT_SIZE_LIMIT);
     }
 }


### PR DESCRIPTION
In #114002 the maximum size of a mustache script output was made configurable. However, the setting was not registered. This commit registers the setting so that it can be set in elasticsearch.yml.