### PR TITLE
[8.19] Allow LimitOperator in Driver assertion (#130235)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
@@ -292,6 +292,8 @@ public class Driver implements Releasable, Describable {
 
             if (op.isFinished() == false && nextOp.needsInput()) {
                 driverContext.checkForEarlyTermination();
+                assert nextOp.isFinished() == false || nextOp instanceof ExchangeSinkOperator || nextOp instanceof LimitOperator
+                    : "next operator should not be finished yet: " + nextOp;
                 Page page = op.getOutput();
                 if (page == null) {
                     // No result, just move to the next iteration


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Allow LimitOperator in Driver assertion (#130235)](https://github.com/elastic/elasticsearch/pull/130235)