### PR TITLE
Disable disk space checks for threadpool merge scheduler

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorService.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorService.java
@@ -59,7 +59,10 @@ public class ThreadPoolMergeExecutorService implements Closeable {
     /** How frequently we check disk usage (default: 5 seconds). */
     public static final Setting<TimeValue> INDICES_MERGE_DISK_CHECK_INTERVAL_SETTING = Setting.positiveTimeSetting(
         "indices.merge.disk.check_interval",
-        TimeValue.timeValueSeconds(5),
+        // disabled by default
+        // there's currently a problem where (aborting) merges are blocked when shards are closed (because disk space is insufficient)
+        // see: https://github.com/elastic/elasticsearch/issues/129335
+        TimeValue.timeValueSeconds(0),
         Property.Dynamic,
         Property.NodeScope
     );


### PR DESCRIPTION
There is a problem with the disk space checker which blocks (aborting) merges when shards are being closed.

Addresses https://github.com/elastic/elasticsearch/issues/129335