### PR TITLE
Don't use ThrottledTaskRunner for async cache evictions

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCachePlugin.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCachePlugin.java
@@ -27,8 +27,7 @@ public class BlobCachePlugin extends Plugin implements ExtensiblePlugin {
             SharedBlobCacheService.SHARED_CACHE_DECAY_INTERVAL_SETTING,
             SharedBlobCacheService.SHARED_CACHE_MIN_TIME_DELTA_SETTING,
             SharedBlobCacheService.SHARED_CACHE_MMAP,
-            SharedBlobCacheService.SHARED_CACHE_COUNT_READS,
-            SharedBlobCacheService.SHARED_CACHE_CONCURRENT_EVICTIONS_SETTING
+            SharedBlobCacheService.SHARED_CACHE_COUNT_READS
         );
     }
 }


### PR DESCRIPTION
Minor improvement to asynchronous shared blob cache evictions

- Avoids creating the additional lambda
- Only allows a single executor thread

In [testing](https://github.com/elastic/elasticsearch/pull/129459) the deletion of 2,000 searchable snapshots, the time taken for the cluster state update was
- The pre-optimization version took ~1.9s
- The optimised version took ~900ms
- This version took ~600ms

The pre-optimised version would increase exponentially with the amount deleted, whereas the difference between the status quo and this change would be linear. It also looks like the JIT kicked in by the time the third node did the evictions and then all implementations went down to ~200 -> 220ms. So I guess the. danger is the first time this happens on a node that hasn't JIT-ted the cache eviction codepath?

Not sure if it's worth the additional complexity.