### PR TITLE
[Profiling] Don't group by address if executable is known but function is unknown

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetFlameGraphActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetFlameGraphActionIT.java
@@ -26,7 +26,7 @@ public class GetFlameGraphActionIT extends ProfilingTestCase {
         );
         GetFlamegraphResponse response = client().execute(GetFlamegraphAction.INSTANCE, request).get();
         // only spot-check top level properties - detailed tests are done in unit tests
-        assertEquals(1010, response.getSize());
+        assertEquals(1008, response.getSize());
         assertEquals(1.0d, response.getSamplingRate(), 0.001d);
         assertEquals(46, response.getSelfCPU());
         assertEquals(1995, response.getTotalCPU());

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetTopNFunctionsActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetTopNFunctionsActionIT.java
@@ -29,7 +29,7 @@ public class GetTopNFunctionsActionIT extends ProfilingTestCase {
         );
         request.setAdjustSampleCount(true);
         GetTopNFunctionsResponse response = client().execute(GetTopNFunctionsAction.INSTANCE, request).get();
-        assertEquals(747, response.getTopN().size());
+        assertEquals(671, response.getTopN().size());
     }
 
     public void testGetTopNFunctionsGroupedByServiceName() throws Exception {
@@ -76,6 +76,6 @@ public class GetTopNFunctionsActionIT extends ProfilingTestCase {
             null
         );
         GetTopNFunctionsResponse response = client().execute(GetTopNFunctionsAction.INSTANCE, request).get();
-        assertEquals(45, response.getTopN().size());
+        assertEquals(42, response.getTopN().size());
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/FrameGroupID.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/FrameGroupID.java
@@ -30,7 +30,10 @@ public final class FrameGroupID {
 
     public static String create(String fileId, Integer addressOrLine, String exeFilename, String sourceFilename, String functionName) {
         if (Strings.isEmpty(functionName)) {
-            return Integer.toString(Objects.hash(fileId, addressOrLine));
+            if (Strings.isEmpty(exeFilename)) {
+                return Integer.toString(Objects.hash(fileId, addressOrLine));
+            }
+            return Integer.toString(Objects.hash(exeFilename));
         }
         if (Strings.isEmpty(sourceFilename)) {
             return Integer.toString(Objects.hash(fileId, functionName));

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/TransportGetFlamegraphActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/TransportGetFlamegraphActionTests.java
@@ -62,19 +62,21 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
         assertEquals(1.0d, response.getSamplingRate(), 0.001d);
         assertEquals(List.of(1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L), response.getCountInclusive());
         assertEquals(List.of(0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 1L), response.getCountExclusive());
+        // {145245218=3}, {145245218=4}, {145245218=5}, {145245218=6}, {145245218=7}, {145245218=8}, {145245218=9}, {145245218=10},
+        // {145245218=11}
         assertEquals(
             List.of(
                 Map.of("1220", 1),
                 Map.of("1219", 2),
-                Map.of("174640828", 3),
-                Map.of("181190529", 4),
-                Map.of("181192637", 5),
-                Map.of("180652335", 6),
-                Map.of("180479184", 7),
-                Map.of("180475689", 8),
-                Map.of("174846197", 9),
-                Map.of("175515318", 10),
-                Map.of("178196121", 11),
+                Map.of("145245218", 3),
+                Map.of("145245218", 4),
+                Map.of("145245218", 5),
+                Map.of("145245218", 6),
+                Map.of("145245218", 7),
+                Map.of("145245218", 8),
+                Map.of("145245218", 9),
+                Map.of("145245218", 10),
+                Map.of("145245218", 11),
                 Map.of()
             ),
             response.getEdges()

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/TransportGetTopNFunctionsActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/TransportGetTopNFunctionsActionTests.java
@@ -60,26 +60,13 @@ public class TransportGetTopNFunctionsActionTests extends ESTestCase {
         GetTopNFunctionsResponse response = TransportGetTopNFunctionsAction.buildTopNFunctions(stacktraces, null);
         assertNotNull(response);
         assertEquals(1, response.getSelfCount());
-        assertEquals(9, response.getTotalCount());
+        assertEquals(1, response.getTotalCount());
 
         List<TopNFunction> topNFunctions = response.getTopN();
         assertNotNull(topNFunctions);
-        assertEquals(9, topNFunctions.size());
+        assertEquals(1, topNFunctions.size());
 
-        assertEquals(
-            List.of(
-                topN("178196121", 1, 16339645, 1L, 1L, 0.3d, 0.3d, 2.7d, 2.7d),
-                topN("181192637", 2, 19336161, 0L, 1L, 0.0d, 0.3d, 0.0d, 2.7d),
-                topN("181190529", 3, 19334053, 0L, 1L, 0.0d, 0.3d, 0.0d, 2.7d),
-                topN("180652335", 4, 18795859, 0L, 1L, 0.0d, 0.3d, 0.0d, 2.7d),
-                topN("180479184", 5, 18622708, 0L, 1L, 0.0d, 0.3d, 0.0d, 2.7d),
-                topN("180475689", 6, 18619213, 0L, 1L, 0.0d, 0.3d, 0.0d, 2.7d),
-                topN("175515318", 7, 13658842, 0L, 1L, 0.0d, 0.3d, 0.0d, 2.7d),
-                topN("174846197", 8, 12989721, 0L, 1L, 0.0d, 0.3d, 0.0d, 2.7d),
-                topN("174640828", 9, 12784352, 0L, 1L, 0.0d, 0.3d, 0.0d, 2.7d)
-            ),
-            topNFunctions
-        );
+        assertEquals(List.of(topN("145245218", 1, 12784352, 1L, 1L, 0.3d, 0.3d, 2.7d, 2.7d)), topNFunctions);
     }
 
     public void testCreateTopNFunctionsWithLimit() {
@@ -129,20 +116,13 @@ public class TransportGetTopNFunctionsActionTests extends ESTestCase {
         GetTopNFunctionsResponse response = TransportGetTopNFunctionsAction.buildTopNFunctions(stacktraces, 3);
         assertNotNull(response);
         assertEquals(1, response.getSelfCount());
-        assertEquals(9, response.getTotalCount());
+        assertEquals(1, response.getTotalCount());
 
         List<TopNFunction> topNFunctions = response.getTopN();
         assertNotNull(topNFunctions);
-        assertEquals(3, topNFunctions.size());
+        assertEquals(1, topNFunctions.size());
 
-        assertEquals(
-            List.of(
-                topN("178196121", 1, 16339645, 1L, 1L, 0.3d, 0.3d, 2.7d, 2.7d),
-                topN("181192637", 2, 19336161, 0L, 1L, 0.0d, 0.3d, 0.0d, 2.7d),
-                topN("181190529", 3, 19334053, 0L, 1L, 0.0d, 0.3d, 0.0d, 2.7d)
-            ),
-            topNFunctions
-        );
+        assertEquals(List.of(topN("145245218", 1, 12784352, 1L, 1L, 0.3d, 0.3d, 2.7d, 2.7d)), topNFunctions);
     }
 
     private TopNFunction topN(


### PR DESCRIPTION
This PR ignores the address or line number when grouping frames with unknown function name but known executable name.

Fully symbolized frames are not affected at all.
This change only affects how unsymbolized frames are grouped / aggregated.

For example, an unsymbolized `lib.so.6` sill appear as a single entry in the TopN functions view, and no longer as hundreds of different entries.

In the flamegraph, this changed aggregation of frames leads to less complexity.
Here are screenshots that show the change as it is otherwise hard to phrase and understand.

**Before**
![Screenshot_20250616_161518](https://github.com/user-attachments/assets/46aee30a-e5b8-42ae-b7c2-533535608485)

**After**
![Screenshot_20250616_161656](https://github.com/user-attachments/assets/4e55aa53-ba6c-4d85-903f-2bd2dcefcf2f)

