### PR TITLE
ESQL: Mute GenerativeForkIT for some LOOKUP JOIN tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -517,6 +517,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
   method: test {lookup-join.EnrichLookupStatsBug SYNC}
   issue: https://github.com/elastic/elasticsearch/issues/129229
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
+  method: test {lookup-join.MultipleBatches*
+  issue: https://github.com/elastic/elasticsearch/issues/129210
 
 # Examples:
 #


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/issues/129210.

These test failures block CI atm, let's mute them for now.