### PR TITLE
[Build] Build maven aggregation zip as part of DRA build

### DIFF
--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -71,6 +71,7 @@ echo --- Building release artifacts
   buildReleaseArtifacts \
   exportCompressedDockerImages \
   exportDockerContexts \
+  :zipAggregation \
   :distribution:generateDependenciesReport
 
 PATH="$PATH:${JAVA_HOME}/bin" # Required by the following script

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ nmcpAggregation {
 }
 
 tasks.named('zipAggregation').configure {
+  archiveFileName.unset();
+  archiveBaseName.set("elasticsearch-maven-aggregration")
+  archiveVersion.set(VersionProperties.elasticsearch)
   dependsOn gradle.includedBuild('build-tools').task(':zipElasticPublication')
   from(zipTree(gradle.includedBuild('build-tools').task(':zipElasticPublication').resolveTask().archiveFile.get()))
 }

--- a/build.gradle
+++ b/build.gradle
@@ -68,9 +68,12 @@ nmcpAggregation {
 }
 
 tasks.named('zipAggregation').configure {
+  // put this in a place that works well with our DRA infrastructure
   archiveFileName.unset();
-  archiveBaseName.set("elasticsearch-maven-aggregration")
+  archiveBaseName.set("elasticsearch-maven-aggregation")
   archiveVersion.set(VersionProperties.elasticsearch)
+  destinationDirectory.set(layout.buildDirectory.dir("distributions"));
+
   dependsOn gradle.includedBuild('build-tools').task(':zipElasticPublication')
   from(zipTree(gradle.includedBuild('build-tools').task(':zipElasticPublication').resolveTask().archiveFile.get()))
 }


### PR DESCRIPTION
This ensures we build the aggregation zip as part of our DRA pipeline. We need to update the releasemanager to take this artifact into account.