### PR TITLE
[9.0] Add `complete` attribute to .fleet-agents docs (#127651)

### DIFF
--- a/docs/changelog/127651.yaml
+++ b/docs/changelog/127651.yaml
@@ -1,0 +1,5 @@
+pr: 127651
+summary: Add complete attribute to .fleet-agents docs
+area: Infra/Plugins
+type: bug
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -96,6 +96,9 @@
                     "snapshot": {
                       "type": "boolean"
                     },
+                    "complete": {
+                      "type": "boolean"
+                    },
                     "upgradeable": {
                       "type": "boolean"
                     },


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Add `complete` attribute to .fleet-agents docs (#127651)