### PR TITLE
Fix fieldName in FieldAttribute

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
@@ -156,8 +156,9 @@ public class FieldAttribute extends TypedAttribute {
             // name starting with `$$`.
             if ((synthetic() || name().startsWith(SYNTHETIC_ATTRIBUTE_NAME_PREFIX)) == false) {
                 lazyFieldName = new FieldName(name());
+            } else {
+                lazyFieldName = new FieldName(Strings.hasText(parentName) ? parentName + "." + field.getName() : field.getName());
             }
-            lazyFieldName = new FieldName(Strings.hasText(parentName) ? parentName + "." + field.getName() : field.getName());
         }
         return lazyFieldName;
     }


### PR DESCRIPTION
I believe we missed the if/else here in #128910; without it, we won't maintain backward compatibility with pre-8.15. This is no longer necessary in main since it doesn't interact with pre-8.15 nodes. I'll open a follow-up to remove it from main, but it's required in 8.19 and 8.18 because mixed cluster tests are failing without it.

Relates #128910
Closes #129412
Closes #129411
Closes #129375
Closes #129374
Closes #129373
Closes #129340
Closes #129339
Closes #129304
Closes #129303

Closes #129410
Closes #129409
Closes #129408
Closes #129407
Closes #129379
Closes #129378
Closes #129377
Closes #129376
Closes #129307
Closes #129306
Closes #129305