### PR TITLE
[8.19] ESQL: Declare LOOKUP JOIN as GA in docs

### DIFF
--- a/docs/reference/esql/esql-commands.asciidoc
+++ b/docs/reference/esql/esql-commands.asciidoc
@@ -43,7 +43,7 @@ ifeval::["{release-state}"=="unreleased"]
 endif::[]
 * <<esql-keep>>
 * <<esql-limit>>
-* experimental:[] <<esql-lookup-join>>
+* <<esql-lookup-join>>
 * experimental:[] <<esql-mv_expand>>
 * <<esql-rename>>
 * experimental:[] <<esql-sample>>

--- a/docs/reference/esql/processing-commands/lookup.asciidoc
+++ b/docs/reference/esql/processing-commands/lookup.asciidoc
@@ -2,14 +2,6 @@
 [[esql-lookup-join]]
 === `LOOKUP JOIN`
 
-[WARNING]
-====
-This functionality is in technical preview and may be
-changed or removed in a future release. Elastic will work to fix any
-issues, but features in technical preview are not subject to the support
-SLA of official GA features.
-====
-
 `LOOKUP JOIN` enables you to add data from another index, AKA a 'lookup'
 index, to your {esql} query results, simplifying data enrichment
 and analysis workflows.


### PR DESCRIPTION
Manual "backport" of https://github.com/elastic/elasticsearch/pull/129947.