### PR TITLE
ESQL: Run tests with `allow_partial_results` set to `false`

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/AbstractEsqlClientYamlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/AbstractEsqlClientYamlIT.java
@@ -51,6 +51,20 @@ abstract class AbstractEsqlClientYamlIT extends ESClientYamlSuiteTestCase {
         EsqlSpecTestCase.assertRequestBreakerEmpty();
     }
 
+    public static Iterable<Object[]> partialResultsDisablingParameters() throws Exception {
+        return updateEsqlQueryDoSections(createParameters(), AbstractEsqlClientYamlIT::modifyEsqlQueryExecutableSection);
+    }
+
+    private static ExecutableSection modifyEsqlQueryExecutableSection(DoSection doSection) {
+        var apiCallSection = doSection.getApiCallSection();
+        if (apiCallSection.getApi().equals("esql.query")) {
+            if (apiCallSection.getParams().containsKey("allow_partial_results") == false) {
+                apiCallSection.addParam("allow_partial_results", "false"); // we want any error to fail the test
+            }
+        }
+        return doSection;
+    }
+
     public static Iterable<Object[]> updateEsqlQueryDoSections(Iterable<Object[]> parameters, Function<DoSection, ExecutableSection> modify)
         throws Exception {
         List<Object[]> result = new ArrayList<>();

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncIT.java
@@ -26,7 +26,7 @@ public class EsqlClientYamlAsyncIT extends AbstractEsqlClientYamlIT {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
-        return updateEsqlQueryDoSections(createParameters(), doSection -> {
+        return updateEsqlQueryDoSections(partialResultsDisablingParameters(), doSection -> {
             ApiCallSection copy = doSection.getApiCallSection().copyWithNewApi("esql.async_query");
             for (Map<String, Object> body : copy.getBodies()) {
                 body.put("wait_for_completion_timeout", "30m");

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncSubmitAndFetchIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncSubmitAndFetchIT.java
@@ -32,7 +32,7 @@ public class EsqlClientYamlAsyncSubmitAndFetchIT extends AbstractEsqlClientYamlI
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
-        return updateEsqlQueryDoSections(createParameters(), DoEsqlAsync::new);
+        return updateEsqlQueryDoSections(partialResultsDisablingParameters(), DoEsqlAsync::new);
     }
 
     private static class DoEsqlAsync implements ExecutableSection {

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlIT.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.qa.single_node;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.section.DoSection;
+import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
 
 /**
  * Run the ESQL yaml tests against the synchronous API.
@@ -22,6 +24,17 @@ public class EsqlClientYamlIT extends AbstractEsqlClientYamlIT {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
-        return createParameters();
+        return updateEsqlQueryDoSections(createParameters(), EsqlClientYamlIT::modifyEsqlQueryExecutableSection);
     }
+
+    private static ExecutableSection modifyEsqlQueryExecutableSection(DoSection doSection) {
+        var apiCallSection = doSection.getApiCallSection();
+        if (apiCallSection.getApi().equals("esql.query")) {
+            if (apiCallSection.getParams().containsKey("allow_partial_results") == false) {
+                apiCallSection.addParam("allow_partial_results", "false"); // we want any error to fail the test
+            }
+        }
+        return doSection;
+    }
+
 }

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlIT.java
@@ -10,8 +10,6 @@ package org.elasticsearch.xpack.esql.qa.single_node;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
-import org.elasticsearch.test.rest.yaml.section.DoSection;
-import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
 
 /**
  * Run the ESQL yaml tests against the synchronous API.
@@ -24,17 +22,6 @@ public class EsqlClientYamlIT extends AbstractEsqlClientYamlIT {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
-        return updateEsqlQueryDoSections(createParameters(), EsqlClientYamlIT::modifyEsqlQueryExecutableSection);
+        return partialResultsDisablingParameters();
     }
-
-    private static ExecutableSection modifyEsqlQueryExecutableSection(DoSection doSection) {
-        var apiCallSection = doSection.getApiCallSection();
-        if (apiCallSection.getApi().equals("esql.query")) {
-            if (apiCallSection.getParams().containsKey("allow_partial_results") == false) {
-                apiCallSection.addParam("allow_partial_results", "false"); // we want any error to fail the test
-            }
-        }
-        return doSection;
-    }
-
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/63_enrich_int_range.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/63_enrich_int_range.yml
@@ -203,6 +203,5 @@ teardown:
   - do:
       catch: /ENRICH range and input types are incompatible. range\[INTEGER\], input\[DOUBLE\]/
       esql.query:
-        allow_partial_results: false
         body:
           query: 'FROM employees | ENRICH ages-policy ON salary | STATS count=COUNT(*) BY description | SORT count DESC, description ASC'

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/63_enrich_int_range.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/63_enrich_int_range.yml
@@ -203,5 +203,6 @@ teardown:
   - do:
       catch: /ENRICH range and input types are incompatible. range\[INTEGER\], input\[DOUBLE\]/
       esql.query:
+        allow_partial_results: false
         body:
           query: 'FROM employees | ENRICH ages-policy ON salary | STATS count=COUNT(*) BY description | SORT count DESC, description ASC'


### PR DESCRIPTION
This switches spec-based and YAML integration tests to run with `"allow_partial_results": false`
to conteract the default, set to `true`.

Closes #129256