### PR TITLE
Use withEngine in IndexShard#seqNoStats

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1386,7 +1386,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * @throws AlreadyClosedException if shard is closed
      */
     public SeqNoStats seqNoStats() {
-        return getEngine().getSeqNoStats(replicationTracker.getGlobalCheckpoint());
+        return withEngine(engine -> engine.getSeqNoStats(getLastKnownGlobalCheckpoint()));
     }
 
     public IndexingStats indexingStats() {

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3061,7 +3061,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
         assert assertPrimaryMode();
         // only sync if there are no operations in flight, or when using async durability
-        final SeqNoStats stats = getEngine().getSeqNoStats(replicationTracker.getGlobalCheckpoint());
+        final SeqNoStats stats = seqNoStats();
         final boolean asyncDurability = indexSettings().getTranslogDurability() == Translog.Durability.ASYNC;
         if (stats.getMaxSeqNo() == stats.getGlobalCheckpoint() || asyncDurability) {
             final var trackedGlobalCheckpointsNeedSync = replicationTracker.trackedGlobalCheckpointsNeedSync();

--- a/server/src/main/java/org/elasticsearch/index/shard/LocalShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/LocalShardSnapshot.java
@@ -40,7 +40,7 @@ final class LocalShardSnapshot implements Closeable {
     }
 
     long maxSeqNo() {
-        return shard.getEngine().getSeqNoStats(-1).getMaxSeqNo();
+        return shard.withEngine(engine -> engine.getSeqNoStats(-1)).getMaxSeqNo();
     }
 
     long maxUnsafeAutoIdTimestamp() {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
@@ -403,13 +403,13 @@ public class ShardChangesAction extends ActionType<ShardChangesAction.Response> 
             throws IOException {
             final IndexService indexService = indicesService.indexServiceSafe(request.getShard().getIndex());
             final IndexShard indexShard = indexService.getShard(request.getShard().id());
-            final SeqNoStats seqNoStats = indexShard.seqNoStats();
+            final long lastKnownGlobalCheckpoint = indexShard.getLastKnownGlobalCheckpoint();
 
-            if (request.getFromSeqNo() > seqNoStats.getGlobalCheckpoint()) {
+            if (request.getFromSeqNo() > lastKnownGlobalCheckpoint) {
                 logger.trace(
                     "{} waiting for global checkpoint advancement from [{}] to [{}]",
                     shardId,
-                    seqNoStats.getGlobalCheckpoint(),
+                    lastKnownGlobalCheckpoint,
                     request.getFromSeqNo()
                 );
                 indexShard.addGlobalCheckpointListener(request.getFromSeqNo(), new GlobalCheckpointListeners.GlobalCheckpointListener() {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetCheckpointNodeAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetCheckpointNodeAction.java
@@ -96,7 +96,7 @@ public class TransportGetCheckpointNodeAction extends HandledTransportAction<Req
                     Arrays.fill(seqNumbers, SequenceNumbers.UNASSIGNED_SEQ_NO);
                     return seqNumbers;
                 });
-                checkpointsByIndexOfThisNode.get(shardId.getIndexName())[shardId.getId()] = indexShard.seqNoStats().getGlobalCheckpoint();
+                checkpointsByIndexOfThisNode.get(shardId.getIndexName())[shardId.getId()] = indexShard.getLastKnownGlobalCheckpoint();
                 ++numProcessedShards;
             } catch (Exception e) {
                 logger.atDebug()


### PR DESCRIPTION
Also remove a usage of seqNoStats() that is executed on the transport worker thread.