### PR TITLE
Fixing race condition in DynamicMappingIT when checking for updates in mappings

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -568,9 +568,6 @@ tests:
 - class: org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapperTests
   method: testExistsQueryMinimalMapping
   issue: https://github.com/elastic/elasticsearch/issues/129911
-- class: org.elasticsearch.index.mapper.DynamicMappingIT
-  method: testDenseVectorDynamicMapping
-  issue: https://github.com/elastic/elasticsearch/issues/129928
 
 # Examples:
 #

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -920,9 +920,11 @@ public class DynamicMappingIT extends ESIntegTestCase {
 
         client().index(
             new IndexRequest("test").source("vector_int8", Randomness.get().doubles(BBQ_DIMS_DEFAULT_THRESHOLD - 1, 0.0, 5.0).toArray())
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
         ).get();
         client().index(
             new IndexRequest("test").source("vector_bbq", Randomness.get().doubles(BBQ_DIMS_DEFAULT_THRESHOLD, 0.0, 5.0).toArray())
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
         ).get();
 
         assertBusy(() -> {
@@ -960,8 +962,10 @@ public class DynamicMappingIT extends ESIntegTestCase {
         assertTrue(new WriteField("properties.vector", () -> mappings).exists());
         assertFalse(new WriteField("properties.vector.index_options.type", () -> mappings).exists());
 
-        client().index(new IndexRequest("test").source("vector", Randomness.get().doubles(BBQ_DIMS_DEFAULT_THRESHOLD, 0.0, 5.0).toArray()))
-            .get();
+        client().index(
+            new IndexRequest("test").source("vector", Randomness.get().doubles(BBQ_DIMS_DEFAULT_THRESHOLD, 0.0, 5.0).toArray())
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+        ).get();
 
         assertBusy(() -> {
             Map<String, Object> updatedMappings = indicesAdmin().prepareGetMappings(TEST_REQUEST_TIMEOUT, "test")


### PR DESCRIPTION
As mentioned in the linked issue, the following exception is only reproducible under heavy load, so I had to use `stress-ng` locally to get some errors. It seems that there is a race condition in the tests, when we try to read the mappings before they actually have been updated by the ingested documents. 

Updated tests `testBBQDynamicMappingWhenFirstIngestingDoc` and `testDenseVectorDynamicMapping` to use the `assertBusy` pattern, similarly to other tests in the class.

Closes https://github.com/elastic/elasticsearch/issues/129928