### PR TITLE
[8.19] ESQL: Hide spatial grid functions behind SNAPSHOT (#129839)

### DIFF
--- a/docs/changelog/125143.yaml
+++ b/docs/changelog/125143.yaml
@@ -1,6 +1,0 @@
-pr: 125143
-summary: "ES|QL Support for ST_GEOHASH, ST_GEOTILE and ST_GEOHEX"
-area: "ES|QL"
-type: enhancement
-issues:
- - 123903

--- a/docs/reference/esql/functions/kibana/definition/st_geohash.json
+++ b/docs/reference/esql/functions/kibana/definition/st_geohash.json
@@ -51,5 +51,5 @@
     "FROM airports\n| EVAL geohash = ST_GEOHASH(location, 1)\n| STATS\n    count = COUNT(*),\n    centroid = ST_CENTROID_AGG(location)\n      BY geohash\n| WHERE count >= 10\n| EVAL geohashString = ST_GEOHASH_TO_STRING(geohash)\n| KEEP count, centroid, geohashString\n| SORT count DESC, geohashString ASC"
   ],
   "preview" : false,
-  "snapshot_only" : false
+  "snapshot_only" : true
 }

--- a/docs/reference/esql/functions/kibana/definition/st_geohash_to_long.json
+++ b/docs/reference/esql/functions/kibana/definition/st_geohash_to_long.json
@@ -33,5 +33,5 @@
     "ROW geohash = \"u3bu\"\n| EVAL geohashLong = ST_GEOHASH_TO_LONG(geohash)"
   ],
   "preview" : false,
-  "snapshot_only" : false
+  "snapshot_only" : true
 }

--- a/docs/reference/esql/functions/kibana/definition/st_geohash_to_string.json
+++ b/docs/reference/esql/functions/kibana/definition/st_geohash_to_string.json
@@ -33,5 +33,5 @@
     "ROW geohash = TO_LONG(13686180)\n| EVAL geohashString = ST_GEOHASH_TO_STRING(geohash)"
   ],
   "preview" : false,
-  "snapshot_only" : false
+  "snapshot_only" : true
 }

--- a/docs/reference/esql/functions/kibana/definition/st_geohex.json
+++ b/docs/reference/esql/functions/kibana/definition/st_geohex.json
@@ -51,5 +51,5 @@
     "FROM airports\n| EVAL geohex = ST_GEOHEX(location, 1)\n| STATS\n    count = COUNT(*),\n    centroid = ST_CENTROID_AGG(location)\n      BY geohex\n| WHERE count >= 10\n| EVAL geohexString = ST_GEOHEX_TO_STRING(geohex)\n| KEEP count, centroid, geohexString\n| SORT count DESC, geohexString ASC"
   ],
   "preview" : false,
-  "snapshot_only" : false
+  "snapshot_only" : true
 }

--- a/docs/reference/esql/functions/kibana/definition/st_geohex_to_long.json
+++ b/docs/reference/esql/functions/kibana/definition/st_geohex_to_long.json
@@ -33,5 +33,5 @@
     "ROW geohex = \"841f059ffffffff\"\n| EVAL geohexLong = ST_GEOHEX_TO_LONG(geohex)"
   ],
   "preview" : false,
-  "snapshot_only" : false
+  "snapshot_only" : true
 }

--- a/docs/reference/esql/functions/kibana/definition/st_geohex_to_string.json
+++ b/docs/reference/esql/functions/kibana/definition/st_geohex_to_string.json
@@ -33,5 +33,5 @@
     "ROW geohex = 595020895127339007\n| EVAL geohexString = ST_GEOHEX_TO_STRING(geohex)"
   ],
   "preview" : false,
-  "snapshot_only" : false
+  "snapshot_only" : true
 }

--- a/docs/reference/esql/functions/kibana/definition/st_geotile.json
+++ b/docs/reference/esql/functions/kibana/definition/st_geotile.json
@@ -51,5 +51,5 @@
     "FROM airports\n| EVAL geotile = ST_GEOTILE(location, 2)\n| STATS\n    count = COUNT(*),\n    centroid = ST_CENTROID_AGG(location)\n      BY geotile\n| EVAL geotileString = ST_GEOTILE_TO_STRING(geotile)\n| SORT count DESC, geotileString ASC\n| KEEP count, centroid, geotileString"
   ],
   "preview" : false,
-  "snapshot_only" : false
+  "snapshot_only" : true
 }

--- a/docs/reference/esql/functions/kibana/definition/st_geotile_to_long.json
+++ b/docs/reference/esql/functions/kibana/definition/st_geotile_to_long.json
@@ -33,5 +33,5 @@
     "ROW geotile = \"4/8/5\"\n| EVAL geotileLong = ST_GEOTILE_TO_LONG(geotile)"
   ],
   "preview" : false,
-  "snapshot_only" : false
+  "snapshot_only" : true
 }

--- a/docs/reference/esql/functions/kibana/definition/st_geotile_to_string.json
+++ b/docs/reference/esql/functions/kibana/definition/st_geotile_to_string.json
@@ -33,5 +33,5 @@
     "ROW geotile = 1152921508901814277\n| EVAL geotileString = ST_GEOTILE_TO_STRING(geotile)"
   ],
   "preview" : false,
