### PR TITLE
[DOCS] Viewer role needs experimental settings for Fleet UI access

### DIFF
--- a/docs/reference/security/authorization/built-in-roles.asciidoc
+++ b/docs/reference/security/authorization/built-in-roles.asciidoc
@@ -228,6 +228,7 @@ Grants read-only access to all features in {kib} (including Solutions) and to da
 ===============================
 * This role provides read access to any index that is not prefixed with a dot.
 * This role automatically grants read-only access to new {kib} features as soon as they are available.
+* In version 8.17, access to Fleet UI with this role requires Fleet experimental features to be enabled which are disabled by default. See `xpack.fleet.enableExperimental` in https://www.elastic.co/guide/en/kibana/8.17/fleet-settings-kb.html[Kibana settings documentation,title=Kibana 8.17 settings].
 ===============================
 
 --

--- a/docs/reference/security/authorization/built-in-roles.asciidoc
+++ b/docs/reference/security/authorization/built-in-roles.asciidoc
@@ -228,7 +228,7 @@ Grants read-only access to all features in {kib} (including Solutions) and to da
 ===============================
 * This role provides read access to any index that is not prefixed with a dot.
 * This role automatically grants read-only access to new {kib} features as soon as they are available.
-* In version 8.17, access to Fleet UI with this role requires Fleet experimental features to be enabled which are disabled by default. See `xpack.fleet.enableExperimental` in https://www.elastic.co/guide/en/kibana/8.17/fleet-settings-kb.html[Kibana settings documentation,title=Kibana 8.17 settings].
+* In version 8.17, access to the Fleet UI with this role requires Fleet experimental features to be enabled. Experimental features are disabled by default. See `xpack.fleet.enableExperimental` in the https://www.elastic.co/guide/en/kibana/8.17/fleet-settings-kb.html[Kibana 8.17 settings reference].
 ===============================
 
 --


### PR DESCRIPTION
Make users aware that for 8.17, viewer role requires Fleet experimental settings enabled for read only access to the Fleet UI.
Used a hard link to Kibana 8.17 docs.
This mention isn't required for 8.18 as the Fleet experimental setting is enabled by default.
I wasn't able to locate the setting in 9.x docs, so may not be relevant to that version.