### PR TITLE
ESQL: Move explain command validation off EsqlSession

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -562,9 +562,6 @@ tests:
 - class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
   method: test {yaml=rrf/950_pinned_interaction/rrf with pinned retriever as a sub-retriever}
   issue: https://github.com/elastic/elasticsearch/issues/129845
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
-  issue: https://github.com/elastic/elasticsearch/issues/129888
 - class: org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapperTests
   method: testExistsQueryMinimalMapping
   issue: https://github.com/elastic/elasticsearch/issues/129911

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -120,6 +120,13 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
 
     protected LogicalPlan plan(ParseTree ctx) {
         LogicalPlan p = ParserUtils.typedParsing(this, ctx, LogicalPlan.class);
+        if (p instanceof Explain == false && p.anyMatch(logicalPlan -> logicalPlan instanceof Explain)) {
+            throw new ParsingException(source(ctx), "EXPLAIN does not support downstream commands");
+        }
+        if (p instanceof Explain explain && explain.query().anyMatch(logicalPlan -> logicalPlan instanceof Explain)) {
+            // TODO this one is never reached because the Parser fails to understand multiple round brackets
+            throw new ParsingException(source(ctx), "EXPLAIN cannot be used inside another EXPLAIN command");
+        }
         var errors = this.context.params().parsingErrors();
         if (errors.hasNext() == false) {
             return p;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -3500,7 +3500,10 @@ public class StatementParserTests extends AbstractStatementParserTests {
         assumeTrue("Requires EXPLAIN capability", EsqlCapabilities.Cap.EXPLAIN.isEnabled());
         // TODO this one is incorrect
         expectError("explain ( from test ) | limit 1", "line 1:23: mismatched input '|' expecting {'|', ',', ')', 'metadata'}");
-        expectError("explain (row x=\"Elastic\" | eval y=concat(x,to_upper(\"search\"))) | mv_expand y", "line 1:1: EXPLAIN does not support downstream commands");
+        expectError(
+            "explain (row x=\"Elastic\" | eval y=concat(x,to_upper(\"search\"))) | mv_expand y",
+            "line 1:1: EXPLAIN does not support downstream commands"
+        );
     }
 
     public void testRerankDefaultInferenceIdAndScoreAttribute() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -3496,6 +3496,13 @@ public class StatementParserTests extends AbstractStatementParserTests {
         }
     }
 
+    public void testExplainErrors() {
+        assumeTrue("Requires EXPLAIN capability", EsqlCapabilities.Cap.EXPLAIN.isEnabled());
+        // TODO this one is incorrect
+        expectError("explain ( from test ) | limit 1", "line 1:23: mismatched input '|' expecting {'|', ',', ')', 'metadata'}");
+        expectError("explain (row x=\"Elastic\" | eval y=concat(x,to_upper(\"search\"))) | mv_expand y", "line 1:1: EXPLAIN does not support downstream commands");
+    }
+
     public void testRerankDefaultInferenceIdAndScoreAttribute() {
         assumeTrue("RERANK requires corresponding capability", EsqlCapabilities.Cap.RERANK.isEnabled());
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/220_explain.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/220_explain.yml
@@ -97,5 +97,5 @@ explainDownstream:
           query: 'EXPLAIN (row a = 1) | eval b = 2'
       catch: "bad_request"
 
-  - match: { error.type: "verification_exception" }
+  - match: { error.type: "parsing_exception" }
   - contains: { error.reason: "EXPLAIN does not support downstream commands" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -46,7 +46,7 @@ setup:
   - do: {xpack.usage: {}}
   - match: { esql.available: true }
   - match: { esql.enabled: true }
-  - length: { esql.features: 26 }
+  - length: { esql.features: 27 }
   - set: {esql.features.dissect: dissect_counter}
   - set: {esql.features.drop: drop_counter}
   - set: {esql.features.eval: eval_counter}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -46,7 +46,7 @@ setup:
   - do: {xpack.usage: {}}
   - match: { esql.available: true }
   - match: { esql.enabled: true }
-  - length: { esql.features: 27 }
+  - length: { esql.features: 26 }
   - set: {esql.features.dissect: dissect_counter}
   - set: {esql.features.drop: drop_counter}
   - set: {esql.features.eval: eval_counter}


### PR DESCRIPTION
Move the command validation to a better place.
Fixes https://github.com/elastic/elasticsearch/issues/129888