### PR TITLE
Add missing format param to "esql.async_query_get" json spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_get.json
@@ -26,6 +26,10 @@
       ]
     },
     "params":{
+      "format":{
+        "type":"string",
+        "description":"a short version of the Accept header, e.g. json, yaml"
+      },
       "wait_for_completion_timeout":{
         "type":"time",
         "description":"Specify the time that the request should block waiting for the final response"


### PR DESCRIPTION
[RestEsqlGetAsyncResultAction](https://github.com/elastic/elasticsearch/blob/b0bd718b969fc29255804b18894978880377fcbb/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlGetAsyncResultAction.java) supports `format` through `BaseRestHandler`, so the json spec should also support this parameter. 