### PR TITLE
Update constant-keyword.asciidoc

### DIFF
--- a/docs/reference/mapping/types/constant-keyword.asciidoc
+++ b/docs/reference/mapping/types/constant-keyword.asciidoc
@@ -40,14 +40,14 @@ indexing requests are equivalent:
 --------------------------------
 POST logs-debug/_doc
 {
-  "date": "2019-12-12",
+  "@timestamp": "2019-12-12",
   "message": "Starting up Elasticsearch",
   "level": "debug"
 }
 
 POST logs-debug/_doc
 {
-  "date": "2019-12-12",
+  "@timestamp": "2019-12-12",
   "message": "Starting up Elasticsearch"
 }
 --------------------------------


### PR DESCRIPTION
Change the field name `date` to `@timestamp` so that users will be able to follow along with documentation.  If not, then the date field is mapped as a keyword, which confuses users.

