### PR TITLE
[8.19] [ML] Add hint about using input_output in the inference processor to error message (#129864)

### DIFF
--- a/x-pack/plugin/ml/qa/ml-inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/CoordinatedInferenceIngestIT.java
+++ b/x-pack/plugin/ml/qa/ml-inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/CoordinatedInferenceIngestIT.java
@@ -150,7 +150,9 @@ public class CoordinatedInferenceIngestIT extends InferenceBaseRestTest {
             var responseMap = simulatePipeline(ExampleModels.nlpModelPipelineDefinitionWithFieldMap(inferenceServiceModelId), docs);
             var simulatedDocs = (List<Map<String, Object>>) responseMap.get("docs");
             var errorMsg = (String) MapHelper.dig("error.reason", simulatedDocs.get(0));
-            assertThat(errorMsg, containsString("[is_model] is configured for the _inference API and does not accept documents as input"));
+            var expectedMessage = "[is_model] is configured for the _inference API and does not accept documents as input. "
+                + "If using an inference ingest processor configure it with the [input_output] option instead of [field_map].";
+            assertThat(errorMsg, containsString(expectedMessage));
             assertThat(simulatedDocs, hasSize(2));
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCoordinatedInferenceAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCoordinatedInferenceAction.java
@@ -190,7 +190,11 @@ public class TransportCoordinatedInferenceAction extends HandledTransportAction<
                     ActionListener.wrap(
                         model -> listener.onFailure(
                             new ElasticsearchStatusException(
-                                "[" + modelId + "] is configured for the _inference API and does not accept documents as input",
+                                "["
+                                    + modelId
+                                    + "] is configured for the _inference API and does not accept documents as input. "
+                                    + "If using an inference ingest processor configure it with the [input_output] option instead of "
+                                    + "[field_map].",
                                 RestStatus.BAD_REQUEST
                             )
                         ),


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ML] Add hint about using input_output in the inference processor to error message (#129864)