### PR TITLE
Fixing multiproject handling in TransportUpdateDataStreamMappingsAction

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamMappingsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamMappingsAction.java
@@ -161,7 +161,7 @@ public class TransportUpdateDataStreamMappingsAction extends TransportMasterNode
                                 true,
                                 null,
                                 mappingsOverrides,
-                                dataStream.getEffectiveMappings(clusterService.state().projectState(projectId).metadata())
+                                dataStream.getEffectiveMappings(clusterService.state().metadata().getProject(projectId))
                             )
                         );
                     } catch (IOException e) {

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamMappingsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamMappingsAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetadataDataStreamsService;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -82,7 +83,7 @@ public class TransportUpdateDataStreamMappingsAction extends TransportMasterNode
         ActionListener<UpdateDataStreamMappingsAction.Response> listener
     ) throws Exception {
         List<String> dataStreamNames = indexNameExpressionResolver.dataStreamNames(
-            state.projectState(projectResolver.getProjectId()).metadata(),
+            projectResolver.getProjectMetadata(state),
             IndicesOptions.DEFAULT,
             request.indices()
         );
@@ -143,8 +144,9 @@ public class TransportUpdateDataStreamMappingsAction extends TransportMasterNode
             );
             return;
         }
+        ProjectId projectId = projectResolver.getProjectId();
         metadataDataStreamsService.updateMappings(
-            projectResolver.getProjectId(),
+            projectId,
             masterNodeTimeout,
             ackTimeout,
             dataStreamName,
@@ -159,9 +161,7 @@ public class TransportUpdateDataStreamMappingsAction extends TransportMasterNode
                                 true,
                                 null,
                                 mappingsOverrides,
-                                dataStream.getEffectiveMappings(
-                                    clusterService.state().projectState(projectResolver.getProjectId()).metadata()
-                                )
+                                dataStream.getEffectiveMappings(clusterService.state().projectState(projectId).metadata())
                             )
                         );
                     } catch (IOException e) {

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamMappingsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamMappingsAction.java
@@ -82,8 +82,9 @@ public class TransportUpdateDataStreamMappingsAction extends TransportMasterNode
         ClusterState state,
         ActionListener<UpdateDataStreamMappingsAction.Response> listener
     ) throws Exception {
+        ProjectId projectId = projectResolver.getProjectId();
         List<String> dataStreamNames = indexNameExpressionResolver.dataStreamNames(
-            projectResolver.getProjectMetadata(state),
+            state.metadata().getProject(projectId),
             IndicesOptions.DEFAULT,
             request.indices()
         );
@@ -99,6 +100,7 @@ public class TransportUpdateDataStreamMappingsAction extends TransportMasterNode
         countDownListener.onResponse(null);
         for (String dataStreamName : dataStreamNames) {
             updateSingleDataStream(
+                projectId,
                 dataStreamName,
                 request.getMappings(),
                 request.masterNodeTimeout(),
@@ -124,6 +126,7 @@ public class TransportUpdateDataStreamMappingsAction extends TransportMasterNode
     }
 
     private void updateSingleDataStream(
+        ProjectId projectId,
         String dataStreamName,
         CompressedXContent mappingsOverrides,
         TimeValue masterNodeTimeout,
@@ -144,7 +147,6 @@ public class TransportUpdateDataStreamMappingsAction extends TransportMasterNode
             );
             return;
         }
-        ProjectId projectId = projectResolver.getProjectId();
         metadataDataStreamsService.updateMappings(
             projectId,
             masterNodeTimeout,


### PR DESCRIPTION
This addresses a couple of bugs in multiproject handling that were raised here: https://github.com/elastic/elasticsearch/pull/130042#discussion_r2172111109