### PR TITLE
[Test] Fix FileSettingsRoleMappingsRestartIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -158,9 +158,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test140CgroupOsStatsAreAvailable
   issue: https://github.com/elastic/elasticsearch/issues/120914
-- class: org.elasticsearch.xpack.security.FileSettingsRoleMappingsRestartIT
-  method: testReservedStatePersistsOnRestart
-  issue: https://github.com/elastic/elasticsearch/issues/120923
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test070BindMountCustomPathConfAndJvmOptions
   issue: https://github.com/elastic/elasticsearch/issues/120910
@@ -173,9 +170,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
   issue: https://github.com/elastic/elasticsearch/issues/120950
-- class: org.elasticsearch.xpack.security.FileSettingsRoleMappingsRestartIT
-  method: testFileSettingsReprocessedOnRestartWithoutVersionChange
-  issue: https://github.com/elastic/elasticsearch/issues/120964
 - class: org.elasticsearch.xpack.ml.integration.PyTorchModelIT
   issue: https://github.com/elastic/elasticsearch/issues/121165
 - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectorySessionFactoryTests

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
@@ -114,7 +114,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
         internalCluster().setBootstrapMasterNodeIndex(0);
 
         final String masterNode = internalCluster().startMasterOnlyNode();
-        awaitMasterNode(masterNode, masterNode);
+        awaitMasterNode();
         var savedClusterState = setupClusterStateListener(masterNode, "everyone_kibana_alone");
 
         awaitFileSettingsWatcher();
@@ -195,7 +195,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
         internalCluster().setBootstrapMasterNodeIndex(0);
 
         final String masterNode = internalCluster().startMasterOnlyNode();
-        awaitMasterNode(masterNode, masterNode);
+        awaitMasterNode();
 
         Tuple<CountDownLatch, AtomicLong> savedClusterState = setupClusterStateListener(masterNode, "everyone_kibana_alone");
         awaitFileSettingsWatcher();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
@@ -113,7 +113,8 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
     public void testReservedStatePersistsOnRestart() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
 
-        final String masterNode = internalCluster().getMasterName();
+        final String masterNode = internalCluster().startMasterOnlyNode();
+        awaitMasterNode(masterNode, masterNode);
         var savedClusterState = setupClusterStateListener(masterNode, "everyone_kibana_alone");
 
         awaitFileSettingsWatcher();
@@ -193,7 +194,8 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
     public void testFileSettingsReprocessedOnRestartWithoutVersionChange() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
 
-        final String masterNode = internalCluster().getMasterName();
+        final String masterNode = internalCluster().startMasterOnlyNode();
+        awaitMasterNode(masterNode, masterNode);
 
         Tuple<CountDownLatch, AtomicLong> savedClusterState = setupClusterStateListener(masterNode, "everyone_kibana_alone");
         awaitFileSettingsWatcher();


### PR DESCRIPTION
The #127318 changed the behaviour of `client()` to not start a node if there is none found in the cluster. Which also changed the `getMasterName()` behaviour to simply fail if there are no nodes instead of starting one.

This is why the `getMasterName()` is failing now. There were no nodes started because the test scope is set to manually manage master nodes (`autoManageMasterNodes = false`) without data nodes (`numDataNodes = 0`).

The fix is to actually start the master node instead of attempting to get the master node name from an empty cluster and depend on a side effect to actually boostrap a node.

Additionally it awaits for the master node to process all cluster state events before proceeding, which should hopefully solve the original cause of failures.

Resolves #120964
Resolves #120923
