### PR TITLE
ES|QL: Fix generative tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -565,9 +565,6 @@ tests:
 - class: org.elasticsearch.search.query.VectorIT
   method: testFilteredQueryStrategy
   issue: https://github.com/elastic/elasticsearch/issues/129517
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/129453
 - class: org.elasticsearch.test.apmintegration.TracesApmIT
   method: testApmIntegration
   issue: https://github.com/elastic/elasticsearch/issues/129651

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
@@ -13,7 +13,6 @@ import org.elasticsearch.xpack.esql.qa.rest.generative.command.pipe.DissectGener
 import org.elasticsearch.xpack.esql.qa.rest.generative.command.pipe.DropGenerator;
 import org.elasticsearch.xpack.esql.qa.rest.generative.command.pipe.EnrichGenerator;
 import org.elasticsearch.xpack.esql.qa.rest.generative.command.pipe.EvalGenerator;
-import org.elasticsearch.xpack.esql.qa.rest.generative.command.pipe.ForkGenerator;
 import org.elasticsearch.xpack.esql.qa.rest.generative.command.pipe.GrokGenerator;
 import org.elasticsearch.xpack.esql.qa.rest.generative.command.pipe.KeepGenerator;
 import org.elasticsearch.xpack.esql.qa.rest.generative.command.pipe.LimitGenerator;
@@ -54,7 +53,8 @@ public class EsqlQueryGenerator {
         DropGenerator.INSTANCE,
         EnrichGenerator.INSTANCE,
         EvalGenerator.INSTANCE,
-        ForkGenerator.INSTANCE,
+        // Awaits fix: https://github.com/elastic/elasticsearch/issues/129715
+        // ForkGenerator.INSTANCE,
         GrokGenerator.INSTANCE,
         KeepGenerator.INSTANCE,
         LimitGenerator.INSTANCE,

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/command/pipe/LimitGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/command/pipe/LimitGenerator.java
@@ -42,15 +42,9 @@ public class LimitGenerator implements CommandGenerator {
         List<List<Object>> output
     ) {
         int limit = (int) commandDescription.context().get(LIMIT);
-        boolean defaultLimit = false;
-        for (CommandDescription previousCommand : previousCommands) {
-            if (previousCommand.commandName().equals(LIMIT)) {
-                defaultLimit = true;
-            }
-        }
 
-        if (previousOutput.size() > limit && output.size() != limit || defaultLimit && previousOutput.size() < output.size()) {
-            return new ValidationResult(false, "Expecting [" + limit + "] records, got [" + output.size() + "]");
+        if (output.size() > limit) {
+            return new ValidationResult(false, "Expecting at most [" + limit + "] records, got [" + output.size() + "]");
         }
         return CommandGenerator.expectSameColumns(previousColumns, columns);
     }


### PR DESCRIPTION
- Reducing correctness checks for LIMIT (they were too strinct, queries are not deterministic enough)
- Disabling ForkGenerator, waiting for a fix to https://github.com/elastic/elasticsearch/issues/129715 (cc. @ioanatia )

Fixes: https://github.com/elastic/elasticsearch/issues/129453