### PR TITLE
ESQL: Fix failing yaml test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/200_queries.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/200_queries.yml
@@ -35,6 +35,6 @@ Get with invalid task ID:
 ---
 Get with non-existent task ID:
   - do:
-      catch: /task \[X1naBAymScGJ3z-YK6l2nw:52\] belongs to the node \[X1naBAymScGJ3z-YK6l2nw\] which isn't part of the cluster and there is no record of the task/
+      catch: /task \[X1naBAymScGJ3z-YK6l2nw:52\] belongs to the node \[X1naBAymScGJ3z-YK6l2nw\] which isn't part of the cluster and there is no record of the task|malformed task id FmJKWHpFRi1OU0l5SU1YcnpuWWhoUWcZWDFuYUJBeW1TY0dKM3otWUs2bDJudzo1Mg==/
       esql.get_query:
         id: "FmJKWHpFRi1OU0l5SU1YcnpuWWhoUWcZWDFuYUJBeW1TY0dKM3otWUs2bDJudzo1Mg=="


### PR DESCRIPTION
This PR fixes a failing test in serverless introduced by #127472. This was caused by a different error message between serverless and the main repo.