### PR TITLE
(Doc) ILM Force Merge not on HDD and happens on hosting node not current phase tier

### DIFF
--- a/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
+++ b/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
@@ -15,11 +15,11 @@ To use the `forcemerge` action in the `hot` phase, the `rollover` action **must*
 :name: ilm-forcemerge-performance
 
 Force merge is a resource-intensive operation. If too many force merges are triggered at once, it can negatively impact your cluster. For example, this can happen when you 
-* modify an existing {{ilm-init}} policy's phase `min_age` such that indices trigger into force-merging phase faster.
+* modify an existing {{ilm-init}} policy's phase `min_age`, causing indices to trigger the force merge at a faster rate.
 * apply an {{ilm-init}} policy that includes a force merge action to existing indices. If the indices meet the `min_age` criteria, they can immediately proceed through multiple actions. You can prevent this by increasing the `min_age` or setting `index.lifecycle.origination_date` to change how the index age is calculated.
 * run the [{{ilm-init}} Move Step API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-move-to-step) against multiple indices.
 
-If you experience a force merge task queue backlog, you might need to increase the size of the force merge threadpool so indices can be force merged in parallel. To do this, configure the `thread_pool.force_merge.size` [cluster setting](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-get-settings). 
+If you experience a force merge task queue backlog, you might need to increase the size of the force merge threadpool so indices can be force merged in parallel. To do this, configure the `thread_pool.force_merge.size` [cluster setting](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-get-settings).
 
 ::::{important}
 Note that `thread_pool.force_merge.size` is an advanced setting. Adjusting it can cause cascading performance impacts. Monitor cluster performance and increment the size of the thread pool slowly to reduce the backlog.

--- a/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
+++ b/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
@@ -25,7 +25,7 @@ If you experience a force merge task queue backlog, you might need to increase t
 Note that `thread_pool.force_merge.size` is an advanced setting. Adjusting it can cause cascading performance impacts. Monitor cluster performance and increment the size of the thread pool slowly to reduce the backlog.
 ::::
 
