### PR TITLE
[9.1] Fix typo in ILM retry action (#130255)

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportRetryAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportRetryAction.java
@@ -80,7 +80,7 @@ public class TransportRetryAction extends TransportMasterNodeAction<RetryActionR
         submitUnbatchedTask("ilm-re-run", new AckedClusterStateUpdateTask(request, listener) {
             @Override
             public ClusterState execute(ClusterState currentState) {
-                final var project = state.metadata().getProject(projectState.projectId());
+                final var project = currentState.metadata().getProject(projectState.projectId());
                 final var updatedProject = indexLifecycleService.moveIndicesToPreviouslyFailedStep(project, request.indices());
                 return ClusterState.builder(currentState).putProjectMetadata(updatedProject).build();
             }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Fix typo in ILM retry action (#130255)