### PR TITLE
[8.18] Fix NPE when `date_buckets` aggregation is missing in the response (#128974)

### DIFF
--- a/docs/changelog/128974.yaml
+++ b/docs/changelog/128974.yaml
@@ -1,0 +1,5 @@
+pr: 128974
+summary: Fix NPE when `date_buckets` aggregation is missing in the response
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Fix NPE when `date_buckets` aggregation is missing in the response (#128974)](https://github.com/elastic/elasticsearch/pull/128974)

<!--- Backport version: 8.8.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)