### PR TITLE
Better description of skip-un funciton in 8.19

### DIFF
--- a/docs/reference/esql/esql-across-clusters.asciidoc
+++ b/docs/reference/esql/esql-across-clusters.asciidoc
@@ -525,6 +525,7 @@ FROM my-index-000001,cluster*:my-index-*,cluster_three:-my-index-000001
 
 If the remote cluster is configured with `skip_unavailable: true` (the default setting), the cluster would be set
 to `skipped` or `partial` status but the query will not fail, if:
+
 * The remote cluster is disconnected from the querying cluster, either before or during the query.
 * The remote cluster does not have the requested index.
 * An error happened while processing the query on the remote cluster.

--- a/docs/reference/esql/esql-across-clusters.asciidoc
+++ b/docs/reference/esql/esql-across-clusters.asciidoc
@@ -523,9 +523,23 @@ FROM my-index-000001,cluster*:my-index-*,cluster_three:-my-index-000001
 [[ccq-skip-unavailable-clusters]]
 ==== Optional remote clusters
 
-{ccs-cap} for {esql} will set the remote cluster which is disconnected from the querying cluster to `skipped`
-and continue the query with other clusters, unless the cluster's `skip_unavailable` setting is set to `false`,
-in which case the query will fail.
+If the remote cluster is configured with `skip_unavailable: true` (the default setting), the cluster would be set
+to `skipped` or `partial` status but the query will not fail, if:
+* The remote cluster is disconnected from the querying cluster, either before or during the query.
+* The remote cluster does not have the requested index.
+* An error happened while processing the query on the remote cluster.
+
+The `partial` status will be used if the remote query was partially successful and some data was returned.
+
+This however does not apply to the situation when the remote cluster is missing an index and this is the only index in the query,
+or all the indices in the query are missing. For example, the following queries will fail:
+
+[source,esql]
+----
+FROM cluster_one:missing-index | LIMIT 10
+FROM cluster_one:missing-index* | LIMIT 10
+FROM cluster_one:missing-index*,cluster_two:missing-index | LIMIT 10
+----
 
 [discrete]
 [[ccq-during-upgrade]]


### PR DESCRIPTION
Update the description of `skip_unavailable` functionality with recent changes. 