### PR TITLE
Pass empty lists instead of nulls to FileAccessTree.of

### DIFF
--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
@@ -461,7 +461,7 @@ public class FileAccessTreeTests extends ESTestCase {
                 )
             ),
             TEST_PATH_LOOKUP,
-            null,
+            List.of(),
             List.of()
         );
 
@@ -487,7 +487,7 @@ public class FileAccessTreeTests extends ESTestCase {
                 )
             ),
             TEST_PATH_LOOKUP,
-            null,
+            List.of(),
             List.of()
         );
 


### PR DESCRIPTION
Fixes #129168.
Fixes #129167.