### PR TITLE
Waiting for desired allocation before starting shard snapshot

### DIFF
--- a/docs/changelog/130300.yaml
+++ b/docs/changelog/130300.yaml
@@ -1,0 +1,5 @@
+pr: 130300
+summary: Waiting for desired allocation before starting shard snapshot
+area: Snapshot/Restore
+type: enhancement
+issues: []

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportDeleteDesiredBalanceActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportDeleteDesiredBalanceActionTests.java
@@ -121,7 +121,8 @@ public class TransportDeleteDesiredBalanceActionTests extends ESAllocationTestCa
             computer,
             (state, action) -> state,
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         );
         var allocationService = new MockAllocationService(
             randomAllocationDeciders(settings, clusterSettings),

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
@@ -168,7 +168,8 @@ public class ClusterModuleTests extends ModuleTestCase {
                 EmptySystemIndices.INSTANCE,
                 TestProjectResolvers.alwaysThrow(),
                 WriteLoadForecaster.DEFAULT,
-                TelemetryProvider.NOOP
+                TelemetryProvider.NOOP,
+                () -> (desiredBalance) -> {}
             )
         );
         assertEquals(e.getMessage(), "Cannot specify allocation decider [" + EnableAllocationDecider.class.getName() + "] twice");
@@ -187,7 +188,8 @@ public class ClusterModuleTests extends ModuleTestCase {
             EmptySystemIndices.INSTANCE,
             TestProjectResolvers.alwaysThrow(),
             WriteLoadForecaster.DEFAULT,
-            TelemetryProvider.NOOP
+            TelemetryProvider.NOOP,
+            () -> (desiredBalance) -> {}
         );
         assertTrue(module.deciderList.stream().anyMatch(d -> d.getClass().equals(FakeAllocationDecider.class)));
     }
@@ -205,7 +207,8 @@ public class ClusterModuleTests extends ModuleTestCase {
             EmptySystemIndices.INSTANCE,
             TestProjectResolvers.alwaysThrow(),
             WriteLoadForecaster.DEFAULT,
-            TelemetryProvider.NOOP
+            TelemetryProvider.NOOP,
+            () -> (desiredBalance) -> {}
         );
     }
 
@@ -241,7 +244,8 @@ public class ClusterModuleTests extends ModuleTestCase {
                 EmptySystemIndices.INSTANCE,
                 TestProjectResolvers.alwaysThrow(),
                 WriteLoadForecaster.DEFAULT,
-                TelemetryProvider.NOOP
+                TelemetryProvider.NOOP,
+                () -> (desiredBalance) -> {}
             )
         );
         assertEquals("Unknown ShardsAllocator [dne]", e.getMessage());
@@ -305,7 +309,8 @@ public class ClusterModuleTests extends ModuleTestCase {
             EmptySystemIndices.INSTANCE,
             TestProjectResolvers.alwaysThrow(),
             WriteLoadForecaster.DEFAULT,
-            TelemetryProvider.NOOP
+            TelemetryProvider.NOOP,
+            () -> (desiredBalance) -> {}
         );
         expectThrows(IllegalArgumentException.class, () -> clusterModule.setExistingShardsAllocators(new TestGatewayAllocator()));
     }
