### PR TITLE
[8.19] ESQL: Assert no partial results in integration tests (#129293)

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/AbstractEsqlClientYamlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/AbstractEsqlClientYamlIT.java
@@ -14,6 +14,8 @@ import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.elasticsearch.test.rest.yaml.section.ClientYamlTestSection;
 import org.elasticsearch.test.rest.yaml.section.DoSection;
 import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
+import org.elasticsearch.test.rest.yaml.section.IsFalseAssertion;
+import org.elasticsearch.xcontent.XContentLocation;
 import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -51,18 +53,25 @@ abstract class AbstractEsqlClientYamlIT extends ESClientYamlSuiteTestCase {
         EsqlSpecTestCase.assertRequestBreakerEmpty();
     }
 
-    public static Iterable<Object[]> updateEsqlQueryDoSections(Iterable<Object[]> parameters, Function<DoSection, ExecutableSection> modify)
-        throws Exception {
+    public static Iterable<Object[]> partialResultsCheckingParameters() throws Exception {
+        return updateExecutableSections(createParameters(), AbstractEsqlClientYamlIT::insertPartialResultsAssertion);
+    }
+
+    public static Iterable<Object[]> updateExecutableSections(
+        Iterable<Object[]> parameters,
+        Function<List<ExecutableSection>, List<ExecutableSection>> updateFunction
+    ) {
         List<Object[]> result = new ArrayList<>();
         for (Object[] orig : parameters) {
             assert orig.length == 1;
             ClientYamlTestCandidate candidate = (ClientYamlTestCandidate) orig[0];
             try {
+                var testSection = candidate.getTestSection();
                 ClientYamlTestSection modified = new ClientYamlTestSection(
-                    candidate.getTestSection().getLocation(),
-                    candidate.getTestSection().getName(),
-                    candidate.getTestSection().getPrerequisiteSection(),
-                    candidate.getTestSection().getExecutableSections().stream().map(e -> modifyExecutableSection(e, modify)).toList()
+                    testSection.getLocation(),
+                    testSection.getName(),
+                    testSection.getPrerequisiteSection(),
+                    updateFunction.apply(testSection.getExecutableSections())
                 );
                 result.add(new Object[] { new ClientYamlTestCandidate(candidate.getRestTestSuite(), modified) });
             } catch (IllegalArgumentException e) {
@@ -70,6 +79,33 @@ abstract class AbstractEsqlClientYamlIT extends ESClientYamlSuiteTestCase {
             }
         }
         return result;
+    }
+
+    public static Iterable<Object[]> updateEsqlQueryDoSections(
+        Iterable<Object[]> parameters,
+        Function<DoSection, ExecutableSection> modify
+    ) {
+        return updateExecutableSections(parameters, sections -> sections.stream().map(e -> modifyExecutableSection(e, modify)).toList());
+    }
+
+    private static List<ExecutableSection> insertPartialResultsAssertion(List<ExecutableSection> sections) {
+        var newSections = new ArrayList<ExecutableSection>(sections.size());
+        for (var section : sections) {
+            var insertIsPartial = false;
+            if (section instanceof DoSection doSection) {
+                var apiCallSection = doSection.getApiCallSection();
+                if (apiCallSection.getApi().equals("esql.query")) {
+                    // If `allow_partial_results` is explicitly set to true, partial results are allowed.
+                    // If it's missing, no partial results are expected, even if the parameter's default is true.
+                    insertIsPartial = "true".equals(apiCallSection.getParams().get("allow_partial_results")) == false;
+                }
+            }
+            newSections.add(section);
+            if (insertIsPartial) {
+                newSections.add(new IsFalseAssertion(XContentLocation.UNKNOWN, "is_partial"));
+            }
+        }
+        return newSections.size() == sections.size() ? sections : newSections;
     }
 
     private static ExecutableSection modifyExecutableSection(ExecutableSection e, Function<DoSection, ExecutableSection> modify) {

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncIT.java
@@ -26,7 +26,7 @@ public class EsqlClientYamlAsyncIT extends AbstractEsqlClientYamlIT {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
-        return updateEsqlQueryDoSections(createParameters(), doSection -> {
+        return updateEsqlQueryDoSections(partialResultsCheckingParameters(), doSection -> {
             ApiCallSection copy = doSection.getApiCallSection().copyWithNewApi("esql.async_query");
             for (Map<String, Object> body : copy.getBodies()) {
                 body.put("wait_for_completion_timeout", "30m");

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncSubmitAndFetchIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncSubmitAndFetchIT.java
@@ -32,7 +32,7 @@ public class EsqlClientYamlAsyncSubmitAndFetchIT extends AbstractEsqlClientYamlI
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
-        return updateEsqlQueryDoSections(createParameters(), DoEsqlAsync::new);
+        return updateEsqlQueryDoSections(partialResultsCheckingParameters(), DoEsqlAsync::new);
     }
 
     private static class DoEsqlAsync implements ExecutableSection {

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlIT.java
@@ -22,6 +22,6 @@ public class EsqlClientYamlIT extends AbstractEsqlClientYamlIT {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
-        return createParameters();
+        return partialResultsCheckingParameters();
     }
 }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -74,6 +74,9 @@ import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.COMPLETIO
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.RERANK;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.SEMANTIC_TEXT_FIELD_CAPS;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.cap;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 // This test can run very long in serverless configurations
 @TimeoutSuite(millis = 30 * TimeUnits.MINUTE)
@@ -265,6 +268,10 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         }
 
         Map<String, Object> answer = runEsql(builder.query(testCase.query), testCase.assertWarnings(deduplicateExactWarnings()));
+
+        var clusters = answer.get("_clusters");
+        var reason = "unexpected partial results" + (clusters != null ? ": _clusters=" + clusters : "");
+        assertThat(reason, answer.get("is_partial"), anyOf(nullValue(), is(false)));
 
         var expectedColumnsWithValues = loadCsvSpecValues(testCase.expectedResults);
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/knn-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/knn-function.csv-spec
@@ -48,7 +48,8 @@ aqua marine | [127.0, 255.0, 212.0]
 teal        | [0.0, 128.0, 128.0]
 ;
 
-knnSearchWithSimilarityOption
+# https://github.com/elastic/elasticsearch/issues/129550
+knnSearchWithSimilarityOption-Ignore
 required_capability: knn_function
 
 from colors metadata _score 
@@ -227,7 +228,8 @@ green      | false
 maroon     | false
 ;
 
-testKnnWithNonPushableDisjunctions
+# https://github.com/elastic/elasticsearch/issues/129550
+testKnnWithNonPushableDisjunctions-Ignore
 required_capability: knn_function
 
 from colors metadata _score 
@@ -243,7 +245,8 @@ lemon chiffon
 papaya whip
 ;
 
-testKnnWithNonPushableDisjunctionsOnComplexExpressions
+# https://github.com/elastic/elasticsearch/issues/129550
+testKnnWithNonPushableDisjunctionsOnComplexExpressions-Ignore
 required_capability: knn_function
 
 from colors metadata _score 


### PR DESCRIPTION
This injects assertions in spec-based and YAML integration tests that the received results aren't partial. This only happens in case the tests themselves don't set "allow_partial_results": true.

Closes #129256

(cherry picked from commit d51d643cf21707c099b28da9b7d604442af5f846)
