### PR TITLE
[8.19] Mute the &quot;rrf with pinned retriever as a sub-retriever&quot; test (#129846)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -221,6 +221,9 @@ tests:
   - class: org.elasticsearch.discovery.ClusterDisruptionIT
     method: testAckedIndexing
     issue: https://github.com/elastic/elasticsearch/issues/117024
+  - class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
+    method: test {yaml=rrf/950_pinned_interaction/rrf with pinned retriever as a sub-retriever}
+    issue: https://github.com/elastic/elasticsearch/issues/129845
 
   # Examples:
   #


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Mute the &quot;rrf with pinned retriever as a sub-retriever&quot; test (#129846)](https://github.com/elastic/elasticsearch/pull/129846)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)