### PR TITLE
Fix translation for two time-series aggregations

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-mappings.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-mappings.json
@@ -30,6 +30,10 @@
           "type": "long",
           "time_series_metric": "counter"
         },
+        "total_bytes_out": {
+          "type": "long",
+          "time_series_metric": "counter"
+        },
         "cost": {
           "type": "double"
         },

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -336,3 +336,17 @@ distincts:long | distincts_imprecise:long | cluster:keyword | time_bucket:dateti
 2              |2              | staging         | 2024-05-10T00:18:00.000Z
 
 ;
+
+
+two_rates
+required_capability: metrics_command
+
+TS k8s | STATS cost_per_mb=max(rate(network.total_bytes_in) / 1024 * 1024 * rate(network.total_cost)) BY cluster, time_bucket = bucket(@timestamp,5minute) | SORT cost_per_mb DESC, cluster, time_bucket DESC | LIMIT 5;
+
+cost_per_mb:double | cluster:keyword | time_bucket:datetime
+5.119502189662629  | qa              | 2024-05-10T00:15:00.000Z
+4.1135056380088795 | qa              | 2024-05-10T00:05:00.000Z
+2.0974277092655393 | qa              | 2024-05-10T00:10:00.000Z
+2.071474095190272  | prod            | 2024-05-10T00:15:00.000Z
+1.59556462585034   | staging         | 2024-05-10T00:10:00.000Z
+;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -6900,6 +6900,27 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         assertThat(Expressions.attribute(clusterValues.field()).name(), equalTo("cluster"));
     }
 
+    public void testTranslateSumOfTwoRates() {
+        assumeTrue("requires snapshot builds", Build.current().isSnapshot());
+        var query = """
+            TS k8s
+            | STATS max(rate(network.total_bytes_in) + rate(network.total_bytes_out)) BY pod, bucket(@timestamp, 5 minute), cluster
+            | SORT cluster
+            | LIMIT 10
+            """;
+        var plan = logicalOptimizer.optimize(metricsAnalyzer.analyze(parser.createStatement(query)));
+        TopN topN = as(plan, TopN.class);
+        Aggregate finalAgg = as(topN.child(), Aggregate.class);
+        Eval eval = as(finalAgg.child(), Eval.class);
+        assertThat(eval.fields(), hasSize(1));
+        Add sum = as(Alias.unwrap(eval.fields().get(0)), Add.class);
+        assertThat(Expressions.name(sum.left()), equalTo("RATE_$1"));
+        assertThat(Expressions.name(sum.right()), equalTo("RATE_$2"));
+        TimeSeriesAggregate aggsByTsid = as(eval.child(), TimeSeriesAggregate.class);
+        assertThat(Expressions.name(aggsByTsid.aggregates().get(0)), equalTo("RATE_$1"));
+        assertThat(Expressions.name(aggsByTsid.aggregates().get(1)), equalTo("RATE_$2"));
+    }
+
     public void testTranslateMixedAggsGroupedByTimeBucketAndDimensions() {
         assumeTrue("requires snapshot builds", Build.current().isSnapshot());
         var query = """


### PR DESCRIPTION
This PR fixes the time-series translation for cases where two time-series aggregation functions are used within an outer aggregation function, for example: `STATS max(rate(r1) + rate(r2))`.