### PR TITLE
Fix missing feature flag on Streams YAML tests

### DIFF
--- a/modules/streams/src/yamlRestTest/java/org/elasticsearch/streams/StreamsYamlTestSuiteIT.java
+++ b/modules/streams/src/yamlRestTest/java/org/elasticsearch/streams/StreamsYamlTestSuiteIT.java
@@ -13,6 +13,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.junit.ClassRule;
@@ -28,10 +29,11 @@ public class StreamsYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
     }
 
     @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("streams").build();
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("streams").feature(FeatureFlag.LOGS_STREAM).build();
 
     @Override
     protected String getTestRestCluster() {
         return cluster.getHttpAddresses();
     }
+
 }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -568,12 +568,6 @@ tests:
 - class: org.elasticsearch.search.query.RescoreKnnVectorQueryIT
   method: testKnnSearchRescore
   issue: https://github.com/elastic/elasticsearch/issues/129713
-- class: org.elasticsearch.streams.StreamsYamlTestSuiteIT
-  method: test {yaml=streams/logs/10_basic/Basic toggle of logs state enable to disable and back}
-  issue: https://github.com/elastic/elasticsearch/issues/129733
-- class: org.elasticsearch.streams.StreamsYamlTestSuiteIT
-  method: test {yaml=streams/logs/10_basic/Check for repeated toggle to same state}
-  issue: https://github.com/elastic/elasticsearch/issues/129735
 - class: org.elasticsearch.snapshots.GetSnapshotsIT
   method: testFilterByState
   issue: https://github.com/elastic/elasticsearch/issues/129740


### PR DESCRIPTION
This pull request updates the `StreamsYamlTestSuiteIT` integration test to enable the `LOGS_STREAM` feature flag in the Elasticsearch cluster configuration.

Fixes #129733 
Fixes #129735 