### PR TITLE
[8.19] Simplified RRF Retriever (#129659)

### DIFF
--- a/docs/changelog/129659.yaml
+++ b/docs/changelog/129659.yaml
@@ -1,0 +1,5 @@
+pr: 129659
+summary: Simplified RRF Retriever
+area: Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
@@ -39,7 +39,8 @@ public class RankRRFFeatures implements FeatureSpecification {
             LINEAR_RETRIEVER_MINMAX_SINGLE_DOC_FIX,
             LINEAR_RETRIEVER_L2_NORM,
             LINEAR_RETRIEVER_MINSCORE_FIX,
-            LinearRetrieverBuilder.MULTI_FIELDS_QUERY_FORMAT_SUPPORT
+            LinearRetrieverBuilder.MULTI_FIELDS_QUERY_FORMAT_SUPPORT,
+            RRFRetrieverBuilder.MULTI_FIELDS_QUERY_FORMAT_SUPPORT
         );
     }
 }

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
@@ -8,21 +8,28 @@
 package org.elasticsearch.xpack.rank.rrf;
 
 import org.apache.lucene.search.ScoreDoc;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ResolvedIndices;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.license.LicenseUtils;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.rank.RankBuilder;
 import org.elasticsearch.search.rank.RankDoc;
 import org.elasticsearch.search.retriever.CompoundRetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverParserContext;
