### PR TITLE
[8.18] Fix RestCancellableNodeClientTests.testConcurrentExecuteAndClose() (#129294)

### DIFF
--- a/server/src/test/java/org/elasticsearch/rest/action/RestCancellableNodeClientTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/RestCancellableNodeClientTests.java
@@ -303,6 +303,11 @@ public class RestCancellableNodeClientTests extends ESTestCase {
             // if the channel is already closed, the listener gets notified immediately, from the same thread.
             if (open.get() == false) {
                 listener.onResponse(null);
+                // Ensure closeLatch is pulled by completing the closeListener with a noop that is ignored if it is already completed.
+                // Note that when the channel is closed we may see multiple addCloseListener() calls, so we do not assert on isDone() here,
+                // and since closeListener may already be completed we cannot rely on it to complete the current listener, so we first
+                // complete it directly and then pass a noop to closeListener.
+                closeListener.onResponse(ActionListener.assertOnce(ActionListener.noop()));
             } else {
                 assertFalse("close listener already set, only one is allowed!", closeListener.isDone());
                 closeListener.onResponse(ActionListener.assertOnce(listener));


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix RestCancellableNodeClientTests.testConcurrentExecuteAndClose() (#129294)