### PR TITLE
[9.0] Fix example in keyword.md (#129056)

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/keyword.md
+++ b/docs/reference/elasticsearch/mapping-reference/keyword.md
@@ -259,14 +259,14 @@ It is both allowed to submit documents that don’t have a value for the field o
 ```console
 POST logs-debug/_doc
 {
-  "date": "2019-12-12",
+  "@timestamp": "2019-12-12",
   "message": "Starting up Elasticsearch",
   "level": "debug"
 }
 
 POST logs-debug/_doc
 {
-  "date": "2019-12-12",
+  "@timestamp": "2019-12-12",
   "message": "Starting up Elasticsearch"
 }
 ```


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Fix example in keyword.md (#129056)