### PR TITLE
Fix model settings propagation when merging semantic text fields

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -333,7 +333,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
             var resolvedModelSettings = modelSettings.get();
             if (modelSettings.get() == null) {
-                resolvedModelSettings = getResolvedModelSettings(true);
+                resolvedModelSettings = getResolvedModelSettings(context, true);
             }
 
             if (modelSettings.get() != null) {


### PR DESCRIPTION
Ensure that model settings are correctly set during mapping merges. While this is not an issue currently, since the underlying embedding field is not customizable, this fix is required for correct behavior in #119967.