### PR TITLE
Removed unnecessary character from the kNN query documentation

### DIFF
--- a/docs/reference/query-languages/query-dsl/query-dsl-knn-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-knn-query.md
@@ -165,7 +165,6 @@ POST my-image-index/_search
 
 Knn query can be used as a part of hybrid search, where knn query is combined with other lexical queries. For example, the query below finds documents with `title` matching `mountain lake`, and combines them with the top 10 documents that have the closest image vectors to the `query_vector`. The combined documents are then scored and the top 3 top scored documents are returned.
 
-+
 
 ```console
 POST my-image-index/_search


### PR DESCRIPTION
Hi, while reading the [kNN query documentation](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-knn-query), I found this + character that I think shouldn't be there.

![knn_query_docs](https://github.com/user-attachments/assets/c1aa386f-c3aa-4dbe-a036-5386c2f6390c)
