### PR TITLE
Mute GeoIpMultiProjectIT test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -578,6 +578,8 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/130067
+- class: geoip.GeoIpMultiProjectIT
+  issue: https://github.com/elastic/elasticsearch/issues/130073
 
 # Examples:
 #


### PR DESCRIPTION
Muting GeoIpMultiProjectIT that is consistently failing on release tests

see https://github.com/elastic/elasticsearch/issues/130073