### PR TITLE
[8.19] Watch SSL files instead of directories (#129738)

### DIFF
--- a/docs/changelog/129738.yaml
+++ b/docs/changelog/129738.yaml
@@ -1,0 +1,5 @@
+pr: 129738
+summary: Watch SSL files instead of directories
+area: TLS
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/watcher/FileWatcher.java
+++ b/server/src/main/java/org/elasticsearch/watcher/FileWatcher.java
@@ -57,6 +57,11 @@ public class FileWatcher extends AbstractResourceWatcher<FileChangesListener> {
         rootFileObserver = new FileObserver(path);
     }
 
+    // For testing
+    public Path getPath() {
+        return path;
+    }
+
     /**
      * Clears any state with the FileWatcher, making all files show up as new
      */

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationReloader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationReloader.java
@@ -22,10 +22,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
@@ -80,7 +78,7 @@ public final class SSLConfigurationReloader {
     }
 
     /**
-     * Collects all of the directories that need to be monitored for the provided {@link SslConfiguration} instances and ensures that
+     * Collects all of the files that need to be monitored for the provided {@link SslConfiguration} instances and ensures that
      * they are being watched for changes
      */
     private static void startWatching(
@@ -91,8 +89,8 @@ public final class SSLConfigurationReloader {
         Map<Path, List<SslConfiguration>> pathToConfigurationsMap = new HashMap<>();
         for (SslConfiguration sslConfiguration : sslConfigurations) {
             final Collection<Path> filesToMonitor = sslConfiguration.getDependentFiles();
-            for (Path directory : directoriesToMonitor(filesToMonitor)) {
-                pathToConfigurationsMap.compute(directory, (path, list) -> {
+            for (Path file : filesToMonitor) {
+                pathToConfigurationsMap.compute(file, (path, list) -> {
                     if (list == null) {
                         list = new ArrayList<>();
                     }
@@ -109,20 +107,9 @@ public final class SSLConfigurationReloader {
             try {
                 resourceWatcherService.add(fileWatcher, Frequency.HIGH);
             } catch (IOException | SecurityException e) {
-                logger.error("failed to start watching directory [{}] for ssl configurations [{}] - {}", path, configurations, e);
+                logger.error("failed to start watching file [{}] for ssl configurations [{}] - {}", path, configurations, e);
             }
         });
-    }
-
-    /**
-     * Returns a unique set of directories that need to be monitored based on the provided file paths
-     */
-    private static Set<Path> directoriesToMonitor(Iterable<Path> filePaths) {
-        Set<Path> paths = new HashSet<>();
-        for (Path path : filePaths) {
-            paths.add(path.getParent());
-        }
-        return paths;
     }
 
     private static class ChangeListener implements FileChangesListener {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Watch SSL files instead of directories (#129738)