### PR TITLE
ESQL: Check for errors while loading blocks

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -103,7 +103,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 
 /**
- * Test case that lets you easilly build {@link MapperService} based on some
+ * Test case that lets you easily build {@link MapperService} based on some
  * mapping. Useful when you don't need to spin up an entire index but do
  * need most of the trapping of the mapping.
  */

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
@@ -566,13 +566,29 @@ public class ValuesSourceReaderOperator extends AbstractPageMappingOperator {
      */
     private void sanityCheckBlock(Object loader, int expectedPositions, Block block, int field) {
         if (block.getPositionCount() != expectedPositions) {
-            throw new IllegalStateException(loader + ": " + block + " didn't have [" + expectedPositions + "] positions");
+            throw new IllegalStateException(
+                sanityCheckBlockErrorPrefix(loader, block, field)
+                    + " has ["
+                    + block.getPositionCount()
+                    + "] positions instead of ["
+                    + expectedPositions
+                    + "]"
+            );
         }
         if (block.elementType() != ElementType.NULL && block.elementType() != fields[field].info.type) {
             throw new IllegalStateException(
-                loader + ": " + block + "'s element_type [" + block.elementType() + "] NOT IN (NULL, " + fields[field].info.type + ")"
+                sanityCheckBlockErrorPrefix(loader, block, field)
+                    + "'s element_type ["
+                    + block.elementType()
+                    + "] NOT IN (NULL, "
+                    + fields[field].info.type
+                    + ")"
             );
         }
+    }
+
+    private String sanityCheckBlockErrorPrefix(Object loader, Block block, int field) {
+        return fields[field].info.name + "[" + loader + "]: " + block;
     }
 
     public static class Status extends AbstractPageMappingOperator.Status {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
@@ -557,13 +557,20 @@ public class ValuesSourceReaderOperator extends AbstractPageMappingOperator {
         return new Status(new TreeMap<>(readersBuilt), processNanos, pagesProcessed, rowsReceived, rowsEmitted, valuesLoaded);
     }
 
-    private void sanityCheckBlock(Object loader, int expectedPositions, Block block, int f) {
+    /**
+     * Quick checks for on the loaded block to make sure it looks reasonable.
+     * @param loader the object that did the loading - we use it to make error messages if the block is busted
+     * @param expectedPositions how many positions the block should have - it's as many as the incoming {@link Page} has
+     * @param block the block to sanity check
+     * @param field offset into the {@link #fields} array for the block being loaded
+     */
+    private void sanityCheckBlock(Object loader, int expectedPositions, Block block, int field) {
         if (block.getPositionCount() != expectedPositions) {
             throw new IllegalStateException(loader + ": " + block + " didn't have [" + expectedPositions + "] positions");
         }
-        if (block.elementType() != ElementType.NULL && block.elementType() != fields[f].info.type) {
+        if (block.elementType() != ElementType.NULL && block.elementType() != fields[field].info.type) {
             throw new IllegalStateException(
-                loader + ": " + block + "'s element_type [" + block.elementType() + "] NOT IN (NULL, " + fields[f].info.type + ")"
+                loader + ": " + block + "'s element_type [" + block.elementType() + "] NOT IN (NULL, " + fields[field].info.type + ")"
             );
         }
     }


### PR DESCRIPTION
Runs a sanity check after loading a block of values. Previously we were doing a quick check if assertions were enabled. Now we do two quick checks all the time. Better - we attach information about how a block was loaded when there's a problem.

Relates to #128959
