### PR TITLE
[8.19] Fix PushQueriesIT.testLike() fails (#129647)

### DIFF
--- a/docs/changelog/129647.yaml
+++ b/docs/changelog/129647.yaml
@@ -1,0 +1,5 @@
+pr: 129647
+summary: Fix `PushQueriesIT.testLike()` fails
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -240,7 +240,7 @@ public class PushQueriesIT extends ESRestTestCase {
     }
 
     public void testLike() throws IOException {
-        String value = "v".repeat(between(0, 256));
+        String value = "v".repeat(between(1, 256));
         String esqlQuery = """
             FROM test
             | WHERE test like "%value*"
@@ -258,7 +258,7 @@ public class PushQueriesIT extends ESRestTestCase {
     }
 
     public void testLikeList() throws IOException {
-        String value = "v".repeat(between(0, 256));
+        String value = "v".repeat(between(1, 256));
         String esqlQuery = """
             FROM test
             | WHERE test like ("%value*", "abc*")


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix PushQueriesIT.testLike() fails (#129647)](https://github.com/elastic/elasticsearch/pull/129647)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)