### PR TITLE
[9.0] Include mapper extras yaml tests into mixed cluster qa module. (#130023)

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -23,6 +23,7 @@ apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   restTestConfig project(path: ':modules:aggregations', configuration: 'restTests')
+  restTestConfig project(path: ':modules:mapper-extras', configuration: 'restTests')
 }
 
 restResources {


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Include mapper extras yaml tests into mixed cluster qa module. (#130023)