### PR TITLE
[8.17] Avoid dropping aggregate groupings in local plans (#129370)

### DIFF
--- a/docs/changelog/129370.yaml
+++ b/docs/changelog/129370.yaml
@@ -1,0 +1,7 @@
+pr: 129370
+summary: Avoid dropping aggregate groupings in local plans
+area: ES|QL
+type: bug
+issues:
+ - 129811
+ - 128054

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -1454,6 +1454,39 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         }
     }
 
+    public void testGroupingStatsOnMissingFields() {
+        assertAcked(client().admin().indices().prepareCreate("missing_field_index").setMapping("data", "type=long"));
+        long oneValue = between(1, 1000);
+        indexDoc("missing_field_index", "1", "data", oneValue);
+        refresh("missing_field_index");
+        QueryPragmas pragmas = randomPragmas();
+        pragmas = new QueryPragmas(
+            Settings.builder().put(pragmas.getSettings()).put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()
+        );
+        EsqlQueryRequest request = new EsqlQueryRequest();
+        request.query("FROM missing_field_index,test | STATS s = sum(data) BY color, tag | SORT color");
+        request.pragmas(pragmas);
+        try (var r = run(request)) {
+            var rows = getValuesList(r);
+            assertThat(rows, hasSize(4));
+            for (List<Object> row : rows) {
+                assertThat(row, hasSize(3));
+            }
+            assertThat(rows.get(0).get(0), equalTo(20L));
+            assertThat(rows.get(0).get(1), equalTo("blue"));
+            assertNull(rows.get(0).get(2));
+            assertThat(rows.get(1).get(0), equalTo(10L));
+            assertThat(rows.get(1).get(1), equalTo("green"));
+            assertNull(rows.get(1).get(2));
+            assertThat(rows.get(2).get(0), equalTo(30L));
+            assertThat(rows.get(2).get(1), equalTo("red"));
+            assertNull(rows.get(2).get(2));
+            assertThat(rows.get(3).get(0), equalTo(oneValue));
+            assertNull(rows.get(3).get(1));
+            assertNull(rows.get(3).get(2));
+        }
+    }
+
     private void assertEmptyIndexQueries(String from) {
         try (EsqlQueryResponse resp = run(from + "METADATA _source | KEEP _source | LIMIT 1")) {
             assertFalse(resp.values().hasNext());
@@ -1588,6 +1621,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
                     "time",
                     "type=long",
                     "color",
+                    "type=keyword",
+                    "tag",
                     "type=keyword"
                 )
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
@@ -29,7 +29,8 @@ import static org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer.operat
  * This class is part of the planner. Data node level logical optimizations.  At this point we have access to
  * {@link org.elasticsearch.xpack.esql.stats.SearchStats} which provides access to metadata about the index.
  *
- * <p>NB: This class also reapplies all the rules from {@link LogicalPlanOptimizer#operators()} and {@link LogicalPlanOptimizer#cleanup()}
+ * <p>NB: This class also reapplies all the rules from {@link LogicalPlanOptimizer#operators(boolean)}
+ * and {@link LogicalPlanOptimizer#cleanup()}
  */
 public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan, LocalLogicalOptimizerContext> {
 
@@ -51,7 +52,7 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
         var rules = new ArrayList<Batch<LogicalPlan>>();
         rules.add(local);
         // TODO: if the local rules haven't touched the tree, the rest of the rules can be skipped
-        rules.addAll(asList(operators(), cleanup()));
+        rules.addAll(asList(operators(true), cleanup()));
         return replaceRules(rules);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
@@ -15,18 +15,26 @@ import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.expression.function.grouping.Categorize;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public final class CombineProjections extends OptimizerRules.OptimizerRule<UnaryPlan> {
+    // don't drop groupings from a local plan, as the layout has already been agreed upon
+    private final boolean local;
 
-    public CombineProjections() {
+    public CombineProjections(boolean local) {
         super(OptimizerRules.TransformDirection.UP);
+        this.local = local;
     }
 
     @Override
@@ -57,26 +65,89 @@ public final class CombineProjections extends OptimizerRules.OptimizerRule<Unary
             return plan;
         }
 
-        // Agg with underlying Project (group by on sub-queries)
-        if (plan instanceof Aggregate a) {
-            if (child instanceof Project p) {
-                var groupings = a.groupings();
-                List<Attribute> groupingAttrs = new ArrayList<>(a.groupings().size());
-                for (Expression grouping : groupings) {
-                    if (grouping instanceof Attribute attribute) {
-                        groupingAttrs.add(attribute);
+        if (plan instanceof Aggregate a && child instanceof Project p) {
+            var groupings = a.groupings();
+
+            // sanity checks
+            for (Expression grouping : groupings) {
+                if ((grouping instanceof Attribute || grouping instanceof Alias as && as.child() instanceof Categorize) == false) {
+                    // After applying ReplaceAggregateNestedExpressionWithEval,
+                    // evaluatable groupings can only contain attributes.
+                    throw new EsqlIllegalArgumentException("Expected an attribute or grouping function, got {}", grouping);
+                }
+            }
+            assert groupings.size() <= 1
+                || groupings.stream().anyMatch(group -> group.anyMatch(expr -> expr instanceof Categorize)) == false
+                : "CombineProjections only tested with a single CATEGORIZE with no additional groups";
+
+            // Collect the alias map for resolving the source (f1 = 1, f2 = f1, etc..)
+            AttributeMap.Builder<Attribute> aliasesBuilder = AttributeMap.builder();
+            for (NamedExpression ne : p.projections()) {
+                // Record the aliases.
+                // Projections are just aliases for attributes, so casting is safe.
+                aliasesBuilder.put(ne.toAttribute(), (Attribute) Alias.unwrap(ne));
+            }
+            var aliases = aliasesBuilder.build();
+
+            // Propagate any renames from the lower projection into the upper groupings.
+            List<Expression> resolvedGroupings = new ArrayList<>();
+            for (Expression grouping : groupings) {
+                Expression transformed = grouping.transformUp(Attribute.class, as -> aliases.resolve(as, as));
+                resolvedGroupings.add(transformed);
+            }
+
+            // This can lead to duplicates in the groupings: e.g.
+            // | EVAL x = y | STATS ... BY x, y
+            if (local) {
+                // On the data node, the groupings must be preserved because they affect the physical output (see
+                // AbstractPhysicalOperationProviders#intermediateAttributes).
+                // In case that propagating the lower projection leads to duplicates in the resolved groupings, we'll leave an Eval in place
+                // of the original projection to create new attributes for the duplicate groups.
+                Set<Expression> seenResolvedGroupings = new HashSet<>(resolvedGroupings.size());
+                List<Expression> newGroupings = new ArrayList<>();
+                List<Alias> aliasesAgainstDuplication = new ArrayList<>();
+
+                for (int i = 0; i < groupings.size(); i++) {
+                    Expression resolvedGrouping = resolvedGroupings.get(i);
+                    if (seenResolvedGroupings.add(resolvedGrouping)) {
+                        newGroupings.add(resolvedGrouping);
                     } else {
-                        // After applying ReplaceAggregateNestedExpressionWithEval, groupings can only contain attributes.
-                        throw new EsqlIllegalArgumentException("Expected an Attribute, got {}", grouping);
+                        // resolving the renames leads to a duplicate here - we need to alias the underlying attribute this refers to.
+                        // should really only be 1 attribute, anyway, but going via .references() includes the case of a
+                        // GroupingFunction.NonEvaluatableGroupingFunction.
+                        Attribute coreAttribute = resolvedGrouping.references().iterator().next();
+
+                        Alias renameAgainstDuplication = new Alias(
+                            coreAttribute.source(),
+                            TemporaryNameUtils.locallyUniqueTemporaryName(coreAttribute.name(), "temp_name"),
+                            coreAttribute
+                        );
+                        aliasesAgainstDuplication.add(renameAgainstDuplication);
+
+                        // propagate the new alias into the new grouping
+                        AttributeMap.Builder<Attribute> resolverBuilder = AttributeMap.builder();
+                        resolverBuilder.put(coreAttribute, renameAgainstDuplication.toAttribute());
+                        AttributeMap<Attribute> resolver = resolverBuilder.build();
+
+                        newGroupings.add(resolvedGrouping.transformUp(Attribute.class, attr -> resolver.resolve(attr, attr)));
                     }
                 }
-                plan = new Aggregate(
-                    a.source(),
-                    p.child(),
-                    a.aggregateType(),
-                    combineUpperGroupingsAndLowerProjections(groupingAttrs, p.projections()),
-                    combineProjections(a.aggregates(), p.projections())
-                );
+
+                LogicalPlan newChild = aliasesAgainstDuplication.isEmpty()
+                    ? p.child()
+                    : new Eval(p.source(), p.child(), aliasesAgainstDuplication);
+                plan = a.with(newChild, newGroupings, combineProjections(a.aggregates(), p.projections()));
+            } else {
+                // On the coordinator, we can just discard the duplicates.
+                // All substitutions happen before; groupings must be attributes at this point except for non-evaluatable groupings which
+                // will be an alias like `c = CATEGORIZE(attribute)`.
+                // Due to such aliases, we can't use an AttributeSet to deduplicate. But we can use a regular set to deduplicate based on
+                // regular equality (i.e. based on names) instead of name ids.
+                // TODO: The deduplication based on simple equality will be insufficient in case of multiple non-evaluatable groupings, e.g.
+                // for `| EVAL x = y | STATS ... BY CATEGORIZE(x), CATEGORIZE(y)`. That will require semantic equality instead. Also
+                // applies in the local case below.
+                List<Expression> newGroupings = new ArrayList<>(new LinkedHashSet<>(resolvedGroupings));
+                plan = a.with(p.child(), newGroupings, combineProjections(a.aggregates(), p.projections()));
             }
         }
 
@@ -134,26 +205,6 @@ public final class CombineProjections extends OptimizerRules.OptimizerRule<Unary
             replaced.add((NamedExpression) trimNonTopLevelAliases(replacedExp));
         }
         return replaced;
-    }
-
-    private static List<Expression> combineUpperGroupingsAndLowerProjections(
-        List<? extends Attribute> upperGroupings,
-        List<? extends NamedExpression> lowerProjections
-    ) {
-        // Collect the alias map for resolving the source (f1 = 1, f2 = f1, etc..)
-        AttributeMap<Attribute> aliases = new AttributeMap<>();
-        for (NamedExpression ne : lowerProjections) {
-            // Projections are just aliases for attributes, so casting is safe.
-            aliases.put(ne.toAttribute(), (Attribute) Alias.unwrap(ne));
-        }
-
-        // Replace any matching attribute directly with the aliased attribute from the projection.
-        AttributeSet replaced = new AttributeSet();
-        for (Attribute attr : upperGroupings) {
-            // All substitutions happen before; groupings must be attributes at this point.
-            replaced.add(aliases.resolve(attr, attr));
-        }
-        return new ArrayList<>(replaced);
     }
 
     /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Avoid dropping aggregate groupings in local plans (#129370)](https://github.com/elastic/elasticsearch/pull/129370)