### PR TITLE
Fix tests depending on `_ilm/status` API

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1056,7 +1056,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         deleteAllNodeShutdownMetadata();
     }
 
-    private void waitForClusterUpdates() throws Exception {
+    public void waitForClusterUpdates() throws Exception {
         logger.info("Waiting for all cluster updates up to this moment to be processed");
 
         try {

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/MigrateToDataTiersIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/MigrateToDataTiersIT.java
@@ -169,6 +169,8 @@ public class MigrateToDataTiersIT extends ESRestTestCase {
             Response response = client().performRequest(new Request("GET", "_ilm/status"));
             assertThat(EntityUtils.toString(response.getEntity()), containsString(OperationMode.STOPPED.toString()));
         });
+        // Wait for cluster state to be published to all nodes.
+        waitForClusterUpdates();
 
         String indexWithDataWarmRouting = "indexwithdatawarmrouting";
         Settings.Builder settings = Settings.builder()
@@ -340,6 +342,8 @@ public class MigrateToDataTiersIT extends ESRestTestCase {
                 Response response = client().performRequest(new Request("GET", "_ilm/status"));
                 assertThat(EntityUtils.toString(response.getEntity()), containsString(OperationMode.STOPPED.toString()));
             });
+            // Wait for cluster state to be published to all nodes.
+            waitForClusterUpdates();
         }
 
         Request migrateRequest = new Request("POST", "_ilm/migrate_to_data_tiers");

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -766,6 +766,8 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             String status = (String) statusResponseMap.get("operation_mode");
             assertEquals("STOPPED", status);
         });
+        // Wait for cluster state to be published to all nodes.
+        waitForClusterUpdates();
 
         // Re-start ILM so that subsequent tests don't fail
         Request startILMRequest = new Request("POST", "_ilm/start");


### PR DESCRIPTION
Since #129367 we run the `_ilm/status` API on the local node, which could cause issues in tests that assume the API runs on the master node (i.e. they assumed that once the assertion passed, all nodes in the cluster would have that cluster state, which is not true).

There's no test issue yet, I just happened to run into a failure on a branch of my own.