### PR TITLE
Serialize default index_options for semantic_text fields

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextIndexOptions.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextIndexOptions.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents index options for a semantic_text field.
@@ -48,6 +49,18 @@ public class SemanticTextIndexOptions implements ToXContent {
 
     public IndexOptions indexOptions() {
         return indexOptions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof SemanticTextIndexOptions == false) return false;
+        SemanticTextIndexOptions that = (SemanticTextIndexOptions) o;
+        return type == that.type && Objects.equals(indexOptions, that.indexOptions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, indexOptions);
     }
 
     public enum SupportedIndexOptions {


### PR DESCRIPTION
This PR fixes an issue from https://github.com/elastic/elasticsearch/pull/119967 where the default `index_options` were not displayed when `include_defaults` is set to true. 

Part of this fix requires serializing the `model_settings` earlier so they're accessible when we're performing serialization checks for `index_options`. 

Here is an example of how to test this: 

```
PUT my-dense-semantic-index/
{
  "mappings": {
    "properties": {
      "inference_field": {
        "type": "semantic_text",
        "inference_id": "my-e5-model"
        }
      }
    }
  }
}

// Should not return index_options
GET my-dense-semantic-index/_mapping

// Returns BBQ hnsw default index_options
GET my-dense-semantic-index/_mapping/field/inference_field?include_defaults
```