### PR TITLE
[8.19] feat: enable date_detection for all apm data streams (#128913)

### DIFF
--- a/docs/changelog/128913.yml
+++ b/docs/changelog/128913.yml
@@ -1,0 +1,5 @@
+pr: 128913
+summary: "[apm-data] Enable 'date_detection' for all apm data streams"
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@mappings.yaml
@@ -4,7 +4,6 @@ _meta:
   managed: true
 template:
   mappings:
-    date_detection: false
     dynamic: true
     dynamic_templates:
     - numeric_labels:

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 13
+version: 14
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [feat: enable date_detection for all apm data streams (#128913)](https://github.com/elastic/elasticsearch/pull/128913)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)