### PR TITLE
Introduce a vectorized soarDistance function

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
@@ -237,20 +237,21 @@ public class ESVectorUtil {
     }
 
     /**
-     * calculates the spill-over score for a vector and a centroid, given its residual with
-     * its actually nearest centroid
+     * calculates the soar distance for a vector and a centroid
      * @param v1 the vector
      * @param centroid the centroid
      * @param originalResidual the residual with the actually nearest centroid
-     * @return the spill-over score (soar)
+     * @param soarLambda the lambda parameter
+     * @param rnorm distance to the nearest centroid
+     * @return the soar distance
      */
-    public static float soarResidual(float[] v1, float[] centroid, float[] originalResidual) {
+    public static float soarDistance(float[] v1, float[] centroid, float[] originalResidual, float soarLambda, float rnorm) {
         if (v1.length != centroid.length) {
             throw new IllegalArgumentException("vector dimensions differ: " + v1.length + "!=" + centroid.length);
         }
         if (originalResidual.length != v1.length) {
             throw new IllegalArgumentException("vector dimensions differ: " + originalResidual.length + "!=" + v1.length);
         }
-        return IMPL.soarResidual(v1, centroid, originalResidual);
+        return IMPL.soarDistance(v1, centroid, originalResidual, soarLambda, rnorm);
     }
 }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
@@ -11,6 +11,7 @@ package org.elasticsearch.simdvec.internal.vectorization;
 
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.Constants;
+import org.apache.lucene.util.VectorUtil;
 
 final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
 
@@ -139,15 +140,16 @@ final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
     }
 
     @Override
-    public float soarResidual(float[] v1, float[] centroid, float[] originalResidual) {
+    public float soarDistance(float[] v1, float[] centroid, float[] originalResidual, float soarLambda, float rnorm) {
         assert v1.length == centroid.length;
         assert v1.length == originalResidual.length;
+        float dsq = VectorUtil.squareDistance(v1, centroid);
         float proj = 0;
         for (int i = 0; i < v1.length; i++) {
             float djk = v1[i] - centroid[i];
             proj = fma(djk, originalResidual[i], proj);
         }
-        return proj;
+        return dsq + soarLambda * proj * proj / rnorm;
     }
 
     public static int ipByteBitImpl(byte[] q, byte[] d) {

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
@@ -37,6 +37,6 @@ public interface ESVectorUtilSupport {
 
     void centerAndCalculateOSQStatsDp(float[] target, float[] centroid, float[] centered, float[] stats);
 
-    float soarResidual(float[] v1, float[] centroid, float[] originalResidual);
+    float soarDistance(float[] v1, float[] centroid, float[] originalResidual, float soarLambda, float rnorm);
 
 }

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
@@ -268,7 +268,7 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         }
     }
 
-    public void testSoarOverspillScore() {
+    public void testSoarDistance() {
         int size = random().nextInt(128, 512);
         float deltaEps = 1e-5f * size;
         var vector = new float[size];
@@ -279,8 +279,10 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
             centroid[i] = random().nextFloat();
             preResidual[i] = random().nextFloat();
         }
-        var expected = defaultedProvider.getVectorUtilSupport().soarResidual(vector, centroid, preResidual);
-        var result = defOrPanamaProvider.getVectorUtilSupport().soarResidual(vector, centroid, preResidual);
+        float soarLambda = random().nextFloat();
+        float rnorm = random().nextFloat();
+        var expected = defaultedProvider.getVectorUtilSupport().soarDistance(vector, centroid, preResidual, soarLambda, rnorm);
+        var result = defOrPanamaProvider.getVectorUtilSupport().soarDistance(vector, centroid, preResidual, soarLambda, rnorm);
         assertEquals(expected, result, deltaEps);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocal.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocal.java
@@ -202,7 +202,7 @@ class KMeansLocal {
                     continue;
                 }
                 float[] neighborCentroid = centroids[neighbor];
-                float soar = distanceSoar(diffs, vector, neighborCentroid, vectorCentroidDist);
+                float soar = ESVectorUtil.soarDistance(vector, neighborCentroid, diffs, soarLambda, vectorCentroidDist);
                 if (soar < minSoar) {
                     bestAssignment = neighbor;
                     minSoar = soar;
@@ -213,13 +213,6 @@ class KMeansLocal {
         }
 
         return spilledAssignments;
-    }
-
-    private float distanceSoar(float[] residual, float[] vector, float[] centroid, float rnorm) {
-        // TODO: combine these to be more efficient
-        float dsq = VectorUtil.squareDistance(vector, centroid);
-        float rproj = ESVectorUtil.soarResidual(vector, centroid, residual);
-        return dsq + soarLambda * rproj * rproj / rnorm;
     }
 
     /**


### PR DESCRIPTION
We are computing soar distance in a two step process. First we compute the distance between the vector and the centroid using a vectorized function. Then we compute the residual using another vectorized function. Finally we compute the soar distance.

Looking at the distance and residual functions, they are actually executing very similar operations, therefore combining them in the same function should lead to a nice speed up. This commit replaces the method #soarResidual with a method call #soarDistance. Microbenchmarks shows a nice speed up in this operation:

Mac:
```

Ignacio Vera Sequeiros
  8:27 AM
Benchmark                              (dims)   Mode  Cnt   Score   Error   Units
SoarDistanceBenchmark.soarDistanceNew      96  thrpt    5  58.639 ± 0.401  ops/ms
SoarDistanceBenchmark.soarDistanceNew     768  thrpt    5   9.806 ± 0.338  ops/ms
SoarDistanceBenchmark.soarDistanceNew    1024  thrpt    5   7.414 ± 0.273  ops/ms
SoarDistanceBenchmark.soarDistanceOld      96  thrpt    5  38.164 ± 1.216  ops/ms
SoarDistanceBenchmark.soarDistanceOld     768  thrpt    5   6.223 ± 0.113  ops/ms
SoarDistanceBenchmark.soarDistanceOld    1024  thrpt    5   4.790 ± 0.135  ops/ms
```

GCP:
```
Benchmark                              (dims)   Mode  Cnt   Score   Error   Units
SoarDistanceBenchmark.soarDistanceNew      96  thrpt    5  93.833 ± 0.975  ops/ms
SoarDistanceBenchmark.soarDistanceNew     768  thrpt    5  10.478 ± 3.752  ops/ms
SoarDistanceBenchmark.soarDistanceNew    1024  thrpt    5   8.644 ± 0.136  ops/ms
SoarDistanceBenchmark.soarDistanceOld      96  thrpt    5  52.466 ± 2.436  ops/ms
SoarDistanceBenchmark.soarDistanceOld     768  thrpt    5   8.336 ± 0.117  ops/ms
SoarDistanceBenchmark.soarDistanceOld    1024  thrpt    5   5.290 ± 0.071  ops/ms
```