### PR TITLE
[8.18] [Build] Build maven aggregation zip as part of DRA build (#129175)

### DIFF
--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -58,6 +58,7 @@ echo --- Building release artifacts
   $BUILD_SNAPSHOT_ARG \
   buildReleaseArtifacts \
   exportCompressedDockerImages \
+  :zipAggregation \
   :distribution:generateDependenciesReport
 
 PATH="$PATH:${JAVA_HOME}/bin" # Required by the following script

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,12 @@ nmcpAggregation {
 }
 
 tasks.named('zipAggregation').configure {
+  // put this in a place that works well with our DRA infrastructure
+  archiveFileName.unset();
+  archiveBaseName.set("elasticsearch-maven-aggregation")
+  archiveVersion.set(VersionProperties.elasticsearch)
+  destinationDirectory.set(layout.buildDirectory.dir("distributions"));
+
   dependsOn gradle.includedBuild('build-tools').task(':zipElasticPublication')
   from(zipTree(gradle.includedBuild('build-tools').task(':zipElasticPublication').resolveTask().archiveFile.get()))
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Build] Build maven aggregation zip as part of DRA build (#129175)](https://github.com/elastic/elasticsearch/pull/129175)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)