### PR TITLE
[8.17] Fix DRA dependenciesInfo task dependency resolution (#129209)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoPlugin.java
@@ -15,9 +15,13 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPlugin;
 
 public class DependenciesInfoPlugin implements Plugin<Project> {
+
+    public static String USAGE_ATTRIBUTE = "DependenciesInfo";
+
     @Override
     public void apply(final Project project) {
         project.getPlugins().apply(CompileOnlyResolvePlugin.class);
@@ -43,6 +47,9 @@ public class DependenciesInfoPlugin implements Plugin<Project> {
             )
         );
 
+        dependenciesInfoFilesConfiguration.attributes(
+            attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, USAGE_ATTRIBUTE))
+        );
         project.getArtifacts().add("dependenciesInfoFiles", depsInfo);
 
     }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -30,6 +30,9 @@ configurations {
     attributes {
       attribute(Category.CATEGORY_ATTRIBUTE, project.getObjects().named(Category.class, Category.DOCUMENTATION))
     }
+    attributes {
+      attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, DependenciesInfoPlugin.USAGE_ATTRIBUTE))
+    }
   }
   featuresMetadata {
     attributes {


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Fix DRA dependenciesInfo task dependency resolution (#129209)