### PR TITLE
Allow LimitOperator in Driver assertion

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
@@ -267,7 +267,7 @@ public class Driver implements Releasable, Describable {
 
             if (op.isFinished() == false && nextOp.needsInput()) {
                 driverContext.checkForEarlyTermination();
-                assert nextOp.isFinished() == false || nextOp instanceof ExchangeSinkOperator
+                assert nextOp.isFinished() == false || nextOp instanceof ExchangeSinkOperator || nextOp instanceof LimitOperator
                     : "next operator should not be finished yet: " + nextOp;
                 Page page = op.getOutput();
                 if (page == null) {


### PR DESCRIPTION
The LimitOperator can be finished early because the Limiter may be shared across operators. This PR relaxes the assertion to allow for this.

Closes #130228
Closes #130219