### PR TITLE
fix: bump resources version in apm-data plugin

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 15
+version: 16
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
Bump resource version to ensure all templates and pipelines are updated on Elasticsearch upgrade.

This PR targets 8.19 branch as addresses an issue introduced with https://github.com/elastic/elasticsearch/pull/117970