### PR TITLE
[9.0] Add inference YAML tests to rest-resources-zip (#130070)

### DIFF
--- a/x-pack/plugin/inference/build.gradle
+++ b/x-pack/plugin/inference/build.gradle
@@ -404,3 +404,6 @@ tasks.named('yamlRestTest') {
   usesDefaultDistribution()
 }
 
+artifacts {
+  restXpackTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
+}

--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   platinumTests project(path: ':x-pack:plugin', configuration: 'restXpackTests')
   platinumTests project(path: ':x-pack:plugin:eql:qa:rest', configuration: 'restXpackTests')
   platinumTests project(path: ':x-pack:plugin:ent-search', configuration: 'restXpackTests')
+  platinumTests project(path: ':x-pack:plugin:inference', configuration: 'restXpackTests')
   platinumCompatTests project(path: ':x-pack:plugin', configuration: 'restCompatTests')
   platinumCompatTests project(path: ':x-pack:plugin:eql:qa:rest', configuration: 'restCompatTests')
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Add inference YAML tests to rest-resources-zip (#130070)](https://github.com/elastic/elasticsearch/pull/130070)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)