### PR TITLE
rename ES|QL sample capability

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestSampleTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestSampleTestCase.java
@@ -33,7 +33,7 @@ public class RestSampleTestCase extends ESRestTestCase {
     public void skipWhenSampleDisabled() throws IOException {
         assumeTrue(
             "Requires SAMPLE capability",
-            EsqlSpecTestCase.hasCapabilities(adminClient(), List.of(EsqlCapabilities.Cap.SAMPLE.capabilityName()))
+            EsqlSpecTestCase.hasCapabilities(adminClient(), List.of(EsqlCapabilities.Cap.SAMPLE_V2.capabilityName()))
         );
     }
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/sample.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/sample.csv-spec
@@ -9,7 +9,7 @@
 // because the CSV tests don't support such assertions.
 
 row
-required_capability: sample
+required_capability: sample_v2
 
 ROW x = 1 | SAMPLE .999999999
 ;
@@ -20,7 +20,7 @@ x:integer
 
 
 row and mv_expand
-required_capability: sample
+required_capability: sample_v2
 
 ROW x = [1,2,3,4,5] | MV_EXPAND x | SAMPLE .999999999
 ;
@@ -35,7 +35,7 @@ x:integer
 
 
 adjust stats for sampling
-required_capability: sample
+required_capability: sample_v2
 
 FROM employees
   | SAMPLE 0.5
@@ -53,7 +53,7 @@ true
 
 
 before where
-required_capability: sample
+required_capability: sample_v2
 
 FROM employees
   | SAMPLE 0.5
@@ -71,7 +71,7 @@ true
 
 
 after where
-required_capability: sample
+required_capability: sample_v2
 
 FROM employees
   | WHERE emp_no <= 10050 
@@ -89,7 +89,7 @@ true
 
 
 before sort
-required_capability: sample
+required_capability: sample_v2
 
 FROM employees
   | SAMPLE 0.5
@@ -107,7 +107,7 @@ true
 
 
 after sort
-required_capability: sample
+required_capability: sample_v2
 
 FROM employees
   | SORT emp_no
@@ -125,7 +125,7 @@ true
 
 
 before limit
-required_capability: sample
+required_capability: sample_v2
 
 FROM employees
   | SAMPLE 0.5
@@ -141,7 +141,7 @@ true
 
 
 after limit
-required_capability: sample
+required_capability: sample_v2
 
 FROM employees
   | LIMIT 50
@@ -158,7 +158,7 @@ true
 
 
 before mv_expand
-required_capability: sample
+required_capability: sample_v2
 
 ROW x = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50], y = [1,2]
   | MV_EXPAND x
@@ -176,7 +176,7 @@ true
 
 
 after mv_expand
-required_capability: sample
+required_capability: sample_v2
 
 ROW x = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50], y = [1,2]
   | MV_EXPAND x
@@ -194,7 +194,7 @@ true
 
 
 multiple samples
-required_capability: sample
+required_capability: sample_v2
 
 FROM employees
   | SAMPLE 0.7
@@ -213,7 +213,7 @@ true
 
 
 after stats
-required_capability: sample
+required_capability: sample_v2
 
 FROM employees
   | SAMPLE 0.5

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1077,7 +1077,7 @@ public class EsqlCapabilities {
         /**
          * Support for the SAMPLE command
          */
-        SAMPLE(Build.current().isSnapshot()),
+        SAMPLE_V2(Build.current().isSnapshot()),
 
         /**
          * The {@code _query} API now gives a cast recommendation if multiple types are found in certain instances.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -3460,7 +3460,7 @@ public class AnalyzerTests extends ESTestCase {
     }
 
     public void testRandomSampleProbability() {
-        assumeTrue("requires SAMPLE capability", EsqlCapabilities.Cap.SAMPLE.isEnabled());
+        assumeTrue("requires SAMPLE capability", EsqlCapabilities.Cap.SAMPLE_V2.isEnabled());
 
         var e = expectThrows(VerificationException.class, () -> analyze("FROM test | SAMPLE 1."));
         assertThat(e.getMessage(), containsString("RandomSampling probability must be strictly between 0.0 and 1.0, was [1.0]"));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -7858,7 +7858,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      *        \_EsRelation[test][_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, ge..]
      */
     public void testSampleMerged() {
-        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE.isEnabled());
+        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE_V2.isEnabled());
 
         var query = """
             FROM TEST
@@ -7879,7 +7879,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
     }
 
     public void testSamplePushDown() {
-        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE.isEnabled());
+        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE_V2.isEnabled());
 
         for (var command : List.of(
             "ENRICH languages_idx on first_name",
@@ -7904,7 +7904,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
     }
 
     public void testSamplePushDown_sort() {
-        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE.isEnabled());
+        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE_V2.isEnabled());
 
         var query = "FROM TEST | WHERE emp_no > 0 | SAMPLE 0.5 | LIMIT 100";
         var optimized = optimizedPlan(query);
@@ -7918,7 +7918,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
     }
 
     public void testSamplePushDown_where() {
-        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE.isEnabled());
+        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE_V2.isEnabled());
 
         var query = "FROM TEST | SORT emp_no | SAMPLE 0.5 | LIMIT 100";
         var optimized = optimizedPlan(query);
@@ -7931,7 +7931,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
     }
 
     public void testSampleNoPushDown() {
-        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE.isEnabled());
+        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE_V2.isEnabled());
 
         for (var command : List.of("LIMIT 100", "MV_EXPAND languages", "STATS COUNT()")) {
             var query = "FROM TEST | " + command + " | SAMPLE .5";
@@ -7953,7 +7953,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      *        \_EsRelation[languages_lookup][LOOKUP][language_code{f}#17, language_name{f}#18]
      */
     public void testSampleNoPushDownLookupJoin() {
-        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE.isEnabled());
+        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE_V2.isEnabled());
 
         var query = """
             FROM TEST
@@ -7979,7 +7979,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      *            \_EsRelation[test][_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, ge..]
      */
     public void testSampleNoPushDownChangePoint() {
-        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE.isEnabled());
+        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE_V2.isEnabled());
 
         var query = """
             FROM TEST

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -8045,7 +8045,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *                  [_doc{f}#24], limit[1000], sort[] estimatedRowSize[332]
      */
     public void testSamplePushDown() {
-        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE.isEnabled());
+        assumeTrue("sample must be enabled", EsqlCapabilities.Cap.SAMPLE_V2.isEnabled());
 
         var plan = physicalPlan("""
             FROM test

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -3482,7 +3482,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
     }
 
     public void testSample() {
-        assumeTrue("SAMPLE requires corresponding capability", EsqlCapabilities.Cap.SAMPLE.isEnabled());
+        assumeTrue("SAMPLE requires corresponding capability", EsqlCapabilities.Cap.SAMPLE_V2.isEnabled());
         expectError("FROM test | SAMPLE .1 2", "line 1:23: extraneous input '2' expecting <EOF>");
         expectError("FROM test | SAMPLE .1 \"2\"", "line 1:23: extraneous input '\"2\"' expecting <EOF>");
         expectError("FROM test | SAMPLE 1", "line 1:20: mismatched input '1' expecting {DECIMAL_LITERAL, '+', '-'}");


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/128887 changed how we serialize SAMPLE, but existing nodes on Serverless still use the old serialization.

Let's bump the capability used for the tests to just not run against these older nodes.