### PR TITLE
[CI] [8.19] Fix ThreadPoolMergeExecutorServiceDiskSpaceTests testAbortingOrRunningMergeTaskHoldsUpBudget

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorServiceDiskSpaceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorServiceDiskSpaceTests.java
@@ -533,7 +533,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
         aFileStore.totalSpace = randomLongBetween(1_000L, 10_000L);
         bFileStore.totalSpace = randomLongBetween(1_000L, 10_000L);
         aFileStore.usableSpace = randomLongBetween(900L, aFileStore.totalSpace);
-        bFileStore.usableSpace = randomLongBetween(900L, bFileStore.totalSpace);
+        bFileStore.usableSpace = randomValueOtherThan(aFileStore.usableSpace, () -> randomLongBetween(900L, bFileStore.totalSpace));
         boolean aHasMoreSpace = aFileStore.usableSpace > bFileStore.usableSpace;
         try (
             ThreadPoolMergeExecutorService threadPoolMergeExecutorService = ThreadPoolMergeExecutorService
@@ -611,7 +611,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
         aFileStore.totalSpace = randomLongBetween(1_000L, 10_000L);
         bFileStore.totalSpace = randomLongBetween(1_000L, 10_000L);
         aFileStore.usableSpace = randomLongBetween(900L, aFileStore.totalSpace);
-        bFileStore.usableSpace = randomLongBetween(900L, bFileStore.totalSpace);
+        bFileStore.usableSpace = randomValueOtherThan(aFileStore.usableSpace, () -> randomLongBetween(900L, bFileStore.totalSpace));
         boolean aHasMoreSpace = aFileStore.usableSpace > bFileStore.usableSpace;
         try (
             ThreadPoolMergeExecutorService threadPoolMergeExecutorService = ThreadPoolMergeExecutorService
@@ -896,7 +896,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
         long diskSpaceLimitBytes = randomLongBetween(10L, 100L);
         aFileStore.usableSpace = diskSpaceLimitBytes + randomLongBetween(1L, 100L);
         aFileStore.totalSpace = aFileStore.usableSpace + randomLongBetween(1L, 10L);
-        bFileStore.usableSpace = diskSpaceLimitBytes + randomLongBetween(1L, 100L);
+        bFileStore.usableSpace = randomValueOtherThan(aFileStore.usableSpace, () -> diskSpaceLimitBytes + randomLongBetween(1L, 100L));
         bFileStore.totalSpace = bFileStore.usableSpace + randomLongBetween(1L, 10L);
         boolean aHasMoreSpace = aFileStore.usableSpace > bFileStore.usableSpace;
         Settings.Builder settingsBuilder = Settings.builder().put(settings);
@@ -997,7 +997,10 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
         bFileStore.totalSpace = randomLongBetween(300L, 1_000L);
         long grantedUsableSpaceBuffer = randomLongBetween(10L, 50L);
         aFileStore.usableSpace = randomLongBetween(200L, aFileStore.totalSpace - grantedUsableSpaceBuffer);
-        bFileStore.usableSpace = randomLongBetween(200L, bFileStore.totalSpace - grantedUsableSpaceBuffer);
+        bFileStore.usableSpace = randomValueOtherThan(
+            aFileStore.usableSpace,
+            () -> randomLongBetween(200L, bFileStore.totalSpace - grantedUsableSpaceBuffer)
+        );
         boolean aHasMoreSpace = aFileStore.usableSpace > bFileStore.usableSpace;
         Settings.Builder settingsBuilder = Settings.builder().put(settings);
         // change the watermark level, just for coverage and it's easier with the calculations


### PR DESCRIPTION
When there are multiple FS with the same available disk space but different total sizes, it's unpredictable (and irrelevant) which one the checker uses.

Backport https://github.com/elastic/elasticsearch/pull/129979
Fixes https://github.com/elastic/elasticsearch/issues/129823