@@ -321,7 +326,8 @@ public class ClusterModuleTests extends ModuleTestCase {
             EmptySystemIndices.INSTANCE,
             TestProjectResolvers.alwaysThrow(),
             WriteLoadForecaster.DEFAULT,
-            TelemetryProvider.NOOP
+            TelemetryProvider.NOOP,
+            () -> (desiredBalance) -> {}
         );
         expectThrows(IllegalArgumentException.class, () -> clusterModule.setExistingShardsAllocators(new TestGatewayAllocator()));
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationStatsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationStatsServiceTests.java
@@ -182,7 +182,8 @@ public class AllocationStatsServiceTests extends ESAllocationTestCase {
                     clusterService,
                     (innerState, strategy) -> innerState,
                     TelemetryProvider.NOOP,
-                    EMPTY_NODE_ALLOCATION_STATS
+                    EMPTY_NODE_ALLOCATION_STATS,
+                    () -> (desiredBalance) -> {}
                 ) {
                     @Override
                     public DesiredBalance getDesiredBalance() {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterAllocationSimulationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterAllocationSimulationTests.java
@@ -490,7 +490,8 @@ public class ClusterAllocationSimulationTests extends ESAllocationTestCase {
             (clusterState, routingAllocationAction) -> strategyRef.get()
                 .executeWithRoutingAllocation(clusterState, "reconcile-desired-balance", routingAllocationAction),
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         ) {
             @Override
             public void allocate(RoutingAllocation allocation, ActionListener<Void> listener) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
@@ -174,7 +174,8 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             clusterService,
             reconcileAction,
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         );
         assertValidStats(desiredBalanceShardsAllocator.getStats());
         var allocationService = createAllocationService(desiredBalanceShardsAllocator, createGatewayAllocator(allocateUnassigned));
@@ -302,7 +303,8 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             clusterService,
             reconcileAction,
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         );
         var allocationService = new AllocationService(
             new AllocationDeciders(List.of()),
@@ -421,7 +423,8 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             },
             reconcileAction,
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         );
         var allocationService = createAllocationService(desiredBalanceShardsAllocator, gatewayAllocator);
         allocationServiceRef.set(allocationService);
@@ -549,7 +552,8 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             },
             reconcileAction,
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         );
         var allocationService = createAllocationService(desiredBalanceShardsAllocator, gatewayAllocator);
         allocationServiceRef.set(allocationService);
@@ -653,7 +657,8 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             },
             reconcileAction,
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         );
 
         var allocationService = createAllocationService(desiredBalanceShardsAllocator, gatewayAllocator);
@@ -746,7 +751,8 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             desiredBalanceComputer,
             (reconcilerClusterState, rerouteStrategy) -> reconcilerClusterState,
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         );
 
         var service = createAllocationService(desiredBalanceShardsAllocator, createGatewayAllocator());
@@ -800,7 +806,8 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             desiredBalanceComputer,
             (reconcilerClusterState, rerouteStrategy) -> reconcilerClusterState,
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         );
 
         var service = createAllocationService(desiredBalanceShardsAllocator, createGatewayAllocator());
@@ -850,7 +857,8 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             desiredBalanceComputer,
             (reconcilerClusterState, rerouteStrategy) -> reconcilerClusterState,
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         ) {
             @Override
             public void resetDesiredBalance() {
@@ -946,7 +954,8 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             },
             (clusterState, rerouteStrategy) -> null,
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         ) {
 
             private ActionListener<Void> lastListener;

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalance;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
@@ -745,7 +746,8 @@ public class SnapshotsServiceTests extends ESTestCase {
             final SnapshotsInProgress existing = SnapshotsInProgress.get(batchExecutionContext.initialState());
             final var context = new SnapshotsService.SnapshotShardsUpdateContext(
                 batchExecutionContext,
-                /* on completion handler */ (shardSnapshotUpdateResult, newlyCompletedEntries, updatedRepositories) -> {}
+                /* on completion handler */ (shardSnapshotUpdateResult, newlyCompletedEntries, updatedRepositories) -> {},
+                DesiredBalance.BECOME_MASTER_INITIAL
             );
             final SnapshotsInProgress updated = context.computeUpdatedState();
             context.setupSuccessfulPublicationCallbacks(updated);

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
@@ -175,7 +175,8 @@ public abstract class ESAllocationTestCase extends ESTestCase {
             clusterService,
             null,
             TelemetryProvider.NOOP,
-            EMPTY_NODE_ALLOCATION_STATS
+            EMPTY_NODE_ALLOCATION_STATS,
+            () -> (desiredBalance) -> {}
         ) {
             private RoutingAllocation lastAllocation;
 


### PR DESCRIPTION
If the allocation of a shard is undesired, its snapshort now waits for the desired allocation.
