### PR TITLE
[9.0] Update traces duration mappings with appropriate unit type (#129418)

### DIFF
--- a/docs/changelog/129418.yaml
+++ b/docs/changelog/129418.yaml
@@ -1,0 +1,5 @@
+pr: 129418
+summary: Update traces duration mappings with appropriate unit type
+area: Ingest Node
+type: enhancement
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm@mappings.yaml
@@ -43,6 +43,8 @@ template:
       # span.*
       span.duration.us:
         type: long
+        meta:
+          unit: micros
       span.representative_count:
         type: scaled_float
         scaling_factor: 1000
@@ -57,6 +59,8 @@ template:
         dynamic: false
       transaction.duration.us:
         type: long
+        meta:
+          unit: micros
       transaction.representative_count:
         type: scaled_float
         scaling_factor: 1000

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 12
+version: 15
 
 component-templates:
   # Data lifecycle.

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 15
+version: 13
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Update traces duration mappings with appropriate unit type (#129418)](https://github.com/elastic/elasticsearch/pull/129418)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)