### PR TITLE
ES|QL: Resolve Keep plan added to FORK branches

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -74,7 +74,6 @@ import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.Fork;
 import org.elasticsearch.xpack.esql.plan.logical.Insist;
-import org.elasticsearch.xpack.esql.plan.logical.Keep;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Lookup;
@@ -3090,27 +3089,27 @@ public class AnalyzerTests extends ESTestCase {
         // fork branch 1
         limit = as(subPlans.get(0), Limit.class);
         assertThat(as(limit.limit(), Literal.class).value(), equalTo(DEFAULT_LIMIT));
-        Keep keep = as(limit.child(), Keep.class);
-        List<String> keptColumns = keep.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
-        assertThat(keptColumns, equalTo(expectedOutput));
-        Eval eval = as(keep.child(), Eval.class);
+        EsqlProject project = as(limit.child(), EsqlProject.class);
+        List<String> projectColumns = project.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
+        assertThat(projectColumns, equalTo(expectedOutput));
+        Eval eval = as(project.child(), Eval.class);
         assertThat(as(eval.fields().get(0), Alias.class), equalTo(alias("_fork", string("fork1"))));
         Filter filter = as(eval.child(), Filter.class);
         assertThat(as(filter.condition(), GreaterThan.class).right(), equalTo(literal(1)));
 
         filter = as(filter.child(), Filter.class);
         assertThat(as(filter.condition(), Equals.class).right(), equalTo(string("Chris")));
-        EsqlProject project = as(filter.child(), EsqlProject.class);
+        project = as(filter.child(), EsqlProject.class);
         var esRelation = as(project.child(), EsRelation.class);
         assertThat(esRelation.indexPattern(), equalTo("test"));
 
         // fork branch 2
         limit = as(subPlans.get(1), Limit.class);
         assertThat(as(limit.limit(), Literal.class).value(), equalTo(DEFAULT_LIMIT));
-        keep = as(limit.child(), Keep.class);
-        keptColumns = keep.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
-        assertThat(keptColumns, equalTo(expectedOutput));
-        eval = as(keep.child(), Eval.class);
+        project = as(limit.child(), EsqlProject.class);
+        projectColumns = project.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
+        assertThat(projectColumns, equalTo(expectedOutput));
+        eval = as(project.child(), Eval.class);
         assertThat(as(eval.fields().get(0), Alias.class), equalTo(alias("_fork", string("fork2"))));
         filter = as(eval.child(), Filter.class);
         assertThat(as(filter.condition(), GreaterThan.class).right(), equalTo(literal(2)));
@@ -3124,10 +3123,10 @@ public class AnalyzerTests extends ESTestCase {
         // fork branch 3
         limit = as(subPlans.get(2), Limit.class);
         assertThat(as(limit.limit(), Literal.class).value(), equalTo(MAX_LIMIT));
-        keep = as(limit.child(), Keep.class);
-        keptColumns = keep.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
-        assertThat(keptColumns, equalTo(expectedOutput));
-        eval = as(keep.child(), Eval.class);
+        project = as(limit.child(), EsqlProject.class);
+        projectColumns = project.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
+        assertThat(projectColumns, equalTo(expectedOutput));
+        eval = as(project.child(), Eval.class);
         assertThat(as(eval.fields().get(0), Alias.class), equalTo(alias("_fork", string("fork3"))));
         limit = as(eval.child(), Limit.class);
         assertThat(as(limit.limit(), Literal.class).value(), equalTo(7));
@@ -3143,10 +3142,10 @@ public class AnalyzerTests extends ESTestCase {
         // fork branch 4
         limit = as(subPlans.get(3), Limit.class);
         assertThat(as(limit.limit(), Literal.class).value(), equalTo(DEFAULT_LIMIT));
-        keep = as(limit.child(), Keep.class);
-        keptColumns = keep.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
-        assertThat(keptColumns, equalTo(expectedOutput));
-        eval = as(keep.child(), Eval.class);
+        project = as(limit.child(), EsqlProject.class);
+        projectColumns = project.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
+        assertThat(projectColumns, equalTo(expectedOutput));
+        eval = as(project.child(), Eval.class);
         assertThat(as(eval.fields().get(0), Alias.class), equalTo(alias("_fork", string("fork4"))));
         orderBy = as(eval.child(), OrderBy.class);
         filter = as(orderBy.child(), Filter.class);
@@ -3158,10 +3157,10 @@ public class AnalyzerTests extends ESTestCase {
         // fork branch 5
         limit = as(subPlans.get(4), Limit.class);
         assertThat(as(limit.limit(), Literal.class).value(), equalTo(MAX_LIMIT));
-        keep = as(limit.child(), Keep.class);
-        keptColumns = keep.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
-        assertThat(keptColumns, equalTo(expectedOutput));
-        eval = as(keep.child(), Eval.class);
+        project = as(limit.child(), EsqlProject.class);
+        projectColumns = project.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
+        assertThat(projectColumns, equalTo(expectedOutput));
+        eval = as(project.child(), Eval.class);
         assertThat(as(eval.fields().get(0), Alias.class), equalTo(alias("_fork", string("fork5"))));
         limit = as(eval.child(), Limit.class);
         assertThat(as(limit.limit(), Literal.class).value(), equalTo(9));
@@ -3193,11 +3192,11 @@ public class AnalyzerTests extends ESTestCase {
         // fork branch 1
         limit = as(subPlans.get(0), Limit.class);
         assertThat(as(limit.limit(), Literal.class).value(), equalTo(MAX_LIMIT));
-        Keep keep = as(limit.child(), Keep.class);
-        List<String> keptColumns = keep.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
-        assertThat(keptColumns, equalTo(expectedOutput));
+        EsqlProject project = as(limit.child(), EsqlProject.class);
+        List<String> projectColumns = project.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
+        assertThat(projectColumns, equalTo(expectedOutput));
 
-        Eval eval = as(keep.child(), Eval.class);
+        Eval eval = as(project.child(), Eval.class);
         assertEquals(eval.fields().size(), 3);
 
         Set<String> evalFieldNames = eval.fields().stream().map(a -> a.name()).collect(Collectors.toSet());
@@ -3215,7 +3214,7 @@ public class AnalyzerTests extends ESTestCase {
         Filter filter = as(orderBy.child(), Filter.class);
         assertThat(as(filter.condition(), GreaterThan.class).right(), equalTo(literal(3)));
 
-        EsqlProject project = as(filter.child(), EsqlProject.class);
+        project = as(filter.child(), EsqlProject.class);
         filter = as(project.child(), Filter.class);
         assertThat(as(filter.condition(), Equals.class).right(), equalTo(string("Chris")));
         var esRelation = as(filter.child(), EsRelation.class);
@@ -3224,10 +3223,10 @@ public class AnalyzerTests extends ESTestCase {
         // fork branch 2
         limit = as(subPlans.get(1), Limit.class);
         assertThat(as(limit.limit(), Literal.class).value(), equalTo(DEFAULT_LIMIT));
-        keep = as(limit.child(), Keep.class);
-        keptColumns = keep.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
-        assertThat(keptColumns, equalTo(expectedOutput));
-        eval = as(keep.child(), Eval.class);
+        project = as(limit.child(), EsqlProject.class);
+        projectColumns = project.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
+        assertThat(projectColumns, equalTo(expectedOutput));
+        eval = as(project.child(), Eval.class);
         assertEquals(eval.fields().size(), 2);
         evalFieldNames = eval.fields().stream().map(a -> a.name()).collect(Collectors.toSet());
         assertThat(evalFieldNames, equalTo(Set.of("x", "y")));
@@ -3254,10 +3253,10 @@ public class AnalyzerTests extends ESTestCase {
         // fork branch 3
         limit = as(subPlans.get(2), Limit.class);
         assertThat(as(limit.limit(), Literal.class).value(), equalTo(DEFAULT_LIMIT));
-        keep = as(limit.child(), Keep.class);
-        keptColumns = keep.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
-        assertThat(keptColumns, equalTo(expectedOutput));
-        eval = as(keep.child(), Eval.class);
+        project = as(limit.child(), EsqlProject.class);
+        projectColumns = project.expressions().stream().map(exp -> as(exp, Attribute.class).name()).toList();
+        assertThat(projectColumns, equalTo(expectedOutput));
+        eval = as(project.child(), Eval.class);
         assertEquals(eval.fields().size(), 2);
         evalFieldNames = eval.fields().stream().map(a -> a.name()).collect(Collectors.toSet());
         assertThat(evalFieldNames, equalTo(Set.of("emp_no", "first_name")));


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/issues/121950
fixes https://github.com/elastic/elasticsearch/issues/129715

In order to align the output of FORK branches, we always add an explicit Keep plan at end of each branch.
However, we never actually resolve the KEEP plans we are adding.
KEEP can be unresolved in case it contains columns with unsupported or conflicting types.

Then we end up skipping validations in the verifier because the KEEP is unresolved:

https://github.com/elastic/elasticsearch/blob/b2acda9a9fe150cb643ff07da93d15d00a9c58a3/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java#L109-L113

