### PR TITLE
Fail startup if entitlement instrumentation failed (#130051)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
@@ -122,7 +122,12 @@ public class EntitlementBootstrap {
             suppressFailureLogPackages
         );
         exportInitializationToAgent();
+
         loadAgent(findAgentJar());
+
+        if (EntitlementInitialization.getError() != null) {
+            throw EntitlementInitialization.getError();
+        }
     }
 
     private static Path getUserHome() {

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/DynamicInstrumentation.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/DynamicInstrumentation.java
@@ -119,6 +119,10 @@ class DynamicInstrumentation {
             // We should have failed already in the loop above, but just in case we did not, rethrow.
             throw e;
         }
+
+        if (transformer.hadErrors()) {
+            throw new RuntimeException("Failed to transform JDK classes for entitlements");
+        }
     }
 
     private static Map<MethodKey, CheckMethod> getMethodsToInstrument(Class<?> checkerInterface) throws ClassNotFoundException,

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -75,7 +75,7 @@ public class EntitlementInitialization {
     public static void initialize(Instrumentation inst) {
         try {
             manager = initChecker();
-            
+
             var verifyBytecode = Booleans.parseBoolean(System.getProperty("es.entitlements.verify_bytecode", "false"));
             if (verifyBytecode) {
                 ensureClassesSensitiveToVerificationAreInitialized();

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/Transformer.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/Transformer.java
@@ -9,16 +9,22 @@
 
 package org.elasticsearch.entitlement.instrumentation;
 
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+
 import java.lang.instrument.ClassFileTransformer;
 import java.security.ProtectionDomain;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A {@link ClassFileTransformer} that applies an {@link Instrumenter} to the appropriate classes.
  */
 public class Transformer implements ClassFileTransformer {
+    private static final Logger logger = LogManager.getLogger(Transformer.class);
     private final Instrumenter instrumenter;
     private final Set<String> classesToTransform;
+    private final AtomicBoolean hadErrors = new AtomicBoolean(false);
 
     private boolean verifyClasses;
 
@@ -33,6 +39,10 @@ public class Transformer implements ClassFileTransformer {
         this.verifyClasses = true;
     }
 
+    public boolean hadErrors() {
+        return hadErrors.get();
+    }
+
     @Override
     public byte[] transform(
         ClassLoader loader,
@@ -42,13 +52,19 @@ public class Transformer implements ClassFileTransformer {
         byte[] classfileBuffer
     ) {
         if (classesToTransform.contains(className)) {
-            // System.out.println("Transforming " + className);
-            return instrumenter.instrumentClass(className, classfileBuffer, verifyClasses);
+            logger.debug("Transforming " + className);
+            try {
+                return instrumenter.instrumentClass(className, classfileBuffer, verifyClasses);
+            } catch (Throwable t) {
+                hadErrors.set(true);
+                logger.error("Failed to instrument class " + className, t);
+                // throwing an exception from a transformer results in the exception being swallowed,
+                // effectively the same as returning null anyways, so we instead log it here completely
+                return null;
+            }
         } else {
-            // System.out.println("Not transforming " + className);
+            logger.trace("Not transforming " + className);
             return null;
         }
     }
-
-    // private static final Logger LOGGER = LogManager.getLogger(Transformer.class);
 }


### PR DESCRIPTION
Java class transformers swallow exceptions, so any instrumentation failures, for example due to a java version mismatch, will silently proceed with startup, which then will cryptically fail the entitlement self test. This commit logs exceptions that occur during instrumentation, as well as plumb through the fact that any occured so that bootstrap can fail rather than allow startup to proceed.