### PR TITLE
Integrate project global blocks into existing checks for cluster blocks (Part 2)

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamSettingsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamSettingsAction.java
@@ -63,7 +63,7 @@ public class TransportGetDataStreamSettingsAction extends TransportLocalProjectM
 
     @Override
     protected ClusterBlockException checkBlock(GetDataStreamSettingsAction.Request request, ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     @Override

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
@@ -410,6 +410,6 @@ public class TransportGetDataStreamsAction extends TransportLocalProjectMetadata
 
     @Override
     protected ClusterBlockException checkBlock(GetDataStreamAction.Request request, ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportMigrateToDataStreamAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportMigrateToDataStreamAction.java
@@ -77,6 +77,6 @@ public class TransportMigrateToDataStreamAction extends AcknowledgedTransportMas
 
     @Override
     protected ClusterBlockException checkBlock(MigrateToDataStreamAction.Request request, ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportModifyDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportModifyDataStreamsAction.java
@@ -67,7 +67,7 @@ public class TransportModifyDataStreamsAction extends AcknowledgedTransportMaste
 
     @Override
     protected ClusterBlockException checkBlock(ModifyDataStreamsAction.Request request, ProjectState state) {
-        ClusterBlockException globalBlock = state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        ClusterBlockException globalBlock = state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_WRITE);
         if (globalBlock != null) {
             return globalBlock;
         }

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamSettingsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamSettingsAction.java
@@ -339,6 +339,6 @@ public class TransportUpdateDataStreamSettingsAction extends TransportMasterNode
 
     @Override
     protected ClusterBlockException checkBlock(UpdateDataStreamSettingsAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/TransportGetDataStreamLifecycleStatsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/TransportGetDataStreamLifecycleStatsAction.java
@@ -105,6 +105,6 @@ public class TransportGetDataStreamLifecycleStatsAction extends TransportMasterN
 
     @Override
     protected ClusterBlockException checkBlock(GetDataStreamLifecycleStatsAction.Request request, ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_READ);
     }
 }

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/TransportPutDataStreamLifecycleAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/TransportPutDataStreamLifecycleAction.java
@@ -94,6 +94,6 @@ public class TransportPutDataStreamLifecycleAction extends AcknowledgedTransport
 
     @Override
     protected ClusterBlockException checkBlock(PutDataStreamLifecycleAction.Request request, ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/action/TransportGetDataStreamOptionsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/action/TransportGetDataStreamOptionsAction.java
@@ -121,6 +121,6 @@ public class TransportGetDataStreamOptionsAction extends TransportLocalProjectMe
 
     @Override
     protected ClusterBlockException checkBlock(GetDataStreamOptionsAction.Request request, ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_READ);
     }
 }

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/action/TransportPutDataStreamOptionsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/action/TransportPutDataStreamOptionsAction.java
@@ -93,6 +93,6 @@ public class TransportPutDataStreamOptionsAction extends AcknowledgedTransportMa
 
     @Override
     protected ClusterBlockException checkBlock(PutDataStreamOptionsAction.Request request, ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/TransportGetStoredScriptAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/TransportGetStoredScriptAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
@@ -25,12 +26,15 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportGetStoredScriptAction extends TransportMasterNodeReadAction<GetStoredScriptRequest, GetStoredScriptResponse> {
 
+    private final ProjectResolver projectResolver;
+
     @Inject
     public TransportGetStoredScriptAction(
         TransportService transportService,
         ClusterService clusterService,
         ThreadPool threadPool,
-        ActionFilters actionFilters
+        ActionFilters actionFilters,
+        ProjectResolver projectResolver
     ) {
         super(
             GetStoredScriptAction.NAME,
@@ -42,6 +46,7 @@ public class TransportGetStoredScriptAction extends TransportMasterNodeReadActio
             GetStoredScriptResponse::new,
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -56,7 +61,7 @@ public class TransportGetStoredScriptAction extends TransportMasterNodeReadActio
 
     @Override
     protected ClusterBlockException checkBlock(GetStoredScriptRequest request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_READ);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/TransportPutStoredScriptAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/TransportPutStoredScriptAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAc
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
@@ -29,6 +30,7 @@ public class TransportPutStoredScriptAction extends AcknowledgedTransportMasterN
 
     public static final ActionType<AcknowledgedResponse> TYPE = new ActionType<>("cluster:admin/script/put");
     private final ScriptService scriptService;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutStoredScriptAction(
@@ -36,7 +38,8 @@ public class TransportPutStoredScriptAction extends AcknowledgedTransportMasterN
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        ScriptService scriptService
+        ScriptService scriptService,
+        ProjectResolver projectResolver
     ) {
         super(
             TYPE.name(),
@@ -48,6 +51,7 @@ public class TransportPutStoredScriptAction extends AcknowledgedTransportMasterN
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.scriptService = scriptService;
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -62,7 +66,7 @@ public class TransportPutStoredScriptAction extends AcknowledgedTransportMasterN
 
     @Override
     protected ClusterBlockException checkBlock(PutStoredScriptRequest request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -200,7 +200,7 @@ public class TransportSimulateIndexTemplateAction extends TransportLocalProjectM
 
     @Override
     protected ClusterBlockException checkBlock(SimulateIndexTemplateRequest request, ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_READ);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
@@ -200,6 +200,6 @@ public class TransportSimulateTemplateAction extends TransportLocalProjectMetada
 
     @Override
     protected ClusterBlockException checkBlock(SimulateTemplateAction.Request request, ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_READ);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutComponentTemplateAction.java
@@ -67,7 +67,7 @@ public class TransportPutComponentTemplateAction extends AcknowledgedTransportMa
 
     @Override
     protected ClusterBlockException checkBlock(PutComponentTemplateAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     public static ComponentTemplate normalizeComponentTemplate(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutComposableIndexTemplateAction.java
@@ -75,7 +75,7 @@ public class TransportPutComposableIndexTemplateAction extends AcknowledgedTrans
 
     @Override
     protected ClusterBlockException checkBlock(Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
@@ -121,6 +122,9 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
 
     protected abstract boolean resolveIndex(Request request);
 
+    @FixForMultiProject(
+        description = "Many actions extend TransportSingleShardAction, consider checking for project global blocks when applicable"
+    )
     protected static ClusterBlockException checkGlobalBlock(ProjectState state) {
         return state.blocks().globalBlockedException(ClusterBlockLevel.READ);
     }

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -31,7 +31,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
@@ -122,11 +121,8 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
 
     protected abstract boolean resolveIndex(Request request);
 
-    @FixForMultiProject(
-        description = "Many actions extend TransportSingleShardAction, consider checking for project global blocks when applicable"
-    )
     protected static ClusterBlockException checkGlobalBlock(ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.READ);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.READ);
     }
 
     protected ClusterBlockException checkRequestBlock(ProjectState state, InternalRequest request) {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyAction.java
@@ -91,6 +91,6 @@ public class TransportGetEnrichPolicyAction extends TransportLocalProjectMetadat
 
     @Override
     protected ClusterBlockException checkBlock(GetEnrichPolicyAction.Request request, ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_READ);
     }
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportPutEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportPutEnrichPolicyAction.java
@@ -124,6 +124,6 @@ public class TransportPutEnrichPolicyAction extends AcknowledgedTransportMasterN
 
     @Override
     protected ClusterBlockException checkBlock(PutEnrichPolicyAction.Request request, ProjectState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(state.projectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -38,6 +39,7 @@ public class TransportPutAnalyticsCollectionAction extends TransportMasterNodeAc
     PutAnalyticsCollectionAction.Response> {
 
     private final AnalyticsCollectionService analyticsCollectionService;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutAnalyticsCollectionAction(
@@ -46,7 +48,8 @@ public class TransportPutAnalyticsCollectionAction extends TransportMasterNodeAc
         ThreadPool threadPool,
         ActionFilters actionFilters,
         AnalyticsCollectionService analyticsCollectionService,
-        FeatureService featureService
+        FeatureService featureService,
+        ProjectResolver projectResolver
     ) {
         super(
             PutAnalyticsCollectionAction.NAME,
@@ -59,11 +62,12 @@ public class TransportPutAnalyticsCollectionAction extends TransportMasterNodeAc
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.analyticsCollectionService = analyticsCollectionService;
+        this.projectResolver = projectResolver;
     }
 
     @Override
     protected ClusterBlockException checkBlock(PutAnalyticsCollectionAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -65,6 +66,7 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
     private final ModelRegistry modelRegistry;
     private final InferenceServiceRegistry serviceRegistry;
     private volatile boolean skipValidationAndStart;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutInferenceModelAction(
@@ -75,7 +77,8 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
         XPackLicenseState licenseState,
         ModelRegistry modelRegistry,
         InferenceServiceRegistry serviceRegistry,
-        Settings settings
+        Settings settings,
+        ProjectResolver projectResolver
     ) {
         super(
             PutInferenceModelAction.NAME,
@@ -93,6 +96,7 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
         this.skipValidationAndStart = InferencePlugin.SKIP_VALIDATE_AND_START.get(settings);
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(InferencePlugin.SKIP_VALIDATE_AND_START, this::setSkipValidationAndStart);
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -251,7 +255,7 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
 
     @Override
     protected ClusterBlockException checkBlock(PutInferenceModelAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -75,6 +76,7 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
     private final ModelRegistry modelRegistry;
     private final InferenceServiceRegistry serviceRegistry;
     private final Client client;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportUpdateInferenceModelAction(
@@ -85,7 +87,8 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
         XPackLicenseState licenseState,
         ModelRegistry modelRegistry,
         InferenceServiceRegistry serviceRegistry,
-        Client client
+        Client client,
+        ProjectResolver projectResolver
     ) {
         super(
             UpdateInferenceModelAction.NAME,
@@ -101,6 +104,7 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
         this.modelRegistry = modelRegistry;
         this.serviceRegistry = serviceRegistry;
         this.client = client;
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -345,7 +349,7 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
 
     @Override
     protected ClusterBlockException checkBlock(UpdateInferenceModelAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
@@ -29,6 +30,7 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
     private static final Logger logger = LogManager.getLogger(TransportGetDatafeedsAction.class);
 
     private final DatafeedManager datafeedManager;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportGetDatafeedsAction(
@@ -36,7 +38,8 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        DatafeedManager datafeedManager
+        DatafeedManager datafeedManager,
+        ProjectResolver projectResolver
     ) {
         super(
             GetDatafeedsAction.NAME,
@@ -50,6 +53,7 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
         );
 
         this.datafeedManager = datafeedManager;
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -71,6 +75,6 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
 
     @Override
     protected ClusterBlockException checkBlock(GetDatafeedsAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_READ);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
@@ -36,6 +37,7 @@ public class TransportGetJobsAction extends TransportMasterNodeReadAction<GetJob
 
     private final JobManager jobManager;
     private final DatafeedManager datafeedManager;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportGetJobsAction(
@@ -44,7 +46,8 @@ public class TransportGetJobsAction extends TransportMasterNodeReadAction<GetJob
         ThreadPool threadPool,
         ActionFilters actionFilters,
         JobManager jobManager,
-        DatafeedManager datafeedManager
+        DatafeedManager datafeedManager,
+        ProjectResolver projectResolver
     ) {
         super(
             GetJobsAction.NAME,
@@ -58,6 +61,7 @@ public class TransportGetJobsAction extends TransportMasterNodeReadAction<GetJob
         );
         this.jobManager = jobManager;
         this.datafeedManager = datafeedManager;
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -92,6 +96,6 @@ public class TransportGetJobsAction extends TransportMasterNodeReadAction<GetJob
 
     @Override
     protected ClusterBlockException checkBlock(GetJobsAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_READ);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -77,6 +78,7 @@ public class TransportPutDataFrameAnalyticsAction extends TransportMasterNodeAct
     private final DataFrameAnalyticsAuditor auditor;
     private final SourceDestValidator sourceDestValidator;
     private final Supplier<ByteSizeValue> maxModelMemoryLimitSupplier;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutDataFrameAnalyticsAction(
@@ -89,7 +91,8 @@ public class TransportPutDataFrameAnalyticsAction extends TransportMasterNodeAct
         ClusterService clusterService,
         IndexNameExpressionResolver indexNameExpressionResolver,
         DataFrameAnalyticsConfigProvider configProvider,
-        DataFrameAnalyticsAuditor auditor
+        DataFrameAnalyticsAuditor auditor,
+        ProjectResolver projectResolver
     ) {
         super(
             PutDataFrameAnalyticsAction.NAME,
@@ -118,11 +121,12 @@ public class TransportPutDataFrameAnalyticsAction extends TransportMasterNodeAct
             clusterService.getNodeName(),
             License.OperationMode.PLATINUM.description()
         );
+        this.projectResolver = projectResolver;
     }
 
     @Override
     protected ClusterBlockException checkBlock(PutDataFrameAnalyticsAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -33,6 +34,7 @@ public class TransportPutDatafeedAction extends TransportMasterNodeAction<PutDat
     private final XPackLicenseState licenseState;
     private final SecurityContext securityContext;
     private final DatafeedManager datafeedManager;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutDatafeedAction(
@@ -42,7 +44,8 @@ public class TransportPutDatafeedAction extends TransportMasterNodeAction<PutDat
         ThreadPool threadPool,
         XPackLicenseState licenseState,
         ActionFilters actionFilters,
-        DatafeedManager datafeedManager
+        DatafeedManager datafeedManager,
+        ProjectResolver projectResolver
     ) {
         super(
             PutDatafeedAction.NAME,
@@ -59,6 +62,7 @@ public class TransportPutDatafeedAction extends TransportMasterNodeAction<PutDat
             ? new SecurityContext(settings, threadPool.getThreadContext())
             : null;
         this.datafeedManager = datafeedManager;
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -73,7 +77,7 @@ public class TransportPutDatafeedAction extends TransportMasterNodeAction<PutDat
 
     @Override
     protected ClusterBlockException checkBlock(PutDatafeedAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutJobAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -48,6 +49,7 @@ public class TransportPutJobAction extends TransportMasterNodeAction<PutJobActio
     private final XPackLicenseState licenseState;
     private final AnalysisRegistry analysisRegistry;
     private final SecurityContext securityContext;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutJobAction(
@@ -59,7 +61,8 @@ public class TransportPutJobAction extends TransportMasterNodeAction<PutJobActio
         ActionFilters actionFilters,
         JobManager jobManager,
         DatafeedManager datafeedManager,
-        AnalysisRegistry analysisRegistry
+        AnalysisRegistry analysisRegistry,
+        ProjectResolver projectResolver
     ) {
         super(
             PutJobAction.NAME,
@@ -78,6 +81,7 @@ public class TransportPutJobAction extends TransportMasterNodeAction<PutJobActio
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings)
             ? new SecurityContext(settings, threadPool.getThreadContext())
             : null;
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -133,7 +137,7 @@ public class TransportPutJobAction extends TransportMasterNodeAction<PutJobActio
 
     @Override
     protected ClusterBlockException checkBlock(PutJobAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -92,6 +93,7 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
     private final XPackLicenseState licenseState;
     private final NamedXContentRegistry xContentRegistry;
     private final OriginSettingClient client;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutTrainedModelAction(
@@ -102,7 +104,8 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
         ActionFilters actionFilters,
         Client client,
         TrainedModelProvider trainedModelProvider,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        ProjectResolver projectResolver
     ) {
         super(
             PutTrainedModelAction.NAME,
@@ -118,6 +121,7 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
         this.trainedModelProvider = trainedModelProvider;
         this.xContentRegistry = xContentRegistry;
         this.client = new OriginSettingClient(client, ML_ORIGIN);
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -533,7 +537,7 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
 
     @Override
     protected ClusterBlockException checkBlock(Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAliasAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAliasAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -63,6 +64,7 @@ public class TransportPutTrainedModelAliasAction extends AcknowledgedTransportMa
     private final XPackLicenseState licenseState;
     private final TrainedModelProvider trainedModelProvider;
     private final InferenceAuditor auditor;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutTrainedModelAliasAction(
@@ -72,7 +74,8 @@ public class TransportPutTrainedModelAliasAction extends AcknowledgedTransportMa
         ThreadPool threadPool,
         XPackLicenseState licenseState,
         ActionFilters actionFilters,
-        InferenceAuditor auditor
+        InferenceAuditor auditor,
+        ProjectResolver projectResolver
     ) {
         super(
             PutTrainedModelAliasAction.NAME,
@@ -86,6 +89,7 @@ public class TransportPutTrainedModelAliasAction extends AcknowledgedTransportMa
         this.licenseState = licenseState;
         this.trainedModelProvider = trainedModelProvider;
         this.auditor = auditor;
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -277,6 +281,6 @@ public class TransportPutTrainedModelAliasAction extends AcknowledgedTransportMa
 
     @Override
     protected ClusterBlockException checkBlock(PutTrainedModelAliasAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportResetJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportResetJobAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -62,6 +63,7 @@ public class TransportResetJobAction extends AcknowledgedTransportMasterNodeActi
     private final JobConfigProvider jobConfigProvider;
     private final JobResultsProvider jobResultsProvider;
     private final AnomalyDetectionAuditor auditor;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportResetJobAction(
@@ -73,7 +75,8 @@ public class TransportResetJobAction extends AcknowledgedTransportMasterNodeActi
         Client client,
         JobConfigProvider jobConfigProvider,
         JobResultsProvider jobResultsProvider,
-        AnomalyDetectionAuditor auditor
+        AnomalyDetectionAuditor auditor,
+        ProjectResolver projectResolver
     ) {
         super(
             ResetJobAction.NAME,
@@ -89,6 +92,7 @@ public class TransportResetJobAction extends AcknowledgedTransportMasterNodeActi
         this.jobConfigProvider = Objects.requireNonNull(jobConfigProvider);
         this.jobResultsProvider = Objects.requireNonNull(jobResultsProvider);
         this.auditor = Objects.requireNonNull(auditor);
+        this.projectResolver = Objects.requireNonNull(projectResolver);
     }
 
     @Override
@@ -275,6 +279,6 @@ public class TransportResetJobAction extends AcknowledgedTransportMasterNodeActi
 
     @Override
     protected ClusterBlockException checkBlock(ResetJobAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.HeaderWarning;
@@ -114,6 +115,7 @@ public class TransportStartDataFrameAnalyticsAction extends TransportMasterNodeA
     private final MlMemoryTracker memoryTracker;
     private final DataFrameAnalyticsAuditor auditor;
     private final SourceDestValidator sourceDestValidator;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportStartDataFrameAnalyticsAction(
@@ -127,7 +129,8 @@ public class TransportStartDataFrameAnalyticsAction extends TransportMasterNodeA
         PersistentTasksService persistentTasksService,
         DataFrameAnalyticsConfigProvider configProvider,
         MlMemoryTracker memoryTracker,
-        DataFrameAnalyticsAuditor auditor
+        DataFrameAnalyticsAuditor auditor,
+        ProjectResolver projectResolver
     ) {
         super(
             StartDataFrameAnalyticsAction.NAME,
@@ -154,6 +157,7 @@ public class TransportStartDataFrameAnalyticsAction extends TransportMasterNodeA
             clusterService.getNodeName(),
             License.OperationMode.PLATINUM.description()
         );
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -161,7 +165,7 @@ public class TransportStartDataFrameAnalyticsAction extends TransportMasterNodeA
         // We only delegate here to PersistentTasksService, but if there is a metadata writeblock,
         // then delegating to PersistentTasksService doesn't make a whole lot of sense,
         // because PersistentTasksService will then fail.
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -103,6 +104,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
     private final AnomalyDetectionAuditor auditor;
     private final NamedXContentRegistry xContentRegistry;
     private final boolean remoteClusterClient;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportStartDatafeedAction(
@@ -117,7 +119,8 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         JobConfigProvider jobConfigProvider,
         DatafeedConfigProvider datafeedConfigProvider,
         AnomalyDetectionAuditor auditor,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        ProjectResolver projectResolver
     ) {
         super(
             StartDatafeedAction.NAME,
@@ -137,6 +140,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         this.auditor = auditor;
         this.xContentRegistry = xContentRegistry;
         this.remoteClusterClient = DiscoveryNode.isRemoteClusterClient(settings);
+        this.projectResolver = projectResolver;
     }
 
     static void validate(
@@ -356,7 +360,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         // We only delegate here to PersistentTasksService, but if there is a metadata writeblock,
         // then delagating to PersistentTasksService doesn't make a whole lot of sense,
         // because PersistentTasksService will then fail.
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     private void waitForDatafeedStarted(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -100,6 +101,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
     private final TrainedModelAssignmentService trainedModelAssignmentService;
     private final MlMemoryTracker memoryTracker;
     private final InferenceAuditor auditor;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportStartTrainedModelDeploymentAction(
@@ -111,7 +113,8 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         XPackLicenseState licenseState,
         TrainedModelAssignmentService trainedModelAssignmentService,
         MlMemoryTracker memoryTracker,
-        InferenceAuditor auditor
+        InferenceAuditor auditor,
+        ProjectResolver projectResolver
     ) {
         super(
             StartTrainedModelDeploymentAction.NAME,
@@ -128,6 +131,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         this.memoryTracker = Objects.requireNonNull(memoryTracker);
         this.trainedModelAssignmentService = Objects.requireNonNull(trainedModelAssignmentService);
         this.auditor = Objects.requireNonNull(auditor);
+        this.projectResolver = Objects.requireNonNull(projectResolver);
     }
 
     @Override
@@ -642,7 +646,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         // We only delegate here to PersistentTasksService, but if there is a metadata writeblock,
         // then delegating to PersistentTasksService doesn't make a whole lot of sense,
         // because PersistentTasksService will then fail.
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     private static ElasticsearchStatusException missingFieldsError(String modelId, String hitId, Collection<String> missingFields) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -29,6 +30,7 @@ public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<Upd
 
     private final DatafeedManager datafeedManager;
     private final SecurityContext securityContext;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportUpdateDatafeedAction(
@@ -37,7 +39,8 @@ public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<Upd
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        DatafeedManager datafeedManager
+        DatafeedManager datafeedManager,
+        ProjectResolver projectResolver
     ) {
         super(
             UpdateDatafeedAction.NAME,
@@ -54,6 +57,7 @@ public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<Upd
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings)
             ? new SecurityContext(settings, threadPool.getThreadContext())
             : null;
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -69,6 +73,6 @@ public class TransportUpdateDatafeedAction extends TransportMasterNodeAction<Upd
 
     @Override
     protected ClusterBlockException checkBlock(UpdateDatafeedAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateJobAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
@@ -25,6 +26,7 @@ import org.elasticsearch.xpack.ml.job.JobManager;
 public class TransportUpdateJobAction extends TransportMasterNodeAction<UpdateJobAction.Request, PutJobAction.Response> {
 
     private final JobManager jobManager;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportUpdateJobAction(
@@ -32,7 +34,8 @@ public class TransportUpdateJobAction extends TransportMasterNodeAction<UpdateJo
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        JobManager jobManager
+        JobManager jobManager,
+        ProjectResolver projectResolver
     ) {
         super(
             UpdateJobAction.NAME,
@@ -45,6 +48,7 @@ public class TransportUpdateJobAction extends TransportMasterNodeAction<UpdateJo
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.jobManager = jobManager;
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -59,6 +63,6 @@ public class TransportUpdateJobAction extends TransportMasterNodeAction<UpdateJo
 
     @Override
     protected ClusterBlockException checkBlock(UpdateJobAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateTrainedModelDeploymentAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
@@ -39,6 +40,7 @@ public class TransportUpdateTrainedModelDeploymentAction extends TransportMaster
 
     private final TrainedModelAssignmentClusterService trainedModelAssignmentClusterService;
     private final InferenceAuditor auditor;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportUpdateTrainedModelDeploymentAction(
@@ -47,7 +49,8 @@ public class TransportUpdateTrainedModelDeploymentAction extends TransportMaster
         ThreadPool threadPool,
         ActionFilters actionFilters,
         TrainedModelAssignmentClusterService trainedModelAssignmentClusterService,
-        InferenceAuditor auditor
+        InferenceAuditor auditor,
+        ProjectResolver projectResolver
     ) {
         super(
             UpdateTrainedModelDeploymentAction.NAME,
@@ -61,6 +64,7 @@ public class TransportUpdateTrainedModelDeploymentAction extends TransportMaster
         );
         this.trainedModelAssignmentClusterService = Objects.requireNonNull(trainedModelAssignmentClusterService);
         this.auditor = Objects.requireNonNull(auditor);
+        this.projectResolver = Objects.requireNonNull(projectResolver);
     }
 
     @Override
@@ -95,6 +99,6 @@ public class TransportUpdateTrainedModelDeploymentAction extends TransportMaster
 
     @Override
     protected ClusterBlockException checkBlock(UpdateTrainedModelDeploymentAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelActionTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -367,7 +368,8 @@ public class TransportPutTrainedModelActionTests extends ESTestCase {
             mockFilters,
             mockClient,
             null,
-            null
+            null,
+            TestProjectResolvers.DEFAULT_PROJECT_ONLY
         );
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -65,6 +66,7 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
     private final SecurityContext securityContext;
     private final TransformAuditor auditor;
     private final TransformConfigAutoMigration transformConfigAutoMigration;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutTransformAction(
@@ -76,7 +78,8 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
         ClusterService clusterService,
         TransformServices transformServices,
         Client client,
-        TransformConfigAutoMigration transformConfigAutoMigration
+        TransformConfigAutoMigration transformConfigAutoMigration,
+        ProjectResolver projectResolver
     ) {
         super(
             PutTransformAction.NAME,
@@ -96,6 +99,7 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
             : null;
         this.auditor = transformServices.auditor();
         this.transformConfigAutoMigration = transformConfigAutoMigration;
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -183,7 +187,7 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
 
     @Override
     protected ClusterBlockException checkBlock(PutTransformAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_WRITE);
     }
 
     private void putTransform(Request request, ActionListener<AcknowledgedResponse> listener) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportResetTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportResetTransformAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -63,6 +64,7 @@ public class TransportResetTransformAction extends AcknowledgedTransportMasterNo
     private final SecurityContext securityContext;
     private final Settings settings;
     private final Settings destIndexSettings;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportResetTransformAction(
@@ -74,7 +76,8 @@ public class TransportResetTransformAction extends AcknowledgedTransportMasterNo
         TransformServices transformServices,
         Client client,
         Settings settings,
-        TransformExtensionHolder transformExtensionHolder
+        TransformExtensionHolder transformExtensionHolder,
+        ProjectResolver projectResolver
     ) {
         super(
             ResetTransformAction.NAME,
@@ -94,6 +97,7 @@ public class TransportResetTransformAction extends AcknowledgedTransportMasterNo
             : null;
         this.settings = settings;
         this.destIndexSettings = transformExtensionHolder.getTransformExtension().getTransformDestinationIndexSettings();
+        this.projectResolver = projectResolver;
     }
 
     @Override
@@ -217,6 +221,6 @@ public class TransportResetTransformAction extends AcknowledgedTransportMasterNo
 
     @Override
     protected ClusterBlockException checkBlock(Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(projectResolver.getProjectId(), ClusterBlockLevel.METADATA_READ);
     }
 }


### PR DESCRIPTION
I went through the second half of callers to `globalBlockedException` and updated the obvious cases.

Relates https://github.com/elastic/elasticsearch/pull/129467
Resolves ES-11209