### PR TITLE
Async cache evictions performance test

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -268,6 +268,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
 
     @Override
     public synchronized void applyClusterState(final ClusterChangedEvent event) {
+        long startTime = System.nanoTime();
         final var previousShardsClosedListener = lastClusterStateShardsClosedListener;
         lastClusterStateShardsClosedListener = new SubscribableListener<>();
         currentClusterStateShardsClosedListeners = new RefCountingListener(lastClusterStateShardsClosedListener);
@@ -277,6 +278,10 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         } finally {
             currentClusterStateShardsClosedListeners.close();
             currentClusterStateShardsClosedListeners = null;
+        }
+        long nanos = System.nanoTime() - startTime;
+        if (nanos > 10_000_000) {
+            logger.info("SUPD Took {}", TimeValue.timeValueNanos(nanos));
         }
     }
 

--- a/x-pack/plugin/searchable-snapshots/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/build.gradle
@@ -28,5 +28,5 @@ addQaCheckDependencies(project)
 tasks.named("internalClusterTest").configure {
   // Reduce the buffer size per cache-fetch thread to keep direct memory usage under control.
   systemProperty 'es.searchable.snapshot.shared_cache.write_buffer.size', '256k'
-  jvmArgs '-Xms6g', '-Xmx6g'
+  jvmArgs '-Xms10g', '-Xmx10g'
 }

--- a/x-pack/plugin/searchable-snapshots/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/build.gradle
@@ -28,4 +28,5 @@ addQaCheckDependencies(project)
 tasks.named("internalClusterTest").configure {
   // Reduce the buffer size per cache-fetch thread to keep direct memory usage under control.
   systemProperty 'es.searchable.snapshot.shared_cache.write_buffer.size', '256k'
+  jvmArgs '-Xms6g', '-Xmx6g'
 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/DeleteBulkSearchableSnapshotsIT.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/DeleteBulkSearchableSnapshotsIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
+
+import java.util.List;
+
+public class DeleteBulkSearchableSnapshotsIT extends BaseFrozenSearchableSnapshotsIntegTestCase {
+
+    private static final int NUMBER_OF_NODES = 3;
+    // Configure the cache to be able to hold thousands of regions
+    private static final ByteSizeValue REGION_SIZE = ByteSizeValue.ofKb(80);
+    private static final ByteSizeValue CACHE_SIZE = ByteSizeValue.ofGb(3);
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings));
+        if (DiscoveryNode.canContainData(otherSettings)) {
+            builder.put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), CACHE_SIZE);
+            builder.put(SharedBlobCacheService.SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), REGION_SIZE);
+            builder.put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), REGION_SIZE);
+        }
+        return builder.build();
+    }
+
+    public void testDeleteManySearchableSnapshotIndices() throws Exception {
+        assertEquals(NUMBER_OF_NODES, internalCluster().numDataNodes());
+
+        String indexName = randomIdentifier();
+        createIndex(indexName);
+        indexRandom(true, indexName, 10_000);
+
+        String repositoryName = randomIdentifier();
+        createRepository(repositoryName, "fs");
+
+        String snapshotName = randomIdentifier();
+        SnapshotInfo snapshot = createSnapshot(repositoryName, snapshotName, List.of(indexName));
+
+        int numberOfIndices = 2_000;
+        logger.info("Mounting {} searchable snapshots", numberOfIndices);
+        final String indexPrefix = randomIdentifier() + "_";
+        for (int i = 0; i < numberOfIndices; i++) {
+            String searchableSnapshotName = indexPrefix + i;
+            logger.info("Mounting [{}]", searchableSnapshotName);
+            mountSnapshot(
+                repositoryName,
+                snapshotName,
+                indexName,
+                searchableSnapshotName,
+                Settings.EMPTY,
+                MountSearchableSnapshotRequest.Storage.SHARED_CACHE
+            );
+        }
+        ensureGreen();
+
+        logger.info("Warming the shared blob cache");
+        for (int i = 0; i < numberOfIndices; i++) {
+            SearchResponse searchResponse = client().search(
+                new SearchRequest(indexPrefix + i).source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()))
+            ).actionGet();
+            searchResponse.decRef();
+        }
+
+        // Just to minimise the possibility our results are interfered with by a GC
+        System.gc();
+
+        long startTime = System.currentTimeMillis();
+        client().execute(TransportDeleteIndexAction.TYPE, new DeleteIndexRequest("_all")).actionGet();
+        logger.info("Deleting {} indices took {}", numberOfIndices, TimeValue.timeValueMillis(System.currentTimeMillis() - startTime));
+    }
+
+    @Override
+    protected int numberOfShards() {
+        // a shard on each node
+        return NUMBER_OF_NODES;
+    }
+}


### PR DESCRIPTION
This was a test I wrote to reproduce bulk searchable snapshot deletions. I don't think we can make it run in CI because it takes ages and I'm not sure what to assert on.

But here for reference/validation.