### PR TITLE
[8.19] Fix size of the bulks used in BulkInferenceExecutorTests (#129640)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/bulk/BulkInferenceExecutorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/bulk/BulkInferenceExecutorTests.java
@@ -61,7 +61,7 @@ public class BulkInferenceExecutorTests extends ESTestCase {
     }
 
     public void testSuccessfulExecution() throws Exception {
-        List<InferenceAction.Request> requests = randomInferenceRequestList(between(1, 10_000));
+        List<InferenceAction.Request> requests = randomInferenceRequestList(between(1, 1000));
         List<InferenceAction.Response> responses = randomInferenceResponseList(requests.size());
 
         InferenceRunner inferenceRunner = mockInferenceRunner(invocation -> {
@@ -93,7 +93,7 @@ public class BulkInferenceExecutorTests extends ESTestCase {
     }
 
     public void testInferenceRunnerAlwaysFails() throws Exception {
-        List<InferenceAction.Request> requests = randomInferenceRequestList(between(1, 10_000));
+        List<InferenceAction.Request> requests = randomInferenceRequestList(between(1, 1000));
 
         InferenceRunner inferenceRunner = mock(invocation -> {
             runWithRandomDelay(() -> {
@@ -115,7 +115,7 @@ public class BulkInferenceExecutorTests extends ESTestCase {
     }
 
     public void testInferenceRunnerSometimesFails() throws Exception {
-        List<InferenceAction.Request> requests = randomInferenceRequestList(between(1, 10_000));
+        List<InferenceAction.Request> requests = randomInferenceRequestList(between(1, 1000));
 
         InferenceRunner inferenceRunner = mockInferenceRunner(invocation -> {
             ActionListener<InferenceAction.Response> listener = invocation.getArgument(1);


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix size of the bulks used in BulkInferenceExecutorTests (#129640)