### PR TITLE
Fix StatementParserTests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -3473,8 +3473,8 @@ public class StatementParserTests extends AbstractStatementParserTests {
     }
 
     // [ and ( are used to trigger a double mode causing their symbol name (instead of text) to be used in error reporting
-    // this test checks that their are properly replaced in the error message
-    public void testPreserveParanthesis() {
+    // this test checks that they are properly replaced in the error message
+    public void testPreserveParentheses() {
         // test for (
         expectError("row a = 1 not in", "line 1:17: mismatched input '<EOF>' expecting '('");
         expectError("row a = 1 | where a not in", "line 1:27: mismatched input '<EOF>' expecting '('");
@@ -3482,9 +3482,11 @@ public class StatementParserTests extends AbstractStatementParserTests {
         expectError("row a = 1 | where a not in [1", "line 1:28: missing '(' at '['");
         expectError("row a = 1 | where a not in 123", "line 1:28: missing '(' at '123'");
         // test for [
-        expectError("explain", "line 1:8: mismatched input '<EOF>' expecting '('");
-        expectError("explain ]", "line 1:9: token recognition error at: ']'");
-        expectError("explain ( row x = 1", "line 1:20: missing ')' at '<EOF>'");
+        if (EsqlCapabilities.Cap.EXPLAIN.isEnabled()) {
+            expectError("explain", "line 1:8: mismatched input '<EOF>' expecting '('");
+            expectError("explain ]", "line 1:9: token recognition error at: ']'");
+            expectError("explain ( row x = 1", "line 1:20: missing ')' at '<EOF>'");
+        }
     }
 
     public void testRerankDefaultInferenceIdAndScoreAttribute() {


### PR DESCRIPTION
This change fixes StatementParserTests.testPreserveParanthesis as it now depends on capability enabled only on snapshot builds

Closes: #129887
Related to: #129526