### PR TITLE
[9.1] Fix typo (#130195)

### DIFF
--- a/docs/reference/query-languages/query-dsl/query-dsl-knn-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-knn-query.md
@@ -249,9 +249,6 @@ Here is an example using the `query_vector_builder`:
         }
       }
     }
-  },
-  "_source": {
-    "exclude": "inference_field.inference.chunks"
   }
 }
 ```


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Fix typo (#130195)