### PR TITLE
Sharepoint Online Connector documentation: add known issue about DLS

### DIFF
--- a/docs/reference/search-connectors/es-connectors-sharepoint-online.md
+++ b/docs/reference/search-connectors/es-connectors-sharepoint-online.md
@@ -592,6 +592,19 @@ make ftest NAME=sharepoint_online DATA_SIZE=small
 
         **Workaround**: Disable `Enumerate All Sites?`, and configure full site paths for all desired sites.
 
+* **ACL is not properly inherited for Site Pages and List Items inside of a folder with Unique Permissions when DLS is enabled with Fetch unique list item permissions, Fetch unique page permissions or Fetch drive item permissions**
+
+    There is a known issue with ACL propagation when List Items, Site Pages or Drive Items are located inside of a folder that has Unique permissions enabled. Consider the following example:
+
+    ```
+    [0] Root Site (Access: All)
+    [1]  Subsite Travel (Access: inherit)
+    [2]    Folder "/es" (Access: Spanish Employees)
+    [3]      Page "destinations.html" (Access: inherit)
+    ```
+
+    Expected permissions for `destinations.html` should be `Access: Spanish Employees`, but will be `Access: All`, because permissions will be assumed from Subsite Travel, rather than folder "/es".
+
 
 Refer to [Known issues](/release-notes/known-issues.md) for a list of known issues for all connectors.
 


### PR DESCRIPTION
Adding documentation for known bug https://github.com/elastic/connectors/issues/3491 for Sharepoint Online connector: some permissions are not properly inherited when Unique permissions are enable for parent objects.