### PR TITLE
Backport Fix `RetrySearchIntegTests` (#122919)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/RetrySearchIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/RetrySearchIntegTests.java
@@ -90,6 +90,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
         for (String allocatedNode : allocatedNodes) {
             if (randomBoolean()) {
                 internalCluster().restartNode(allocatedNode);
+                ensureGreen(indexName);
             }
         }
         ensureGreen(indexName);
@@ -151,6 +152,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
             final Set<String> allocatedNodes = internalCluster().nodesInclude(indexName);
             for (String allocatedNode : allocatedNodes) {
                 internalCluster().restartNode(allocatedNode);
+                ensureGreen(indexName);
             }
             ensureGreen(indexName);
             assertNoFailuresAndResponse(


### PR DESCRIPTION
This backports #122919 to the 8.17 branch since we still get
occasional test failures related to it there.

Closes #127136 