### PR TITLE
[DOCS] Add docs-preview-comment.yml

### DIFF
--- a/.github/workflows/docs-preview-comment.yml
+++ b/.github/workflows/docs-preview-comment.yml
@@ -1,0 +1,66 @@
+name: "Docs preview comment"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  preview-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment preview links for changed docs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr     = context.payload.pull_request;
+            const prNum  = pr.number;
+            const owner  = context.repo.owner;
+            const repo   = context.repo.repo;
+            const base   = `https://docs-v3-preview.elastic.dev/${owner}/${repo}/pull/${prNum}`;
+            // 1) List all files in this PR
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner, repo, pull_number: prNum
+            });
+            // 2) Filter to only added/modified .md files (skip removed and _snippets/)
+            const links = files
+              .filter(f =>
+                f.status !== 'removed' &&
+                /\.md$/i.test(f.filename) &&
+                !/(^|\/)_snippets\//i.test(f.filename)
+              )
+              .map(f => {
+                let p = f.filename.replace(/\/index\.md$/i, '/');
+                if (p === f.filename) p = p.replace(/\.md$/i, '');
+                return `- [\`${f.filename}\`](${base}/${p})`;
+              });
+            if (!links.length) return;  // nothing to do
+            // 3) Build the comment body
+            const body = [
+              "🔍 **Preview links for changed docs:**",
+              "",
+              ...links,
+              "",
+              "🔔 *The preview site may take up to **3 minutes** to finish building. These links will become live once it completes.*"
+            ].join("\n");
+            // 4) Post or update a single bot comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: prNum
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' &&
+              c.body.startsWith("🔍 **Preview links for changed docs:**")
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: prNum,
+                body
+              });
+            }

--- a/.github/workflows/docs-preview-comment.yml
+++ b/.github/workflows/docs-preview-comment.yml
@@ -1,8 +1,13 @@
 name: "Docs preview comment"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   preview-links:


### PR DESCRIPTION
> [!NOTE]
> This will probably eventually be built into the docs-build and we'll be able to remove this standalone workflow 

Copies workflow added to `docs-content` repo in https://github.com/elastic/docs-content/pull/1341

• triggers on pull request events (open, reopen, sync) to comment with URL preview links for changed docs 
• fetches all files in the pr using github api
• filters for added/modified .md files, excluding removed files and _snippets/ directory 
• checks for existing bot comment
  • updates existing comment or creates new one if none exists

