### PR TITLE
[8.18] Prevent invalid privileges in manage roles privilege (#128532) (#128847)

### DIFF
--- a/docs/changelog/128532.yaml
+++ b/docs/changelog/128532.yaml
@@ -1,0 +1,5 @@
+pr: 128532
+summary: "Prevent invalid privileges in manage roles privilege"
+area: "Authorization"
+type: bug
+issues: [127496]

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConfigurableClusterPrivileges.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConfigurableClusterPrivileges.java
@@ -555,6 +555,13 @@ public final class ConfigurableClusterPrivileges {
                 if (indexPrivilege.privileges == null || indexPrivilege.privileges.length == 0) {
                     throw new IllegalArgumentException("Indices privileges must define at least one privilege");
                 }
+
+                for (String privilege : indexPrivilege.privileges) {
+                    // Use resolveBySelectorAccess to determine whether the passed privilege is valid.
+                    // IllegalArgumentException is thrown here when an invalid permission is encountered.
+                    IndexPrivilege.get(Set.of(privilege));
+                }
+
             }
             return new ManageRolesPrivilege(indexPrivileges);
         }


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Prevent invalid privileges in manage roles privilege (#128532) (#128847)