### PR TITLE
Tidy up project metadata fetching

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamSettingsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamSettingsAction.java
@@ -222,9 +222,7 @@ public class TransportUpdateDataStreamSettingsAction extends TransportMasterNode
         Map<String, Object> settingsToApply = new HashMap<>();
         List<String> appliedToDataStreamOnly = new ArrayList<>();
         List<String> appliedToDataStreamAndBackingIndices = new ArrayList<>();
-        Settings effectiveSettings = dataStream.getEffectiveSettings(
-            clusterService.state().projectState(projectResolver.getProjectId()).metadata()
-        );
+        Settings effectiveSettings = dataStream.getEffectiveSettings(projectResolver.getProjectMetadata(clusterService.state()));
         for (String settingName : requestSettings.keySet()) {
             if (APPLY_TO_BACKING_INDICES.contains(settingName)) {
                 settingsToApply.put(settingName, effectiveSettings.get(settingName));

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/EnterpriseGeoIpTaskState.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/EnterpriseGeoIpTaskState.java
@@ -151,7 +151,7 @@ class EnterpriseGeoIpTaskState implements PersistentTaskState, VersionedNamedWri
     @FixForMultiProject(description = "Replace ProjectId.DEFAULT")
     static EnterpriseGeoIpTaskState getEnterpriseGeoIpTaskState(ClusterState state) {
         PersistentTasksCustomMetadata.PersistentTask<?> task = getTaskWithId(
-            state.projectState(ProjectId.DEFAULT).metadata(),
+            state.metadata().getProject(ProjectId.DEFAULT),
             EnterpriseGeoIpTask.ENTERPRISE_GEOIP_DOWNLOADER
         );
         return (task == null) ? null : (EnterpriseGeoIpTaskState) task.getState();

--- a/modules/streams/src/main/java/org/elasticsearch/rest/streams/logs/TransportLogsStreamsToggleActivation.java
+++ b/modules/streams/src/main/java/org/elasticsearch/rest/streams/logs/TransportLogsStreamsToggleActivation.java
@@ -77,7 +77,7 @@ public class TransportLogsStreamsToggleActivation extends AcknowledgedTransportM
         ActionListener<AcknowledgedResponse> listener
     ) throws Exception {
         ProjectId projectId = projectResolver.getProjectId();
-        StreamsMetadata streamsState = state.projectState(projectId).metadata().custom(StreamsMetadata.TYPE, StreamsMetadata.EMPTY);
+        StreamsMetadata streamsState = state.metadata().getProject(projectId).custom(StreamsMetadata.TYPE, StreamsMetadata.EMPTY);
         boolean currentlyEnabled = streamsState.isLogsEnabled();
         boolean shouldEnable = request.shouldEnable();
         if (shouldEnable != currentlyEnabled) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -215,7 +215,7 @@ public class IndexNameExpressionResolver {
      * indices options in the context don't allow such a case; if a remote index is requested.
      */
     public String[] concreteIndexNames(ClusterState state, IndicesOptions options, String... indexExpressions) {
-        return concreteIndexNames(state.metadata().getProject(projectResolver.getProjectId()), options, indexExpressions);
+        return concreteIndexNames(projectResolver.getProjectMetadata(state), options, indexExpressions);
     }
 
     /**
@@ -243,12 +243,7 @@ public class IndexNameExpressionResolver {
     }
 
     public String[] concreteIndexNames(ClusterState state, IndicesOptions options, boolean includeDataStreams, String... indexExpressions) {
-        return concreteIndexNames(
-            state.metadata().getProject(projectResolver.getProjectId()),
-            options,
-            includeDataStreams,
-            indexExpressions
-        );
+        return concreteIndexNames(projectResolver.getProjectMetadata(state), options, includeDataStreams, indexExpressions);
     }
 
     public String[] concreteIndexNames(
@@ -271,7 +266,7 @@ public class IndexNameExpressionResolver {
     }
 
     public String[] concreteIndexNames(ClusterState state, IndicesOptions options, IndicesRequest request) {
-        return concreteIndexNames(state.metadata().getProject(projectResolver.getProjectId()), options, request);
+        return concreteIndexNames(projectResolver.getProjectMetadata(state), options, request);
     }
 
     public String[] concreteIndexNames(ProjectMetadata project, IndicesOptions options, IndicesRequest request) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsService.java
@@ -127,7 +127,7 @@ public class MetadataDataStreamsService {
                     ClusterState.builder(clusterState)
                         .putProjectMetadata(
                             updateDataStreamOptions(
-                                clusterState.projectState(modifyOptionsTask.projectId).metadata(),
+                                clusterState.metadata().getProject(modifyOptionsTask.projectId),
                                 modifyOptionsTask.getDataStreamNames(),
                                 modifyOptionsTask.getOptions()
                             )
@@ -739,7 +739,7 @@ public class MetadataDataStreamsService {
         ) {
             super(ackTimeout, listener.safeMap(response -> {
                 if (response.isAcknowledged()) {
-                    return clusterService.state().projectState(projectId).metadata().dataStreams().get(dataStreamName);
+                    return clusterService.state().metadata().getProject(projectId).dataStreams().get(dataStreamName);
                 } else {
                     throw new ElasticsearchException("Updating settings not accepted for unknown reasons");
                 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -649,12 +649,12 @@ public class MetadataRolloverServiceTests extends ESTestCase {
             );
             long after = testThreadPool.absoluteTimeInMillis();
             Settings rolledOverIndexSettings = rolloverResult.clusterState()
-                .projectState(projectId)
                 .metadata()
+                .getProject(projectId)
                 .index(rolloverResult.rolloverIndexName())
                 .getSettings();
             Set<String> rolledOverIndexSettingNames = rolledOverIndexSettings.keySet();
-            for (String settingName : dataStream.getEffectiveSettings(clusterState.projectState(projectId).metadata()).keySet()) {
+            for (String settingName : dataStream.getEffectiveSettings(clusterState.metadata().getProject(projectId)).keySet()) {
                 assertTrue(rolledOverIndexSettingNames.contains(settingName));
             }
             String newIndexName = rolloverResult.rolloverIndexName();


### PR DESCRIPTION
This is just a search and replace for some places where we can avoid allocating a `ProjectState` or can lean more heavily on different methods to conserve precious characters. As far as I'm aware there shouldn't be any change in behavior, but if I'm wrong about that then I guess I'll learn something.