### PR TITLE
[8.19] Upgrade tests to MinIO `RELEASE.2025-06-13T11-33-47Z` (#129920)

### DIFF
--- a/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
+++ b/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
@@ -17,7 +17,7 @@ public final class MinioTestContainer extends DockerEnvironmentAwareTestContaine
 
     // NB releases earlier than 2025-05-24 are buggy, see https://github.com/minio/minio/issues/21189, and #127166 for a workaround
     // However the 2025-05-24 release is also buggy, see https://github.com/minio/minio/issues/21377, and this has no workaround
-    public static final String DOCKER_BASE_IMAGE = "minio/minio:RELEASE.2024-12-18T13-15-44Z";
+    public static final String DOCKER_BASE_IMAGE = "minio/minio:RELEASE.2025-06-13T11-33-47Z";
 
     private static final int servicePort = 9000;
     private final boolean enabled;

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/minio/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/MinioRepositoryAnalysisRestIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/minio/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/MinioRepositoryAnalysisRestIT.java
@@ -33,10 +33,6 @@ public class MinioRepositoryAnalysisRestIT extends AbstractRepositoryAnalysisRes
         .keystore("s3.client.repository_test_kit.secret_key", "s3_test_secret_key")
         .setting("s3.client.repository_test_kit.endpoint", minioFixture::getAddress)
         .setting("xpack.security.enabled", "false")
-        // Skip listing of pre-existing uploads during a CAS because MinIO sometimes leaks them; also reduce the delay before proceeding
-        // TODO do not set these if running a MinIO version in which https://github.com/minio/minio/issues/21189 is fixed
-        .setting("repository_s3.compare_and_exchange.time_to_live", "-1")
-        .setting("repository_s3.compare_and_exchange.anti_contention_delay", "100ms")
         .setting("xpack.ml.enabled", "false")
         .build();
 


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Upgrade tests to MinIO `RELEASE.2025-06-13T11-33-47Z` (#129920)