### PR TITLE
[8.18] [9.0] Fix unsupported privileges error message during role and API key creation (#128858) (#129158)

### DIFF
--- a/docs/changelog/129158.yaml
+++ b/docs/changelog/129158.yaml
@@ -1,0 +1,6 @@
+pr: 129158
+summary: Fix unsupported privileges error message during role and API key creation
+area: Authorization
+type: enhancement
+issues:
+  - 128132

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -291,7 +291,7 @@ public final class IndexPrivilege extends Privilege {
                         + part
                         + "]. a privilege must be either "
                         + "one of the predefined fixed indices privileges ["
-                        + Strings.collectionToCommaDelimitedString(VALUES.entrySet())
+                        + Strings.collectionToCommaDelimitedString(names().stream().sorted().collect(Collectors.toList()))
                         + "] or a pattern over one of the available index"
                         + " actions";
                     logger.debug(errorMessage);


### PR DESCRIPTION
Backports the following commits to 8.18:
 - [9.0] Fix unsupported privileges error message during role and API key creation (#128858) (#129158)