### PR TITLE
Mute testEnqueuedMergeTasksAreUnblockedWhenEstimatedMergeSizeChanges

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -458,3 +458,6 @@ tests:
   - class: org.elasticsearch.index.engine.ThreadPoolMergeSchedulerTests
     method: testSchedulerCloseWaitsForRunningMerge
     issue: https://github.com/elastic/elasticsearch/issues/125236
+  - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
+    method: testEnqueuedMergeTasksAreUnblockedWhenEstimatedMergeSizeChanges
+    issue: https://github.com/elastic/elasticsearch/issues/129761


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/129761

Mute `testEnqueuedMergeTasksAreUnblockedWhenEstimatedMergeSizeChanges` in `ThreadPoolMergeExecutorServiceDiskSpaceTests`. This is currently failing 50% of times and affects backports to 8.19.