### PR TITLE
RFC 9557 : Add support for parsing ISO date time with zone-id

### DIFF
--- a/docs/changelog/130054.yaml
+++ b/docs/changelog/130054.yaml
@@ -1,0 +1,5 @@
+pr: 130054
+summary: Add support for parsing ISO date time with zone-id (RFC 9557)
+area: Mapping
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/time/Iso8601Parser.java
+++ b/server/src/main/java/org/elasticsearch/common/time/Iso8601Parser.java
@@ -450,7 +450,7 @@ class Iso8601Parser {
 
         boolean positive;
         switch (first) {
-            case '+' -> positive = true;
+            case '+', 'Z' -> positive = true;
             case '-' -> positive = false;
             default -> {
                 // non-trivial zone offset, fallback on the built-in java zoneid parser
@@ -462,6 +462,9 @@ class Iso8601Parser {
             }
         }
         pos++;  // read the + or -
+        if (str.charAt(pos) == '[' && str.charAt(len - 1) == ']') {
+            return parseRawZoneId(str, pos);
+        }
 
         Integer hours = parseInt(str, pos, pos += 2);
         if (hours == null || hours > 23) return null;

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -615,6 +615,7 @@ public class DateFormattersTests extends ESTestCase {
         formatter.format(formatter.parse("2031-12-03T10:15:30.123456789+01:00:00[Europe/Paris]"));
         formatter.format(formatter.parse("2031-12-03T10:15:30.123456789+01:00:00[PST]"));
         formatter.format(formatter.parse("2031-12-03T10:15:30.123456789+01:00:00[EST]"));
+        formatter.format(formatter.parse("2031-12-03T10:15:30.123456789Z[UTC]"));
     }
 
     public void testRoundupFormatterWithEpochDates() {

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -608,6 +608,15 @@ public class DateFormattersTests extends ESTestCase {
         formatter.format(formatter.parse("2018-05-15T17:14:56,123456789+01:00"));
     }
 
+    public void testParsingDateTimeWithZoneId() {
+        DateFormatter formatter = DateFormatters.forPattern("strict_date_optional_time");
+        formatter.format(formatter.parse("2018-05-15T17:14:56-08:00[America/Los_Angeles]"));
+        formatter.format(formatter.parse("2029-05-15T17:14:56.123456789-08:00[America/Los_Angeles]"));
+        formatter.format(formatter.parse("2031-12-03T10:15:30.123456789+01:00:00[Europe/Paris]"));
+        formatter.format(formatter.parse("2031-12-03T10:15:30.123456789+01:00:00[PST]"));
+        formatter.format(formatter.parse("2031-12-03T10:15:30.123456789+01:00:00[EST]"));
+    }
+
     public void testRoundupFormatterWithEpochDates() {
         assertRoundupFormatter("epoch_millis", "1234567890", 1234567890L);
         // also check nanos of the epoch_millis formatter if it is rounded up to the nano second


### PR DESCRIPTION
We can now parse [RFC 9557](https://www.rfc-editor.org/rfc/rfc9557.html#name-examples) ISO date-time such as :

We can now parse ISO date-time such as :

2029-05-15T17:14:56.123456789-08:00[America/Los_Angeles]

or

2031-12-03T10:15:30.123456789+01:00:00[Europe/Paris]

or with "short-id" (like `NST` for `Pacific/Auckland`)

2025-06-26T12:01:48.211+12:00[NST]