### PR TITLE
Use ES_VERSION to resolve manifest for ML and Beats

### DIFF
--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -35,10 +35,10 @@ if [[ -n "${VERSION_QUALIFIER:-}" ]]; then
   echo "Version qualifier specified. ES_VERSION=${ES_VERSION}."
 fi
 
-BEATS_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh beats "$RM_BRANCH" "$ES_VERSION" "$WORKFLOW")"
+BEATS_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh beats "$ES_VERSION" "$WORKFLOW")"
 echo "BEATS_BUILD_ID=$BEATS_BUILD_ID"
 
-ML_CPP_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh ml-cpp "$RM_BRANCH" "$ES_VERSION" "$WORKFLOW")"
+ML_CPP_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh ml-cpp "$ES_VERSION" "$WORKFLOW")"
 echo "ML_CPP_BUILD_ID=$ML_CPP_BUILD_ID"
 
 LICENSE_KEY_ARG=""

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -35,10 +35,10 @@ if [[ -n "${VERSION_QUALIFIER:-}" ]]; then
   echo "Version qualifier specified. ES_VERSION=${ES_VERSION}."
 fi
 
-BEATS_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh beats "$ES_VERSION" "$WORKFLOW")"
+BEATS_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh beats "$RM_BRANCH" "$ES_VERSION" "$WORKFLOW")"
 echo "BEATS_BUILD_ID=$BEATS_BUILD_ID"
 
-ML_CPP_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh ml-cpp "$ES_VERSION" "$WORKFLOW")"
+ML_CPP_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh ml-cpp "$RM_BRANCH" "$ES_VERSION" "$WORKFLOW")"
 echo "ML_CPP_BUILD_ID=$ML_CPP_BUILD_ID"
 
 LICENSE_KEY_ARG=""

--- a/.ci/scripts/resolve-dra-manifest.sh
+++ b/.ci/scripts/resolve-dra-manifest.sh
@@ -11,21 +11,14 @@ fetch_build() {
 }
 
 ARTIFACT="${ARTIFACT:-$1}"
-BRANCH="${BRANCH:-$2}"
-ES_VERSION="${ES_VERSION:-$3}"
-WORKFLOW=${WORKFLOW:-$4}
+ES_VERSION="${ES_VERSION:-$2}"
+WORKFLOW=${WORKFLOW:-$3}
 
-LATEST_BUILD=$(fetch_build $WORKFLOW $ARTIFACT $BRANCH)
+LATEST_BUILD=$(fetch_build $WORKFLOW $ARTIFACT $ES_VERSION)
 LATEST_VERSION=$(strip_version $LATEST_BUILD)
 
-# If the latest artifact version doesn't match what we expect, try the corresponding version branch.
-# This can happen when the version of artifact has been bumped on the master branch.
 if [ "$LATEST_VERSION" != "$ES_VERSION" ]; then
-  echo "Latest build for '$ARTIFACT' is version $LATEST_VERSION but expected version $ES_VERSION." 1>&2
-  NEW_BRANCH=$(echo $ES_VERSION | sed -E "s/([0-9]+\.[0-9]+)\.[0-9]/\1/g")
-
-  echo "Using branch $NEW_BRANCH instead of $BRANCH." 1>&2
-  LATEST_BUILD=$(fetch_build $WORKFLOW $ARTIFACT $NEW_BRANCH)
+  echo "warning: Latest build for '$ARTIFACT' is version $LATEST_VERSION but expected version $ES_VERSION."
 fi
 
 echo $LATEST_BUILD

--- a/.ci/scripts/resolve-dra-manifest.sh
+++ b/.ci/scripts/resolve-dra-manifest.sh
@@ -16,9 +16,9 @@ BRANCH="${BRANCH:-$2}"
 ES_VERSION="${ES_VERSION:-$3}"
 WORKFLOW=${WORKFLOW:-$4}
 
-if [[ "$WORKFLOW" == "staging" ]]
+if [[ "$WORKFLOW" == "staging" ]]; then
   LATEST_BUILD=$(fetch_build $WORKFLOW $ARTIFACT $ES_VERSION)
-elif [[ "$WORKFLOW" == "snapshot" ]]
+elif [[ "$WORKFLOW" == "snapshot" ]]; then
   LATEST_BUILD=$(fetch_build $WORKFLOW $ARTIFACT $BRANCH)
 else
   echo "Unknown workflow: $WORKFLOW"

--- a/.ci/scripts/resolve-dra-manifest.sh
+++ b/.ci/scripts/resolve-dra-manifest.sh
@@ -6,7 +6,8 @@ strip_version() {
 }
 
 fetch_build() {
-  curl -sS https://artifacts-$1.elastic.co/$2/latest/$3.json \
+  >&2 echo "Checking for build id: https://artifacts-$1.elastic.co/$2/latest/$3.json"
+  curl -sSf https://artifacts-$1.elastic.co/$2/latest/$3.json \
     | jq -r '.build_id'
 }
 


### PR DESCRIPTION
Previously BRANCH was used in all cases, but if there is a newer version of the dependency, the incorrect version could be used. BRANCH is still used for snapshot DRA builds because full version is not available in artifacts-snapshot API.

Additionally, added log what URL is used to fetch manifest and make the curl command fail in  case of error like 404 response.