### PR TITLE
Mute the "rrf with pinned retriever as a sub-retriever" test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -577,6 +577,9 @@ tests:
 - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
   method: testAbortingOrRunningMergeTaskHoldsUpBudget
   issue: https://github.com/elastic/elasticsearch/issues/129823
+- class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
+  method: test {yaml=rrf/950_pinned_interaction/rrf with pinned retriever as a sub-retriever}
+  issue: https://github.com/elastic/elasticsearch/issues/129845
 
 # Examples:
 #


### PR DESCRIPTION
Mutes the the "rrf with pinned retriever as a sub-retriever" YAML test. Test failure is tracked by https://github.com/elastic/elasticsearch/issues/129845.