### PR TITLE
[9.0] Mute testSnapshotRestore in bcUpgradeTest (#129767)

### DIFF
--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -29,6 +29,15 @@ tasks.register("luceneBwcTest", StandaloneRestIntegTestTask) {
   onlyIf("tests.bwc.main.version system property exists") { System.getProperty("tests.bwc.main.version") != null }
 }
 
+tasks.named("bcUpgradeTest").configure {
+  filter {
+    // Mute testSnapshotRestore: it uses string compare of Version (from the cluster, saved in the snapshot) with tests.bwc.main.version,
+    // which does not work for SNAPSHOT builds
+    excludeTestsMatching("org.elasticsearch.upgrades.FullClusterRestartIT.testSnapshotRestore")
+    excludeTestsMatching("org.elasticsearch.upgrades.FullClusterRestartIT.testSnapshotRestore *")
+  }
+}
+
 tasks.withType(Test).configureEach {
   // CI doesn't like it when there's multiple clusters running at once
   maxParallelForks = 1

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -29,3 +29,12 @@ buildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
     maxParallelForks = 1
   }
 }
+
+tasks.named("bcUpgradeTest").configure {
+  filter {
+    // Mute testSnapshotRestore: it uses string compare of Version (from the cluster, saved in the snapshot) with tests.bwc.main.version,
+    // which does not work for SNAPSHOT builds
+    excludeTestsMatching("org.elasticsearch.xpack.restart.CoreFullClusterRestartIT.testSnapshotRestore")
+    excludeTestsMatching("org.elasticsearch.xpack.restart.CoreFullClusterRestartIT.testSnapshotRestore *")
+  }
+}


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Mute testSnapshotRestore in bcUpgradeTest (#129767)