### PR TITLE
DOCS] Adds update cross cluster API key API examples

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/update-cc-api-key-examples.md
+++ b/docs/reference/elasticsearch/rest-apis/update-cc-api-key-examples.md
@@ -7,6 +7,8 @@ navigation_title: Update cross-cluster API examples
 
 The [update cross-cluster API key API](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-security-update-cross-cluster-api-key) updates the attributes of an existing cross-cluster API key, which is used for API key based remote cluster access. This page shows you examples of using this API.
 
+## Create a cross-cluster API key
+
 If you create a cross-cluster API key as follows:
 
 ```console
@@ -40,6 +42,8 @@ A successful call returns a JSON structure that provides API key information. Fo
 % TESTRESPONSE[s/VuaCfGcBCdbkQm-e5aOx/$body.id/]
 % TESTRESPONSE[s/ui2lp2axTNmsyakw9tvNnw/$body.api_key/]
 % TESTRESPONSE[s/VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==/$body.encoded/]
+
+## Inspect the API key
 
 To retrieve key information about the API key, including the exact role descriptor, use the [Get API key API](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-security-get-api-key).
 
@@ -111,6 +115,8 @@ A successful call returns a JSON structure that contains the information of the 
 1. Role descriptor corresponding to the specified `access` scope at creation time.
 In this example, it grants cross cluster search permission for the `logs*` index pattern.
 2. The `access` corresponds to the value specified at API key creation time.
+
+## Update access permissions and metadata
 
 The following example updates the API key created above, assigning it new access scope and metadata:
 

--- a/docs/reference/elasticsearch/rest-apis/update-cc-api-key-examples.md
+++ b/docs/reference/elasticsearch/rest-apis/update-cc-api-key-examples.md
@@ -108,9 +108,9 @@ A successful call returns a JSON structure that contains the information of the 
 
 % NOTCONSOLE
 
-<1> Role descriptor corresponding to the specified `access` scope at creation time.
+1. Role descriptor corresponding to the specified `access` scope at creation time.
 In this example, it grants cross cluster search permission for the `logs*` index pattern.
-<2> The `access` corresponds to the value specified at API key creation time.
+2. The `access` corresponds to the value specified at API key creation time.
 
 The following example updates the API key created above, assigning it new access scope and metadata:
 
@@ -195,10 +195,11 @@ The API key's permissions after the update can be inspected again with the [Get 
     }
   ]
 }
+```
 
 % NOTCONSOLE
 
-<1> Role descriptor is updated to be the `access` scope specified at update time.
+1. Role descriptor is updated to be the `access` scope specified at update time.
 In this example, it is updated to grant the cross cluster replication permission
 for the `archive*` index pattern.
-<2> The `access` corresponds to the value specified at API key update time.
+2. The `access` corresponds to the value specified at API key update time.

--- a/docs/reference/elasticsearch/rest-apis/update-cc-api-key-examples.md
+++ b/docs/reference/elasticsearch/rest-apis/update-cc-api-key-examples.md
@@ -41,7 +41,7 @@ A successful call returns a JSON structure that provides API key information. Fo
 % TESTRESPONSE[s/ui2lp2axTNmsyakw9tvNnw/$body.api_key/]
 % TESTRESPONSE[s/VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==/$body.encoded/]
 
