### PR TITLE
[8.17] Update constant-keyword.asciidoc (#129053)

### DIFF
--- a/docs/reference/mapping/types/constant-keyword.asciidoc
+++ b/docs/reference/mapping/types/constant-keyword.asciidoc
@@ -40,14 +40,14 @@ indexing requests are equivalent:
 --------------------------------
 POST logs-debug/_doc
 {
-  "date": "2019-12-12",
+  "@timestamp": "2019-12-12",
   "message": "Starting up Elasticsearch",
   "level": "debug"
 }
 
 POST logs-debug/_doc
 {
-  "date": "2019-12-12",
+  "@timestamp": "2019-12-12",
   "message": "Starting up Elasticsearch"
 }
 --------------------------------


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.18` to `8.17`:
 - [Update constant-keyword.asciidoc (#129053)](https://github.com/elastic/elasticsearch/pull/129053)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)