### PR TITLE
Fixing transport versions

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -199,8 +199,9 @@ public class TransportVersions {
     public static final TransportVersion SETTINGS_IN_DATA_STREAMS_8_19 = def(8_841_0_51);
     public static final TransportVersion ML_INFERENCE_CUSTOM_SERVICE_REMOVE_ERROR_PARSING_8_19 = def(8_841_0_52);
     public static final TransportVersion ML_INFERENCE_CUSTOM_SERVICE_EMBEDDING_BATCH_SIZE_8_19 = def(8_841_0_53);
-    public static final TransportVersion STREAMS_LOGS_SUPPORT_8_19 = def(8_841_0_54);
+    public static final TransportVersion RANDOM_SAMPLER_QUERY_BUILDER_8_19 = def(8_841_0_54);
     public static final TransportVersion ML_INFERENCE_CUSTOM_SERVICE_INPUT_TYPE_8_19 = def(8_841_0_55);
+    public static final TransportVersion STREAMS_LOGS_SUPPORT_8_19 = def(8_841_0_56);
 
     public static final TransportVersion V_9_0_0 = def(9_000_0_09);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0_1 = def(9_000_0_10);


### PR DESCRIPTION
The current state `TransportVersions` is out of sync between `main` and `8.19`.

`main` has:

https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/TransportVersions.java#L202

```
STREAMS_LOGS_SUPPORT_8_19 = def(8_841_0_54);
```

But `8.19` has:
https://github.com/elastic/elasticsearch/blob/8.19/server/src/main/java/org/elasticsearch/TransportVersions.java#L247

```
RANDOM_SAMPLER_QUERY_BUILDER_8_19 = def(8_841_0_54);
```