### PR TITLE
[8.17] [Test] Ignore PublishPluginFuncTest on windows for now (#129348)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
@@ -9,11 +9,16 @@
 
 package org.elasticsearch.gradle.internal
 
+import spock.lang.IgnoreIf
+
 import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
 import org.gradle.testkit.runner.TaskOutcome
 import org.xmlunit.builder.DiffBuilder
 import org.xmlunit.builder.Input
 
+// Ignoring this test on windows due to what appears to be a bug in the gradle testkit runner.
+// https://github.com/elastic/elasticsearch/issues/129100
+@IgnoreIf({ os.isWindows() })
 class PublishPluginFuncTest extends AbstractGradleFuncTest {
 
     def setup() {


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [Test] Ignore PublishPluginFuncTest on windows for now (#129348)