-  "snapshot_only" : false
+  "snapshot_only" : true
 }

--- a/docs/reference/esql/functions/spatial-functions.asciidoc
+++ b/docs/reference/esql/functions/spatial-functions.asciidoc
@@ -20,15 +20,6 @@
 * experimental:[] <<esql-st_xmin>>
 * experimental:[] <<esql-st_ymax>>
 * experimental:[] <<esql-st_ymin>>
-* experimental:[] <<esql-st_geohash>>
-* experimental:[] <<esql-st_geohash_to_long>>
-* experimental:[] <<esql-st_geohash_to_string>>
-* experimental:[] <<esql-st_geotile>>
-* experimental:[] <<esql-st_geotile_to_long>>
-* experimental:[] <<esql-st_geotile_to_string>>
-* experimental:[] <<esql-st_geohex>>
-* experimental:[] <<esql-st_geohex_to_long>>
-* experimental:[] <<esql-st_geohex_to_string>>
 // end::spatial_list[]
 
 include::layout/st_distance.asciidoc[]
@@ -43,12 +34,3 @@ include::layout/st_xmax.asciidoc[]
 include::layout/st_xmin.asciidoc[]
 include::layout/st_ymax.asciidoc[]
 include::layout/st_ymin.asciidoc[]
-include::layout/st_geohash.asciidoc[]
-include::layout/st_geohash_to_long.asciidoc[]
-include::layout/st_geohash_to_string.asciidoc[]
-include::layout/st_geotile.asciidoc[]
-include::layout/st_geotile_to_long.asciidoc[]
-include::layout/st_geotile_to_string.asciidoc[]
-include::layout/st_geohex.asciidoc[]
-include::layout/st_geohex_to_long.asciidoc[]
-include::layout/st_geohex_to_string.asciidoc[]

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -248,7 +248,7 @@ public class EsqlCapabilities {
         /**
          * Support ST_GEOHASH, ST_GEOTILE and ST_GEOHEX functions
          */
-        SPATIAL_GRID,
+        SPATIAL_GRID(Build.current().isSnapshot()),
 
         /**
          * Fix to GROK and DISSECT that allows extracting attributes with the same name as the input

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -388,16 +388,7 @@ public class EsqlFunctionRegistry {
                 def(StYMax.class, StYMax::new, "st_ymax"),
                 def(StYMin.class, StYMin::new, "st_ymin"),
                 def(StX.class, StX::new, "st_x"),
-                def(StY.class, StY::new, "st_y"),
-                def(StGeohash.class, StGeohash::new, "st_geohash"),
-                def(StGeohashToLong.class, StGeohashToLong::new, "st_geohash_to_long"),
-                def(StGeohashToString.class, StGeohashToString::new, "st_geohash_to_string"),
-                def(StGeotile.class, StGeotile::new, "st_geotile"),
-                def(StGeotileToLong.class, StGeotileToLong::new, "st_geotile_to_long"),
-                def(StGeotileToString.class, StGeotileToString::new, "st_geotile_to_string"),
-                def(StGeohex.class, StGeohex::new, "st_geohex"),
-                def(StGeohexToLong.class, StGeohexToLong::new, "st_geohex_to_long"),
-                def(StGeohexToString.class, StGeohexToString::new, "st_geohex_to_string") },
+                def(StY.class, StY::new, "st_y") },
             // conditional
             new FunctionDefinition[] { def(Case.class, Case::new, "case") },
             // null
@@ -465,7 +456,16 @@ public class EsqlFunctionRegistry {
                 def(Delay.class, Delay::new, "delay"),
                 def(Rate.class, Rate::withUnresolvedTimestamp, "rate"),
                 def(Term.class, bi(Term::new), "term"),
-                def(Knn.class, tri(Knn::new), "knn") } };
+                def(Knn.class, tri(Knn::new), "knn"),
+                def(StGeohash.class, StGeohash::new, "st_geohash"),
+                def(StGeohashToLong.class, StGeohashToLong::new, "st_geohash_to_long"),
+                def(StGeohashToString.class, StGeohashToString::new, "st_geohash_to_string"),
+                def(StGeotile.class, StGeotile::new, "st_geotile"),
+                def(StGeotileToLong.class, StGeotileToLong::new, "st_geotile_to_long"),
+                def(StGeotileToString.class, StGeotileToString::new, "st_geotile_to_string"),
+                def(StGeohex.class, StGeohex::new, "st_geohex"),
+                def(StGeohexToLong.class, StGeohexToLong::new, "st_geohex_to_long"),
+                def(StGeohexToString.class, StGeohexToString::new, "st_geohex_to_string") } };
     }
 
     public EsqlFunctionRegistry snapshotRegistry() {


### PR DESCRIPTION
This will backport the following commits from `main` to `8.19`:
 - [ESQL: Hide spatial grid functions behind SNAPSHOT (#129839)](https://github.com/elastic/elasticsearch/pull/129839)