### PR TITLE
[9.1] [ES|QL] Fix mapping for the colors & dense vector CSV datasets (failing bwc tests) (#130090)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -561,8 +561,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.qa.mixed.CohereServiceMixedIT
   method: testCohereEmbeddings
   issue: https://github.com/elastic/elasticsearch/issues/130010
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/128224
 - class: org.elasticsearch.cluster.metadata.ComposableIndexTemplateTests
   method: testMergeEmptyMappingsIntoTemplateWithNonEmptySettings
   issue: https://github.com/elastic/elasticsearch/issues/130050

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-colors.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-colors.json
@@ -13,7 +13,9 @@
       "type": "dense_vector",
       "similarity": "l2_norm",
       "index_options": {
-        "type": "hnsw"
+        "type": "hnsw",
+        "m": 16,
+        "ef_construction": 100
       }
     }
   }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-dense_vector.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mapping-dense_vector.json
@@ -5,7 +5,12 @@
     },
     "vector": {
       "type": "dense_vector",
-      "similarity": "l2_norm"
+      "similarity": "l2_norm",
+      "index_options": {
+        "type": "hnsw",
+        "m": 16,
+        "ef_construction": 100
+      }
     }
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ES|QL] Fix mapping for the colors & dense vector CSV datasets (failing bwc tests) (#130090)](https://github.com/elastic/elasticsearch/pull/130090)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)