### PR TITLE
[8.18] Fix fieldName in FieldAttribute (#129427)

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
@@ -204,8 +204,9 @@ public class FieldAttribute extends TypedAttribute {
             // name starting with `$$`.
             if ((synthetic() || name().startsWith(SYNTHETIC_ATTRIBUTE_NAME_PREFIX)) == false) {
                 lazyFieldName = new FieldName(name());
+            } else {
+                lazyFieldName = new FieldName(Strings.hasText(parentName) ? parentName + "." + field.getName() : field.getName());
             }
-            lazyFieldName = new FieldName(Strings.hasText(parentName) ? parentName + "." + field.getName() : field.getName());
         }
         return lazyFieldName;
     }


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix fieldName in FieldAttribute (#129427)