### PR TITLE
[8.18] Remove docs warning that synthetic source is in es|ql is experimental. (#129948)

### DIFF
--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -99,9 +99,6 @@ unless they're <<esql-multi-index-union-types, explicitly converted to a single 
 {esql} does not support configurations where the
 <<mapping-source-field,_source field>> is <<disable-source-field,disabled>>.
 
-experimental:[] {esql}'s support for <<synthetic-source,synthetic `_source`>>
-is currently experimental.
-
 [discrete]
 [[esql-limitations-full-text-search]]
 === Full-text search


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Remove docs warning that synthetic source is in es|ql is experimental. (#129948)