-Force merging will be performed by the node hosting the shard. The [node's role](docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-settings.md#node-roles) frequently matches the [data tier](docs-content://manage-data/lifecycle/data-tiers.md) of the {{ilm-init}}'s phase of the index, but this is not guaranteed. For example: 
+Force merging will be performed by the node hosting the shard. The [node's role](docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-settings.md#node-roles) frequently matches the [data tier](docs-content://manage-data/lifecycle/data-tiers.md) of the {{ilm-init}}'s phase of the index, you may choose to adjust this behavior. For example: 
 * A force merge in the `hot` phase will use hot nodes. Merges may be faster on this potentially higher performance hardware but may have the tradeoff of impacting ingestion. 
 * A force merge in the `warm` phase will use warm nodes. Merges may take longer to perform on potentially lower performance hardware but will avoid impacting ingestion in the `hot` tier.
 * A force merge in the `cold` or `frozen` phase [{{ilm-init}} Searchable Snapshots](./ilm-searchable-snapshot.md) using `force_merge_index` happens on the preceeding data tier.

--- a/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
+++ b/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
@@ -25,7 +25,7 @@ If you experience a force merge task queue backlog, you might need to increase t
 Note that `thread_pool.force_merge.size` is an advanced setting. Adjusting it can cause cascading performance impacts. Monitor cluster performance and increment the size of the thread pool slowly to reduce the backlog.
 ::::
 
-Force merging will be performed by the node hosting the shard. The [node's role](docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-settings.md#node-roles) frequently matches the [data tier](docs-content://manage-data/lifecycle/data-tiers.md) of the {{ilm-init}}'s phase of the index, you may choose to adjust this behavior. For example: 
+Force merging will be performed by the node hosting the shard. The [node's role](docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles.md#set-node-roles) frequently matches the [data tier](docs-content://manage-data/lifecycle/data-tiers.md) of the {{ilm-init}}'s phase of the index, you may choose to adjust this behavior. For example: 
 * A force merge in the `hot` phase will use hot nodes. Merges may be faster on this potentially higher performance hardware but may have the tradeoff of impacting ingestion. 
 * A force merge in the `warm` phase will use warm nodes. Merges may take longer to perform on potentially lower performance hardware but will avoid impacting ingestion in the `hot` tier.
 * A force merge in the `cold` or `frozen` phase [{{ilm-init}} Searchable Snapshots](./ilm-searchable-snapshot.md) using `force_merge_index` happens on the preceeding data tier.

--- a/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
+++ b/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
@@ -28,7 +28,7 @@ Note that `thread_pool.force_merge.size` is an advanced setting. Adjusting it ca
 Force merging will be performed by the node hosting the shard. The [node's role](docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-settings.md#node-roles) frequently matches the [data tier](docs-content://manage-data/lifecycle/data-tiers.md) of the {{ilm-init}}'s phase of the index, but this is not guaranteed. For example: 
 * A force merge in the `hot` phase will use hot nodes. Merges may be faster on this potentially higher performance hardware but may have the tradeoff of impacting ingestion. 
 * A force merge in the `warm` phase will use warm nodes. Merges may take longer to perform on potentially lower performance hardware but will avoid impacting ingestion in the `hot` tier.
-* A force merge in the `cold` or `frozen` phase [{{ilm-init}} Searchable Snapshots](./ilm-searchable-snapshot) using `force_merge_index` happens on the preceeding data tier.
+* A force merge in the `cold` or `frozen` phase [{{ilm-init}} Searchable Snapshots](./ilm-searchable-snapshot.md) using `force_merge_index` happens on the preceeding data tier.
 
 We recommend that merges be targetted against SSD and not HDD disks.
 :::::

--- a/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
+++ b/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
@@ -7,7 +7,7 @@ mapped_pages:
 
 Phases allowed: hot, warm.
 
-[Force merges](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-forcemerge) the index into the specified maximum number of [segments](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-segments). This operation is best effort. For example, shards that are relocating during a `forcemerge` will not be merged.
+[Force merges](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-forcemerge) the index into the specified maximum number of [segments](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-segments). This operation is performed on a best effort basis. For example, shards that are relocating during a `forcemerge` will not be merged.
 
 To use the `forcemerge` action in the `hot` phase, the `rollover` action **must** be present. If no rollover action is configured, {{ilm-init}} will reject the policy.
 
@@ -16,15 +16,19 @@ To use the `forcemerge` action in the `hot` phase, the `rollover` action **must*
 
 Force merge is a resource-intensive operation. If too many force merges are triggered at once, it can negatively impact your cluster. For example, this can happen when you 
 * modify an existing {{ilm-init}} policy's phase `min_age` such that indices trigger into force-merging phase faster.
-* apply an {{ilm-init}} policy that includes a force merge action to existing indices. If they meet the `min_age` criteria, they can immediately proceed through multiple actions. You can prevent this by increasing the `min_age` or setting `index.lifecycle.origination_date` to change how the index age is calculated.
+* apply an {{ilm-init}} policy that includes a force merge action to existing indices. If the indices meet the `min_age` criteria, they can immediately proceed through multiple actions. You can prevent this by increasing the `min_age` or setting `index.lifecycle.origination_date` to change how the index age is calculated.
 * run the [{{ilm-init}} Move Step API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ilm-move-to-step) against multiple indices.
 
-If you experience a force merge task queue backlog, you might need to increase the size of the force merge threadpool so indices can be force merged in parallel. To do this, configure the `thread_pool.force_merge.size` [cluster setting](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-get-settings). This is considered an expert setting override as this can have cascading performance impacts. Monitor cluster performance and increment the size of the thread pool slowly to reduce the backlog.
+If you experience a force merge task queue backlog, you might need to increase the size of the force merge threadpool so indices can be force merged in parallel. To do this, configure the `thread_pool.force_merge.size` [cluster setting](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-get-settings). 
 
-Force merging will be performed by the node hosting the shard. The [node's role](https://www.elastic.co/docs/deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles#data-node-role) frequently is equal to the [data tier](https://www.elastic.co/docs/manage-data/lifecycle/data-tiers) of the {{ilm-init}}'s phase of the index, but this is not guaranteed. For example, a forcemerge in the 
-* `hot` phase will use hot nodes; however, performing merges on this potentially higher performance hardware may have a trade off of impacting ingestion. 
-* `warm` phase will use warm nodes; however, merges may potentially take longer to perform on less performant hardware but will avoid impacting ingestion in the `hot` tier.
-* `cold` or `frozen` phase [{{ilm-init}} Searchable Snapshots](https://www.elastic.co/docs/reference/elasticsearch/index-lifecycle-actions/ilm-searchable-snapshot) via `force_merge_index` happens on the preceeding data tier.
+::::{important}
+Note that `thread_pool.force_merge.size` is an advanced setting. Adjusting it can cause cascading performance impacts. Monitor cluster performance and increment the size of the thread pool slowly to reduce the backlog.
+::::
+
+Force merging will be performed by the node hosting the shard. The [node's role](docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-settings.md#node-roles) frequently matches the [data tier](docs-content://manage-data/lifecycle/data-tiers.md) of the {{ilm-init}}'s phase of the index, but this is not guaranteed. For example: 
+* A force merge in the `hot` phase will use hot nodes. Merges may be faster on this potentially higher performance hardware but may have the tradeoff of impacting ingestion. 
+* A force merge in the `warm` phase will use warm nodes. Merges may take longer to perform on potentially lower performance hardware but will avoid impacting ingestion in the `hot` tier.
+* A force merge in the `cold` or `frozen` phase [{{ilm-init}} Searchable Snapshots](./ilm-searchable-snapshot) using `force_merge_index` happens on the preceeding data tier.
 
 We recommend that merges be targetted against SSD and not HDD disks.
 :::::

--- a/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
+++ b/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md
@@ -25,10 +25,10 @@ If you experience a force merge task queue backlog, you might need to increase t
 Note that `thread_pool.force_merge.size` is an advanced setting. Adjusting it can cause cascading performance impacts. Monitor cluster performance and increment the size of the thread pool slowly to reduce the backlog.
 ::::
 
-Force merging will be performed by the node hosting the shard. The [node's role](docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles.md#set-node-roles) frequently matches the [data tier](docs-content://manage-data/lifecycle/data-tiers.md) of the {{ilm-init}}'s phase of the index, you may choose to adjust this behavior. For example: 
+Force merging will be performed by the node hosting the shard. Usually, the [node's role](docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles.md#set-node-roles) matches the [data tier](docs-content://manage-data/lifecycle/data-tiers.md) of the {{ilm-init}} phase that the index is in. One of the exceptions is when you have manually disabled [ILM Migrate](https://www.elastic.co/docs/reference/elasticsearch/index-lifecycle-actions/ilm-migrate) and have specified custom allocations using [ILM allocate](https://www.elastic.co/docs/reference/elasticsearch/index-lifecycle-actions/ilm-allocate). The other exception is searchable snapshots; force merges for [{{ilm-init}} Searchable Snapshots](./ilm-searchable-snapshot.md) using `force_merge_index` are performed in the phase that the index is in **prior** to the `searchable_snapshot` action. You may want to explicitly choose in which data tier the force merge should occur, for example:
 * A force merge in the `hot` phase will use hot nodes. Merges may be faster on this potentially higher performance hardware but may have the tradeoff of impacting ingestion. 
 * A force merge in the `warm` phase will use warm nodes. Merges may take longer to perform on potentially lower performance hardware but will avoid impacting ingestion in the `hot` tier.
-* A force merge in the `cold` or `frozen` phase [{{ilm-init}} Searchable Snapshots](./ilm-searchable-snapshot.md) using `force_merge_index` happens on the preceeding data tier.
+*  [{{ilm-init}} Searchable Snapshot](./ilm-searchable-snapshot.md) performance is dependant upon the shard having been force merged, so by default this ILM action will enable `force_merge_index`. This will trigger force merges in the preceding node data tier for `cold` and `frozen` phases.
 
 We recommend that merges be targetted against SSD and not HDD disks.
 :::::


### PR DESCRIPTION
👋 howdy, team!

A handful of changes for the top of the [ILM Force Merge doc](https://www.elastic.co/docs/reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge), please have Dev confirm 🙏 

1. (Main) Elasticsearch Dev now recommends merges target SSD-not-HDD. (Part of the cultural shift of warm tier having HDD to SSD disk, but specifically merges are _much faster_ on SSD.)
2. Force Merges aren't guaranteed to happen on the phase's data tier ever since Searchable Snapshots have existed. Related [info](https://gist.github.com/stefnestor/9dc1b28fa86ccc6a9a54c3f4041a0cb6), [video](https://www.youtube.com/watch?v=onrnnwjYWSQ). Ex: you can force merge on cold for cold>frozen even though force merge action not allowed in cold & you never force merge on frozen.
3. added some "how you can accidentally kick this off"

I'm not tied to formatting at all. And kindly fix links as I'm catching up to the new system. However it needs said, kindly help ensure (1) and (2) correct but feel free to revert (3) as desired 🙏 .