+import org.elasticsearch.search.retriever.StandardRetrieverBuilder;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.rank.MultiFieldsInnerRetrieverUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
@@ -42,6 +48,7 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  * formula.
  */
 public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetrieverBuilder> {
+    public static final NodeFeature MULTI_FIELDS_QUERY_FORMAT_SUPPORT = new NodeFeature("rrf_retriever.multi_fields_query_format_support");
 
     public static final String NAME = "rrf";
     public static final NodeFeature RRF_RETRIEVER_SUPPORTED = new NodeFeature("rrf_retriever_supported", true);
@@ -49,6 +56,8 @@ public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetri
 
     public static final ParseField RETRIEVERS_FIELD = new ParseField("retrievers");
     public static final ParseField RANK_CONSTANT_FIELD = new ParseField("rank_constant");
+    public static final ParseField FIELDS_FIELD = new ParseField("fields");
+    public static final ParseField QUERY_FIELD = new ParseField("query");
 
     public static final int DEFAULT_RANK_CONSTANT = 60;
     @SuppressWarnings("unchecked")
@@ -57,15 +66,20 @@ public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetri
         false,
         args -> {
             List<RetrieverBuilder> childRetrievers = (List<RetrieverBuilder>) args[0];
-            List<RetrieverSource> innerRetrievers = childRetrievers.stream().map(RetrieverSource::from).toList();
-            int rankWindowSize = args[1] == null ? RankBuilder.DEFAULT_RANK_WINDOW_SIZE : (int) args[1];
-            int rankConstant = args[2] == null ? DEFAULT_RANK_CONSTANT : (int) args[2];
-            return new RRFRetrieverBuilder(innerRetrievers, rankWindowSize, rankConstant);
+            List<String> fields = (List<String>) args[1];
+            String query = (String) args[2];
+            int rankWindowSize = args[3] == null ? RankBuilder.DEFAULT_RANK_WINDOW_SIZE : (int) args[3];
+            int rankConstant = args[4] == null ? DEFAULT_RANK_CONSTANT : (int) args[4];
+
+            List<RetrieverSource> innerRetrievers = childRetrievers != null
+                ? childRetrievers.stream().map(RetrieverSource::from).toList()
+                : List.of();
+            return new RRFRetrieverBuilder(innerRetrievers, fields, query, rankWindowSize, rankConstant);
         }
     );
 
     static {
-        PARSER.declareObjectArray(constructorArg(), (p, c) -> {
+        PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> {
             p.nextToken();
             String name = p.currentName();
             RetrieverBuilder retrieverBuilder = p.namedObject(RetrieverBuilder.class, name, c);
@@ -73,6 +87,8 @@ public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetri
             p.nextToken();
             return retrieverBuilder;
         }, RETRIEVERS_FIELD);
+        PARSER.declareStringArray(optionalConstructorArg(), FIELDS_FIELD);
+        PARSER.declareString(optionalConstructorArg(), QUERY_FIELD);
         PARSER.declareInt(optionalConstructorArg(), RANK_WINDOW_SIZE_FIELD);
         PARSER.declareInt(optionalConstructorArg(), RANK_CONSTANT_FIELD);
         RetrieverBuilder.declareBaseParserFields(NAME, PARSER);
@@ -91,15 +107,30 @@ public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetri
         return PARSER.apply(parser, context);
     }
 
+    private final List<String> fields;
+    private final String query;
     private final int rankConstant;
 
-    public RRFRetrieverBuilder(int rankWindowSize, int rankConstant) {
-        this(new ArrayList<>(), rankWindowSize, rankConstant);
+    public RRFRetrieverBuilder(List<RetrieverSource> childRetrievers, int rankWindowSize, int rankConstant) {
+        this(childRetrievers, null, null, rankWindowSize, rankConstant);
     }
 
-    RRFRetrieverBuilder(List<RetrieverSource> childRetrievers, int rankWindowSize, int rankConstant) {
-        super(childRetrievers, rankWindowSize);
+    public RRFRetrieverBuilder(
+        List<RetrieverSource> childRetrievers,
+        List<String> fields,
+        String query,
+        int rankWindowSize,
+        int rankConstant
+    ) {
+        // Use a mutable list for childRetrievers so that we can use addChild
+        super(childRetrievers == null ? new ArrayList<>() : new ArrayList<>(childRetrievers), rankWindowSize);
+        this.fields = fields == null ? List.of() : List.copyOf(fields);
+        this.query = query;
         this.rankConstant = rankConstant;
+    }
+
+    public int rankConstant() {
+        return rankConstant;
     }
 
     @Override
@@ -108,8 +139,28 @@ public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetri
     }
 
     @Override
+    public ActionRequestValidationException validate(
+        SearchSourceBuilder source,
+        ActionRequestValidationException validationException,
+        boolean isScroll,
+        boolean allowPartialSearchResults
+    ) {
+        validationException = super.validate(source, validationException, isScroll, allowPartialSearchResults);
+        return MultiFieldsInnerRetrieverUtils.validateParams(
+            innerRetrievers,
+            fields,
+            query,
+            getName(),
+            RETRIEVERS_FIELD.getPreferredName(),
+            FIELDS_FIELD.getPreferredName(),
+            QUERY_FIELD.getPreferredName(),
+            validationException
+        );
+    }
+
+    @Override
     protected RRFRetrieverBuilder clone(List<RetrieverSource> newRetrievers, List<QueryBuilder> newPreFilterQueryBuilders) {
-        RRFRetrieverBuilder clone = new RRFRetrieverBuilder(newRetrievers, this.rankWindowSize, this.rankConstant);
+        RRFRetrieverBuilder clone = new RRFRetrieverBuilder(newRetrievers, this.fields, this.query, this.rankWindowSize, this.rankConstant);
         clone.preFilterQueryBuilders = newPreFilterQueryBuilders;
         clone.retrieverName = retrieverName;
         return clone;
@@ -172,17 +223,72 @@ public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetri
         return topResults;
     }
 
+    @Override
+    protected RetrieverBuilder doRewrite(QueryRewriteContext ctx) {
+        RetrieverBuilder rewritten = this;
+
+        ResolvedIndices resolvedIndices = ctx.getResolvedIndices();
+        if (resolvedIndices != null && query != null) {
+            // TODO: Refactor duplicate code
+            // Using the multi-fields query format
+            var localIndicesMetadata = resolvedIndices.getConcreteLocalIndicesMetadata();
+            if (localIndicesMetadata.size() > 1) {
+                throw new IllegalArgumentException(
+                    "[" + NAME + "] cannot specify [" + QUERY_FIELD.getPreferredName() + "] when querying multiple indices"
+                );
+            } else if (resolvedIndices.getRemoteClusterIndices().isEmpty() == false) {
+                throw new IllegalArgumentException(
+                    "[" + NAME + "] cannot specify [" + QUERY_FIELD.getPreferredName() + "] when querying remote indices"
+                );
+            }
+
+            List<RetrieverSource> fieldsInnerRetrievers = MultiFieldsInnerRetrieverUtils.generateInnerRetrievers(
+                fields,
+                query,
+                localIndicesMetadata.values(),
+                r -> {
+                    List<RetrieverSource> retrievers = r.stream()
+                        .map(MultiFieldsInnerRetrieverUtils.WeightedRetrieverSource::retrieverSource)
+                        .toList();
+                    return new RRFRetrieverBuilder(retrievers, rankWindowSize, rankConstant);
+                },
+                w -> {
+                    if (w != 1.0f) {
+                        throw new IllegalArgumentException(
+                            "[" + NAME + "] does not support per-field weights in [" + FIELDS_FIELD.getPreferredName() + "]"
+                        );
+                    }
+                }
+            ).stream().map(RetrieverSource::from).toList();
+
+            if (fieldsInnerRetrievers.isEmpty() == false) {
+                // TODO: This is a incomplete solution as it does not address other incomplete copy issues
+                // (such as dropping the retriever name and min score)
+                rewritten = new RRFRetrieverBuilder(fieldsInnerRetrievers, rankWindowSize, rankConstant);
+                rewritten.getPreFilterQueryBuilders().addAll(preFilterQueryBuilders);
+            } else {
+                // Inner retriever list can be empty when using an index wildcard pattern that doesn't match any indices
+                rewritten = new StandardRetrieverBuilder(new MatchNoneQueryBuilder());
+            }
+        }
+
+        return rewritten;
+    }
+
     // ---- FOR TESTING XCONTENT PARSING ----
 
     @Override
     public boolean doEquals(Object o) {
         RRFRetrieverBuilder that = (RRFRetrieverBuilder) o;
-        return super.doEquals(o) && rankConstant == that.rankConstant;
+        return super.doEquals(o)
+            && Objects.equals(fields, that.fields)
+            && Objects.equals(query, that.query)
+            && rankConstant == that.rankConstant;
     }
 
     @Override
     public int doHashCode() {
-        return Objects.hash(super.doHashCode(), rankConstant);
+        return Objects.hash(super.doHashCode(), fields, query, rankConstant);
     }
 
     @Override
@@ -194,6 +300,17 @@ public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetri
                 entry.retriever().toXContent(builder, params);
             }
             builder.endArray();
+        }
+
+        if (fields.isEmpty() == false) {
+            builder.startArray(FIELDS_FIELD.getPreferredName());
+            for (String field : fields) {
+                builder.value(field);
+            }
+            builder.endArray();
+        }
+        if (query != null) {
+            builder.field(QUERY_FIELD.getPreferredName(), query);
         }
 
         builder.field(RANK_WINDOW_SIZE_FIELD.getPreferredName(), rankWindowSize);

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderParsingTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderParsingTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.rank.rrf;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.retriever.CompoundRetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverParserContext;
 import org.elasticsearch.search.retriever.TestRetrieverBuilder;
