### PR TITLE
[DOCS] Switches order of warning and note for ES|QL command

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/change_point.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/change_point.md
@@ -1,15 +1,15 @@
 ## `CHANGE_POINT` [esql-change_point]
 
-:::{note}
-The `CHANGE_POINT` command requires a [platinum license](https://www.elastic.co/subscriptions).
-:::
-
 ::::{warning}
 This functionality is in technical preview and may be
 changed or removed in a future release. Elastic will work to fix any
 issues, but features in technical preview are not subject to the support
 SLA of official GA features.
 ::::
+
+:::{note}
+The `CHANGE_POINT` command requires a [platinum license](https://www.elastic.co/subscriptions).
+:::
 
 `CHANGE_POINT` detects spikes, dips, and change points in a metric.
 


### PR DESCRIPTION
## Overview

This PR switches the order of a note and a warning in the top of the CHANGE POINT command, so the preview tag can be displayed in the command list.