### PR TITLE
[9.0] Unmute IngestGeoIpClientYamlTestSuiteIT (#129178)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -5,8 +5,6 @@ tests:
 - class: org.elasticsearch.smoketest.WatcherYamlRestIT
   method: test {p0=watcher/usage/10_basic/Test watcher usage stats output}
   issue: https://github.com/elastic/elasticsearch/issues/112189
-- class: org.elasticsearch.ingest.geoip.IngestGeoIpClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/111497
 - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
   method: test20SecurityNotAutoConfiguredOnReInstallation
   issue: https://github.com/elastic/elasticsearch/issues/112635


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Unmute IngestGeoIpClientYamlTestSuiteIT (#129178)