### PR TITLE
[8.19] Adding `space_id` field mapping to kibana reporting template (#128336)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/kibana-reporting@template.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/kibana-reporting@template.json
@@ -82,6 +82,9 @@
         "status": {
           "type": "keyword"
         },
+        "space_id": {
+          "type": "keyword"
+        },
         "parent_id": {
           "type": "keyword"
         },

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -47,7 +47,7 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
-    public static final int REGISTRY_VERSION = 14;
+    public static final int REGISTRY_VERSION = 15;
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.template.version";
     public static final Setting<Boolean> STACK_TEMPLATES_ENABLED = Setting.boolSetting(


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Adding `space_id` field mapping to kibana reporting template (#128336)