### PR TITLE
Fix generative tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -577,9 +577,6 @@ tests:
 - class: org.elasticsearch.qa.verify_version_constants.VerifyVersionConstantsIT
   method: testLuceneVersionConstant
   issue: https://github.com/elastic/elasticsearch/issues/125638
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/129819
 - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
   method: testAbortingOrRunningMergeTaskHoldsUpBudget
   issue: https://github.com/elastic/elasticsearch/issues/129823

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
@@ -184,7 +184,7 @@ public class EsqlQueryGenerator {
             };
         }
         // all types
-        name = randomName(previousOutput);
+        name = randomBoolean() ? randomStringField(previousOutput) : randomNumericOrDateField(previousOutput);
         if (name == null) {
             return "count(*)";
         }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/command/pipe/LookupJoinGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/command/pipe/LookupJoinGenerator.java
@@ -55,8 +55,15 @@ public class LookupJoinGenerator implements CommandGenerator {
         }
 
         // the -1 is for the additional RENAME, that could drop one column
-        if (previousColumns.size() - 1 > columns.size()) {
-            return new ValidationResult(false, "Expecting at least [" + previousColumns.size() + "] columns, got [" + columns.size() + "]");
+        int prevCols = previousColumns.size() - 1;
+
+        if (previousColumns.stream().anyMatch(x -> x.name().equals("<all-fields-projected>"))) {
+            // known bug https://github.com/elastic/elasticsearch/issues/121741
+            prevCols--;
+        }
+
+        if (prevCols > columns.size()) {
+            return new ValidationResult(false, "Expecting at least [" + prevCols + "] columns, got [" + columns.size() + "]");
         }
         return VALIDATION_OK;
     }


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/129819

To small changes to make the tests more strict:
- Make `count_distinct()` generation more consistent (only text/number/date fields for now, eg. to avoid unsupported fields)
- Take known bugs into consideration when validating LOOKUP JOIN