### PR TITLE
[9.0] Show entitlement jar path in agent load failure (#130233)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
@@ -143,7 +143,7 @@ public class EntitlementBootstrap {
                 vm.detach();
             }
         } catch (AttachNotSupportedException | IOException | AgentLoadException | AgentInitializationException e) {
-            throw new IllegalStateException("Unable to attach entitlement agent", e);
+            throw new IllegalStateException("Unable to attach entitlement agent [" + agentPath + "]", e);
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Show entitlement jar path in agent load failure (#130233)