@@ -45,13 +46,22 @@ public class RRFRetrieverBuilderParsingTests extends AbstractXContentTestCase<RR
         if (randomBoolean()) {
             rankConstant = randomIntBetween(1, 1000000);
         }
-        var ret = new RRFRetrieverBuilder(rankWindowSize, rankConstant);
+
+        List<String> fields = null;
+        String query = null;
+        if (randomBoolean()) {
+            fields = randomList(1, 10, () -> randomAlphaOfLengthBetween(1, 10));
+            query = randomAlphaOfLengthBetween(1, 10);
+        }
+
         int retrieverCount = randomIntBetween(2, 50);
+        List<CompoundRetrieverBuilder.RetrieverSource> innerRetrievers = new ArrayList<>(retrieverCount);
         while (retrieverCount > 0) {
-            ret.addChild(TestRetrieverBuilder.createRandomTestRetrieverBuilder());
+            innerRetrievers.add(CompoundRetrieverBuilder.RetrieverSource.from(TestRetrieverBuilder.createRandomTestRetrieverBuilder()));
             --retrieverCount;
         }
-        return ret;
+
+        return new RRFRetrieverBuilder(innerRetrievers, fields, query, rankWindowSize, rankConstant);
     }
 
     @Override
@@ -94,28 +104,32 @@ public class RRFRetrieverBuilderParsingTests extends AbstractXContentTestCase<RR
     }
 
     public void testRRFRetrieverParsing() throws IOException {
-        String restContent = "{"
-            + "  \"retriever\": {"
-            + "    \"rrf\": {"
-            + "      \"retrievers\": ["
-            + "        {"
-            + "          \"test\": {"
-            + "            \"value\": \"foo\""
-            + "          }"
-            + "        },"
-            + "        {"
-            + "          \"test\": {"
-            + "            \"value\": \"bar\""
-            + "          }"
-            + "        }"
-            + "      ],"
-            + "      \"rank_window_size\": 100,"
-            + "      \"rank_constant\": 10,"
-            + "      \"min_score\": 20.0,"
-            + "      \"_name\": \"foo_rrf\""
-            + "    }"
-            + "  }"
-            + "}";
+        String restContent = """
+            {
+              "retriever": {
+                "rrf": {
+                  "retrievers": [
+                    {
+                      "test": {
+                        "value": "foo"
+                      }
+                    },
+                    {
+                      "test": {
+                        "value": "bar"
+                      }
+                    }
+                  ],
+                  "fields": ["field1", "field2"],
+                  "query": "baz",
+                  "rank_window_size": 100,
+                  "rank_constant": 10,
+                  "min_score": 20.0,
+                  "_name": "foo_rrf"
+                }
+              }
+            }
+            """;
         SearchUsageHolder searchUsageHolder = new UsageService().getSearchUsageHolder();
         try (XContentParser jsonParser = createParser(JsonXContent.jsonXContent, restContent)) {
             SearchSourceBuilder source = new SearchSourceBuilder().parseXContent(jsonParser, true, searchUsageHolder, nf -> true);

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
@@ -7,16 +7,28 @@
 
 package org.elasticsearch.xpack.rank.rrf;
 
+import org.elasticsearch.action.MockResolvedIndices;
+import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.ResolvedIndices;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.InferenceFieldMetadata;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.retriever.CompoundRetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverParserContext;
+import org.elasticsearch.search.retriever.StandardRetrieverBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
@@ -24,7 +36,13 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.search.rank.RankBuilder.DEFAULT_RANK_WINDOW_SIZE;
 
 /** Tests for the rrf retriever. */
 public class RRFRetrieverBuilderTests extends ESTestCase {
@@ -80,13 +98,121 @@ public class RRFRetrieverBuilderTests extends ESTestCase {
         }
     }
 
+    public void testMultiFieldsParamsRewrite() {
+        final String indexName = "test-index";
+        final List<String> testInferenceFields = List.of("semantic_field_1", "semantic_field_2");
+        final ResolvedIndices resolvedIndices = createMockResolvedIndices(indexName, testInferenceFields, null);
+        final QueryRewriteContext queryRewriteContext = new QueryRewriteContext(
+            parserConfig(),
+            null,
+            null,
+            resolvedIndices,
+            new PointInTimeBuilder(new BytesArray("pitid")),
+            null
+        );
+
+        // No wildcards
+        RRFRetrieverBuilder rrfRetrieverBuilder = new RRFRetrieverBuilder(
+            null,
+            List.of("field_1", "field_2", "semantic_field_1", "semantic_field_2"),
+            "foo",
+            DEFAULT_RANK_WINDOW_SIZE,
+            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT
+        );
+        assertMultiFieldsParamsRewrite(
+            rrfRetrieverBuilder,
+            queryRewriteContext,
+            Map.of("field_1", 1.0f, "field_2", 1.0f),
+            Map.of("semantic_field_1", 1.0f, "semantic_field_2", 1.0f),
+            "foo"
+        );
+
+        // Non-default rank window size and rank constant
+        rrfRetrieverBuilder = new RRFRetrieverBuilder(
+            null,
+            List.of("field_1", "field_2", "semantic_field_1", "semantic_field_2"),
+            "foo2",
+            DEFAULT_RANK_WINDOW_SIZE * 2,
+            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT / 2
+        );
+        assertMultiFieldsParamsRewrite(
+            rrfRetrieverBuilder,
+            queryRewriteContext,
+            Map.of("field_1", 1.0f, "field_2", 1.0f),
+            Map.of("semantic_field_1", 1.0f, "semantic_field_2", 1.0f),
+            "foo2"
+        );
+
+        // Glob matching on inference and non-inference fields
+        rrfRetrieverBuilder = new RRFRetrieverBuilder(
+            null,
+            List.of("field_*", "*_field_1"),
+            "bar",
+            DEFAULT_RANK_WINDOW_SIZE,
+            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT
+        );
+        assertMultiFieldsParamsRewrite(
+            rrfRetrieverBuilder,
+            queryRewriteContext,
+            Map.of("field_*", 1.0f, "*_field_1", 1.0f),
+            Map.of("semantic_field_1", 1.0f),
+            "bar"
+        );
+
+        // All-fields wildcard
+        rrfRetrieverBuilder = new RRFRetrieverBuilder(
+            null,
+            List.of("*"),
+            "baz",
+            DEFAULT_RANK_WINDOW_SIZE,
+            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT
+        );
+        assertMultiFieldsParamsRewrite(
+            rrfRetrieverBuilder,
+            queryRewriteContext,
+            Map.of("*", 1.0f),
+            Map.of("semantic_field_1", 1.0f, "semantic_field_2", 1.0f),
+            "baz"
+        );
+    }
+
+    public void testSearchRemoteIndex() {
+        final ResolvedIndices resolvedIndices = createMockResolvedIndices(
+            "local-index",
+            List.of(),
+            Map.of("remote-cluster", "remote-index")
+        );
+        final QueryRewriteContext queryRewriteContext = new QueryRewriteContext(
+            parserConfig(),
+            null,
+            null,
+            resolvedIndices,
+            new PointInTimeBuilder(new BytesArray("pitid")),
+            null
+        );
+
+        RRFRetrieverBuilder rrfRetrieverBuilder = new RRFRetrieverBuilder(
+            null,
+            null,
+            "foo",
+            DEFAULT_RANK_WINDOW_SIZE,
+            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT
+        );
+
+        IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> rrfRetrieverBuilder.doRewrite(queryRewriteContext)
+        );
+        assertEquals("[rrf] cannot specify [query] when querying remote indices", iae.getMessage());
+    }
+
     @Override
     protected NamedXContentRegistry xContentRegistry() {
         List<NamedXContentRegistry.Entry> entries = new SearchModule(Settings.EMPTY, List.of()).getNamedXContents();
         entries.add(
             new NamedXContentRegistry.Entry(
                 RetrieverBuilder.class,
-                new ParseField(RRFRankPlugin.NAME),
+                new ParseField(RRFRetrieverBuilder.NAME),
                 (p, c) -> RRFRetrieverBuilder.fromXContent(p, (RetrieverParserContext) c)
             )
         );
@@ -94,10 +220,94 @@ public class RRFRetrieverBuilderTests extends ESTestCase {
         entries.add(
             new NamedXContentRegistry.Entry(
                 RetrieverBuilder.class,
-                new ParseField(RRFRankPlugin.NAME + "_nl"),
+                new ParseField(RRFRetrieverBuilder.NAME + "_nl"),
                 (p, c) -> RRFRetrieverBuilder.PARSER.apply(p, (RetrieverParserContext) c)
             )
         );
         return new NamedXContentRegistry(entries);
+    }
+
+    private static ResolvedIndices createMockResolvedIndices(
+        String localIndexName,
+        List<String> inferenceFields,
+        Map<String, String> remoteIndexNames
+    ) {
+        Index index = new Index(localIndexName, randomAlphaOfLength(10));
+        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(index.getName())
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                    .put(IndexMetadata.SETTING_INDEX_UUID, index.getUUID())
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0);
+
+        for (String inferenceField : inferenceFields) {
+            indexMetadataBuilder.putInferenceField(
+                new InferenceFieldMetadata(inferenceField, randomAlphaOfLengthBetween(3, 5), new String[] { inferenceField }, null)
+            );
+        }
+
+        Map<String, OriginalIndices> remoteIndices = new HashMap<>();
+        if (remoteIndexNames != null) {
+            for (Map.Entry<String, String> entry : remoteIndexNames.entrySet()) {
+                remoteIndices.put(entry.getKey(), new OriginalIndices(new String[] { entry.getValue() }, IndicesOptions.DEFAULT));
+            }
+        }
+
+        return new MockResolvedIndices(
+            remoteIndices,
+            new OriginalIndices(new String[] { localIndexName }, IndicesOptions.DEFAULT),
+            Map.of(index, indexMetadataBuilder.build())
+        );
+    }
+
+    private static void assertMultiFieldsParamsRewrite(
+        RRFRetrieverBuilder retriever,
+        QueryRewriteContext ctx,
+        Map<String, Float> expectedNonInferenceFields,
+        Map<String, Float> expectedInferenceFields,
+        String expectedQuery
+    ) {
+        Set<Object> expectedInnerRetrievers = Set.of(
+            CompoundRetrieverBuilder.RetrieverSource.from(
+                new StandardRetrieverBuilder(
+                    new MultiMatchQueryBuilder(expectedQuery).type(MultiMatchQueryBuilder.Type.MOST_FIELDS)
+                        .fields(expectedNonInferenceFields)
+                )
+            ),
+            Set.of(expectedInferenceFields.entrySet().stream().map(e -> {
+                if (e.getValue() != 1.0f) {
+                    throw new IllegalArgumentException("Cannot apply per-field weights in RRF");
+                }
+                return CompoundRetrieverBuilder.RetrieverSource.from(
+                    new StandardRetrieverBuilder(new MatchQueryBuilder(e.getKey(), expectedQuery))
+                );
+            }).toArray())
+        );
+
+        RetrieverBuilder rewritten = retriever.doRewrite(ctx);
+        assertNotSame(retriever, rewritten);
+        assertTrue(rewritten instanceof RRFRetrieverBuilder);
+
+        RRFRetrieverBuilder rewrittenRrf = (RRFRetrieverBuilder) rewritten;
+        assertEquals(retriever.rankWindowSize(), rewrittenRrf.rankWindowSize());
+        assertEquals(retriever.rankConstant(), rewrittenRrf.rankConstant());
+        assertEquals(expectedInnerRetrievers, getInnerRetrieversAsSet(rewrittenRrf));
+    }
+
+    private static Set<Object> getInnerRetrieversAsSet(RRFRetrieverBuilder retriever) {
+        Set<Object> innerRetrieversSet = new HashSet<>();
+        for (CompoundRetrieverBuilder.RetrieverSource innerRetriever : retriever.innerRetrievers()) {
+            if (innerRetriever.retriever() instanceof RRFRetrieverBuilder innerRrfRetriever) {
+                assertEquals(retriever.rankWindowSize(), innerRrfRetriever.rankWindowSize());
+                assertEquals(retriever.rankConstant(), innerRrfRetriever.rankConstant());
+                innerRetrieversSet.add(getInnerRetrieversAsSet(innerRrfRetriever));
+            } else {
+                innerRetrieversSet.add(innerRetriever);
+            }
+        }
+
+        return innerRetrieversSet;
     }
 }

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankClientYamlTestSuiteIT.java
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankClientYamlTestSuiteIT.java
@@ -11,6 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.junit.ClassRule;
@@ -25,8 +26,12 @@ public class RRFRankClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
         .module("rank-rrf")
         .module("lang-painless")
         .module("x-pack-inference")
