### PR TITLE
Clone IndexInput when creating MemorySegmentPostingsVisitor

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsReader.java
@@ -122,7 +122,7 @@ public class DefaultIVFVectorsReader extends IVFVectorsReader implements OffHeap
     PostingVisitor getPostingVisitor(FieldInfo fieldInfo, IndexInput indexInput, float[] target, IntPredicate needsScoring)
         throws IOException {
         FieldEntry entry = fields.get(fieldInfo.number);
-        return new MemorySegmentPostingsVisitor(target, indexInput, entry, fieldInfo, needsScoring);
+        return new MemorySegmentPostingsVisitor(target, indexInput.clone(), entry, fieldInfo, needsScoring);
     }
 
     // TODO can we do this in off-heap blocks?

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/IVFVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/IVFVectorsFormatTests.java
@@ -34,6 +34,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.lang.String.format;
 import static org.elasticsearch.index.codec.vectors.IVFVectorsFormat.MAX_VECTORS_PER_CLUSTER;
@@ -124,6 +125,51 @@ public class IVFVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
                     var fieldInfo = r.getFieldInfos().fieldInfo("f");
                     var offHeap = OffHeapByteSizeUtils.getOffHeapByteSize(knnVectorsReader, fieldInfo);
                     assertEquals(0, offHeap.size());
+                }
+            }
+        }
+    }
+
+    public void testWithThreads() throws Exception {
+        final int numThreads = random().nextInt(2, 5);
+        final int numSearches = atLeast(100);
+        final int numDocs = atLeast(1000);
+        final int dimensions = random().nextInt(12, 500);
+        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+            for (int docCount = 0; docCount < numDocs; docCount++) {
+                final Document doc = new Document();
+                doc.add(new KnnFloatVectorField("f", randomVector(dimensions), VectorSimilarityFunction.EUCLIDEAN));
+                w.addDocument(doc);
+            }
+            w.forceMerge(1);
+            try (IndexReader reader = DirectoryReader.open(w)) {
+                final AtomicBoolean failed = new AtomicBoolean();
+                Thread[] threads = new Thread[numThreads];
+                for (int threadID = 0; threadID < numThreads; threadID++) {
+                    threads[threadID] =
+                        new Thread(() -> {
+                            try {
+                                long totSearch = 0;
+                                for (; totSearch < numSearches && failed.get() == false; totSearch++) {
+                                    float[] vector = randomVector(dimensions);
+                                    LeafReader leafReader = getOnlyLeafReader(reader);
+                                    leafReader.searchNearestVectors("f", vector, 10, leafReader.getLiveDocs(), Integer.MAX_VALUE);
+                                }
+                                assertTrue(totSearch > 0);
+                            } catch (Exception exc) {
+                                failed.set(true);
+                                throw new RuntimeException(exc);
+                            }
+                        });
+                    threads[threadID].setDaemon(true);
+                }
+
+                for (Thread t : threads) {
+                    t.start();
+                }
+
+                for (Thread t : threads) {
+                    t.join();
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/IVFVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/IVFVectorsFormatTests.java
@@ -147,21 +147,20 @@ public class IVFVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
                 final AtomicBoolean failed = new AtomicBoolean();
                 Thread[] threads = new Thread[numThreads];
                 for (int threadID = 0; threadID < numThreads; threadID++) {
-                    threads[threadID] =
-                        new Thread(() -> {
-                            try {
-                                long totSearch = 0;
-                                for (; totSearch < numSearches && failed.get() == false; totSearch++) {
-                                    float[] vector = randomVector(dimensions);
-                                    LeafReader leafReader = getOnlyLeafReader(reader);
-                                    leafReader.searchNearestVectors("f", vector, 10, leafReader.getLiveDocs(), Integer.MAX_VALUE);
-                                }
-                                assertTrue(totSearch > 0);
-                            } catch (Exception exc) {
-                                failed.set(true);
-                                throw new RuntimeException(exc);
+                    threads[threadID] = new Thread(() -> {
+                        try {
+                            long totSearch = 0;
+                            for (; totSearch < numSearches && failed.get() == false; totSearch++) {
+                                float[] vector = randomVector(dimensions);
+                                LeafReader leafReader = getOnlyLeafReader(reader);
+                                leafReader.searchNearestVectors("f", vector, 10, leafReader.getLiveDocs(), Integer.MAX_VALUE);
                             }
-                        });
+                            assertTrue(totSearch > 0);
+                        } catch (Exception exc) {
+                            failed.set(true);
+                            throw new RuntimeException(exc);
+                        }
+                    });
                     threads[threadID].setDaemon(true);
                 }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/IVFVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/IVFVectorsFormatTests.java
@@ -130,6 +130,7 @@ public class IVFVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
         }
     }
 
+    // this is a modified version of lucene's TestSearchWithThreads test case
     public void testWithThreads() throws Exception {
         final int numThreads = random().nextInt(2, 5);
         final int numSearches = atLeast(100);


### PR DESCRIPTION
VectorsReaders are shared between threads, therefore when creating MemorySegmentPostingsVisitor we must clone the IndexInput to avoid concurrency issues when accessing it.

I label the PR as non-issue as this feature is behind a feature flag.