### PR TITLE
ESQL: Mute only dense vector tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -567,8 +567,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.qa.mixed.CohereServiceMixedIT
   method: testCohereEmbeddings
   issue: https://github.com/elastic/elasticsearch/issues/130010
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/128224
 - class: org.elasticsearch.xpack.autoscaling.storage.ReactiveStorageIT
   method: testScaleDuringSplitOrClone
   issue: https://github.com/elastic/elasticsearch/issues/130044

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -212,7 +212,8 @@ public class CsvTestsDataLoader {
         Map.entry(SEMANTIC_TEXT.indexName, SEMANTIC_TEXT),
         Map.entry(LOGS.indexName, LOGS),
         Map.entry(MV_TEXT.indexName, MV_TEXT),
-        Map.entry(DENSE_VECTOR.indexName, DENSE_VECTOR),
+        // Awaitsfix: https://github.com/elastic/elasticsearch/issues/130085
+        // Map.entry(DENSE_VECTOR.indexName, DENSE_VECTOR),
         Map.entry(COLORS.indexName, COLORS)
     );
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dense_vector.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dense_vector.csv-spec
@@ -1,6 +1,8 @@
-
+# All tests skipped for now due to issues in bwc tests
+# https://github.com/elastic/elasticsearch/issues/130085
 retrieveDenseVectorData
 required_capability: dense_vector_field_type
+required_capability: awaitsfix
 
 FROM dense_vector
 | KEEP id, vector
@@ -16,6 +18,7 @@ id:l | vector:dense_vector
 
 denseVectorWithEval
 required_capability: dense_vector_field_type
+required_capability: awaitsfix
 
 FROM dense_vector
 | EVAL v = vector
@@ -32,6 +35,7 @@ id:l | v:dense_vector
 
 denseVectorWithRenameAndDrop
 required_capability: dense_vector_field_type
+required_capability: awaitsfix
 
 FROM dense_vector 
 | EVAL v = vector 


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/130085

The `dense_vector` dataset started acting up in 9.1->9.0 bwc tests. Let's skip the corresponding dataset whose index failed to be created in the tests.