+        .systemProperty("tests.seed", System.getProperty("tests.seed"))
+        .setting("xpack.security.enabled", "false")
+        .setting("xpack.security.http.ssl.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
         .plugin("inference-service-test")
+        .distribution(DistributionType.DEFAULT)
         .build();
 
     public RRFRankClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/310_rrf_retriever_simplified.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/310_rrf_retriever_simplified.yml
@@ -1,8 +1,8 @@
 setup:
   - requires:
-      cluster_features: [ "linear_retriever.multi_fields_query_format_support" ]
-      reason: "Linear retriever multi-fields query format support"
-      test_runner_features: [ "close_to", "headers", "contains" ]
+      cluster_features: [ "rrf_retriever.multi_fields_query_format_support" ]
+      reason: "RRF retriever multi-fields query format support"
+      test_runner_features: [ "contains" ]
 
   - do:
       inference.put:
@@ -114,176 +114,111 @@ setup:
 ---
 "Query all fields using the simplified format":
   - do:
-      headers:
-        Content-Type: application/json
       search:
         index: test-index
         body:
           retriever:
-            linear:
+            rrf:
               query: "match"
-              normalizer: "minmax"
 
-  - match: { hits.total.value: 3 }
-  - length: { hits.hits: 3 }
-  - match: { hits.hits.0._id: "3" }
-  - lte: { hits.hits.0._score: 2.0 }
-  - match: { hits.hits.1._id: "2" }
-  - lte: { hits.hits.1._score: 2.0 }
-  - match: { hits.hits.2._id: "1" }
-  - lte: { hits.hits.2._score: 2.0 }
-
----
-"Lexical match per-field boosting using the simplified format":
-  - do:
-      headers:
-        Content-Type: application/json
-      search:
-        index: test-index
-        body:
-          retriever:
-            linear:
-              fields: [ "text_1", "text_2" ]
-              query: "foo 1 z"
-              normalizer: "minmax"
-
-  # Lexical-only match, so max score is 1
-  - match: { hits.total.value: 2 }
-  - length: { hits.hits: 2 }
-  - match: { hits.hits.0._id: "1" }
-  - close_to: { hits.hits.0._score: { value: 1.0, error: 0.0001 } }
-  - match: { hits.hits.1._id: "3" }
-  - lt: { hits.hits.1._score: 1.0 }
-
-  - do:
-      headers:
-        Content-Type: application/json
-      search:
-        index: test-index
-        body:
-          retriever:
-            linear:
-              fields: ["text_1", "text_2^3"]
-              query: "foo 1 z"
-              normalizer: "minmax"
-
-  # Lexical-only match, so max score is 1
-  - match: { hits.total.value: 2 }
-  - length: { hits.hits: 2 }
-  - match: { hits.hits.0._id: "3" }
-  - close_to: { hits.hits.0._score: { value: 1.0, error: 0.0001 } }
-  - match: { hits.hits.1._id: "1" }
-  - lt: { hits.hits.1._score: 1.0 }
-
----
-"Semantic match per-field boosting using the simplified format":
-  # The mock inference services generate synthetic vectors that don't accurately represent similarity to non-identical
-  # input, so it's hard to create a test that produces intuitive results. Instead, we rely on the fact that the inference
-  # services generate consistent vectors (i.e. same input -> same output) to demonstrate that per-field boosting on
-  # a semantic_text field can change the result order.
-  - do:
-      headers:
-        Content-Type: application/json
-      search:
-        index: test-index
-        body:
-          retriever:
-            linear:
-              fields: [ "dense_inference", "sparse_inference" ]
-              query: "distributed, RESTful, search engine"
-              normalizer: "minmax"
-
-  # Semantic-only match, so max score is 1
   - match: { hits.total.value: 3 }
   - length: { hits.hits: 3 }
   - match: { hits.hits.0._id: "2" }
-  - close_to: { hits.hits.0._score: { value: 1.0, error: 0.0001 } }
-  - match: { hits.hits.1._id: "3" }
-  - lt: { hits.hits.1._score: 1.0 }
-  - match: { hits.hits.2._id: "1" }
-  - lt: { hits.hits.2._score: 1.0 }
+  - match: { hits.hits.1._id: "1" }
+  - match: { hits.hits.2._id: "3" }
 
+---
+"Per-field boosting is not supported":
   - do:
-      headers:
-        Content-Type: application/json
+      catch: bad_request
       search:
         index: test-index
         body:
           retriever:
-            linear:
-              fields: [ "dense_inference^3", "sparse_inference" ]
-              query: "distributed, RESTful, search engine"
-              normalizer: "minmax"
+            rrf:
+              fields: [ "text_1", "text_2^3" ]
+              query: "foo"
 
-  # Semantic-only match, so max score is 1
+  - match: { error.root_cause.0.reason: "[rrf] does not support per-field weights in [fields]" }
+
+---
+"Can query text fields":
+  - do:
+      search:
+        index: test-index
+        body:
+          retriever:
+            rrf:
+              fields: [ "text_1", "text_2" ]
+              query: "foo z"
+
+  - match: { hits.total.value: 2 }
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "3" }
+
+---
+"Can query semantic text fields":
+  # Result order is not correlated with relevance because we generate synthetic embeddings
+  - do:
+      search:
+        index: test-index
+        body:
+          retriever:
+            rrf:
+              fields: [ "sparse_inference", "dense_inference" ]
+              query: "elasticsearch"
+
   - match: { hits.total.value: 3 }
   - length: { hits.hits: 3 }
