### PR TITLE
Remove tmp_fdt_no_mmap feature flag.

### DIFF
--- a/docs/changelog/130308.yaml
+++ b/docs/changelog/130308.yaml
@@ -1,0 +1,5 @@
+pr: 130308
+summary: Remove `tmp_fdt_no_mmap` feature flag
+area: Logs
+type: bug
+issues: []

--- a/docs/changelog/130308.yaml
+++ b/docs/changelog/130308.yaml
@@ -1,5 +1,5 @@
 pr: 130308
-summary: Remove `tmp_fdt_no_mmap` feature flag
+summary: Force niofs for fdt tmp file read access when flushing stored fields
 area: Logs
 type: bug
 issues: []

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -533,9 +533,6 @@ tests:
 - class: org.elasticsearch.qa.verify_version_constants.VerifyVersionConstantsIT
   method: testLuceneVersionConstant
   issue: https://github.com/elastic/elasticsearch/issues/125638
-- class: org.elasticsearch.index.store.FsDirectoryFactoryTests
-  method: testPreload
-  issue: https://github.com/elastic/elasticsearch/issues/129852
 - class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
   method: test {yaml=rrf/950_pinned_interaction/rrf with pinned retriever as a sub-retriever}
   issue: https://github.com/elastic/elasticsearch/issues/129845

--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
@@ -46,7 +46,6 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
 
     private static final Logger Log = LogManager.getLogger(FsDirectoryFactory.class);
     private static final FeatureFlag MADV_RANDOM_FEATURE_FLAG = new FeatureFlag("madv_random");
-    private static final FeatureFlag TMP_FDT_NO_MMAP_FEATURE_FLAG = new FeatureFlag("tmp_fdt_no_mmap");
 
     public static final Setting<LockFactory> INDEX_LOCK_FACTOR_SETTING = new Setting<>("index.store.fs.fs_lock", "native", (s) -> {
         return switch (s) {
@@ -261,8 +260,7 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
          * @return whether to avoid using delegate if the file is a tmp fdt file.
          */
         static boolean avoidDelegateForFdtTempFiles(String name, LuceneFilesExtensions extension) {
-            // NOTE, for now gated behind feature flag to observe impact of this change in benchmarks only:
-            return TMP_FDT_NO_MMAP_FEATURE_FLAG.isEnabled() && extension == LuceneFilesExtensions.TMP && name.contains("fdt");
+            return extension == LuceneFilesExtensions.TMP && name.contains("fdt");
         }
 
         MMapDirectory getDelegate() {


### PR DESCRIPTION
After running this change (#129538) for a week,
no regressions where detected in
nightly benchmarks that use index sorting.

While at the same time the median indexing throughput for logsdb with stored fields improved significantly:
https://elasticsearch-benchmarks.elastic.co/#tracks/logsdb/nightly/default/30d (nightly-elastic/logs-indexing-throughput)