### PR TITLE
[Fips] Explicitly set trustStoreType to BCFKS in FIPS docker image

### DIFF
--- a/distribution/docker/src/docker/dockerfiles/cloud_ess_fips/Dockerfile
+++ b/distribution/docker/src/docker/dockerfiles/cloud_ess_fips/Dockerfile
@@ -172,8 +172,10 @@ RUN cat <<EOF > /usr/share/elasticsearch/config/jvm.options.d/fips.options
 -Dorg.bouncycastle.fips.approved_only=true
 -Djava.security.properties=config/fips_java.security
 -Djava.security.policy=config/fips_java.policy
+-Djavax.net.ssl.trustStoreType=BCFKS
 -Djavax.net.ssl.trustStore=config/cacerts.bcfks
 -Djavax.net.ssl.trustStorePassword=passwordcacert
+
 EOF
 
 EXPOSE 9200 9300


### PR DESCRIPTION
We see an certificate issue when using fips docker image creating searchable snapshots in aws
and gcs. This is likely related to a configuration issue not explicitly setting the trust store
type for our bcfks cacerts