### PR TITLE
Reverse disordered-version warning message

### DIFF
--- a/docs/changelog/129904.yaml
+++ b/docs/changelog/129904.yaml
@@ -1,0 +1,5 @@
+pr: 129904
+summary: Reverse disordered-version warning message
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -301,8 +301,8 @@ final class TransportHandshaker {
                     logger.warn(
                         """
                             Negotiating transport handshake with remote node with version [{}/{}] received on [{}] which appears to be \
-                            from a chronologically-older release with a numerically-newer version compared to this node's version [{}/{}]. \
-                            Upgrading to a chronologically-older release may not work reliably and is not recommended. \
+                            from a chronologically-newer release with a numerically-older version compared to this node's version [{}/{}]. \
+                            Upgrading to this version from a chronologically-newer release may not work reliably and is not recommended. \
                             Falling back to transport protocol version [{}].""",
                         remoteReleaseVersion,
                         remoteTransportVersion,

--- a/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
@@ -132,9 +132,9 @@ public class TransportHandshakerTests extends ESTestCase {
                     Strings.format(
                         """
                             Negotiating transport handshake with remote node with version [%s/%s] received on [*] which appears to be from \
-                            a chronologically-older release with a numerically-newer version compared to this node's version [%s/%s]. \
-                            Upgrading to a chronologically-older release may not work reliably and is not recommended. Falling back to \
-                            transport protocol version [%s].""",
+                            a chronologically-newer release with a numerically-older version compared to this node's version [%s/%s]. \
+                            Upgrading to this version from a chronologically-newer release may not work reliably and is not recommended. \
+                            Falling back to transport protocol version [%s].""",
                         handshakeRequest.transportVersion.toReleaseVersion(),
                         handshakeRequest.transportVersion,
                         Build.current().version(),
@@ -220,9 +220,9 @@ public class TransportHandshakerTests extends ESTestCase {
                     Strings.format(
                         """
                             Negotiating transport handshake with remote node with version [%s/%s] received on [*] which appears to be from \
-                            a chronologically-older release with a numerically-newer version compared to this node's version [%s/%s]. \
-                            Upgrading to a chronologically-older release may not work reliably and is not recommended. Falling back to \
-                            transport protocol version [%s].""",
+                            a chronologically-newer release with a numerically-older version compared to this node's version [%s/%s]. \
+                            Upgrading to this version from a chronologically-newer release may not work reliably and is not recommended. \
+                            Falling back to transport protocol version [%s].""",
                         handshakeResponse.getReleaseVersion(),
                         handshakeResponse.getTransportVersion(),
                         Build.current().version(),


### PR DESCRIPTION
The comment in `TransportHandshaker` indicates (correctly) that we emit
a warning when talking to a chronologically-newer-yet-numerically-older
version, but the wording of the warning message is inverted and says
that the remote is chronologically-older-yet-numerically-newer. This
commit straightens out the message to match the situation it is
describing.

Relates #123397
Backport of #129904 to `8.19`