### PR TITLE
[8.19] Adding `scheduled_report_id` field to kibana reporting template (#127827)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/kibana-reporting@template.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/kibana-reporting@template.json
@@ -42,6 +42,9 @@
         "jobtype": {
           "type": "keyword"
         },
+        "scheduled_report_id": {
+          "type": "keyword"
+        },
         "payload": {
           "type": "object",
           "enabled": false

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -47,7 +47,7 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
-    public static final int REGISTRY_VERSION = 15;
+    public static final int REGISTRY_VERSION = 16;
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.template.version";
     public static final Setting<Boolean> STACK_TEMPLATES_ENABLED = Setting.boolSetting(


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Adding `scheduled_report_id` field to kibana reporting template (#127827)