-  - match: { hits.hits.0._id: "3" }
-  - close_to: { hits.hits.0._score: { value: 1.0, error: 0.0001 } }
-  - match: { hits.hits.1._id: "2" }
-  - lt: { hits.hits.1._score: 1.0 }
+  - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "3" }
   - match: { hits.hits.2._id: "1" }
-  - lt: { hits.hits.2._score: 1.0 }
 
 ---
 "Can query keyword fields":
   - do:
-      headers:
-        Content-Type: application/json
       search:
         index: test-index
         body:
           retriever:
-            linear:
+            rrf:
               fields: [ "keyword" ]
               query: "keyword match 1"
-              normalizer: "minmax"
 
-  # Lexical-only match, so max score is 1
   - match: { hits.total.value: 1 }
   - length: { hits.hits: 1 }
   - match: { hits.hits.0._id: "1" }
-  - close_to: { hits.hits.0._score: { value: 1.0, error: 0.0001 } }
 
 ---
 "Can query date fields":
   - do:
-      headers:
-        Content-Type: application/json
       search:
         index: test-index
         body:
           retriever:
-            linear:
+            rrf:
               fields: [ "timestamp" ]
               query: "2010-02-08"
-              normalizer: "minmax"
 
-  # Lexical-only match, so max score is 1
   - match: { hits.total.value: 1 }
   - length: { hits.hits: 1 }
   - match: { hits.hits.0._id: "2" }