-Information of the API key, including its exact role descriptor can be inspected with the [Get API key API](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-security-get-api-key).
+To retrieve key information about the API key, including the exact role descriptor, use the [Get API key API](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-security-get-api-key).
 
 ```console
 GET /_security/api_key?id=VuaCfGcBCdbkQm-e5aOx

--- a/docs/reference/elasticsearch/rest-apis/update-cc-api-key-examples.md
+++ b/docs/reference/elasticsearch/rest-apis/update-cc-api-key-examples.md
@@ -1,0 +1,204 @@
+---
+applies_to:
+  stack: all
+navigation_title: Update cross-cluster API examples 
+---
+# Update cross-cluster API key API examples
+
+The [update cross-cluster API key API](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-security-update-cross-cluster-api-key) updates the attributes of an existing cross-cluster API key, which is used for API key based remote cluster access. This page shows you examples of using this API.
+
+If you create a cross-cluster API key as follows:
+
+```console
+POST /_security/cross_cluster/api_key
+{
+  "name": "my-cross-cluster-api-key",
+  "access": {
+    "search": [
+      {
+        "names": ["logs*"]
+      }
+    ]
+  },
+  "metadata": {
+    "application": "search"
+  }
+}
+```
+
+A successful call returns a JSON structure that provides API key information. For example:
+
+```console-result
+{
+  "id": "VuaCfGcBCdbkQm-e5aOx",
+  "name": "my-cross-cluster-api-key",
+  "api_key": "ui2lp2axTNmsyakw9tvNnw",
+  "encoded": "VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw=="
+}
+```
+
+% TESTRESPONSE[s/VuaCfGcBCdbkQm-e5aOx/$body.id/]
+% TESTRESPONSE[s/ui2lp2axTNmsyakw9tvNnw/$body.api_key/]
+% TESTRESPONSE[s/VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==/$body.encoded/]
+
+Information of the API key, including its exact role descriptor can be inspected with the [Get API key API](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-security-get-api-key).
+
+```console
+GET /_security/api_key?id=VuaCfGcBCdbkQm-e5aOx
+```
+
+% TEST[s/VuaCfGcBCdbkQm-e5aOx/$body.id/]
+% TEST[continued]
+
+A successful call returns a JSON structure that contains the information of the API key:
+
+```js
+{
+  "api_keys": [
+    {
+      "id": "VuaCfGcBCdbkQm-e5aOx",
+      "name": "my-cross-cluster-api-key",
+      "type": "cross_cluster",
+      "creation": 1548550550158,
+      "expiration": null,
+      "invalidated": false,
+      "username": "myuser",
+      "realm": "native1",
+      "metadata": {
+        "application": "search"
+      },
+      "role_descriptors": {
+        "cross_cluster": {  <1>
+          "cluster": [
+              "cross_cluster_search"
+          ],
+          "indices": [
+            {
+              "names": [
+                "logs*"
+              ],
+              "privileges": [
+                "read", "read_cross_cluster", "view_index_metadata"
+              ],
+              "allow_restricted_indices": false
+            }
+          ],
+          "applications": [ ],
+          "run_as": [ ],
+          "metadata": { },
+          "transient_metadata": {
+            "enabled": true
+          }
+        }
+      },
+      "access": {  <2>
+        "search": [
+          {
+            "names": [
+              "logs*"
+            ],
+            "allow_restricted_indices": false
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+% NOTCONSOLE
+
+<1> Role descriptor corresponding to the specified `access` scope at creation time.
+In this example, it grants cross cluster search permission for the `logs*` index pattern.
+<2> The `access` corresponds to the value specified at API key creation time.
+
+The following example updates the API key created above, assigning it new access scope and metadata:
+
+```console
+PUT /_security/cross_cluster/api_key/VuaCfGcBCdbkQm-e5aOx
+{
+  "access": {
+    "replication": [
+      {
+        "names": ["archive"]
+      }
+    ]
+  },
+  "metadata": {
+    "application": "replication"
+  }
+}
+```
+
+% TEST[s/VuaCfGcBCdbkQm-e5aOx/\${body.api_keys.0.id}/]
+% TEST[continued]
+
+A successful call returns a JSON structure indicating that the API key was updated:
+
+```console-result
+{
+  "updated": true
+}
+```
+
+The API key's permissions after the update can be inspected again with the [Get API key API](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-security-get-api-key) and it will be:
+
+```js
+{
+  "api_keys": [
+    {
+      "id": "VuaCfGcBCdbkQm-e5aOx",
+      "name": "my-cross-cluster-api-key",
+      "type": "cross_cluster",
+      "creation": 1548550550158,
+      "expiration": null,
+      "invalidated": false,
+      "username": "myuser",
+      "realm": "native1",
+      "metadata": {
+        "application": "replication"
+      },
+      "role_descriptors": {
+        "cross_cluster": {  <1>
+          "cluster": [
+              "cross_cluster_replication"
+          ],
+          "indices": [
+            {
+              "names": [
+                "archive*"
+              ],
+              "privileges": [
+                "cross_cluster_replication", "cross_cluster_replication_internal"
+              ],
+              "allow_restricted_indices": false
+            }
+          ],
+          "applications": [ ],
+          "run_as": [ ],
+          "metadata": { },
+          "transient_metadata": {
+            "enabled": true
+          }
+        }
+      },
+      "access": {  <2>
+        "replication": [
+          {
+            "names": [
+              "archive*"
+            ],
+            "allow_restricted_indices": false
+          }
+        ]
+      }
+    }
+  ]
+}
+
+% NOTCONSOLE
+
+<1> Role descriptor is updated to be the `access` scope specified at update time.
+In this example, it is updated to grant the cross cluster replication permission
+for the `archive*` index pattern.
+<2> The `access` corresponds to the value specified at API key update time.

--- a/docs/reference/elasticsearch/toc.yml
+++ b/docs/reference/elasticsearch/toc.yml
@@ -104,6 +104,7 @@ toc:
             - file: rest-apis/searching-with-query-rules.md
             - file: rest-apis/shard-request-cache.md
             - file: rest-apis/term-vectors-examples.md
+            - file: rest-apis/update-cc-api-key-examples.md
   - file: mapping-reference/index.md
     children:
       - file: mapping-reference/document-metadata-fields.md


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/docs-projects/issues/302

This PR adds the update cross cluster API key API examples to the API examples section.

### [PREVIEW](https://docs-v3-preview.elastic.dev/elastic/elasticsearch/pull/129843/reference/elasticsearch/rest-apis/update-cc-api-key-examples)