### PR TITLE
ES|QL: fix an unmute generative tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -520,9 +520,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {knn-function.KnnSearchWithKOption ASYNC}
   issue: https://github.com/elastic/elasticsearch/issues/129447
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/129453
 - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
   method: testWithDatastreams
   issue: https://github.com/elastic/elasticsearch/issues/129457

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -55,7 +55,8 @@ public abstract class GenerativeRestTest extends ESRestTestCase {
         "The incoming YAML document exceeds the limit:", // still to investigate, but it seems to be specific to the test framework
 
         // Awaiting fixes for correctness
-        "Expecting the following columns \\[.*\\], got" // https://github.com/elastic/elasticsearch/issues/129000
+        "Expecting the following columns \\[.*\\], got", // https://github.com/elastic/elasticsearch/issues/129000
+        "Expecting at most \\[.*\\] columns, got \\[.*\\]" // https://github.com/elastic/elasticsearch/issues/129561
     );
 
     public static final Set<Pattern> ALLOWED_ERROR_PATTERNS = ALLOWED_ERRORS.stream()


### PR DESCRIPTION
Unmuting generative tests and adding https://github.com/elastic/elasticsearch/issues/129561 as a known exception