### PR TITLE
Mute PatternedTextFieldMapperTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -569,6 +569,8 @@ tests:
 - class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
   method: testManyInitialManyPartialFinalRunnerThrowing
   issue: https://github.com/elastic/elasticsearch/issues/130145
+- class: org.elasticsearch.xpack.logsdb.patternedtext.PatternedTextFieldMapperTests
+  issue: https://github.com/elastic/elasticsearch/issues/130162
 
 # Examples:
 #


### PR DESCRIPTION
Consistently failing in release tests

See https://github.com/elastic/elasticsearch/issues/130162