### PR TITLE
Fix ivf nodestats impl for getOffHeapByteSize

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsReader.java
@@ -11,7 +11,6 @@ package org.elasticsearch.index.codec.vectors;
 
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnCollector;
@@ -20,10 +19,12 @@ import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.NeighborQueue;
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
+import org.elasticsearch.index.codec.vectors.reflect.OffHeapStats;
 import org.elasticsearch.simdvec.ES91OSQVectorsScorer;
 import org.elasticsearch.simdvec.ESVectorUtil;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.IntPredicate;
 
 import static org.apache.lucene.codecs.lucene102.Lucene102BinaryQuantizedVectorsFormat.QUERY_BITS;
@@ -38,7 +39,7 @@ import static org.elasticsearch.simdvec.ES91OSQVectorsScorer.BULK_SIZE;
  * Default implementation of {@link IVFVectorsReader}. It scores the posting lists centroids using
  * brute force and then scores the top ones using the posting list.
  */
-public class DefaultIVFVectorsReader extends IVFVectorsReader {
+public class DefaultIVFVectorsReader extends IVFVectorsReader implements OffHeapStats {
     private static final float FOUR_BIT_SCALE = 1f / ((1 << 4) - 1);
 
     public DefaultIVFVectorsReader(SegmentReadState state, FlatVectorsReader rawVectorsReader) throws IOException {
@@ -163,57 +164,9 @@ public class DefaultIVFVectorsReader extends IVFVectorsReader {
         }
     }
 
-    static class OffHeapCentroidFloatVectorValues extends FloatVectorValues {
-        private final int numCentroids;
-        private final IndexInput input;
-        private final int dimension;
-        private final float[] centroid;
-        private final long centroidByteSize;
-        private int ord = -1;
-
-        OffHeapCentroidFloatVectorValues(int numCentroids, IndexInput input, int dimension) {
-            this.numCentroids = numCentroids;
-            this.input = input;
-            this.dimension = dimension;
-            this.centroid = new float[dimension];
-            this.centroidByteSize = dimension + 3 * Float.BYTES + Short.BYTES;
-        }
-
-        @Override
-        public float[] vectorValue(int ord) throws IOException {
-            if (ord < 0 || ord >= numCentroids) {
-                throw new IllegalArgumentException("ord must be in [0, " + numCentroids + "]");
-            }
-            if (ord == this.ord) {
-                return centroid;
-            }
-            readQuantizedCentroid(ord);
-            return centroid;
-        }
-
-        private void readQuantizedCentroid(int centroidOrdinal) throws IOException {
-            if (centroidOrdinal == ord) {
-                return;
-            }
-            input.seek(numCentroids * centroidByteSize + (long) Float.BYTES * dimension * centroidOrdinal);
-            input.readFloats(centroid, 0, centroid.length);
-            ord = centroidOrdinal;
-        }
-
-        @Override
-        public int dimension() {
-            return dimension;
-        }
-
-        @Override
-        public int size() {
-            return numCentroids;
-        }
-
-        @Override
-        public FloatVectorValues copy() throws IOException {
-            return new OffHeapCentroidFloatVectorValues(numCentroids, input.clone(), dimension);
-        }
+    @Override
+    public Map<String, Long> getOffHeapByteSize(FieldInfo fieldInfo) {
+        return Map.of();
     }
 
     private static class MemorySegmentPostingsVisitor implements PostingVisitor {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/IVFVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/IVFVectorsFormatTests.java
@@ -13,13 +13,25 @@ import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.elasticsearch.common.logging.LogConfigurator;
+import org.elasticsearch.index.codec.vectors.reflect.OffHeapByteSizeUtils;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
@@ -93,5 +105,27 @@ public class IVFVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
     public void testLimits() {
         expectThrows(IllegalArgumentException.class, () -> new IVFVectorsFormat(MIN_VECTORS_PER_CLUSTER - 1));
         expectThrows(IllegalArgumentException.class, () -> new IVFVectorsFormat(MAX_VECTORS_PER_CLUSTER + 1));
+    }
+
+    public void testSimpleOffHeapSize() throws IOException {
+        float[] vector = randomVector(random().nextInt(12, 500));
+        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+            Document doc = new Document();
+            doc.add(new KnnFloatVectorField("f", vector, VectorSimilarityFunction.EUCLIDEAN));
+            w.addDocument(doc);
+            w.commit();
+            try (IndexReader reader = DirectoryReader.open(w)) {
+                LeafReader r = getOnlyLeafReader(reader);
+                if (r instanceof CodecReader codecReader) {
+                    KnnVectorsReader knnVectorsReader = codecReader.getVectorReader();
+                    if (knnVectorsReader instanceof PerFieldKnnVectorsFormat.FieldsReader fieldsReader) {
+                        knnVectorsReader = fieldsReader.getFieldReader("f");
+                    }
+                    var fieldInfo = r.getFieldInfos().fieldInfo("f");
+                    var offHeap = OffHeapByteSizeUtils.getOffHeapByteSize(knnVectorsReader, fieldInfo);
+                    assertEquals(0, offHeap.size());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This fixes a silly bug where we didn't override `OffHeapStats` for IVF.