### PR TITLE
[apm-data] fix(8.17): update resource version

### DIFF
--- a/docs/changelog/129539.yaml
+++ b/docs/changelog/129539.yaml
@@ -1,0 +1,5 @@
+pr: 129539
+summary: "[apm-data] fix(8.17): update resource version"
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 12
+version: 13
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
We introduced some changes in 8.17 that did not update the
resource version. As such for cluster upgrading from an
older version Elasticsearch would not detect the need to
apply the new templates, effectively not introducing the
new changes.

Related to https://github.com/elastic/ingest-dev/issues/5701
