### PR TITLE
[8.19] Docs: Add knn query example over semantic_text 

### DIFF
--- a/docs/reference/query-dsl/knn-query.asciidoc
+++ b/docs/reference/query-dsl/knn-query.asciidoc
@@ -274,6 +274,36 @@ A sample query can look like below:
 ----
 // NOTCONSOLE
 
+[[knn-query-with-semantic-text]]
+==== Knn query on a semantic_text field
+
+Elasticsearch supports `knn` query over a <<semantic-text, semantic_text>> field.
+
+Here is an example using the `query_vector_builder`:
+
+[source,js]
+----
+{
+  "query": {
+    "knn": {
+      "field": "inference_field",
+      "k": 10,
+      "num_candidates": 100,
+      "query_vector_builder": {
+        "text_embedding": {
+          "model_text": "test"
+        }
+      }
+    }
+  }
+}
+----
+// NOTCONSOLE
+
+Note that for `semantic_text` fields, the `model_id` does not have to be provided as it can be inferred from the `semantic_text` field mapping.
+
+Knn search using query vectors over `semantic_text` fields is also supported, with no change to the API.
+
 [[knn-query-aggregations]]
 ==== Knn query with aggregations
 `knn` query calculates aggregations on top `k` documents from each shard.


### PR DESCRIPTION
Applies the docs change in https://github.com/elastic/elasticsearch/pull/130135 to 8.19 