### PR TITLE
ES|QL: Add missing capability in csv tests

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
@@ -706,6 +706,7 @@ null   | null         | fork2         | spike
 
 forkBeforeCompletion
 required_capability: fork_v8
+required_capability: completion
 
 FROM employees
 | KEEP emp_no, first_name, last_name
@@ -724,6 +725,7 @@ emp_no:integer | first_name:keyword | last_name:keyword | _fork:keyword | x:keyw
 
 forkBranchWithCompletion
 required_capability: fork_v8
+required_capability: completion
 
 FROM employees
 | KEEP emp_no, first_name, last_name
@@ -742,6 +744,7 @@ emp_no:integer | first_name:keyword | last_name:keyword | x:keyword        | _fo
 
 forkAfterCompletion
 required_capability: fork_v8
+required_capability: completion
 
 FROM employees
 | KEEP emp_no, first_name, last_name


### PR DESCRIPTION
Mixed clusters tests don't support inference endpoints, so commands like COMPLETION cannot be executed.
This adds a missing capability to FORK tests when we use COMPLETION, so these tests are skipped for mixed clusters tests.