-  - close_to: { hits.hits.0._score: { value: 1.0, error: 0.0001 } }
 
 ---
 "Can query sparse vector fields":
   - do:
-      headers:
-        Content-Type: application/json
       search:
         index: test-index
         body:
           retriever:
-            linear:
+            rrf:
               fields: [ "sparse_vector" ]
               query: "foo"
-              normalizer: "minmax"
 
-  # Lexical-only match, so max score is 1
   - match: { hits.total.value: 1 }
   - length: { hits.hits: 1 }
   - match: { hits.hits.0._id: "1" }
-  - close_to: { hits.hits.0._score: { value: 1.0, error: 0.0001 } }
 
 ---
 "Cannot query dense vector fields":
@@ -293,26 +228,22 @@ setup:
         index: test-index
         body:
           retriever:
-            linear:
+            rrf:
               fields: [ "dense_vector" ]
               query: "foo"
-              normalizer: "minmax"
 
-  - contains: { error.root_cause.0.reason: "[linear] search failed - retrievers '[standard]' returned errors" }
+  - contains: { error.root_cause.0.reason: "[rrf] search failed - retrievers '[standard]' returned errors" }
   - contains: { error.root_cause.0.suppressed.0.failed_shards.0.reason.reason: "Field [dense_vector] of type [dense_vector] does not support match queries" }
 
 ---
 "Filters are propagated":
   - do:
-      headers:
-        Content-Type: application/json
       search:
         index: test-index
         body:
           retriever:
-            linear:
+            rrf:
               query: "match"
-              normalizer: "minmax"
               filter:
                 - term:
                     keyword: "keyword match 1"
@@ -320,7 +251,6 @@ setup:
   - match: { hits.total.value: 1 }
   - length: { hits.hits: 1 }
   - match: { hits.hits.0._id: "1" }
-  - close_to: { hits.hits.0._score: { value: 2.0, error: 0.0001 } }
 
 ---
 "Wildcard index patterns that do not resolve to any index are handled gracefully":
@@ -329,9 +259,8 @@ setup:
         index: wildcard-*
         body:
           retriever:
-            linear:
+            rrf:
               query: "match"
-              normalizer: "minmax"
 
   - match: { hits.total.value: 0 }
   - length: { hits.hits: 0 }
@@ -348,11 +277,10 @@ setup:
         index: [ test-index, test-index-2 ]
         body:
           retriever:
-            linear:
+            rrf:
               query: "match"
-              normalizer: "minmax"
 
-  - match: { error.root_cause.0.reason: "[linear] cannot specify [query] when querying multiple indices" }
+  - match: { error.root_cause.0.reason: "[rrf] cannot specify [query] when querying multiple indices" }
 
   - do:
       indices.put_alias:
