### PR TITLE
Unmute #112189 WatcherYamlRestIT watcher/usage/10_basic/Test watcher usage stats output

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -2,9 +2,6 @@ tests:
 - class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
   issue: "https://github.com/elastic/elasticsearch/issues/102717"
   method: "testRequestResetAndAbort"
-- class: org.elasticsearch.smoketest.WatcherYamlRestIT
-  method: test {p0=watcher/usage/10_basic/Test watcher usage stats output}
-  issue: https://github.com/elastic/elasticsearch/issues/112189
 - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
   method: test20SecurityNotAutoConfiguredOnReInstallation
   issue: https://github.com/elastic/elasticsearch/issues/112635


### PR DESCRIPTION
This test has been muted for a long time and only seemed to fail on v7 compatability tests. We're unmuting this to see if it's still relevant.

Closes #112189