### PR TITLE
Fix DRA dependenciesInfo task dependency resolution

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoPlugin.java
@@ -48,10 +48,7 @@ public class DependenciesInfoPlugin implements Plugin<Project> {
         );
 
         dependenciesInfoFilesConfiguration.attributes(
-            attributes -> attributes.attribute(
-                Usage.USAGE_ATTRIBUTE,
-                project.getObjects().named(Usage.class, USAGE_ATTRIBUTE)
-            )
+            attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, USAGE_ATTRIBUTE))
         );
         project.getArtifacts().add("dependenciesInfoFiles", depsInfo);
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoPlugin.java
@@ -15,9 +15,13 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPlugin;
 
 public class DependenciesInfoPlugin implements Plugin<Project> {
+
+    public static String USAGE_ATTRIBUTE = "DependenciesInfo";
+
     @Override
     public void apply(final Project project) {
         project.getPlugins().apply(CompileOnlyResolvePlugin.class);
@@ -43,6 +47,12 @@ public class DependenciesInfoPlugin implements Plugin<Project> {
             )
         );
 
+        dependenciesInfoFilesConfiguration.attributes(
+            attributes -> attributes.attribute(
+                Usage.USAGE_ATTRIBUTE,
+                project.getObjects().named(Usage.class, USAGE_ATTRIBUTE)
+            )
+        );
         project.getArtifacts().add("dependenciesInfoFiles", depsInfo);
 
     }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -31,6 +31,9 @@ configurations {
     attributes {
       attribute(Category.CATEGORY_ATTRIBUTE, project.getObjects().named(Category.class, Category.DOCUMENTATION))
     }
+    attributes {
+      attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, DependenciesInfoPlugin.USAGE_ATTRIBUTE))
+    }
   }
   featuresMetadata {
     attributes {


### PR DESCRIPTION
With tweaking sourcesJar and javadoc generation in #128659 we broke variant selection
for dependenciesInfo information as there are now multiple artifacts available with category "documentation".

This fixes the resolution by adding the explicit usage attribute to allow distinguishing.