### PR TITLE
Remove geoip multi-project tests from release build

### DIFF
--- a/modules/ingest-geoip/qa/multi-project/build.gradle
+++ b/modules/ingest-geoip/qa/multi-project/build.gradle
@@ -22,3 +22,8 @@ dependencies {
 tasks.withType(Test).configureEach {
   it.systemProperty "tests.multi_project.enabled", true
 }
+
+// Exclude multi-project tests from release build
+tasks.named { it == "javaRestTest" || it == "yamlRestTest" }.configureEach {
+  it.onlyIf("snapshot build") { buildParams.snapshotBuild }
+}


### PR DESCRIPTION
Removes MP tests from release build.

Closes https://github.com/elastic/elasticsearch/issues/129936