### PR TITLE
[apm-data] fix(9.0): update resource version

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 13
+version: 20
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
We introduced some changes in 8.17 that did not update the
resource version. As such for cluster upgrading from an
older version Elasticsearch would not detect the need to
apply the new templates, effectively not introducing the
new changes

As we updated 8.18 to match and there are some changes to
templates between 8.18 and 9.0 we want to ensure the resource
version triggers the template upgrade on stack version upgrade.

Related to https://github.com/elastic/ingest-dev/issues/5701
