### PR TITLE
Run `TransportGetStatusAction` on local node

### DIFF
--- a/docs/changelog/129367.yaml
+++ b/docs/changelog/129367.yaml
@@ -1,0 +1,5 @@
+pr: 129367
+summary: Run `TransportGetStatusAction` on local node
+area: ILM+SLM
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetStatusAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetStatusAction.java
@@ -9,14 +9,21 @@ package org.elasticsearch.xpack.core.ilm.action;
 
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.local.LocalClusterStateRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.UpdateForV10;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Objects;
 
 public class GetStatusAction extends ActionType<GetStatusAction.Response> {
@@ -25,6 +32,29 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
 
     protected GetStatusAction() {
         super(NAME);
+    }
+
+    public static class Request extends LocalClusterStateRequest {
+
+        public Request(TimeValue masterTimeout) {
+            super(masterTimeout);
+        }
+
+        /**
+         * NB prior to 9.1 this was a TransportMasterNodeAction so for BwC we must remain able to read these requests until
+         * we no longer need to support calling this action remotely.
+         */
+        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        public Request(StreamInput in) throws IOException {
+            super(in, false);
+            // Read and ignore ack timeout.
+            in.readTimeValue();
+        }
+
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new CancellableTask(id, type, action, "", parentTaskId, headers);
+        }
     }
 
     public static class Response extends ActionResponse implements ToXContentObject {

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ilm;
 
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
-import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
@@ -442,10 +441,9 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
 
         assertAcked(client().execute(ILMActions.STOP, new StopILMRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)).get());
         assertBusy(() -> {
-            OperationMode mode = client().execute(
-                GetStatusAction.INSTANCE,
-                new AcknowledgedRequest.Plain(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
-            ).get().getMode();
+            OperationMode mode = client().execute(GetStatusAction.INSTANCE, new GetStatusAction.Request(TEST_REQUEST_TIMEOUT))
+                .get()
+                .getMode();
             logger.info("--> waiting for STOPPED, currently: {}", mode);
             assertThat(mode, equalTo(OperationMode.STOPPED));
         });
@@ -473,7 +471,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         // assert ILM is still stopped
         GetStatusAction.Response statusResponse = client().execute(
             GetStatusAction.INSTANCE,
-            new AcknowledgedRequest.Plain(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            new GetStatusAction.Request(TEST_REQUEST_TIMEOUT)
         ).get();
         assertThat(statusResponse.getMode(), equalTo(OperationMode.STOPPED));
     }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestGetStatusAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestGetStatusAction.java
@@ -7,17 +7,20 @@
 
 package org.elasticsearch.xpack.ilm.action;
 
-import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.action.support.local.TransportLocalClusterStateAction;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ilm.action.GetStatusAction;
 
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
-import static org.elasticsearch.rest.RestUtils.getAckTimeout;
 import static org.elasticsearch.rest.RestUtils.getMasterNodeTimeout;
 
 public class RestGetStatusAction extends BaseRestHandler {
@@ -34,7 +37,25 @@ public class RestGetStatusAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
-        final var request = new AcknowledgedRequest.Plain(getMasterNodeTimeout(restRequest), getAckTimeout(restRequest));
-        return channel -> client.execute(GetStatusAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        final var request = new GetStatusAction.Request(getMasterNodeTimeout(restRequest));
+        if (restRequest.hasParam("timeout")) {
+            // Consume this param just for validation when in BWC mode.
+            final var timeout = restRequest.paramAsTime("timeout", null);
+            if (restRequest.getRestApiVersion() != RestApiVersion.V_8) {
+                DeprecationLogger.getLogger(TransportLocalClusterStateAction.class)
+                    .critical(
+                        DeprecationCategory.API,
+                        "TransportLocalClusterStateAction-timeout-parameter",
+                        "the [?timeout] query parameter to this API has no effect, is now deprecated, "
+                            + "and will be removed in a future version"
+                    );
+            }
+
+        }
+        return channel -> new RestCancellableNodeClient(client, restRequest.getHttpChannel()).execute(
+            GetStatusAction.INSTANCE,
+            request,
+            new RestToXContentListener<>(channel)
+        );
     }
 }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/LifecycleOperationSnapshotTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/LifecycleOperationSnapshotTests.java
@@ -134,9 +134,7 @@ public class LifecycleOperationSnapshotTests extends ESSingleNodeTestCase {
     }
 
     private OperationMode ilmMode() throws Exception {
-        return client().execute(GetStatusAction.INSTANCE, new AcknowledgedRequest.Plain(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT))
-            .get()
-            .getMode();
+        return client().execute(GetStatusAction.INSTANCE, new GetStatusAction.Request(TEST_REQUEST_TIMEOUT)).get().getMode();
     }
 
     private OperationMode slmMode() throws Exception {

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CopyLifecycleIndexMetadataTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/CopyLifecycleIndexMetadataTransportActionIT.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.admin.indices.template.put.TransportPutComposabl
 import org.elasticsearch.action.datastreams.CreateDataStreamAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
@@ -139,9 +138,7 @@ public class CopyLifecycleIndexMetadataTransportActionIT extends ESIntegTestCase
         // stop ILM so source does not change after copying metadata
         assertAcked(safeGet(client().execute(ILMActions.STOP, new StopILMRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT))));
         assertBusy(() -> {
-            var statusResponse = safeGet(
-                client().execute(GetStatusAction.INSTANCE, new AcknowledgedRequest.Plain(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT))
-            );
+            var statusResponse = safeGet(client().execute(GetStatusAction.INSTANCE, new GetStatusAction.Request(TEST_REQUEST_TIMEOUT)));
             assertEquals(OperationMode.STOPPED, statusResponse.getMode());
         });
 

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
@@ -27,7 +27,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.action.ingest.PutPipelineTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
@@ -623,9 +622,7 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
     private void stopILM() throws Exception {
         assertAcked(safeGet(client().execute(ILMActions.STOP, new StopILMRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT))));
         assertBusy(() -> {
-            var statusResponse = safeGet(
-                client().execute(GetStatusAction.INSTANCE, new AcknowledgedRequest.Plain(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT))
-            );
+            var statusResponse = safeGet(client().execute(GetStatusAction.INSTANCE, new GetStatusAction.Request(TEST_REQUEST_TIMEOUT)));
             assertEquals(OperationMode.STOPPED, statusResponse.getMode());
         });
     }


### PR DESCRIPTION
This action solely needs the cluster state, it can run on any node.

Relates #101805