### PR TITLE
Remove `ClusterState` param from ILM `AsyncBranchingStep`

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncBranchingStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncBranchingStep.java
@@ -13,9 +13,9 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.common.TriConsumer;
 
 import java.util.Objects;
+import java.util.function.BiConsumer;
 
 /**
  * This step changes its {@link #getNextStepKey()} depending on the
@@ -26,14 +26,14 @@ public class AsyncBranchingStep extends AsyncActionStep {
 
     private final StepKey nextStepKeyOnFalse;
     private final StepKey nextStepKeyOnTrue;
-    private final TriConsumer<IndexMetadata, ClusterState, ActionListener<Boolean>> asyncPredicate;
+    private final BiConsumer<IndexMetadata, ActionListener<Boolean>> asyncPredicate;
     private final SetOnce<Boolean> predicateValue;
 
     public AsyncBranchingStep(
         StepKey key,
         StepKey nextStepKeyOnFalse,
         StepKey nextStepKeyOnTrue,
-        TriConsumer<IndexMetadata, ClusterState, ActionListener<Boolean>> asyncPredicate,
+        BiConsumer<IndexMetadata, ActionListener<Boolean>> asyncPredicate,
         Client client
     ) {
         // super.nextStepKey is set to null since it is not used by this step
@@ -56,7 +56,7 @@ public class AsyncBranchingStep extends AsyncActionStep {
         ClusterStateObserver observer,
         ActionListener<Void> listener
     ) {
-        asyncPredicate.apply(indexMetadata, currentClusterState, listener.safeMap(value -> {
+        asyncPredicate.accept(indexMetadata, listener.safeMap(value -> {
             predicateValue.set(value);
             return null;
         }));
@@ -87,7 +87,7 @@ public class AsyncBranchingStep extends AsyncActionStep {
     /**
      * @return the next step if {@code predicate} is true
      */
-    final TriConsumer<IndexMetadata, ClusterState, ActionListener<Boolean>> getAsyncPredicate() {
+    final BiConsumer<IndexMetadata, ActionListener<Boolean>> getAsyncPredicate() {
         return asyncPredicate;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkAction.java
@@ -187,7 +187,7 @@ public class ShrinkAction implements LifecycleAction {
             preShrinkBranchingKey,
             checkNotWriteIndex,
             lastOrNextStep,
-            (indexMetadata, clusterState, listener) -> {
+            (indexMetadata, listener) -> {
                 if (indexMetadata.getSettings().get(LifecycleSettings.SNAPSHOT_INDEX_NAME) != null) {
                     logger.warn(
                         "[{}] action is configured for index [{}] in policy [{}] which is mounted as searchable snapshot. "

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AsyncBranchingStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AsyncBranchingStepTests.java
@@ -11,12 +11,12 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.TriConsumer;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -34,7 +34,7 @@ public class AsyncBranchingStepTests extends AbstractStepTestCase<AsyncBranching
         StepKey nextStepKey = new StepKey(randomAlphaOfLength(6), randomAlphaOfLength(6), BranchingStep.NAME);
         StepKey nextSkipKey = new StepKey(randomAlphaOfLength(7), randomAlphaOfLength(7), BranchingStep.NAME);
         {
-            AsyncBranchingStep step = new AsyncBranchingStep(stepKey, nextStepKey, nextSkipKey, (i, c, l) -> l.onResponse(true), client);
+            AsyncBranchingStep step = new AsyncBranchingStep(stepKey, nextStepKey, nextSkipKey, (i, l) -> l.onResponse(true), client);
             expectThrows(IllegalStateException.class, step::getNextStepKey);
             CountDownLatch latch = new CountDownLatch(1);
             step.performAction(state.metadata().getProject().index(indexName), state, null, new Listener(latch));
@@ -42,7 +42,7 @@ public class AsyncBranchingStepTests extends AbstractStepTestCase<AsyncBranching
             assertThat(step.getNextStepKey(), equalTo(step.getNextStepKeyOnTrue()));
         }
         {
-            AsyncBranchingStep step = new AsyncBranchingStep(stepKey, nextStepKey, nextSkipKey, (i, c, l) -> l.onResponse(false), client);
+            AsyncBranchingStep step = new AsyncBranchingStep(stepKey, nextStepKey, nextSkipKey, (i, l) -> l.onResponse(false), client);
             expectThrows(IllegalStateException.class, step::getNextStepKey);
             CountDownLatch latch = new CountDownLatch(1);
             step.performAction(state.metadata().getProject().index(indexName), state, null, new Listener(latch));
@@ -56,7 +56,7 @@ public class AsyncBranchingStepTests extends AbstractStepTestCase<AsyncBranching
         StepKey stepKey = new StepKey(randomAlphaOfLength(5), randomAlphaOfLength(5), BranchingStep.NAME);
         StepKey nextStepKey = new StepKey(randomAlphaOfLength(6), randomAlphaOfLength(6), BranchingStep.NAME);
         StepKey nextSkipKey = new StepKey(randomAlphaOfLength(7), randomAlphaOfLength(7), BranchingStep.NAME);
-        return new AsyncBranchingStep(stepKey, nextStepKey, nextSkipKey, (i, c, l) -> l.onResponse(randomBoolean()), client);
+        return new AsyncBranchingStep(stepKey, nextStepKey, nextSkipKey, (i, l) -> l.onResponse(randomBoolean()), client);
     }
 
     @Override
@@ -64,7 +64,7 @@ public class AsyncBranchingStepTests extends AbstractStepTestCase<AsyncBranching
         StepKey key = instance.getKey();
         StepKey nextStepKey = instance.getNextStepKeyOnFalse();
         StepKey nextSkipStepKey = instance.getNextStepKeyOnTrue();
-        TriConsumer<IndexMetadata, ClusterState, ActionListener<Boolean>> asyncPredicate = instance.getAsyncPredicate();
+        BiConsumer<IndexMetadata, ActionListener<Boolean>> asyncPredicate = instance.getAsyncPredicate();
 
         switch (between(0, 2)) {
             case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));


### PR DESCRIPTION
The `ClusterState` parameter of the `asyncPredicate` is not used anywhere.