### PR TITLE
[9.0] [ML] Fix timeout bug in DBQ deletion of unused and orphan ML data (#130083)

### DIFF
--- a/docs/changelog/130083.yaml
+++ b/docs/changelog/130083.yaml
@@ -1,0 +1,5 @@
+pr: 130083
+summary: Fix timeout bug in DBQ deletion of unused and orphan ML data
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [ML] Fix timeout bug in DBQ deletion of unused and orphan ML data (#130083)