### PR TITLE
[8.19] ESQL: Add one more test of FTF with LOOKUP JOIN (#129781)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -85,7 +85,8 @@ public class CsvTestsDataLoader {
     private static final TestDataset SAMPLE_DATA_TS_NANOS = SAMPLE_DATA.withIndex("sample_data_ts_nanos")
         .withData("sample_data_ts_nanos.csv")
         .withTypeMapping(Map.of("@timestamp", "date_nanos"));
-    private static final TestDataset LOOKUP_SAMPLE_DATA_TS_NANOS = SAMPLE_DATA_TS_NANOS.withIndex("lookup_sample_data_ts_nanos")
+    // the double underscore is meant to not match `sample_data*`, but do match `sample_*`
+    private static final TestDataset SAMPLE_DATA_TS_NANOS_LOOKUP = SAMPLE_DATA_TS_NANOS.withIndex("sample__data_ts_nanos_lookup")
         .withSetting("lookup-settings.json");
     private static final TestDataset MISSING_IP_SAMPLE_DATA = new TestDataset("missing_ip_sample_data");
     private static final TestDataset CLIENT_IPS = new TestDataset("clientips");
@@ -143,7 +144,7 @@ public class CsvTestsDataLoader {
         Map.entry(SAMPLE_DATA_STR.indexName, SAMPLE_DATA_STR),
         Map.entry(SAMPLE_DATA_TS_LONG.indexName, SAMPLE_DATA_TS_LONG),
         Map.entry(SAMPLE_DATA_TS_NANOS.indexName, SAMPLE_DATA_TS_NANOS),
-        Map.entry(LOOKUP_SAMPLE_DATA_TS_NANOS.indexName, LOOKUP_SAMPLE_DATA_TS_NANOS),
+        Map.entry(SAMPLE_DATA_TS_NANOS_LOOKUP.indexName, SAMPLE_DATA_TS_NANOS_LOOKUP),
         Map.entry(MISSING_IP_SAMPLE_DATA.indexName, MISSING_IP_SAMPLE_DATA),
         Map.entry(CLIENT_IPS.indexName, CLIENT_IPS),
         Map.entry(CLIENT_IPS_LOOKUP.indexName, CLIENT_IPS_LOOKUP),

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -120,6 +120,22 @@ language_code:integer | language_name:keyword
 4                     | German
 ;
 
+selfJoinWithOffset
+required_capability: join_lookup_v12
+
+FROM languages_lookup
+| EVAL language_code = language_code + 2
+| LOOKUP JOIN languages_lookup ON language_code
+| SORT language_code
+;
+
+language_code:integer | language_name:keyword
+3                     |Spanish
+4                     |German
+5                     |null
+6                     |null
+;
+
 nonUniqueLeftKeyOnTheDataNode
 required_capability: join_lookup_v12
 
@@ -4602,7 +4618,7 @@ required_capability: join_lookup_v12
 required_capability: date_nanos_lookup_join
 
 FROM sample_data_ts_nanos
-| LOOKUP JOIN lookup_sample_data_ts_nanos ON @timestamp
+| LOOKUP JOIN sample__data_ts_nanos_lookup ON @timestamp
 | KEEP @timestamp, client_ip, event_duration, message
 | SORT @timestamp DESC
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
@@ -752,6 +752,31 @@ host:keyword | semantic_text_field:text | language_name:keyword | language_code:
 "host1"      | live long and prosper    | English               | 1
 ;
 
+testFTFWithLookupJoin
+required_capability: match_operator_colon
+required_capability: match_phrase_function
+required_capability: kql_function
+required_capability: qstr_function
+required_capability: join_lookup_v12
+
+FROM sample_*,-sample__data_*
+| WHERE message : "Connected to 10.1.0.1"
+| WHERE MATCH_PHRASE(message, "Connected to 10.1.0.1")
+| WHERE KQL("message : Connected*")
+| WHERE QSTR("message : *")
+| EVAL @timestamp_millis = TO_DATETIME(@timestamp)
+| EVAL client_ip = TO_IP(client_ip)
+| LOOKUP JOIN sample__data_ts_nanos_lookup ON client_ip
+| STATS BY @timestamp_millis, client_ip, @timestamp, event_duration, message
+| SORT event_duration
+;
+
+@timestamp_millis:date  |client_ip:ip   |@timestamp:date_nanos         |event_duration:long |message:keyword
+2023-10-23T13:55:01.543Z|172.21.3.15    |2023-10-23T13:51:54.732123456Z|725448              |Connection error     
+2023-10-23T13:55:01.543Z|172.21.3.15    |2023-10-23T13:55:01.543123456Z|1756467             |Connected to 10.1.0.1
+2023-10-23T13:55:01.543Z|172.21.3.15    |2023-10-23T13:53:55.832123456Z|5033755             |Connection error     
+2023-10-23T13:55:01.543Z|172.21.3.15    |2023-10-23T13:52:55.015123456Z|8268153             |Connection error     
+;
 
 testMatchInStatsNonPushable
 required_capability: match_operator_colon


### PR DESCRIPTION
Backports the following commits to 8.19:
 - ESQL: Add one more test of FTF with LOOKUP JOIN (#129781)