### PR TITLE
[7.17] Fix custom naming on plugin based DRA maven artifacts

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/PublishPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/PublishPlugin.java
@@ -23,6 +23,7 @@ import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.XmlProvider;
+import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.BasePluginExtension;
@@ -82,7 +83,8 @@ public class PublishPlugin implements Plugin<Project> {
             if (project1.getPlugins().hasPlugin(ShadowPlugin.class)) {
                 configureWithShadowPlugin(project1, publication);
             } else if (project1.getPlugins().hasPlugin(JavaPlugin.class)) {
-                publication.from(project.getComponents().getByName("java"));
+                SoftwareComponent java = project.getComponents().getByName("java");
+                publication.from(java);
             }
         });
         project.getPlugins().withType(JavaPlugin.class, plugin -> {

--- a/modules/aggs-matrix-stats/build.gradle
+++ b/modules/aggs-matrix-stats/build.gradle
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 apply plugin: 'elasticsearch.legacy-yaml-rest-test'
+apply plugin: 'elasticsearch.publish'
 
 esplugin {
   description 'Adds aggregations whose input are a list of numeric fields and output includes a matrix.'

--- a/modules/lang-mustache/build.gradle
+++ b/modules/lang-mustache/build.gradle
@@ -8,6 +8,7 @@
 apply plugin: 'elasticsearch.legacy-yaml-rest-test'
 apply plugin: 'elasticsearch.legacy-java-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.publish'
 
 esplugin {
   description 'Mustache scripting integration for Elasticsearch'

--- a/modules/mapper-extras/build.gradle
+++ b/modules/mapper-extras/build.gradle
@@ -7,6 +7,7 @@
  */
 apply plugin: 'elasticsearch.legacy-yaml-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.publish'
 
 esplugin {
   description 'Adds advanced field mappers'

--- a/modules/parent-join/build.gradle
+++ b/modules/parent-join/build.gradle
@@ -7,6 +7,8 @@
  */
 apply plugin: 'elasticsearch.legacy-yaml-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.publish'
+
 
 esplugin {
   description 'This module adds the support parent-child queries and aggregations'

--- a/modules/percolator/build.gradle
+++ b/modules/percolator/build.gradle
@@ -7,6 +7,7 @@
  */
 apply plugin: 'elasticsearch.legacy-yaml-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.publish'
 
 esplugin {
   description 'Percolator module adds capability to index queries and query these queries by specifying documents'

--- a/modules/rank-eval/build.gradle
+++ b/modules/rank-eval/build.gradle
@@ -7,6 +7,7 @@
  */
 apply plugin: 'elasticsearch.legacy-yaml-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.publish'
 
 esplugin {
   description 'The Rank Eval module adds APIs to evaluate ranking quality.'

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'elasticsearch.jdk-download'
 apply plugin: 'elasticsearch.legacy-yaml-rest-test'
 apply plugin: 'elasticsearch.legacy-java-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.publish'
 
 esplugin {
   description 'The Reindex module adds APIs to reindex from one index to another or update documents in place.'

--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -13,6 +13,7 @@ import org.elasticsearch.gradle.internal.test.InternalClusterTestPlugin
 apply plugin: 'elasticsearch.legacy-yaml-rest-test'
 apply plugin: 'elasticsearch.legacy-java-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.publish'
 
 /*
  TODOs:

--- a/plugins/analysis-icu/build.gradle
+++ b/plugins/analysis-icu/build.gradle
@@ -9,6 +9,7 @@ import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
  */
 apply plugin: 'elasticsearch.legacy-yaml-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.publish'
 
 esplugin {
   description 'The ICU Analysis plugin integrates the Lucene ICU module into Elasticsearch, adding ICU-related analysis components.'

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -14,7 +14,6 @@ subprojects {
 configure(subprojects.findAll { it.parent.path == project.path }) {
   group = 'org.elasticsearch.plugin'
   apply plugin: 'elasticsearch.internal-es-plugin'
-  apply plugin: 'elasticsearch.publish'
 
   esplugin {
     // for local ES plugins, the name of the plugin is the same as the directory

--- a/plugins/transport-nio/build.gradle
+++ b/plugins/transport-nio/build.gradle
@@ -9,6 +9,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
  */
 apply plugin: "elasticsearch.publish"
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.publish'
 
 esplugin {
   description 'The nio transport.'

--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -1,6 +1,5 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 apply plugin: 'elasticsearch.internal-es-plugin'
-apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.internal-cluster-test'
 esplugin {
   name 'x-pack-identity-provider'

--- a/x-pack/transport-client/build.gradle
+++ b/x-pack/transport-client/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.publish'
+
 group = 'org.elasticsearch.client'
 
 base {


### PR DESCRIPTION
For 7.17 we have used some custom naming of the artifacts that are based on plugin projects but published as maven artifacts. This addresses this and also fixes an issue in the configuration ordering causing trouble when configuring custom artifactIDs when using nmcp plugin