### PR TITLE
Update Test Framework To Handle Query Rewrites That Rely on Non-Null Searchers

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -948,10 +948,12 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
      */
     public void testCacheability() throws IOException {
         QB queryBuilder = createTestQueryBuilder();
-        SearchExecutionContext context = createSearchExecutionContext();
-        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, createQueryRewriteContext(), new SearchExecutionContext(context));
-        assertNotNull(rewriteQuery.toQuery(context));
-        assertTrue("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
+        try (IndexReaderManager irm = getIndexReaderManager()) {
+            SearchExecutionContext context = createSearchExecutionContext(irm.getIndexSearcher());
+            QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, createQueryRewriteContext(), new SearchExecutionContext(context));
+            assertNotNull(rewriteQuery.toQuery(context));
+            assertTrue("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
+        }
     }
 
     public static class IndexReaderManager implements Closeable {


### PR DESCRIPTION
Adds the `IndexReaderManager` class, which allows the developer to define a non-null `IndexSearcher` instance that is passed to the `SearchExecutionContext`s used in `testToQuery` and `testCacheability`. By default, a `null` `IndexSearcher` is used, maintaining the current behavior.

This is necessary to support future tests on queries that use the `IndexSearcher` during rewrite. One example is the `sparse_vector` query, which uses it during rewrite to determine which tokens to prune.