### PR TITLE
[9.0] Reverse disordered-version warning message (#129904)

### DIFF
--- a/docs/changelog/129904.yaml
+++ b/docs/changelog/129904.yaml
@@ -1,0 +1,5 @@
+pr: 129904
+summary: Reverse disordered-version warning message
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -241,8 +241,8 @@ final class TransportHandshaker {
                     logger.warn(
                         """
                             Negotiating transport handshake with remote node with version [{}/{}] received on [{}] which appears to be \
-                            from a chronologically-older release with a numerically-newer version compared to this node's version [{}/{}]. \
-                            Upgrading to a chronologically-older release may not work reliably and is not recommended. \
+                            from a chronologically-newer release with a numerically-older version compared to this node's version [{}/{}]. \
+                            Upgrading to this version from a chronologically-newer release may not work reliably and is not recommended. \
                             Falling back to transport protocol version [{}].""",
                         releaseVersion,
                         remoteTransportVersion,

--- a/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
@@ -134,9 +134,9 @@ public class TransportHandshakerTests extends ESTestCase {
                     Strings.format(
                         """
                             Negotiating transport handshake with remote node with version [%s/%s] received on [*] which appears to be from \
-                            a chronologically-older release with a numerically-newer version compared to this node's version [%s/%s]. \
-                            Upgrading to a chronologically-older release may not work reliably and is not recommended. Falling back to \
-                            transport protocol version [%s].""",
+                            a chronologically-newer release with a numerically-older version compared to this node's version [%s/%s]. \
+                            Upgrading to this version from a chronologically-newer release may not work reliably and is not recommended. \
+                            Falling back to transport protocol version [%s].""",
                         handshakeRequest.releaseVersion,
                         handshakeRequest.transportVersion,
                         Build.current().version(),
@@ -216,9 +216,9 @@ public class TransportHandshakerTests extends ESTestCase {
                     Strings.format(
                         """
                             Negotiating transport handshake with remote node with version [%s/%s] received on [*] which appears to be from \
-                            a chronologically-older release with a numerically-newer version compared to this node's version [%s/%s]. \
-                            Upgrading to a chronologically-older release may not work reliably and is not recommended. Falling back to \
-                            transport protocol version [%s].""",
+                            a chronologically-newer release with a numerically-older version compared to this node's version [%s/%s]. \
+                            Upgrading to this version from a chronologically-newer release may not work reliably and is not recommended. \
+                            Falling back to transport protocol version [%s].""",
                         handshakeResponse.getReleaseVersion(),
                         handshakeResponse.getTransportVersion(),
                         Build.current().version(),


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Reverse disordered-version warning message (#129904)