### PR TITLE
[8.19] fix esql categorize csv test for old JDKs (#129746)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/categorize.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/categorize.csv-spec
@@ -309,6 +309,7 @@ COUNT():long | category:keyword
 
 on REVERSE(CONCAT())
 required_capability: categorize_v6
+required_capability: fn_reverse_grapheme_clusters
 
 FROM sample_data
   | STATS COUNT() BY category=CATEGORIZE(REVERSE(CONCAT(message, " 👍🏽😊")))


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix esql categorize csv test for old JDKs (#129746)