### PR TITLE
[9.0] ESQL: Throw ISE instead of IAE for illegal block in page (#128960)

### DIFF
--- a/docs/changelog/128960.yaml
+++ b/docs/changelog/128960.yaml
@@ -1,0 +1,5 @@
+pr: 128960
+summary: Throw ISE instead of IAE for illegal block in page
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
@@ -83,7 +83,7 @@ public final class Page implements Writeable {
     private Page(Page prev, Block[] toAdd) {
         for (Block block : toAdd) {
             if (prev.positionCount != block.getPositionCount()) {
-                throw new IllegalArgumentException(
+                throw new IllegalStateException(
                     "Block [" + block + "] does not have same position count: " + block.getPositionCount() + " != " + prev.positionCount
                 );
             }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - ESQL: Throw ISE instead of IAE for illegal block in page (#128960)