### PR TITLE
[CI] [9.1] Fix ThreadPoolMergeSchedulerTests testSchedulerCloseWaitsForRunningMerge

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -281,9 +281,6 @@ tests:
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/122707
-- class: org.elasticsearch.index.engine.ThreadPoolMergeSchedulerTests
-  method: testSchedulerCloseWaitsForRunningMerge
-  issue: https://github.com/elastic/elasticsearch/issues/125236
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test020PluginsListWithNoPlugins
   issue: https://github.com/elastic/elasticsearch/issues/126232

--- a/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeSchedulerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeSchedulerTests.java
@@ -612,11 +612,12 @@ public class ThreadPoolMergeSchedulerTests extends ESTestCase {
                         fail(e);
                     }
                 });
+                // test expects that there definitely is a running merge before closing the merge scheduler
+                mergeRunningLatch.await();
+                // closes the merge scheduler
                 t.start();
                 try {
                     assertTrue(t.isAlive());
-                    // wait for the merge to actually run
-                    mergeRunningLatch.await();
                     // ensure the merge scheduler is effectively "closed"
                     assertBusy(() -> {
                         MergeSource mergeSource2 = mock(MergeSource.class);


### PR DESCRIPTION
This fixes a race condition in the test scenario, between the merge scheduler closing and the merge task being scheduled to run. The test scenario expects that the merge task runs when the scheduler is closed. If the merge scheduler is closed before the merge task is scheduled, the merge task will instead be scheduled as aborted.

Backport of https://github.com/elastic/elasticsearch/pull/130078
Fixes: https://github.com/elastic/elasticsearch/issues/125236