@@ -369,11 +297,10 @@ setup:
         index: test-alias
         body:
           retriever:
-            linear:
+            rrf:
               query: "match"
-              normalizer: "minmax"
 
-  - match: { error.root_cause.0.reason: "[linear] cannot specify [query] when querying multiple indices" }
+  - match: { error.root_cause.0.reason: "[rrf] cannot specify [query] when querying multiple indices" }
 
 ---
 "Wildcard field patterns that do not resolve to any field are handled gracefully":
@@ -382,10 +309,9 @@ setup:
         index: test-index
         body:
           retriever:
-            linear:
+            rrf:
               fields: [ "wildcard-*" ]
               query: "match"
-              normalizer: "minmax"
 
   - match: { hits.total.value: 0 }
   - length: { hits.hits: 0 }
@@ -398,36 +324,15 @@ setup:
         index: test-index
         body:
           retriever:
-            linear:
+            rrf:
               query: "foo"
-              normalizer: "minmax"
               retrievers:
-                - retriever:
-                    standard:
-                      query:
-                        match:
-                          keyword: "bar"
+                - standard:
+                    query:
+                      match:
+                        keyword: "bar"
 
-  - contains: { error.root_cause.0.reason: "[linear] cannot combine [retrievers] and [query]" }
-
----
-"Cannot set top-level normalizer when using custom sub-retrievers":
-  - do:
-      catch: bad_request
-      search:
-        index: test-index
-        body:
-          retriever:
-            linear:
-              normalizer: "minmax"
-              retrievers:
-                - retriever:
-                    standard:
-                      query:
-                        match:
-                          keyword: "bar"
-
-  - contains: { error.root_cause.0.reason: "[linear] [normalizer] cannot be provided when [retrievers] is specified" }
+  - contains: { error.root_cause.0.reason: "[rrf] cannot combine [retrievers] and [query]" }
 
 ---
 "Missing required params":
@@ -437,21 +342,10 @@ setup:
         index: test-index
         body:
           retriever:
-            linear:
-              query: "foo"
+            rrf:
+              fields: [ "text_1", "text_2" ]
 
-  - contains: { error.root_cause.0.reason: "[linear] [normalizer] must be provided when [query] is specified" }
-
-  - do:
-      catch: bad_request
-      search:
-        index: test-index
-        body:
-          retriever:
-            linear:
-              fields: ["text_1", "text_2"]
-
-  - contains: { error.root_cause.0.reason: "[linear] [query] must be provided when [fields] is specified" }
+  - contains: { error.root_cause.0.reason: "[rrf] [query] must be provided when [fields] is specified" }
 
   - do:
       catch: bad_request
@@ -459,11 +353,11 @@ setup:
         index: test-index
         body:
           retriever:
-            linear:
+            rrf:
               fields: [ "text_1", "text_2" ]
               query: ""
 
-  - contains: { error.root_cause.0.reason: "[linear] [query] cannot be empty" }
+  - contains: { error.root_cause.0.reason: "[rrf] [query] cannot be empty" }
 
   - do:
       catch: bad_request
@@ -471,6 +365,55 @@ setup:
         index: test-index
         body:
           retriever:
-            linear: {}
+            rrf: {}
 
-  - contains: { error.root_cause.0.reason: "[linear] must provide [retrievers] or [query]" }
+  - contains: { error.root_cause.0.reason: "[rrf] must provide [retrievers] or [query]" }
+
+---
+"Expansion to equivalent custom sub-retrievers returns the same results":
+  - do:
+      search:
+        index: test-index
+        body:
+          retriever:
+            rrf:
+              fields: [ "text_1", "text_2", "sparse_inference", "dense_inference" ]
+              query: "match"
+
+  - match: { hits.total.value: 3 }
+  - length: { hits.hits: 3 }
+  - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "1" }
+  - match: { hits.hits.2._id: "3" }
+
+  - do:
+      search:
+        index: test-index
+        body:
+          retriever:
+            rrf:
+              retrievers:
+                - standard:
+                    query:
+                      multi_match:
+                        query: "match"
+                        fields: [ "text_1", "text_2" ]
+                        type: "most_fields"
+                - rrf:
+                    retrievers:
+                      - standard:
+                          query:
+                            match:
+                              dense_inference:
+                                query: "match"
+                      - standard:
+                          query:
+                            match:
+                              sparse_inference:
+                                query: "match"
+
+  - match: { hits.total.value: 3 }
+  - length: { hits.hits: 3 }
+  - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "1" }
+  - match: { hits.hits.2._id: "3" }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Simplified RRF Retriever (#129659)](https://github.com/elastic/elasticsearch/pull/129659)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)