### PR TITLE
[8.19] indices.merge.disk.check_interval defaults to 0 (#129575)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorService.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorService.java
@@ -59,7 +59,10 @@ public class ThreadPoolMergeExecutorService implements Closeable {
     /** How frequently we check disk usage (default: 5 seconds). */
     public static final Setting<TimeValue> INDICES_MERGE_DISK_CHECK_INTERVAL_SETTING = Setting.positiveTimeSetting(
         "indices.merge.disk.check_interval",
-        TimeValue.timeValueSeconds(5),
+        // disabled by default
+        // there's currently a problem where (aborting) merges are blocked when shards are closed (because disk space is insufficient)
+        // see: https://github.com/elastic/elasticsearch/issues/129335
+        TimeValue.timeValueSeconds(0),
         Property.Dynamic,
         Property.NodeScope
     );


### PR DESCRIPTION
Backports the following commits to 8.19:
 - indices.merge.disk.check_interval defaults to 0 (#129575)