### PR TITLE
Docs: Fix indentation for query options

### DIFF
--- a/docs/reference/query-languages/query-dsl/query-dsl-combined-fields-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-combined-fields-query.md
@@ -76,7 +76,6 @@ See [Use synonyms with match query](/reference/query-languages/query-dsl/query-d
 
 `operator`
 :   (Optional, string) Boolean logic used to interpret text in the `query` value. Valid values are:
-
   - `or` (Default)
   For example, a `query` value of `database systems` is interpreted as `database OR systems`.
   - `and`

--- a/docs/reference/query-languages/query-dsl/query-dsl-combined-fields-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-combined-fields-query.md
@@ -88,7 +88,6 @@ See [Use synonyms with match query](/reference/query-languages/query-dsl/query-d
 
 `zero_terms_query`
 :   (Optional, string) Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter. Valid values are:
-
   - `none` (Default)
   No documents are returned if the `analyzer` removes all tokens.
   - `all`

--- a/docs/reference/query-languages/query-dsl/query-dsl-combined-fields-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-combined-fields-query.md
@@ -77,11 +77,10 @@ See [Use synonyms with match query](/reference/query-languages/query-dsl/query-d
 `operator`
 :   (Optional, string) Boolean logic used to interpret text in the `query` value. Valid values are:
 
-`or` (Default)
-:   For example, a `query` value of `database systems` is interpreted as `database OR systems`.
-
-`and`
-:   For example, a `query` value of `database systems` is interpreted as `database AND systems`.
+  - `or` (Default)
+  For example, a `query` value of `database systems` is interpreted as `database OR systems`.
+  - `and`
+  For example, a `query` value of `database systems` is interpreted as `database AND systems`.
 
 
 `minimum_should_match`
@@ -91,11 +90,10 @@ See [Use synonyms with match query](/reference/query-languages/query-dsl/query-d
 `zero_terms_query`
 :   (Optional, string) Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter. Valid values are:
 
-`none` (Default)
-:   No documents are returned if the `analyzer` removes all tokens.
-
-`all`
-:   Returns all documents, similar to a [`match_all`](/reference/query-languages/query-dsl/query-dsl-match-all-query.md) query.
+  - `none` (Default)
+  No documents are returned if the `analyzer` removes all tokens.
+  - `all`
+  Returns all documents, similar to a [`match_all`](/reference/query-languages/query-dsl/query-dsl-match-all-query.md) query.
 
 See [Zero terms query](/reference/query-languages/query-dsl/query-dsl-match-query.md#query-dsl-match-query-zero) for an example.
 

--- a/docs/reference/query-languages/query-dsl/query-dsl-match-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-match-query.md
@@ -88,10 +88,8 @@ If the `fuzziness` parameter is not `0`, the `match` query uses a `fuzzy_rewrite
   - `AND`
   For example, a `query` value of `capital of Hungary` is interpreted as `capital AND of AND Hungary`.
 
-
 `minimum_should_match`
 :   (Optional, string) Minimum number of clauses that must match for a document to be returned. See the [`minimum_should_match` parameter](/reference/query-languages/query-dsl/query-dsl-minimum-should-match.md) for valid values and more information.
-
 
 `zero_terms_query`
 :   (Optional, string) Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter. Valid values are:

--- a/docs/reference/query-languages/query-dsl/query-dsl-match-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-match-query.md
@@ -11,7 +11,7 @@ Returns documents that match a provided text, number, date or boolean value. The
 
 The `match` query is the standard query for performing a full-text search, including options for fuzzy matching.
 
-`Match` will also work against [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md) fields. 
+`Match` will also work against [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md) fields.
 As `semantic_text` does not support lexical text search, `match` queries against `semantic_text` fields will automatically perform the correct semantic search.
 Because of this, options that specifically target lexical search such as `fuzziness` or `analyzer` will be ignored.
 
@@ -84,11 +84,10 @@ If the `fuzziness` parameter is not `0`, the `match` query uses a `fuzzy_rewrite
 `operator`
 :   (Optional, string) Boolean logic used to interpret text in the `query` value. Valid values are:
 
-`OR` (Default)
-:   For example, a `query` value of `capital of Hungary` is interpreted as `capital OR of OR Hungary`.
-
-`AND`
-:   For example, a `query` value of `capital of Hungary` is interpreted as `capital AND of AND Hungary`.
+  - `OR` (Default)
+  For example, a `query` value of `capital of Hungary` is interpreted as `capital OR of OR Hungary`.
+  - `AND`
+  For example, a `query` value of `capital of Hungary` is interpreted as `capital AND of AND Hungary`.
 
 
 `minimum_should_match`

--- a/docs/reference/query-languages/query-dsl/query-dsl-match-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-match-query.md
@@ -83,7 +83,6 @@ If the `fuzziness` parameter is not `0`, the `match` query uses a `fuzzy_rewrite
 
 `operator`
 :   (Optional, string) Boolean logic used to interpret text in the `query` value. Valid values are:
-
   - `OR` (Default)
   For example, a `query` value of `capital of Hungary` is interpreted as `capital OR of OR Hungary`.
   - `AND`
@@ -96,7 +95,6 @@ If the `fuzziness` parameter is not `0`, the `match` query uses a `fuzzy_rewrite
 
 `zero_terms_query`
 :   (Optional, string) Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter. Valid values are:
-
   - `none` (Default)
   No documents are returned if the `analyzer` removes all tokens.
   - `all`

--- a/docs/reference/query-languages/query-dsl/query-dsl-match-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-match-query.md
@@ -97,11 +97,10 @@ If the `fuzziness` parameter is not `0`, the `match` query uses a `fuzzy_rewrite
 `zero_terms_query`
 :   (Optional, string) Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter. Valid values are:
 
-`none` (Default)
-:   No documents are returned if the `analyzer` removes all tokens.
-
-`all`
-:   Returns all documents, similar to a [`match_all`](/reference/query-languages/query-dsl/query-dsl-match-all-query.md) query.
+  - `none` (Default)
+  No documents are returned if the `analyzer` removes all tokens.
+  - `all`
+  Returns all documents, similar to a [`match_all`](/reference/query-languages/query-dsl/query-dsl-match-all-query.md) query.
 
 See [Zero terms query](#query-dsl-match-query-zero) for an example.
 

--- a/docs/reference/query-languages/query-dsl/query-dsl-query-string-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-query-string-query.md
@@ -88,10 +88,8 @@ Boost values are relative to the default value of `1.0`. A boost value between `
 
 `default_operator`
 :   (Optional, string) Default boolean logic used to interpret text in the query string if no operators are specified. Valid values are:
-
   - `OR` (Default)
   For example, a query string of `capital of Hungary` is interpreted as `capital OR of OR Hungary`.
-
   - `AND`
   For example, a query string of `capital of Hungary` is interpreted as `capital AND of AND Hungary`.
 

--- a/docs/reference/query-languages/query-dsl/query-dsl-query-string-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-query-string-query.md
@@ -89,11 +89,11 @@ Boost values are relative to the default value of `1.0`. A boost value between `
 `default_operator`
 :   (Optional, string) Default boolean logic used to interpret text in the query string if no operators are specified. Valid values are:
 
-`OR` (Default)
-:   For example, a query string of `capital of Hungary` is interpreted as `capital OR of OR Hungary`.
+  - `OR` (Default)
+  For example, a query string of `capital of Hungary` is interpreted as `capital OR of OR Hungary`.
 
-`AND`
-:   For example, a query string of `capital of Hungary` is interpreted as `capital AND of AND Hungary`.
+  - `AND`
+  For example, a query string of `capital of Hungary` is interpreted as `capital AND of AND Hungary`.
 
 
 `enable_position_increments`

--- a/docs/reference/query-languages/query-dsl/query-dsl-query-string-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-query-string-query.md
@@ -85,14 +85,12 @@ are only [normalized](/reference/text-analysis/normalizers.md).
 
 Boost values are relative to the default value of `1.0`. A boost value between `0` and `1.0` decreases the relevance score. A value greater than `1.0` increases the relevance score.
 
-
 `default_operator`
 :   (Optional, string) Default boolean logic used to interpret text in the query string if no operators are specified. Valid values are:
   - `OR` (Default)
   For example, a query string of `capital of Hungary` is interpreted as `capital OR of OR Hungary`.
   - `AND`
   For example, a query string of `capital of Hungary` is interpreted as `capital AND of AND Hungary`.
-
 
 `enable_position_increments`
 :   (Optional, Boolean) If `true`, enable position increments in queries constructed from a `query_string` search. Defaults to `true`.

--- a/docs/reference/query-languages/query-dsl/query-dsl-simple-query-string-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-simple-query-string-query.md
@@ -50,11 +50,11 @@ There is a limit on the number of fields that can be queried at once. It is defi
 `default_operator`
 :   (Optional, string) Default boolean logic used to interpret text in the query string if no operators are specified. Valid values are:
 
-`OR` (Default)
-:   For example, a query string of `capital of Hungary` is interpreted as `capital OR of OR Hungary`.
+  - `OR` (Default)
+  For example, a query string of `capital of Hungary` is interpreted as `capital OR of OR Hungary`.
 
-`AND`
-:   For example, a query string of `capital of Hungary` is interpreted as `capital AND of AND Hungary`.
+  - `AND`
+  For example, a query string of `capital of Hungary` is interpreted as `capital AND of AND Hungary`.
 
 
 `analyze_wildcard`

--- a/docs/reference/query-languages/query-dsl/query-dsl-simple-query-string-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-simple-query-string-query.md
@@ -49,10 +49,8 @@ There is a limit on the number of fields that can be queried at once. It is defi
 
 `default_operator`
 :   (Optional, string) Default boolean logic used to interpret text in the query string if no operators are specified. Valid values are:
-
   - `OR` (Default)
   For example, a query string of `capital of Hungary` is interpreted as `capital OR of OR Hungary`.
-
   - `AND`
   For example, a query string of `capital of Hungary` is interpreted as `capital AND of AND Hungary`.
 


### PR DESCRIPTION
Does what it says. 

This is how we display the `operator` and `zero_terms_query` options right now for the [match](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-match-query) query:

<img width="887" alt="Screenshot 2025-06-13 at 10 35 26" src="https://github.com/user-attachments/assets/20a6ee37-167b-4450-abda-b1936ebdb128" />

With the changes from this PR:

<img width="891" alt="Screenshot 2025-06-13 at 12 15 56" src="https://github.com/user-attachments/assets/3ca86e2e-9e58-4767-b7fd-a7ee7df3ed2c" />


after I fixed this for the match query I noticed we had the same problems with indentation for others as well.

here are the docs preview links:

https://docs-v3-preview.elastic.dev/elastic/elasticsearch/pull/129395/reference/query-languages/query-dsl/query-dsl-query-string-query

https://docs-v3-preview.elastic.dev/elastic/elasticsearch/pull/129395/reference/query-languages/query-dsl/query-dsl-simple-query-string-query

https://docs-v3-preview.elastic.dev/elastic/elasticsearch/pull/129395/reference/query-languages/query-dsl/query-dsl-combined-fields-query

https://docs-v3-preview.elastic.dev/elastic/elasticsearch/pull/129395/reference/query-languages/query-dsl/query-dsl-match-query