### PR TITLE
[9.0] Remove docs warning that synthetic source is in es|ql is experimental. (#129930)

### DIFF
--- a/docs/reference/query-languages/esql/limitations.md
+++ b/docs/reference/query-languages/esql/limitations.md
@@ -100,9 +100,6 @@ In addition, when [querying multiple indexes](docs-content://explore-analyze/que
 
 {{esql}} does not support configurations where the [_source field](/reference/elasticsearch/mapping-reference/mapping-source-field.md) is [disabled](/reference/elasticsearch/mapping-reference/mapping-source-field.md#disable-source-field).
 
-[preview] {{esql}}'s support for [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) is currently experimental.
-
-
 ## Full-text search [esql-limitations-full-text-search]
 
 [preview] {{esql}}'s support for [full-text search](/reference/query-languages/esql/functions-operators/search-functions.md) is currently in Technical Preview.


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Remove docs warning that synthetic source is in es|ql is experimental. (#129930)