### PR TITLE
Fix typo in ILM retry action

### DIFF
--- a/docs/changelog/130255.yaml
+++ b/docs/changelog/130255.yaml
@@ -1,0 +1,5 @@
+pr: 130255
+summary: Fix typo in ILM retry action
+area: ILM+SLM
+type: bug
+issues: []

--- a/docs/changelog/130255.yaml
+++ b/docs/changelog/130255.yaml
@@ -1,5 +1,0 @@
-pr: 130255
-summary: Fix typo in ILM retry action
-area: ILM+SLM
-type: bug
-issues: []

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportRetryAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportRetryAction.java
@@ -80,7 +80,7 @@ public class TransportRetryAction extends TransportMasterNodeAction<RetryActionR
         submitUnbatchedTask("ilm-re-run", new AckedClusterStateUpdateTask(request, listener) {
             @Override
             public ClusterState execute(ClusterState currentState) {
-                final var project = state.metadata().getProject(projectState.projectId());
+                final var project = currentState.metadata().getProject(projectState.projectId());
                 final var updatedProject = indexLifecycleService.moveIndicesToPreviouslyFailedStep(project, request.indices());
                 return ClusterState.builder(currentState).putProjectMetadata(updatedProject).build();
             }


### PR DESCRIPTION
A change in #128930 introduced a typo which could result in erroneous cluster state updates.