### PR TITLE
ESQL: Fix wildcard for `_index` field

### DIFF
--- a/docs/changelog/129650.yaml
+++ b/docs/changelog/129650.yaml
@@ -1,0 +1,5 @@
+pr: 129650
+summary: Fix wildcard for `_index` field
+area: ES|QL
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/ConstantFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ConstantFieldType.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.logging.LogManager;
 
 import java.util.Collection;
 import java.util.Map;
@@ -128,6 +129,12 @@ public abstract class ConstantFieldType extends MappedFieldType {
     }
 
     public final Query wildcardQuery(String value, boolean caseInsensitive, QueryRewriteContext context) {
+        LogManager.getLogger(ConstantFieldType.class)
+            .error(
+                "ADSFA const eval {} {}",
+                value,
+                matches(value, caseInsensitive, context)
+            );
         if (matches(value, caseInsensitive, context)) {
             return Queries.newMatchAllQuery();
         } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ConstantFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ConstantFieldType.java
@@ -129,12 +129,7 @@ public abstract class ConstantFieldType extends MappedFieldType {
     }
 
     public final Query wildcardQuery(String value, boolean caseInsensitive, QueryRewriteContext context) {
-        LogManager.getLogger(ConstantFieldType.class)
-            .error(
-                "ADSFA const eval {} {}",
-                value,
-                matches(value, caseInsensitive, context)
-            );
+        LogManager.getLogger(ConstantFieldType.class).error("ADSFA const eval {} {}", value, matches(value, caseInsensitive, context));
         if (matches(value, caseInsensitive, context)) {
             return Queries.newMatchAllQuery();
         } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -38,7 +38,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
 
     public static final TypeParser PARSER = new FixedTypeParser(c -> INSTANCE);
 
-    static final class IndexFieldType extends ConstantFieldType {
+    public static final class IndexFieldType extends ConstantFieldType {
 
         static final IndexFieldType INSTANCE = new IndexFieldType();
 

--- a/server/src/main/java/org/elasticsearch/index/query/SearchIndexNameMatcher.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchIndexNameMatcher.java
@@ -13,6 +13,8 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.index.mapper.ConstantFieldType;
+import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.transport.RemoteClusterAware;
 
 import java.util.function.Predicate;
@@ -53,7 +55,9 @@ public class SearchIndexNameMatcher implements Predicate<String> {
      *  the separator ':', and must match on both the cluster alias and index name.
      */
     public boolean test(String pattern) {
+
         String[] splitIndex = RemoteClusterAware.splitIndexName(pattern);
+        LogManager.getLogger(ConstantFieldType.class).error("ADSFA {}", (Object) splitIndex);
 
         if (splitIndex[0] == null) {
             return clusterAlias == null && matchesIndex(pattern);

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/querydsl/query/WildcardQuery.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/querydsl/query/WildcardQuery.java
@@ -18,14 +18,11 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.WildcardQueryBuilder;
 import org.elasticsearch.index.query.support.QueryParsers;
 import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Objects;
-
-import static org.elasticsearch.index.query.QueryBuilders.wildcardQuery;
 
 public class WildcardQuery extends Query {
 

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/querydsl/query/WildcardQuery.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/querydsl/query/WildcardQuery.java
@@ -6,10 +6,23 @@
  */
 package org.elasticsearch.xpack.esql.core.querydsl.query;
 
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.MultiTermQuery;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.index.mapper.IndexFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.WildcardQueryBuilder;
+import org.elasticsearch.index.query.support.QueryParsers;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
+import java.io.IOException;
+import java.util.Locale;
 import java.util.Objects;
 
 import static org.elasticsearch.index.query.QueryBuilders.wildcardQuery;
@@ -44,9 +57,34 @@ public class WildcardQuery extends Query {
 
     @Override
     protected QueryBuilder asBuilder() {
-        WildcardQueryBuilder wb = wildcardQuery(field, query);
-        // ES does not allow case_insensitive to be set to "false", it should be either "true" or not specified
-        return caseInsensitive == false ? wb : wb.caseInsensitive(caseInsensitive);
+        /*
+         * Builds WildcardQueryBuilder with simple text matching semantics for
+         * all fields, including the `_index` field which insists on implementing
+         * some fairly unexpected matching rules.
+         *
+         * Note that
+         */
+        return new WildcardQueryBuilder(field, query) {
+            @Override
+            protected org.apache.lucene.search.Query doToQuery(SearchExecutionContext context) throws IOException {
+                MappedFieldType fieldType = context.getFieldType(fieldName());
+                MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewrite(), null, LoggingDeprecationHandler.INSTANCE);
+                LogManager.getLogger(WildcardQuery.class).error("ADSFA special query {}", fieldType);
+                if (fieldType instanceof IndexFieldMapper.IndexFieldType) {
+                    String value = value();
+                    String indexName = context.getFullyQualifiedIndex().getName();
+                    if (WildcardQuery.this.caseInsensitive) {
+                        value = value.toLowerCase(Locale.ROOT);
+                        indexName = indexName.toLowerCase(Locale.ROOT);
+                    }
+                    if (Regex.simpleMatch(value, indexName)) {
+                        return new MatchAllDocsQuery();
+                    }
+                    return new MatchNoDocsQuery();
+                }
+                return fieldType.wildcardQuery(value(), method, WildcardQuery.this.caseInsensitive, context);
+            }
+        };
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/RegexMatch.java
@@ -12,6 +12,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -48,6 +49,7 @@ abstract class RegexMatch<P extends AbstractStringPattern> extends org.elasticse
 
     @Override
     public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
+        LogManager.getLogger(WildcardLike.class).error("ADSFA toEvaluator");
         return AutomataMatch.toEvaluator(
             source(),
             toEvaluator.apply(field()),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/WildcardLike.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/WildcardLike.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.string.regex;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
@@ -108,6 +109,7 @@ public class WildcardLike extends RegexMatch<WildcardPattern> {
 
     @Override
     public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        LogManager.getLogger(WildcardLike.class).error("ADSFA translatable", new Exception());
         return pushdownPredicates.isPushableAttribute(field()) ? Translatable.YES : Translatable.NO;
     }
 
@@ -115,6 +117,13 @@ public class WildcardLike extends RegexMatch<WildcardPattern> {
     public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         var field = field();
         LucenePushdownPredicates.checkIsPushableAttribute(field);
+        LogManager.getLogger(WildcardLike.class)
+            .error(
+                "ADSFA asQuery {} {}",
+                field,
+                translateField(handler.nameOf(field instanceof FieldAttribute fa ? fa.exactAttribute() : field)),
+                new Exception()
+            );
         return translateField(handler.nameOf(field instanceof FieldAttribute fa ? fa.exactAttribute() : field));
     }
 


### PR DESCRIPTION
This is a fairly hacky fix for #129511, a bug where we don't run `LIKE` against the `_index` field in a consistent way. I feel like there should be a better way to fix this, but should work.
