### PR TITLE
[ES|QL] Fix NPE in the completion operator.

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/bulk/BulkInferenceExecutionState.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/bulk/BulkInferenceExecutionState.java
@@ -75,7 +75,7 @@ public class BulkInferenceExecutionState {
      *  @param response The inference response.
      */
     public synchronized void onInferenceResponse(long seqNo, InferenceAction.Response response) {
-        if (failureCollector.hasFailure() == false) {
+        if (response != null && failureCollector.hasFailure() == false) {
             bufferedResponses.put(seqNo, response);
         }
         checkpoint.markSeqNoAsProcessed(seqNo);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/completion/CompletionOperatorOutputBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/completion/CompletionOperatorOutputBuilder.java
@@ -51,6 +51,11 @@ public class CompletionOperatorOutputBuilder implements InferenceOperator.Output
      */
     @Override
     public void addInferenceResponse(InferenceAction.Response inferenceResponse) {
+        if (inferenceResponse == null) {
+            outputBlockBuilder.appendNull();
+            return;
+        }
+
         ChatCompletionResults completionResults = inferenceResults(inferenceResponse);
 
         if (completionResults == null) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/completion/CompletionOperatorRequestIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/completion/CompletionOperatorRequestIterator.java
@@ -58,6 +58,10 @@ public class CompletionOperatorRequestIterator implements BulkInferenceRequestIt
      * Wraps a single prompt string into an {@link InferenceAction.Request}.
      */
     private InferenceAction.Request inferenceRequest(String prompt) {
+        if (prompt == null) {
+            return null;
+        }
+
         return InferenceAction.Request.builder(inferenceId, TaskType.COMPLETION).setInput(List.of(prompt)).build();
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/InferenceOperatorTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/InferenceOperatorTestCase.java
@@ -88,12 +88,17 @@ public abstract class InferenceOperatorTestCase<InferenceResultsType extends Inf
             @Override
             protected Page createPage(int positionOffset, int length) {
                 length = Integer.min(length, remaining());
-                try (var builder = blockFactory.newBytesRefVectorBuilder(length)) {
+                try (var builder = blockFactory.newBytesRefBlockBuilder(length)) {
                     for (int i = 0; i < length; i++) {
-                        builder.appendBytesRef(new BytesRef(randomAlphaOfLength(10)));
+                        if (randomInt() % 100 == 0) {
+                            builder.appendNull();
+                        } else {
+                            builder.appendBytesRef(new BytesRef(randomAlphaOfLength(10)));
+                        }
+
                     }
                     currentPosition += length;
-                    return new Page(builder.build().asBlock());
+                    return new Page(builder.build());
                 }
             }
         };


### PR DESCRIPTION
Fix #129214

The NPE is raised when a null prompt is sent to the command.
In this case, the fix does not try to build the inference request and we add a null value in the output block at this position.