### PR TITLE
Use ES_VERSION to resolve manifest for ML

### DIFF
--- a/.ci/scripts/resolve-dra-manifest.sh
+++ b/.ci/scripts/resolve-dra-manifest.sh
@@ -16,7 +16,7 @@ BRANCH="${BRANCH:-$2}"
 ES_VERSION="${ES_VERSION:-$3}"
 WORKFLOW=${WORKFLOW:-$4}
 
-LATEST_BUILD=$(fetch_build $WORKFLOW $ARTIFACT $BRANCH)
+LATEST_BUILD=$(fetch_build $WORKFLOW $ARTIFACT $ES_VERSION)
 
 # Commented out because there's only one 7.17 branch now
 # LATEST_VERSION=$(strip_version $LATEST_BUILD)


### PR DESCRIPTION
Previously BRANCH was used, but if there is newer version of the ml-cpp then incorrect version could be used.

Fixing now on 7.17 to unblock DRA. I will also introduce that change on other branches later.