### PR TITLE
[8.19] Reword lookup join error messages (#129312)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -228,6 +228,8 @@ tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
   task.skipTest("esql/40_unsupported_types/unsupported with sort", "TODO: support for subset of metric fields")
   task.skipTest("esql/63_enrich_int_range/Invalid age as double", "TODO: require disable allow_partial_results")
   task.skipTest("esql/191_lookup_join_on_datastreams/data streams not supported in LOOKUP JOIN", "Added support for aliases in JOINs")
+  task.skipTest("esql/190_lookup_join/non-lookup index", "Error message changed")
+  task.skipTest("esql/192_lookup_join_on_aliases/alias-pattern-multiple", "Error message changed")
 })
 
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -938,6 +938,11 @@ public class EsqlCapabilities {
         ENABLE_LOOKUP_JOIN_ON_ALIASES,
 
         /**
+         * Lookup error messages were updated to make them a bit easier to understand.
+         */
+        UPDATE_LOOKUP_JOIN_ERROR_MESSAGES,
+
+        /**
          * Allow lookup join on mixed numeric fields, among byte, short, int, long, half_float, scaled_float, float and double.
          */
         LOOKUP_JOIN_ON_MIXED_NUMERIC_FIELDS,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/LookupJoin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/LookupJoin.java
@@ -90,15 +90,24 @@ public class LookupJoin extends Join implements SurrogateLogicalPlan, PostAnalys
             var indexNameWithModes = esr.indexNameWithModes();
             if (indexNameWithModes.size() != 1) {
                 failures.add(
-                    fail(esr, "invalid [{}] resolution in lookup mode to [{}] indices", esr.indexPattern(), indexNameWithModes.size())
+                    fail(
+                        esr,
+                        "Lookup Join requires a single lookup mode index; [{}] resolves to [{}] indices",
+                        esr.indexPattern(),
+                        indexNameWithModes.size()
+                    )
                 );
-            } else if (indexNameWithModes.values().iterator().next() != IndexMode.LOOKUP) {
+                return;
+            }
+            var indexAndMode = indexNameWithModes.entrySet().iterator().next();
+            if (indexAndMode.getValue() != IndexMode.LOOKUP) {
                 failures.add(
                     fail(
                         esr,
-                        "invalid [{}] resolution in lookup mode to an index in [{}] mode",
+                        "Lookup Join requires a single lookup mode index; [{}] resolves to [{}] in [{}] mode",
                         esr.indexPattern(),
-                        indexNameWithModes.values().iterator().next()
+                        indexAndMode.getKey(),
+                        indexAndMode.getValue()
                     )
                 );
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -2298,12 +2298,18 @@ public class AnalyzerTests extends ESTestCase {
                 AnalyzerTestUtils.analyzer(lookupResolutionAsIndex, indexResolutionAsLookup)
             )
         );
-        assertThat(e.getMessage(), containsString("1:70: invalid [test] resolution in lookup mode to an index in [standard] mode"));
+        assertThat(
+            e.getMessage(),
+            containsString("1:70: Lookup Join requires a single lookup mode index; [test] resolves to [test] in [standard] mode")
+        );
         e = expectThrows(
             VerificationException.class,
             () -> analyze("FROM test | LOOKUP JOIN test ON languages", AnalyzerTestUtils.analyzer(indexResolution, indexResolutionAsLookup))
         );
-        assertThat(e.getMessage(), containsString("1:25: invalid [test] resolution in lookup mode to an index in [standard] mode"));
+        assertThat(
+            e.getMessage(),
+            containsString("1:25: Lookup Join requires a single lookup mode index; [test] resolves to [test] in [standard] mode")
+        );
     }
 
     public void testImplicitCasting() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/190_lookup_join.yml
@@ -78,7 +78,14 @@ basic:
   - match: {values.1: [2, "yellow"]}
 
 ---
-non-lookup index:
+fails with non-lookup index:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [update_lookup_join_error_messages]
+      reason: "checks updated error messages"
   - do:
       esql.query:
         body:
@@ -86,7 +93,7 @@ non-lookup index:
       catch: "bad_request"
 
   - match: { error.type: "verification_exception" }
-  - contains: { error.reason: "Found 1 problem\nline 1:45: invalid [test] resolution in lookup mode to an index in [standard] mode" }
+  - contains: { error.reason: "Found 1 problem\nline 1:45: Lookup Join requires a single lookup mode index; [test] resolves to [test] in [standard] mode" }
 
 ---
 pattern-multiple:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/192_lookup_join_on_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/192_lookup_join_on_aliases.yml
@@ -186,7 +186,14 @@ alias-repeated-index:
   - match: {values.1: [2, "yellow"]}
 
 ---
-alias-pattern-multiple:
+fails when alias or pattern resolves to multiple:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [update_lookup_join_error_messages]
+      reason: "checks updated error messages"
   - do:
       esql.query:
         body:
@@ -194,7 +201,7 @@ alias-pattern-multiple:
       catch: "bad_request"
 
   - match: { error.type: "verification_exception" }
-  - contains: { error.reason: "Found 1 problem\nline 1:34: invalid [test-lookup-alias-pattern-multiple] resolution in lookup mode to [4] indices" }
+  - contains: { error.reason: "Found 1 problem\nline 1:34: Lookup Join requires a single lookup mode index; [test-lookup-alias-pattern-multiple] resolves to [4] indices" }
 
 ---
 alias-pattern-single:


### PR DESCRIPTION
This backports following changes to 8.19:

* #129312