### PR TITLE
[8.19] ESQL: Fix test by add excluding capability (#129202)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -224,12 +224,6 @@ tests:
   - class: org.elasticsearch.discovery.ClusterDisruptionIT
     method: testAckedIndexing
     issue: https://github.com/elastic/elasticsearch/issues/117024
-  - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-    method: test {lookup-join.LookupJoinOnTimeSeriesIndex ASYNC}
-    issue: https://github.com/elastic/elasticsearch/issues/129078
-  - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-    method: test {lookup-join.LookupJoinOnTimeSeriesIndex SYNC}
-    issue: https://github.com/elastic/elasticsearch/issues/129078
 
   # Examples:
   #

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -4481,6 +4481,7 @@ language_code_float:double | language_code_double:double | language_name:keyword
 
 lookupJoinOnTimeSeriesIndex
 required_capability: join_lookup_v12
+required_capability: lookup_join_on_mixed_numeric_fields
 
 FROM k8s
 | RENAME network.bytes_in AS language_code


### PR DESCRIPTION
Closes #129078
Closes #129082

(cherry picked from commit 8e0e9e805c67f4295ede6fc1d6f61c8fde41042a)
