### PR TITLE
Fix and unmute GetSnapshotsIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -574,9 +574,6 @@ tests:
 - class: org.elasticsearch.streams.StreamsYamlTestSuiteIT
   method: test {yaml=streams/logs/10_basic/Check for repeated toggle to same state}
   issue: https://github.com/elastic/elasticsearch/issues/129735
-- class: org.elasticsearch.snapshots.GetSnapshotsIT
-  method: testFilterByState
-  issue: https://github.com/elastic/elasticsearch/issues/129740
 
 # Examples:
 #

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -71,6 +71,7 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.repositories.blobstore.BlobStoreRepository.getRepositoryDataBlobName;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
@@ -672,8 +673,8 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
         snapshots = getSnapshotsForStates.apply(EnumSet.of(SnapshotState.SUCCESS, SnapshotState.IN_PROGRESS));
         assertThat(snapshots, hasSize(2));
         var states = snapshots.stream().map(SnapshotInfo::state).collect(Collectors.toSet());
-        assertTrue(states.contains(SnapshotState.SUCCESS));
-        assertTrue(states.contains(SnapshotState.IN_PROGRESS));
+        assertThat(states, hasItem(SnapshotState.SUCCESS));
+        assertThat(states, hasItem(SnapshotState.IN_PROGRESS));
 
         // Fetch all snapshots (without state)
         snapshots = clusterAdmin().prepareGetSnapshots(TEST_REQUEST_TIMEOUT, repoName).get().getSnapshots();

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -655,6 +655,9 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(snapshots, hasSize(1));
         assertThat(snapshots.getFirst().state(), is(SnapshotState.SUCCESS));
 
+        // Add some more state (so the next snapshot has some work to do)
+        indexRandomDocs(randomIdentifier(), 100);
+
         // Create a snapshot in progress
         blockAllDataNodes(repoName);
         startFullSnapshot(repoName, "snapshot-in-progress");


### PR DESCRIPTION
I think because there was no new content since the last snapshot, `snapshot-in-progress` never got blocked by the repository block because it never went to the repository.

Closes: #129740
