### PR TITLE
[8.18] Fix EsqlActionIT.testGroupingStatsOnMissingFields in release tests (#130177)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -1477,6 +1477,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testGroupingStatsOnMissingFields() {
+        assumeTrue("Pragmas are only allowed in snapshots", Build.current().isSnapshot());
         assertAcked(client().admin().indices().prepareCreate("missing_field_index").setMapping("data", "type=long"));
         long oneValue = between(1, 1000);
         indexDoc("missing_field_index", "1", "data", oneValue);


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix EsqlActionIT.testGroupingStatsOnMissingFields in release tests (#130177)